### PR TITLE
Fix the typo in saml config.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -641,7 +641,7 @@
         <UseAuthenticatedUserDomainCrypto>{{saml.enable_user_domain_crpto}}</UseAuthenticatedUserDomainCrypto>
         <SAMLDefaultSigningAlgorithmURI>{{saml.signing_alg}}</SAMLDefaultSigningAlgorithmURI>
         <SAMLDefaultDigestAlgorithmURI>{{saml.digest_alg}}</SAMLDefaultDigestAlgorithmURI>
-        <SAMLDefaultAssertionEncryptionAlgorithmURI>{{saml.assertion_entryption_alg}}</SAMLDefaultAssertionEncryptionAlgorithmURI>
+        <SAMLDefaultAssertionEncryptionAlgorithmURI>{{saml.assertion_encryption_alg}}</SAMLDefaultAssertionEncryptionAlgorithmURI>
         <SAMLDefaultKeyEncryptionAlgorithmURI>{{saml.key_encryption_alg}}</SAMLDefaultKeyEncryptionAlgorithmURI>
         <SLOHostNameVerificationEnabled>{{saml.slo.host_name_verification}}</SLOHostNameVerificationEnabled>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -160,7 +160,7 @@
   "saml.tenant_partitioning.enable": false,
   "saml.signing_alg": "http://www.w3.org/2000/09/xmldsig#rsa-sha1",
   "saml.digest_alg": "http://www.w3.org/2000/09/xmldsig#sha1",
-  "saml.assertion_entryption_alg": "http://www.w3.org/2001/04/xmlenc#aes256-cbc",
+  "saml.assertion_encryption_alg": "http://www.w3.org/2001/04/xmlenc#aes256-cbc",
   "saml.key_encryption_alg": "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p",
   "saml.enable_user_domain_crpto": false,
   "saml.enable_request_validity_period": false,


### PR DESCRIPTION
### Proposed changes in this pull request

- Fix the typo in the key `saml.assertion_entryption_alg`

- New toml related key:
```
[saml]
assertion_encryption_alg = ""
```
