### PR TITLE
Introduce a property to whitelist host names to remove query params from the redirect url

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/builder/FileBasedConfigurationBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/builder/FileBasedConfigurationBuilder.java
@@ -100,6 +100,7 @@ public class FileBasedConfigurationBuilder {
     private boolean authEndpointRedirectParamsConfigAvailable;
     private String authEndpointRedirectParamsAction;
     private List<String> authEndpointRedirectParams = new ArrayList<>();
+    private List<String> filteringEnabledHostNames = new ArrayList<>();
 
     public static FileBasedConfigurationBuilder getInstance() {
         if (instance == null) {
@@ -188,6 +189,9 @@ public class FileBasedConfigurationBuilder {
 
             //########### Read Maximum Login Attempt Count ###########
             readMaximumLoginAttemptCount(rootElement);
+
+            // ########### Read White Listed Host Names ###########
+            readFilteringEnabledHostNames(rootElement);
 
             // ########### Read Authentication Endpoint Query Params ###########
             readAuthenticationEndpointQueryParams(rootElement);
@@ -401,6 +405,23 @@ public class FileBasedConfigurationBuilder {
             }
         }
         return true;
+    }
+
+    private void readFilteringEnabledHostNames(OMElement documentElement){
+        OMElement filteringEnabledHostNamesElem = documentElement.getFirstChildWithName(IdentityApplicationManagementUtil.
+                getQNameWithIdentityApplicationNS(FrameworkConstants.Config.QNAME_FILTERING_ENABLED_HOST_NAMES));
+        if (filteringEnabledHostNamesElem != null) {
+            Iterator<OMElement> hostNames = filteringEnabledHostNamesElem.getChildrenWithName(IdentityApplicationManagementUtil.
+                    getQNameWithIdentityApplicationNS(FrameworkConstants.Config.ELEM_HOST_NAME));
+            if (hostNames != null) {
+                while (hostNames.hasNext()) {
+                    OMElement hostNameElement = hostNames.next();
+                    if (hostNameElement != null) {
+                        filteringEnabledHostNames.add(hostNameElement.getText());
+                    }
+                }
+            }
+        }
     }
 
     private void readAuthenticationEndpointQueryParams(OMElement documentElement) {
@@ -1035,5 +1056,10 @@ public class FileBasedConfigurationBuilder {
     public List<String> getAuthEndpointRedirectParams() {
 
         return authEndpointRedirectParams;
+    }
+
+    public List<String> getFilteringEnabledHostNames() {
+
+        return filteringEnabledHostNames;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -135,6 +135,7 @@ public abstract class FrameworkConstants {
         public static final String ELEM_AUTHENTICATOR = "Authenticator";
         public static final String ELEM_AUTHENTICATOR_CONFIG = "AuthenticatorConfig";
         public static final String ELEM_AUTH_ENDPOINT_QUERY_PARAM = "AuthenticationEndpointQueryParam";
+        public static final String ELEM_HOST_NAME = "HostName";
         public static final String ELEM_AUTHENTICATOR_NAME_MAPPING = "AuthenticatorNameMapping";
         public static final String ELEM_IDP_CONFIG = "IdPConfig";
         public static final String ELEM_PARAMETER = "Parameter";
@@ -181,6 +182,7 @@ public abstract class FrameworkConstants {
         public static final String QNAME_SEQUENCES = "Sequences";
         public static final String QNAME_AUTH_ENDPOINT_QUERY_PARAMS = "AuthenticationEndpointQueryParams";
         public static final String QNAME_AUTH_ENDPOINT_REDIRECT_PARAMS = "AuthenticationEndpointRedirectParams";
+        public static final String QNAME_FILTERING_ENABLED_HOST_NAMES = "FilteringEnabledHostNames";
         /**
          * Configuration name for the collection of urls for receiving tenant list
          */

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.application.authentication.framework.util;
 
 import jdk.nashorn.api.scripting.ScriptObjectMirror;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
@@ -1293,6 +1294,13 @@ public class FrameworkUtils {
             log.warn("Unable to filter redirect params for url." + redirectUrl, e);
             return redirectUrl;
         }
+
+        // If the host name is not white listed then the query params will not be removed from the redirect url.
+        List<String> filteringEnabledHosts = FileBasedConfigurationBuilder.getInstance().getFilteringEnabledHostNames();
+        if (CollectionUtils.isNotEmpty(filteringEnabledHosts) && !filteringEnabledHosts.contains(uriBuilder.getHost())) {
+            return redirectUrl;
+        }
+
         List<NameValuePair> queryParamsList = uriBuilder.getQueryParams();
 
         if (action != null


### PR DESCRIPTION
### Proposed changes in this pull request
Introduce a property to whitelist host names to remove query params from the redirect url.
Inside application_authentication.xml file a new property is introduced as FilteringEnabledHostNames with the child element HostName. Multiple HostNames can be configured.

The query param filtering will be applied only for the  configured host names. For federated scenarios the federated host names should not configured as a HostName. So for federated scenarios it wont exclude the query params from the redirect url and the flow will happen smoothly.

### When should this PR be merged
Immediately


### Follow up actions
None
