### PR TITLE
Template ResourceAccessControl section to add custom resource.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1393,6 +1393,14 @@
         <Resource context="/smsotpauthenticationendpoint(.*)" secured="false" http-method="all"/>
         <Resource context="/totpauthenticationendpoint(.*)" secured="false" http-method="all"/>
         <Resource context="/x509certificateauthenticationendpoint(.*)" secured="false" http-method="all"/>
+
+        {% for resource in resource.access_control %}
+        <Resource context="{{resource.context}}" secured="{{resource.secure}}" http-method="{{resource.http_method}}">
+            {% for permission in resource.permissions %}
+            <Permissions>{{permission}}</Permissions>
+            {% endfor %}
+        </Resource>
+        {% endfor %}
 </ResourceAccessControl>
 
     <ClientAppAuthentication>


### PR DESCRIPTION
### Proposed changes in this pull request

- Template ResourceAccessControl section to add custom resource.

Fixing: https://github.com/wso2/product-is/issues/5833

Related Toml key:
```
[[resource.access_control]]
context = "test1"
secured = true
http_method = "all"
permissions = ["p1","p2"]
```

