### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityConfigParser.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityConfigParser.java
@@ -294,7 +294,7 @@ public class IdentityConfigParser {
     }
 
     private String getKey(Stack<String> nameStack) {
-        StringBuffer key = new StringBuffer();
+        StringBuilder key = new StringBuilder();
         for (int i = 0; i < nameStack.size(); i++) {
             String name = nameStack.elementAt(i);
             key.append(name).append(".");

--- a/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/config/SecurityConfigAdmin.java
+++ b/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/config/SecurityConfigAdmin.java
@@ -852,7 +852,7 @@ public class SecurityConfigAdmin {
 
 
     private String getArrayAsString(String[] userGroups) {
-        StringBuffer groups = new StringBuffer();
+        StringBuilder groups = new StringBuilder();
         boolean isFirst = true;
         for (String group : userGroups) {
             if (isFirst) {

--- a/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/util/ServerCrypto.java
+++ b/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/util/ServerCrypto.java
@@ -216,10 +216,10 @@ public class ServerCrypto implements Crypto {
      */
     public byte[] getCertificateData(boolean reverse, X509Certificate[] certs)
             throws WSSecurityException {
-        Vector list = new Vector();
+        List list = new ArrayList();
         for (int i = 0; i < certs.length; i++) {
             if (reverse) {
-                list.insertElementAt(certs[i], 0);
+                list.add(0, certs[i]);
             } else {
                 list.add(certs[i]);
             }
@@ -634,7 +634,7 @@ public class ServerCrypto implements Crypto {
     public String[] getAliasesForDN(String subjectDN) throws WSSecurityException {
 
         // Store the aliases found
-        Vector aliases = new Vector();
+        List aliases = new Vector();
         Certificate cert;
 
         // The DN to search the keystore for
@@ -667,7 +667,7 @@ public class ServerCrypto implements Crypto {
         // Convert the vector into an array
         String[] result = new String[aliases.size()];
         for (int i = 0; i < aliases.size(); i++) {
-            result[i] = (String) aliases.elementAt(i);
+            result[i] = (String) aliases.get(i);
         }
         return result;
 

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/test/java/org/wso2/carbon/user/core/LDAPTestCase.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/test/java/org/wso2/carbon/user/core/LDAPTestCase.java
@@ -100,7 +100,7 @@ public class LDAPTestCase extends TestCase {
 				searchCtls.setReturningAttributes(returnedAtts);
 
 				// / search filter TODO
-				StringBuffer buff = new StringBuffer();
+				StringBuilder buff = new StringBuilder();
 				buff.append("(&").append(searchFilter).append("(").append(roleNameProperty)
 				    .append("=").append(filter).append("))");
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.
