### PR TITLE
Revert System wide capability to ignore case sensitivity based hashing

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/User.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/User.java
@@ -37,15 +37,6 @@ public class User implements Serializable {
     protected String tenantDomain;
     protected String userStoreDomain;
     protected String userName;
-    private static boolean ignoreCaseSensitivityBasedHashing = false;
-
-    static {
-
-        if (StringUtils.isNotBlank(System.getProperty("ignoreCaseSensitivityBasedHashing"))) {
-            ignoreCaseSensitivityBasedHashing = Boolean
-                    .parseBoolean(System.getProperty("ignoreCaseSensitivityBasedHashing"));
-        }
-    }
 
     /**
      * Returns a User instance populated from the given OMElement
@@ -220,15 +211,10 @@ public class User implements Serializable {
     public int hashCode() {
         int result = tenantDomain.hashCode();
         result = 31 * result + userStoreDomain.hashCode();
-
-        if (ignoreCaseSensitivityBasedHashing) {
-            result = 31 * result + userName.toLowerCase().hashCode();
+        if(IdentityUtil.isUserStoreCaseSensitive(userStoreDomain, IdentityTenantUtil.getTenantId(tenantDomain))) {
+            result = 31 * result + userName.hashCode();
         } else {
-            if (IdentityUtil.isUserStoreCaseSensitive(userStoreDomain, IdentityTenantUtil.getTenantId(tenantDomain))) {
-                result = 31 * result + userName.hashCode();
-            } else {
-                result = 31 * result + userName.toLowerCase().hashCode();
-            }
+            result = 31 * result + userName.toLowerCase().hashCode();
         }
         return result;
     }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/User.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/User.java
@@ -38,13 +38,12 @@ public class User implements Serializable {
     protected String userStoreDomain;
     protected String userName;
     private static boolean ignoreCaseSensitivityBasedHashing = false;
-    private static final String IGNORE_CASE_SENSITIVITY_BASED_HASHING = "ignoreCaseSensitivityBasedHashing";
 
     static {
 
-        String propertyToIgnoreCaseSensitivityBasedHashing = System.getProperty(IGNORE_CASE_SENSITIVITY_BASED_HASHING);
-        if (StringUtils.isNotBlank(propertyToIgnoreCaseSensitivityBasedHashing)) {
-            ignoreCaseSensitivityBasedHashing = Boolean.parseBoolean(propertyToIgnoreCaseSensitivityBasedHashing);
+        if (StringUtils.isNotBlank(System.getProperty("ignoreCaseSensitivityBasedHashing"))) {
+            ignoreCaseSensitivityBasedHashing = Boolean
+                    .parseBoolean(System.getProperty("ignoreCaseSensitivityBasedHashing"));
         }
     }
 


### PR DESCRIPTION
Revert changes applied by https://github.com/wso2/carbon-identity-framework/pull/1606.
This will be fixed later with a different approach.