### PR TITLE
Fix for invalid authenticator name in multi-option steps

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
@@ -149,6 +149,7 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
                 // Setting this value to authentication context in order to use in AuthenticationSuccess Event
                 context.setProperty(FrameworkConstants.AnalyticsAttributes.HAS_FEDERATED_STEP, true);
                 paramMap.put(FrameworkConstants.AnalyticsAttributes.IS_FEDERATED, true);
+                paramMap.put(FrameworkConstants.AUTHENTICATOR, getName());
             } else {
                 // Setting this value to authentication context in order to use in AuthenticationSuccess Event
                 context.setProperty(FrameworkConstants.AnalyticsAttributes.HAS_LOCAL_STEP, true);


### PR DESCRIPTION
Part of the fix for wso2/product-is#2245

When we are using the AuthenticationContext.getCurrentAuthenticator() method at the publisher proxy to get the authenticator name for multi option step configuration scenario this is evaluated as null since this value is explicitly set for only few scenarios.

With this fix, we pass the name as a property from abstract authenticator when calling the publisher proxy, and update the proxy to get the authenticator name from the property instead of context's current authenticator.