### PR TITLE
Fixing Open Redirect vulnerability in workflow.mgt.ui

### DIFF
--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/pom.xml
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/pom.xml
@@ -44,6 +44,10 @@
             <artifactId>org.wso2.carbon.identity.workflow.mgt.stub</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity</groupId>
+            <artifactId>org.wso2.carbon.identity.base</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.ws.commons.axiom.wso2</groupId>
             <artifactId>axiom</artifactId>
         </dependency>
@@ -89,7 +93,8 @@
                             org.wso2.carbon.identity.workflow.mgt.stub.bean.*;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.workflow.mgt.stub.mgt.*;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.workflow.mgt.stub.metadata.*;version="${carbon.identity.package.import.version.range}",
-                            org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.*;version="${carbon.identity.package.import.version.range}"
+                            org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.*;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.base;version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
                         <Export-Package>
                             org.wso2.carbon.identity.workflow.mgt.ui.*;version="${carbon.identity.package.export.version}"

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/add-wf-wizard.jsp
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/add-wf-wizard.jsp
@@ -19,21 +19,19 @@
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib uri="http://wso2.org/projects/carbon/taglibs/carbontags.jar" prefix="carbon" %>
 
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.WorkflowUIConstants" %>
-<%@ page import="java.util.HashMap" %>
-<%@ page import="java.util.Map" %>
-<%@ page import="org.apache.commons.lang.StringUtils" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.WorkflowAdminServiceClient" %>
-<%@ page import="java.util.ResourceBundle" %>
-<%@ page import="org.wso2.carbon.utils.ServerConstants" %>
-<%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
 <%@ page import="org.apache.axis2.context.ConfigurationContext" %>
-<%@ page import="org.wso2.carbon.CarbonConstants" %>
-<%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
-<%@ page import="java.util.UUID" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.util.WorkflowUIUtil" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.WorkflowWizard" %>
+<%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="org.wso2.carbon.CarbonConstants" %>
+<%@ page import="org.wso2.carbon.identity.base.IdentityValidationUtil" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.WorkflowWizard" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.WorkflowAdminServiceClient" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.WorkflowUIConstants" %>
+<%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
+<%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
+<%@ page import="org.wso2.carbon.utils.ServerConstants" %>
+<%@ page import="java.util.ResourceBundle" %>
+<%@ page import="java.util.UUID" %>
 
 
 <script type="text/javascript" src="extensions/js/vui.js"></script>
@@ -50,8 +48,9 @@
 
     String requestPath = "list-workflows";
     //'path' parameter to use to track parent wizard path if this wizard trigger by another wizard
-    if(request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH) != null &&
-       !request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH).isEmpty()){
+    if (StringUtils.isNotBlank(request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH)) && IdentityValidationUtil
+            .isValidOverBlackListPatterns(request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH),
+                                          IdentityValidationUtil.ValidatorPattern.URI_RESERVED_EXISTS.name())) {
         requestPath = request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH);
     }
 

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/finish-wf-wizard-ajaxprocessor.jsp
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/finish-wf-wizard-ajaxprocessor.jsp
@@ -19,16 +19,17 @@
 <%@ page import="org.apache.axis2.context.ConfigurationContext" %>
 <%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.wso2.carbon.CarbonConstants" %>
+<%@ page import="org.wso2.carbon.identity.base.IdentityValidationUtil" %>
 <%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.WorkflowAdminServiceWorkflowException" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.WorkflowWizard" %>
 <%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.WorkflowAdminServiceClient" %>
 <%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.WorkflowUIConstants" %>
+
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.util.WorkflowUIUtil" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
-
 <%@ page import="org.wso2.carbon.utils.ServerConstants" %>
 <%@ page import="java.util.ResourceBundle" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.WorkflowWizard" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.util.WorkflowUIUtil" %>
 
 
 <%
@@ -62,7 +63,9 @@
 
         WorkflowWizard workflowWizard = (WorkflowWizard)session.getAttribute(requestToken);
         WorkflowUIUtil.loadWorkflowImplParameters(request.getParameterMap(),workflowWizard);
-        if(StringUtils.isNotBlank(reqPath)){
+        if (StringUtils.isNotBlank(reqPath) && IdentityValidationUtil
+                .isValidOverBlackListPatterns(reqPath,
+                                              IdentityValidationUtil.ValidatorPattern.URI_RESERVED_EXISTS.name())) {
             forwardTo = reqPath +".jsp?wizard=finish&" + WorkflowUIConstants.PARAM_WORKFLOW_NAME + "=" +workflowWizard.getWorkflowName() ;
         }
         try {

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/template-wf-wizard.jsp
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/template-wf-wizard.jsp
@@ -19,29 +19,29 @@
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="carbon" uri="http://wso2.org/projects/carbon/taglibs/carbontags.jar" %>
 <%@ page import="org.apache.axis2.context.ConfigurationContext" %>
+<%@ page import="org.apache.commons.lang.StringUtils" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.wso2.carbon.CarbonConstants" %>
+<%@ page import="org.wso2.carbon.identity.base.IdentityValidationUtil" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.bean.metadata.type.InputType" %>
+
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.WorkflowAdminServiceWorkflowException" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.bean.Parameter" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.Template" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.WorkflowWizard" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.InputData" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.Item" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.MapType" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.ParameterMetaData" %>
 <%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.WorkflowAdminServiceClient" %>
 <%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.WorkflowUIConstants" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
-
 <%@ page import="org.wso2.carbon.utils.ServerConstants" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.ResourceBundle" %>
-<%@ page import="org.apache.commons.lang.StringUtils" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.bean.Parameter" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.util.WorkflowUIUtil" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.Template" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.ParameterMetaData" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.InputData" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.MapType" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.Item" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.bean.metadata.type.InputType" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.WorkflowWizard" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.WorkflowAdminServiceWorkflowException" %>
 <%@ page import="java.util.Set" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 
 
 <script type="text/javascript" src="extensions/js/vui.js"></script>
@@ -58,7 +58,9 @@
 
     String requestPath = "list-workflows";
     //'path' parameter to use to track parent wizard path if this wizard trigger by another wizard
-    if(request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH) != null && !request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH).isEmpty()){
+    if (StringUtils.isNotBlank(request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH)) && IdentityValidationUtil
+            .isValidOverBlackListPatterns(request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH),
+                                          IdentityValidationUtil.ValidatorPattern.URI_RESERVED_EXISTS.name())) {
         requestPath = request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH);
     }
 

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/workflowimpl-wf-wizard.jsp
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/workflowimpl-wf-wizard.jsp
@@ -19,29 +19,30 @@
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="carbon" uri="http://wso2.org/projects/carbon/taglibs/carbontags.jar" %>
 <%@ page import="org.apache.axis2.context.ConfigurationContext" %>
+<%@ page import="org.apache.commons.lang.StringUtils" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.wso2.carbon.CarbonConstants" %>
+<%@ page import="org.wso2.carbon.identity.base.IdentityValidationUtil" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.bean.metadata.type.InputType" %>
+
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.WorkflowAdminServiceWorkflowException" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.bean.Parameter" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.WorkflowImpl" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.WorkflowWizard" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.InputData" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.Item" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.MapType" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.ParameterMetaData" %>
 <%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.WorkflowAdminServiceClient" %>
 <%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.WorkflowUIConstants" %>
+<%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.util.WorkflowUIUtil" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
-
 <%@ page import="org.wso2.carbon.utils.ServerConstants" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.ResourceBundle" %>
-<%@ page import="org.apache.commons.lang.StringUtils" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.bean.Parameter" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.ParameterMetaData" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.InputData" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.MapType" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.bean.Item" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.bean.metadata.type.InputType" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.WorkflowImpl" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.metadata.WorkflowWizard" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.stub.WorkflowAdminServiceWorkflowException" %>
-<%@ page import="org.wso2.carbon.identity.workflow.mgt.ui.util.WorkflowUIUtil" %>
 <%@ page import="java.util.Set" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 
 
 <%
@@ -52,7 +53,9 @@
 
     String requestPath = "list-workflows";
     //'path' parameter to use to track parent wizard path if this wizard trigger by another wizard
-    if(request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH) != null && !request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH).isEmpty()){
+    if (StringUtils.isNotBlank(request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH)) && IdentityValidationUtil
+            .isValidOverBlackListPatterns(request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH),
+                                          IdentityValidationUtil.ValidatorPattern.URI_RESERVED_EXISTS.name())) {
         requestPath = request.getParameter(WorkflowUIConstants.PARAM_REQUEST_PATH);
     }
 


### PR DESCRIPTION
In workflow.mgt.ui page redirections were done based on the page received as a query parameter from the previous page.
Received parameter is neither validated, thus, they even expose for redirections to other domains.
This fix validates the received query parameter for URI characters which avoid redirections for external domains.