### PR TITLE
Removing Collections.sort() being called for each IdentityRequest

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityProcessCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityProcessCoordinator.java
@@ -46,7 +46,6 @@ public class IdentityProcessCoordinator {
 
     private IdentityProcessor getIdentityProcessor(IdentityRequest identityRequest) {
         List<IdentityProcessor> processors = FrameworkServiceDataHolder.getInstance().getIdentityProcessors();
-        Collections.sort(processors, new HandlerComparator());
         for (IdentityProcessor requestProcessor : processors) {
             if (requestProcessor.canHandle(identityRequest)) {
                 return requestProcessor;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityServlet.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityServlet.java
@@ -138,8 +138,6 @@ public class IdentityServlet extends HttpServlet {
     private HttpIdentityRequestFactory getIdentityRequestFactory(HttpServletRequest request, HttpServletResponse response) {
 
         List<HttpIdentityRequestFactory> factories = FrameworkServiceDataHolder.getInstance().getHttpIdentityRequestFactories();
-        Collections.sort(factories,new org.wso2.carbon.identity.core.handler.HandlerComparator());
-
         for (HttpIdentityRequestFactory requestBuilder : factories) {
             if (requestBuilder.canHandle(request, response)) {
                 return requestBuilder;
@@ -158,8 +156,6 @@ public class IdentityServlet extends HttpServlet {
 
         List<HttpIdentityResponseFactory> factories = FrameworkServiceDataHolder.getInstance()
                 .getHttpIdentityResponseFactories();
-        Collections.sort(factories,new HandlerComparator());
-
         for (HttpIdentityResponseFactory responseFactory : factories) {
             if (responseFactory.canHandle(identityResponse)) {
                 return responseFactory;
@@ -178,8 +174,6 @@ public class IdentityServlet extends HttpServlet {
 
         List<HttpIdentityResponseFactory> factories = FrameworkServiceDataHolder.getInstance()
                 .getHttpIdentityResponseFactories();
-        Collections.sort(factories,new HandlerComparator());
-
         for (HttpIdentityResponseFactory responseFactory : factories) {
             if (responseFactory.canHandle(exception)) {
                 return responseFactory;


### PR DESCRIPTION
Removing Collections.sort() being called for each IdentityRequest to fix concurrency issue.