### PR TITLE
Improve application deletion logic

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/STSApplicationMgtListener.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/STSApplicationMgtListener.java
@@ -93,6 +93,12 @@ public class STSApplicationMgtListener extends AbstractApplicationMgtListener {
             // Remove WSTrust inbound data.
             String trustedService = storedWstrustInbound.getInboundAuthKey();
             try {
+                if (log.isDebugEnabled()) {
+                    log.debug("WSTrust inbound with trustService: " + trustedService + " has been removed from " +
+                            "service provider with id: " + appId + ". Removing the stale WSTrust data for " +
+                            "trustService: " + trustedService);
+                }
+
                 STSAdminServiceImpl stsAdminService = new STSAdminServiceImpl();
                 stsAdminService.removeTrustedService(trustedService);
             } catch (SecurityConfigException e) {


### PR DESCRIPTION
Previously during a application DELETE, 

* SAML, OAuth inbound details from the framework Application Management Service. 
* WS Trust inbound details were removed from a listener using the preDeleteServiceProvider() method

Handling deletion logic specific to an inbound type inside the framework components is not clean. The framework does not need to be aware of the specific of what needs to be cleaned up during an application delete specific to an inbound. 

For example, framework does not need to know that tokens issued to a SP needs to be revoked during an application delete. These need to be handled by the respective inbound. 

Therefore the most suitable approach would be to allow inbounds to cleanup their inbound specific data.

Improvements for SAML and OAuth have been added with,
https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/267
https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1228

where a listener registered on the inbound side would handle tasks that need to be done from the inbound side during an application DELETE.