### PR TITLE
Remove idp page heading

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit.jsp
@@ -3195,15 +3195,6 @@
 
 <fmt:bundle basename="org.wso2.carbon.idp.mgt.ui.i18n.Resources">
     <div id="middle">
-        <% if ( idPName != null && idPName != "") { %>
-        <h2>
-            <fmt:message key = 'identity.provider'/>
-        </h2>
-        <% } else { %>
-        <h2>
-            <fmt:message key='add.identity.provider'/>
-        </h2>
-        <% } %>
         <div id="workArea">
             <form id="idp-mgt-edit-form" name="idp-mgt-edit-form" method="post"
                   action="idp-mgt-edit-finish-ajaxprocessor.jsp?<csrf:tokenname/>=<csrf:tokenvalue/>"


### PR DESCRIPTION
### Proposed changes in this pull request

With the tomcat 9 update, the following error is thrown when loading the idp-mgt-edit.jsp,
```The code of method _jspService(HttpServletRequest, HttpServletResponse) is exceeding the 65535 bytes limit```

The tomcat discussion says (https://bz.apache.org/bugzilla/show_bug.cgi?id=60126) "The changelog for 8.0.37 mentions a number of changes in Jasper around error handling that will have increased the volume of the auto-generated code Jasper creates."

Our idp-mgt-edit.jsp page has more than 6000 lines, removing this if checks compile the jsp class. So I am removing this title as temporary fix moving forward, we need to refactor this class.

Created an issue to track this https://github.com/wso2/product-is/issues/6185