### PR TITLE
Fix role mapping issue when SAML federated IDP with custom role claim URI.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -812,28 +812,4 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
         return null;
     }
 
-    private String getRoleClaimUriInLocalDialect(ExternalIdPConfig idPConfig) {
-        // get external identity provider role claim URI.
-        String roleClaimUri = idPConfig.getRoleClaimUri();
-
-        if (StringUtils.isBlank(roleClaimUri)) {
-            return null;
-        }
-
-        boolean useDefaultLocalIdpDialect = idPConfig.useDefaultLocalIdpDialect();
-        if (useDefaultLocalIdpDialect) {
-            return roleClaimUri;
-        } else {
-            ClaimMapping[] claimMappings = idPConfig.getClaimMappings();
-            if (!ArrayUtils.isEmpty(claimMappings)) {
-                for (ClaimMapping claimMapping : claimMappings) {
-                    if (roleClaimUri.equals(claimMapping.getRemoteClaim().getClaimUri())) {
-                        return claimMapping.getLocalClaim().getClaimUri();
-                    }
-                }
-            }
-        }
-
-        return null;
-    }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -663,7 +663,7 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
             idpRoleClaimUri = claimMapping.get(FrameworkConstants.LOCAL_ROLE_CLAIM_URI);
         } else if (idPStandardDialect == null && !useDefaultIdpDialect) {
             //Ex. SAML custom claims.
-            idpRoleClaimUri = getRoleClaimUriInLocalDialect(externalIdPConfig);
+            idpRoleClaimUri = FrameworkUtils.getIdpRoleClaimUri(externalIdPConfig);
         }
 
         /* Get the mapped user roles according to the mapping in the IDP configuration. Exclude the unmapped from the


### PR DESCRIPTION
### Proposed changes in this pull request

Fix https://github.com/wso2/product-is/issues/4957
-  Previously, when there was a custom claim URI defined for an IDP, inside the JITProvisioningPostAuthenticationHandler.java, role claim was set to local claim. 
- This fix will consider custom role-claim defined in the IDP config

### When should this PR be merged
Now