### PR TITLE
Add additional application management service APIs required for the fix of DCR delete behaviour

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
@@ -348,5 +348,21 @@ public abstract class ApplicationManagementService {
     public abstract List<SpTemplate> getAllApplicationTemplateInfo(String tenantDomain)
             throws IdentityApplicationManagementException;
 
+    /**
+     * Delete an OAuth application.
+     *
+     * @param clientID of the OAuth application
+     * @throws IdentityApplicationManagementException
+     */
+    public abstract void deleteOAuthApplication(String clientID) throws IdentityApplicationManagementException;
+
+    /**
+     * Read the default service provider from the service provider file configuration
+     *
+     * @return the default service provider
+     * @throws IdentityApplicationManagementException
+     */
+    public abstract ServiceProvider getDefaultServiceProvider() throws IdentityApplicationManagementException;
+
 }
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
@@ -349,15 +349,7 @@ public abstract class ApplicationManagementService {
             throws IdentityApplicationManagementException;
 
     /**
-     * Delete an OAuth application.
-     *
-     * @param clientID of the OAuth application
-     * @throws IdentityApplicationManagementException
-     */
-    public abstract void deleteOAuthApplication(String clientID) throws IdentityApplicationManagementException;
-
-    /**
-     * Read the default service provider from the service provider file configuration
+     * Read the default service provider from the service provider file configuration.
      *
      * @return the default service provider
      * @throws IdentityApplicationManagementException

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -1239,6 +1239,21 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
         return doGetAllApplicationTemplateInfo(tenantDomain);
     }
 
+    @Override
+    public void deleteOAuthApplication(String clientID) throws IdentityApplicationManagementException {
+
+        OAuthApplicationDAO oathDAO = ApplicationMgtSystemConfig.getInstance().getOAuthOIDCClientDAO();
+        oathDAO.removeOAuthApplication(clientID);
+    }
+
+    @Override
+    public ServiceProvider getDefaultServiceProvider() throws IdentityApplicationManagementException {
+
+        return ApplicationManagementServiceComponent.getFileBasedSPs().get(IdentityApplicationConstants
+                .DEFAULT_SP_CONFIG);
+    }
+
+
     /**
      * Add SP template to database and cache.
      *

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -1240,19 +1240,11 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
     }
 
     @Override
-    public void deleteOAuthApplication(String clientID) throws IdentityApplicationManagementException {
-
-        OAuthApplicationDAO oathDAO = ApplicationMgtSystemConfig.getInstance().getOAuthOIDCClientDAO();
-        oathDAO.removeOAuthApplication(clientID);
-    }
-
-    @Override
     public ServiceProvider getDefaultServiceProvider() throws IdentityApplicationManagementException {
 
         return ApplicationManagementServiceComponent.getFileBasedSPs().get(IdentityApplicationConstants
                 .DEFAULT_SP_CONFIG);
     }
-
 
     /**
      * Add SP template to database and cache.


### PR DESCRIPTION
This PR adds required APIs to delete OAuth application only when there is no associated SP and a method to get the default SP from file base SP configuration during DCRM delete