### PR TITLE
When SSO to a web application using X509Certificate when other local authenticators are enabled as options other options does not show up in the UI Fixed

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/login.jsp
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/login.jsp
@@ -349,7 +349,7 @@
                                             'x509CertificateAuthenticator')" class="main-link" style="cursor:pointer" id="icon-<%=iconId%>">
                                         <img class="idp-image" src="images/login-icon.png" data-toggle="tooltip"
                                              data-placement="top" title="<%=AuthenticationEndpointUtil.i18n(resourceBundle,
-                                                       "sign.in.with")%> x509CertificateAuthenticator"/>
+                                                       "sign.in.with")%> X509 Certificate"/>
                                     </a>
                                     <label for="icon-<%=iconId%>">x509CertificateAuthenticator</label>
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/login.jsp
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/login.jsp
@@ -44,6 +44,7 @@
     private static final String IDENTIFIER_EXECUTOR = "IdentifierExecutor";
     private static final String OPEN_ID_AUTHENTICATOR = "OpenIDAuthenticator";
     private static final String JWT_BASIC_AUTHENTICATOR = "JWTBasicAuthenticator";
+    private static final String X509_CERTIFICATE_AUTHENTICATOR = "x509CertificateAuthenticator";
 %>
 
     <%
@@ -337,6 +338,21 @@
                                                        "sign.in.with")%> IWA"/>
                                 </a>
                                 <label for="icon-<%=iconId%>">IWA</label>
+                                </div>
+                                <%
+                                    }
+                                    if (localAuthenticatorNames.contains(X509_CERTIFICATE_AUTHENTICATOR)) {
+                                %>
+                                <div>
+                                    <a onclick="javascript: handleNoDomain('<%=Encode.forJavaScriptAttribute(Encode.
+                                forUriComponent(idpEntry.getKey()))%>',
+                                            'x509CertificateAuthenticator')" class="main-link" style="cursor:pointer" id="icon-<%=iconId%>">
+                                        <img class="idp-image" src="images/login-icon.png" data-toggle="tooltip"
+                                             data-placement="top" title="<%=AuthenticationEndpointUtil.i18n(resourceBundle,
+                                                       "sign.in.with")%> x509CertificateAuthenticator"/>
+                                    </a>
+                                    <label for="icon-<%=iconId%>">x509CertificateAuthenticator</label>
+
                                 </div>
                                 <%
                                     }


### PR DESCRIPTION
Fix wso2/product-is#4763
### Proposed changes in this pull request
added the UI support to authenticate using X509 Certificate
