### PR TITLE
Use user store level filtering while listing users in a role

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserRealmProxy.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserRealmProxy.java
@@ -1072,9 +1072,8 @@ public class UserRealmProxy {
             UserStoreManager usMan = realm.getUserStoreManager();
             String[] usersOfRole;
             boolean canLimitAndFilterUsersFromUMLevel = canLimitAndFilterUsersFromUMLevel(roleName, usMan);
-            boolean limitUserList = isLimitUserList(limit, canLimitAndFilterUsersFromUMLevel);
 
-            if (domain == null && limitUserList) {
+            if (domain == null && limit != 0) {
                 if (filter != null) {
                     filter = CarbonConstants.DOMAIN_SEPARATOR + filter;
                 } else {
@@ -1100,7 +1099,7 @@ public class UserRealmProxy {
             Arrays.sort(usersOfRole);
             Map<String, Integer> userCount = new HashMap<String, Integer>();
 
-            if (!limitUserList) {
+            if (limit == 0) {
                 filter = filter.replace("*", ".*");
                 Pattern pattern = Pattern.compile(filter, Pattern.CASE_INSENSITIVE);
                 List<FlaggedName> flaggedNames = new ArrayList<FlaggedName>();
@@ -2378,11 +2377,6 @@ public class UserRealmProxy {
             canLimitAndFilterWithUM = userStoreManager instanceof JDBCUserStoreManager;
         }
         return canLimitAndFilterWithUM;
-    }
-
-    private boolean isLimitUserList(int limit, boolean canLimitAndFilterUsersFromUMLevel) {
-
-        return limit != 0 && !canLimitAndFilterUsersFromUMLevel;
     }
 
     private String getDomainFreeFilter(String filter) {


### PR DESCRIPTION
## `This PR depends on the kernel release - 4.6.0`


Contains the changes introduced with https://github.com/wso2/carbon-identity-framework/pull/2475
### Proposed changes in this pull request
- Fixes wso2/product-is#6511
- Fixes https://github.com/wso2/product-is/issues/6769
- Depends on wso2/carbon-kernel#2317

### The Issues Addressed In This PR
When retrieving the users in a role, the method getUsersOfRole retrieves all the users in the given role and perform in-memory filtering with the given filter.
If the number of users is large, this task can take time and can lead to request timeout scenarios.
### Changes Introduced
Use user store level filtering by providing the filter parameter to the user store if possible with the user store manager.
### When should this PR be merged
When,

- wso2/carbon-kernel#2317 is merged
- A new kernel version is released including the above fix
- **_Kernal dependency version needs to be updated in this repository to match above release_**

### Documentation
N/A