### PR TITLE
Fixing Open Redirect vulnerabilities in idp.mgt.ui

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-list-load.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-list-load.jsp
@@ -17,9 +17,11 @@
 -->
 
 <%@page import="org.apache.axis2.context.ConfigurationContext"%>
-<%@page import="org.owasp.encoder.Encode"%>
+<%@page import="org.apache.commons.lang.StringUtils" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.wso2.carbon.CarbonConstants" %>
 <%@ page import="org.wso2.carbon.identity.application.common.model.idp.xsd.IdentityProvider" %>
+<%@ page import="org.wso2.carbon.identity.base.IdentityValidationUtil" %>
 <%@ page import="org.wso2.carbon.idp.mgt.ui.client.IdentityProviderMgtServiceClient" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
@@ -35,7 +37,9 @@
     String BUNDLE = "org.wso2.carbon.idp.mgt.ui.i18n.Resources";
     ResourceBundle resourceBundle = ResourceBundle.getBundle(BUNDLE, request.getLocale());
     String callback = request.getParameter("callback");
-    if(callback == null || callback != null && callback.equals("")){
+    if (StringUtils.isBlank(callback) || !IdentityValidationUtil
+            .isValidOverBlackListPatterns(callback, IdentityValidationUtil.ValidatorPattern.URI_RESERVED_EXISTS
+                    .name())) {
         callback = "idp-mgt-list.jsp";
     }
     try {


### PR DESCRIPTION
In idp.mgt.ui page redirections were done based on the page received as a query parameter from the previous page.
Received parameter is neither validated, thus, they even expose for redirections to other domains.
This fix validates the received query parameter for URI characters which avoid redirections for external domains.