### PR TITLE
Fixing issue 5941: Adding support for federated users attributes in XACML

### DIFF
--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/PDPConstants.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/PDPConstants.java
@@ -279,4 +279,7 @@ public class PDPConstants {
 
     public static final String XACML_JSON_SHORT_FORM_ENABLED = "JSON.Shorten.Form.Enabled";
 
+    public static final String USER_CATEGORY = "http://wso2.org/identity/user";
+
+    public static final String USER_TYPE_ID = USER_CATEGORY + "/user-type";
 }

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/pip/DefaultAttributeFinder.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/pip/DefaultAttributeFinder.java
@@ -50,7 +50,7 @@ public class DefaultAttributeFinder extends AbstractPIPAttributeFinder {
 
     private static Log log = LogFactory.getLog(DefaultAttributeFinder.class);
     private Set<String> supportedAttrs = new HashSet<String>();
-    private boolean mapFederatedUsersToLocal = true;
+    private boolean mapFederatedUsersToLocal = false;
     private static final String MAP_FEDERATED_USERS_TO_LOCAL = "MapFederatedUsersToLocal";
 
     /**

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/pip/DefaultAttributeFinder.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/pip/DefaultAttributeFinder.java
@@ -21,14 +21,21 @@ package org.wso2.carbon.identity.entitlement.pip;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.balana.attr.AttributeValue;
+import org.wso2.balana.attr.BagAttribute;
+import org.wso2.balana.attr.StringAttribute;
+import org.wso2.balana.cond.EvaluationResult;
+import org.wso2.balana.ctx.EvaluationCtx;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.entitlement.PDPConstants;
 import org.wso2.carbon.user.api.ClaimManager;
 import org.wso2.carbon.user.api.ClaimMapping;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
+import java.net.URI;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -43,6 +50,8 @@ public class DefaultAttributeFinder extends AbstractPIPAttributeFinder {
 
     private static Log log = LogFactory.getLog(DefaultAttributeFinder.class);
     private Set<String> supportedAttrs = new HashSet<String>();
+    private boolean mapFederatedUsersToLocal = true;
+    private static final String MAP_FEDERATED_USERS_TO_LOCAL = "MapFederatedUsersToLocal";
 
     /**
      * Loads all the claims defined under http://wso2.org/claims dialect.
@@ -50,6 +59,8 @@ public class DefaultAttributeFinder extends AbstractPIPAttributeFinder {
      * @throws Exception
      */
     public void init(Properties properties) throws Exception {
+
+        mapFederatedUsersToLocal = Boolean.parseBoolean(properties.getProperty(MAP_FEDERATED_USERS_TO_LOCAL));
         if (log.isDebugEnabled()) {
             log.debug("DefaultAttributeFinder is initialized successfully");
         }
@@ -60,7 +71,46 @@ public class DefaultAttributeFinder extends AbstractPIPAttributeFinder {
         return "Default Attribute Finder";
     }
 
-    /*
+    /**
+     * This method is introduced in order to check whether the user is a local or federated and if it is a
+     * federated user, prevent from obtaining user attributes from userstore.
+     * @param attributeType
+     * @param attributeId The unique id of the required attribute.
+     * @param category  The category of the required attribute.
+     * @param issuer The attribute issuer.
+     * @param evaluationCtx The evaluation context object.
+     * @return return the set of values for the required attribute.
+     * @throws Exception throws if fails.
+     */
+    @Override
+    public Set<String> getAttributeValues(URI attributeType, URI attributeId, URI category,
+                                          String issuer, EvaluationCtx evaluationCtx) throws Exception {
+
+        Set<String> values = null;
+        EvaluationResult userType = evaluationCtx.getAttribute(new URI(StringAttribute.identifier), new URI(
+                PDPConstants.USER_TYPE_ID), issuer, new URI(PDPConstants.USER_CATEGORY));
+        String userTypeId = null;
+        if (userType != null && userType.getAttributeValue() != null && userType.getAttributeValue().isBag()) {
+            BagAttribute bagAttribute = (BagAttribute) userType.getAttributeValue();
+            if (bagAttribute.size() > 0) {
+                userTypeId = ((AttributeValue) bagAttribute.iterator().next()).encode();
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("The user is a %1$s user", userTypeId));
+                }
+            }
+        }
+
+        if (!StringUtils.equalsIgnoreCase(userTypeId, "FEDERATED")) {
+            // If the user is not a federated user, user attributes should be be populated from local userstore.
+            values = super.getAttributeValues(attributeType, attributeId, category, issuer, evaluationCtx);
+        } else if (mapFederatedUsersToLocal) {
+            // If the user is federated and the MapFederatedToLocal config is enabled, then populate user attributes
+            // from userstore.
+            values = super.getAttributeValues(attributeType, attributeId, category, issuer, evaluationCtx);
+        }
+        return values;
+    }
+        /*
      * (non-Javadoc)
 	 * 
 	 * @see

--- a/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/entitlement.properties
+++ b/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/entitlement.properties
@@ -63,7 +63,7 @@ PDP.Policy.Store.Module=org.wso2.carbon.identity.entitlement.policy.store.Regist
 PDP.Policy.Data.Store.Module=org.wso2.carbon.identity.entitlement.policy.store.DefaultPolicyDataStore
 
 # Properties needed for each extension.
-# org.wso2.carbon.identity.entitlement.pip.DefaultAttributeFinder.1=name,value
+org.wso2.carbon.identity.entitlement.pip.DefaultAttributeFinder.1=MapFederatedUserToLocal,value
 # org.wso2.carbon.identity.entitlement.pip.DefaultAttributeFinder.2=name,value
 # org.wso2.carbon.identity.entitlement.pip.DefaultResourceFinder.1=name.value
 # org.wso2.carbon.identity.entitlement.pip.DefaultResourceFinder.2=name,value

--- a/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/entitlement.properties
+++ b/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/entitlement.properties
@@ -63,7 +63,7 @@ PDP.Policy.Store.Module=org.wso2.carbon.identity.entitlement.policy.store.Regist
 PDP.Policy.Data.Store.Module=org.wso2.carbon.identity.entitlement.policy.store.DefaultPolicyDataStore
 
 # Properties needed for each extension.
-org.wso2.carbon.identity.entitlement.pip.DefaultAttributeFinder.1=MapFederatedUserToLocal,value
+org.wso2.carbon.identity.entitlement.pip.DefaultAttributeFinder.1=MapFederatedUsersToLocal,true
 # org.wso2.carbon.identity.entitlement.pip.DefaultAttributeFinder.2=name,value
 # org.wso2.carbon.identity.entitlement.pip.DefaultResourceFinder.1=name.value
 # org.wso2.carbon.identity.entitlement.pip.DefaultResourceFinder.2=name,value

--- a/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/entitlement.properties.j2
+++ b/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/entitlement.properties.j2
@@ -129,6 +129,10 @@ org.wso2.carbon.identity.entitlement.{{extension.name}}.{{loop.index}}={{key}},{
 {% endfor %}
 {% endif %}
 
+{% for key,value in identity.entitlement.default_attribute_finder.properties.items() %}
+org.wso2.carbon.identity.entitlement.pip.DefaultAttributeFinder.{{loop.index}}={{key}},{{value}}
+{% endfor %}
+
 # Properties needed for each extension.
 # org.wso2.carbon.identity.entitlement.pip.DefaultAttributeFinder.1=name,value
 # org.wso2.carbon.identity.entitlement.pip.DefaultAttributeFinder.2=name,value

--- a/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/org.wso2.carbon.identity.xacml.server.feature.default.json
+++ b/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/org.wso2.carbon.identity.xacml.server.feature.default.json
@@ -41,5 +41,5 @@
   ],
   "identity.entitlement.entitlement_engine_caching_interval": "1d",
   "identity.entitlement.JSON_shorten_form_enabled": false,
-  "identity.entitlement.default_attribute_finder.MapFederatedUserToLocal": true
+  "identity.entitlement.default_attribute_finder.properties.MapFederatedUsersToLocal": true
 }

--- a/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/org.wso2.carbon.identity.xacml.server.feature.default.json
+++ b/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/org.wso2.carbon.identity.xacml.server.feature.default.json
@@ -40,5 +40,6 @@
     "org.wso2.carbon.identity.entitlement.pip.DefaultResourceFinder"
   ],
   "identity.entitlement.entitlement_engine_caching_interval": "1d",
-  "identity.entitlement.JSON_shorten_form_enabled": false
+  "identity.entitlement.JSON_shorten_form_enabled": false,
+  "identity.entitlement.default_attribute_finder.MapFederatedUserToLocal": true
 }


### PR DESCRIPTION
Fixes wso2/product-is#5941

### Proposed changes in this pull request

As an improvement for the above issue, a flag will be set in the PEPs for federated users. If that flag is set, we check in DefaultAttributeFinder, whether the flag is coming in XACML request from PEP and prevent from pulling attributes from userstore if the flag is set.

In order to have backword compatibility, some people may already use federated users with JIT provisioning and have the XACML policy to read the userattributes from userstore. In order have the backwardcompatibility, intorduced a config in EntitlementProperties config file.

If the below config is true,
`org.wso2.carbon.identity.entitlement.pip.DefaultAttributeFinder.1=MapFederatedUsersToLocal,true` 
Then for federated users also , attribute values can be taken from local userstore. Else, PIP will not pull the attributes from userstore. If it is false, it will skip the local userstore. **By default this is enabled**

In order to skip userstore, According to the new config model, in the deployment.toml file it should be as follows:
```
[identity.entitlement.default_attribute_finder.properties]
MapFederatedUsersToLocal=false
```


### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
