### PR TITLE
Change the API name to get full qualified username as toFullQualifiedUsername()

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/User.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/User.java
@@ -181,7 +181,7 @@ public class User implements Serializable {
     }
 
     /**
-     * Get full qualified username of the {@link User} object.
+     * Returns full qualified username of the {@link User} object.
      * ie. We append the tenantDomain and userStoreDomain to the username.
      * <p>
      * Note that the PRIMARY domain will not be appended to username when building the full qualified username.
@@ -190,7 +190,7 @@ public class User implements Serializable {
      *
      * @return full qualified username
      */
-    public String getFullQualifiedUsername() {
+    public String toFullQualifiedUsername() {
         String username = null;
         if (StringUtils.isNotBlank(this.userName)) {
             username = this.userName;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -295,12 +295,12 @@ public class AuthenticatedUser extends User {
     }
 
     @Override
-    public String getFullQualifiedUsername() {
+    public String toFullQualifiedUsername() {
         if (isFederatedUser && StringUtils.isBlank(userName)) {
             //username,userstore domain may be null for federated users
             return authenticatedSubjectIdentifier;
         }
-        return super.getFullQualifiedUsername();
+        return super.toFullQualifiedUsername();
     }
 
     @Override


### PR DESCRIPTION
### Proposed changes in this pull request
- Changing the API name to avoid breaking changes to wsdl. When we have getFullQualifedUsername() it expects a variable fullQualifiedUsername is the bean classes generated. This is not required since we are building the full qualified name on the fly.

### Follow up actions
- Change API signature in the dependent OAuth component.

