### PR TITLE
Add tenant mgt listner which adds default purpose category for a tenant

### DIFF
--- a/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/pom.xml
+++ b/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/pom.xml
@@ -66,6 +66,10 @@
             <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.commons</groupId>
+            <artifactId>org.wso2.carbon.tenant.common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.eclipse.osgi</groupId>
             <artifactId>org.eclipse.osgi.services</artifactId>
         </dependency>
@@ -98,6 +102,9 @@
                         <Import-Package>
                             org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent;
                             version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.util;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.util;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.model;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event;version="${carbon.identity.package.import.version.range}",
@@ -112,6 +119,7 @@
                             org.wso2.carbon.user.core; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.util; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
+                            org.wso2.carbon.stratos.common.*;version="${carbon.commons.imp.pkg.version}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",

--- a/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/internal/IdentityConsentServiceComponent.java
+++ b/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/internal/IdentityConsentServiceComponent.java
@@ -31,8 +31,10 @@ import org.wso2.carbon.identity.application.authentication.framework.handler.req
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
 import org.wso2.carbon.identity.consent.mgt.listener.ConsentDeletionAppMgtListener;
 import org.wso2.carbon.identity.consent.mgt.handler.ConsentDeletionUserEventHandler;
+import org.wso2.carbon.identity.consent.mgt.listener.TenantConsentMgtListener;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 
 /**
  * OSGi declarative services component which handled registration and unregistration of IdentityConsentServiceComponent.
@@ -54,6 +56,8 @@ public class IdentityConsentServiceComponent {
                     new ConsentDeletionUserEventHandler(), null);
             ctxt.getBundleContext().registerService(ApplicationMgtListener.class.getName(),
                     new ConsentDeletionAppMgtListener(), null);
+            ctxt.getBundleContext().registerService(TenantMgtListener.class.getName(), new TenantConsentMgtListener()
+                    , null);
         } catch (Throwable throwable) {
             log.error("Error while activating Identity Consent Service Component.", throwable);
         }

--- a/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/listener/TenantConsentMgtListener.java
+++ b/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/listener/TenantConsentMgtListener.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.consent.mgt.listener;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementException;
+import org.wso2.carbon.consent.mgt.core.model.PurposeCategory;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.consent.mgt.internal.IdentityConsentDataHolder;
+import org.wso2.carbon.identity.core.AbstractIdentityTenantMgtListener;
+import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
+import org.wso2.carbon.stratos.common.exception.StratosException;
+
+/**
+ * Tenant listener which adds default purpose category for a tenant
+ */
+public class TenantConsentMgtListener extends AbstractIdentityTenantMgtListener {
+
+    private static final Log log = LogFactory.getLog(TenantConsentMgtListener.class);
+    private static final String DEFAULT_PURPOSE_CATEGORY = "DEFAULT";
+
+    @Override
+    public void onTenantCreate(TenantInfoBean tenantInfoBean) throws StratosException {
+
+        if (isSsoConsentManagementEnabled()) {
+            addDefaultPurposeCategory(tenantInfoBean);
+        }
+    }
+
+    protected void addDefaultPurposeCategory(TenantInfoBean tenantInfoBean) throws StratosException {
+
+        FrameworkUtils.startTenantFlow(tenantInfoBean.getTenantDomain());
+        try {
+            PurposeCategory purposeCategory;
+            PurposeCategory defaultPurposeCategory = new PurposeCategory(DEFAULT_PURPOSE_CATEGORY, "Core " +
+                    "functionality");
+            try {
+                purposeCategory = IdentityConsentDataHolder.getInstance().getConsentManager().addPurposeCategory
+                        (defaultPurposeCategory);
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("Added default purpose category for tenant: %s. Default purpose category " +
+                            "id: %d", tenantInfoBean.getTenantDomain(), purposeCategory.getId()));
+                }
+            } catch (ConsentManagementException e) {
+                throw new StratosException("Error while adding default purpose category for tenant:" + tenantInfoBean
+                        .getTenantDomain());
+            }
+        } finally {
+            FrameworkUtils.endTenantFlow();
+        }
+    }
+
+    protected boolean isSsoConsentManagementEnabled() {
+
+        return IdentityConsentDataHolder.getInstance().getSSOConsentService().
+                isSSOConsentManagementEnabled(null);
+    }
+
+}

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/self-registration-with-verification.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/self-registration-with-verification.jsp
@@ -43,6 +43,7 @@
     boolean isLastNameRequired = true;
     boolean isEmailInClaims = true;
     boolean isEmailRequired = true;
+    Integer defaultPurposeCatId = null;
     Integer userNameValidityStatusCode = null;
     String username = request.getParameter("username");
     String callback = Encode.forHtmlAttribute(request.getParameter("callback"));
@@ -83,6 +84,9 @@
     String purposes = selfRegistrationMgtClient.getPurposes(user.getTenantDomain());
     boolean hasPurposes = StringUtils.isNotEmpty(purposes);
     
+    if (hasPurposes) {
+        defaultPurposeCatId = selfRegistrationMgtClient.getDefaultPurposeId(user.getTenantDomain());
+    }
     Claim[] claims = new Claim[0];
 
     List<Claim> claimsList;
@@ -545,7 +549,7 @@
                 newPurpose["purposeId"] = purpose.li_attr.purposeid;
                 //newPurpose = oldPurpose[0];
                 newPurpose['piiCategory'] = [];
-                newPurpose['purposeCategoryId'] = [1];
+                newPurpose['purposeCategoryId'] = [<%=defaultPurposeCatId%>];
 
                 var piiCategory = [];
                 var categories = purpose.children;


### PR DESCRIPTION
Add proper default purpose id based on user tenant domain

### Proposed changes in this pull request

[List all changes you want to add here. If you fixed an issue, please
add a reference to that issue as well.]

-Add tenant mgt listner which adds default purpose category for a tenant.
-Add proper default purpose id based on user tenant domain