### PR TITLE
Use new API to search consents for users in all tenant domains for consent deletion

### DIFF
--- a/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/listener/ConsentDeletionAppMgtListener.java
+++ b/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/listener/ConsentDeletionAppMgtListener.java
@@ -116,7 +116,7 @@ public class ConsentDeletionAppMgtListener extends AbstractApplicationMgtListene
         }
         try {
             List<ReceiptListResponse> receiptListResponses = consentManager.searchReceipts(consentSearchLimit, 0,
-                    "*", tenantDomain, applicationName, null);
+                    "*", tenantDomain, applicationName, null, null);
             if (log.isDebugEnabled()) {
                 log.debug(String.format("%d number of consents found for application %s", receiptListResponses.size(),
                         applicationName));

--- a/pom.xml
+++ b/pom.xml
@@ -1700,7 +1700,7 @@
         <com.fasterxml.core.version2>2.5.4</com.fasterxml.core.version2>
         <org.apache.cxf.cxf-rt.version>2.7.18</org.apache.cxf.cxf-rt.version>
         <io.swagger.version>1.5.8</io.swagger.version>
-        <carbon.consent.mgt.version>1.0.43</carbon.consent.mgt.version>
+        <carbon.consent.mgt.version>1.0.46</carbon.consent.mgt.version>
 
         <javax.xml.range>[0.0.0,1.0.0)</javax.xml.range>
         <org.apache.xml.security.range>[0.0.0,2.0.0)</org.apache.xml.security.range>


### PR DESCRIPTION

Use new API to search consents for users in all tenant domains for consent deletion