### PR TITLE
IDENTITY-4779: Display scopes in oauth/oidc consent pages

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/WEB-INF/web.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/WEB-INF/web.xml
@@ -47,6 +47,12 @@
     </context-param-->
     <!-- *************** End of Global configurations ********************** -->
 
+    <!--Display scopes in the consent page.-->
+    <context-param>
+        <param-name>displayScopes</param-name>
+        <param-value>true</param-value>
+    </context-param>
+
     <filter>
         <filter-name>HttpHeaderSecurityFilter</filter-name>
         <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/oauth2_authz.jsp
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/oauth2_authz.jsp
@@ -22,6 +22,7 @@
 <%
     String loggedInUser = request.getParameter("loggedInUser");
     String scopeString = request.getParameter("scope");
+    boolean displayScopes = Boolean.parseBoolean(getServletContext().getInitParameter("displayScopes"));
 %>
 
 <html>
@@ -93,6 +94,26 @@
                                 <p><strong>
                                     <%=Encode.forHtml(request.getParameter("application"))%>
                                 </strong> requests access to your profile information </p>
+                                <%
+                                    if (displayScopes && scopeString != null) {
+                                %>
+                                <ul>
+                                <%
+                                        String[] scopes = scopeString.split(" ");
+                                        for (String scopeID : scopes) {
+
+                                            if ("openid".equals(scopeID)) {
+                                                continue;
+                                            }
+                                %>
+                                        <li><%=Encode.forHtml(scopeID)%></li>
+                                <%
+                                        }
+                                %>
+                                </ul>
+                                <%
+                                    }
+                                %>
                             </div>
                     <table width="100%" class="styledLeft">
                         <tbody>

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/oauth2_consent.jsp
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/oauth2_consent.jsp
@@ -21,6 +21,8 @@
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%
     String app = request.getParameter("application");
+    String scopeString = request.getParameter("scope");
+    boolean displayScopes = Boolean.parseBoolean(getServletContext().getInitParameter("displayScopes"));
 %>
 
 <html>
@@ -93,6 +95,26 @@
                                 <p><strong>
                                     <%=Encode.forHtml(request.getParameter("application"))%>
                                 </strong> requests access to your profile information </p>
+                                <%
+                                    if (displayScopes && scopeString != null) {
+                                %>
+                                <ul>
+                                <%
+                                        String[] scopes = scopeString.split(" ");
+                                        for (String scopeID : scopes) {
+
+                                            if ("openid".equals(scopeID)) {
+                                                continue;
+                                            }
+                                %>
+                                        <li><%=Encode.forHtml(scopeID)%></li>
+                                <%
+                                        }
+                                %>
+                                </ul>
+                                <%
+                                    }
+                                %>
                             </div>
                             <table width="100%" class="styledLeft">
                                 <tbody>


### PR DESCRIPTION
https://wso2.org/jira/browse/IDENTITY-4779

This will display the scopes in oauth/oidc consent pages by default. To disable displaying the scopes set `displayScopes` param in `web.xml` to `false` or comment out the context-parameter.