### PR TITLE
SAML metadata upload support for Service Provider done.

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/pom.xml
+++ b/components/identity-core/org.wso2.carbon.identity.core/pom.xml
@@ -149,12 +149,15 @@
 
                             org.xml.sax,
                             org.wso2.carbon.is.migration.client; resolution:=optional,
+                            org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
+                            <!--org.opensaml.xml.security.keyinfo; version=[2.6.4,3.0.0)-->
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.core.internal,
                             org.wso2.carbon.identity.core.*;
                             version="${carbon.identity.package.export.version}"
                         </Export-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAO.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAO.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.identity.core.dao;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -161,7 +162,7 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
     public boolean addServiceProvider(SAMLSSOServiceProviderDO serviceProviderDO)
             throws IdentityException {
         String path = null;
-        Resource resource;
+
 
         if (serviceProviderDO.getIssuer() != null) {
             path = IdentityRegistryResources.SAML_SSO_SERVICE_PROVIDERS
@@ -178,7 +179,7 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
                 return false;
             }
 
-            resource = createResource(serviceProviderDO);
+            Resource resource = createResource(serviceProviderDO);
             try {
                 if (!isTransactionStarted) {
                     registry.beginTransaction();
@@ -262,8 +263,7 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
         String doSignAssertions = serviceProviderDO.isDoSignAssertions() ? "true" : "false";
         resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_DO_SIGN_ASSERTIONS,
                 doSignAssertions);
-        if (serviceProviderDO.getRequestedClaimsList() != null
-                && serviceProviderDO.getRequestedClaimsList().size() > 0) {
+        if (CollectionUtils.isNotEmpty(serviceProviderDO.getRequestedClaimsList())) {
             resource.setProperty(IdentityRegistryResources.PROP_SAML_SSO_REQUESTED_CLAIMS,
                     serviceProviderDO.getRequestedClaimsList());
         }
@@ -272,13 +272,11 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
                     IdentityRegistryResources.PROP_SAML_SSO_ATTRIB_CONSUMING_SERVICE_INDEX,
                     serviceProviderDO.getAttributeConsumingServiceIndex());
         }
-        if (serviceProviderDO.getRequestedAudiencesList() != null
-                && serviceProviderDO.getRequestedAudiencesList().size() > 0) {
+        if (CollectionUtils.isNotEmpty(serviceProviderDO.getRequestedAudiencesList()) ) {
             resource.setProperty(IdentityRegistryResources.PROP_SAML_SSO_REQUESTED_AUDIENCES,
                     serviceProviderDO.getRequestedAudiencesList());
         }
-        if (serviceProviderDO.getRequestedRecipientsList() != null
-                && serviceProviderDO.getRequestedRecipientsList().size() > 0) {
+        if (CollectionUtils.isNotEmpty(serviceProviderDO.getRequestedRecipientsList())) {
             resource.setProperty(IdentityRegistryResources.PROP_SAML_SSO_REQUESTED_RECIPIENTS,
                     serviceProviderDO.getRequestedRecipientsList());
         }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAO.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAO.java
@@ -15,7 +15,6 @@
  */
 
 package org.wso2.carbon.identity.core.dao;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -90,9 +89,9 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
 
         if (serviceProviderDO.isDoSingleLogout()) {
             serviceProviderDO.setSloResponseURL(resource.getProperty(IdentityRegistryResources
-                                                                             .PROP_SAML_SLO_RESPONSE_URL));
+                    .PROP_SAML_SLO_RESPONSE_URL));
             serviceProviderDO.setSloRequestURL(resource.getProperty(IdentityRegistryResources
-                                                                            .PROP_SAML_SLO_REQUEST_URL));
+                    .PROP_SAML_SLO_REQUEST_URL));
         }
 
         if (resource.getProperty(IdentityRegistryResources.PROP_SAML_SSO_DO_SIGN_ASSERTIONS) != null) {
@@ -105,7 +104,7 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
             serviceProviderDO
                     .setAttributeConsumingServiceIndex(resource
                             .getProperty(IdentityRegistryResources.PROP_SAML_SSO_ATTRIB_CONSUMING_SERVICE_INDEX));
-        }else{
+        } else {
             // Specific DB's (like oracle) returns empty strings as null.
             serviceProviderDO.setAttributeConsumingServiceIndex("");
         }
@@ -179,98 +178,7 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
                 return false;
             }
 
-            resource = registry.newResource();
-            resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_ISSUER,
-                    serviceProviderDO.getIssuer());
-            resource.setProperty(IdentityRegistryResources.PROP_SAML_SSO_ASSERTION_CONS_URLS,
-                                 serviceProviderDO.getAssertionConsumerUrlList());
-            resource.addProperty(IdentityRegistryResources.PROP_DEFAULT_SAML_SSO_ASSERTION_CONS_URL,
-                                 serviceProviderDO.getDefaultAssertionConsumerUrl());
-            resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_ISSUER_CERT_ALIAS,
-                    serviceProviderDO.getCertAlias());
-            resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_LOGIN_PAGE_URL,
-                    serviceProviderDO.getLoginPageURL());
-            resource.addProperty(
-                    IdentityRegistryResources.PROP_SAML_SSO_NAMEID_FORMAT,
-                    serviceProviderDO.getNameIDFormat());
-            resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_SIGNING_ALGORITHM, serviceProviderDO
-                    .getSigningAlgorithmUri());
-            resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_DIGEST_ALGORITHM, serviceProviderDO
-                    .getDigestAlgorithmUri());
-            if (serviceProviderDO.getNameIdClaimUri() != null
-                    && serviceProviderDO.getNameIdClaimUri().trim().length() > 0) {
-                resource.addProperty(
-                        IdentityRegistryResources.PROP_SAML_SSO_ENABLE_NAMEID_CLAIMURI,
-                        "true");
-                resource.addProperty(
-                        IdentityRegistryResources.PROP_SAML_SSO_NAMEID_CLAIMURI,
-                        serviceProviderDO.getNameIdClaimUri());
-            } else {
-                resource.addProperty(
-                        IdentityRegistryResources.PROP_SAML_SSO_ENABLE_NAMEID_CLAIMURI,
-                        "false");
-            }
-
-            String doSingleLogout = serviceProviderDO.isDoSingleLogout() ? "true" : "false";
-            resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_DO_SINGLE_LOGOUT, doSingleLogout);
-            if(serviceProviderDO.isDoSingleLogout()) {
-                if(StringUtils.isNotBlank(serviceProviderDO.getSloResponseURL())) {
-                    resource.addProperty(IdentityRegistryResources.PROP_SAML_SLO_RESPONSE_URL,
-                                         serviceProviderDO.getSloResponseURL());
-                }
-                if(StringUtils.isNotBlank(serviceProviderDO.getSloRequestURL())) {
-                    resource.addProperty(IdentityRegistryResources.PROP_SAML_SLO_REQUEST_URL,
-                                         serviceProviderDO.getSloRequestURL());
-                }
-            }
-
-            String doSignResponse = serviceProviderDO.isDoSignResponse() ? "true" : "false";
-            resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_DO_SIGN_RESPONSE,
-                    doSignResponse);
-            String doSignAssertions = serviceProviderDO.isDoSignAssertions() ? "true" : "false";
-            resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_DO_SIGN_ASSERTIONS,
-                    doSignAssertions);
-            if (serviceProviderDO.getRequestedClaimsList() != null
-                    && serviceProviderDO.getRequestedClaimsList().size() > 0) {
-                resource.setProperty(IdentityRegistryResources.PROP_SAML_SSO_REQUESTED_CLAIMS,
-                        serviceProviderDO.getRequestedClaimsList());
-            }
-            if (serviceProviderDO.getAttributeConsumingServiceIndex() != null) {
-                resource.addProperty(
-                        IdentityRegistryResources.PROP_SAML_SSO_ATTRIB_CONSUMING_SERVICE_INDEX,
-                        serviceProviderDO.getAttributeConsumingServiceIndex());
-            }
-            if (serviceProviderDO.getRequestedAudiencesList() != null
-                    && serviceProviderDO.getRequestedAudiencesList().size() > 0) {
-                resource.setProperty(IdentityRegistryResources.PROP_SAML_SSO_REQUESTED_AUDIENCES,
-                        serviceProviderDO.getRequestedAudiencesList());
-            }
-            if (serviceProviderDO.getRequestedRecipientsList() != null
-                    && serviceProviderDO.getRequestedRecipientsList().size() > 0) {
-                resource.setProperty(IdentityRegistryResources.PROP_SAML_SSO_REQUESTED_RECIPIENTS,
-                        serviceProviderDO.getRequestedRecipientsList());
-            }
-
-            String enableAttributesByDefault = serviceProviderDO.isEnableAttributesByDefault() ? "true"
-                    : "false";
-            resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_ENABLE_ATTRIBUTES_BY_DEFAULT,
-                    enableAttributesByDefault);
-            String idPInitSSOEnabled = serviceProviderDO.isIdPInitSSOEnabled() ? "true" : "false";
-            resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_IDP_INIT_SSO_ENABLED,
-                    idPInitSSOEnabled);
-            resource.addProperty(IdentityRegistryResources.PROP_SAML_SLO_IDP_INIT_SLO_ENABLED,
-                                 serviceProviderDO.isIdPInitSLOEnabled() ? "true" : "false");
-            if(serviceProviderDO.isIdPInitSLOEnabled() && serviceProviderDO.getIdpInitSLOReturnToURLList().size() > 0) {
-                resource.setProperty(IdentityRegistryResources.PROP_SAML_IDP_INIT_SLO_RETURN_URLS,
-                                     serviceProviderDO.getIdpInitSLOReturnToURLList());
-            }
-            String enableEncryptedAssertion = serviceProviderDO.isDoEnableEncryptedAssertion() ? "true" : "false";
-            resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_ENABLE_ENCRYPTED_ASSERTION,
-                    enableEncryptedAssertion);
-
-            String validateSignatureInRequests = serviceProviderDO.isDoValidateSignatureInRequests() ? "true" : "false";
-            resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_VALIDATE_SIGNATURE_IN_REQUESTS,
-                    validateSignatureInRequests);
+            resource = createResource(serviceProviderDO);
             try {
                 if (!isTransactionStarted) {
                     registry.beginTransaction();
@@ -299,6 +207,103 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
                     + " is added successfully.");
         }
         return true;
+    }
+
+    private Resource createResource(SAMLSSOServiceProviderDO serviceProviderDO) throws RegistryException {
+        Resource resource;
+        resource = registry.newResource();
+        resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_ISSUER,
+                serviceProviderDO.getIssuer());
+        resource.setProperty(IdentityRegistryResources.PROP_SAML_SSO_ASSERTION_CONS_URLS,
+                serviceProviderDO.getAssertionConsumerUrlList());
+        resource.addProperty(IdentityRegistryResources.PROP_DEFAULT_SAML_SSO_ASSERTION_CONS_URL,
+                serviceProviderDO.getDefaultAssertionConsumerUrl());
+        resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_ISSUER_CERT_ALIAS,
+                serviceProviderDO.getCertAlias());
+        resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_LOGIN_PAGE_URL,
+                serviceProviderDO.getLoginPageURL());
+        resource.addProperty(
+                IdentityRegistryResources.PROP_SAML_SSO_NAMEID_FORMAT,
+                serviceProviderDO.getNameIDFormat());
+        resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_SIGNING_ALGORITHM, serviceProviderDO
+                .getSigningAlgorithmUri());
+        resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_DIGEST_ALGORITHM, serviceProviderDO
+                .getDigestAlgorithmUri());
+        if (serviceProviderDO.getNameIdClaimUri() != null
+                && serviceProviderDO.getNameIdClaimUri().trim().length() > 0) {
+            resource.addProperty(
+                    IdentityRegistryResources.PROP_SAML_SSO_ENABLE_NAMEID_CLAIMURI,
+                    "true");
+            resource.addProperty(
+                    IdentityRegistryResources.PROP_SAML_SSO_NAMEID_CLAIMURI,
+                    serviceProviderDO.getNameIdClaimUri());
+        } else {
+            resource.addProperty(
+                    IdentityRegistryResources.PROP_SAML_SSO_ENABLE_NAMEID_CLAIMURI,
+                    "false");
+        }
+
+        String doSingleLogout = serviceProviderDO.isDoSingleLogout() ? "true" : "false";
+        resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_DO_SINGLE_LOGOUT, doSingleLogout);
+        if (serviceProviderDO.isDoSingleLogout()) {
+            if (StringUtils.isNotBlank(serviceProviderDO.getSloResponseURL())) {
+                resource.addProperty(IdentityRegistryResources.PROP_SAML_SLO_RESPONSE_URL,
+                        serviceProviderDO.getSloResponseURL());
+            }
+            if (StringUtils.isNotBlank(serviceProviderDO.getSloRequestURL())) {
+                resource.addProperty(IdentityRegistryResources.PROP_SAML_SLO_REQUEST_URL,
+                        serviceProviderDO.getSloRequestURL());
+            }
+        }
+
+        String doSignResponse = serviceProviderDO.isDoSignResponse() ? "true" : "false";
+        resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_DO_SIGN_RESPONSE,
+                doSignResponse);
+        String doSignAssertions = serviceProviderDO.isDoSignAssertions() ? "true" : "false";
+        resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_DO_SIGN_ASSERTIONS,
+                doSignAssertions);
+        if (serviceProviderDO.getRequestedClaimsList() != null
+                && serviceProviderDO.getRequestedClaimsList().size() > 0) {
+            resource.setProperty(IdentityRegistryResources.PROP_SAML_SSO_REQUESTED_CLAIMS,
+                    serviceProviderDO.getRequestedClaimsList());
+        }
+        if (serviceProviderDO.getAttributeConsumingServiceIndex() != null) {
+            resource.addProperty(
+                    IdentityRegistryResources.PROP_SAML_SSO_ATTRIB_CONSUMING_SERVICE_INDEX,
+                    serviceProviderDO.getAttributeConsumingServiceIndex());
+        }
+        if (serviceProviderDO.getRequestedAudiencesList() != null
+                && serviceProviderDO.getRequestedAudiencesList().size() > 0) {
+            resource.setProperty(IdentityRegistryResources.PROP_SAML_SSO_REQUESTED_AUDIENCES,
+                    serviceProviderDO.getRequestedAudiencesList());
+        }
+        if (serviceProviderDO.getRequestedRecipientsList() != null
+                && serviceProviderDO.getRequestedRecipientsList().size() > 0) {
+            resource.setProperty(IdentityRegistryResources.PROP_SAML_SSO_REQUESTED_RECIPIENTS,
+                    serviceProviderDO.getRequestedRecipientsList());
+        }
+
+        String enableAttributesByDefault = serviceProviderDO.isEnableAttributesByDefault() ? "true"
+                : "false";
+        resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_ENABLE_ATTRIBUTES_BY_DEFAULT,
+                enableAttributesByDefault);
+        String idPInitSSOEnabled = serviceProviderDO.isIdPInitSSOEnabled() ? "true" : "false";
+        resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_IDP_INIT_SSO_ENABLED,
+                idPInitSSOEnabled);
+        resource.addProperty(IdentityRegistryResources.PROP_SAML_SLO_IDP_INIT_SLO_ENABLED,
+                serviceProviderDO.isIdPInitSLOEnabled() ? "true" : "false");
+        if (serviceProviderDO.isIdPInitSLOEnabled() && serviceProviderDO.getIdpInitSLOReturnToURLList().size() > 0) {
+            resource.setProperty(IdentityRegistryResources.PROP_SAML_IDP_INIT_SLO_RETURN_URLS,
+                    serviceProviderDO.getIdpInitSLOReturnToURLList());
+        }
+        String enableEncryptedAssertion = serviceProviderDO.isDoEnableEncryptedAssertion() ? "true" : "false";
+        resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_ENABLE_ENCRYPTED_ASSERTION,
+                enableEncryptedAssertion);
+
+        String validateSignatureInRequests = serviceProviderDO.isDoValidateSignatureInRequests() ? "true" : "false";
+        resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_VALIDATE_SIGNATURE_IN_REQUESTS,
+                validateSignatureInRequests);
+        return resource;
     }
 
     public SAMLSSOServiceProviderDO[] getServiceProviders() throws IdentityException {
@@ -389,21 +394,21 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
         } catch (RegistryException e) {
             throw IdentityException.error("Error occurred while checking if resource path \'" + path + "\' exists in " +
                     "registry for tenant domain : " + tenantDomain, e);
-            } catch (UserStoreException e) {
-                throw IdentityException.error("Error occurred while getting tenant domain from tenant ID : " +
+        } catch (UserStoreException e) {
+            throw IdentityException.error("Error occurred while getting tenant domain from tenant ID : " +
                     userRegistry.getTenantId(), e);
         }
 
         return serviceProviderDO;
     }
 
-    public  boolean isServiceProviderExists(String issuer) throws IdentityException {
+    public boolean isServiceProviderExists(String issuer) throws IdentityException {
         String path = IdentityRegistryResources.SAML_SSO_SERVICE_PROVIDERS + encodePath(issuer);
         try {
             return registry.resourceExists(path);
         } catch (RegistryException e) {
             throw IdentityException.error("Error occurred while checking if resource path \'" + path + "\' exists in " +
-                                        "registry");
+                    "registry");
         }
     }
 
@@ -412,4 +417,65 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
         return encodedStr.replace("=", "");
     }
 
+    /**
+     * Upload service Provider
+     *
+     * @param serviceProviderDO
+     * @return
+     * @throws IdentityException
+     */
+
+
+    public SAMLSSOServiceProviderDO uploadServiceProvider(SAMLSSOServiceProviderDO serviceProviderDO) throws IdentityException {
+
+        if (serviceProviderDO.getIssuer() != null && serviceProviderDO.getAssertionConsumerUrl() != null) {
+            String path = IdentityRegistryResources.SAML_SSO_SERVICE_PROVIDERS + encodePath(serviceProviderDO
+                    .getIssuer());
+            Resource resource;
+
+            boolean isTransactionStarted = Transaction.isStarted();
+            try {
+                if (registry.resourceExists(path)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Service Provider already exists with the same issuer name" + serviceProviderDO
+                                .getIssuer());
+                    }
+                    throw IdentityException.error("Service provider already exists");
+                }
+
+                resource = createResource(serviceProviderDO);
+
+                try {
+                    if (!isTransactionStarted) {
+                        registry.beginTransaction();
+                    }
+
+                    registry.put(path, resource);
+
+                    if (!isTransactionStarted) {
+                        registry.commitTransaction();
+                    }
+
+                } catch (RegistryException e) {
+                    if (!isTransactionStarted) {
+                        registry.rollbackTransaction();
+                    }
+                    throw e;
+                }
+
+            } catch (RegistryException e) {
+                throw IdentityException.error("Error while adding Service Provider.", e);
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug("Service Provider " + serviceProviderDO.getIssuer() + " is added successfully.");
+            }
+        } else {
+            throw IdentityException.error("Invalid Service Provider Metadata.");
+        }
+
+
+        return serviceProviderDO;
+
+    }
 }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/IdentityCoreServiceComponent.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/IdentityCoreServiceComponent.java
@@ -18,10 +18,12 @@ package org.wso2.carbon.identity.core.internal;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.opensaml.DefaultBootstrap;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.persistence.JDBCPersistenceManager;
@@ -43,6 +45,10 @@ import org.wso2.carbon.utils.ConfigurationContextService;
  * interface="org.wso2.carbon.utils.ConfigurationContextService" cardinality="1..1"
  * policy="dynamic" bind="setConfigurationContextService"
  * unbind="unsetConfigurationContextService"
+ * @scr.reference name="server.configuration.service"
+ * interface="org.wso2.carbon.base.api.ServerConfigurationService" cardinality="1..1"
+ * policy="dynamic"  bind="setServerConfigurationService"
+ * unbind="unsetServerConfigurationService"
  * @scr.reference name="registry.service"
  * interface="org.wso2.carbon.registry.core.service.RegistryService"
  * cardinality="1..1" policy="dynamic" bind="setRegistryService"
@@ -58,11 +64,29 @@ import org.wso2.carbon.utils.ConfigurationContextService;
 public class IdentityCoreServiceComponent {
     private static final String MIGRATION_CLIENT_CLASS_NAME = "org.wso2.carbon.is.migration.client.MigrateFrom5to510";
     private static Log log = LogFactory.getLog(IdentityCoreServiceComponent.class);
+    private static ServerConfigurationService serverConfigurationService = null;
 
     private static BundleContext bundleContext = null;
     private static ConfigurationContextService configurationContextService = null;
 
     public IdentityCoreServiceComponent() {
+    }
+    public static ServerConfigurationService getServerConfigurationService() {
+        return IdentityCoreServiceComponent.serverConfigurationService;
+    }
+
+    protected void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
+        if (log.isDebugEnabled()) {
+            log.debug("Set the ServerConfiguration Service");
+        }
+        IdentityCoreServiceComponent.serverConfigurationService = serverConfigurationService;
+
+    }
+    protected void unsetServerConfigurationService(ServerConfigurationService serverConfigurationService) {
+        if (log.isDebugEnabled()) {
+            log.debug("Unset the ServerConfiguration Service");
+        }
+        IdentityCoreServiceComponent.serverConfigurationService = null;
     }
 
     public static BundleContext getBundleContext() {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/model/SAMLSSOServiceProviderDO.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/model/SAMLSSOServiceProviderDO.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.io.Serializable;
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -62,6 +63,10 @@ public class SAMLSSOServiceProviderDO implements Serializable {
     private boolean doValidateSignatureInRequests;
     private String signingAlgorithmUri;
     private String digestAlgorithmUri;
+    private String signingCertificate ;
+    private String encryptionCertificate ;
+    private X509Certificate x509Certificate;
+
 
     public SAMLSSOServiceProviderDO() {
         if (StringUtils.isNotBlank(IdentityUtil.getProperty(IdentityConstants.ServerConfig
@@ -80,12 +85,28 @@ public class SAMLSSOServiceProviderDO implements Serializable {
         }
     }
 
+    public String getSigningCertificate() {
+        return signingCertificate;
+    }
+
+    public void setSigningCertificate(String signingCertificate) {
+        this.signingCertificate = signingCertificate;
+    }
+
     public String getNameIDFormat() {
         return nameIDFormat;
     }
 
     public void setNameIDFormat(String nameIDFormat) {
         this.nameIDFormat = nameIDFormat;
+    }
+
+    public String getEncryptionCertificatee() {
+        return encryptionCertificate;
+    }
+
+    public void setEncryptionCertificate(String encryptionCertificate) {
+        this.encryptionCertificate= encryptionCertificate;
     }
 
     public String getNameIdClaimUri() {
@@ -474,5 +495,13 @@ public class SAMLSSOServiceProviderDO implements Serializable {
         } else {
             this.idpInitSLOReturnToURLs = null;
         }
+    }
+
+    public X509Certificate getX509Certificate() {
+        return x509Certificate;
+    }
+
+    public void setX509Certificate(X509Certificate x509Certificate) {
+        this.x509Certificate = x509Certificate;
     }
 }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/persistence/IdentityPersistenceManager.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/persistence/IdentityPersistenceManager.java
@@ -240,6 +240,17 @@ public class IdentityPersistenceManager {
         SAMLSSOServiceProviderDAO serviceProviderDAO = new SAMLSSOServiceProviderDAO(registry);
         return serviceProviderDAO.addServiceProvider(serviceProviderDO);
     }
+    /**
+     * Upload Service Provider
+     *
+     * @param registry,samlssoServiceProviderDO
+     * @return
+     * @throws IdentityException
+     */
+    public SAMLSSOServiceProviderDO uploadServiceProvider(Registry registry, SAMLSSOServiceProviderDO samlssoServiceProviderDO) throws IdentityException {
+        SAMLSSOServiceProviderDAO serviceProviderDAO = new SAMLSSOServiceProviderDAO(registry);
+        return serviceProviderDAO.uploadServiceProvider(samlssoServiceProviderDO);
+    }
 
     /**
      * Get all the relying party service providers


### PR DESCRIPTION
Moving DO and DAO objects to saml repo was unsuccessful due to cross dependencies. Hence they remain in the identity core itself. 
