### PR TITLE
Fix NPE at authentication failure when fail node not present.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
@@ -429,6 +429,9 @@ public class JsGraphBuilder {
         public String evaluate(AuthenticationContext authenticationContext, Consumer<JSObject> jsConsumer) {
 
             String result = null;
+            if (jsFunction == null) {
+                return null;
+            }
             if (jsFunction.isFunction()) {
                 ScriptEngine scriptEngine = getEngine(authenticationContext);
                 try {


### PR DESCRIPTION
If an auth step fails, and there is no on.fail() defined, NPE can be observed.