### PR TITLE
Fix wso2/product-is#2404: Use a display name instead of the claim URI for consent SSO page.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/consent.jsp
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/consent.jsp
@@ -140,9 +140,9 @@
                                     %>
                                     <div class="checkbox claim-cb">
                                         <label>
-                                            <input class="mandatory-claim" type="checkbox" name="consent_<%=claimId%>" id="consent_<%=claimId%>"
+                                            <input class="mandatory-claim" type="checkbox" name="consent_<%=Encode.forHtmlAttribute(claimId)%>" id="consent_<%=Encode.forHtmlAttribute(claimId)%>"
                                                    required/>
-                                            <%=displayName%>
+                                            <%=Encode.forHtml(displayName)%>
                                             <span class="required font-medium">*</span>
                                         </label>
                                     </div>
@@ -158,8 +158,8 @@
                                     %>
                                     <div class="checkbox claim-cb">
                                         <label>
-                                            <input type="checkbox" name="consent_<%=claimId%>" id="consent_<%=claimId%>"/>
-                                            <%=displayName%>
+                                            <input type="checkbox" name="consent_<%=Encode.forHtmlAttribute(claimId)%>" id="consent_<%=Encode.forHtmlAttribute(claimId)%>"/>
+                                            <%=Encode.forHtml(displayName)%>
                                         </label>
                                     </div>
                                     <%

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/consent.jsp
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/consent.jsp
@@ -21,11 +21,11 @@
 <%@include file="localize.jsp" %>
 
 <%
-    String[] missingClaimList = new String[0];
+    String[] requestedClaimList = new String[0];
     String[] mandatoryClaimList = new String[0];
     String appName = null;
     if (request.getParameter(Constants.REQUESTED_CLAIMS) != null) {
-        missingClaimList = request.getParameter(Constants.REQUESTED_CLAIMS).split(Constants.CLAIM_SEPARATOR);
+        requestedClaimList = request.getParameter(Constants.REQUESTED_CLAIMS).split(Constants.CLAIM_SEPARATOR);
     }
 
     if (request.getParameter(Constants.MANDATORY_CLAIMS) != null) {
@@ -131,24 +131,41 @@
                                     </div>
                                 </div>
                                 <div class="claim-list">
-                                    <% for (String claim : mandatoryClaimList) { %>
+                                    <% for (String claim : mandatoryClaimList) {
+                                            String[] mandatoryClaimData = claim.split("_", 2);
+                                            if (mandatoryClaimData.length == 2) {
+                                                String claimId = mandatoryClaimData[0];
+                                                String displayName = mandatoryClaimData[1];
+
+                                    %>
                                     <div class="checkbox claim-cb">
                                         <label>
-                                            <input class="mandatory-claim" type="checkbox" name="consent_<%=claim%>" id="consent_<%=claim%>"
+                                            <input class="mandatory-claim" type="checkbox" name="consent_<%=claimId%>" id="consent_<%=claimId%>"
                                                    required/>
-                                            <%=claim%>
+                                            <%=displayName%>
                                             <span class="required font-medium">*</span>
                                         </label>
                                     </div>
-                                    <%}%>
-                                    <% for (String claim : missingClaimList) { %>
+                                    <%
+                                            }
+                                        }
+                                    %>
+                                    <% for (String claim : requestedClaimList) {
+                                            String[] requestedClaimData = claim.split("_", 2);
+                                            if (requestedClaimData.length == 2) {
+                                                String claimId = requestedClaimData[0];
+                                                String displayName = requestedClaimData[1];
+                                    %>
                                     <div class="checkbox claim-cb">
                                         <label>
-                                            <input type="checkbox" name="consent_<%=claim%>" id="consent_<%=claim%>"/>
-                                            <%=claim%>
+                                            <input type="checkbox" name="consent_<%=claimId%>" id="consent_<%=claimId%>"/>
+                                            <%=displayName%>
                                         </label>
                                     </div>
-                                    <%}%>
+                                    <%
+                                            }
+                                        }
+                                    %>
                                 </div>
                                 <div class="text-right padding-top">
                                     <a href="#">Privacy Policy</a>

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/ClaimMetaData.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/ClaimMetaData.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent;
+
+import java.io.Serializable;
+
+/**
+ * This class represents claim meta data required for concept receipt creation.
+ */
+class ClaimMetaData implements Serializable {
+
+    private int id;
+    private String claimUri;
+    private String displayName;
+    private String description;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getClaimUri() {
+        return claimUri;
+    }
+
+    public void setClaimUri(String claimUri) {
+        this.claimUri = claimUri;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ClaimMetaData that = (ClaimMetaData) o;
+
+        return id == that.id;
+    }
+
+    @Override
+    public String toString() {
+        return claimUri;
+    }
+
+    @Override
+    public int hashCode() {
+        return id;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/ConsentClaimsData.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/ConsentClaimsData.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class represents the claim metadata required for a particular service provider
+ */
+class ConsentClaimsData implements Serializable {
+
+    List<ClaimMetaData> mandatoryClaims = new ArrayList<>();
+    List<ClaimMetaData> requestedClaims = new ArrayList<>();
+
+    public List<ClaimMetaData> getMandatoryClaims() {
+        return mandatoryClaims;
+    }
+
+    public void setMandatoryClaims(
+            List<ClaimMetaData> mandatoryClaims) {
+        this.mandatoryClaims = mandatoryClaims;
+    }
+
+    public List<ClaimMetaData> getRequestedClaims() {
+        return requestedClaims;
+    }
+
+    public void setRequestedClaims(
+            List<ClaimMetaData> requestedClaims) {
+        this.requestedClaims = requestedClaims;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/UserConsent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/UserConsent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class represents consents provided for user attributes by the user.
+ */
+class UserConsent {
+
+    private List<ClaimMetaData> approvedClaims = new ArrayList<>();
+    private List<ClaimMetaData> disapprovedClaims = new ArrayList<>();
+
+    List<ClaimMetaData> getApprovedClaims() {
+
+        return approvedClaims;
+    }
+
+    void setApprovedClaims(List<ClaimMetaData> approvedClaims) {
+
+        this.approvedClaims = approvedClaims;
+    }
+
+    List<ClaimMetaData> getDisapprovedClaims() {
+
+        return disapprovedClaims;
+    }
+
+    void setDisapprovedClaims(List<ClaimMetaData> disapprovedClaims) {
+
+        this.disapprovedClaims = disapprovedClaims;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -45,7 +45,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsGraphBuilderFactory;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.PostAuthenticationHandler;
-import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.ConsentMgtPostAuthnHandler;
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.ConsentMgtPostAuthnHandler;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.PostAuthnMissingClaimHandler;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.FrameworkLoginResponseFactory;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.FrameworkLogoutResponseFactory;
@@ -65,6 +65,7 @@ import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorC
 import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticatorConfig;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.core.handler.HandlerComparator;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.registry.core.service.RegistryService;
@@ -509,4 +510,20 @@ public class FrameworkServiceComponent {
         consentMgtPostAuthnHandler.setConsentManager(null);
     }
 
+    @Reference(
+            name = "claim.meta.mgt.service",
+            service = ClaimMetadataManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetClaimMetaMgtService"
+    )
+    protected void setClaimMetaMgtService(ClaimMetadataManagementService claimMetaMgtService) {
+
+        consentMgtPostAuthnHandler.setClaimMetadataManagementService(claimMetaMgtService);
+    }
+
+    protected void unsetClaimMetaMgtService(ClaimMetadataManagementService claimMetaMgtService) {
+
+        consentMgtPostAuthnHandler.setClaimMetadataManagementService(null);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1692,7 +1692,7 @@
         <com.fasterxml.core.version2>2.5.4</com.fasterxml.core.version2>
         <org.apache.cxf.cxf-rt.version>2.7.18</org.apache.cxf.cxf-rt.version>
         <io.swagger.version>1.5.8</io.swagger.version>
-        <carbon.consent.mgt.version>1.0.20</carbon.consent.mgt.version>
+        <carbon.consent.mgt.version>1.0.26</carbon.consent.mgt.version>
 
         <javax.xml.range>[0.0.0,1.0.0)</javax.xml.range>
         <org.apache.xml.security.range>[0.0.0,2.0.0)</org.apache.xml.security.range>


### PR DESCRIPTION
### Proposed changes in this pull request

Introduced the capability to show, claim display names instead of claim URI in SSO consent page. The display name is extracted from the `DisplayName` property of a claim. If the display name is not available for a claim, the claim URI will be used to display in the SSO consent page.