### PR TITLE
Allow https://<host>:<port>/ resource to access Management console.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -890,6 +890,7 @@
 
     <ResourceAccessControl default-access="deny">
         <Resource context="(.*)" secured="false" http-method="OPTIONS"/>
+        <Resource context="/" secured="false" http-method="GET"/>
         <Resource context="(.*)/api/identity/user/v1.0/validate-code(.*)" secured="true" http-method="all">
             <Permissions>/permission/admin/manage/identity/identitymgt</Permissions>
         </Resource>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1143,6 +1143,7 @@
 
     <ResourceAccessControl default-access="deny">
         <Resource context="(.*)" secured="false" http-method="OPTIONS"/>
+        <Resource context="/" secured="false" http-method="GET"/>
         <Resource context="(.*)/api/identity/user/v1.0/validate-code(.*)" secured="true" http-method="all">
             <Permissions>/permission/admin/manage/identity/identitymgt</Permissions>
         </Resource>


### PR DESCRIPTION
### Proposed changes in this pull request
- Allow https://localhost:9443 resource to access Management console.