### PR TITLE
Add JWKS CacheConfig to identity.xml

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -744,6 +744,7 @@
             <Cache name="AuthenticationResultCache"  enable="true" timeout="300" capacity="5000" isDistributed="false"/>
             <Cache name="AppInfoCache"               enable="true"  timeout="900" capacity="5000" isDistributed="false"/>
             <Cache name="AuthorizationGrantCache"    enable="true" timeout="300" capacity="5000" isDistributed="false"/>
+            <Cache name="JWKSCache"                  enable="true" timeout="300" capacity="5000" isDistributed="false"/>
             <Cache name="OAuthCache"                 enable="true" timeout="300" capacity="5000" isDistributed="false"/>
             <Cache name="OAuthScopeCache"            enable="true"  timeout="300" capacity="5000" isDistributed="false"/>
             <Cache name="OAuthSessionDataCache"      enable="true" timeout="300" capacity="5000" isDistributed="false"/>


### PR DESCRIPTION
### Proposed changes in this pull request

This PR is to fix https://github.com/wso2/product-is/issues/4122

JWKS cache is extended by the BaseCache class and the invalidation time for the JWKS Cache can be set through "JWKSCache" CacheConfig entry in the identity.xml

` <Cache name="JWKSCache"                  enable="true" timeout="300" capacity="5000" isDistributed="false"/>
`
### When should this PR be merged

This should be merged with https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/999

