### PR TITLE
Session termination during user password reset and user delete

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/UserSessionManagementService.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/UserSessionManagementService.java
@@ -1,0 +1,35 @@
+/*
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework;
+
+import org.wso2.carbon.user.core.UserStoreManager;
+
+/**
+ * This is an interface used to define the session management service operations.
+ */
+public interface UserSessionManagementService {
+
+    /**
+     * This method is used to terminate all the active sessions of a given user.
+     *
+     * @param userName         name of the user
+     * @param userStoreManager {@link UserStoreManager} object of the user
+     */
+    void terminateSessionsOfUser(String userName, UserStoreManager userStoreManager);
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/UserSessionManagementServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/UserSessionManagementServiceImpl.java
@@ -1,0 +1,76 @@
+/*
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.carbon.identity.application.authentication.framework;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
+import org.wso2.carbon.identity.application.authentication.framework.store.UserSessionStore;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This a service class used to manage user sessions.
+ */
+public class UserSessionManagementServiceImpl implements UserSessionManagementService {
+
+    private static final Log log = LogFactory.getLog(UserSessionManagementServiceImpl.class);
+
+    @Override
+    public void terminateSessionsOfUser(String userName, UserStoreManager userStoreManager) {
+
+        List<String> sessionIdList = new ArrayList<>();
+        String userId;
+        try {
+            userId = UserSessionStore.getInstance().getUserId(userName, getTenantId(userStoreManager),
+                    getUserDomain(userStoreManager));
+            sessionIdList = UserSessionStore.getInstance().getSessionId(userId);
+        } catch (UserSessionException e) {
+            log.error("Error while retrieving the session data of the user.", e);
+        }
+
+        terminateSessions(sessionIdList);
+    }
+
+    private void terminateSessions(List<String> sessionIdList) {
+
+        for (String sessionId : sessionIdList) {
+            if (FrameworkUtils.getSessionContextFromCache(sessionId) != null) {
+                FrameworkUtils.removeSessionContextFromCache(sessionId);
+            }
+        }
+    }
+
+    private int getTenantId(UserStoreManager userStoreManager) throws UserSessionException {
+
+        try {
+            return userStoreManager.getTenantId();
+        } catch (UserStoreException e) {
+            throw new UserSessionException("Error while retrieving the tenant id from the user store.", e);
+        }
+    }
+
+    private String getUserDomain(UserStoreManager userStoreManager) {
+
+        return userStoreManager.getRealmConfiguration().getUserStoreProperty("DomainName");
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/exception/UserSessionException.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/exception/UserSessionException.java
@@ -1,0 +1,34 @@
+/*
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.carbon.identity.application.authentication.framework.exception;
+
+import org.wso2.carbon.identity.base.IdentityException;
+
+/**
+ * This class is used to manage the failures happen at UserSessionStore.
+ */
+public class UserSessionException extends IdentityException {
+
+    public UserSessionException(String errorDescription) {
+        super(errorDescription);
+    }
+
+    public UserSessionException(String errorDescription, Throwable cause) {
+        super(errorDescription, cause);
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -34,16 +34,20 @@ import org.wso2.carbon.identity.application.authentication.framework.context.Aut
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.AuthenticationRequestHandler;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationContextProperty;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationResult;
 import org.wso2.carbon.identity.application.authentication.framework.model.CommonAuthResponseWrapper;
 import org.wso2.carbon.identity.application.authentication.framework.services.PostAuthenticationMgtService;
+import org.wso2.carbon.identity.application.authentication.framework.store.UserSessionStore;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authentication.framework.util.LoginContextManagementUtil;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.idp.mgt.util.IdPManagementUtil;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
@@ -418,6 +422,14 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             }
             publishAuthenticationSuccess(request, context, sequenceConfig.getAuthenticatedUser());
 
+            if (isUserSessionMappingEnabled()) {
+                try {
+                    storeSessionData(context, sessionContextKey);
+                } catch (UserSessionException e) {
+                    throw new FrameworkException("Error while storing session details of the authenticated user to " +
+                            "the database", e);
+                }
+            }
         }
 
         // Checking weather inbound protocol is an already cache removed one, request come from federated or other
@@ -441,6 +453,62 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
         }
 
         sendResponse(request, response, context);
+    }
+
+    /**
+     * Method used to store user and session related data to the database.
+     *
+     * @param context           {@link AuthenticationContext} object with the authentication request related data
+     * @param sessionContextKey of the authenticated session
+     */
+    private void storeSessionData(AuthenticationContext context, String sessionContextKey)
+            throws UserSessionException {
+
+        for (AuthenticatedIdPData authenticatedIdPData : context.getCurrentAuthenticatedIdPs().values()) {
+            String userName = authenticatedIdPData.getUser().getUserName();
+            String tenantDomain = getAuthenticatedUserTenantDomain(context, null);
+            Integer tenantId = (tenantDomain == null) ? MultitenantConstants.INVALID_TENANT_ID : IdentityTenantUtil
+                    .getTenantId(tenantDomain);
+            String userStoreDomain = authenticatedIdPData.getUser().getUserStoreDomain();
+            String idpName = authenticatedIdPData.getIdpName();
+            String userId;
+            try {
+                int idpId = UserSessionStore.getInstance().getIdPId(idpName);
+                userId = UserSessionStore.getInstance().getUserId(userName, tenantId, userStoreDomain, idpId);
+
+                // This synchronized block is added to handle a situation when new user try to get authenticated
+                // from multiple nodes at the same time (which is rare case).
+                if (userId == null) {
+                    synchronized (this) {
+                        userId = UserSessionStore.getInstance().getUserId(userName, tenantId, userStoreDomain,
+                                idpId);
+                        if (userId == null) {
+                            userId = UUIDGenerator.generateUUID();
+                            UserSessionStore.getInstance().storeUserData(userId, userName, tenantId,
+                                    userStoreDomain, idpId);
+                        }
+                    }
+                }
+
+                if (!UserSessionStore.getInstance().isExistingMapping(userId, sessionContextKey)) {
+                    UserSessionStore.getInstance().storeUserSessionData(userId, sessionContextKey);
+                }
+            } catch (UserSessionException e) {
+                throw new UserSessionException("Error while storing the session data.", e);
+            }
+        }
+    }
+
+    /**
+     * Method to check whether the SessionUserManager configuration is enabled.
+     *
+     * @return the boolean value of the enable decision
+     */
+    private boolean isUserSessionMappingEnabled() {
+
+        String sessionUserManagerConfig = IdentityUtil
+                .getProperty(FrameworkConstants.Config.USER_SESSION_MAPPING_ENABLED);
+        return Boolean.parseBoolean(sessionUserManagerConfig);
     }
 
     private String getApplicationTenantDomain(AuthenticationContext context) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -40,6 +40,8 @@ import org.wso2.carbon.identity.application.authentication.framework.JsFunctionR
 import org.wso2.carbon.identity.application.authentication.framework.LocalApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticationFlowHandler;
 import org.wso2.carbon.identity.application.authentication.framework.RequestPathApplicationAuthenticator;
+import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
+import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementServiceImpl;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.loader.UIBasedConfigurationLoader;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsFunctionRegistryImpl;
@@ -184,6 +186,8 @@ public class FrameworkServiceComponent {
         bundleContext.registerService(ApplicationAuthenticationService.class.getName(), new
                 ApplicationAuthenticationService(), null);
         bundleContext.registerService(JsFunctionRegistry.class, dataHolder.getJsFunctionRegistry(), null);
+        bundleContext.registerService(UserSessionManagementService.class.getName(),
+                new UserSessionManagementServiceImpl(), null);
         boolean tenantDropdownEnabled = ConfigurationFacade.getInstance().getTenantDropdownEnabled();
 
         if (tenantDropdownEnabled) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
@@ -1,0 +1,77 @@
+/*
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.carbon.identity.application.authentication.framework.store;
+
+/**
+ * This class holds the SQL queries used by {@link UserSessionStore}.
+ */
+public class SQLQueries {
+
+    private static final String SESSION_CONTEXT_CACHE_NAME = "AppAuthFrameworkSessionContextCache";
+    private static final String DELETE_OPERATION = "DELETE";
+
+    /**
+     * Queries to store session data.
+     */
+    public static final String SQL_INSERT_USER_STORE_OPERATION =
+            "INSERT INTO IDN_AUTH_USER(USER_ID, USER_NAME, TENANT_ID, DOMAIN_NAME, IDP_ID) VALUES " +
+                    "(?,?,?,?,?)";
+
+    public static final String SQL_INSERT_USER_SESSION_STORE_OPERATION =
+            "INSERT INTO IDN_AUTH_USER_SESSION_MAPPING(USER_ID,SESSION_ID )VALUES (?,?)";
+
+    /**
+     * Queries to retrieve user ID.
+     */
+    public static final String SQL_SELECT_USER_ID =
+            "SELECT USER_ID FROM IDN_AUTH_USER WHERE USER_NAME =? AND TENANT_ID =? AND " +
+                    "DOMAIN_NAME =? AND IDP_ID = ?";
+
+    public static final String SQL_SELECT_USER_IDS_OF_USER =
+            "SELECT USER_ID FROM IDN_AUTH_USER WHERE USER_NAME =? AND TENANT_ID =? AND DOMAIN_NAME =?";
+
+    public static final String SQL_SELECT_USER_IDS_OF_USER_STORE =
+            "SELECT USER_ID FROM IDN_AUTH_USER WHERE DOMAIN_NAME = ? AND TENANT_ID =?";
+
+    /**
+     * Queries to retrieve session ID.
+     */
+    public static final String SQL_SELECT_SESSION_ID_OF_USER_ID =
+            "SELECT SESSION_ID FROM IDN_AUTH_USER_SESSION_MAPPING WHERE USER_ID = ?";
+
+    public static final String SQL_SELECT_TERMINATED_SESSION_IDS =
+            "SELECT SESSION_ID FROM IDN_AUTH_SESSION_STORE WHERE SESSION_TYPE = '" + SESSION_CONTEXT_CACHE_NAME
+                    + "' AND OPERATION = '" + DELETE_OPERATION + "' AND  TIME_CREATED < ?";
+
+    /**
+     * Query to retrieve user session mapping.
+     */
+    public static final String SQL_SELECT_USER_SESSION_MAP =
+            "SELECT * FROM IDN_AUTH_USER_SESSION_MAPPING WHERE USER_ID =? AND SESSION_ID =?";
+
+    /**
+     * Query to retrieve IdP Id of a registered IdP.
+     */
+    public static final String SQL_SELECT_IDP_ID_OF_IDP = "SELECT IDP.ID FROM IDP WHERE NAME = ?";
+
+    /**
+     * Query to delete session data.
+     */
+    public static final String SQL_DELETE_TERMINATED_SESSION_DATA =
+            "DELETE FROM IDN_AUTH_USER_SESSION_MAPPING WHERE SESSION_ID = ?";
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionCleanUpService.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionCleanUpService.java
@@ -21,6 +21,8 @@ package org.wso2.carbon.identity.application.authentication.framework.store;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -68,6 +70,11 @@ public final class SessionCleanUpService {
         public void run() {
 
             log.debug("Start running the Session Data cleanup task.");
+            if (Boolean.parseBoolean(IdentityUtil
+                    .getProperty(FrameworkConstants.Config.USER_SESSION_MAPPING_ENABLED))) {
+                UserSessionStore.getInstance().removeExpiredSessionRecords();
+            }
+
             SessionDataStore.getInstance().removeExpiredSessionData();
             log.debug("Stop running the Session Data cleanup task.");
             log.info("Session Data cleanup task is running successfully for removing expired Data");

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -1,0 +1,341 @@
+/*
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.carbon.identity.application.authentication.framework.store;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Class to store and retrieve user related data.
+ */
+public class UserSessionStore {
+
+    private static final Log log = LogFactory.getLog(UserSessionStore.class);
+
+    private static UserSessionStore instance = new UserSessionStore();
+    private static final String FEDERATED_USER_DOMAIN = "FEDERATED";
+
+    private UserSessionStore() {
+    }
+
+    public static UserSessionStore getInstance() {
+        return instance;
+    }
+
+    /**
+     * Method to store user and session mapping.
+     *
+     * @param userName   Name of the authenticated user
+     * @param tenantId   Id of the tenant domain
+     * @param userDomain Name of the user Store domain
+     * @param idPId      Identity Provider id
+     * @throws UserSessionException if an error occurs when storing the authenticated user details to the database
+     */
+    public void storeUserData(String userId, String userName, int tenantId, String userDomain, int idPId)
+            throws UserSessionException {
+
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection();
+             PreparedStatement preparedStatement = connection
+                     .prepareStatement(SQLQueries.SQL_INSERT_USER_STORE_OPERATION)) {
+            preparedStatement.setString(1, userId);
+            preparedStatement.setString(2, userName);
+            preparedStatement.setInt(3, tenantId);
+            preparedStatement.setString(4, (userDomain == null) ? FEDERATED_USER_DOMAIN : userDomain);
+            preparedStatement.setInt(5, idPId);
+            preparedStatement.executeUpdate();
+            if (!connection.getAutoCommit()) {
+                connection.commit();
+            }
+        } catch (SQLException e) {
+            throw new UserSessionException("Error while storing authenticated user details to the database table " +
+                    "IDN_AUTH_USER_STORE of user: " + userName + ", Tenant Id: " + tenantId + ", User domain: " +
+                    userDomain + ", Identity provider id: " + idPId, e);
+        }
+    }
+
+    /**
+     * Method to get the unique Id of a user from the database.
+     *
+     * @param userName   Name of the authenticated user
+     * @param tenantId   Id of the tenant domain
+     * @param userDomain Name of the user Store domain
+     * @param idPId      Identity Provider id
+     * @return the user id of the user
+     * @throws UserSessionException if an error occurs when retrieving the user id of the user from the database
+     */
+    public String getUserId(String userName, int tenantId, String userDomain, int idPId)
+            throws UserSessionException {
+
+        String userId = null;
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection();
+             PreparedStatement preparedStatement = connection
+                     .prepareStatement(SQLQueries.SQL_SELECT_USER_ID)) {
+            preparedStatement.setString(1, userName);
+            preparedStatement.setInt(2, tenantId);
+            preparedStatement.setString(3, (userDomain == null) ? FEDERATED_USER_DOMAIN : userDomain);
+            preparedStatement.setInt(4, idPId);
+
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                if (resultSet.next()) {
+                    userId = resultSet.getString(1);
+                }
+            }
+
+            if (!connection.getAutoCommit()) {
+                connection.commit();
+            }
+
+        } catch (SQLException e) {
+            throw new UserSessionException("Error while retrieving User Id of the user: " + userName + ", Tenant Id: "
+                    + tenantId + ", User domain: " + userDomain + ", Identity provider id: " + idPId, e);
+        }
+        return userId;
+    }
+
+    /**
+     * Method to return the user Id of a user from the database.
+     *
+     * @param userName   Name of the authenticated user
+     * @param tenantId   Id of the tenant domain
+     * @param userDomain Name of the user Store domain
+     * @return the user id of the user
+     * @throws UserSessionException if an error occurs when retrieving the user id of the user from the database
+     */
+    public String getUserId(String userName, int tenantId, String userDomain) throws UserSessionException {
+
+        String userId = null;
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection();
+             PreparedStatement preparedStatement = connection
+                     .prepareStatement(SQLQueries.SQL_SELECT_USER_IDS_OF_USER)) {
+            preparedStatement.setString(1, userName);
+            preparedStatement.setInt(2, tenantId);
+            preparedStatement.setString(3, (userDomain == null) ? FEDERATED_USER_DOMAIN : userDomain);
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                if (resultSet.next()) {
+                    userId = resultSet.getString(1);
+                }
+            }
+
+            if (!connection.getAutoCommit()) {
+                connection.commit();
+            }
+
+        } catch (SQLException e) {
+            throw new UserSessionException("Error while retrieving User Id of the user: " + userName + ", Tenant Id: "
+                    + tenantId + ", User domain: " + userDomain, e);
+        }
+        return userId;
+    }
+
+    /**
+     * Method to return the user Ids of the users in a given user store from the database.
+     *
+     * @param userDomain Name of the user Store domain
+     * @param tenantId   Id of the tenant domain
+     * @return the list of user Ids of users stored in the given user store
+     * @throws UserSessionException if an error occurs when retrieving the user id list from the database
+     */
+    public List<String> getUserIdsOfUserStore(String userDomain, int tenantId) throws UserSessionException {
+
+        List<String> userIds = new ArrayList<>();
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection();
+             PreparedStatement preparedStatement = connection
+                     .prepareStatement(SQLQueries.SQL_SELECT_USER_IDS_OF_USER_STORE)) {
+            preparedStatement.setString(1, userDomain);
+            preparedStatement.setInt(2, tenantId);
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                while (resultSet.next()) {
+                    userIds.add(resultSet.getString(1));
+                }
+            }
+
+            if (!connection.getAutoCommit()) {
+                connection.commit();
+            }
+
+        } catch (SQLException e) {
+            throw new UserSessionException("Error while retrieving user Ids stored in the user domain: " + userDomain
+                    + ", Tenant Id: " + tenantId, e);
+        }
+        return userIds;
+    }
+
+    /**
+     * Method to identity providers id from the IDP table.
+     *
+     * @param idPName name of the identity provider
+     * @return id of the identity provider
+     * @throws UserSessionException if an error occurs when retrieving the identity provider id list from the database
+     */
+    public int getIdPId(String idPName) throws UserSessionException {
+
+        int idPId = -1;
+        if (idPName.equals("LOCAL")) {
+            return idPId;
+        }
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection();
+             PreparedStatement preparedStatement = connection
+                     .prepareStatement(SQLQueries.SQL_SELECT_IDP_ID_OF_IDP)) {
+            preparedStatement.setString(1, idPName);
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                if (resultSet.next()) {
+                    idPId = resultSet.getInt(1);
+                }
+            }
+        } catch (SQLException e) {
+            throw new UserSessionException("Error while retrieving the IdP id of: " + idPName, e);
+        }
+        return idPId;
+    }
+
+    /**
+     * Method to store user id and session id mapping in the database table IDN_AUTH_USER_SESSION_STORE.
+     *
+     * @param userId    Id of the user
+     * @param sessionId Id of the authenticated session
+     * @throws UserSessionException if an error occurs when storing the mapping in the database
+     */
+    public void storeUserSessionData(String userId, String sessionId) throws UserSessionException {
+
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection();
+             PreparedStatement preparedStatement = connection
+                     .prepareStatement(SQLQueries.SQL_INSERT_USER_SESSION_STORE_OPERATION)) {
+            preparedStatement.setString(1, userId);
+            preparedStatement.setString(2, sessionId);
+            preparedStatement.executeUpdate();
+            if (!connection.getAutoCommit()) {
+                connection.commit();
+            }
+        } catch (SQLException e) {
+            throw new UserSessionException("Error while storing mapping between user Id: " + userId +
+                    " and session Id: " + sessionId, e);
+        }
+    }
+
+    /**
+     * Method to check whether the user id and session id mapping is already exists in the database.
+     *
+     * @param userId    Id of the user
+     * @param sessionId Id of the authenticated session
+     * @return the boolean decision
+     * @throws UserSessionException if an error occurs when retrieving the mapping from the database
+     */
+    public boolean isExistingMapping(String userId, String sessionId) throws UserSessionException {
+
+        Boolean isExisting = false;
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection();
+             PreparedStatement preparedStatement = connection
+                     .prepareStatement(SQLQueries.SQL_SELECT_USER_SESSION_MAP)) {
+            preparedStatement.setString(1, userId);
+            preparedStatement.setString(2, sessionId);
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                if (resultSet.next()) {
+                    isExisting = true;
+                }
+            }
+
+            if (!connection.getAutoCommit()) {
+                connection.commit();
+            }
+
+        } catch (SQLException e) {
+            throw new UserSessionException("Error while retrieving existing mapping between user Id: " + userId
+                    + " and session Id: " + sessionId, e);
+        }
+        return isExisting;
+    }
+
+    /**
+     * Method to get session Id list of a given user Id.
+     *
+     * @param userId Id of the user
+     * @return the list of session ids
+     * @throws UserSessionException if an error occurs when retrieving the session id list from the database
+     */
+    public List<String> getSessionId(String userId) throws UserSessionException {
+
+        List<String> sessionIdList = new ArrayList<>();
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection();
+             PreparedStatement preparedStatement = connection
+                     .prepareStatement(SQLQueries.SQL_SELECT_SESSION_ID_OF_USER_ID)) {
+            preparedStatement.setString(1, userId);
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                while (resultSet.next()) {
+                    sessionIdList.add(resultSet.getString(1));
+                }
+            }
+
+            if (!connection.getAutoCommit()) {
+                connection.commit();
+            }
+
+        } catch (SQLException e) {
+            throw new UserSessionException("Error while retrieving session Id of user Id: " + userId, e);
+        }
+        return sessionIdList;
+    }
+
+    /**
+     * Method used to remove the expired sessions from the database table IDN_AUTH_USER_SESSION_STORE.
+     */
+    public void removeExpiredSessionRecords() {
+
+        long cleanupLimitNano = FrameworkUtils.getCurrentStandardNano() -
+                TimeUnit.MINUTES.toNanos(IdentityUtil.getOperationCleanUpTimeout());
+        List<String> terminatedAuthSessionIds = new ArrayList<>();
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection();
+             PreparedStatement preparedStatement = connection
+                     .prepareStatement(SQLQueries.SQL_SELECT_TERMINATED_SESSION_IDS)) {
+            preparedStatement.setLong(1, cleanupLimitNano);
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                while (resultSet.next()) {
+                    terminatedAuthSessionIds.add(resultSet.getString(1));
+                }
+            }
+
+            for (String terminatedSessionId : terminatedAuthSessionIds) {
+                try (PreparedStatement preparedStatementForDelete = connection
+                        .prepareStatement(SQLQueries.SQL_DELETE_TERMINATED_SESSION_DATA)) {
+                    preparedStatementForDelete.setString(1, terminatedSessionId);
+                    preparedStatementForDelete.addBatch();
+                    preparedStatementForDelete.executeBatch();
+                }
+            }
+
+            if (!connection.getAutoCommit()) {
+                connection.commit();
+            }
+
+        } catch (SQLException e) {
+            log.error("Error while removing the terminated sessions from the table IDN_AUTH_USER_SESSION_STORE."
+                    , e);
+        }
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -192,6 +192,12 @@ public abstract class FrameworkConstants {
         public static final String QNAME_EXT_AUTHORIZATION_HANDLER = "AuthorizationHandler";
         public static final String QNAME_EXT_POST_AUTHENTICATION_HANDLER = "PostAuthenticationHandler";
 
+        /**
+         * Configuration used for user session mapping.
+         */
+        public static final String USER_SESSION_MAPPING_ENABLED =
+                "JDBCPersistenceManager.SessionDataPersist.UserSessionMapping.Enable";
+
         private Config() {
         }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/pom.xml
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/pom.xml
@@ -71,6 +71,10 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.core</artifactId>
         </dependency>
         <dependency>
@@ -155,7 +159,8 @@
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.base.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.captcha.mgt.*; version="${carbon.captcha.mgt.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.notification.mgt.*; version="${carbon.identity.package.import.version.range}"
+                            org.wso2.carbon.identity.notification.mgt.*; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.*; version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/internal/IdentityMgtServiceComponent.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/internal/IdentityMgtServiceComponent.java
@@ -31,6 +31,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
 import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -45,6 +46,7 @@ import org.wso2.carbon.identity.mgt.config.StorageType;
 import org.wso2.carbon.identity.mgt.constants.IdentityMgtConstants;
 import org.wso2.carbon.identity.mgt.listener.TenantManagementListener;
 import org.wso2.carbon.identity.mgt.listener.UserOperationsNotificationListener;
+import org.wso2.carbon.identity.mgt.listener.UserSessionTerminationListener;
 import org.wso2.carbon.identity.mgt.store.RegistryCleanUpService;
 import org.wso2.carbon.identity.mgt.util.UserIdentityManagementUtil;
 import org.wso2.carbon.identity.notification.mgt.NotificationSender;
@@ -78,6 +80,7 @@ public class IdentityMgtServiceComponent {
     private static RecoveryProcessor recoveryProcessor;
     private static NotificationSender notificationSender;
     private static AttributeSearchService attributeSearchService;
+    private static UserSessionManagementService userSessionManagementService;
 
     public static RealmService getRealmService() {
         return realmService;
@@ -191,6 +194,8 @@ public class IdentityMgtServiceComponent {
                 UserOperationEventListener.class.getName(), notificationListener, null);
         context.getBundleContext().registerService(TenantMgtListener.class.getName(), new TenantManagementListener()
                 , null);
+        context.getBundleContext().registerService(UserOperationEventListener.class.getName(),
+                new UserSessionTerminationListener(), null);
 
         if (userOperationNotificationSR != null) {
             if (log.isDebugEnabled()) {
@@ -296,5 +301,35 @@ public class IdentityMgtServiceComponent {
 
     public static AttributeSearchService getAttributeSearchService() {
         return attributeSearchService;
+    }
+
+    @Reference(
+            name = "userSessionManagementService",
+            service = UserSessionManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetUserSessionManagementService"
+    )
+    protected void setUserSessionManagementService(UserSessionManagementService sessionService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting Session Management Service");
+        }
+
+        userSessionManagementService = sessionService;
+    }
+
+    protected void unsetUserSessionManagementService(UserSessionManagementService sessionService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Unsetting Session Management Service");
+        }
+
+        userSessionManagementService = null;
+    }
+
+    public static UserSessionManagementService getUserSessionManagementService() {
+
+        return userSessionManagementService;
     }
 }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/UserSessionTerminationListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/UserSessionTerminationListener.java
@@ -1,0 +1,92 @@
+/*
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.carbon.identity.mgt.listener;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.mgt.internal.IdentityMgtServiceComponent;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+
+/**
+ * This is an implementation of UserOperationEventListener which is responsible for termination of active sessions
+ * of the user.
+ */
+public class UserSessionTerminationListener extends AbstractIdentityUserOperationEventListener {
+
+    private static final Log log = LogFactory.getLog(UserSessionTerminationListener.class);
+
+    private static final String USER_SESSION_MAPPING_ENABLED =
+            "JDBCPersistenceManager.SessionDataPersist.UserSessionMapping.Enable";
+
+    @Override
+    public int getExecutionOrderId() {
+
+        int orderId = getOrderId();
+        if (orderId != IdentityCoreConstants.EVENT_LISTENER_ORDER_ID) {
+            return orderId;
+        }
+
+        return 85;
+    }
+
+    @Override
+    public boolean doPostUpdateCredentialByAdmin(String userName, Object credential, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+
+        if (!Boolean.parseBoolean(IdentityUtil.getProperty(USER_SESSION_MAPPING_ENABLED))) {
+            return true;
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Terminating all the active sessions of the password reset user: " + userName);
+        }
+
+        IdentityMgtServiceComponent.getUserSessionManagementService()
+                .terminateSessionsOfUser(userName, userStoreManager);
+        return true;
+    }
+
+    @Override
+    public boolean doPreDeleteUser(String userName, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+
+        if (!Boolean.parseBoolean(IdentityUtil.getProperty(USER_SESSION_MAPPING_ENABLED))) {
+            return true;
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Terminating all the active sessions of the deleted user: " + userName);
+        }
+
+        IdentityMgtServiceComponent.getUserSessionManagementService()
+                .terminateSessionsOfUser(userName, userStoreManager);
+        return true;
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/wso2/carbon-identity-framework/issues/1940

For this feature, we have introduced 2 new database tables in order to track the user and session mapping details and a configuration to enable the functionality. 

- Add the following configured in the identity.xml file 
```
<JDBCPersistenceManager>
.....
   <SessionDataPersist>
   .....
       <UserSessionMapping>
	    <Enable>true</Enable>
       </UserSessionMapping>
   </SessionDataPersist>
</JDBCPersistenceManager>
```

- Create the 2 tables in the database using the below queries,
```
CREATE TABLE IDN_AUTH_USER (
	USER_ID VARCHAR(255) NOT NULL, 
	USER_NAME VARCHAR(255) NOT NULL, 
	TENANT_ID INTEGER, 
	DOMAIN_NAME VARCHAR(255), 
	IDP_ID INTEGER, 
	PRIMARY KEY (USER_ID),
	CONSTRAINT USER_STORE_CONSTRAINT UNIQUE (USER_NAME, TENANT_ID, DOMAIN_NAME, IDP_ID));
```

```
CREATE TABLE IDN_AUTH_USER_SESSION_MAPPING (
	USER_ID VARCHAR(255) NOT NULL, 
	SESSION_ID VARCHAR(255) NOT NULL,
	CONSTRAINT USER_SESSION_STORE_CONSTRAINT UNIQUE (USER_ID, SESSION_ID));

CREATE INDEX IDX_USER_ID ON IDN_AUTH_USER_SESSION_MAPPING (USER_ID);

CREATE INDEX IDX_SESSION_ID ON IDN_AUTH_USER_SESSION_MAPPING (SESSION_ID);
```
