### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ApplicationPermission.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ApplicationPermission.java
@@ -38,7 +38,7 @@ public class ApplicationPermission implements Serializable {
         Iterator<?> iter = applicationPermissionOM.getChildElements();
 
         while (iter.hasNext()) {
-            OMElement element = (OMElement) (iter.next());
+            OMElement element = (OMElement) iter.next();
             String elementName = element.getLocalName();
 
             if ("value".equals(elementName)) {

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/AuthenticationStep.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/AuthenticationStep.java
@@ -93,8 +93,8 @@ public class AuthenticationStep implements Serializable {
 
                 if (localAuthenticatorConfigsIter != null) {
                     while (localAuthenticatorConfigsIter.hasNext()) {
-                        OMElement localAuthenticatorConfigsElement = (OMElement) (localAuthenticatorConfigsIter
-                                .next());
+                        OMElement localAuthenticatorConfigsElement = (OMElement) localAuthenticatorConfigsIter
+                                .next();
                         LocalAuthenticatorConfig localAuthConfig = LocalAuthenticatorConfig
                                 .build(localAuthenticatorConfigsElement);
                         if (localAuthConfig != null) {

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/Claim.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/Claim.java
@@ -44,7 +44,7 @@ public class Claim implements Serializable {
         Iterator<?> iter = claimOM.getChildElements();
 
         while (iter.hasNext()) {
-            OMElement element = (OMElement) (iter.next());
+            OMElement element = (OMElement) iter.next();
             String elementName = element.getLocalName();
 
             if ("ClaimUri".equals(elementName)) {

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ClaimConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ClaimConfig.java
@@ -48,7 +48,7 @@ public class ClaimConfig implements Serializable {
 
         while (iter.hasNext()) {
 
-            OMElement element = (OMElement) (iter.next());
+            OMElement element = (OMElement) iter.next();
             String elementName = element.getLocalName();
 
             if ("RoleClaimURI".equals(elementName)) {
@@ -69,7 +69,7 @@ public class ClaimConfig implements Serializable {
 
                 if (idpClaimsIter != null) {
                     while (idpClaimsIter.hasNext()) {
-                        OMElement idpClaimsElement = (OMElement) (idpClaimsIter.next());
+                        OMElement idpClaimsElement = (OMElement) idpClaimsIter.next();
                         Claim claim = Claim.build(idpClaimsElement);
                         if (claim != null) {
                         }
@@ -87,7 +87,7 @@ public class ClaimConfig implements Serializable {
 
                 if (claimMappingsIter != null) {
                     while (claimMappingsIter.hasNext()) {
-                        OMElement claimMappingsElement = (OMElement) (claimMappingsIter.next());
+                        OMElement claimMappingsElement = (OMElement) claimMappingsIter.next();
                         ClaimMapping claimMapping = ClaimMapping.build(claimMappingsElement);
                         if (claimMapping != null) {
                             claimMappingsArrList.add(claimMapping);

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ClaimMapping.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ClaimMapping.java
@@ -67,7 +67,7 @@ public class ClaimMapping implements Serializable {
         Iterator<?> iter = claimMappingOM.getChildElements();
 
         while (iter.hasNext()) {
-            OMElement element = (OMElement) (iter.next());
+            OMElement element = (OMElement) iter.next();
             String elementName = element.getLocalName();
 
             if ("LocalClaim".equals(elementName)) {

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/RequestPathAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/RequestPathAuthenticatorConfig.java
@@ -56,7 +56,7 @@ public class RequestPathAuthenticatorConfig extends LocalAuthenticatorConfig {
 
                 if (propertiesIter != null) {
                     while (propertiesIter.hasNext()) {
-                        OMElement propertiesElement = (OMElement) (propertiesIter.next());
+                        OMElement propertiesElement = (OMElement) propertiesIter.next();
                         Property prop = Property.build(propertiesElement);
                         propertiesArrList.add(prop);
                     }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/java/org/wso2/carbon/identity/application/mgt/ui/ApplicationBean.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/java/org/wso2/carbon/identity/application/mgt/ui/ApplicationBean.java
@@ -365,7 +365,7 @@ public class ApplicationBean {
 
         RoleMapping[] roleMapping = serviceProvider.getPermissionAndRoleConfig().getRoleMappings();
 
-        if (roleMap != null && roleMapping != null && (roleMapping.length == roleMap.size())) {
+        if (roleMap != null && roleMapping != null && roleMapping.length == roleMap.size()) {
             return roleMap;
         }
 
@@ -400,7 +400,7 @@ public class ApplicationBean {
 
         ClaimMapping[] claimMapping = serviceProvider.getClaimConfig().getClaimMappings();
 
-        if (claimMap != null && claimMapping != null && (claimMapping.length == claimMap.size())) {
+        if (claimMap != null && claimMapping != null && claimMapping.length == claimMap.size()) {
             return claimMap;
         }
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -521,7 +521,7 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
             for (ClaimMapping claimMap : claimMappings) {
                 claimUris.add(claimMap.getClaim().getClaimUri());
             }
-            String[] allLocalClaimUris = (claimUris.toArray(new String[claimUris.size()]));
+            String[] allLocalClaimUris = claimUris.toArray(new String[claimUris.size()]);
             if (ArrayUtils.isNotEmpty(allLocalClaimUris)) {
                 Arrays.sort(allLocalClaimUris);
             }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -277,7 +277,7 @@ public class SessionDataStore {
             resultSet = preparedStatement.executeQuery();
             if(resultSet.next()) {
                 String operation = resultSet.getString(1);
-                if ((OPERATION_STORE.equals(operation))) {
+                if (OPERATION_STORE.equals(operation)) {
                     return new SessionContextDO(key, type, getBlobObject(resultSet.getBinaryStream(2)), new Timestamp
                             (resultSet.getLong(3)));
                 }

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/policy/collection/DefaultPolicyCollection.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/policy/collection/DefaultPolicyCollection.java
@@ -195,7 +195,7 @@ public class DefaultPolicyCollection implements PolicyCollection {
                     log.debug("Matching XACML policy found " + policy.getId().toString());
                 }
 
-                if ((combiningAlg == null) && (list.size() > 0)) {
+                if (combiningAlg == null && list.size() > 0) {
                     ArrayList<String> code = new ArrayList<String>();
                     code.add(Status.STATUS_PROCESSING_ERROR);
                     Status status = new Status(code, "too many applicable top-level policies");
@@ -215,7 +215,7 @@ public class DefaultPolicyCollection implements PolicyCollection {
                 }
                 return null;
             case 1:
-                return ((AbstractPolicy) (list.get(0)));
+                return (AbstractPolicy) list.get(0);
             default:
                 return new PolicySet(parentId, combiningAlg, null, list);
         }
@@ -265,7 +265,7 @@ public class DefaultPolicyCollection implements PolicyCollection {
      */
     public AbstractPolicy getEffectivePolicy(ArrayList<AbstractPolicy> policies) throws EntitlementException {
 
-        if ((combiningAlg == null) && (policies.size() > 0)) {
+        if (combiningAlg == null && policies.size() > 0) {
             log.error("Too many applicable top-level policies");
             throw new EntitlementException("Too many applicable top-level policies");
         }
@@ -277,7 +277,7 @@ public class DefaultPolicyCollection implements PolicyCollection {
                 }
                 return null;
             case 1:
-                return ((AbstractPolicy) (policies.get(0)));
+                return (AbstractPolicy) policies.get(0);
             default:
                 return new PolicySet(parentId, combiningAlg, target, policies);
         }
@@ -306,7 +306,7 @@ public class DefaultPolicyCollection implements PolicyCollection {
         // for a match until we exhaust all known versions
         Iterator<AbstractPolicy> it = set.iterator();
         while (it.hasNext()) {
-            AbstractPolicy policy = (AbstractPolicy) (it.next());
+            AbstractPolicy policy = (AbstractPolicy) it.next();
             if (constraints.meetsConstraint(policy.getVersion())) {
                 // we found a valid version, so see if it's the right kind,
                 // and if it is then we return it

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/policy/collection/SimplePolicyCollection.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/policy/collection/SimplePolicyCollection.java
@@ -101,7 +101,7 @@ public class SimplePolicyCollection implements PolicyCollection {
                     log.debug("Matching XACML policy found " + policy.getId().toString());
                 }
 
-                if ((combiningAlg == null) && (list.size() > 0)) {
+                if (combiningAlg == null && list.size() > 0) {
                     log.error("Too many applicable top-level policies");
                     throw new EntitlementException("Too many applicable top-level policies");
                 }
@@ -119,7 +119,7 @@ public class SimplePolicyCollection implements PolicyCollection {
                 }
                 return null;
             case 1:
-                return ((AbstractPolicy) (list.get(0)));
+                return (AbstractPolicy) list.get(0);
             default:
                 return new PolicySet(parentId, combiningAlg, null, list);
         }

--- a/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/config/SecurityConfigAdmin.java
+++ b/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/config/SecurityConfigAdmin.java
@@ -441,9 +441,9 @@ public class SecurityConfigAdmin {
             for (Iterator iter = it.iterator(); iter.hasNext(); ) {
                 Assertion assertion = (Assertion) iter.next();
                 if (assertion instanceof XmlPrimtiveAssertion) {
-                    OMElement xmlPrimitiveAssertion = (((XmlPrimtiveAssertion) assertion).getValue());
+                    OMElement xmlPrimitiveAssertion = ((XmlPrimtiveAssertion) assertion).getValue();
                     if (SecurityConstants.CARBON_SEC_CONFIG.equals(xmlPrimitiveAssertion.getLocalName())) {
-                        OMElement carbonSecConfigElement = (((XmlPrimtiveAssertion) assertion).getValue());
+                        OMElement carbonSecConfigElement = ((XmlPrimtiveAssertion) assertion).getValue();
                         if (log.isDebugEnabled()) {
                             log.debug("carbonSecConfig : " + carbonSecConfigElement.toString());
                         }

--- a/components/user-mgt/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/AddUserWFRequestHandler.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/AddUserWFRequestHandler.java
@@ -111,7 +111,7 @@ public class AddUserWFRequestHandler extends AbstractWorkflowRequestHandler {
             }
             CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
             encryptedCredentials = cryptoUtil.
-                    encryptAndBase64Encode((credential.toString()).getBytes(Charset.forName("UTF-8")));
+                    encryptAndBase64Encode(credential.toString().getBytes(Charset.forName("UTF-8")));
         } catch (CryptoException e) {
             throw new WorkflowException("Error while encrypting the Credential for User Name" + " " + userName, e);
         }
@@ -219,7 +219,7 @@ public class AddUserWFRequestHandler extends AbstractWorkflowRequestHandler {
             throw new WorkflowException("Error while decrypting the Credential for user " + userName, e);
         }
 
-        List<String> roleList = ((List<String>) requestParams.get(ROLE_LIST));
+        List<String> roleList = (List<String>) requestParams.get(ROLE_LIST);
         String[] roles;
         if (roleList != null) {
             roles = new String[roleList.size()];


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.
