### PR TITLE
Revert "Fix #5009:JIT provisioning password policy validation is enabled, backend throws a error for a incorrect password But UI proceed the user for the next step"

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -58,10 +58,6 @@ import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreManager;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -72,6 +68,10 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ACCOUNT_DISABLED_CLAIM_URI;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI;
@@ -273,15 +273,6 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
         } catch (PostAuthenticationFailedException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error occurred while evaluating post authentication", e);
-            }
-            Throwable cause = e;
-            while (cause != null) {
-                if (cause instanceof org.wso2.carbon.user.core.UserStoreException) {
-                    FrameworkUtils.sendToRetryPage(request, responseWrapper, "JIT provisioning Failed",
-                            cause.getMessage());
-                    return;
-                }
-                cause = cause.getCause();
             }
             FrameworkUtils.removeCookie(request, responseWrapper,
                     FrameworkUtils.getPASTRCookieName(context.getContextIdentifier()));

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -611,7 +611,7 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
                     extAttributesValueMap, userStoreDomain, context.getTenantDomain());
 
         } catch (FrameworkException e) {
-            throw e;
+            log.error("User provisioning failed!", e);
         } finally {
             IdentityApplicationManagementUtil.resetThreadLocalProvisioningServiceProvider();
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandlerTest.java
@@ -572,7 +572,6 @@ public class DefaultStepBasedSequenceHandlerTest {
         return context;
     }
 
-    /* Test is not valid with the fix for wso2/product-is#5009
     @Test
     public void testHandleJitProvisioningFailure() throws Exception {
 
@@ -594,7 +593,7 @@ public class DefaultStepBasedSequenceHandlerTest {
         } catch (FrameworkException ex) {
             fail("Possible API change. This method did not throw any exception to outside before.");
         }
-    }*/
+    }
 
     private void returnMockProvisioningHandler(ProvisioningHandler mockProvisioningHandler) throws FrameworkException {
         // Mock framework util to returned mocked provisioning handler


### PR DESCRIPTION
Reverts wso2/carbon-identity-framework#2186