### PR TITLE
Option to ignore existing user consent when retrieving required consent of a user for an SP

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentService.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentService.java
@@ -30,13 +30,14 @@ public interface SSOConsentService {
     /**
      * Get consent required claims for a given service from a user.
      *
-     * @param serviceProvider   Service provider requesting consent.
-     * @param authenticatedUser Authenticated user requesting consent form.
+     * @param serviceProvider       Service provider requesting consent.
+     * @param authenticatedUser     Authenticated user requesting consent form.
+     * @param ignoreExistingConsent Ignore existing consent given by the user.
      * @return ConsentClaimsData which contains mandatory and required claims for consent.
      * @throws FrameworkException If error occurs while building claim information.
      */
-    ConsentClaimsData getConsentRequiredClaims(ServiceProvider serviceProvider, AuthenticatedUser authenticatedUser)
-            throws FrameworkException;
+    ConsentClaimsData getConsentRequiredClaims(ServiceProvider serviceProvider, AuthenticatedUser authenticatedUser,
+                                               boolean ignoreExistingConsent) throws FrameworkException;
 
     /**
      * Process the provided user consent and creates a consent receipt.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
@@ -84,7 +84,7 @@ public class SSOConsentServiceImpl implements SSOConsentService {
      * @throws FrameworkException If error occurs while building claim information.
      */
     public ConsentClaimsData getConsentRequiredClaims(ServiceProvider serviceProvider, AuthenticatedUser
-            authenticatedUser) throws FrameworkException {
+            authenticatedUser, boolean ignoreExistingConsent) throws FrameworkException {
 
         if (serviceProvider == null) {
             throw new FrameworkException("Service provider cannot be null.");
@@ -117,7 +117,7 @@ public class SSOConsentServiceImpl implements SSOConsentService {
 
         List<ReceiptListResponse> receiptListResponses = getReceiptOfUser(serviceProvider, authenticatedUser,
                                                                           spName, spTenantDomain, subject);
-        if (hasUserSingleReceipts(receiptListResponses)) {
+        if (!ignoreExistingConsent && hasUserSingleReceipt(receiptListResponses)) {
 
             String receiptId = getFirstConsentReceiptFromList(receiptListResponses);
             Receipt receipt = getReceipt(authenticatedUser, receiptId);
@@ -741,7 +741,7 @@ public class SSOConsentServiceImpl implements SSOConsentService {
         return receiptListResponses.size() == 0;
     }
 
-    private boolean hasUserSingleReceipts(List<ReceiptListResponse> receiptListResponses) {
+    private boolean hasUserSingleReceipt(List<ReceiptListResponse> receiptListResponses) {
 
         return receiptListResponses.size() == 1;
     }


### PR DESCRIPTION
### Proposed changes in this pull request

Option to ignore existing user consent when retrieving required consent of a user for an SP