### PR TITLE
Fix subject step being reset in case of incomplete authentication state

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandler.java
@@ -221,7 +221,8 @@ public class GraphBasedSequenceHandler extends DefaultStepBasedSequenceHandler i
         AuthenticatorFlowStatus flowStatus = (AuthenticatorFlowStatus) request
                 .getAttribute(FrameworkConstants.RequestParams.FLOW_STATUS);
 
-        if (flowStatus != AuthenticatorFlowStatus.SUCCESS_COMPLETED) {
+        if (flowStatus != AuthenticatorFlowStatus.SUCCESS_COMPLETED && flowStatus != AuthenticatorFlowStatus
+                .INCOMPLETE) {
             stepConfig.setSubjectAttributeStep(false);
             stepConfig.setSubjectIdentifierStep(false);
         }


### PR DESCRIPTION
### Proposed changes in this pull request

Fix subject step being reset in case of incomplete authentication state. Without this, any outbound authentication requests which produces incomplete state will unset that step as a subject/attribute step.