### PR TITLE
Fix authenticated subject value in associated user flow

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthAssociationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthAssociationHandler.java
@@ -166,7 +166,7 @@ public class PostAuthAssociationHandler extends AbstractPostAuthnHandler {
         String tenantDomain = MultitenantUtils.getTenantDomain(associatedLocalUserName);
         Map<String, Object> authProperties = context.getProperties();
 
-        if (MapUtils.isNotEmpty(authProperties)) {
+        if (authProperties == null) {
             authProperties = new HashMap<>();
             context.setProperties(authProperties);
         }


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves https://github.com/wso2/product-is/issues/4207

Creating new context properties map cause all the information already set in the authentication context. Which caused PostAuthenticatedSubjectIdentifierHandler to be skipped..

This caused the issue https://github.com/wso2/product-is/issues/4207 & it could cause for many more  issues which depends on the properties on the authentication context.