### PR TITLE
AuthenticatedUser constructor fails to add federated IDP name

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -72,6 +72,7 @@ public class AuthenticatedUser extends User {
             this.userAttributes.putAll(authenticatedUser.getUserAttributes());
         }
         this.isFederatedUser = authenticatedUser.isFederatedUser();
+        this.federatedIdPName = authenticatedUser.getFederatedIdPName();
         if (!isFederatedUser && StringUtils.isNotEmpty(userStoreDomain) && StringUtils.isNotEmpty(tenantDomain)) {
             updateCaseSensitivity();
         }


### PR DESCRIPTION
Part of fix for https://github.com/wso2/product-is/issues/4879
Depends on the OAuth fix : https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1097