### PR TITLE
Issue4804: Adhereing to SPlevelConfig in introspection endpoint by default

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -328,19 +328,18 @@
         </EnableAssertions>
 
 
-        <!-- This should be true if subject identifier in the token validation response needs to adhere to the
-        following SP configuration.
+        <!-- This value should be false if subject identifier in the token validation response needs to be set as the
+             fully qualified username.
+         This value is true if subject identifier needs to adhere to the following SP configuration.
 
         - Use tenant domain in local subject identifier.
         - Use user store domain in local subject identifier.
 
-        if the value is false, subject identifier will be set as the fully qualified username.
+        Default value : true
 
-        Default value : false
-
-        Supported versions: IS 5.4.0 beta onwards
+        Supported versions: IS 5.8.0 beta onwards
         -->
-        <!--<BuildSubjectIdentifierFromSPConfig>true</BuildSubjectIdentifierFromSPConfig>-->
+        <!--<BuildSubjectIdentifierFromSPConfig>false</BuildSubjectIdentifierFromSPConfig>-->
 
         <!-- This should be set to true when using multiple user stores and keys
             should saved into different tables according to the user store. By default


### PR DESCRIPTION

### Proposed changes in this pull request

This fix is to solve the issue raised in the https://github.com/wso2/product-is/issues/4804.

- Before this fix `<BuildSubjectIdentifierFromSPConfig>` is by default enabled as false. So response in introspection endpoint is not adhering to the SP level configurations such as
1. Use tenant domain in local subject identifier.
2.  Use user store domain in local subject identifier.

- So subject value in id_token and username in introspection endpoint have different values. 

- By this fix, response from introspection endpoint adheres to SP level configurations by default. 

- But if we want to have username from introspection endpoint as a fully qualified username ( that includes user store domain and tenant domain) by default, then `<BuildSubjectIdentifierFromSPConfig>` configuration should be configured as false.

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.