### PR TITLE
Add configuration for session data persistence

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -49,6 +49,9 @@
                 and would be deleted during cleanup task -->
                 <CleanUpTimeout>{{session_data.cleanup.expire_pre_session_data_after}}</CleanUpTimeout>
             </TempDataCleanup>
+            <UserSessionMapping>
+                <Enable>{{session_data.persistence.enable_user_session_mapping}}</Enable>
+            </UserSessionMapping>
         </SessionDataPersist>
     </JDBCPersistenceManager>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -8,6 +8,7 @@
   "session_data.persistence.enable_persistance": true,
   "session_data.persistence.persistance_pool_size": "0",
   "session_data.persistence.persist_temporary_data": true,
+  "session_data.persistence.enable_user_session_mapping": true,
   "session_data.cleanup.enable_expired_data_cleanup": true,
   "session_data.cleanup.expire_session_data_after": "$ref{session.timeout.remember_me_session_timeout}",
   "session_data.cleanup.expire_pre_session_data_after": "40m",


### PR DESCRIPTION
Enable the persistence of user session mapping by default. Feature introduced in https://github.com/wso2/carbon-identity-framework/pull/2288
