### PR TITLE
Fix wso2/product-is#2724: Introduced a global config to disable consent management for SSO

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentService.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentService.java
@@ -16,7 +16,10 @@
 
 package org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent;
 
-import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.exception
+        .SSOConsentDisabledException;
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.exception
+        .SSOConsentServiceException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 
@@ -33,11 +36,11 @@ public interface SSOConsentService {
      * @param serviceProvider       Service provider requesting consent.
      * @param authenticatedUser     Authenticated user requesting consent form.
      * @return ConsentClaimsData which contains mandatory and required claims for consent.
-     * @throws FrameworkException If error occurs while building claim information.
+     * @throws SSOConsentServiceException If error occurs while building claim information.
      */
     ConsentClaimsData getConsentRequiredClaimsWithExistingConsents(ServiceProvider serviceProvider,
                                                                    AuthenticatedUser authenticatedUser)
-            throws FrameworkException;
+            throws SSOConsentServiceException, SSOConsentDisabledException;
 
     /**
      * Get consent required claims for a given service from a user ignoring existing user consents.
@@ -45,11 +48,11 @@ public interface SSOConsentService {
      * @param serviceProvider       Service provider requesting consent.
      * @param authenticatedUser     Authenticated user requesting consent form.
      * @return ConsentClaimsData which contains mandatory and required claims for consent.
-     * @throws FrameworkException If error occurs while building claim information.
+     * @throws SSOConsentServiceException If error occurs while building claim information.
      */
     ConsentClaimsData getConsentRequiredClaimsWithoutExistingConsents(ServiceProvider serviceProvider,
                                                                       AuthenticatedUser authenticatedUser)
-            throws FrameworkException;
+            throws SSOConsentServiceException, SSOConsentDisabledException;
 
     /**
      * Process the provided user consent and creates a consent receipt.
@@ -58,11 +61,11 @@ public interface SSOConsentService {
      * @param serviceProvider           Service provider receiving consent.
      * @param authenticatedUser         Authenticated user providing consent.
      * @param consentClaimsData         Claims which the consent requested for.
-     * @throws FrameworkException If error occurs while processing user consent.
+     * @throws SSOConsentServiceException If error occurs while processing user consent.
      */
     void processConsent(List<Integer> consentApprovedClaimIds, ServiceProvider serviceProvider,
                                       AuthenticatedUser authenticatedUser, ConsentClaimsData consentClaimsData)
-            throws FrameworkException;
+            throws SSOConsentServiceException, SSOConsentDisabledException;
 
     /**
      * Retrieves claims which a user has provided consent for a given service provider.
@@ -70,8 +73,16 @@ public interface SSOConsentService {
      * @param serviceProvider   Service provider to retrieve the consent against.
      * @param authenticatedUser Authenticated user to related to consent claim retrieval.
      * @return List of claim which the user has provided consent for the given service provider.
-     * @throws FrameworkException If error occurs while retrieve user consents.
+     * @throws SSOConsentServiceException If error occurs while retrieve user consents.
      */
     List<ClaimMetaData> getClaimsWithConsents(ServiceProvider serviceProvider, AuthenticatedUser authenticatedUser)
-            throws FrameworkException;
+            throws SSOConsentServiceException, SSOConsentDisabledException;
+
+
+    /**
+     * Specifies whether consent management for SSO is enabled or disabled.
+     * @param serviceProvider Service provider to check whether consent management is enabled.
+     * @return true if enabled, false otherwise.
+     */
+    boolean isSSOConsentManagementEnabled(ServiceProvider serviceProvider);
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/constant/SSOConsentConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/constant/SSOConsentConstants.java
@@ -19,10 +19,12 @@ package org.wso2.carbon.identity.application.authentication.framework.handler.re
 /**
  * Constants related to SSO consent handling.
  */
-public class ConsentSSOConstants {
+public class SSOConsentConstants {
 
     public static final String CONSENT_VALIDITY_SEPARATOR = ",";
     public static final String CONSENT_VALIDITY_TYPE_SEPARATOR = ":";
     public static final String CONSENT_VALIDITY_TYPE_VALID_UNTIL = "VALID_UNTIL";
     public static final String CONSENT_VALIDITY_TYPE_VALID_UNTIL_INDEFINITE = "INDEFINITE";
+    public static final String CONFIG_ELEM_CONSENT = "Consent";
+    public static final String CONFIG_ELEM_ENABLE_SSO_CONSENT_MANAGEMENT = "EnableSSOConsentManagement";
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/exception/SSOConsentDisabledException.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/exception/SSOConsentDisabledException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.exception;
+
+import org.wso2.carbon.identity.base.IdentityException;
+
+/**
+ * This exception will be used to indicate when consent management for SSO is disabled. Extends of
+ * {@link SSOConsentServiceException}.
+ */
+public class SSOConsentDisabledException extends IdentityException {
+
+    public SSOConsentDisabledException(String message) {
+        super(message);
+    }
+
+    public SSOConsentDisabledException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public SSOConsentDisabledException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SSOConsentDisabledException(String errorCode, String message, Throwable cause) {
+        super(errorCode, message, cause);
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/exception/SSOConsentServiceException.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/exception/SSOConsentServiceException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.exception;
+
+
+import org.wso2.carbon.identity.base.IdentityException;
+
+/**
+ * Exception used in SSOConsentService. Extends {@link IdentityException}.
+ */
+public class SSOConsentServiceException extends IdentityException {
+
+    public SSOConsentServiceException(String message) {
+        super(message);
+    }
+
+    public SSOConsentServiceException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public SSOConsentServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SSOConsentServiceException(String errorCode, String message, Throwable cause) {
+        super(errorCode, message, cause);
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -227,7 +227,7 @@ public class FrameworkServiceComponent {
 
         SSOConsentService ssoConsentService = new SSOConsentServiceImpl();
         bundleContext.registerService(SSOConsentService.class.getName(), ssoConsentService, null);
-        consentMgtPostAuthnHandler.setSSOConsentService(ssoConsentService);
+        FrameworkServiceDataHolder.getInstance().setSSOConsentService(ssoConsentService);
         bundleContext.registerService(PostAuthenticationHandler.class.getName(), consentMgtPostAuthnHandler, null);
         //this is done to load SessionDataStore class and start the cleanup tasks.
         SessionDataStore.getInstance();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.load
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsGraphBuilderFactory;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.PostAuthenticationHandler;
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.SSOConsentService;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.HttpIdentityRequestFactory;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.HttpIdentityResponseFactory;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.IdentityProcessor;
@@ -60,6 +61,7 @@ public class FrameworkServiceDataHolder {
     private PostAuthenticationMgtService postAuthenticationMgtService = null;
     private ConsentManager consentManager = null;
     private ClaimMetadataManagementService claimMetadataManagementService = null;
+    private SSOConsentService ssoConsentService;
 
     private FrameworkServiceDataHolder() {
         setNanoTimeReference(System.nanoTime());
@@ -239,5 +241,21 @@ public class FrameworkServiceDataHolder {
     public void setClaimMetadataManagementService (ClaimMetadataManagementService claimMetadataManagementService) {
 
         this.claimMetadataManagementService = claimMetadataManagementService;
+    }
+
+    /**
+     * Get {@link SSOConsentService}.
+     * @return SSOConsentService.
+     */
+    public SSOConsentService getSSOConsentService() {
+        return ssoConsentService;
+    }
+
+    /**
+     * Set {@link SSOConsentService}.
+     * @param ssoConsentService Instance of {@link SSOConsentService}.
+     */
+    public void setSSOConsentService(SSOConsentService ssoConsentService) {
+        this.ssoConsentService = ssoConsentService;
     }
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -416,6 +416,11 @@
         <SLOHostNameVerificationEnabled>true</SLOHostNameVerificationEnabled>
     </SSOService>
 
+    <Consent>
+        <!--Specify whether consent management should be enable during SSO.-->
+        <EnableSSOConsentManagement>true</EnableSSOConsentManagement>
+    </Consent>
+
     <SecurityTokenService>
         <!--
             Default value for IdentityProviderURL is  built in following format


### PR DESCRIPTION
### Proposed changes in this pull request

The following config is introduced from this PR in identity.xml to enable/disable consent management during SSO. The feature will be enabled by default.

```xml
<Consent>
       <!--Specify whether consent management should be enable during SSO.-->
       <EnableSSOConsentManagement>true</EnableSSOConsentManagement>
</Consent>
```

When invoking the `SSOConsentManagementService` if the above property is set to `false`, an `SSOConsentDisabledException` will be thrown.

This PR also introduces the `SSOConsentDisabledException` and `SSOConsentServiceException` exception types for service specific error handling.

### When should this PR be merged

Immediately

### Follow up actions

@mefarazath Update the OAuth endpoint according to the new service changes.