### PR TITLE
Add config property for SCIM2 filtering enhancements

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -571,6 +571,7 @@
         <!--UserEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/scim2/Users</UserEPUrl-->
         <!--GroupEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/scim2/Groups</GroupEPUrl-->
         <!--<ComplexMultiValuedAttributeSupportEnabled>true</ComplexMultiValuedAttributeSupportEnabled>-->
+        <!--<EnableFilteringEnhancements>true</EnableFilteringEnhancements>-->
     </SCIM2>
 
     <!--Recovery>


### PR DESCRIPTION
Part of fix for https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/123

`<EnableFilteringEnhancements>` property introduced for applying filtering enhancements for SCIM2 filter results. This makes sure that Eq should strictly check for the String match (in this case cross user store search should not be performed). This config also enforces consistency on the filtered attribute formats in the response when filtering is done via different endpoints. e.g. Users and Groups endpoints.
     