### PR TITLE
Remove guava dependency duplicated in webapp libs

### DIFF
--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.endpoint/pom.xml
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.endpoint/pom.xml
@@ -138,6 +138,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.endpoint/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.endpoint/pom.xml
@@ -128,6 +128,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.code.findbugs</groupId>

--- a/components/template-mgt/org.wso2.carbon.identity.template.mgt.endpoint/pom.xml
+++ b/components/template-mgt/org.wso2.carbon.identity.template.mgt.endpoint/pom.xml
@@ -134,6 +134,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Proposed changes in this pull request
This is done for the CXF3 dependency upgrade effort. It removes guava jars that get packed unnecessarily inside the lib folder of webapps.
