### PR TITLE
Fix invalid backend URL is getting generated in the password recovery flow when hostname has 'services' string

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/IdentityManagementEndpointConstants.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/IdentityManagementEndpointConstants.java
@@ -63,6 +63,8 @@ public class IdentityManagementEndpointConstants {
     }
 
     public static final class UserInfoRecovery {
+
+        public static final String SERVICE_CONTEXT = "/services";
         public static final String SERVICE_CONTEXT_URL_DOMAIN = "services";
         public static final String REST_API_URL_DOMAIN = "account-recovery";
     }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/ApiClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/ApiClient.java
@@ -52,7 +52,7 @@ import java.util.Map.Entry;
 public class ApiClient {
     private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
     private String basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                     "api/identity/recovery/v0.9");
     private boolean debugging = false;
     private int connectionTimeout = 0;

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/SelfRegistrationMgtClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/SelfRegistrationMgtClient.java
@@ -134,11 +134,11 @@ public class SelfRegistrationMgtClient {
         String purposesEndpoint;
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
             purposesEndpoint = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                             "t/" + tenantDomain + CONSENT_API_RELATIVE_PATH + PURPOSES_ENDPOINT_RELATIVE_PATH);
         } else {
             purposesEndpoint = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                             CONSENT_API_RELATIVE_PATH + PURPOSES_ENDPOINT_RELATIVE_PATH);
         }
         return purposesEndpoint;
@@ -149,12 +149,12 @@ public class SelfRegistrationMgtClient {
         String purposesEndpoint;
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
             purposesEndpoint = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                             "t/" + tenantDomain + CONSENT_API_RELATIVE_PATH +
                                     PURPOSES_CATEGORIES_ENDPOINT_RELATIVE_PATH);
         } else {
             purposesEndpoint = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                             CONSENT_API_RELATIVE_PATH + PURPOSES_CATEGORIES_ENDPOINT_RELATIVE_PATH);
         }
         return purposesEndpoint;
@@ -163,7 +163,7 @@ public class SelfRegistrationMgtClient {
     private String getUserAPIEndpoint() {
 
         String purposesEndpoint = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                         USERNAME_VALIDATE_API_RELATIVE_PATH);
         return purposesEndpoint;
     }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/api/NotificationApi.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/api/NotificationApi.java
@@ -46,7 +46,7 @@ public class NotificationApi {
     private ApiClient apiClient;
 
     String basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                     "api/identity/recovery/v0.9");
 
     public NotificationApi() {
@@ -285,7 +285,7 @@ public class NotificationApi {
 
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
             basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                             "t/" + tenantDomain + "/api/identity/recovery/v0.9");
         }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/api/PasswordRecoveryApi.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/api/PasswordRecoveryApi.java
@@ -40,7 +40,7 @@ public class PasswordRecoveryApi {
     private ApiClient apiClient;
 
     String basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                     "api/identity/recovery/v0.9");
 
     public PasswordRecoveryApi() {
@@ -83,7 +83,7 @@ public class PasswordRecoveryApi {
 
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
             basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                             "t/" + tenantDomain + "/api/identity/recovery/v0.9");
         }
 
@@ -143,7 +143,7 @@ public class PasswordRecoveryApi {
 
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
             basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                             "t/" + tenantDomain + "/api/identity/recovery/v0.9");
         }
 
@@ -203,7 +203,7 @@ public class PasswordRecoveryApi {
 
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
             basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                             "t/" + tenantDomain + "/api/identity/recovery/v0.9");
         }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/api/ReCaptchaApi.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/api/ReCaptchaApi.java
@@ -46,7 +46,7 @@ public class ReCaptchaApi {
     private final String[] localVarAccepts = {"application/json"};
     private final String[] localVarContentTypes = {"application/json"};
     private String basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                     "api/identity/recovery/v0.9");
     private ApiClient apiClient;
 
@@ -75,7 +75,7 @@ public class ReCaptchaApi {
 
         if (isEndpointTenantAware && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
             basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                             "t/" + tenantDomain + "/api/identity/recovery/v0.9");
         }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/api/SecurityQuestionApi.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/api/SecurityQuestionApi.java
@@ -43,7 +43,7 @@ public class SecurityQuestionApi {
     private ApiClient apiClient;
 
     String basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                     "api/identity/recovery/v0.9");
 
     public SecurityQuestionApi() {
@@ -109,7 +109,7 @@ public class SecurityQuestionApi {
 
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
             basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                             "t/" + tenantDomain + "/api/identity/recovery/v0.9");
         }
 
@@ -197,7 +197,7 @@ public class SecurityQuestionApi {
 
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
             basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                             "t/" + tenantDomain + "/api/identity/recovery/v0.9");
         }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/api/SelfRegisterApi.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/api/SelfRegisterApi.java
@@ -47,7 +47,7 @@ import java.util.Map;
 public class SelfRegisterApi {
 
     String basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                     "api/identity/user/v1.0");
     private ApiClient apiClient;
 
@@ -89,7 +89,7 @@ public class SelfRegisterApi {
 
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
             basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                             "t/"+tenantDomain+"/api/identity/user/v1.0");
         }
         apiClient.setBasePath(basePath);
@@ -150,7 +150,7 @@ public class SelfRegisterApi {
 
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
             basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                             "t/"+tenantDomain+"/api/identity/user/v1.0");
         }
 
@@ -211,7 +211,7 @@ public class SelfRegisterApi {
 
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
             basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+                    .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                             "t/" + tenantDomain + "/api/identity/user/v1.0");
         }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/api/UsernameRecoveryApi.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/client/api/UsernameRecoveryApi.java
@@ -44,7 +44,7 @@ public class UsernameRecoveryApi {
   final String[] localVarAccepts = {"application/json"};
   final String[] localVarContentTypes = {"application/json"};
   String basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-          .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+          .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                   "api/identity/recovery/v0.9");
   private ApiClient apiClient;
 
@@ -93,7 +93,7 @@ public class UsernameRecoveryApi {
 
     if (isEndpointTenantAware && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
       basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-              .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+              .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                       "t/" + tenantDomain + API_PATH);
     }
 
@@ -160,7 +160,7 @@ public class UsernameRecoveryApi {
 
     if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
       basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-              .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+              .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                       "t/" + tenantDomain + API_PATH);
     }
 
@@ -210,7 +210,7 @@ public class UsernameRecoveryApi {
 
     if (isEndpointTenantAware && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
       basePath = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-              .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+              .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                       "t/" + tenantDomain + API_PATH);
     }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/serviceclient/PasswordRecoverySecurityQuestionClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/serviceclient/PasswordRecoverySecurityQuestionClient.java
@@ -17,10 +17,7 @@
  */
 package org.wso2.carbon.identity.mgt.endpoint.serviceclient;
 
-import org.apache.cxf.Bus;
-import org.apache.cxf.bus.spring.SpringBusFactory;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
-import org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean;
 import org.wso2.carbon.identity.mgt.beans.User;
 import org.wso2.carbon.identity.mgt.endpoint.IdentityManagementEndpointConstants;
 import org.wso2.carbon.identity.mgt.endpoint.IdentityManagementEndpointUtil;
@@ -31,8 +28,6 @@ import org.wso2.carbon.identity.mgt.endpoint.serviceclient.beans.VerifyAnswerReq
 import org.wso2.carbon.identity.mgt.endpoint.serviceclient.client.proxy.api.PasswordRecoverySecurityQuestion;
 
 import javax.ws.rs.core.Response;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -42,7 +37,7 @@ public class PasswordRecoverySecurityQuestionClient {
 
     StringBuilder builder = new StringBuilder();
     String url = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                     IdentityManagementEndpointConstants.UserInfoRecovery.REST_API_URL_DOMAIN);
 
     public Response initiateUserChallengeQuestion(User user) {

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/serviceclient/UserInfoRecoveryWithNotificationClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/serviceclient/UserInfoRecoveryWithNotificationClient.java
@@ -34,7 +34,7 @@ import javax.ws.rs.core.Response;
 public class UserInfoRecoveryWithNotificationClient {
 
     private static final String ENDPOINT_URL = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                     IdentityManagementEndpointConstants.UserInfoRecovery.REST_API_URL_DOMAIN);
 
     // Validate user and returns a new key through a notification

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/serviceclient/UserRegistrationClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/java/org/wso2/carbon/identity/mgt/endpoint/serviceclient/UserRegistrationClient.java
@@ -1,14 +1,12 @@
 package org.wso2.carbon.identity.mgt.endpoint.serviceclient;
 
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
-import org.wso2.carbon.identity.mgt.beans.User;
 import org.wso2.carbon.identity.mgt.endpoint.IdentityManagementEndpointConstants;
 import org.wso2.carbon.identity.mgt.endpoint.IdentityManagementEndpointUtil;
 import org.wso2.carbon.identity.mgt.endpoint.IdentityManagementServiceUtil;
 import org.wso2.carbon.identity.mgt.endpoint.serviceclient.beans.ConfirmSelfRegistrationRequest;
 import org.wso2.carbon.identity.mgt.endpoint.serviceclient.beans.SelfRegistrationRequest;
 import org.wso2.carbon.identity.mgt.endpoint.serviceclient.client.proxy.api.NotificationUsernameRecoveryResource;
-import org.wso2.carbon.identity.mgt.endpoint.serviceclient.client.proxy.api.PasswordRecoverySecurityQuestion;
 import org.wso2.carbon.identity.mgt.endpoint.serviceclient.client.proxy.api.SelfUserRegistrationResource;
 
 import javax.ws.rs.core.Response;
@@ -17,7 +15,7 @@ import java.util.Map;
 public class UserRegistrationClient {
     StringBuilder builder = new StringBuilder();
     String url = IdentityManagementServiceUtil.getInstance().getServiceContextURL()
-            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT_URL_DOMAIN,
+            .replace(IdentityManagementEndpointConstants.UserInfoRecovery.SERVICE_CONTEXT,
                      IdentityManagementEndpointConstants.UserInfoRecovery.REST_API_URL_DOMAIN);
 
     public Response getAllClaims(String tenantDomain) {


### PR DESCRIPTION

### Proposed changes in this pull request
Fix invalid backend URL is getting generated in the password recovery flow when hostname has 'services' string

### When should this PR be merged
Immediately

### Follow up actions
None
