### PR TITLE
Fix local claims getting listed as null in adaptive auth script when there is an existing session

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsClaims.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
@@ -49,6 +50,7 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Represent the user's claim. Can be either remote or local.
@@ -87,6 +89,46 @@ public class JsClaims extends AbstractJSContextMemberObject {
         super.initializeContext(context);
         if (StringUtils.isNotBlank(idp) && getContext().getCurrentAuthenticatedIdPs().containsKey(idp)) {
             this.authenticatedUser = getContext().getCurrentAuthenticatedIdPs().get(idp).getUser();
+        } else {
+            this.authenticatedUser = getAuthenticatedUserFromSubjectIdentifierStep();
+        }
+    }
+
+    /**
+     * Get authenticated user from step config of current subject identifier.
+     *
+     * @return AuthenticatedUser.
+     */
+    private AuthenticatedUser getAuthenticatedUserFromSubjectIdentifierStep() {
+
+        AuthenticatedUser authenticatedUser = null;
+        StepConfig stepConfig = getCurrentSubjectIdentifierStep();
+        if (stepConfig != null) {
+            authenticatedUser = getCurrentSubjectIdentifierStep().getAuthenticatedUser();
+        }
+        return authenticatedUser;
+    }
+
+    /**
+     * Retrieve step config of current subject identifier.
+     *
+     * @return StepConfig.
+     */
+    private StepConfig getCurrentSubjectIdentifierStep() {
+
+        if (getContext().getSequenceConfig() == null) {
+            // Sequence config is not yet initialized.
+            return null;
+        }
+        Map<Integer, StepConfig> stepConfigs = getContext().getSequenceConfig().getAuthenticationGraph().getStepMap();
+        Optional<StepConfig> subjectIdentifierStep = stepConfigs.values().stream()
+                .filter(stepConfig -> (stepConfig.isCompleted() && stepConfig.isSubjectIdentifierStep())).findFirst();
+        if (subjectIdentifierStep.isPresent()) {
+            return subjectIdentifierStep.get();
+        } else if (getContext().getCurrentStep() > 0) {
+            return stepConfigs.get(getContext().getCurrentStep());
+        } else {
+            return null;
         }
     }
 


### PR DESCRIPTION
Fixes wso2/product-is#6079

with [1] we have added a fix to include Identity Provider name for the currentKnownSubject for all scenarios. With this fix when there is an already authenticated session by the 1st SP , and when the second SP tries to login, the user's local claims becomes null in the adaptive authentication script. This is because, in [2] when creating a JSClaims Object, as IDP name is now available it will always go to the method [2] instead of [3]. In that method the JSAuthenticatedUser is retrieved by getting the currentAuthenticatedIPS from authenticationContext. This is null for the second SP. As a possible solution, if the currentAuthenticatedIDPs is null, we can retrieve the StepConfig of subject identifier Step and retrieve the authenticated user.

[1] https://github.com/wso2/carbon-identity-framework/pull/2188
[2] 