### PR TITLE
Add SAML ECP profile 

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -247,8 +247,9 @@ public class FrameworkUtils {
 
                 log.debug("\nInbound Request parameters: " + queryStringBuilder.toString());
             }
+
             return new AuthenticationFrameworkWrapper(request, modifiableParameters,
-                                                        authenticationRequest.getRequestHeaders());
+                                                      authenticationRequest.getRequestHeaders());
         }
         return request;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -247,9 +247,8 @@ public class FrameworkUtils {
 
                 log.debug("\nInbound Request parameters: " + queryStringBuilder.toString());
             }
-
             return new AuthenticationFrameworkWrapper(request, modifiableParameters,
-                                                      authenticationRequest.getRequestHeaders());
+                                                        authenticationRequest.getRequestHeaders());
         }
         return request;
     }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/IdentityRegistryResources.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/IdentityRegistryResources.java
@@ -159,6 +159,7 @@ public class IdentityRegistryResources {
     public static final String PROP_SAML_SSO_SUPPORTED_ASSERTION_QUERY_REQUEST_TYPES =
             "SupportedAssertionQueryRequestTypes";
     public static final String PROP_SAML_SSO_ENABLE_SAML2_ARTIFACT_BINDING = "EnableSAML2ArtifactBinding";
+    public static final String PROP_SAML_ENABLE_ECP = "EnableSAMLECP";
 
     // OpenID Admin
     public final static String SUB_DOMAIN = "SubDomain";

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAO.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAO.java
@@ -154,7 +154,7 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
                     IdentityRegistryResources.PROP_SAML_SSO_DO_SIGN_ASSERTIONS).trim()));
         }
 
-        if(resource.getProperty(IdentityRegistryResources.PROP_SAML_ENABLE_ECP) != null){
+        if (resource.getProperty(IdentityRegistryResources.PROP_SAML_ENABLE_ECP) != null) {
             serviceProviderDO.setSamlECP(Boolean.valueOf(resource.getProperty(
                     IdentityRegistryResources.PROP_SAML_ENABLE_ECP).trim()));
         }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAO.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAO.java
@@ -159,7 +159,6 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
                     IdentityRegistryResources.PROP_SAML_ENABLE_ECP).trim()));
         }
 
-
         if (resource
                 .getProperty(IdentityRegistryResources.PROP_SAML_SSO_ATTRIB_CONSUMING_SERVICE_INDEX) != null) {
             serviceProviderDO

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAO.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAO.java
@@ -154,6 +154,12 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
                     IdentityRegistryResources.PROP_SAML_SSO_DO_SIGN_ASSERTIONS).trim()));
         }
 
+        if(resource.getProperty(IdentityRegistryResources.PROP_SAML_ENABLE_ECP) != null){
+            serviceProviderDO.setSamlECP(Boolean.valueOf(resource.getProperty(
+                    IdentityRegistryResources.PROP_SAML_ENABLE_ECP).trim()));
+        }
+
+
         if (resource
                 .getProperty(IdentityRegistryResources.PROP_SAML_SSO_ATTRIB_CONSUMING_SERVICE_INDEX) != null) {
             serviceProviderDO
@@ -327,6 +333,9 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
         String doSignAssertions = String.valueOf(serviceProviderDO.isDoSignAssertions());
         resource.addProperty(IdentityRegistryResources.PROP_SAML_SSO_DO_SIGN_ASSERTIONS,
                 doSignAssertions);
+        String isSamlECP = String.valueOf(serviceProviderDO.isSamlECP());
+        resource.addProperty(IdentityRegistryResources.PROP_SAML_ENABLE_ECP,
+                isSamlECP);
         if (CollectionUtils.isNotEmpty(serviceProviderDO.getRequestedClaimsList())) {
             resource.setProperty(IdentityRegistryResources.PROP_SAML_SSO_REQUESTED_CLAIMS,
                     serviceProviderDO.getRequestedClaimsList());

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/model/SAMLSSOServiceProviderDO.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/model/SAMLSSOServiceProviderDO.java
@@ -582,11 +582,11 @@ public class SAMLSSOServiceProviderDO implements Serializable {
         this.x509Certificate = x509Certificate;
     }
 
-    public  void setSamlECP(boolean samlECP) {
+    public void setSamlECP(boolean samlECP) {
         this.samlECP = samlECP;
     }
 
-    public boolean isSamlECP(){
+    public boolean isSamlECP() {
         return samlECP;
     }
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/model/SAMLSSOServiceProviderDO.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/model/SAMLSSOServiceProviderDO.java
@@ -72,6 +72,7 @@ public class SAMLSSOServiceProviderDO implements Serializable {
     private boolean isAssertionQueryRequestProfileEnabled;
     private String supportedAssertionQueryRequestTypes;
     private boolean enableSAML2ArtifactBinding;
+    private boolean samlECP;
 
     public void setDoValidateSignatureInArtifactResolve(boolean doValidateSignatureInArtifactResolve) {
 
@@ -580,4 +581,13 @@ public class SAMLSSOServiceProviderDO implements Serializable {
     public void setX509Certificate(X509Certificate x509Certificate) {
         this.x509Certificate = x509Certificate;
     }
+
+    public  void setSamlECP(boolean samlECP) {
+        this.samlECP = samlECP;
+    }
+
+    public boolean isSamlECP(){
+        return samlECP;
+    }
+
 }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAOTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAOTest.java
@@ -170,6 +170,8 @@ public class SAMLSSOServiceProviderDAOTest extends PowerMockTestCase {
                 ("recipient1", "recipient2"));
         dummyAdvProperties.put(IdentityRegistryResources.PROP_SAML_SSO_ATTRIB_CONSUMING_SERVICE_INDEX, Collections
                 .singletonList("attribConsumingSvcIndex"));
+        dummyAdvProperties.put(IdentityRegistryResources.PROP_SAML_ENABLE_ECP, Collections
+                .singletonList("true"));
     }
 
     @AfterMethod
@@ -268,6 +270,8 @@ public class SAMLSSOServiceProviderDAOTest extends PowerMockTestCase {
                 .PROP_SAML_SLO_RESPONSE_URL), "SLO response URL Mismatch.");
         assertEquals(serviceProviderDO.getSloRequestURL(), dummyResource.getProperty(IdentityRegistryResources
                 .PROP_SAML_SLO_REQUEST_URL), "SLO req url Mismatch.");
+        assertEquals(serviceProviderDO.isSamlECP(), Boolean.parseBoolean(dummyResource.getProperty(IdentityRegistryResources
+                .PROP_SAML_ENABLE_ECP)), "ECP enabled mismatch");
 
         if (dummyResource.getPropertyValues
                 (IdentityRegistryResources.PROP_SAML_SSO_REQUESTED_CLAIMS) == null) {


### PR DESCRIPTION
### Proposed changes in this pull request

Add a SAML service provider (Boolean) attribute EnableSAMLECP in the SAML Registry.

#### Tests
Added unit test cases for SAMLSSOServiceProviderDAO


