### PR TITLE
IDENTITY-5328: Fixing permission tree display names

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.claim.mgt/src/main/resources/META-INF/component.xml
+++ b/components/claim-mgt/org.wso2.carbon.claim.mgt/src/main/resources/META-INF/component.xml
@@ -23,6 +23,10 @@
         </ManagementPermission>
 
         <ManagementPermission>
+            <DisplayName>Claim</DisplayName>
+            <ResourceId>/permission/admin/manage/identity/claimmgt</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
             <DisplayName>Claim Management</DisplayName>
             <ResourceId>/permission/admin/manage/identity/claimmgt/claim</ResourceId>
         </ManagementPermission>

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/resources/META-INF/component.xml
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/resources/META-INF/component.xml
@@ -26,6 +26,12 @@
             <ResourceId>/permission/admin/manage/identity/entitlement</ResourceId>
         </ManagementPermission>
 
+        <!--Entitlement PAP-->
+        <ManagementPermission>
+            <DisplayName>Entitlement PAP Management</DisplayName>
+            <ResourceId>/permission/admin/manage/identity/entitlement/pap</ResourceId>
+        </ManagementPermission>
+
         <!--Entitlement Policy-->
         <ManagementPermission>
             <DisplayName>Entitlement Policy Management</DisplayName>


### PR DESCRIPTION
Added missing display names in the permission tree