### PR TITLE
Fix #5115: Idle timeout for a tenant is also taken from super tenant

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -611,9 +611,16 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
             }
 
             String sessionContextKey = DigestUtils.sha256Hex(cookie.getValue());
-
+            SessionContext sessionContext;
             // get the authentication details from the cache
-            SessionContext sessionContext = FrameworkUtils.getSessionContextFromCache(sessionContextKey);
+            try {
+                //Starting tenant-flow as tenant domain is retrieved downstream from the carbon-context to get the
+                // tenant wise session expiry time
+                FrameworkUtils.startTenantFlow(context.getTenantDomain());
+                sessionContext = FrameworkUtils.getSessionContextFromCache(sessionContextKey);
+            } finally {
+                FrameworkUtils.endTenantFlow();
+            }
 
             if (sessionContext != null) {
 


### PR DESCRIPTION
### Proposed changes in this pull request

Fix for https://github.com/wso2/product-is/issues/5115

While checking the validity of the existing session[1], tenant domain in the carbon-context evaluates to be Super-Tenant-Domain as corresponding tenant flow is not started.

Therefore we need to start the tenant flow before proceeding.

[1] https://github.com/wso2-support/carbon-identity-framework/blob/support-5.7.5/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/SessionContextCache.java#L123

