### PR TITLE
Fix not passing additional claims to the username recovery API from the web app

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/recovery.jsp
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/recovery.jsp
@@ -75,18 +75,11 @@
         List<UserClaim> claimDTOList = new ArrayList<UserClaim>();
 
         for (Claim claimDTO : claims) {
-            if (StringUtils.equals(claimDTO.getUri(),
-                    IdentityManagementEndpointConstants.ClaimURIs.FIRST_NAME_CLAIM) ||
-                    StringUtils.equals(claimDTO.getUri(),
-                            IdentityManagementEndpointConstants.ClaimURIs.LAST_NAME_CLAIM) ||
-                    StringUtils.equals(claimDTO.getUri(),
-                            IdentityManagementEndpointConstants.ClaimURIs.EMAIL_CLAIM)) {
-                if (StringUtils.isNotBlank(request.getParameter(claimDTO.getUri()))) {
-                    UserClaim userClaim = new UserClaim();
-                    userClaim.setUri(claimDTO.getUri());
-                    userClaim.setValue(request.getParameter(claimDTO.getUri()));
-                    claimDTOList.add(userClaim);
-                }
+            if (StringUtils.isNotBlank(request.getParameter(claimDTO.getUri()))) {
+                UserClaim userClaim = new UserClaim();
+                userClaim.setUri(claimDTO.getUri());
+                userClaim.setValue(request.getParameter(claimDTO.getUri()));
+                claimDTOList.add(userClaim);
             }
         }
 


### PR DESCRIPTION
When rendering the username recovery page, we list all the "required" claims as per [1]. But, when we are invoking the username recovery API, it gets the first name, last name, and email only, other claims are discarded as per [2]. This fix will allow all the claim.

[1] https://github.com/wso2/carbon-identity-framework/blob/master/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/username-recovery.jsp#L259
[2] https://github.com/wso2/carbon-identity-framework/blob/master/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint/src/main/webapp/recovery.jsp#L77


issue: https://github.com/wso2/product-is/issues/6158