### PR TITLE
Fix database connection did not close properly

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -3015,7 +3015,7 @@ public class IdPManagementDAO {
         } catch (SQLException e) {
             throw new IdentityProviderManagementException("Error occurred while searching for similar IdP EntityIds", e);
         } finally {
-            IdentityDatabaseUtil.closeAllConnections(null, rs, prepStmt);
+            IdentityDatabaseUtil.closeAllConnections(dbConnection, rs, prepStmt);
         }
         return isAvailable;
     }


### PR DESCRIPTION
In isIdPAvailableForAuthenticatorProperty() [1] we create a new connection. But, we have not closed it.
Connection dbConnection = IdentityDatabaseUtil.getDBConnection(false);
PreparedStatement prepStmt = null;
ResultSet rs = null;

try {
...
} catch (SQLException e) {
...
} finally {
IdentityDatabaseUtil.closeAllConnections(null, rs, prepStmt);
}
[1] https://github.com/wso2/carbon-identity-framework/blob/master/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java#L2995

issue: wso2/product-is#6094