### PR TITLE
Make the pax logging as provided

### DIFF
--- a/components/template-mgt/org.wso2.carbon.identity.template.mgt.endpoint/pom.xml
+++ b/components/template-mgt/org.wso2.carbon.identity.template.mgt.endpoint/pom.xml
@@ -159,6 +159,7 @@
         <dependency>
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>


### PR DESCRIPTION
### Proposed changes in this pull request

Make the pax logging as provided as it is not needed to be packed with the war. Fix: https://github.com/wso2/product-is/issues/6340