### PR TITLE
fix server start up error in template-mgt.war deployment

### DIFF
--- a/components/template-mgt/org.wso2.carbon.identity.template.mgt.endpoint/src/main/webapp/META-INF/webapp-classloading.xml
+++ b/components/template-mgt/org.wso2.carbon.identity.template.mgt.endpoint/src/main/webapp/META-INF/webapp-classloading.xml
@@ -33,5 +33,5 @@
 	Tomcat environment is the default and every webapps gets it even if they didn't specify it.
 	e.g. If a webapps requires CXF, they will get both Tomcat and CXF.
      -->
-    <Environments>CXF,Carbon</Environments>
+    <Environments>Carbon</Environments>
 </Classloading>


### PR DESCRIPTION
### Purpose

This PR fixes the server start up error in template-mgt.war deployment caused due to tomcat upgrade. (to 7.0.93) 