### PR TITLE
Minor improvement on SP Claim Configuration UI

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider.jsp
@@ -1134,7 +1134,7 @@
                 }
             }
         } else {
-            $('#addClaimUrisLbl').text('Identity Provider Claim URIs:');
+            $('#addClaimUrisLbl').text('Service Provider Claim URIs:');
             $('#roleMappingSelection').show();
         }
     }


### PR DESCRIPTION
Change the field Identity Provider Claim URIs in Service Provider Claim Configuration UI into Service Provider Claim URIs.

Fixes https://github.com/wso2/product-is/issues/5617 
