### PR TITLE
Fix SP creation fails when the base64 encoded value of SAML issuer contains slash

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAO.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAO.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.core.KeyStoreCertificateRetriever;
 import org.wso2.carbon.identity.core.model.SAMLSSOServiceProviderDO;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.registry.core.Collection;
 import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
@@ -43,6 +44,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProviderDO> {
 
@@ -472,15 +475,16 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
     }
 
     public SAMLSSOServiceProviderDO[] getServiceProviders() throws IdentityException {
-        SAMLSSOServiceProviderDO[] serviceProvidersList = new SAMLSSOServiceProviderDO[0];
+        List<SAMLSSOServiceProviderDO> serviceProvidersList = new ArrayList<>();
         try {
             if (registry.resourceExists(IdentityRegistryResources.SAML_SSO_SERVICE_PROVIDERS)) {
-                String[] providers = (String[]) registry.get(
-                        IdentityRegistryResources.SAML_SSO_SERVICE_PROVIDERS).getContent();
-                if (providers != null) {
-                    serviceProvidersList = new SAMLSSOServiceProviderDO[providers.length];
-                    for (int i = 0; i < providers.length; i++) {
-                        serviceProvidersList[i] = resourceToObject(registry.get(providers[i]));
+                Resource samlSSOServiceProvidersResource = registry.get(IdentityRegistryResources
+                        .SAML_SSO_SERVICE_PROVIDERS);
+                if (samlSSOServiceProvidersResource instanceof Collection) {
+                    Collection samlSSOServiceProvidersCollection = (Collection) samlSSOServiceProvidersResource;
+                    String[] resources = samlSSOServiceProvidersCollection.getChildren();
+                    for (String resource : resources) {
+                        getChildResources(resource, serviceProvidersList);
                     }
                 }
             }
@@ -488,7 +492,7 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
             log.error("Error reading Service Providers from Registry", e);
             throw IdentityException.error("Error reading Service Providers from Registry", e);
         }
-        return serviceProvidersList;
+        return serviceProvidersList.toArray(new SAMLSSOServiceProviderDO[serviceProvidersList.size()]);
     }
 
     /**
@@ -735,6 +739,30 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
             }
         } catch (RegistryException ex) {
             throw new IdentityException("Error occurred while trying to commit or rollback the registry operation.", ex);
+        }
+    }
+
+    /**
+     * This helps to find resources in a recursive manner.
+     *
+     * @param parentResource      parent resource Name.
+     * @param serviceProviderList child resource list.
+     * @throws RegistryException
+     */
+    private void getChildResources(String parentResource, List<SAMLSSOServiceProviderDO>
+            serviceProviderList) throws RegistryException {
+
+        if (registry.resourceExists(parentResource)) {
+            Resource resource = registry.get(parentResource);
+            if (resource instanceof Collection) {
+                Collection collection = (Collection) resource;
+                String[] resources = collection.getChildren();
+                for (String res : resources) {
+                    getChildResources(res, serviceProviderList);
+                }
+            } else {
+                serviceProviderList.add(resourceToObject(resource));
+            }
         }
     }
 }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAOTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAOTest.java
@@ -375,7 +375,7 @@ public class SAMLSSOServiceProviderDAOTest extends PowerMockTestCase {
         when(mockRegistry.resourceExists(IdentityRegistryResources.SAML_SSO_SERVICE_PROVIDERS)).thenReturn(true);
         Resource collection = new CollectionImpl();
         String[] paths = new String[]{
-                getPath("DummyIssuer"), getPath("DummyAdvIssuer")
+                getPath("DummyIssuer"), getPath("DummyAdvIssuer"), getPath("https://example.com/url?abc")
         };
         Properties dummyResourceProperties = new Properties();
         dummyResourceProperties.putAll(dummyBasicProperties);
@@ -386,13 +386,22 @@ public class SAMLSSOServiceProviderDAOTest extends PowerMockTestCase {
         dummyAdvProperties.putAll((Map<?, ?>) dummyAdvProperties);
         Resource dummyAdvResource = new ResourceImpl();
         dummyAdvResource.setProperties(dummyAdvProperties);
-        Resource[] spResources = new Resource[]{dummyResource, dummyAdvResource};
+
+        Properties urlBasedIssuerResourceProperties = new Properties();
+        urlBasedIssuerResourceProperties.putAll((Map<?, ?>) urlBasedIssuerResourceProperties);
+        Resource urlBasedIssuerResource = new ResourceImpl();
+        urlBasedIssuerResource.setProperties(urlBasedIssuerResourceProperties);
+        Resource[] spResources = new Resource[]{dummyResource, dummyAdvResource, urlBasedIssuerResource};
         collection.setContent(paths);
         when(mockRegistry.get(IdentityRegistryResources.SAML_SSO_SERVICE_PROVIDERS)).thenReturn(collection);
         when(mockRegistry.get(paths[0])).thenReturn(spResources[0]);
         when(mockRegistry.get(paths[1])).thenReturn(spResources[1]);
+        when(mockRegistry.get(paths[2])).thenReturn(spResources[2]);
+        when(mockRegistry.resourceExists(paths[0])).thenReturn(true);
+        when(mockRegistry.resourceExists(paths[1])).thenReturn(true);
+        when(mockRegistry.resourceExists(paths[2])).thenReturn(true);
         SAMLSSOServiceProviderDO[] serviceProviders = objUnderTest.getServiceProviders();
-        assertEquals(serviceProviders.length, 2, "Should have returned 2 service providers.");
+        assertEquals(serviceProviders.length, 3, "Should have returned 3 service providers.");
     }
 
     @Test


### PR DESCRIPTION
Fixes wso2/product-is#4554

### Issue

When we register a SAML SSO app under a service provider, its details are stored in the registry. The registry location path is built as follows.
path = "_system/config/repository/identity/SAMLSSO/" + base64_encode(SAML_ISSUER_NAME)

For example, if we use "https://example.com/url?abc" as the issuer name, its base64 encoded value will be "aHR0cHM6Ly9leGFtcGxlLmNvbS91cmw/YWJj" and the constructed path will be as follows.
_system/config/repository/identity/SAMLSSO/aHR0cHM6Ly9leGFtcGxlLmNvbS91cmw/YWJj

The slash "/" has caused to create another sub-resource in the registry and put the SAML SSO configs there.

In getServiceProviders() method, we list all the registry resources in the reg path "_system/config/repository/identity/SAMLSSO" and tries to get properties for each SP from the resource. But in this case, we have SP properties in a sub resource. This is because SP resources (YWJj) was created under a collection (aHR0cHM6Ly9leGFtcGxlLmNvbS91cmw) due to the slash in the resource path. Due to that all the properties in the SAMLSSOServiceProviderDO will be set as NULL. This results in an NPE.

### Solution

In this fix, I have introduced a method to recursively go through each collection if available in reg path "_system/config/repository/identity/SAMLSSO" and identify all the available SP resources.