### PR TITLE
Protect Scope endpoint

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1054,7 +1054,9 @@
         <Resource context="(.*)/api/identity/user/v1.0/update-username(.*)" secured="true" http-method="PUT">
             <Permissions>/permission/admin/manage/identity/usermgt/update</Permissions>
         </Resource>
-    </ResourceAccessControl>
+
+        <Resource context="(.*)/api/identity/oauth2/v1.0/(.*)" secured="true" http-method="all"/>
+</ResourceAccessControl>
 
     <ClientAppAuthentication>
         <Application name="dashboard" hash="66cd9688a2ae068244ea01e70f0e230f5623b7fa4cdecb65070a09ec06452262"/>
@@ -1075,6 +1077,7 @@
             <Context>/scim2/</Context>
             <Context>/api/identity/entitlement/</Context>
             <Context>/api/identity/oauth2/dcr/v1.1/</Context>
+            <Context>/api/identity/oauth2/v1.0/</Context>
         </WebApp>
         <Servlet>
             <Context>/identity/(.*)</Context>


### PR DESCRIPTION
Currently, the API[1] to add scope bindings is unprotected. This fix adds the necessary configurations to protect it.

[1] https://docs.wso2.com/display/IS570/Using+the+OAuth2+Scopes+REST+APIs