### PR TITLE
Fix unit test failures in windows env

### DIFF
--- a/components/identity-event/org.wso2.carbon.identity.event/src/test/java/org.wso2.carbon.identity.event/IdentityEventUtilsTest.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/test/java/org.wso2.carbon.identity.event/IdentityEventUtilsTest.java
@@ -56,7 +56,7 @@ public class IdentityEventUtilsTest extends IdentityBaseTest {
     public void testReadMessageTemplate() throws IOException {
 
         String identityEventUtils = IdentityEventUtils.readMessageTemplate("src/test/resources/sample-file.xml");
-        String fileContent = "<file></file>\n";
+        String fileContent = "<file></file>" + System.lineSeparator();
         Assert.assertTrue(fileContent.equals(identityEventUtils));
     }
 


### PR DESCRIPTION
Here we use Sytem.getProperty("line.separator") [1]. This System.getProperty("line.separator") is platform dependent one. In Unix systems, it is "\n" and in windows it is "\r\n". 

[1]https://github.com/wso2/carbon-identity-framework/blob/master/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventUtils.java#L189