### PR TITLE
Fix wso2/product-is#4487: [5.3.0][Bug] Error Logs are not getting printed.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -564,8 +564,12 @@ public class DefaultStepHandler implements StepHandler {
             handleFailedAuthentication(request, response, context, authenticatorConfig, e.getUser());
         } catch (AuthenticationFailedException e) {
             IdentityErrorMsgContext errorContext = IdentityUtil.getIdentityErrorMsg();
-            if (errorContext != null && !IdentityCoreConstants.ADMIN_FORCED_USER_PASSWORD_RESET_VIA_OTP_ERROR_CODE.
-                    equals(errorContext.getErrorCode())) {
+            if (errorContext != null) {
+                if (!IdentityCoreConstants.ADMIN_FORCED_USER_PASSWORD_RESET_VIA_OTP_ERROR_CODE.
+                        equals(errorContext.getErrorCode())) {
+                    log.error("Authentication failed exception!", e);
+                }
+            } else {
                 log.error("Authentication failed exception!", e);
             }
             handleFailedAuthentication(request, response, context, authenticatorConfig, e.getUser());


### PR DESCRIPTION
This contains a fix for https://github.com/wso2/product-is/issues/4487

### Proposed changes in this pull request

- This PR will log the AuthenticationFailedException when the errorContext is null. 
- This will also cater the fix with the PR https://github.com/wso2-support/carbon-identity-framework/pull/451

