### PR TITLE
Fix userstore domain name updating issue.

### DIFF
--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/dao/AbstractUserStoreDAO.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/dao/AbstractUserStoreDAO.java
@@ -38,7 +38,7 @@ public abstract class AbstractUserStoreDAO implements UserStoreDAO {
     public void addUserStore(UserStoreDTO userStoreDTO) throws IdentityUserStoreMgtException {
 
         UserStorePersistanceDTO userStorePersistanceDTO = getUserStorePersistanceDTO(userStoreDTO,
-                getUserStoreProperties(userStoreDTO));
+                getUserStoreProperties(userStoreDTO, userStoreDTO.getDomainId()));
         doAddUserStore(userStorePersistanceDTO);
     }
 
@@ -49,7 +49,7 @@ public abstract class AbstractUserStoreDAO implements UserStoreDAO {
             userStoreDTO = getUserStoreProperty(userStoreDTO);
         }
         UserStorePersistanceDTO userStorePersistanceDTO = getUserStorePersistanceDTO(userStoreDTO,
-                getUserStoreProperties(userStoreDTO));
+                getUserStoreProperties(userStoreDTO, userStoreDTO.getDomainId()));
         userStorePersistanceDTO.setUserStoreDTO(userStoreDTO);
         doUpdateUserStore(userStorePersistanceDTO, isStateChange);
     }
@@ -76,7 +76,7 @@ public abstract class AbstractUserStoreDAO implements UserStoreDAO {
             throws IdentityUserStoreMgtException {
 
         UserStorePersistanceDTO userStorePersistanceDTO = getUserStorePersistanceDTO(userStoreDTO,
-                getUserStoreProperties(userStoreDTO));
+                getUserStoreProperties(userStoreDTO, previousDomainName));
         doUpdateUserStoreDomainName(previousDomainName, userStorePersistanceDTO);
     }
 
@@ -114,9 +114,10 @@ public abstract class AbstractUserStoreDAO implements UserStoreDAO {
 
     protected abstract UserStorePersistanceDTO[] doGetAllUserStores() throws IdentityUserStoreMgtException;
 
-    private String getUserStoreProperties(UserStoreDTO userStoreDTO) throws IdentityUserStoreMgtException {
+    private String getUserStoreProperties(UserStoreDTO userStoreDTO, String existingDomainName)
+            throws IdentityUserStoreMgtException {
 
-        return SecondaryUserStoreConfigurationUtil.getUserStoreProperties(userStoreDTO);
+        return SecondaryUserStoreConfigurationUtil.getUserStoreProperties(userStoreDTO, existingDomainName);
     }
 
     private UserStorePersistanceDTO getUserStorePersistanceDTO(UserStoreDTO userStoreDTO, String userStoreProperties) {

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/dao/impl/FileBasedUserStoreDAOImpl.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/dao/impl/FileBasedUserStoreDAOImpl.java
@@ -126,11 +126,13 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
     }
 
     private void writeToUserStoreConfigurationFile(Path userStoreConfigFile, UserStoreDTO userStoreDTO,
-                                                   boolean editSecondaryUserStore, boolean isStateChange)
+                                                   boolean editSecondaryUserStore, boolean isStateChange,
+                                                   String existingDomainName)
             throws IdentityUserStoreMgtException {
 
         try {
-            writeUserMgtXMLFile(userStoreConfigFile, userStoreDTO, editSecondaryUserStore, isStateChange);
+            writeUserMgtXMLFile(userStoreConfigFile, userStoreDTO, editSecondaryUserStore, isStateChange,
+                    existingDomainName);
             if (log.isDebugEnabled()) {
                 log.debug("New user store successfully written to the file" + userStoreConfigFile.toAbsolutePath());
             }
@@ -279,7 +281,8 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
                 if (Files.exists(userStoreConfigFile)) {
                     throwException(userStorePersistanceDTO.getUserStoreDTO().getDomainId(), false);
                 }
-                writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(), false, false);
+                writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(), false, false,
+                        userStorePersistanceDTO.getUserStoreDTO().getDomainId());
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("The user store domain: " + domainName + "is not a valid domain name.");
@@ -309,7 +312,7 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
                 throwException(userStorePersistanceDTO.getUserStoreDTO().getDomainId(), true);
             }
             writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(), true,
-                    isStateChange);
+                    isStateChange, userStorePersistanceDTO.getUserStoreDTO().getDomainId());
         } else {
             String errorMessage = "Trying to edit an invalid domain : " + domainName;
             throw new IdentityUserStoreClientException(errorMessage);
@@ -366,7 +369,7 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
         }
         try {
             Files.delete(previousUserStoreConfigFile);
-            writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(), true, false);
+            writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(), true, false, previousDomainName);
         } catch (IOException e) {
             log.info("Error when deleting previous configuration files " + previousUserStoreConfigFile);
         }

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/dao/impl/FileBasedUserStoreDAOImpl.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/dao/impl/FileBasedUserStoreDAOImpl.java
@@ -281,8 +281,8 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
                 if (Files.exists(userStoreConfigFile)) {
                     throwException(userStorePersistanceDTO.getUserStoreDTO().getDomainId(), false);
                 }
-                writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(), false, false,
-                        userStorePersistanceDTO.getUserStoreDTO().getDomainId());
+                writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(),
+                        false, false, domainName);
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("The user store domain: " + domainName + "is not a valid domain name.");
@@ -311,8 +311,8 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
             if (!Files.exists(userStoreConfigFile)) {
                 throwException(userStorePersistanceDTO.getUserStoreDTO().getDomainId(), true);
             }
-            writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(), true,
-                    isStateChange, userStorePersistanceDTO.getUserStoreDTO().getDomainId());
+            writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(),
+                    true, isStateChange, domainName);
         } else {
             String errorMessage = "Trying to edit an invalid domain : " + domainName;
             throw new IdentityUserStoreClientException(errorMessage);
@@ -369,7 +369,8 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
         }
         try {
             Files.delete(previousUserStoreConfigFile);
-            writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(), true, false, previousDomainName);
+            writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(),
+                    true, false, previousDomainName);
         } catch (IOException e) {
             log.info("Error when deleting previous configuration files " + previousUserStoreConfigFile);
         }

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/SecondaryUserStoreConfigurationUtil.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/SecondaryUserStoreConfigurationUtil.java
@@ -239,14 +239,12 @@ public class SecondaryUserStoreConfigurationUtil {
         return Paths.get(userStore.toString(), fileName + FILE_EXTENSION_XML);
     }
 
-    @Deprecated
     /**
      * This method is used to write userStore xml file.
-     * @param userStoreConfigFile path of the userStore configuration file
-     * @param userStoreDTO instance of {@link UserStoreDTO}
-     * @param editSecondaryUserStore true if it is update operation
-     * @throws IdentityUserStoreMgtException throws if an error occured while writing to the xml file.
+     *
+     * @deprecated use {@link #writeUserMgtXMLFile(Path, UserStoreDTO, boolean, boolean, String)} instead.
      */
+    @Deprecated
     public static void writeUserMgtXMLFile(Path userStoreConfigFile, UserStoreDTO userStoreDTO,
                                            boolean editSecondaryUserStore, boolean isStateChange)
             throws IdentityUserStoreMgtException {
@@ -260,7 +258,8 @@ public class SecondaryUserStoreConfigurationUtil {
      * @param userStoreConfigFile path of the userStore configuration file
      * @param userStoreDTO instance of {@link UserStoreDTO}
      * @param editSecondaryUserStore true if it is update operation
-     * @throws IdentityUserStoreMgtException throws if an error occured while writing to the xml file.
+     * @param  existingDomainName domain name of existing userstore
+     * @throws IdentityUserStoreMgtException throws if an error occurred while writing to the xml file.
      */
     public static void writeUserMgtXMLFile(Path userStoreConfigFile, UserStoreDTO userStoreDTO,
                                            boolean editSecondaryUserStore, boolean isStateChange,
@@ -298,13 +297,13 @@ public class SecondaryUserStoreConfigurationUtil {
         }
     }
 
-    @Deprecated
+
     /**
-     * Get the user store config file.
-     * @param userStoreDTO an instance of {@link UserStoreDTO}
-     * @return user store properties as a String.
-     * @throws IdentityUserStoreMgtException throws if an error occured while getting the user store properties.
+     * This method is used to Get the user store config file.
+     *
+     * @deprecated use {@link #getUserStoreProperties(UserStoreDTO, String)} instead.
      */
+    @Deprecated
     public static String getUserStoreProperties(UserStoreDTO userStoreDTO) throws IdentityUserStoreMgtException {
         return getUserStoreProperties(userStoreDTO, userStoreDTO.getDomainId());
     }
@@ -314,7 +313,7 @@ public class SecondaryUserStoreConfigurationUtil {
      * @param userStoreDTO an instance of {@link UserStoreDTO}
      * @param existingDomainName existing userstore domain name
      * @return user store properties as a String.
-     * @throws IdentityUserStoreMgtException throws if an error occured while getting the user store properties.
+     * @throws IdentityUserStoreMgtException throws if an error occurred while getting the user store properties.
      */
     public static String getUserStoreProperties(UserStoreDTO userStoreDTO, String existingDomainName) throws IdentityUserStoreMgtException {
 

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/SecondaryUserStoreConfigurationUtil.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/SecondaryUserStoreConfigurationUtil.java
@@ -239,6 +239,7 @@ public class SecondaryUserStoreConfigurationUtil {
         return Paths.get(userStore.toString(), fileName + FILE_EXTENSION_XML);
     }
 
+    @Deprecated
     /**
      * This method is used to write userStore xml file.
      * @param userStoreConfigFile path of the userStore configuration file
@@ -248,6 +249,22 @@ public class SecondaryUserStoreConfigurationUtil {
      */
     public static void writeUserMgtXMLFile(Path userStoreConfigFile, UserStoreDTO userStoreDTO,
                                            boolean editSecondaryUserStore, boolean isStateChange)
+            throws IdentityUserStoreMgtException {
+
+        writeUserMgtXMLFile(userStoreConfigFile, userStoreDTO, editSecondaryUserStore, isStateChange,
+                userStoreDTO.getDomainId());
+    }
+
+    /**
+     * This method is used to write userStore xml file.
+     * @param userStoreConfigFile path of the userStore configuration file
+     * @param userStoreDTO instance of {@link UserStoreDTO}
+     * @param editSecondaryUserStore true if it is update operation
+     * @throws IdentityUserStoreMgtException throws if an error occured while writing to the xml file.
+     */
+    public static void writeUserMgtXMLFile(Path userStoreConfigFile, UserStoreDTO userStoreDTO,
+                                           boolean editSecondaryUserStore, boolean isStateChange,
+                                           String existingDomainName)
             throws IdentityUserStoreMgtException {
 
         boolean isDisable = false;
@@ -264,7 +281,8 @@ public class SecondaryUserStoreConfigurationUtil {
             if (isStateChange) {
                 updateStateOfUserStore(userStoreConfigFile, isDisable, domain, documentBuilder);
             } else {
-                updateUserStoreProperties(userStoreConfigFile, userStoreDTO, editSecondaryUserStore, documentBuilder);
+                updateUserStoreProperties(userStoreConfigFile, userStoreDTO, editSecondaryUserStore, documentBuilder,
+                        existingDomainName);
             }
         } catch (ParserConfigurationException e) {
             String errMsg = " Error occurred due to serious parser configuration exception of " + userStoreConfigFile;
@@ -280,6 +298,7 @@ public class SecondaryUserStoreConfigurationUtil {
         }
     }
 
+    @Deprecated
     /**
      * Get the user store config file.
      * @param userStoreDTO an instance of {@link UserStoreDTO}
@@ -287,12 +306,23 @@ public class SecondaryUserStoreConfigurationUtil {
      * @throws IdentityUserStoreMgtException throws if an error occured while getting the user store properties.
      */
     public static String getUserStoreProperties(UserStoreDTO userStoreDTO) throws IdentityUserStoreMgtException {
+        return getUserStoreProperties(userStoreDTO, userStoreDTO.getDomainId());
+    }
+
+    /**
+     * Get the user store config file.
+     * @param userStoreDTO an instance of {@link UserStoreDTO}
+     * @param existingDomainName existing userstore domain name
+     * @return user store properties as a String.
+     * @throws IdentityUserStoreMgtException throws if an error occured while getting the user store properties.
+     */
+    public static String getUserStoreProperties(UserStoreDTO userStoreDTO, String existingDomainName) throws IdentityUserStoreMgtException {
 
         String userStoreProperties;
         DocumentBuilderFactory documentFactory = IdentityUtil.getSecuredDocumentBuilderFactory();
         try {
             DocumentBuilder documentBuilder = documentFactory.newDocumentBuilder();
-            Document doc = getDocument(userStoreDTO, false, documentBuilder);
+            Document doc = getDocument(userStoreDTO, false, documentBuilder, existingDomainName);
             StringWriter writer = new StringWriter();
             transformProperties().transform(new DOMSource(doc), new StreamResult(writer));
             //To replace the line breaks
@@ -336,10 +366,11 @@ public class SecondaryUserStoreConfigurationUtil {
     }
 
     private static void updateUserStoreProperties(Path userStoreConfigFile, UserStoreDTO userStoreDTO,
-                                                  boolean editSecondaryUserStore, DocumentBuilder documentBuilder)
+                                                  boolean editSecondaryUserStore, DocumentBuilder documentBuilder,
+                                                  String existingDomainName)
             throws IdentityUserStoreMgtException, IOException, TransformerException {
 
-        Document doc = getDocument(userStoreDTO, editSecondaryUserStore, documentBuilder);
+        Document doc = getDocument(userStoreDTO, editSecondaryUserStore, documentBuilder, existingDomainName);
         StreamResult result = new StreamResult(Files.newOutputStream(userStoreConfigFile));
         DOMSource source = new DOMSource(doc);
         transformProperties().transform(source, result);
@@ -351,7 +382,7 @@ public class SecondaryUserStoreConfigurationUtil {
     }
 
     private static Document getDocument(UserStoreDTO userStoreDTO, boolean editSecondaryUserStore,
-                                        DocumentBuilder documentBuilder) throws IdentityUserStoreMgtException {
+                                        DocumentBuilder documentBuilder, String existingDomainName) throws IdentityUserStoreMgtException {
 
         Document doc = documentBuilder.newDocument();
 
@@ -364,7 +395,7 @@ public class SecondaryUserStoreConfigurationUtil {
             attrClass.setValue(userStoreDTO.getClassName());
             userStoreElement.setAttributeNode(attrClass);
             if (userStoreDTO.getClassName() != null) {
-                addProperties(userStoreDTO.getDomainId(), userStoreDTO.getClassName(), userStoreDTO.getProperties(),
+                addProperties(existingDomainName, userStoreDTO.getClassName(), userStoreDTO.getProperties(),
                         doc, userStoreElement, editSecondaryUserStore);
             }
             addProperty(UserStoreConfigConstants.DOMAIN_NAME, userStoreDTO.getDomainId(), doc, userStoreElement, false);


### PR DESCRIPTION
**Proposed Changes in PR**

Pass the previous domain name when updating the userstore name so that the previous domain will be used to remove the masked password.

Resolve - https://github.com/wso2/product-is/issues/7012