### PR TITLE
Revert "Bump axis2.wso2.version from 1.6.1.wso2v12 to 1.6.2.wso2v13"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1688,7 +1688,7 @@
         <carbon.logging.imp.pkg.version.range>[1.2.17, 2.0.0)</carbon.logging.imp.pkg.version.range>
 
         <!-- Axis2 Version -->
-        <axis2.wso2.version>1.6.2.wso2v13</axis2.wso2.version>
+        <axis2.wso2.version>1.6.1-wso2v37</axis2.wso2.version>
         <axis2.osgi.version.range>[1.6.1.wso2v12, 2.0.0)</axis2.osgi.version.range>
         <orbit.version.wsdl4j>1.6.2.wso2v4</orbit.version.wsdl4j>
         <orbit.version.neethi>2.0.4.wso2v5</orbit.version.neethi>


### PR DESCRIPTION
Reverts wso2/carbon-identity-framework#2145

Reverting this PR since 1.6.2.wso2v13 version of axis2 seems to be an invalid jar. By invalid what I mean  is that it seems to be released mistakenly. There was no source tag for the jar version not does the jar version follow our usual convention.

The latest released version in https://mvnrepository.com/artifact/org.apache.axis2.wso2/axis2 seems to be 1.6.1.wso2v37