### PR TITLE
Fix redirection fails after username recovery flow

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/password-recovery-notify.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/password-recovery-notify.jsp
@@ -117,7 +117,7 @@
         var infoModel = $("#infoModel");
         infoModel.modal("show");
         infoModel.on('hidden.bs.modal', function () {
-            location.href = "<%=Encode.forJavaScriptBlock(URLDecoder.decode(callback, "UTF-8"))%>";
+            location.href = "<%=Encode.forUri(callback)%>";
         })
     });
 </script>

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/password-reset-complete.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/password-reset-complete.jsp
@@ -133,7 +133,7 @@
         var infoModel = $("#infoModel");
         infoModel.modal("show");
         infoModel.on('hidden.bs.modal', function () {
-            location.href = "<%=Encode.forJavaScriptBlock(URLDecoder.decode(callback, "UTF-8"))%>";
+            location.href = "<%=Encode.forUri(callback)%>";
         })
     });
 </script>

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/self-registration-complete.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/self-registration-complete.jsp
@@ -88,7 +88,7 @@
         var infoModel = $("#infoModel");
         infoModel.modal("show");
         infoModel.on('hidden.bs.modal', function () {
-            location.href = "<%=Encode.forJavaScriptBlock(URLDecoder.decode(callback, "UTF-8"))%>";
+            location.href = "<%=Encode.forUri(callback)%>";
         })
     });
 </script>

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/username-recovery-complete.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/username-recovery-complete.jsp
@@ -63,7 +63,7 @@
         var infoModel = $("#infoModel");
         infoModel.modal("show");
         infoModel.on('hidden.bs.modal', function () {
-            location.href = "<%=Encode.forJavaScriptBlock(URLDecoder.decode(callback, "UTF-8"))%>";
+            location.href = "<%=Encode.forUri(callback)%>";
         })
     });
 </script>


### PR DESCRIPTION
This PR fixes wso2/product-is#4124

**Explanation**
There can be instances when the callback url contains encoded query params with # in the query param value. e.g.
`https://localhost:9443/authenticationendpoint/login.do?SigAlg=http://www.w3.org/2000/09/xmldsig#rsa-sha1`

In the recovery flow, in the current implementation we are url-decoding the callback before redirecting. In this scenario if one query param contained an encoded value of #, after decoding it will be considered as a URL fragment from browser. Therefore the flow will break.

As a solution to this we can avoid URL-decoding and use Encode.forUri to encode to handle callback URLs without encoded query params.

We cannot use Encode.forJavaScriptBlock since it would produce a URL similar to following.

`https:\/\/localhost:9443\/authenticationendpoint\/login.do?SigAlg=http:\/\/www.w3.org\/2000\/09\/xmldsig#rsa\-sha1\x26Signature=K8dHui+jsFgD6gJbedX061864eGo3Nk7DT\/WePrHqynObzX4Bkgd2Gw3hqaT9LI\/rqxtM2sIuC4EHZrb63CMq146PbXnp+8juIaPVLQ\/OL\/vTgpwV+6Q0tGyCjxLsUtr8qXXO++tksipcdgG9PG5jxE2oSGNCYyPt0Dy67w9PjHQyoR\/gwIj9rMitOBXLy1nvKMptLr5aui5lpKct1gOkiSD0QjZD7NT8RV4Xs5t4nS3l5WdGEBrjs4zpMAO4ud232sN44NVYayfI\/4Essjv4kK87\/7ii4pnngbvdDbNGZ7GaRBU4UwhVwIF2VoaBpneT0cHn5SJFZAOMoRpxnpbWA==\x26commonAuthCallerPath=\/samlsso\x26forceAuth=false\x26passiveAuth=false\x26tenantDomain=carbon.super\x26sessionDataKey=2f6e732d\-78b2\-4f68\-ad47\-e56a2a1ef7fd\x26relyingParty=travelocity.com\x26type=samlsso\x26sp=travelocity\x26isSaaSApp=false\x26authenticators=BasicAuthenticator:LOCAL`

Encode.forUri, will only encode the symbols that is not allowed in a URL.