### PR TITLE
Handling request missing claims NPE when user attributes not available

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultPostAuthenticationHandler.java
@@ -105,9 +105,11 @@ public class DefaultPostAuthenticationHandler implements PostAuthenticationHandl
         Map<String, String> mappedAttrs = new HashMap<>();
         Map<ClaimMapping, String> userAttributes = user.getUserAttributes();
 
-        for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
-            String localClaimUri = entry.getKey().getLocalClaim().getClaimUri();
-            mappedAttrs.put(localClaimUri, entry.getValue());
+        if (userAttributes != null) {
+            for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
+                String localClaimUri = entry.getKey().getLocalClaim().getClaimUri();
+                mappedAttrs.put(localClaimUri, entry.getValue());
+            }
         }
 
         Map<String,String> mandatoryClaims =


### PR DESCRIPTION
Fixing below test failure in product-is when updated to carbon-identity-framework v5.6.10

> Failed tests:   testLoginFail(org.wso2.identity.integration.test.requestPathAuthenticator.RequestPathAuthenticatorTestCase): 1

```
INFO  [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - =================== Running the test method org.wso2.identity.integration.test.requestPathAuthenticator.RequestPathAuthenticatorTestCase.testLoginFail ===================
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - [2016-11-14 12:38:14,656] ERROR {org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultRequestCoordinator} -  Exception in Authentication Framework
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - java.lang.NullPointerException
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultPostAuthenticationHandler.handlePostAuthenticationForMissingClaimsRequest(DefaultPostAuthenticationHandler.java:108)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultPostAuthenticationHandler.handle(DefaultPostAuthenticationHandler.java:88)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultAuthenticationRequestHandler.handle(DefaultAuthenticationRequestHandler.java:129)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultRequestCoordinator.handle(DefaultRequestCoordinator.java:142)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.wso2.carbon.identity.application.authentication.framework.CommonAuthenticationHandler.doPost(CommonAuthenticationHandler.java:46)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.wso2.carbon.identity.application.authentication.framework.CommonAuthenticationHandler.doGet(CommonAuthenticationHandler.java:37)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.wso2.carbon.identity.sso.saml.servlet.SAMLSSOProviderServlet.sendRequestToFramework(SAMLSSOProviderServlet.java:1040)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.wso2.carbon.identity.sso.saml.servlet.SAMLSSOProviderServlet.sendToFrameworkForAuthentication(SAMLSSOProviderServlet.java:456)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.wso2.carbon.identity.sso.saml.servlet.SAMLSSOProviderServlet.handleSPInitSSO(SAMLSSOProviderServlet.java:360)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.wso2.carbon.identity.sso.saml.servlet.SAMLSSOProviderServlet.handleRequest(SAMLSSOProviderServlet.java:195)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.wso2.carbon.identity.sso.saml.servlet.SAMLSSOProviderServlet.doPost(SAMLSSOProviderServlet.java:107)


```