### PR TITLE
Fix output encoding and input validation for claim dialect URIs.

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider.jsp
@@ -87,6 +87,7 @@
 <script src="codemirror/util/formatting.js"></script>
 <script src="js/handlebars.min-v4.0.11.js"></script>
 <script src="../admin/js/main.js" type="text/javascript"></script>
+<script type="text/javascript" src="../identity/encode/js/identity-encode.js"></script>
 
 <script type="text/javascript" src="extensions/js/vui.js"></script>
 <script type="text/javascript" src="../extensions/core/js/vui.js"></script>
@@ -810,8 +811,11 @@
             $("#spClaimDialects").val(spClaimDialect);
             var row =
                 '<tr id="spClaimDialectUri_' + parseInt(currentColumnId) + '">' +
-                '</td><td style="padding-left: 30px !important; color: rgb(119, 119, 119);font-style: italic;">' + spClaimDialect +
-                '</td><td><a onclick="removeSpClaimDialect(\'' + spClaimDialect + '\', \'spClaimDialectUri_' + parseInt(currentColumnId) + '\');return false;"' +
+                '</td><td style="padding-left: 30px !important; color: rgb(119, 119, 119);font-style: italic;">' +
+                encodeForHTML(spClaimDialect) +
+                '</td><td><a onclick="removeSpClaimDialect(\'' + encodeForHTML(encodeQuotesForJavascript(spClaimDialect)) +
+                '\', \'spClaimDialectUri_' +
+                parseInt(currentColumnId) + '\');return false;"' +
                 ' href="#" class="icon-link" style="background-image: url(../admin/images/delete.gif)">Delete</a></td></tr>';
             $('#spClaimDialectsTable tbody').append(row);
         } else {
@@ -830,8 +834,12 @@
             $("#spClaimDialects").val(spClaimDialects + "," + spClaimDialect);
             var row =
                 '<tr id="spClaimDialectUri_' + parseInt(currentColumnId) + '">' +
-                '</td><td style="padding-left: 30px !important; color: rgb(119, 119, 119);font-style: italic;">' + spClaimDialect +
-                '</td><td><a onclick="removeSpClaimDialect(\'' + spClaimDialect + '\', \'spClaimDialectUri_' + parseInt(currentColumnId) + '\');return false;"' +
+                '</td><td style="padding-left: 30px !important; color: rgb(119, 119, 119);font-style: italic;">' +
+                encodeForHTML(spClaimDialect) +
+                '</td><td><a onclick="removeSpClaimDialect(\'' +
+                encodeForHTML(encodeQuotesForJavascript(spClaimDialect)) +
+                '\', \'spClaimDialectUri_' +
+                parseInt(currentColumnId) + '\');return false;"' +
                 ' href="#" class="icon-link" style="background-image: url(../admin/images/delete.gif)">Delete</a></td></tr>';
             $('#spClaimDialectsTable tr:last').after(row);
         }

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt.ui/src/main/resources/org/wso2/carbon/identity/claim/metadata/mgt/ui/i18n/Resources.properties
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt.ui/src/main/resources/org/wso2/carbon/identity/claim/metadata/mgt/ui/i18n/Resources.properties
@@ -56,6 +56,7 @@ add.new.claim.dialect=Add New Claim Dialect
 
 dialect.uri.is.required=Dialect URI is required
 dialect.is.too.long=Dialect name should be less than 100 characters.
+dialect.has.unsafe.characters=Dialect URI has unsafe characters matching pattern: {2}
 add.new.dialect.details=Dialect Details
 dialect.uri=Dialect URI
 add=Add

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt.ui/src/main/resources/web/identity-claim-mgt/add-dialect.jsp
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt.ui/src/main/resources/web/identity-claim-mgt/add-dialect.jsp
@@ -27,6 +27,7 @@
     <script type="text/javascript" src="../carbon/admin/js/breadcrumbs.js"></script>
     <script type="text/javascript" src="../carbon/admin/js/cookies.js"></script>
     <script type="text/javascript" src="../carbon/admin/js/main.js"></script>
+    <script type="text/javascript" src="../identity/validation/js/identity-validate.js"></script>
 
     <div id="middle">
         <h2><fmt:message key='add.claim.dialect'/></h2>
@@ -47,12 +48,15 @@
 
                 function validate() {
 
-                    var value = document.getElementsByName("dialect")[0].value;
-                    if (value == '') {
+                    var dialectURIElement = document.getElementById('dialect');
+                    if (dialectURIElement.value == '') {
                         CARBON.showWarningDialog('<fmt:message key="dialect.uri.is.required"/>');
                         return false;
-                    } else if (value.length > 100) {
+                    } else if (dialectURIElement.length > 100) {
                         CARBON.showWarningDialog('<fmt:message key="dialect.is.too.long"/>');
+                        return false;
+                    } else if (!doValidateInput(dialectURIElement,
+                        '<fmt:message key="dialect.has.unsafe.characters"/>')) {
                         return false;
                     }
 
@@ -76,7 +80,8 @@
                                     <td class="leftCol-small"><fmt:message key='dialect.uri'/><font color="red">*</font>
                                     </td>
                                     <td class="leftCol-big">
-                                        <input type="text" name="dialect" id="dialect" class="text-box-big"/>
+                                        <input type="text" name="dialect" id="dialect" class="text-box-big"
+                                               black-list-patterns="xml-meta-exists"/>
                                         <div class="sectionHelp"><fmt:message key="dialect.uri.help"/></div>
                                     </td>
                                 </tr>

--- a/components/identity-core/org.wso2.carbon.identity.core.ui/src/main/resources/web/identity/encode/js/identity-encode.js
+++ b/components/identity-core/org.wso2.carbon.identity.core.ui/src/main/resources/web/identity/encode/js/identity-encode.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function encodeForHTML(value) {
+    // Create a in-memory div, set it's inner text(which jQuery automatically encodes)
+    // then grab the encoded contents back out.  The div never exists on the page.
+    var output = $('<div/>').text(value).html();
+    output = output.replace(/"/g, "&quot;");
+    output = output.replace(/'/g, '&#39;');
+
+    return output;
+}
+
+function encodeQuotesForJavascript(value) {
+    // Escape only non escaped quotes
+    var output = value;
+    output = output.replace(/\\([\s\S])|(['"])/ig, "\\$1$2");
+
+    return output;
+}


### PR DESCRIPTION
This PR applies output encoding when a SP claim dialect is picked in the service provider UI under claim configurations.
Also applies input validation for unsafe characters for the claim dialect URI, when being added to the system from UI level.