### PR TITLE
Add config to allow custom claim mappings for authenticators

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/builder/FileBasedConfigurationBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/builder/FileBasedConfigurationBuilder.java
@@ -74,6 +74,7 @@ public class FileBasedConfigurationBuilder {
     private String identifierFirstConfirmationURL;
     private String authenticationEndpointPromptURL;
     private String authenticationEndpointMissingClaimsURL;
+    private boolean allowCustomClaimMappingsForAuthenticators = false;
 
     /**
      * List of URLs that receive the tenant list
@@ -216,6 +217,9 @@ public class FileBasedConfigurationBuilder {
 
             //########### Read Sequence Configs ###########
             readSequenceConfigs(rootElement);
+
+            //########### Read Authenticator Claim Dialect Configs ###########
+            readAllowCustomClaimMappingsForAuthenticatorsValue(rootElement);
         } catch (XMLStreamException e) {
             log.error("Error reading the " + IdentityApplicationConstants.APPLICATION_AUTHENTICATION_CONGIG, e);
         } catch (Exception e) {
@@ -1061,5 +1065,27 @@ public class FileBasedConfigurationBuilder {
     public List<String> getFilteringEnabledHostNames() {
 
         return filteringEnabledHostNames;
+    }
+
+    private void readAllowCustomClaimMappingsForAuthenticatorsValue(OMElement documentElement) {
+
+        OMElement element = documentElement.getFirstChildWithName(IdentityApplicationManagementUtil.
+                getQNameWithIdentityApplicationNS(
+                        FrameworkConstants.Config.QNAME_ALLOW_AUTHENTICATOR_CUSTOM_CLAIM_MAPPINGS));
+
+        if (element != null) {
+            allowCustomClaimMappingsForAuthenticators = Boolean.valueOf(element.getText());
+        }
+    }
+
+    /**
+     * Indicates whether a custom claim dialect can be used instead
+     * of the authenticator's claim dialect.
+     *
+     * @return True if a custom claim dialect can be used.
+     */
+    public boolean isCustomClaimMappingsForAuthenticatorsAllowed() {
+
+        return allowCustomClaimMappingsForAuthenticators;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.CarbonException;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.core.util.AnonymousSessionUtil;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
+import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ApplicationConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
@@ -146,9 +147,14 @@ public class DefaultClaimHandler implements ClaimHandler {
 
         ApplicationAuthenticator authenticator = stepConfig.
                 getAuthenticatedAutenticator().getApplicationAuthenticator();
-        String idPStandardDialect = authenticator.getClaimDialectURI();
 
         boolean useDefaultIdpDialect = context.getExternalIdP().useDefaultLocalIdpDialect();
+
+        // When null the local claim dialect will be used.
+        String idPStandardDialect = null;
+        if (useDefaultIdpDialect || !useLocalClaimDialectForClaimMappings()) {
+            idPStandardDialect = authenticator.getClaimDialectURI();
+        }
 
         // set unfiltered remote claims as a property
         context.setProperty(FrameworkConstants.UNFILTERED_IDP_CLAIM_VALUES, remoteClaims);
@@ -922,5 +928,17 @@ public class DefaultClaimHandler implements ClaimHandler {
         }
         log.debug(FrameworkConstants.UNFILTERED_SP_CLAIM_VALUES +
                   " map property set to " + sb.toString());
+    }
+
+    /**
+     * Checks if a configuration is available indicating to use the local claim
+     * dialect instead of the federated authenticator's dialect when a custom dialect
+     * claim mapping is used.
+     *
+     * @return True if local claim dialect should be used.
+     */
+    private boolean useLocalClaimDialectForClaimMappings() {
+
+        return FileBasedConfigurationBuilder.getInstance().isCustomClaimMappingsForAuthenticatorsAllowed();
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -188,6 +188,9 @@ public abstract class FrameworkConstants {
         public static final String QNAME_AUTH_ENDPOINT_QUERY_PARAMS = "AuthenticationEndpointQueryParams";
         public static final String QNAME_AUTH_ENDPOINT_REDIRECT_PARAMS = "AuthenticationEndpointRedirectParams";
         public static final String QNAME_FILTERING_ENABLED_HOST_NAMES = "FilteringEnabledHostNames";
+        public static final String QNAME_ALLOW_AUTHENTICATOR_CUSTOM_CLAIM_MAPPINGS =
+                "AllowCustomClaimMappingsForAuthenticators";
+
         /**
          * Configuration name for the collection of urls for receiving tenant list
          */

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml
@@ -232,4 +232,11 @@
           <TenantDataListenerURL>/authenticationendpoint/tenantlistrefresher.do</TenantDataListenerURL>
         </TenantDataListenerURLs-->
 
+    <!--
+    Allow federated authenticators to use the idp local claim dialect instead of the authenticator's claim
+    dialect when using a custom dialect claim mapping. The configuration affects all federated authenticators.
+    Default value: false
+    -->
+    <!--<AllowCustomClaimMappingsForAuthenticators>true</AllowCustomClaimMappingsForAuthenticators>-->
+
 </ApplicationAuthentication>


### PR DESCRIPTION
Improvements for wso2/product-is#5437

This PR introduces a global configuration to allow federated authenticators to use the idp local claim dialect instead of the authenticator's claim dialect when using a custom dialect claim mapping.

The configuration should be added to <CARBON_SERVER>/repository/conf/identity/application-authentication.xml
```
<AllowCustomClaimMappingsForAuthenticators>true</AllowCustomClaimMappingsForAuthenticators>
```
Default value for the config is **false**  to preserve the previous behaviour which was to use the authenticator's claim dialect.

The configuration will affect all federated authenticators as this is a global config.



### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
