### PR TITLE
Add uma grant as a supported grant by default.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -266,6 +266,11 @@
                 <GrantTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.grant.jwt.JWTBearerGrantHandler</GrantTypeHandlerImplClass>
                 <GrantTypeValidatorImplClass>org.wso2.carbon.identity.oauth2.grant.jwt.JWTGrantValidator</GrantTypeValidatorImplClass>
             </SupportedGrantType>
+            <SupportedGrantType>
+                <GrantTypeName>urn:ietf:params:oauth:grant-type:uma-ticket</GrantTypeName>
+                <GrantTypeHandlerImplClass>org.wso2.carbon.identity.oauth.uma.grant.UMA2GrantHandler</GrantTypeHandlerImplClass>
+                <GrantTypeValidatorImplClass>org.wso2.carbon.identity.oauth.uma.grant.GrantValidator</GrantTypeValidatorImplClass>
+            </SupportedGrantType>
         </SupportedGrantTypes>
 
         <!--

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -266,6 +266,7 @@
                 <GrantTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.grant.jwt.JWTBearerGrantHandler</GrantTypeHandlerImplClass>
                 <GrantTypeValidatorImplClass>org.wso2.carbon.identity.oauth2.grant.jwt.JWTGrantValidator</GrantTypeValidatorImplClass>
             </SupportedGrantType>
+            <!-- Supported versions: IS 5.7.0 onwards.-->
             <SupportedGrantType>
                 <GrantTypeName>urn:ietf:params:oauth:grant-type:uma-ticket</GrantTypeName>
                 <GrantTypeHandlerImplClass>org.wso2.carbon.identity.oauth.uma.grant.UMA2GrantHandler</GrantTypeHandlerImplClass>


### PR DESCRIPTION
### Proposed changes in this pull request
Added following to `identity.xml` under `<SupportedGrantTypes>` tag

```
<SupportedGrantType>
  <GrantTypeName>urn:ietf:params:oauth:grant-type:uma-ticket</GrantTypeName> 
  <GrantTypeHandlerImplClass>org.wso2.carbon.identity.oauth.uma.grant.UMA2GrantHandler</GrantTypeHandlerImplClass>
  <GrantTypeValidatorImplClass>org.wso2.carbon.identity.oauth.uma.grant.GrantValidator</GrantTypeValidatorImplClass>
</SupportedGrantType>
```
Fixed Issue - https://github.com/wso2/product-is/issues/4233