### PR TITLE
Update exception in userstore config admin service

### DIFF
--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/UserStoreConfigAdminService.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/UserStoreConfigAdminService.java
@@ -154,7 +154,7 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
         try {
             UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().addUserStore(userStoreDTO);
         } catch (IdentityUserStoreClientException e) {
-            throw throwIdentityUserStoreMgtException(e, "Error while adding the userstore.");
+            throw buildIdentityUserStoreMgtException(e, "Error while adding the userstore.");
         }
     }
 
@@ -170,7 +170,7 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
             UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().updateUserStore(userStoreDTO,
                     false);
         } catch (IdentityUserStoreClientException e) {
-            throw throwIdentityUserStoreMgtException(e, "Error while updating the userstore.");
+            throw buildIdentityUserStoreMgtException(e, "Error while updating the userstore.");
         }
     }
 
@@ -198,7 +198,7 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
             String errorMessage = e.getMessage();
             throw new IdentityUserStoreMgtException(errorMessage);
         } catch (IdentityUserStoreClientException e) {
-            throw throwIdentityUserStoreMgtException(e, "Error while updating the userstore.");
+            throw buildIdentityUserStoreMgtException(e, "Error while updating the userstore.");
         }
     }
 
@@ -233,7 +233,7 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
         try {
             UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().deleteUserStore(domainName);
         } catch (IdentityUserStoreClientException e) {
-            throw throwIdentityUserStoreMgtException(e, "Error while deleting the userstore.");
+            throw buildIdentityUserStoreMgtException(e, "Error while deleting the userstore.");
         }
     }
 
@@ -258,7 +258,7 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
         try {
             UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().deleteUserStoreSet(domains);
         } catch (IdentityUserStoreClientException e) {
-            throw throwIdentityUserStoreMgtException(e, "Error while deleting the userstore list.");
+            throw buildIdentityUserStoreMgtException(e, "Error while deleting the userstore list.");
         }
     }
 
@@ -285,7 +285,7 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
                     try {
                         userStoreDAOFactory.getInstance().deleteUserStores(domains.toArray(new String[0]));
                     } catch (IdentityUserStoreClientException e) {
-                        throw throwIdentityUserStoreMgtException(e, "Error while deleting the userstore list.");
+                        throw buildIdentityUserStoreMgtException(e, "Error while deleting the userstore list.");
                     }
                 }
             }
@@ -347,7 +347,7 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
                     .modifyUserStoreState(domain, isDisable,
                             repositoryClass);
         } catch (IdentityUserStoreClientException e) {
-            throw throwIdentityUserStoreMgtException(e, "Error while modifying the userstore state.");
+            throw buildIdentityUserStoreMgtException(e, "Error while modifying the userstore state.");
         }
     }
 
@@ -394,7 +394,7 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
                 driverName, connectionURL, username, connectionPassword, messageID);
     }
 
-    private IdentityUserStoreMgtException throwIdentityUserStoreMgtException(IdentityUserStoreClientException e,
+    private IdentityUserStoreMgtException buildIdentityUserStoreMgtException(IdentityUserStoreClientException e,
                                                                              String defaultMessage) {
 
         String errorMessage = defaultMessage;

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/UserStoreConfigAdminService.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/UserStoreConfigAdminService.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.core.AbstractAdmin;
 import org.wso2.carbon.identity.user.store.configuration.dao.AbstractUserStoreDAOFactory;
 import org.wso2.carbon.identity.user.store.configuration.dto.UserStoreDTO;
 import org.wso2.carbon.identity.user.store.configuration.internal.UserStoreConfigListenersHolder;
+import org.wso2.carbon.identity.user.store.configuration.utils.IdentityUserStoreClientException;
 import org.wso2.carbon.identity.user.store.configuration.utils.IdentityUserStoreMgtException;
 import org.wso2.carbon.identity.user.store.configuration.utils.SecondaryUserStoreConfigurationUtil;
 import org.wso2.carbon.identity.user.store.configuration.utils.UserStoreConfigurationConstant;
@@ -40,6 +41,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.xml.transform.TransformerConfigurationException;
 
 import static org.wso2.carbon.identity.user.store.configuration.utils.SecondaryUserStoreConfigurationUtil.getFileBasedUserStoreDAOFactory;
@@ -100,7 +102,7 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
 
         Set<String> classNames = UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().
                 getAvailableUserStoreClasses();
-        return classNames.toArray(new String[classNames.size()]);
+        return classNames.toArray(new String[0]);
     }
 
     /**
@@ -149,7 +151,11 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
      */
     public void addUserStore(UserStoreDTO userStoreDTO) throws IdentityUserStoreMgtException {
 
-        UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().addUserStore(userStoreDTO);
+        try {
+            UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().addUserStore(userStoreDTO);
+        } catch (IdentityUserStoreClientException e) {
+            throw throwIdentityUserStoreMgtException(e, "Error while adding the userstore.");
+        }
     }
 
     /**
@@ -160,8 +166,12 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
      */
     public void editUserStore(UserStoreDTO userStoreDTO) throws IdentityUserStoreMgtException {
 
-        UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().updateUserStore(userStoreDTO,
-                false);
+        try {
+            UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().updateUserStore(userStoreDTO,
+                    false);
+        } catch (IdentityUserStoreClientException e) {
+            throw throwIdentityUserStoreMgtException(e, "Error while updating the userstore.");
+        }
     }
 
 
@@ -187,6 +197,8 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
         } catch (UserStoreException e) {
             String errorMessage = e.getMessage();
             throw new IdentityUserStoreMgtException(errorMessage);
+        } catch (IdentityUserStoreClientException e) {
+            throw throwIdentityUserStoreMgtException(e, "Error while updating the userstore.");
         }
     }
 
@@ -201,8 +213,7 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
             Map<String, AbstractUserStoreDAOFactory> userStoreFactories = UserStoreConfigListenersHolder.getInstance().
                     getUserStoreDAOFactories();
             Object[] repositoryArr = userStoreFactories.keySet().toArray(new String[0]);
-            String[] repositoryClasses = Arrays.copyOf(repositoryArr, repositoryArr.length, String[].class);
-            return repositoryClasses;
+            return Arrays.copyOf(repositoryArr, repositoryArr.length, String[].class);
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("Repository separation of user-stores has been disabled. Returning empty " +
@@ -219,7 +230,11 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
      */
     public void deleteUserStore(String domainName) throws IdentityUserStoreMgtException {
 
-        UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().deleteUserStore(domainName);
+        try {
+            UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().deleteUserStore(domainName);
+        } catch (IdentityUserStoreClientException e) {
+            throw throwIdentityUserStoreMgtException(e, "Error while deleting the userstore.");
+        }
     }
 
     /**
@@ -240,7 +255,11 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
      */
     public void deleteUserStoresSet(String[] domains) throws IdentityUserStoreMgtException {
 
-        UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().deleteUserStoreSet(domains);
+        try {
+            UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().deleteUserStoreSet(domains);
+        } catch (IdentityUserStoreClientException e) {
+            throw throwIdentityUserStoreMgtException(e, "Error while deleting the userstore list.");
+        }
     }
 
     /**
@@ -263,7 +282,11 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
                 if (CollectionUtils.isNotEmpty(domains)) {
                     AbstractUserStoreDAOFactory userStoreDAOFactory = UserStoreConfigListenersHolder.getInstance().
                             getUserStoreDAOFactories().get(repositoryClass);
-                    userStoreDAOFactory.getInstance().deleteUserStores(domains.toArray(new String[domains.size()]));
+                    try {
+                        userStoreDAOFactory.getInstance().deleteUserStores(domains.toArray(new String[0]));
+                    } catch (IdentityUserStoreClientException e) {
+                        throw throwIdentityUserStoreMgtException(e, "Error while deleting the userstore list.");
+                    }
                 }
             }
         } else {
@@ -294,10 +317,10 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
 
         validateDomain(domain, isDisable);
         UserStoreDTO userStoreDTO = getUserStoreDTO(domain, isDisable, null);
-        updateTheStateInFileRepository(userStoreDTO);
+        updateStateInFileRepository(userStoreDTO);
     }
 
-    private void updateTheStateInFileRepository(UserStoreDTO userStoreDTO) throws IdentityUserStoreMgtException {
+    private void updateStateInFileRepository(UserStoreDTO userStoreDTO) throws IdentityUserStoreMgtException {
 
         try {
             getFileBasedUserStoreDAOFactory().updateUserStore(userStoreDTO, true);
@@ -319,8 +342,13 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
             throws IdentityUserStoreMgtException {
 
         validateDomain(domain, isDisable);
-        UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().modifyUserStoreState(domain, isDisable,
-                repositoryClass);
+        try {
+            UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService()
+                    .modifyUserStoreState(domain, isDisable,
+                            repositoryClass);
+        } catch (IdentityUserStoreClientException e) {
+            throw throwIdentityUserStoreMgtException(e, "Error while modifying the userstore state.");
+        }
     }
 
     private void validateDomain(String domain, Boolean isDisable) throws IdentityUserStoreMgtException {
@@ -364,5 +392,15 @@ public class UserStoreConfigAdminService extends AbstractAdmin {
 
         return UserStoreConfigListenersHolder.getInstance().getUserStoreConfigService().testRDBMSConnection(domainName,
                 driverName, connectionURL, username, connectionPassword, messageID);
+    }
+
+    private IdentityUserStoreMgtException throwIdentityUserStoreMgtException(IdentityUserStoreClientException e,
+                                                                             String defaultMessage) {
+
+        String errorMessage = defaultMessage;
+        if (e.getMessage() != null) {
+            errorMessage = e.getMessage();
+        }
+        return new IdentityUserStoreMgtException(errorMessage, e);
     }
 }

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/UserStoreConfigServiceImpl.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/UserStoreConfigServiceImpl.java
@@ -321,7 +321,7 @@ public class UserStoreConfigServiceImpl implements UserStoreConfigService {
                         "user-store " + domain + " with file-based configuration.");
             }
             userStoreDTO = getUserStoreDTO(domain, isDisable, null);
-            updateTheStateInFileRepository(userStoreDTO);
+            updateStateInFileRepository(userStoreDTO);
         } else if (StringUtils.isNotEmpty(repositoryClass)) {
             if (log.isDebugEnabled()) {
                 log.debug("Repository separation of user-stores has been disabled. Unable to modify state " +
@@ -329,7 +329,7 @@ public class UserStoreConfigServiceImpl implements UserStoreConfigService {
             }
         } else {
             userStoreDTO = getUserStoreDTO(domain, isDisable, null);
-            updateTheStateInFileRepository(userStoreDTO);
+            updateStateInFileRepository(userStoreDTO);
         }
     }
 
@@ -358,7 +358,7 @@ public class UserStoreConfigServiceImpl implements UserStoreConfigService {
      * @param userStoreDTO {@link UserStoreDTO}
      * @throws IdentityUserStoreMgtException
      */
-    private void updateTheStateInFileRepository(UserStoreDTO userStoreDTO) throws IdentityUserStoreMgtException {
+    private void updateStateInFileRepository(UserStoreDTO userStoreDTO) throws IdentityUserStoreMgtException {
 
         try {
             SecondaryUserStoreConfigurationUtil.getFileBasedUserStoreDAOFactory().updateUserStore(userStoreDTO, true);

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/dao/impl/FileBasedUserStoreDAOImpl.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/dao/impl/FileBasedUserStoreDAOImpl.java
@@ -139,7 +139,7 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
         }
     }
 
-    private IdentityUserStoreMgtException throwException(String domainName, boolean editSecondaryUserStore) {
+    private IdentityUserStoreMgtException buildException(String domainName, boolean editSecondaryUserStore) {
 
         String msg = "Cannot add user store " + domainName + ". User store already exists.";
         String errorCode = UserStoreConfigurationConstant.ErrorMessage.ERROR_CODE_XML_FILE_ALREADY_EXISTS.getCode();
@@ -276,7 +276,7 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
             if (validDomain) {
                 Path userStoreConfigFile = getUserStoreConfigurationFile(userStorePersistanceDTO.getUserStoreDTO());
                 if (Files.exists(userStoreConfigFile)) {
-                    throw throwException(userStorePersistanceDTO.getUserStoreDTO().getDomainId(), false);
+                    throw buildException(userStorePersistanceDTO.getUserStoreDTO().getDomainId(), false);
                 }
                 writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(), false, false);
             } else {
@@ -305,7 +305,7 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
         if (isValidDomain) {
             Path userStoreConfigFile = getUserStoreConfigurationFile(userStorePersistanceDTO.getUserStoreDTO());
             if (!Files.exists(userStoreConfigFile)) {
-                throw throwException(userStorePersistanceDTO.getUserStoreDTO().getDomainId(), true);
+                throw buildException(userStorePersistanceDTO.getUserStoreDTO().getDomainId(), true);
             }
             writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(), true,
                     isStateChange);

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/dao/impl/FileBasedUserStoreDAOImpl.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/dao/impl/FileBasedUserStoreDAOImpl.java
@@ -26,9 +26,8 @@ import org.wso2.carbon.identity.user.store.configuration.beans.MaskedProperty;
 import org.wso2.carbon.identity.user.store.configuration.dao.AbstractUserStoreDAO;
 import org.wso2.carbon.identity.user.store.configuration.dto.UserStoreDTO;
 import org.wso2.carbon.identity.user.store.configuration.dto.UserStorePersistanceDTO;
-import org.wso2.carbon.identity.user.store.configuration.utils.IdentityUserStoreMgtException;
 import org.wso2.carbon.identity.user.store.configuration.utils.IdentityUserStoreClientException;
-import org.wso2.carbon.identity.user.store.configuration.utils.IdentityUserStoreServerException;
+import org.wso2.carbon.identity.user.store.configuration.utils.IdentityUserStoreMgtException;
 import org.wso2.carbon.identity.user.store.configuration.utils.SecondaryUserStoreConfigurationUtil;
 import org.wso2.carbon.identity.user.store.configuration.utils.UserStoreConfigurationConstant;
 import org.wso2.carbon.user.api.RealmConfiguration;
@@ -113,7 +112,7 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
     private void validateFileName(String domainName, String fileName) throws IdentityUserStoreMgtException {
 
         if (!IdentityUtil.isValidFileName(fileName)) {
-            String message = "Provided domain name : '" + domainName + "' is invalid.";
+            String message = "Provided domain name: '" + domainName + "' is invalid.";
             log.error(message);
             throw new IdentityUserStoreClientException(message);
         }
@@ -140,7 +139,7 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
         }
     }
 
-    private void throwException(String domainName, boolean editSecondaryUserStore) throws IdentityUserStoreMgtException {
+    private IdentityUserStoreMgtException throwException(String domainName, boolean editSecondaryUserStore) {
 
         String msg = "Cannot add user store " + domainName + ". User store already exists.";
         String errorCode = UserStoreConfigurationConstant.ErrorMessage.ERROR_CODE_XML_FILE_ALREADY_EXISTS.getCode();
@@ -148,7 +147,7 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
             msg = "Cannot edit user store " + domainName + ". User store cannot be edited.";
             errorCode = UserStoreConfigurationConstant.ErrorMessage.ERROR_CODE_XML_FILE_NOT_FOUND.getCode();
         }
-        throw new IdentityUserStoreClientException(errorCode, msg);
+        return new IdentityUserStoreClientException(errorCode, msg);
     }
 
     @Override
@@ -277,7 +276,7 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
             if (validDomain) {
                 Path userStoreConfigFile = getUserStoreConfigurationFile(userStorePersistanceDTO.getUserStoreDTO());
                 if (Files.exists(userStoreConfigFile)) {
-                    throwException(userStorePersistanceDTO.getUserStoreDTO().getDomainId(), false);
+                    throw throwException(userStorePersistanceDTO.getUserStoreDTO().getDomainId(), false);
                 }
                 writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(), false, false);
             } else {
@@ -306,7 +305,7 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
         if (isValidDomain) {
             Path userStoreConfigFile = getUserStoreConfigurationFile(userStorePersistanceDTO.getUserStoreDTO());
             if (!Files.exists(userStoreConfigFile)) {
-                throwException(userStorePersistanceDTO.getUserStoreDTO().getDomainId(), true);
+                throw throwException(userStorePersistanceDTO.getUserStoreDTO().getDomainId(), true);
             }
             writeToUserStoreConfigurationFile(userStoreConfigFile, userStorePersistanceDTO.getUserStoreDTO(), true,
                     isStateChange);
@@ -459,7 +458,7 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
             // if add, user store domain name shouldn't already exists
             throw new IdentityUserStoreClientException(UserStoreConfigurationConstant.ErrorMessage.
                     ERROR_CODE_USER_STORE_DOMAIN_ALREADY_EXISTS.getCode(),
-                    " Cannot add user store. Domain name : " + domainName + "already exists.");
+                    " Cannot add user store. Domain name: " + domainName + " already exists.");
         }
         return true;
     }

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/IdentityUserStoreClientException.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/IdentityUserStoreClientException.java
@@ -21,6 +21,8 @@ package org.wso2.carbon.identity.user.store.configuration.utils;
  */
 public class IdentityUserStoreClientException extends IdentityUserStoreMgtException {
 
+    private static final long serialVersionUID = 846424495576433422L;
+
     public IdentityUserStoreClientException(String message) {
 
         super(message);

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/IdentityUserStoreServerException.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/IdentityUserStoreServerException.java
@@ -21,6 +21,8 @@ package org.wso2.carbon.identity.user.store.configuration.utils;
  */
 public class IdentityUserStoreServerException extends IdentityUserStoreMgtException {
 
+    private static final long serialVersionUID = 6177043488415616956L;
+
     public IdentityUserStoreServerException(String message) {
 
         super(message);

--- a/service-stubs/identity/org.wso2.carbon.identity.user.store.configuration.stub/src/main/resources/UserStoreConfigAdminService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.user.store.configuration.stub/src/main/resources/UserStoreConfigAdminService.wsdl
@@ -15,20 +15,20 @@
  ~ specific language governing permissions and limitations
  ~ under the License.
  -->
-<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ax2469="http://utils.configuration.store.user.identity.carbon.wso2.org/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://configuration.store.user.identity.carbon.wso2.org" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ax2471="http://dto.configuration.store.user.identity.carbon.wso2.org/xsd" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:ax2473="http://api.user.carbon.wso2.org/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://configuration.store.user.identity.carbon.wso2.org">
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ax2477="http://api.user.carbon.wso2.org/xsd" xmlns:ax2479="http://dto.configuration.store.user.identity.carbon.wso2.org/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://configuration.store.user.identity.carbon.wso2.org" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ax2475="http://utils.configuration.store.user.identity.carbon.wso2.org/xsd" targetNamespace="http://configuration.store.user.identity.carbon.wso2.org">
     <wsdl:documentation>UserStoreConfigAdminService</wsdl:documentation>
     <wsdl:types>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://api.user.carbon.wso2.org/xsd">
             <xs:complexType name="Properties">
                 <xs:sequence>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="advancedProperties" nillable="true" type="ax2473:Property"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="mandatoryProperties" nillable="true" type="ax2473:Property"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="optionalProperties" nillable="true" type="ax2473:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="advancedProperties" nillable="true" type="ax2477:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="mandatoryProperties" nillable="true" type="ax2477:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="optionalProperties" nillable="true" type="ax2477:Property"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="Property">
                 <xs:sequence>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="childProperties" nillable="true" type="ax2473:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="childProperties" nillable="true" type="ax2477:Property"/>
                     <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="value" nillable="true" type="xs:string"/>
@@ -38,18 +38,33 @@
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://utils.configuration.store.user.identity.carbon.wso2.org/xsd">
             <xs:complexType name="IdentityUserStoreMgtException">
                 <xs:sequence>
+                    <xs:element minOccurs="0" name="errorCode" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="message" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
         </xs:schema>
-        <xs:schema xmlns:ax2470="http://utils.configuration.store.user.identity.carbon.wso2.org/xsd" xmlns:ax2472="http://dto.configuration.store.user.identity.carbon.wso2.org/xsd" xmlns:ns="http://org.apache.axis2/xsd" xmlns:ax2474="http://api.user.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://org.apache.axis2/xsd">
+        <xs:schema xmlns:ax2476="http://utils.configuration.store.user.identity.carbon.wso2.org/xsd" xmlns:ax2480="http://dto.configuration.store.user.identity.carbon.wso2.org/xsd" xmlns:ax2478="http://api.user.carbon.wso2.org/xsd" xmlns:ns="http://org.apache.axis2/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://org.apache.axis2/xsd">
             <xs:import namespace="http://utils.configuration.store.user.identity.carbon.wso2.org/xsd"/>
-            <xs:import namespace="http://dto.configuration.store.user.identity.carbon.wso2.org/xsd"/>
             <xs:import namespace="http://api.user.carbon.wso2.org/xsd"/>
+            <xs:import namespace="http://dto.configuration.store.user.identity.carbon.wso2.org/xsd"/>
             <xs:element name="UserStoreConfigAdminServiceIdentityUserStoreMgtException">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="IdentityUserStoreMgtException" nillable="true" type="ax2469:IdentityUserStoreMgtException"/>
+                        <xs:element minOccurs="0" name="IdentityUserStoreMgtException" nillable="true" type="ax2476:IdentityUserStoreMgtException"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getUserStoreManagerProperties">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="className" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getUserStoreManagerPropertiesResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2477:Properties"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -61,21 +76,7 @@
             <xs:element name="getSecondaryRealmConfigurationsResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2471:UserStoreDTO"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getSecondaryRealmConfigurationsOnRepository">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="repositoryClassName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getSecondaryRealmConfigurationsOnRepositoryResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2471:UserStoreDTO"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2479:UserStoreDTO"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -91,31 +92,10 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getUserStoreManagerProperties">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="className" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getUserStoreManagerPropertiesResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2473:Properties"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="addUserStore">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="userStoreDTO" nillable="true" type="ax2471:UserStoreDTO"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
             <xs:element name="editUserStore">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="userStoreDTO" nillable="true" type="ax2471:UserStoreDTO"/>
+                        <xs:element minOccurs="0" name="userStoreDTO" nillable="true" type="ax2479:UserStoreDTO"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -123,7 +103,7 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="previousDomainName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="userStoreDTO" nillable="true" type="ax2471:UserStoreDTO"/>
+                        <xs:element minOccurs="0" name="userStoreDTO" nillable="true" type="ax2479:UserStoreDTO"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -149,7 +129,7 @@
             <xs:element name="deleteUserStoreFromRepository">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="userStoreDTO" nillable="true" type="ax2471:UserStoreDTO"/>
+                        <xs:element minOccurs="0" name="userStoreDTO" nillable="true" type="ax2479:UserStoreDTO"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -163,7 +143,7 @@
             <xs:element name="deleteUserStoresSetFromRepository">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="userStoreDTOs" nillable="true" type="ax2471:UserStoreDTO"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="userStoreDTOs" nillable="true" type="ax2479:UserStoreDTO"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -210,6 +190,27 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="addUserStore">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="userStoreDTO" nillable="true" type="ax2479:UserStoreDTO"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getSecondaryRealmConfigurationsOnRepository">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="repositoryClassName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getSecondaryRealmConfigurationsOnRepositoryResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2479:UserStoreDTO"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
         </xs:schema>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://dto.configuration.store.user.identity.carbon.wso2.org/xsd">
             <xs:complexType name="UserStoreDTO">
@@ -218,7 +219,7 @@
                     <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="disabled" nillable="true" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="domainId" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2471:PropertyDTO"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2479:PropertyDTO"/>
                     <xs:element minOccurs="0" name="repositoryClass" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>


### PR DESCRIPTION
`IdentityUserStoreClientException` is added extending `IdentityUserStoreMgtException` to identify the client exception from the OSGi service. However if the admin service does not declare `IdentityUserStoreClientException` is thrown from the service methods, stub will not contain the `IdentityUserStoreClientException` and will fail to throw it from the stub method invocation. Instead, it will throw an AxisFault which is not an ideal option.