### PR TITLE
Fixed IDENTITY-6682

### DIFF
--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml
@@ -112,6 +112,7 @@
 			<Parameter name="AuthTokenEndpoint">https://graph.facebook.com/oauth/access_token</Parameter>
 			<Parameter name="AuthnEndpoint">http://www.facebook.com/dialog/oauth</Parameter>
 			<Parameter name="UserInfoEndpoint">https://graph.facebook.com/me</Parameter>
+                        <!--<Parameter name="ClaimDialectUri">http://wso2.org/facebook/claims</Parameter>-->
 		</AuthenticatorConfig>
 		<AuthenticatorConfig  name="FIDOAuthenticator" enabled="true">
 			<Parameter name="FidoAuth">/authenticationendpoint/fido-auth.jsp</Parameter>


### PR DESCRIPTION
### Proposed changes in this pull request
Adding facebook Claim Dialect Uri configuration by default in application-authentication.xml.
### When should this PR be merged
### Follow up actions
### Checklist (for reviewing)
#### General
#### Functionality
#### Code
#### Tests
#### Security
#### Documentation
Need to modify documentation in [1] with the facebook claim dialect configuration information.
[1] https://docs.wso2.com/display/ISCONNECTORS/Configuring+Facebook+Authenticator
