### PR TITLE
Improvements to application management service layer

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAndOutboundAuthenticationConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAndOutboundAuthenticationConfig.java
@@ -73,7 +73,7 @@ public class LocalAndOutboundAuthenticationConfig implements Serializable {
     private boolean useTenantDomainInLocalSubjectIdentifier = false;
 
     @XmlElement(name = USE_USERSTORE_DOMAIN_IN_ROLES)
-    private boolean useUserstoreDomainInRoles = false;
+    private boolean useUserstoreDomainInRoles = true;
 
     @XmlElement(name = USE_USERSTORE_DOMAIN_IN_USERNAME)
     private boolean useUserstoreDomainInLocalSubjectIdentifier = false;

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/java/org/wso2/carbon/identity/application/mgt/ui/ApplicationBean.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/java/org/wso2/carbon/identity/application/mgt/ui/ApplicationBean.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.identity.application.common.model.xsd.RequestPathAuthenti
 import org.wso2.carbon.identity.application.common.model.xsd.RoleMapping;
 import org.wso2.carbon.identity.application.common.model.xsd.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.xsd.ServiceProviderProperty;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ui.util.ApplicationMgtUIConstants;
 import org.wso2.carbon.identity.application.mgt.ui.util.ApplicationMgtUIUtil;
 import org.wso2.carbon.identity.base.IdentityConstants;
@@ -490,7 +491,13 @@ public class ApplicationBean {
         return false;
     }
 
+    /**
+     * Returns whether consent needs to be skipped for this service provider.
+     *
+     * @return true of consent is skipped, false otherwise.
+     */
     public boolean isSkipConsent() {
+
         if (serviceProvider.getLocalAndOutBoundAuthenticationConfig() != null) {
             return serviceProvider.getLocalAndOutBoundAuthenticationConfig().getSkipConsent();
         }
@@ -1087,7 +1094,7 @@ public class ApplicationBean {
         serviceProvider.setDescription(request.getParameter("sp-description"));
         serviceProvider.setCertificateContent(request.getParameter("sp-certificate"));
 
-        String jwks = request.getParameter("jwksUri");
+        String jwks = request.getParameter(IdentityApplicationConstants.JWKS_URI_SP_PROPERTY_NAME);
         serviceProvider.setJwksUri(jwks);
 
         if (Boolean.parseBoolean(request.getParameter("deletePublicCert"))) {

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider.jsp
@@ -142,29 +142,9 @@
     boolean isAdvanceConsentManagementEnabled = false;
 
     //adding code to support jwks URI
-    String jwksUri = null;
-    boolean hasJWKSUri = false;
-
-    // SP bound consent skip
-    boolean skipContent = false;
-
-    ServiceProviderProperty[] spProperties = appBean.getServiceProvider().getSpProperties();
-
-    if (spProperties != null) {
-        for (ServiceProviderProperty spProperty : spProperties) {
-            if (ApplicationMgtUIUtil.JWKS_URI.equals(spProperty.getName())) {
-                hasJWKSUri = true;
-                jwksUri = spProperty.getValue();
-            } else if (ApplicationMgtUIConstants.SKIP_CONSENT.equals(spProperty.getName())) {
-                skipContent = Boolean.parseBoolean(spProperty.getValue());
-            }
-        }
-    }
-
-    if (jwksUri == null) {
-       jwksUri = "";
-    }
-
+    String jwksUri = appBean.getServiceProvider().getJwksUri();
+    boolean hasJWKSUri = StringUtils.isNotEmpty(jwksUri);
+    
     String authTypeReq = request.getParameter("authType");
     if (authTypeReq != null && authTypeReq.trim().length() > 0) {
         appBean.setAuthenticationType(authTypeReq);
@@ -1453,7 +1433,7 @@
                             <fmt:message key="config.application.JWKS"/>
                             </td>
                             <td style="width:50%" class="leftCol-med labelField">
-                               <input style="width:50%" id="jwksUri" name="jwksUri" type="text" value="<%=Encode.forHtmlAttribute(jwksUri)%>"
+                               <input style="width:50%" id="jwksUri" name="jwksUri" type="text" value="<%=jwksUri != null ? Encode.forHtmlAttribute(jwksUri) : "" %>"
                                 autofocus required/>
                             </td>
                         </tr>
@@ -2794,7 +2774,7 @@
                                                     </td>
                                                 </tr>
                                                 <tr>
-                                                    <input type="checkbox" id="skipConsent" name="skipConsent" <%= skipContent ? "checked" : ""%> value="true"/>
+                                                    <input type="checkbox" id="skipConsent" name="skipConsent" <%= appBean.isSkipConsent() ? "checked" : ""%> value="true"/>
                                                     <label for="skipConsent"><fmt:message key="config.application.skip.consent"/></label>
                                                     </br>
                                                     <div class="sectionHelp">

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -1822,7 +1822,7 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
             } catch (IdentityApplicationManagementException ex) {
                 if (log.isDebugEnabled()) {
                     log.debug("Creating application: " + applicationName + " in tenantDomain: " + tenantDomain +
-                            " failed. Rolling back by cleaning up partially deleting partial created data.");
+                            " failed. Rolling back by cleaning up partially created data.");
                 }
                 deleteApplicationRole(applicationName);
                 throw ex;

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -1820,6 +1820,10 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
                 PermissionsAndRoleConfig permissionAndRoleConfig = serviceProvider.getPermissionAndRoleConfig();
                 ApplicationMgtUtil.storePermissions(applicationName, username, permissionAndRoleConfig);
             } catch (IdentityApplicationManagementException ex) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Creating application: " + applicationName + " in tenantDomain: " + tenantDomain +
+                            " failed. Rolling back by cleaning up partially deleting partial created data.");
+                }
                 deleteApplicationRole(applicationName);
                 throw ex;
             }
@@ -1829,6 +1833,10 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
                 String resourceId = appDAO.addApplication(serviceProvider, tenantDomain);
                 return appDAO.getApplicationByResourceId(resourceId, tenantDomain);
             } catch (IdentityApplicationManagementException ex) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Creating application: " + applicationName + " in tenantDomain: " + tenantDomain +
+                            " failed. Rolling back by cleaning up partially created data.");
+                }
                 deleteApplicationRole(applicationName);
                 deleteApplicationPermission(applicationName);
                 appDAO.deleteApplication(applicationName);
@@ -2284,7 +2292,7 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
 
         if (isAppRenamed(currentAppName, updatedAppName)
                 && ApplicationConstants.LOCAL_SP.equalsIgnoreCase(updatedAppName)) {
-            String msg = "Cannot update an application's name to system default application's name '%s'";
+            String msg = "Cannot update an application's name to tenant resident service provider's name '%s'";
             throw buildClientException(ERROR_CODE_APP_UPDATE_REQUEST_INVALID,
                     String.format(msg, ApplicationConstants.LOCAL_SP));
         }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -97,8 +97,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.isNull;
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.JWKS_URI_SP_PROPERTY_NAME;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.ErrorMessage.ERROR_APPLICATION_IS_NOT_DISCOVERABLE;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.ErrorMessage.ERROR_INVALID_LIMIT;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.ErrorMessage.ERROR_INVALID_OFFSET;
@@ -209,6 +212,8 @@ import static org.wso2.carbon.identity.application.mgt.ApplicationMgtDBQueries.U
 import static org.wso2.carbon.identity.application.mgt.ApplicationMgtDBQueries.UPDATE_BASIC_APP_INFO_WITH_CONSENT_ENABLED;
 import static org.wso2.carbon.identity.application.mgt.ApplicationMgtDBQueries.UPDATE_CERTIFICATE;
 import static org.wso2.carbon.identity.application.mgt.ApplicationMgtDBQueries.UPDATE_SP_PERMISSIONS;
+import static org.wso2.carbon.identity.base.IdentityConstants.SKIP_CONSENT;
+import static org.wso2.carbon.identity.base.IdentityConstants.SKIP_CONSENT_DISPLAY_NAME;
 
 /**
  * This class access the IDN_APPMGT database to store/update and delete application configurations.
@@ -230,7 +235,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
 
     private List<String> standardInboundAuthTypes;
     public static final String USE_DOMAIN_IN_ROLES = "USE_DOMAIN_IN_ROLES";
-    public static final String DOMAIN_IN_ROLES = "DOMAIN_IN_ROLES";
+    public static final String USE_DOMAIN_IN_ROLE_DISPLAY_NAME = "DOMAIN_IN_ROLES";
 
     public ApplicationDAOImpl() {
 
@@ -258,12 +263,11 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
     private List<ServiceProviderProperty> getServicePropertiesBySpId(Connection dbConnection, int SpId)
             throws SQLException {
 
-        String sqlStmt = GET_SP_METADATA_BY_SP_ID;
         PreparedStatement prepStmt = null;
         ResultSet rs = null;
         List<ServiceProviderProperty> idpProperties = new ArrayList<ServiceProviderProperty>();
         try {
-            prepStmt = dbConnection.prepareStatement(sqlStmt);
+            prepStmt = dbConnection.prepareStatement(GET_SP_METADATA_BY_SP_ID);
             prepStmt.setInt(1, SpId);
             rs = prepStmt.executeQuery();
             while (rs.next()) {
@@ -414,9 +418,6 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                 applicationId = getApplicationIDByName(applicationName, tenantID, connection);
             }
 
-            // To add the property "USE_DOMAIN_IN_ROLES".
-            // TODO: move this to OSGi layer.
-            addUseDomainNameInRolesAsSpProperty(serviceProvider);
             if (serviceProvider.getSpProperties() != null) {
                 addServiceProviderProperties(connection, applicationId,
                         Arrays.asList(serviceProvider.getSpProperties()), tenantID);
@@ -513,11 +514,10 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                         serviceProvider.getPermissionAndRoleConfig().getPermissions());
             }
 
-            updateUseDomainNameInRolesAsSpProperty(serviceProvider);
-            if (serviceProvider.getSpProperties() != null) {
-                // To update 'USE_DOMAIN_IN_ROLES' property value.
-                updateServiceProviderProperties(connection, applicationId, Arrays.asList(serviceProvider
-                        .getSpProperties()), tenantID);
+            updateConfigurationsAsServiceProperties(serviceProvider);
+            if (ArrayUtils.isNotEmpty(serviceProvider.getSpProperties())) {
+                ServiceProviderProperty[] spProperties = serviceProvider.getSpProperties();
+                updateServiceProviderProperties(connection, applicationId, Arrays.asList(spProperties), tenantID);
             }
 
             // Will be supported with 'Advance Consent Management Feature'.
@@ -1721,94 +1721,22 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
     }
 
     @Override
-    public ServiceProvider getApplication(String applicationName, String tenantDomain)
-            throws IdentityApplicationManagementException {
+    public ServiceProvider getApplication(String applicationName,
+                                          String tenantDomain) throws IdentityApplicationManagementException {
 
-        int applicationId = 0;
-        int tenantID = MultitenantConstants.SUPER_TENANT_ID;
-        if (tenantDomain != null) {
-            try {
-                tenantID = ApplicationManagementServiceComponentHolder.getInstance().getRealmService()
-                        .getTenantManager().getTenantId(tenantDomain);
-            } catch (UserStoreException e1) {
-                log.error("Error in reading application", e1);
-                throw new IdentityApplicationManagementException("Error while reading application", e1);
-            }
-        }
-
-        Connection connection = IdentityDatabaseUtil.getDBConnection(false);
         try {
-
-            // Load basic application data
-            ServiceProvider serviceProvider = getBasicApplicationData(applicationName, connection, tenantID);
-
-            if ((serviceProvider == null || serviceProvider.getApplicationName() == null)
-                    && ApplicationConstants.LOCAL_SP.equals(applicationName)) {
+            int applicationId = getApplicationIdByName(applicationName, tenantDomain);
+            if (applicationId == 0 && ApplicationConstants.LOCAL_SP.equals(applicationName)) {
+                // Looking for the resident sp. Create the resident sp for the tenant.
                 ServiceProvider localServiceProvider = new ServiceProvider();
                 localServiceProvider.setApplicationName(applicationName);
                 localServiceProvider.setDescription("Local Service Provider");
-                createApplication(localServiceProvider, tenantDomain);
-                serviceProvider = getBasicApplicationData(applicationName, connection, tenantID);
+                applicationId = createApplication(localServiceProvider, tenantDomain);
             }
-
-            if (serviceProvider == null) {
-                return null;
-            }
-
-            applicationId = serviceProvider.getApplicationID();
-
-            serviceProvider.setInboundAuthenticationConfig(getInboundAuthenticationConfig(
-                    applicationId, connection, tenantID));
-            List<ServiceProviderProperty> propertyList = getServicePropertiesBySpId(connection, applicationId);
-            serviceProvider
-                    .setLocalAndOutBoundAuthenticationConfig(getLocalAndOutboundAuthenticationConfig(
-                            applicationId, connection, tenantID, propertyList));
-
-            serviceProvider.setInboundProvisioningConfig(getInboundProvisioningConfiguration(
-                    applicationId, connection, tenantID));
-
-            serviceProvider.setOutboundProvisioningConfig(getOutboundProvisioningConfiguration(
-                    applicationId, connection, tenantID));
-
-            // Load Claim Mapping
-            serviceProvider.setClaimConfig(getClaimConfiguration(applicationId, connection,
-                    tenantID));
-
-            // Load Role Mappings
-            List<RoleMapping> roleMappings = getRoleMappingOfApplication(applicationId, connection,
-                    tenantID);
-            PermissionsAndRoleConfig permissionAndRoleConfig = new PermissionsAndRoleConfig();
-            permissionAndRoleConfig.setRoleMappings(roleMappings
-                    .toArray(new RoleMapping[roleMappings.size()]));
-            serviceProvider.setPermissionAndRoleConfig(permissionAndRoleConfig);
-
-            RequestPathAuthenticatorConfig[] requestPathAuthenticators = getRequestPathAuthenticators(
-                    applicationId, connection, tenantID);
-            serviceProvider.setRequestPathAuthenticatorConfigs(requestPathAuthenticators);
-
-            serviceProvider.setSpProperties(propertyList.toArray(new ServiceProviderProperty[propertyList.size()]));
-            serviceProvider.setCertificateContent(getCertificateContent(propertyList, connection));
-
-            // Will be supported with 'Advance Consent Management Feature'.
-            /*
-            ConsentConfig consentConfig = serviceProvider.getConsentConfig();
-            if (isNull(consentConfig)) {
-                consentConfig = new ConsentConfig();
-            }
-            consentConfig.setConsentPurposeConfigs(getConsentPurposeConfigs(connection, applicationId, tenantID));
-            serviceProvider.setConsentConfig(consentConfig);
-            */
-
-            if (serviceProvider != null) {
-                loadApplicationPermissions(applicationName, serviceProvider);
-            }
-            return serviceProvider;
-
-        } catch (SQLException | CertificateRetrievingException e) {
-            throw new IdentityApplicationManagementException("Failed to retrieve service provider "
-                    + applicationId, e);
-        } finally {
-            IdentityApplicationManagementUtil.closeConnection(connection);
+            return getApplication(applicationId);
+        } catch (IdentityApplicationManagementException ex) {
+            throw new IdentityApplicationManagementException("Failed to retrieve application: "
+                    + applicationName + " in tenantDomain: " + tenantDomain, ex);
         }
     }
 
@@ -2105,6 +2033,8 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
             }
             int tenantID = IdentityTenantUtil.getTenantId(serviceProvider.getOwner().getTenantDomain());
             List<ServiceProviderProperty> propertyList = getServicePropertiesBySpId(connection, applicationId);
+
+            serviceProvider.setJwksUri(getJwksUri(propertyList));
             serviceProvider.setInboundAuthenticationConfig(getInboundAuthenticationConfig(
                     applicationId, connection, tenantID));
             serviceProvider
@@ -2149,11 +2079,20 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
             loadApplicationPermissions(serviceProviderName, serviceProvider);
             return serviceProvider;
         } catch (SQLException | CertificateRetrievingException e) {
-            throw new IdentityApplicationManagementException("Failed to update service provider "
-                    + applicationId, e);
+            throw new IdentityApplicationManagementException("Failed to get service provider with id: " + applicationId,
+                    e);
         } finally {
             IdentityApplicationManagementUtil.closeConnection(connection);
         }
+    }
+
+    private String getJwksUri(List<ServiceProviderProperty> propertyList) {
+
+        return propertyList.stream()
+                .filter(property -> JWKS_URI_SP_PROPERTY_NAME.equals(property.getName()))
+                .findFirst()
+                .map(ServiceProviderProperty::getValue)
+                .orElse(StringUtils.EMPTY);
     }
 
     /**
@@ -2385,6 +2324,18 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                 log.debug("Application name for id: " + applicationID + " is '" + applicationName + "'");
             }
             return applicationName;
+        }
+    }
+
+    private int getApplicationIdByName(String applicationName,
+                                       String tenantDomain) throws IdentityApplicationManagementException {
+
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            return getApplicationIDByName(applicationName, tenantId, connection);
+        } catch (SQLException e) {
+            throw new IdentityApplicationManagementServerException("Error retrieving id for application: "
+                    + applicationName + " in tenantDomain: " + tenantDomain);
         }
     }
 
@@ -2633,9 +2584,9 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
             getStepInfoPrepStmt.setInt(1, applicationId);
             stepInfoResultSet = getStepInfoPrepStmt.executeQuery();
 
-            Map<String, AuthenticationStep> authSteps = new HashMap<String, AuthenticationStep>();
-            Map<String, Map<String, List<FederatedAuthenticatorConfig>>> stepFedIdPAuthenticators = new HashMap<String, Map<String, List<FederatedAuthenticatorConfig>>>();
-            Map<String, List<LocalAuthenticatorConfig>> stepLocalAuth = new HashMap<String, List<LocalAuthenticatorConfig>>();
+            Map<String, AuthenticationStep> authSteps = new HashMap<>();
+            Map<String, Map<String, List<FederatedAuthenticatorConfig>>> stepFedIdPAuthenticators = new HashMap<>();
+            Map<String, List<LocalAuthenticatorConfig>> stepLocalAuth = new HashMap<>();
 
             while (stepInfoResultSet.next()) {
 
@@ -2736,13 +2687,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                 authenticationSteps[authStepCount++] = authStep;
             }
 
-            Comparator<AuthenticationStep> comparator = new Comparator<AuthenticationStep>() {
-                public int compare(AuthenticationStep step1, AuthenticationStep step2) {
-                    return step1.getStepOrder() - step2.getStepOrder();
-                }
-            };
-
-            Arrays.sort(authenticationSteps, comparator);
+            Arrays.sort(authenticationSteps, Comparator.comparingInt(AuthenticationStep::getStepOrder));
 
             int numSteps = authenticationSteps.length;
             // We check if the steps have consecutive step numbers.
@@ -2805,21 +2750,8 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                             .equals(localAndOutboundConfigResultSet.getString(4)));
                     localAndOutboundConfiguration.setSubjectClaimUri(localAndOutboundConfigResultSet
                             .getString(5));
-                    if (CollectionUtils.isNotEmpty(propertyList)) {
-                        for (ServiceProviderProperty serviceProviderProperty : propertyList) {
-                            if (USE_DOMAIN_IN_ROLES.equals(serviceProviderProperty.getName())) {
-                                if ("TRUE".equalsIgnoreCase(serviceProviderProperty.getValue())) {
-                                    localAndOutboundConfiguration.setUseUserstoreDomainInRoles(true);
-                                } else if (!"TRUE".equalsIgnoreCase(serviceProviderProperty.getValue())) {
-                                    localAndOutboundConfiguration.setUseUserstoreDomainInRoles(false);
-                                } else {
-                                    localAndOutboundConfiguration.setUseUserstoreDomainInRoles(true);
-                                }
-                            }
-                        }
-                    } else {
-                        localAndOutboundConfiguration.setUseUserstoreDomainInRoles(true);
-                    }
+
+                    readAndSetConfigurationsFromProperties(propertyList, localAndOutboundConfiguration);
                 }
             } finally {
                 IdentityApplicationManagementUtil.closeStatement(localAndOutboundConfigPrepStmt);
@@ -2830,6 +2762,24 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         } finally {
             IdentityApplicationManagementUtil.closeStatement(getStepInfoPrepStmt);
             IdentityApplicationManagementUtil.closeResultSet(stepInfoResultSet);
+        }
+    }
+
+    private void readAndSetConfigurationsFromProperties(List<ServiceProviderProperty> propertyList,
+                                                        LocalAndOutboundAuthenticationConfig localAndOutboundConfig) {
+        // Override with changed values.
+        if (CollectionUtils.isNotEmpty(propertyList)) {
+            for (ServiceProviderProperty serviceProviderProperty : propertyList) {
+
+                String name = serviceProviderProperty.getName();
+                String value = serviceProviderProperty.getValue();
+
+                if (USE_DOMAIN_IN_ROLES.equals(name)) {
+                    localAndOutboundConfig.setUseUserstoreDomainInRoles(value == null || Boolean.parseBoolean(value));
+                } else if (SKIP_CONSENT.equals(name)) {
+                    localAndOutboundConfig.setSkipConsent(Boolean.parseBoolean(value));
+                }
+            }
         }
     }
 
@@ -4357,58 +4307,57 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         return null;
     }
 
-    private void updateUseDomainNameInRolesAsSpProperty(ServiceProvider serviceProvider) {
+    private void updateConfigurationsAsServiceProperties(ServiceProvider sp) {
 
-        ServiceProviderProperty[] serviceProviderProperties = serviceProvider.getSpProperties();
-
-        if (serviceProvider.getLocalAndOutBoundAuthenticationConfig() == null
-                || serviceProviderProperties == null) {
-            return;
+        if (sp.getSpProperties() == null) {
+            sp.setSpProperties(new ServiceProviderProperty[0]);
         }
 
-        boolean isUseUserstoreDomainInRolesPropertyExist = false;
-        List<ServiceProviderProperty> serviceProviderPropertiesList = new ArrayList<>
-                (Arrays.asList(serviceProviderProperties));
+        Map<String, ServiceProviderProperty> spPropertyMap = Arrays.stream(sp.getSpProperties())
+                .collect(Collectors.toMap(ServiceProviderProperty::getName, Function.identity()));
 
-        for (ServiceProviderProperty serviceProviderProperty : serviceProviderPropertiesList) {
-            if (USE_DOMAIN_IN_ROLES.equals(serviceProviderProperty.getName())) {
-                isUseUserstoreDomainInRolesPropertyExist = true;
-                serviceProviderProperty.setValue(String.valueOf(serviceProvider.
-                        getLocalAndOutBoundAuthenticationConfig().isUseUserstoreDomainInRoles()));
-            }
+        // Add use user store domain in roles property.
+        if (sp.getLocalAndOutBoundAuthenticationConfig() != null) {
+            ServiceProviderProperty userUserStoreDomainInRoles = buildUserStoreDomainInRolesProperty(sp);
+            spPropertyMap.put(userUserStoreDomainInRoles.getName(), userUserStoreDomainInRoles);
+
+            ServiceProviderProperty skipConsentProperty = buildSkipConsentProperty(sp);
+            spPropertyMap.put(skipConsentProperty.getName(), skipConsentProperty);
         }
 
-        if (!isUseUserstoreDomainInRolesPropertyExist) {
-            ServiceProviderProperty serviceProviderProperty = new ServiceProviderProperty();
-            serviceProviderProperty.setValue(String.valueOf(serviceProvider.
-                    getLocalAndOutBoundAuthenticationConfig().isUseUserstoreDomainInRoles()));
-            serviceProviderProperty.setDisplayName(DOMAIN_IN_ROLES);
-            serviceProviderProperty.setName(USE_DOMAIN_IN_ROLES);
-            serviceProviderPropertiesList.add(serviceProviderProperty);
-        }
+        ServiceProviderProperty jwksUri = buildJwksProperty(sp);
+        spPropertyMap.put(jwksUri.getName(), jwksUri);
 
-        serviceProvider.setSpProperties(serviceProviderPropertiesList.toArray
-                (new ServiceProviderProperty[serviceProviderPropertiesList.size()]));
+        sp.setSpProperties(spPropertyMap.values().toArray(new ServiceProviderProperty[0]));
     }
 
-    private void addUseDomainNameInRolesAsSpProperty(ServiceProvider serviceProvider) {
+    private ServiceProviderProperty buildJwksProperty(ServiceProvider sp) {
 
-        ServiceProviderProperty[] serviceProviderProperties = serviceProvider.getSpProperties();
-        ServiceProviderProperty[] newServiceProviderProperties;
-        if (serviceProviderProperties != null) {
-            newServiceProviderProperties = Arrays.copyOfRange(serviceProviderProperties, 0,
-                    serviceProviderProperties.length + 1);
+        ServiceProviderProperty jwksUri = new ServiceProviderProperty();
+        jwksUri.setName(JWKS_URI_SP_PROPERTY_NAME);
+        jwksUri.setDisplayName(JWKS_URI_SP_PROPERTY_NAME);
+        jwksUri.setValue(StringUtils.isNotBlank(sp.getJwksUri()) ? sp.getJwksUri() : StringUtils.EMPTY);
+        return jwksUri;
+    }
 
-        } else {
-            newServiceProviderProperties = new ServiceProviderProperty[1];
-        }
-        ServiceProviderProperty propertyForDomainInRoles = new ServiceProviderProperty();
-        propertyForDomainInRoles.setDisplayName("DOMAIN_IN_ROLES");
-        propertyForDomainInRoles.setName(USE_DOMAIN_IN_ROLES);
-        propertyForDomainInRoles.setValue(String.valueOf(true));
+    private ServiceProviderProperty buildSkipConsentProperty(ServiceProvider sp) {
 
-        newServiceProviderProperties[newServiceProviderProperties.length - 1] = propertyForDomainInRoles;
-        serviceProvider.setSpProperties(newServiceProviderProperties);
+        ServiceProviderProperty skipConsentProperty = new ServiceProviderProperty();
+        skipConsentProperty.setName(SKIP_CONSENT);
+        skipConsentProperty.setDisplayName(SKIP_CONSENT_DISPLAY_NAME);
+
+        skipConsentProperty.setValue(String.valueOf(sp.getLocalAndOutBoundAuthenticationConfig().isSkipConsent()));
+        return skipConsentProperty;
+    }
+
+    private ServiceProviderProperty buildUserStoreDomainInRolesProperty(ServiceProvider sp) {
+
+        ServiceProviderProperty property = new ServiceProviderProperty();
+        property.setName(USE_DOMAIN_IN_ROLES);
+        property.setDisplayName(USE_DOMAIN_IN_ROLE_DISPLAY_NAME);
+
+        property.setValue(String.valueOf(sp.getLocalAndOutBoundAuthenticationConfig().isUseUserstoreDomainInRoles()));
+        return property;
     }
 
     private void loadApplicationPermissions(String serviceProviderName, ServiceProvider serviceProvider)
@@ -4901,14 +4850,14 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
             throws IdentityApplicationManagementException {
 
         int applicationId = 0;
-        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)){
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
 
             try (NamedPreparedStatement statement = new NamedPreparedStatement(connection, LOAD_APP_ID_BY_UUID)) {
 
                 statement.setString(ApplicationTableColumns.UUID, resourceId);
                 statement.setInt(ApplicationTableColumns.TENANT_ID, IdentityTenantUtil.getTenantId(tenantDomain));
 
-                try (ResultSet resultSet = statement.executeQuery() ) {
+                try (ResultSet resultSet = statement.executeQuery()) {
                     if (resultSet.next()) {
                         applicationId = resultSet.getInt(ApplicationTableColumns.ID);
                     }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -1726,7 +1726,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
 
         try {
             int applicationId = getApplicationIdByName(applicationName, tenantDomain);
-            if (applicationId == 0 && ApplicationConstants.LOCAL_SP.equals(applicationName)) {
+            if (isApplicationNotFound(applicationId) && ApplicationConstants.LOCAL_SP.equals(applicationName)) {
                 // Looking for the resident sp. Create the resident sp for the tenant.
                 ServiceProvider localServiceProvider = new ServiceProvider();
                 localServiceProvider.setApplicationName(applicationName);
@@ -1738,6 +1738,18 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
             throw new IdentityApplicationManagementException("Failed to retrieve application: "
                     + applicationName + " in tenantDomain: " + tenantDomain, ex);
         }
+    }
+
+    /**
+     * Determines whether the application is available based on the internal application id.
+     *
+     * @param applicationId internal application id.
+     * @return
+     */
+    private boolean isApplicationNotFound(int applicationId) {
+
+        // A valid application should have an id > 0 since its an auto increment id.
+        return applicationId <= 0;
     }
 
     private ConsentPurposeConfigs getConsentPurposeConfigs(Connection connection, int applicationId, int tenantId) throws

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/defaultsequence/DefaultAuthSeqMgtServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/defaultsequence/DefaultAuthSeqMgtServiceImpl.java
@@ -405,6 +405,7 @@ public class DefaultAuthSeqMgtServiceImpl implements DefaultAuthSeqMgtService {
         authenticationConfig.setUseUserstoreDomainInLocalSubjectIdentifier(false);
         authenticationConfig.setUseUserstoreDomainInRoles(false);
         authenticationConfig.setEnableAuthorization(false);
+        authenticationConfig.setSkipConsent(false);
     }
 
     private void validateLocalAuthenticatorConfig(List<String> validationMsg,

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -89,9 +89,7 @@ import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.IdentityProviderProperty;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
-import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
-import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.core.model.CookieBuilder;
@@ -2209,18 +2207,16 @@ public class FrameworkUtils {
             throw new IllegalArgumentException("A null reference received for service provider.");
         }
 
-        for (ServiceProviderProperty serviceProviderProperty : serviceProvider.getSpProperties()) {
-            if (serviceProviderProperty.getName().equals(IdentityConstants.SKIP_CONSENT)
-                    && Boolean.parseBoolean(serviceProviderProperty.getValue())) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Consent page skip property set for service provider : " + serviceProvider.getApplicationName());
-                }
-
-                return true;
-            }
+        boolean isSkipConsent = false;
+        if (serviceProvider.getLocalAndOutBoundAuthenticationConfig() != null) {
+            isSkipConsent = serviceProvider.getLocalAndOutBoundAuthenticationConfig().isSkipConsent();
         }
 
-        return false;
+        if (log.isDebugEnabled()) {
+            log.debug("SkipConsent: " + isSkipConsent + " for application: " + serviceProvider.getApplicationName()
+                    + " with id: " + serviceProvider.getApplicationID());
+        }
+        return isSkipConsent;
     }
 
     /**

--- a/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/sts/service/STSAdminServiceInterface.java
+++ b/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/sts/service/STSAdminServiceInterface.java
@@ -33,6 +33,10 @@ public interface STSAdminServiceInterface {
     public void addTrustedService(String serviceAddress, String certAlias)
             throws SecurityConfigException;
 
+    default void removeTrustedService(String serviceAddress) throws SecurityConfigException {
+
+    }
+
     /**
      * @return
      * @throws SecurityConfigException


### PR DESCRIPTION
* Expose STS admin operation to remove a trusted service through the interface. The implementation was already available as a public method but the interface did not expose it.

* Expose skipConsent and JWKS URI through SP model object.
Previously, the only way to get the values for the above was to read service provider properties and check the values. This is inconvenient since in the future we might change the way we store the property value.

This change abstracts how the properties are stored and exposes them directly through methods in the SP object.