### PR TITLE
Fix regression in entitlement ui 

### DIFF
--- a/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/resources/web/entitlement/select-attribute.jsp
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/resources/web/entitlement/select-attribute.jsp
@@ -285,7 +285,7 @@
 
     function preSubmit(){
 
-        jQuery('#attributeValueTable > tbody:last').append('<tr><td><input type="hidden" name="category" id="category" value="<%=Encode.forJavaScript(Encode.forHtmlAttribute(category))%>" /><input type="hidden" name="ruleId" id="ruleId" value="<%=Encode.forJavaScript(Encode.forHtmlAttribute(ruleId))%>" /><input type="hidden" name="returnPage" id="returnPage" value="<%=Encode.forJavaScript(Encode.forHtmlAttribute(returnPage))%>" /></td></tr>') ;
+        jQuery('#attributeValueTable > tbody:last').append('<tr><td><input type="hidden" name="category" id="category" value="<%=Encode.forJavaScript(Encode.forHtmlAttribute(category))%>" /><input type="hidden" name="ruleId" id="ruleId" value="<%=Encode.forJavaScript(Encode.forHtmlAttribute(ruleId))%>" /><input type="hidden" name="initiatedFrom" id="initiatedFrom" value="<%=Encode.forJavaScript(Encode.forHtmlAttribute(initiatedPage))%>" /></td></tr>') ;
 
     }
 


### PR DESCRIPTION
Fix regression introduced by 541a974e82ef5c0a0af0bc81019181a8c3bb0c00

Previous fix removed 'returnPage' parameter and introduced 'initiatedFrom' parameter to identify the page which initiated the request.
But preSubmit() function, still adds the 'returnPage' parameter which is no longer expected. This fix updates the respective parameter to 'initiatedFrom'.