### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/java/org/wso2/carbon/identity/application/mgt/ui/util/ApplicationMgtUIUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/java/org/wso2/carbon/identity/application/mgt/ui/util/ApplicationMgtUIUtil.java
@@ -29,6 +29,9 @@ public class ApplicationMgtUIUtil {
 
     private static final String SP_UNIQUE_ID_MAP = "spUniqueIdMap";
 
+    private ApplicationMgtUIUtil() {
+    }
+
     /**
      * Get related application bean from the session.
      *

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/InboundAuthenticationUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/InboundAuthenticationUtil.java
@@ -20,6 +20,9 @@ package org.wso2.carbon.identity.application.authentication.framework.inbound;
 
 public class InboundAuthenticationUtil {
 
+    private InboundAuthenticationUtil() {
+    }
+
     /**
      * Add to inbound authentication context cache
      * @param key Key

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.common/src/main/java/org/wso2/carbon/identity/entitlement/common/Utils.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.common/src/main/java/org/wso2/carbon/identity/entitlement/common/Utils.java
@@ -27,6 +27,9 @@ import java.util.Arrays;
  */
 public class Utils {
 
+    private Utils() {
+    }
+
     public static boolean isValidRuleAlgorithm(String algorithmUri, boolean isPolicy) {
 
         if (isPolicy) {

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/java/org/wso2/carbon/identity/entitlement/ui/util/ClientUtil.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/java/org/wso2/carbon/identity/entitlement/ui/util/ClientUtil.java
@@ -30,6 +30,9 @@ import javax.xml.namespace.QName;
  */
 public class ClientUtil {
 
+    private ClientUtil() {
+    }
+
     /**
      * Helper method to extract the boolean response
      *

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/java/org/wso2/carbon/identity/entitlement/ui/util/PolicyCreatorUtil.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/java/org/wso2/carbon/identity/entitlement/ui/util/PolicyCreatorUtil.java
@@ -35,6 +35,8 @@ import java.util.Map;
  * This is Util class which help to create a XACML policy
  */
 public class PolicyCreatorUtil {
+    private PolicyCreatorUtil() {
+    }
 //
 //    /**
 //     * This method creates a policy element of the XACML policy

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/java/org/wso2/carbon/identity/entitlement/ui/util/PolicyEditorUtil.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/java/org/wso2/carbon/identity/entitlement/ui/util/PolicyEditorUtil.java
@@ -84,6 +84,9 @@ public class PolicyEditorUtil {
      */
     private static Map<String, ApplyElementDTO> applyElementMap = new HashMap<String, ApplyElementDTO>();
 
+    private PolicyEditorUtil() {
+    }
+
     /**
      * Create XACML policy with the simplest input attributes
      *

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/EntitlementUtil.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/EntitlementUtil.java
@@ -108,6 +108,9 @@ public class EntitlementUtil {
     private static final int ENTITY_EXPANSION_LIMIT = 0;
     public static final String EXTERNAL_GENERAL_ENTITIES_URI = "http://xml.org/sax/features/external-general-entities";
 
+    private EntitlementUtil() {
+    }
+
 
     /**
      * Return an instance of a named cache that is common to all tenants.

--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityBaseUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityBaseUtil.java
@@ -89,7 +89,9 @@ public class IdentityBaseUtil {
             "            </wsp:ExactlyOne>" +
             "        </wsp:Policy>";
 
-
+    private IdentityBaseUtil() {
+    }
+    
     public static Policy getDefaultRampartConfig() {
 
         //Extract the primary keystore information from server configuration

--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityValidationUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityValidationUtil.java
@@ -33,6 +33,9 @@ public class IdentityValidationUtil {
             "contains illegal characters matching one of the black list patterns [ %s ]";
     private static final String msgSection4 = " or ";
 
+    private IdentityValidationUtil() {
+    }
+
     /**
      * Defines a predefined set of pattern list
      */

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityDatabaseUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityDatabaseUtil.java
@@ -36,6 +36,9 @@ public class IdentityDatabaseUtil {
 
     private static final Log log = LogFactory.getLog(IdentityDatabaseUtil.class);
 
+    private IdentityDatabaseUtil() {
+    }
+
     /**
      * Get a database connection instance from the Identity Persistence Manager
      *

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityIOStreamUtils.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityIOStreamUtils.java
@@ -30,6 +30,9 @@ public class IdentityIOStreamUtils {
 
     private static final Log log = LogFactory.getLog(IdentityIOStreamUtils.class);
 
+    private IdentityIOStreamUtils() {
+    }
+
     public static void closeAllStreams(InputStream input, OutputStream output){
         closeInputStream(input);
         closeOutputStream(output);

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
@@ -54,6 +54,9 @@ public class IdentityTenantUtil {
     private static TenantRegistryLoader tenantRegistryLoader;
     private static BundleContext bundleContext;
 
+    private IdentityTenantUtil() {
+    }
+
     public static TenantRegistryLoader getTenantRegistryLoader() {
         return tenantRegistryLoader;
     }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -107,6 +107,9 @@ public class IdentityUtil {
             Constants.SECURITY_MANAGER_PROPERTY;
     private static final int ENTITY_EXPANSION_LIMIT = 0;
 
+    private IdentityUtil() {
+    }
+
     /**
      * @return
      */

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/constants/IdentityMgtConstants.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/constants/IdentityMgtConstants.java
@@ -232,5 +232,7 @@ public class IdentityMgtConstants {
 
         public static final String USER_ACCOUNT = " No user account found for user ";
 
+        private ErrorHandling() {
+        }
     }
 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/java/org/wso2/carbon/idp/mgt/ui/util/IdPManagementUIUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/java/org/wso2/carbon/idp/mgt/ui/util/IdPManagementUIUtil.java
@@ -57,6 +57,9 @@ public class IdPManagementUIUtil {
 
     private static final Log log = LogFactory.getLog(IdPManagementUIUtil.class);
 
+    private IdPManagementUIUtil() {
+    }
+
     /**
      * Validates an URI.
      *

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
@@ -39,6 +39,9 @@ public class IdPManagementUtil {
 
     private static final Log log = LogFactory.getLog(IdPManagementUtil.class);
 
+    private IdPManagementUtil() {
+    }
+
     /**
      * Get the tenant id of the given tenant domain.
      *

--- a/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/util/SecurityPersistenceUtils.java
+++ b/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/util/SecurityPersistenceUtils.java
@@ -39,6 +39,9 @@ public class SecurityPersistenceUtils {
 
     private static Log log = LogFactory.getLog(SecurityPersistenceUtils.class);
 
+    private SecurityPersistenceUtils() {
+    }
+
     /**
      * @param serviceGroupId      serviceGroupId
      * @param serviceId           serviceId

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration.deployer/src/main/java/org/wso2/carbon/identity/user/store/configuration/deployer/util/UserStoreUtil.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration.deployer/src/main/java/org/wso2/carbon/identity/user/store/configuration/deployer/util/UserStoreUtil.java
@@ -43,6 +43,9 @@ public class UserStoreUtil {
 
     private static Log log = LogFactory.getLog(UserStoreUtil.class);
 
+    private UserStoreUtil() {
+    }
+
     public static Cipher getCipherOfSuperTenant() throws UserStoreException {
         Cipher cipher;
         ServerConfigurationService config =

--- a/components/user-store/org.wso2.carbon.identity.user.store.count/src/main/java/org/wso2/carbon/identity/user/store/count/util/UserStoreCountUtils.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.count/src/main/java/org/wso2/carbon/identity/user/store/count/util/UserStoreCountUtils.java
@@ -46,6 +46,9 @@ public class UserStoreCountUtils {
     public static final String countRetrieverClass = "CountRetrieverClass";
     private static Log log = LogFactory.getLog(UserStoreCountUtils.class);
 
+    private UserStoreCountUtils() {
+    }
+
 
     /**
      * Get the available list of user store domains

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/java/org/wso2/carbon/identity/workflow/mgt/ui/util/WorkflowUIUtil.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/java/org/wso2/carbon/identity/workflow/mgt/ui/util/WorkflowUIUtil.java
@@ -15,6 +15,9 @@ import java.util.Set;
 
 public class WorkflowUIUtil {
 
+    private WorkflowUIUtil() {
+    }
+
     /**
      * Load parameters of a workflow template
      *

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/util/WorkflowManagementUtil.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/util/WorkflowManagementUtil.java
@@ -24,6 +24,9 @@ import java.util.List;
 public class WorkflowManagementUtil {
     private static Log log = LogFactory.getLog(WorkflowManagementUtil.class);
 
+    private WorkflowManagementUtil() {
+    }
+
     /**
      * Create a internal role in workflow domain with same name as workflow.
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
