### PR TITLE
Use a mask value for encrypted properties instead of a caching approach

### DIFF
--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/beans/MaskedProperty.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/beans/MaskedProperty.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.user.store.configuration.beans;
+
+/**
+ * This class represents a property which has a mask value.
+ */
+public class MaskedProperty {
+
+    private String name;
+    private String value;
+    private String mask;
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public String getValue() {
+
+        return value;
+    }
+
+    public void setValue(String value) {
+
+        this.value = value;
+    }
+
+    public String getMask() {
+
+        return mask;
+    }
+
+    public void setMask(String mask) {
+
+        this.mask = mask;
+    }
+}

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/beans/RandomPassword.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/beans/RandomPassword.java
@@ -21,7 +21,13 @@ package org.wso2.carbon.identity.user.store.configuration.beans;
 import java.io.Serializable;
 
 /**
- * Class holds the information related to RandomPassword
+ * Class holds the information related to RandomPassword.
+ *
+ * @see <a href="https://github.com/wso2/product-is/issues/6410">https://github.com/wso2/product-is/issues/6410</a>.
+ * @deprecated {@link RandomPassword}, {@link RandomPasswordContainer} and
+ * {@link org.wso2.carbon.identity.user.store.configuration.cache.RandomPasswordContainerCache} based approach in the
+ * {@link org.wso2.carbon.identity.user.store.configuration.UserStoreConfigAdminService} is identified as problematic
+ * in a clustered deployment. Therefore a new approach based {@link MaskedProperty} is used.
  */
 public class RandomPassword implements Serializable {
 

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/beans/RandomPasswordContainer.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/beans/RandomPasswordContainer.java
@@ -23,6 +23,12 @@ import java.io.Serializable;
 /**
  * Class mainatains an array where all the RandomPasswords are kept in an array.
  * This class is stored in distributed cache.
+ *
+ * @see <a href="https://github.com/wso2/product-is/issues/6410">https://github.com/wso2/product-is/issues/6410</a>.
+ * @deprecated {@link RandomPassword}, {@link RandomPasswordContainer} and
+ * {@link org.wso2.carbon.identity.user.store.configuration.cache.RandomPasswordContainerCache} based approach in the
+ * {@link org.wso2.carbon.identity.user.store.configuration.UserStoreConfigAdminService} is identified as problematic
+ * in a clustered deployment. Therefore a new approach based {@link MaskedProperty} is used.
  */
 public class RandomPasswordContainer implements Serializable {
 

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/cache/RandomPasswordContainerCache.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/cache/RandomPasswordContainerCache.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.user.store.configuration.cache;
 
+import org.wso2.carbon.identity.user.store.configuration.beans.MaskedProperty;
+import org.wso2.carbon.identity.user.store.configuration.beans.RandomPassword;
 import org.wso2.carbon.identity.user.store.configuration.beans.RandomPasswordContainer;
 import org.wso2.carbon.identity.user.store.configuration.utils.UserStoreConfigurationConstant;
 
@@ -26,6 +28,12 @@ import javax.cache.Caching;
 
 /**
  * Class to hold the reference for distributed cache object
+ *
+ * @see <a href="https://github.com/wso2/product-is/issues/6410">https://github.com/wso2/product-is/issues/6410</a>.
+ * @deprecated {@link RandomPassword}, {@link RandomPasswordContainer} and
+ * {@link org.wso2.carbon.identity.user.store.configuration.cache.RandomPasswordContainerCache} based approach in the
+ * {@link org.wso2.carbon.identity.user.store.configuration.UserStoreConfigAdminService} is identified as problematic
+ * in a clustered deployment. Therefore a new approach based {@link MaskedProperty} is used.
  */
 public class RandomPasswordContainerCache {
 

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/dao/impl/FileBasedUserStoreDAOImpl.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/dao/impl/FileBasedUserStoreDAOImpl.java
@@ -21,7 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
-import org.wso2.carbon.identity.user.store.configuration.beans.RandomPassword;
+import org.wso2.carbon.identity.user.store.configuration.beans.MaskedProperty;
 import org.wso2.carbon.identity.user.store.configuration.dao.AbstractUserStoreDAO;
 import org.wso2.carbon.identity.user.store.configuration.dto.UserStoreDTO;
 import org.wso2.carbon.identity.user.store.configuration.dto.UserStorePersistanceDTO;
@@ -51,11 +51,12 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.wso2.carbon.identity.user.store.configuration.utils.SecondaryUserStoreConfigurationUtil.convertMapToArray;
-import static org.wso2.carbon.identity.user.store.configuration.utils.SecondaryUserStoreConfigurationUtil.getRandomPasswords;
+import static org.wso2.carbon.identity.user.store.configuration.utils.SecondaryUserStoreConfigurationUtil.setMaskInUserStoreProperties;
 import static org.wso2.carbon.identity.user.store.configuration.utils.SecondaryUserStoreConfigurationUtil.triggerListnersOnUserStorePreDelete;
 import static org.wso2.carbon.identity.user.store.configuration.utils.SecondaryUserStoreConfigurationUtil.triggerListnersOnUserStorePreUpdate;
 import static org.wso2.carbon.identity.user.store.configuration.utils.SecondaryUserStoreConfigurationUtil.validateForFederatedDomain;
 import static org.wso2.carbon.identity.user.store.configuration.utils.SecondaryUserStoreConfigurationUtil.writeUserMgtXMLFile;
+import static org.wso2.carbon.identity.user.store.configuration.utils.UserStoreConfigurationConstant.ENCRYPTED_PROPERTY_MASK;
 import static org.wso2.carbon.identity.user.store.configuration.utils.UserStoreConfigurationConstant.FILE_EXTENSION_XML;
 import static org.wso2.carbon.identity.user.store.configuration.utils.UserStoreConfigurationConstant.USERSTORES;
 import static org.wso2.carbon.identity.user.store.configuration.utils.UserStoreConfigurationConstant.deploymentDirectory;
@@ -240,17 +241,16 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
                 if (uuid == null) {
                     uuid = UUID.randomUUID().toString();
                 }
-                String randomPhrase = UserStoreConfigurationConstant.RANDOM_PHRASE_PREFIX + uuid;
                 String className = secondaryRealmConfiguration.getUserStoreClass();
                 UserStoreDTO userStoreDTO = getUserStoreDTO(secondaryRealmConfiguration, userStoreProperties);
                 userStoreProperties.put("Class", className);
                 userStoreProperties.put(UserStoreConfigurationConstant.UNIQUE_ID_CONSTANT, uuid);
-                RandomPassword[] randomPasswords = getRandomPasswords(secondaryRealmConfiguration, userStoreProperties,
-                        uuid, randomPhrase, className);
+                MaskedProperty[] maskedProperties = setMaskInUserStoreProperties(secondaryRealmConfiguration,
+                        userStoreProperties, ENCRYPTED_PROPERTY_MASK, className);
                 userStoreDTO.setProperties(convertMapToArray(userStoreProperties));
                 // Now revert back to original password.
-                for (RandomPassword randomPassword : randomPasswords) {
-                    userStoreProperties.put(randomPassword.getPropertyName(), randomPassword.getPassword());
+                for (MaskedProperty maskedProperty : maskedProperties) {
+                    userStoreProperties.put(maskedProperty.getName(), maskedProperty.getValue());
                 }
                 domains.add(userStoreDTO);
                 secondaryRealmConfiguration = secondaryRealmConfiguration.getSecondaryRealmConfig();
@@ -393,18 +393,17 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
                 if (uuid == null) {
                     uuid = UUID.randomUUID().toString();
                 }
-                String randomPhrase = UserStoreConfigurationConstant.RANDOM_PHRASE_PREFIX + uuid;
                 String className = secondaryRealmConfiguration.getUserStoreClass();
                 UserStoreDTO userStoreDTO = getUserStoreDTO(secondaryRealmConfiguration, userStoreProperties);
                 userStoreProperties.put("Class", className);
                 userStoreProperties.put(UserStoreConfigurationConstant.UNIQUE_ID_CONSTANT, uuid);
-                RandomPassword[] randomPasswords = getRandomPasswords(secondaryRealmConfiguration, userStoreProperties,
-                        uuid, randomPhrase, className);
+                MaskedProperty[] maskedProperties = setMaskInUserStoreProperties(secondaryRealmConfiguration,
+                        userStoreProperties, ENCRYPTED_PROPERTY_MASK, className);
                 userStoreDTO.setProperties(convertMapToArray(userStoreProperties));
 
                 // Now revert back to original password.
-                for (RandomPassword randomPassword : randomPasswords) {
-                    userStoreProperties.put(randomPassword.getPropertyName(), randomPassword.getPassword());
+                for (MaskedProperty maskedProperty : maskedProperties) {
+                    userStoreProperties.put(maskedProperty.getName(), maskedProperty.getValue());
                 }
                 userStorePersistanceDTO.setUserStoreDTO(userStoreDTO);
                 userStorePersistanceDAOList.add(userStorePersistanceDTO);

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/SecondaryUserStoreConfigurationUtil.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/SecondaryUserStoreConfigurationUtil.java
@@ -27,11 +27,10 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.core.util.CryptoUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
-import org.wso2.carbon.identity.user.store.configuration.beans.RandomPassword;
-import org.wso2.carbon.identity.user.store.configuration.beans.RandomPasswordContainer;
-import org.wso2.carbon.identity.user.store.configuration.cache.RandomPasswordContainerCache;
+import org.wso2.carbon.identity.user.store.configuration.beans.MaskedProperty;
 import org.wso2.carbon.identity.user.store.configuration.dao.UserStoreDAO;
 import org.wso2.carbon.identity.user.store.configuration.dao.impl.FileBasedUserStoreDAOFactory;
 import org.wso2.carbon.identity.user.store.configuration.dto.PropertyDTO;
@@ -43,22 +42,14 @@ import org.wso2.carbon.user.api.Property;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreConfigConstants;
+import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.tracker.UserStoreManagerRegistry;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.xml.sax.SAXException;
 
-import javax.crypto.Cipher;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -77,7 +68,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.crypto.Cipher;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 
+import static org.wso2.carbon.identity.user.store.configuration.utils.UserStoreConfigurationConstant.ENCRYPTED_PROPERTY_MASK;
 import static org.wso2.carbon.identity.user.store.configuration.utils.UserStoreConfigurationConstant.FILE_EXTENSION_XML;
 import static org.wso2.carbon.identity.user.store.configuration.utils.UserStoreConfigurationConstant.USERSTORES;
 import static org.wso2.carbon.identity.user.store.configuration.utils.UserStoreConfigurationConstant.deploymentDirectory;
@@ -320,6 +322,24 @@ public class SecondaryUserStoreConfigurationUtil {
         return userStoreProperties;
     }
 
+    public static Map<String, String> getSecondaryUserStorePropertiesFromTenantUserRealm(String userStoreDomain)
+            throws IdentityUserStoreMgtException {
+
+        Map<String, String> secondaryUserStoreProperties = null;
+        try {
+            UserStoreManager secondaryUserStoreManager = getSecondaryUserStoreManager(userStoreDomain);
+            if (secondaryUserStoreManager != null) {
+                secondaryUserStoreProperties = secondaryUserStoreManager.getRealmConfiguration()
+                        .getUserStoreProperties();
+            }
+        } catch (UserStoreException e) {
+            String errorMessage = "Error while retrieving user store configurations for user store domain: "
+                    + userStoreDomain;
+            throw new IdentityUserStoreMgtException(errorMessage, e);
+        }
+        return secondaryUserStoreProperties;
+    }
+
     private static Transformer transformProperties() throws TransformerException {
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
@@ -356,8 +376,8 @@ public class SecondaryUserStoreConfigurationUtil {
             attrClass.setValue(userStoreDTO.getClassName());
             userStoreElement.setAttributeNode(attrClass);
             if (userStoreDTO.getClassName() != null) {
-                addProperties(userStoreDTO.getClassName(), userStoreDTO.getProperties(), doc, userStoreElement,
-                        editSecondaryUserStore);
+                addProperties(userStoreDTO.getDomainId(), userStoreDTO.getClassName(), userStoreDTO.getProperties(),
+                        doc, userStoreElement, editSecondaryUserStore);
             }
             addProperty(UserStoreConfigConstants.DOMAIN_NAME, userStoreDTO.getDomainId(), doc, userStoreElement, false);
             addProperty(UserStoreConfigurationConstant.DESCRIPTION, userStoreDTO.getDescription(), doc, userStoreElement, false);
@@ -419,17 +439,6 @@ public class SecondaryUserStoreConfigurationUtil {
     }
 
     /**
-     * Get the RandomPasswordContainer object from the cache for given unique id
-     *
-     * @param uniqueID Get and Remove the unique id for that particualr cache
-     * @return RandomPasswordContainer of particular unique ID
-     */
-    private static RandomPasswordContainer getAndRemoveRandomPasswordContainer(String uniqueID) {
-
-        return RandomPasswordContainerCache.getInstance().getRandomPasswordContainerCache().getAndRemove(uniqueID);
-    }
-
-    /**
      * Obtain the UniqueID ID constant value from the propertyDTO object which was set well
      * before sending the edit request.
      *
@@ -447,29 +456,6 @@ public class SecondaryUserStoreConfigurationUtil {
             }
         }
 
-        return null;
-    }
-
-    /**
-     * Find the RandomPassword object for a given propertyName in the RandomPasswordContainer
-     * ( Which is unique per uniqueID )
-     *
-     * @param randomPasswordContainer RandomPasswordContainer object of an unique id
-     * @param propertyName            RandomPassword object to be obtained for that property
-     * @return Returns the RandomPassword object from the
-     */
-    private static RandomPassword getRandomPassword(RandomPasswordContainer randomPasswordContainer,
-                                             String propertyName) {
-
-        RandomPassword[] randomPasswords = randomPasswordContainer.getRandomPasswords();
-
-        if (randomPasswords != null) {
-            for (RandomPassword randomPassword : randomPasswords) {
-                if (randomPassword.getPropertyName().equalsIgnoreCase(propertyName)) {
-                    return randomPassword;
-                }
-            }
-        }
         return null;
     }
 
@@ -505,26 +491,22 @@ public class SecondaryUserStoreConfigurationUtil {
      * @param doc          Document
      * @param parent       Parent element of the properties to be added
      */
-    private static void addProperties(String userStoreClass, PropertyDTO[] propertyDTOs, Document doc, Element parent,
-                               boolean editSecondaryUserStore) throws IdentityUserStoreMgtException {
+    private static void addProperties(String userStoreDomain, String userStoreClass, PropertyDTO[] propertyDTOs, Document doc,
+                                      Element parent, boolean editSecondaryUserStore) throws IdentityUserStoreMgtException {
 
-        RandomPasswordContainer randomPasswordContainer = null;
         if (editSecondaryUserStore) {
             String uniqueID = getUniqueIDFromUserDTO(propertyDTOs);
             if (uniqueID == null) {
                 throw new IdentityUserStoreMgtException("UniqueID property is not provided.");
             }
-            randomPasswordContainer = getAndRemoveRandomPasswordContainer(uniqueID);
-            if (randomPasswordContainer == null) {
-                String errorMsg = "randomPasswordContainer is null for uniqueID therefore " +
-                        "proceeding without encryption=" + uniqueID;
-                log.error(errorMsg); //need this error log to further identify the reason for throwing this exception
-                throw new IdentityUserStoreMgtException("Longer delay causes the edit operation be to " +
-                        "abandoned");
-            }
         }
+
         //First check for mandatory field with #encrypt
         Property[] mandatoryProperties = getMandatoryProperties(userStoreClass);
+
+        Map<String, String> secondaryUserStoreProperties =
+                getSecondaryUserStorePropertiesFromTenantUserRealm(userStoreDomain);
+
         for (PropertyDTO propertyDTO : propertyDTOs) {
             String propertyDTOName = propertyDTO.getName();
             if (UserStoreConfigurationConstant.UNIQUE_ID_CONSTANT.equalsIgnoreCase(propertyDTOName)) {
@@ -535,15 +517,8 @@ public class SecondaryUserStoreConfigurationUtil {
             if (propertyDTOValue != null) {
                 boolean encrypted = false;
                 if (isPropertyToBeEncrypted(mandatoryProperties, propertyDTOName)) {
-                    if (randomPasswordContainer != null) {
-                        RandomPassword randomPassword = getRandomPassword(randomPasswordContainer, propertyDTOName);
-                        if (randomPassword != null) {
-                            if (propertyDTOValue.equalsIgnoreCase(randomPassword.getRandomPhrase())) {
-                                propertyDTOValue = randomPassword.getPassword();
-                            }
-                        }
-                    }
-
+                    propertyDTOValue = getPropertyValueIfMasked(secondaryUserStoreProperties, propertyDTOName,
+                            propertyDTOValue);
                     try {
                         propertyDTOValue = SecondaryUserStoreConfigurationUtil.encryptPlainText(propertyDTOValue);
                         encrypted = true;
@@ -555,6 +530,55 @@ public class SecondaryUserStoreConfigurationUtil {
                 addProperty(propertyDTOName, propertyDTOValue, doc, parent, encrypted);
             }
         }
+    }
+
+    /**
+     * If the property value is a mask value, this method will return the corresponding property value.
+     *
+     * @param secondaryUserStoreProperties Value {@link Map} of a the secondary user store, where actual value is
+     *                                     pulled instead of the mask.
+     * @param propertyDTOName   Name of the property.
+     * @param propertyDTOValue Value of the property.
+     * @return If property value is masked, returns the actual value to be stored instead of the mask. Otherwise the
+     * same propertyDTOValue passed as the argument.
+     */
+    private static String getPropertyValueIfMasked(Map<String, String> secondaryUserStoreProperties, String propertyDTOName,
+                                            String propertyDTOValue) {
+
+        if (ENCRYPTED_PROPERTY_MASK.equalsIgnoreCase(propertyDTOValue)) {
+            propertyDTOValue = getExistingPropertyValue(secondaryUserStoreProperties, propertyDTOName);
+        }
+        return propertyDTOValue;
+    }
+
+    private static String getExistingPropertyValue(Map<String, String> secondaryUserStoreProperties, String propertyDTOName) {
+
+        String existingPropertyValue = null;
+        if (secondaryUserStoreProperties != null) {
+            existingPropertyValue = secondaryUserStoreProperties.get(propertyDTOName);
+        }
+        return existingPropertyValue;
+    }
+
+    private static UserStoreManager getSecondaryUserStoreManager(String userStoreDomain) throws UserStoreException {
+
+        UserStoreManager secondaryUserStoreManager = null;
+        UserRealm userRealm = (UserRealm) UserStoreConfigComponent.getRealmService().getTenantUserRealm(
+                getTenantIdInTheCurrentContext());
+        UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+        if (userStoreManager != null) {
+            secondaryUserStoreManager = userStoreManager.getSecondaryUserStoreManager(userStoreDomain);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Could not locate user store manager for user store domain: " + userStoreDomain);
+            }
+        }
+        return secondaryUserStoreManager;
+    }
+
+    private static int getTenantIdInTheCurrentContext() {
+
+        return PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
     }
 
     /**
@@ -592,61 +616,40 @@ public class SecondaryUserStoreConfigurationUtil {
      * get random passwords generated.
      * @param secondaryRealmConfiguration realm configuration.
      * @param userStoreProperties user store properties.
-     * @param uuid random id.
-     * @param randomPhrase random phrase
+     * @param encryptPropertyMaskValue The value used as the mask.
      * @param className class name
-     * @return random password generated.
+     * @return The array of {@link MaskedProperty} for the user store.
      */
-    public static RandomPassword[] getRandomPasswords(RealmConfiguration secondaryRealmConfiguration,
-                                                Map<String, String> userStoreProperties, String uuid,
-                                                String randomPhrase, String className) {
+    public static MaskedProperty[] setMaskInUserStoreProperties(RealmConfiguration secondaryRealmConfiguration,
+                                                                Map<String, String> userStoreProperties,
+                                                                String encryptPropertyMaskValue, String className) {
 
-        RandomPassword[] randomPasswords = getRandomPasswordProperties(className, randomPhrase,
+        MaskedProperty[] maskedProperties = getMaskedProperties(className, encryptPropertyMaskValue,
                 secondaryRealmConfiguration);
-        if (randomPasswords != null) {
-            updatePasswordContainer(randomPasswords, uuid);
+
+        for (MaskedProperty maskedProperty : maskedProperties) {
+            userStoreProperties.put(maskedProperty.getName(), maskedProperty.getMask());
         }
 
-        // Replace the property with random password.
-        for (RandomPassword randomPassword : randomPasswords) {
-            userStoreProperties.put(randomPassword.getPropertyName(), randomPassword.getRandomPhrase());
-        }
-        return randomPasswords;
+        return maskedProperties;
     }
 
-    private static RandomPassword[] getRandomPasswordProperties(String userStoreClass,
-                                                                String randomPhrase, RealmConfiguration secondaryRealmConfiguration) {
+    private static MaskedProperty[] getMaskedProperties(String userStoreClass, String maskValue,
+                                                        RealmConfiguration secondaryRealmConfiguration) {
         //First check for mandatory field with #encrypt
         Property[] mandatoryProperties = getMandatoryProperties(userStoreClass);
-        ArrayList<RandomPassword> randomPasswordArrayList = new ArrayList<RandomPassword>();
+        ArrayList<MaskedProperty> maskedProperties = new ArrayList<>();
         for (Property property : mandatoryProperties) {
             String propertyName = property.getName();
             if (property.getDescription().contains(UserStoreConfigurationConstant.ENCRYPT_TEXT)) {
-                RandomPassword randomPassword = new RandomPassword();
-                randomPassword.setPropertyName(propertyName);
-                randomPassword.setPassword(secondaryRealmConfiguration.getUserStoreProperty(propertyName));
-                randomPassword.setRandomPhrase(randomPhrase);
-                randomPasswordArrayList.add(randomPassword);
+                MaskedProperty maskedProperty = new MaskedProperty();
+                maskedProperty.setName(propertyName);
+                maskedProperty.setValue(secondaryRealmConfiguration.getUserStoreProperty(propertyName));
+                maskedProperty.setMask(maskValue);
+                maskedProperties.add(maskedProperty);
             }
         }
-        return randomPasswordArrayList.toArray(new RandomPassword[randomPasswordArrayList.size()]);
-    }
-
-
-    private static void updatePasswordContainer(RandomPassword[] randomPasswords, String uuid) {
-
-        if (randomPasswords != null) {
-            if (log.isDebugEnabled()) {
-                log.debug("updatePasswordContainer reached for number of random password properties length = " +
-                        randomPasswords.length);
-            }
-            RandomPasswordContainer randomPasswordContainer = new RandomPasswordContainer();
-            randomPasswordContainer.setRandomPasswords(randomPasswords);
-            randomPasswordContainer.setUniqueID(uuid);
-
-            RandomPasswordContainerCache.getInstance().getRandomPasswordContainerCache().put(uuid,
-                    randomPasswordContainer);
-        }
+        return maskedProperties.toArray(new MaskedProperty[0]);
     }
 
     /**

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/UserStoreConfigurationConstant.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/UserStoreConfigurationConstant.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.utils.CarbonUtils;
 
 public class UserStoreConfigurationConstant {
 
+    public static final String ENCRYPTED_PROPERTY_MASK = "ENCRYPTED PROPERTY";
     public static final String UNIQUE_ID_CONSTANT = "UniqueID";
     public static final String RANDOM_PHRASE_PREFIX = "random-password-generated!@#$%^&*(0)+_";
     public static final String ENCRYPT_TEXT = "#encrypt";


### PR DESCRIPTION
**This pull request fixes the https://github.com/wso2/product-is/issues/6410.**

### Use Case:
1. Secondary user store configurations can be modified with the UserStoreConfigAdminService. A client is calling this admin service to modify secondary user store configurations. 
2. The client retrieves secondary user store configurations from the get method in the admin service.
3. Then the client modifies the received payload, sends the edit request to the IS.

### Existing Implementation:
- The secondary user store configurations contain the password of the user store, along with any other property which marked as encrypted to true.
- The encrypted fields are masked(with a random phrase) in the payload by IS, in step 02/03 above. The masking is done as follows.
-- Each encrypted field is stored in a RandomPassword object. This stores the random password phrase and the password value against the property name.
-- The set of RandomPassword objects for a user store is then stored in the RandomPasswordContainer object with a UUID. Then this RandomPasswordContainer is stored in the RandomPasswordContainerCache against the same UUID value.
-- The UUID value is sent in the get response in step 02, as a user store property. All the encrypted properties in the response have the random phrase as it’s value.
-- When the edit request received during step 03, IS will repopulate all the encrypted values from the RandomPasswordContainerCache instead of the random phrase, using the same UUID value received. 
-- If any of the random phrases are changed by the client, then this is interpreted as a change of the property. Then the new value is encrypted and stored.

### An Issue With A Clustered Deployment:
- The client request user store configurations(during step 02) and the request is processed by the node 01(This will also generate the above-discussed UUID).
- The client sends the edit request(during step 03) but now the request is processed by the node 02.
- The RandomPasswordContainerCache is not handled with Hazelcast clustering thus not shared through the cluster(as we do not enable distributed caching). Then node 02 does not retrieve a RandomPasswordContainer for the received UUID eventually failing the user store update request.

### Solution Introduced With This Pull Request:
- We will be removing the RandomPasswordContainer and the UUID based approach for masking encrypted fields. Instead, a constant value is used as a masking value for an encrypted field.
- During the update request(step 03), the encrypted fields are retrieved from the user realm. 
- If any encrypted field in the update request is equal to the same constant value we used as the mask, then that field is not modified by the client. In such cases, retrieved encrypted values from the user realm are used to replace the masking constant value in the corresponding field.

The UUID value is redundant with this approach. But it will be kept in the payload in order to preserve backward compatibility.