### PR TITLE
Change cookie attributes default value

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/model/CookieBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/model/CookieBuilder.java
@@ -29,9 +29,9 @@ public class CookieBuilder {
     private String domain;
     private int maxAge = -1;
     private String path = "/";
-    private boolean secure = true;
+    private boolean secure = false;
     private int version = 0;
-    private boolean isHttpOnly = true;
+    private boolean isHttpOnly = false;
 
     public CookieBuilder(String name, String value) {
         this.name = name;


### PR DESCRIPTION
The default attribute value in CookieBuilder class is true. It means if user doesn't set particular value specifically, the attribute,  such as "Secure", "HttpOnly"  will be true.

Since identity server allow user to change these settings through identity.xml, the configuration file will be read and use in FrameworkUtils class.

Let's see following [code snippet](https://github.com/wso2/carbon-identity-framework/blob/master/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java#L554).

```
    if (commonAuthIdCookieConfig.isSecure()) {
        cookieBuilder.setSecure(commonAuthIdCookieConfig.isSecure());
    }
```
cookieBuilder.setSecure() will execute only when "Secure" attribute in identity.xml is true. It imply default value of "Secure" should be false.

