### PR TITLE
Fix Password recovery flow ends with an error if user opens username recovery page first

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/basicauth.jsp
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/basicauth.jsp
@@ -26,6 +26,7 @@
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.bean.ResendCodeRequestDTO" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.bean.UserDTO" %>
 <%@ page import="java.net.URLEncoder" %>
+<%@ page import="java.net.URLDecoder" %>
 <%@ page import="javax.ws.rs.core.Response" %>
 <%@ page import="static org.wso2.carbon.identity.core.util.IdentityUtil.isSelfSignUpEPAvailable" %>
 <%@ page import="static org.wso2.carbon.identity.core.util.IdentityUtil.isRecoveryEPAvailable" %>
@@ -220,7 +221,7 @@
                 String serverName = request.getServerName();
                 int serverPort = request.getServerPort();
                 String uri = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_REQUEST_URI);
-                String prmstr = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
+                String prmstr = URLDecoder.decode(((String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING)), UTF_8);
                 String urlWithoutEncoding = scheme + "://" +serverName + ":" + serverPort + uri + "?" + prmstr;
                 String urlEncodedURL = URLEncoder.encode(urlWithoutEncoding, UTF_8);
 


### PR DESCRIPTION
- Resolves wso2/product-is#6008

**PR fixes the following scenario**

1. Go to login page
2. Click on the username recovery link(URL is encoded and redirected to username recovery page). Do nothing and click on Cancel button(Directed to the login page).
3. Click on the username recovery link(previously encoded URL is encoded again)
