### PR TITLE
Set maxlength value of description field for Service Provider Configuration section

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/add-service-provider.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/add-service-provider.jsp
@@ -161,7 +161,7 @@ window.onload = function() {
                     <tr>
                        <td class="leftCol-med labelField">Description:</td>
                      <td>
-                        <textarea style="width:50%" type="text" name="sp-description" id="sp-description" class="text-box-big"></textarea>
+                        <textarea maxlength="1023" style="width:50%" type="text" name="sp-description" id="sp-description" class="text-box-big"></textarea>
                         <div class="sectionHelp">
                                 <fmt:message key='help.desc'/>
                             </div>

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider.jsp
@@ -1102,7 +1102,7 @@
                         <tr>
                             <td style="width:15%" class="leftCol-med labelField">Description:</td>
                             <td>
-                                <textarea style="width:50%" type="text" name="sp-description" id="sp-description"
+                                <textarea maxlength="1023" style="width:50%" type="text" name="sp-description" id="sp-description"
                                           class="text-box-big"><%=appBean.getServiceProvider().getDescription() != null ? Encode.forHtmlContent(appBean.getServiceProvider().getDescription()) : "" %></textarea>
                                 <div class="sectionHelp">
                                     <fmt:message key='help.desc'/>


### PR DESCRIPTION
Set maxlength value of description field(Add service provider and edit service provider configuration page).
In current scenario, If we enter more than 1024 characters in description field then it will generate exception in logs while inserting data in database. 
Refer the below issue 
https://github.com/wso2/product-is/issues/2040
 