### PR TITLE
Reformat role creation audit log

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserMgtAuditLogger.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserMgtAuditLogger.java
@@ -108,8 +108,24 @@ public class UserMgtAuditLogger extends AbstractIdentityUserOperationEventListen
             return true;
         }
 
-        audit.info(String.format(AUDIT_MESSAGE, getUser(), "Add Role", roleName, "Users : "
-                + Arrays.toString(userList) + " Permissions : " + Arrays.toString(permissions), SUCCESS));
+        StringBuilder stringBuilder = new StringBuilder();
+        String permissionsString;
+        String usersString;
+        String format = "ResourceID : %s Action : %s\n";
+        for (Permission permission : permissions) {
+            stringBuilder.append(String.format(format, permission.getResourceId(), permission.getAction()));
+        }
+        permissionsString = stringBuilder.toString();
+        // Clear buffer for reuse.
+        stringBuilder.setLength(0);
+        format = "%s\n";
+        for (String user : userList) {
+            stringBuilder.append(String.format(format, user));
+        }
+        usersString = stringBuilder.toString();
+        format = "\nUsers :\n%sPermissions :\n%s";
+        String data = String.format(format, usersString, permissionsString);
+        audit.info(String.format(AUDIT_MESSAGE, getUser(), "Add Role", roleName, data, SUCCESS));
         return true;
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request
Fixing [Role creation audit log format unredable #3641](https://github.com/wso2/product-apim/issues/3641)
- Print each permission and assigned users in a new line, when creating a new role.
- Print resource ID and action of each permission, instead of permission object ID.