### PR TITLE
deduplicate header in accountrecoveryendpoint

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/challenge-question-add.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/challenge-question-add.jsp
@@ -77,21 +77,7 @@
 
     <body>
 
-    <!-- header -->
-    <header class="header header-default">
-        <div class="container-fluid"><br></div>
-        <div class="container-fluid">
-            <div class="pull-left brand float-remove-xs text-center-xs">
-                <a href="#">
-                    <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> class="logo">
-
-                    <h1><em><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%></em></h1>
-                </a>
-            </div>
-        </div>
-    </header>
+    <jsp:directive.include file="header.jsp"/>
 
     <!-- page content -->
     <div class="container-fluid body-wrapper">

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/challenge-question-view.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/challenge-question-view.jsp
@@ -62,21 +62,7 @@
 
     <body>
 
-    <!-- header -->
-    <header class="header header-default">
-        <div class="container-fluid"><br></div>
-        <div class="container-fluid">
-            <div class="pull-left brand float-remove-xs text-center-xs">
-                <a href="#">
-                    <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> class="logo">
-
-                    <h1><em><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%></em></h1>
-                </a>
-            </div>
-        </div>
-    </header>
+    <jsp:directive.include file="header.jsp"/>
 
     <!-- page content -->
     <div class="container-fluid body-wrapper">

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/challenge-questions-view-all.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/challenge-questions-view-all.jsp
@@ -65,22 +65,7 @@
 
 <body>
 
-<!-- header -->
-<header class="header header-default">
-    <div class="container-fluid"><br></div>
-    <div class="container-fluid">
-        <div class="pull-left brand float-remove-xs text-center-xs">
-            <a href="#">
-                <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> class="logo">
-                
-                <h1><em><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%>
-                </em></h1>
-            </a>
-        </div>
-    </div>
-</header>
+<jsp:directive.include file="header.jsp"/>
 
 <!-- page content -->
 <div class="container-fluid body-wrapper">

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/error.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/error.jsp
@@ -52,21 +52,7 @@
 
     <body>
 
-    <!-- header -->
-    <header class="header header-default">
-        <div class="container-fluid"><br></div>
-        <div class="container-fluid">
-            <div class="pull-left brand float-remove-xs text-center-xs">
-                <a href="#">
-                    <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                    "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                    "Wso2")%> class="logo">
-
-                    <h1><em><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%></em></h1>
-                </a>
-            </div>
-        </div>
-    </header>
+    <jsp:directive.include file="header.jsp"/>
 
     <!-- page content -->
     <div class="container-fluid body-wrapper">

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/header.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/header.jsp
@@ -1,0 +1,17 @@
+<!-- localize.jsp MUST already be included in the calling script -->
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.IdentityManagementEndpointUtil" %>
+
+<header class="header header-default">
+    <div class="container-fluid"><br></div>
+    <div class="container-fluid">
+        <div class="pull-left brand float-remove-xs text-center-xs">
+            <a href="#">
+                <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
+                 "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
+                 "Wso2")%> class="logo">
+
+                <h1><em><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%></em></h1>
+            </a>
+        </div>
+    </div>
+</header>

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/password-recovery-username-request.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/password-recovery-username-request.jsp
@@ -49,22 +49,7 @@
 
 <body>
 
-<!-- header -->
-<header class="header header-default">
-    <div class="container-fluid"><br></div>
-    <div class="container-fluid">
-        <div class="pull-left brand float-remove-xs text-center-xs">
-            <a href="#">
-                <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> class="logo">
-                
-                <h1><em><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%>
-                </em></h1>
-            </a>
-        </div>
-    </div>
-</header>
+<jsp:directive.include file="header.jsp"/>
 
 <!-- page content -->
 <div class="container-fluid body-wrapper">

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/password-recovery.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/password-recovery.jsp
@@ -101,21 +101,7 @@
 
     <body>
 
-    <!-- header -->
-    <header class="header header-default">
-        <div class="container-fluid"><br></div>
-        <div class="container-fluid">
-            <div class="pull-left brand float-remove-xs text-center-xs">
-                <a href="#">
-                    <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> class="logo">
-
-                    <h1><em><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%></em></h1>
-                </a>
-            </div>
-        </div>
-    </header>
+    <jsp:directive.include file="header.jsp"/>
 
     <!-- page content -->
     <div class="container-fluid body-wrapper">

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/password-reset.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/password-reset.jsp
@@ -53,21 +53,7 @@
 
     <body>
 
-    <!-- header -->
-    <header class="header header-default">
-        <div class="container-fluid"><br></div>
-        <div class="container-fluid">
-            <div class="pull-left brand float-remove-xs text-center-xs">
-                <a href="#">
-                    <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> class="logo">
-
-                    <h1><em><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%></em></h1>
-                </a>
-            </div>
-        </div>
-    </header>
+    <jsp:directive.include file="header.jsp"/>
 
     <!-- page content -->
     <div class="container-fluid body-wrapper">

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/self-registration-process.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/self-registration-process.jsp
@@ -57,21 +57,7 @@
 
     <body>
 
-    <!-- header -->
-    <header class="header header-default">
-        <div class="container-fluid"><br></div>
-        <div class="container-fluid">
-            <div class="pull-left brand float-remove-xs text-center-xs">
-                <a href="#">
-                    <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> class="logo">
-
-                    <h1><em><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%></em></h1>
-                </a>
-            </div>
-        </div>
-    </header>
+    <jsp:directive.include file="header.jsp"/>
 
     <!-- page content -->
     <div class="container-fluid body-wrapper">

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/self-registration-username-request.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/self-registration-username-request.jsp
@@ -72,21 +72,7 @@
 
     <body>
 
-    <!-- header -->
-    <header class="header header-default">
-        <div class="container-fluid"><br></div>
-        <div class="container-fluid">
-            <div class="pull-left brand float-remove-xs text-center-xs">
-                <a href="#">
-                    <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> class="logo">
-
-                    <h1><em><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%></em></h1>
-                </a>
-            </div>
-        </div>
-    </header>
+    <jsp:directive.include file="header.jsp"/>
 
     <!-- page content -->
     <div class="container-fluid body-wrapper">

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/self-registration-with-verification-confirm.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/self-registration-with-verification-confirm.jsp
@@ -96,23 +96,7 @@
 
     <body>
 
-    <!-- header -->
-    <header class="header header-default">
-        <div class="container-fluid"><br></div>
-        <div class="container-fluid">
-            <div class="pull-left brand float-remove-xs text-center-xs">
-                <a href="#">
-                    <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> class="logo">
-
-                    <h1><em>
-                        <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%></em>
-                    </h1>
-                </a>
-            </div>
-        </div>
-    </header>
+    <jsp:directive.include file="header.jsp"/>
 
     <!-- page content -->
     <div class="container-fluid body-wrapper">

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/self-registration-with-verification.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/self-registration-with-verification.jsp
@@ -198,21 +198,7 @@
 
     <body>
 
-    <!-- header -->
-    <header class="header header-default">
-        <div class="container-fluid"><br></div>
-        <div class="container-fluid">
-            <div class="pull-left brand float-remove-xs text-center-xs">
-                <a href="#">
-                    <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> class="logo">
-
-                    <h1><em><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%></em></h1>
-                </a>
-            </div>
-        </div>
-    </header>
+    <jsp:directive.include file="header.jsp"/>
 
     <!-- page content -->
     <div class="container-fluid body-wrapper">

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/self-registration-without-verification.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/self-registration-without-verification.jsp
@@ -91,21 +91,7 @@
 
     <body>
 
-    <!-- header -->
-    <header class="header header-default">
-        <div class="container-fluid"><br></div>
-        <div class="container-fluid">
-            <div class="pull-left brand float-remove-xs text-center-xs">
-                <a href="#">
-                    <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> class="logo">
-
-                    <h1><em><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%></em></h1>
-                </a>
-            </div>
-        </div>
-    </header>
+    <jsp:directive.include file="header.jsp"/>
 
     <!-- page content -->
     <div class="container-fluid body-wrapper">

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/username-recovery-tenant-request.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/username-recovery-tenant-request.jsp
@@ -49,22 +49,7 @@
 
 <body>
 
-<!-- header -->
-<header class="header header-default">
-    <div class="container-fluid"><br></div>
-    <div class="container-fluid">
-        <div class="pull-left brand float-remove-xs text-center-xs">
-            <a href="#">
-                <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> class="logo">
-                
-                <h1><em><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%>
-                </em></h1>
-            </a>
-        </div>
-    </div>
-</header>
+<jsp:directive.include file="header.jsp"/>
 
 <!-- page content -->
 <div class="container-fluid body-wrapper">

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/username-recovery.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/username-recovery.jsp
@@ -148,21 +148,7 @@
 
     <body>
 
-    <!-- header -->
-    <header class="header header-default">
-        <div class="container-fluid"><br></div>
-        <div class="container-fluid">
-            <div class="pull-left brand float-remove-xs text-center-xs">
-                <a href="#">
-                    <img src="images/logo-inverse.svg" alt=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> title=<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                 "Wso2")%> class="logo">
-
-                    <h1><em><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Identity.server")%></em></h1>
-                </a>
-            </div>
-        </div>
-    </header>
+    <jsp:directive.include file="header.jsp"/>
 
     <!-- page content -->
     <div class="container-fluid body-wrapper">


### PR DESCRIPTION
### Proposed changes in this pull request

deduplicate the header bar in accountrecoveryendpoint.  This simplifies skinning & corrections.

### Follow up actions

deduplication across all webapps would be ideal, but I'm not yet familiar enough with the overall codebase to do so.