### PR TITLE
Add entity encoding to avoid possible XSS vulnerability in JSP

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/basicauth.jsp
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/basicauth.jsp
@@ -276,7 +276,7 @@
             <div class="form-actions">
                 <%=AuthenticationEndpointUtil.i18n(resourceBundle, "no.confirmation.mail")%>
                 <a id="registerLink"
-                   href="login.do?resend_username=<%=Encode.forHtml(request.getParameter("failedUsername"))%>&<%=AuthenticationEndpointUtil.cleanErrorMessages(request.getQueryString())%>">
+                   href="login.do?resend_username=<%=Encode.forHtml(request.getParameter("failedUsername"))%>&<%=AuthenticationEndpointUtil.cleanErrorMessages(Encode.forJava(request.getQueryString()))%>">
                     <%=AuthenticationEndpointUtil.i18n(resourceBundle, "resend.mail")%>
                 </a>
             </div>

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/login.jsp
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/login.jsp
@@ -132,7 +132,7 @@
             if (reCaptchaEnabled) {
         %>
         <script src='<%=
-        (request.getParameter("reCaptchaAPI"))%>'></script>
+        (Encode.forJavaScriptSource(request.getParameter("reCaptchaAPI")))%>'></script>
         <%
             }
         %>


### PR DESCRIPTION
This is to avoid the XSS vulnerabilities detected in basicauth.jsp and login.jsp