### PR TITLE
Fix wso2/product-is#2399: Handle SSO consent during federation.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/ConsentMgtPostAuthnHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/ConsentMgtPostAuthnHandler.java
@@ -95,8 +95,8 @@ public class ConsentMgtPostAuthnHandler extends AbstractPostAuthnHandler {
         }
 
         // If OAuth flow, skip handling consent from the authentication handler. OAuth related consent will be
-        // handled from OAuth endpoint.
-        if (isOAuthFlow(context)) {
+        // handled from OAuth endpoint. OpenID flow is skipped as it is deprecated.
+        if (isOAuthFlow(context) || isOpenIDFlow(context)) {
             return PostAuthnHandlerFlowStatus.SUCCESS_COMPLETED;
         }
 
@@ -111,6 +111,11 @@ public class ConsentMgtPostAuthnHandler extends AbstractPostAuthnHandler {
 
         return FrameworkConstants.RequestType.CLAIM_TYPE_OIDC.equals(context.getRequestType()) || REQUEST_TYPE_OAUTH2
                 .equalsIgnoreCase(context.getRequestType());
+    }
+
+    private boolean isOpenIDFlow(AuthenticationContext context) {
+
+        return FrameworkConstants.RequestType.CLAIM_TYPE_OPENID.equals(context.getRequestType());
     }
 
     private boolean isDebugEnabled() {


### PR DESCRIPTION
### Proposed changes in this pull request

- This PR handles SSO consent management during federated scenarios when SP side claim mappings are not configured. The service will first check whether SP claim configuration are empty and user has attributes to identify the federated scenario without SP side claim mapping.

### When should this PR be merged

- Immediate


### Follow up actions

- None
