### PR TITLE
Fixing npe authenticated user

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -67,7 +67,9 @@ public class AuthenticatedUser extends User {
         this.tenantDomain = authenticatedUser.getTenantDomain();
         this.userName = authenticatedUser.getUserName();
         this.userStoreDomain = authenticatedUser.getUserStoreDomain();
-        this.userAttributes.putAll(authenticatedUser.getUserAttributes());
+        if (authenticatedUser.getUserAttributes() != null) {
+            this.userAttributes.putAll(authenticatedUser.getUserAttributes());
+        }
         this.isFederatedUser = authenticatedUser.isFederatedUser();
     }
 


### PR DESCRIPTION
fixing NPE throw when copying an AuthenticatedUser instance with userAttributes set as null