### PR TITLE
IDENTITY-6198:Skipping already authenticated authenticators for LOCAL IDP

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -883,7 +883,8 @@ public class FrameworkUtils {
                                                                             Map<String, AuthenticatedIdPData> authenticatedIdPs) {
 
         if (log.isDebugEnabled()) {
-            log.debug("Finding already authenticated IdPs of the Step");
+            log.debug(String.format("Finding already authenticated IdPs of the step {order:%d}",
+                    stepConfig.getOrder()));
         }
 
         Map<String, AuthenticatorConfig> idpAuthenticatorMap = new HashMap<String, AuthenticatorConfig>();
@@ -892,18 +893,65 @@ public class FrameworkUtils {
         if (authenticatedIdPs != null && !authenticatedIdPs.isEmpty()) {
 
             for (AuthenticatorConfig authenticatorConfig : authenticatorConfigs) {
+
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("Considering the authenticator '%s'", authenticatorConfig.getName()));
+                }
+
+                String authenticatorName = authenticatorConfig.getName();
                 List<String> authenticatorIdps = authenticatorConfig.getIdpNames();
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("%d IdP(s) found in the step.", authenticatedIdPs.size()));
+                }
 
                 for (String authenticatorIdp : authenticatorIdps) {
-                    AuthenticatedIdPData authenticatedIdPData = authenticatedIdPs
-                            .get(authenticatorIdp);
 
-                    if (authenticatedIdPData != null
-                        && authenticatedIdPData.getIdpName().equals(authenticatorIdp)) {
-                        idpAuthenticatorMap.put(authenticatorIdp, authenticatorConfig);
-                        break;
+                    if (log.isDebugEnabled()) {
+                        log.debug(String.format("Considering the IDP : '%s'", authenticatorIdp));
+                    }
+
+                    AuthenticatedIdPData authenticatedIdPData = authenticatedIdPs.get(authenticatorIdp);
+
+                    if (authenticatedIdPData != null && authenticatedIdPData.getIdpName() !=  null &&
+                            authenticatedIdPData.getIdpName().equals(authenticatorIdp)) {
+
+                        if (FrameworkConstants.LOCAL.equals(authenticatedIdPData.getIdpName())) {
+                            if (authenticatedIdPData.isAlreadyAuthenticatedUsing(authenticatorName)) {
+                                idpAuthenticatorMap.put(authenticatorIdp, authenticatorConfig);
+
+                                if (log.isDebugEnabled()) {
+                                    log.debug(String.format("('%s', '%s') is an already authenticated " +
+                                            "IDP - authenticator combination.",
+                                            authenticatorConfig.getName(), authenticatorIdp));
+                                }
+
+                                break;
+                            } else {
+                                if (log.isDebugEnabled()) {
+                                    log.debug(String.format("('%s', '%s') is not an already authenticated " +
+                                            "IDP - authenticator combination.",
+                                            authenticatorConfig.getName(), authenticatorIdp));
+                                }
+                            }
+                        } else {
+
+                            if (log.isDebugEnabled()) {
+                                log.debug(String.format("'%s' is an already authenticated IDP.", authenticatorIdp));
+                            }
+
+                            idpAuthenticatorMap.put(authenticatorIdp, authenticatorConfig);
+                            break;
+                        }
+                    } else {
+                        if (log.isDebugEnabled()) {
+                            log.debug(String.format("'%s' is NOT an already authenticated IDP.", authenticatorIdp));
+                        }
                     }
                 }
+            }
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("No authenticators found.");
             }
         }
 


### PR DESCRIPTION
### Proposed changes in this pull request

Previously a step was considered to be authenticated and was skipped if the user had been authenticated using the IdP of the aforementioned authenticator.

With this PR, the behavior is changed for the LOCAL IdP. If the IdP is "LOCAL" a further check happens to see whether the user has been authenticated using this specific authenticator.


### When should this PR be merged

Can be merged anytime. No pre conditions


### Follow up actions

N/A




### Checklist (for reviewing)

#### General

- [x] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [x] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [x] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
