### PR TITLE
Improve AbstractEventHandler to support subscription properties. 

### DIFF
--- a/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
@@ -87,6 +87,7 @@ public class IdentityEventConstants {
         public static final String POST_SEND_RECOVERY_NOTIFICATION = "POST_SEND_RECOVERY_NOTIFICATION";
 
         public static final String TRIGGER_NOTIFICATION = "TRIGGER_NOTIFICATION";
+        public static final String TRIGGER_SMS_NOTIFICATION = "TRIGGER_SMS_NOTIFICATION";
 
     }
 

--- a/components/identity-event/org.wso2.carbon.identity.event/src/test/java/org.wso2.carbon.identity.event/handler/AbstractEventHandlerTest.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/test/java/org.wso2.carbon.identity.event/handler/AbstractEventHandlerTest.java
@@ -84,6 +84,7 @@ public class AbstractEventHandlerTest extends IdentityBaseTest {
         IdentityEventMessageContext messageContext = new IdentityEventMessageContext(event);
 
         TestEventHandler testEventHandler = new TestEventHandler();
+        testEventHandler.init(moduleConfiguration);
         boolean canHandle = testEventHandler.canHandle(messageContext);
         Assert.assertFalse(canHandle);
 
@@ -97,6 +98,7 @@ public class AbstractEventHandlerTest extends IdentityBaseTest {
 
         subscriptionList.add(new Subscription("eventName", new Properties()));
         TestEventHandler testEventHandler = new TestEventHandler();
+        testEventHandler.init(moduleConfiguration);
         boolean isAssociationAsync = testEventHandler.isAssociationAsync("unknownEvent");
 
         Assert.assertFalse(isAssociationAsync);


### PR DESCRIPTION
### Proposed changes in this pull request

Now it is configurable to set the different properties and claims in identity-event.properties files in order to read from the notification handler and it is possible to configure stream id and the notification template as well per subscriptions.

default.notification.sender.subscription.1=TRIGGER_NOTIFICATION
default.notification.sender.subscription.2=TRIGGER_SMS_NOTIFICATION
#you can define stream id here. 'stream' is key word
default.notification.sender.subscription.TRIGGER_SMS_NOTIFICATION.stream=id_gov_sms_notify_stream:1.0.0
#you can define claim uri, then handler will try to read this claim from the current user store and send as the given attribute name 'sample_claim' to the event stream. 'claim' is key word
default.notification.sender.subscription.TRIGGER_SMS_NOTIFICATION.claim.sample_claim=http://wso2.identity/sample/claim
#you can define just a property and value to pass to the event stream.
default.notification.sender.subscription.TRIGGER_SMS_NOTIFICATION.testcustomattribute=testattributevalue
default.notification.sender.subscription.3=POST_ADD_ROLE
default.notification.sender.subscription.POST_ADD_ROLE.stream=id_gov_jms_notify_stream:1.0.0
#you can define the notification template name. 'notification_template' is key word
default.notification.sender.subscription.POST_ADD_ROLE.notification_template=ADDROLETEMPLATE
