### PR TITLE
Add a new method to get fully qualified username instead of relying on toString()

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/User.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/User.java
@@ -180,6 +180,32 @@ public class User implements Serializable {
         return user;
     }
 
+    /**
+     * Get full qualified username of the {@link User} object.
+     * ie. We append the tenantDomain and userStoreDomain to the username.
+     * <p>
+     * Note that the PRIMARY domain will not be appended to username when building the full qualified username.
+     * Therefore a full qualified name without the userStoreDomain indicates the user belongs to the PRIMARY
+     * userStoreDomain.
+     *
+     * @return full qualified username
+     */
+    public String getFullQualifiedUsername() {
+        String username = null;
+        if (StringUtils.isNotBlank(this.userName)) {
+            username = this.userName;
+
+            if (StringUtils.isNotBlank(this.tenantDomain)) {
+                username = UserCoreUtil.addTenantDomainToEntry(username, tenantDomain);
+            }
+
+            if (StringUtils.isNotBlank(this.userStoreDomain)) {
+                username = IdentityUtil.addDomainToName(username, userStoreDomain);
+            }
+        }
+        return username;
+    }
+
 
     @Override
     public int hashCode() {
@@ -199,12 +225,13 @@ public class User implements Serializable {
         String username = null;
         if (StringUtils.isNotBlank(this.userName)) {
             username = this.userName;
-        }
-        if (StringUtils.isNotBlank(this.userStoreDomain)) {
-            username = UserCoreUtil.addDomainToName(username, userStoreDomain);
-        }
-        if (StringUtils.isNotBlank(this.tenantDomain)) {
-            username = UserCoreUtil.addTenantDomainToEntry(username, tenantDomain);
+
+            if (StringUtils.isNotBlank(this.userStoreDomain)) {
+                username = UserCoreUtil.addDomainToName(username, userStoreDomain);
+            }
+            if (StringUtils.isNotBlank(this.tenantDomain)) {
+                username = UserCoreUtil.addTenantDomainToEntry(username, tenantDomain);
+            }
         }
         return username;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -295,6 +295,15 @@ public class AuthenticatedUser extends User {
     }
 
     @Override
+    public String getFullQualifiedUsername() {
+        if (isFederatedUser && StringUtils.isBlank(userName)) {
+            //username,userstore domain may be null for federated users
+            return authenticatedSubjectIdentifier;
+        }
+        return super.getFullQualifiedUsername();
+    }
+
+    @Override
     public String toString() {
 
         if (isFederatedUser && StringUtils.isBlank(userName)) {


### PR DESCRIPTION
### Proposed changes in this pull request
- Introduce a new API to get the full qualified username of a user instead of using toString() method.
