### PR TITLE
Handle empty client id scenario in getServiceProviderNameByClientId()

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -699,12 +699,16 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
             }
         }
 
-        ApplicationDAO appDAO = ApplicationMgtSystemConfig.getInstance().getApplicationDAO();
-        name = appDAO.getServiceProviderNameByClientId(clientId, clientType, tenantDomain);
-        if (name == null) {
-            name = new FileBasedApplicationDAO().getServiceProviderNameByClientId(clientId,
-                    clientType, tenantDomain);
+        if (!StringUtils.isEmpty(clientId)) {
+            ApplicationDAO appDAO = ApplicationMgtSystemConfig.getInstance().getApplicationDAO();
+            name = appDAO.getServiceProviderNameByClientId(clientId, clientType, tenantDomain);
+
+            if (name == null) {
+                name = new FileBasedApplicationDAO().getServiceProviderNameByClientId(clientId,
+                        clientType, tenantDomain);
+            }
         }
+
         if (name == null) {
             ServiceProvider defaultSP = ApplicationManagementServiceComponent.getFileBasedSPs()
                     .get(IdentityApplicationConstants.DEFAULT_SP_CONFIG);


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes https://github.com/wso2/product-is/issues/4706.
- Handles empty/null client id scenarios with the `getServiceProviderNameByClientId()` by bypassing a redundant DAO call.

### When should this PR be merged

- ASAP

#### Documentation

- N/A