### PR TITLE
Fix wso2/product-is#2640: Get consent for subject claim during SSO

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/constant/SSOConsentConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/constant/SSOConsentConstants.java
@@ -27,4 +27,5 @@ public class SSOConsentConstants {
     public static final String CONSENT_VALIDITY_TYPE_VALID_UNTIL_INDEFINITE = "INDEFINITE";
     public static final String CONFIG_ELEM_CONSENT = "Consent";
     public static final String CONFIG_ELEM_ENABLE_SSO_CONSENT_MANAGEMENT = "EnableSSOConsentManagement";
+    public static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
 }


### PR DESCRIPTION
### Proposed changes in this pull request

This PR introduces requesting consent for subject claim URI. If the SPs configurations have subject claim URI configured, that claim will be prompted for consent along with other claims if any. The subject claim is equivalent to a mandatory claim during consent and a user cannot proceed without providing consent for the subject claim.

Incase if the subject claim configurations is not set for the SP, the consent will be requested as `Username`(which is also mandatory) and the consent will be stored as `http://wso2.org/claims/username` claim.

### When should this PR be merged

Immediately

### Follow up actions

Incorporate these changes to integration tests.