### PR TITLE
Making init() method a no-arg method because we can't pass any proper…

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/handler/AbstractIdentityHandler.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/handler/AbstractIdentityHandler.java
@@ -18,26 +18,45 @@
 
 package org.wso2.carbon.identity.core.handler;
 
-import org.wso2.carbon.identity.base.IdentityException;
-import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
+import java.util.Map;
 import java.util.Properties;
 
 public abstract class AbstractIdentityHandler implements IdentityHandler {
 
-    protected Properties properties = new Properties();
+    private static Log log = LogFactory.getLog(AbstractIdentityHandler.class);
 
-    public void init(Properties properties) throws IdentityRuntimeException {
-        if(properties != null){
-            this.properties = properties;
+    protected final Properties properties = new Properties();
+
+    public void init() {
+
+        IdentityEventListenerConfig identityEventListenerConfig = IdentityUtil.readEventListenerProperty
+                (AbstractIdentityHandler.class.getName(), this.getClass().getName());
+
+        if (identityEventListenerConfig == null) {
+            return;
+        }
+
+        if(identityEventListenerConfig.getProperties() != null) {
+            for(Map.Entry<Object,Object> property:identityEventListenerConfig.getProperties().entrySet()) {
+                String key = (String)property.getKey();
+                String value = (String)property.getValue();
+                if(!properties.containsKey(key)) {
+                    properties.setProperty(key, value);
+                } else {
+                    log.warn("Property key " + key + " already exists. Cannot add property!!");
+                }
+            }
         }
     }
 
-    public boolean isEnabled(MessageContext messageContext) throws IdentityException {
+    public boolean isEnabled(MessageContext messageContext) {
 
         IdentityEventListenerConfig identityEventListenerConfig = IdentityUtil.readEventListenerProperty
                 (AbstractIdentityHandler.class.getName(), this.getClass().getName());
@@ -49,7 +68,7 @@ public abstract class AbstractIdentityHandler implements IdentityHandler {
         return Boolean.parseBoolean(identityEventListenerConfig.getEnable());
     }
 
-    public int getPriority(MessageContext messageContext) throws IdentityRuntimeException {
+    public int getPriority(MessageContext messageContext) {
 
         IdentityEventListenerConfig identityEventListenerConfig = IdentityUtil.readEventListenerProperty
                 (AbstractIdentityHandler.class.getName(), this.getClass().getName());
@@ -59,7 +78,7 @@ public abstract class AbstractIdentityHandler implements IdentityHandler {
         return identityEventListenerConfig.getOrder();
     }
 
-    public boolean canHandle(MessageContext messageContext) throws IdentityRuntimeException {
+    public boolean canHandle(MessageContext messageContext) {
         return false;
     }
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/handler/IdentityHandler.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/handler/IdentityHandler.java
@@ -18,11 +18,7 @@
 
 package org.wso2.carbon.identity.core.handler;
 
-import org.wso2.carbon.identity.base.IdentityException;
-import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
-
-import java.util.Properties;
 
 /**
  * This interface needs to be implemented by any identity handler.
@@ -30,11 +26,10 @@ import java.util.Properties;
 public interface IdentityHandler {
 
     /**
-     * Initializes the Extension Handler
+     * Initializes the handler
      *
-     * @throws org.wso2.carbon.identity.base.IdentityRuntimeException
      */
-    public void init(Properties properties) throws IdentityRuntimeException;
+    public void init();
 
     /**
      * Name of the handler.
@@ -48,25 +43,22 @@ public interface IdentityHandler {
      * called.
      *
      * @param messageContext The runtime message context
-     * @throws org.wso2.carbon.identity.base.IdentityRuntimeException
      */
-    public boolean isEnabled(MessageContext messageContext) throws IdentityException;
+    public boolean isEnabled(MessageContext messageContext);
 
     /**
      * Used to sort the set of handlers
      *
      * @param messageContext The runtime message context
      * @return The priority value of the handler
-     * @throws org.wso2.carbon.identity.base.IdentityRuntimeException
      */
-    public int getPriority(MessageContext messageContext) throws IdentityRuntimeException;
+    public int getPriority(MessageContext messageContext);
 
     /**
      * Tells if this request can be handled by this handler
      *
      * @param messageContext The runtime message context
      * @return {@code true} if the message can be handled by this handler
-     * @throws org.wso2.carbon.identity.base.IdentityRuntimeException
      */
-    public abstract boolean canHandle(MessageContext messageContext) throws IdentityRuntimeException;
+    public abstract boolean canHandle(MessageContext messageContext);
 }


### PR DESCRIPTION
Making init() method a no-arg method because we can't pass any properties from identity.core. Individual component making use of this handler can call init method to load properties defined in identity.xml EventListeners