### PR TITLE
Adding new class type InitConfig to hold handler initializing configuration

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/handler/AbstractIdentityHandler.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/handler/AbstractIdentityHandler.java
@@ -34,7 +34,7 @@ public abstract class AbstractIdentityHandler implements IdentityHandler {
 
     protected final Properties properties = new Properties();
 
-    public void init() {
+    public void init(InitConfig initConfig) {
 
         IdentityEventListenerConfig identityEventListenerConfig = IdentityUtil.readEventListenerProperty
                 (AbstractIdentityHandler.class.getName(), this.getClass().getName());

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/handler/IdentityHandler.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/handler/IdentityHandler.java
@@ -29,7 +29,7 @@ public interface IdentityHandler {
      * Initializes the handler
      *
      */
-    public void init();
+    public void init(InitConfig initConfig);
 
     /**
      * Name of the handler.


### PR DESCRIPTION
Adding new class type InitConfig to hold handler initializing configuration. Earlier we used Properties for this and removed because always Properties can't be used.