### PR TITLE
Add configs of tenant oidc logout fails with 'ID token signature validation failed.' error fix

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -426,7 +426,11 @@
             <UserInfoEndpointResponseBuilder>org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoJSONResponseBuilder</UserInfoEndpointResponseBuilder>
             <SkipUserConsent>false</SkipUserConsent>
             <!-- Sign the ID Token with Service Provider Tenant Private Key-->
-            <SignJWTWithSPKey>false</SignJWTWithSPKey>
+            <SignJWTWithSPKey>true</SignJWTWithSPKey>
+            <!-- Add tenant domain to 'realm' claim of ID Token-->
+            <AddTenantDomainToIdToken>false</AddTenantDomainToIdToken>
+            <!-- Add userstore domain to 'realm' claim of ID Token-->
+            <AddUserstoreDomainToIdToken>false</AddUserstoreDomainToIdToken>
             <!--
                 Expiry period of the logout token used in OIDC Back Channel Logout in seconds.
                 Supported versions: IS 5.5.0 onwards


### PR DESCRIPTION
Part of fix https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1063