### PR TITLE
The SAML SSO URL in the resident IDP editable via URL

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-finish-local-ajaxprocessor.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-finish-local-ajaxprocessor.jsp
@@ -100,6 +100,10 @@
         property.setValue(request.getParameter("samlSSOUrl"));
         propertyList.add(property);
         property = new Property();
+        property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.LOGOUT_REQ_URL);
+        property.setValue(request.getParameter("samlSLOUrl"));
+        propertyList.add(property);
+        property = new Property();
         property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.SAML_METADATA_SIGNING_ENABLED);
         String samlMetadataSigningEnabled = "false";
         if (StringUtils.containsIgnoreCase(request.getParameter("samlMetadataSigningEnabled"), "on")) {

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-finish-local-ajaxprocessor.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-finish-local-ajaxprocessor.jsp
@@ -96,6 +96,10 @@
         property.setValue(request.getParameter("samlMetadataValidityPeriod"));
         propertyList.add(property);
         property = new Property();
+        property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.SSO_URL);
+        property.setValue(request.getParameter("samlSSOUrl"));
+        propertyList.add(property);
+        property = new Property();
         property.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.SAML_METADATA_SIGNING_ENABLED);
         String samlMetadataSigningEnabled = "false";
         if (StringUtils.containsIgnoreCase(request.getParameter("samlMetadataSigningEnabled"), "on")) {

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-local.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-local.jsp
@@ -276,6 +276,15 @@ function idpMgtCancel(){
         if (!isSamlMetadataValidityPeriodValidated) {
             return false;
         }
+        var isSSOUrlValidated = doValidateInput(document.getElementById('samlSSOUrl'), "Please enter a valid SSO URL");
+        var SSOUrl = $("#samlSSOUrl").val();
+        if (!isSSOUrlValidated) {
+            return false;
+        }
+        if (SSOUrl == null || SSOUrl.trim().length == 0) {
+            CARBON.showWarningDialog("Please enter a valid SSO URL");
+            return false;
+        }
         return true;
     }
     function onClickAddDestinationUrl() {
@@ -546,7 +555,9 @@ function removeDefaultAuthSeq() {
                         <!--End the if conditions from here. For the destination url table-->
                         <tr>
                             <td class="leftCol-med labelField"><fmt:message key='sso.url'/>:</td>
-                            <td><%=Encode.forHtmlContent(samlSSOUrl)%></td>
+                            <td><input id="samlSSOUrl" name="samlSSOUrl"
+                                       type="text" value="<%=Encode.forHtmlContent(samlSSOUrl)%>"
+                                       white-list-patterns="http-url https-url"/></td>
                         </tr>
                         <tr>
                             <td class="leftCol-med labelField"><fmt:message key='logout.url'/>:</td>

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-local.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-local.jsp
@@ -29,7 +29,6 @@
 <%@ page import="org.wso2.carbon.identity.governance.stub.bean.ConnectorConfig" %>
 <%@ page import="org.wso2.carbon.idp.mgt.ui.client.IdentityGovernanceAdminClient" %>
 <%@ page import="org.wso2.carbon.idp.mgt.ui.util.IdPManagementUIUtil" %>
-<%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
 <%@ page import="org.wso2.carbon.utils.ServerConstants" %>
 <%@ page import="java.util.ArrayList" %>
@@ -277,12 +276,11 @@ function idpMgtCancel(){
             return false;
         }
         var isSSOUrlValidated = doValidateInput(document.getElementById('samlSSOUrl'), "Please enter a valid SSO URL");
-        var SSOUrl = $("#samlSSOUrl").val();
         if (!isSSOUrlValidated) {
             return false;
         }
-        if (SSOUrl == null || SSOUrl.trim().length == 0) {
-            CARBON.showWarningDialog("Please enter a valid SSO URL");
+        var issamlSLOUrlValidated = doValidateInput(document.getElementById('samlSLOUrl'), "Please enter a valid Logout Url");
+        if (!issamlSLOUrlValidated) {
             return false;
         }
         return true;
@@ -561,7 +559,9 @@ function removeDefaultAuthSeq() {
                         </tr>
                         <tr>
                             <td class="leftCol-med labelField"><fmt:message key='logout.url'/>:</td>
-                            <td><%=Encode.forHtmlContent(samlSLOUrl)%></td>
+                            <td><input id="samlSLOUrl" name="samlSLOUrl"
+                                       type="text" value="<%=Encode.forHtmlContent(samlSLOUrl)%>"
+                                       white-list-patterns="http-url https-url"/></td>
                         </tr>
                         <tr style="display:none;">
                             <td class="leftCol-med labelField"><fmt:message key='ecp.url'/>:</td>

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -137,8 +137,6 @@ public class IdentityProviderManager implements IdpManager {
         String scim2GroupsEndpoint;
 
         openIdUrl = IdentityUtil.getProperty(IdentityConstants.ServerConfig.OPENID_SERVER_URL);
-        samlSSOUrl = IdentityUtil.getProperty(IdentityConstants.ServerConfig.SSO_IDP_URL);
-        samlLogoutUrl = samlSSOUrl;
         samlECPUrl = IdentityUtil.getProperty(IdentityConstants.ServerConfig.SAML_ECP_URL);
         samlArtifactUrl = IdentityUtil.getProperty(IdentityConstants.ServerConfig.SSO_ARTIFACT_URL);
         oauth1RequestTokenUrl = IdentityUtil.getProperty(IdentityConstants.OAuth.OAUTH1_REQUEST_TOKEN_URL);
@@ -170,9 +168,9 @@ public class IdentityProviderManager implements IdpManager {
         samlSSOUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true)
                 + IdPManagementUtil.getTenantParameter();
 
-        if (StringUtils.isBlank(samlLogoutUrl)) {
-            samlLogoutUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true);
-        }
+        samlLogoutUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true)
+                + IdPManagementUtil.getTenantParameter();
+
         if (StringUtils.isBlank(samlArtifactUrl)) {
             samlArtifactUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true);
         }
@@ -394,9 +392,9 @@ public class IdentityProviderManager implements IdpManager {
         if (samlSSOUrlProperty == null) {
             samlSSOUrlProperty = new Property();
             samlSSOUrlProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.SSO_URL);
+            // Set the generated saml sso endpoint value.
+            samlSSOUrlProperty.setValue(samlSSOUrl);
         }
-        // Set the generated saml sso endpoint value.
-        samlSSOUrlProperty.setValue(samlSSOUrl);
         propertiesList.add(samlSSOUrlProperty);
 
         Property samlLogoutUrlProperty = IdentityApplicationManagementUtil.getProperty(saml2SSOFedAuthn.getProperties(),
@@ -404,9 +402,9 @@ public class IdentityProviderManager implements IdpManager {
         if (samlLogoutUrlProperty == null) {
             samlLogoutUrlProperty = new Property();
             samlLogoutUrlProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.LOGOUT_REQ_URL);
+            // Set the generated saml slo endpoint value.
+            samlLogoutUrlProperty.setValue(samlLogoutUrl);
         }
-        // Set the generated saml slo endpoint value.
-        samlLogoutUrlProperty.setValue(samlLogoutUrl);
         propertiesList.add(samlLogoutUrlProperty);
 
         Property samlECPUrlProperty = IdentityApplicationManagementUtil.getProperty(saml2SSOFedAuthn.getProperties(),
@@ -2095,18 +2093,6 @@ public class IdentityProviderManager implements IdpManager {
             throws IdentityProviderManagementException {
 
         // Not all endpoints are persisted. So we need to update only a few properties.
-
-//        String samlSSOUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true) +
-//                IdPManagementUtil.getTenantParameter();
-//        updateFederationAuthenticationConfigProperty(residentIDP,
-//                IdentityApplicationConstants.Authenticator
-//                        .SAML2SSO.NAME, IdentityApplicationConstants.Authenticator.SAML2SSO.SSO_URL, samlSSOUrl);
-
-        String samlLogoutUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true) +
-                IdPManagementUtil.getTenantParameter();
-        updateFederationAuthenticationConfigProperty(residentIDP,
-                IdentityApplicationConstants.Authenticator
-                        .SAML2SSO.NAME, IdentityApplicationConstants.Authenticator.SAML2SSO.LOGOUT_REQ_URL, samlLogoutUrl);
 
         String passiveStsUrl = IdentityUtil.getServerURL(IdentityConstants.STS.PASSIVE_STS, true, true);
         updateFederationAuthenticationConfigProperty(residentIDP,

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -167,9 +167,8 @@ public class IdentityProviderManager implements IdpManager {
             openIdUrl = IdentityUtil.getServerURL(IdentityConstants.OpenId.OPENID, true, true);
         }
 
-        if (StringUtils.isBlank(samlSSOUrl)) {
-            samlSSOUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true);
-        }
+        samlSSOUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true)
+                + IdPManagementUtil.getTenantParameter();
 
         if (StringUtils.isBlank(samlLogoutUrl)) {
             samlLogoutUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true);
@@ -2097,11 +2096,11 @@ public class IdentityProviderManager implements IdpManager {
 
         // Not all endpoints are persisted. So we need to update only a few properties.
 
-        String samlSSOUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true) +
-                IdPManagementUtil.getTenantParameter();
-        updateFederationAuthenticationConfigProperty(residentIDP,
-                IdentityApplicationConstants.Authenticator
-                        .SAML2SSO.NAME, IdentityApplicationConstants.Authenticator.SAML2SSO.SSO_URL, samlSSOUrl);
+//        String samlSSOUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true) +
+//                IdPManagementUtil.getTenantParameter();
+//        updateFederationAuthenticationConfigProperty(residentIDP,
+//                IdentityApplicationConstants.Authenticator
+//                        .SAML2SSO.NAME, IdentityApplicationConstants.Authenticator.SAML2SSO.SSO_URL, samlSSOUrl);
 
         String samlLogoutUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true) +
                 IdPManagementUtil.getTenantParameter();


### PR DESCRIPTION
make resident IDP's sso URL editable via management console. fix [https://github.com/wso2/product-is/issues/4616](https://github.com/wso2/product-is/issues/4616)