### PR TITLE
Improve the SP and IDP DAO layer

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -184,12 +184,20 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl {
             prepStmt = dbConnection.prepareStatement(sqlStmt);
 
             for (ServiceProviderProperty property : properties) {
-                prepStmt.setInt(1, spId);
-                prepStmt.setString(2, property.getName());
-                prepStmt.setString(3, property.getValue());
-                prepStmt.setString(4, property.getDisplayName());
-                prepStmt.setInt(5, tenantId);
-                prepStmt.addBatch();
+                if (StringUtils.isNotBlank(property.getValue())) {
+                    prepStmt.setInt(1, spId);
+                    prepStmt.setString(2, property.getName());
+                    prepStmt.setString(3, property.getValue());
+                    prepStmt.setString(4, property.getDisplayName());
+                    prepStmt.setInt(5, tenantId);
+                    prepStmt.addBatch();
+                } else {
+                    if (log.isDebugEnabled()) {
+                        String msg = "SP property '%s' of Sp with id: %d of tenantId: %d is empty or null. " +
+                                "Not adding the property to 'SP_METADATA' table.";
+                        log.debug(String.format(msg, property.getName(), spId, tenantId));
+                    }
+                }
             }
             prepStmt.executeBatch();
 
@@ -216,18 +224,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl {
             prepStmt.setInt(1, spId);
             prepStmt.executeUpdate();
 
-            prepStmt = dbConnection.prepareStatement(ApplicationMgtDBQueries.ADD_SP_METADATA);
-
-            for (ServiceProviderProperty property : properties) {
-                prepStmt.setInt(1, spId);
-                prepStmt.setString(2, property.getName());
-                prepStmt.setString(3, property.getValue());
-                prepStmt.setString(4, property.getDisplayName());
-                prepStmt.setInt(5, tenantId);
-                prepStmt.addBatch();
-            }
-            prepStmt.executeBatch();
-
+            addServiceProviderProperties(dbConnection, spId, properties, tenantId);
         } finally {
             IdentityApplicationManagementUtil.closeStatement(prepStmt);
         }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -203,12 +203,20 @@ public class IdPManagementDAO {
             prepStmt = dbConnection.prepareStatement(sqlStmt);
 
             for (IdentityProviderProperty property : properties) {
-                prepStmt.setInt(1, idpId);
-                prepStmt.setString(2, property.getName());
-                prepStmt.setString(3, property.getValue());
-                prepStmt.setString(4, property.getDisplayName());
-                prepStmt.setInt(5, tenantId);
-                prepStmt.addBatch();
+                if (StringUtils.isNotBlank(property.getValue())) {
+                    prepStmt.setInt(1, idpId);
+                    prepStmt.setString(2, property.getName());
+                    prepStmt.setString(3, property.getValue());
+                    prepStmt.setString(4, property.getDisplayName());
+                    prepStmt.setInt(5, tenantId);
+                    prepStmt.addBatch();
+                } else {
+                    if (log.isDebugEnabled()) {
+                        String msg = "IDP property '%s' of IDP with id:%d of tenantId:%d is empty or null. " +
+                                "Not adding the property to 'IDP_METADATA' table.";
+                        log.debug(String.format(msg, property.getName(), idpId, tenantId));
+                    }
+                }
             }
             prepStmt.executeBatch();
 
@@ -235,18 +243,7 @@ public class IdPManagementDAO {
             prepStmt.setInt(1, idpId);
             prepStmt.executeUpdate();
 
-            prepStmt = dbConnection.prepareStatement(IdPManagementConstants.SQLQueries.ADD_IDP_METADATA);
-
-            for (IdentityProviderProperty property : properties) {
-                prepStmt.setInt(1, idpId);
-                prepStmt.setString(2, property.getName());
-                prepStmt.setString(3, property.getValue());
-                prepStmt.setString(4, property.getDisplayName());
-                prepStmt.setInt(5, tenantId);
-                prepStmt.addBatch();
-            }
-            prepStmt.executeBatch();
-
+            addIdentityProviderProperties(dbConnection, idpId, properties, tenantId);
         } finally {
             IdentityDatabaseUtil.closeStatement(prepStmt);
         }


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/4344

Improve the DAO layers to avoid persisting empty or null properties which result in DB errors in Oracle (ORA-01400). Oracle DB treats empty string as NULL which result in DB errors since the property value column does not accept NULL values.