### PR TITLE
Create connector config API

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ConnectorConfig.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ConnectorConfig.java
@@ -19,26 +19,84 @@ package org.wso2.carbon.identity.core;
 import java.util.Map;
 import java.util.Properties;
 
+/**
+ * Identity connector configuration.
+ */
 public interface ConnectorConfig {
 
+    /**
+     * Get the connector name.
+     *
+     * @return connector name
+     */
     String getName();
 
+    /**
+     * Get the connector friendly name.
+     *
+     * @return connector friendly name
+     */
     String getFriendlyName();
 
+    /**
+     * Get the connector category.
+     *
+     * @return connector category
+     */
     String getCategory();
 
+    /**
+     * Get the connector sub category.
+     *
+     * @return connector sub category
+     */
     String getSubCategory();
 
+    /**
+     * Get the connector order.
+     *
+     * @return connector order
+     */
     int getOrder();
 
+    /**
+     * Get the mapping between properties and property display names.
+     *
+     * @return property to display names mapping
+     */
     Map<String, String> getPropertyNameMapping();
 
+    /**
+     * Get the mapping between connector properties and property descriptions.
+     *
+     * @return property to description mapping
+     */
     Map<String, String> getPropertyDescriptionMapping();
 
+    /**
+     * Get the connector property names.
+     *
+     * @return connector property names
+     */
     String[] getPropertyNames();
 
+    /**
+     * Get the connector property default values.
+     *
+     * @param tenantDomain tenant domain of the config
+     * @return default property values
+     * @throws ConnectorException
+     */
     Properties getDefaultPropertyValues(String tenantDomain) throws ConnectorException;
 
+    /**
+     * Get the connector property default values for the given property names.
+     *
+     * @param propertyNames property names
+     * @param tenantDomain tenant domain of the config
+     * @return default property values
+     * @throws ConnectorException
+     */
     Map<String, String> getDefaultPropertyValues(String[] propertyNames, String tenantDomain) throws ConnectorException;
 
 }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ConnectorConfig.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ConnectorConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.core;
+
+import java.util.Map;
+import java.util.Properties;
+
+public interface ConnectorConfig {
+
+    String getName();
+
+    String getFriendlyName();
+
+    String getCategory();
+
+    String getSubCategory();
+
+    int getOrder();
+
+    Map<String, String> getPropertyNameMapping();
+
+    Map<String, String> getPropertyDescriptionMapping();
+
+    String[] getPropertyNames();
+
+    Properties getDefaultPropertyValues(String tenantDomain) throws ConnectorException;
+
+    Map<String, String> getDefaultPropertyValues(String[] propertyNames, String tenantDomain) throws ConnectorException;
+
+}

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ConnectorException.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ConnectorException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.core;
+
+public class ConnectorException extends Exception {
+
+    public ConnectorException(String message) {
+
+        super(message);
+    }
+
+    public ConnectorException(String message, Throwable cause) {
+
+        super(message, cause);
+    }
+
+    public ConnectorException(Throwable cause) {
+
+        super(cause);
+    }
+
+    public ConnectorException() {
+
+        super();
+    }
+
+}

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAO.java
@@ -427,7 +427,7 @@ public class CacheBackedIdPMgtDAO {
         }
     }
 
-    private void clearIdpCache(String idPName, int tenantId, String tenantDomain) throws IdentityProviderManagementException {
+    public void clearIdpCache(String idPName, int tenantId, String tenantDomain) throws IdentityProviderManagementException {
 
 
         // clearing cache entries related to the deleted IDP

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -1544,13 +1544,19 @@ public class IdPManagementDAO {
 
                 List<IdentityProviderProperty> propertyList = filterIdenityProperties(federatedIdp,
                         getIdentityPropertiesByIdpId(dbConnection, Integer.parseInt(rs.getString("ID"))));
-                federatedIdp.setIdpProperties(propertyList.toArray(new IdentityProviderProperty[propertyList.size()]));
+                if (IdentityApplicationConstants.RESIDENT_IDP_RESERVED_NAME.equals(idPName)) {
+                    propertyList = resolveConnectorProperties(propertyList, tenantDomain);
+                }
+                federatedIdp.setIdpProperties(propertyList.toArray(new IdentityProviderProperty[0]));
 
             }
             return federatedIdp;
         } catch (SQLException e) {
             throw new IdentityProviderManagementException("Error occurred while retrieving Identity Provider " +
                     "information for Authenticator Property : " + property + " and value : " + value, e);
+        } catch (ConnectorException e) {
+            throw new IdentityProviderManagementException("Error occurred while retrieving the identity connector " +
+                    "configurations.", e);
         } finally {
             if (dbConnectionInitialized) {
                 IdentityDatabaseUtil.closeAllConnections(dbConnection, rs, prepStmt);
@@ -1696,13 +1702,20 @@ public class IdPManagementDAO {
 
                 List<IdentityProviderProperty> propertyList = filterIdenityProperties(federatedIdp,
                         getIdentityPropertiesByIdpId(dbConnection, Integer.parseInt(rs.getString("ID"))));
-                federatedIdp.setIdpProperties(propertyList.toArray(new IdentityProviderProperty[propertyList.size()]));
+
+                if (IdentityApplicationConstants.RESIDENT_IDP_RESERVED_NAME.equals(idPName)) {
+                    propertyList = resolveConnectorProperties(propertyList, tenantDomain);
+                }
+                federatedIdp.setIdpProperties(propertyList.toArray(new IdentityProviderProperty[0]));
 
             }
             return federatedIdp;
         } catch (SQLException e) {
             throw new IdentityProviderManagementException("Error occurred while retrieving Identity Provider " +
                     "information for Authenticator Property : " + property + " and value : " + value, e);
+        } catch (ConnectorException e) {
+            throw new IdentityProviderManagementException("Error occurred while retrieving the identity connector " +
+                    "configurations.", e);
         } finally {
             if (dbConnectionInitialized) {
                 IdentityDatabaseUtil.closeAllConnections(dbConnection, rs, prepStmt);

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/internal/IdPManagementServiceComponent.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/internal/IdPManagementServiceComponent.java
@@ -35,6 +35,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.core.ConnectorConfig;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -413,5 +414,25 @@ public class IdPManagementServiceComponent {
         } catch (Throwable e) {
             throw new Exception("Error when adding Resident Identity Provider entry for super tenant ", e);
         }
+    }
+
+    @Reference(
+            name = "identity.core.ConnectorConfig",
+            service = org.wso2.carbon.identity.core.ConnectorConfig.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetGovernanceConnector")
+    protected void setIdentityGovernanceConnector(ConnectorConfig identityConnectorConfig) {
+
+        try {
+            IdpMgtServiceComponentHolder.getInstance().addConnectorConfig(identityConnectorConfig);
+        } catch (IdentityProviderManagementException e) {
+            log.error("Error while clearing the cache with the registered connector config.");
+        }
+    }
+
+    protected void unsetGovernanceConnector(ConnectorConfig identityConnectorConfig) {
+
+        IdpMgtServiceComponentHolder.getInstance().unsetGovernanceConnector(identityConnectorConfig);
     }
 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/internal/IdpMgtServiceComponentHolder.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/internal/IdpMgtServiceComponentHolder.java
@@ -18,6 +18,13 @@
 
 package org.wso2.carbon.idp.mgt.internal;
 
+import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.core.ConnectorConfig;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.dao.CacheBackedIdPMgtDAO;
+import org.wso2.carbon.idp.mgt.dao.IdPManagementDAO;
 import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
 import org.wso2.carbon.idp.mgt.util.MetadataConverter;
 import org.wso2.carbon.registry.core.service.RegistryService;
@@ -35,14 +42,14 @@ public class IdpMgtServiceComponentHolder {
     }
 
 
-    private  RealmService realmService = null;
+    private RealmService realmService = null;
 
     private ConfigurationContextService configurationContextService = null;
     private volatile List<IdentityProviderMgtListener> idpMgtListeners = new ArrayList<>();
+    private volatile List<ConnectorConfig> identityConnectorConfigList = new ArrayList<>();
     private RegistryService registryService;
 
     private List<MetadataConverter> metadataConverters = new ArrayList<>();
-
 
     public RealmService getRealmService() {
         return realmService;
@@ -83,10 +90,31 @@ public class IdpMgtServiceComponentHolder {
     public void setMetadataConverters(List<MetadataConverter> metadataConverters) {
         this.metadataConverters = metadataConverters;
     }
-    public void addMetadataConverter(MetadataConverter converter){
+    public void addMetadataConverter(MetadataConverter converter) {
         this.metadataConverters.add(converter);
     }
-    public void removeMetadataConverter(MetadataConverter converter){
+    public void removeMetadataConverter(MetadataConverter converter) {
         this.metadataConverters.remove(converter);
+    }
+
+    public void addConnectorConfig(ConnectorConfig identityConnectorConfig) throws IdentityProviderManagementException {
+
+        CacheBackedIdPMgtDAO dao = new CacheBackedIdPMgtDAO(new IdPManagementDAO());
+
+        dao.clearIdpCache(IdentityApplicationConstants.RESIDENT_IDP_RESERVED_NAME,
+                IdentityTenantUtil.getTenantId(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME),
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+        this.identityConnectorConfigList.add(identityConnectorConfig);
+    }
+
+    public List<ConnectorConfig> getIdentityConnectorConfigList() {
+
+        return identityConnectorConfigList;
+    }
+
+    protected void unsetGovernanceConnector(ConnectorConfig connector) {
+
+        identityConnectorConfigList.remove(connector);
     }
 }


### PR DESCRIPTION
Add ConnectorConfig interface. IdentityConnectorConfig will be extended from ConnectorConfig so that IdpManager layer can be aware of the IdentityConnectorConfig properties (saved as IDP_METADATA) and skip saving the default values. By doing so, when a new property is added to a connector, the default value will be returned from the API until the admin changes the value (which will be saved in the database).