### PR TITLE
Fixing IDENTITY-5206

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -1091,6 +1091,7 @@ public class FrameworkUtils {
             Claim claim = new Claim();
             claim.setClaimUri(userIdClaimURI);
             claimMapping.setRemoteClaim(claim);
+            claimMapping.setLocalClaim(claim);
             value = claimMappings.get(claimMapping);
         }
         return value;


### PR DESCRIPTION
The overridden 'hashcode' method of 'ClaimMapping' class, take both local and remote claim instance variables into calculation. Thus, the expected key of the 'Map' will not be picked in this case. Therefore, the subject value will be null, which causes to set the default subject value received, later in the flow.
