### PR TITLE
Fixed uneven input box size

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-local.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-local.jsp
@@ -502,7 +502,7 @@ function removeDefaultAuthSeq() {
                                 <font color="red">*</font>
                             </td>
                             <td>
-                                <input type="text" id="destinationURLTxt" class="text-box-big" value="" white-list-patterns="http-url https-url"/>
+                                <input type="text" id="destinationURLTxt" value="" white-list-patterns="http-url https-url"/>
                                 <input id="addDestinationURLBtn" type="button" value="<fmt:message key="idp.destination.add"/>"
                                        onclick="onClickAddDestinationUrl()"/>
                             </td>


### PR DESCRIPTION
Fixed uneven input box size at Main->Identity->Identity Providers->Resident->Inbound Authentication Configuration->SAML2 Web SSO Configuration-> Destination URLs

Issues: https://github.com/wso2/product-is/issues/4863
