### PR TITLE
Fix performance issue when filtering users.

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -143,6 +143,9 @@ public class IdentityConstants {
     public static final String SKIP_CONSENT_DISPLAY_NAME="Skip Consent";
     public static final String SKIP_CONSENT="skipConsent";
 
+    // Use display name of a user when filtering users.
+    public static final String SHOW_DISPLAY_NAME = "UserFiltering.ShowDisplayName";
+
     private IdentityConstants() {
     }
 

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserRealmProxy.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserRealmProxy.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.registry.api.Registry;
 import org.wso2.carbon.registry.api.RegistryException;
@@ -117,15 +118,21 @@ public class UserRealmProxy {
                     flaggedNames[i] = new FlaggedName();
                     flaggedNames[i].setItemName(user);
                     //retrieving the displayName
-                    String displayName = realm.getUserStoreManager().getUserClaimValue(user, DISAPLAY_NAME_CLAIM, null);
-                    int index = user.indexOf(UserCoreConstants.DOMAIN_SEPARATOR);
-                    if (index > 0) {
-                        if (displayName != null) {
+                    // Check whether to use the display name claim when filtering users.
+                    String showDisplayName = IdentityUtil.getProperty(IdentityConstants.SHOW_DISPLAY_NAME);
+                    boolean isShowDisplayNameEnabled = Boolean.parseBoolean(showDisplayName);
+                    if (isShowDisplayNameEnabled) {
+                        String displayName = realm.getUserStoreManager().getUserClaimValue(user, DISAPLAY_NAME_CLAIM,
+                                null);
+                        if (StringUtils.isNotBlank(displayName)) {
+                            int index = user.indexOf(UserCoreConstants.DOMAIN_SEPARATOR);
                             if (index > 0) {
                                 flaggedNames[i].setItemDisplayName(user.substring(0, index + 1) + displayName);
                             } else {
                                 flaggedNames[i].setItemDisplayName(displayName);
                             }
+                        } else {
+                            flaggedNames[i].setItemDisplayName(user);
                         }
                     } else {
                         flaggedNames[i].setItemDisplayName(user);

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1363,4 +1363,8 @@
     <MaximumItemsPerPage>100</MaximumItemsPerPage>
     <DefaultItemsPerPage>15</DefaultItemsPerPage>
 
+    <UserFiltering>
+        <ShowDisplayName>false</ShowDisplayName>
+    </UserFiltering>
+
 </Server>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1724,4 +1724,8 @@
     <MaximumItemsPerPage>{{pagination.max_items_per_page}}</MaximumItemsPerPage>
     <DefaultItemsPerPage>{{pagination.default_items_per_page}}</DefaultItemsPerPage>
 
+    <UserFiltering>
+        <ShowDisplayName>{{user_filtering.show_display_name_of_user}}</ShowDisplayName>
+    </UserFiltering>
+
 </Server>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -452,5 +452,7 @@
     "${carbon.protocol}://${carbon.host}:${carbon.management.port}"
   ],
   "pagination.max_items_per_page": "100",
-  "pagination.default_items_per_page": "15"
+  "pagination.default_items_per_page": "15",
+
+  "user_filtering.show_display_name_of_user": false
 }


### PR DESCRIPTION
**Proposed Changes in PR**

Introduce a new configuration in identity.xml as follow to identify whether to show the display name claim (http://wso2.org/claims/displayName) when filtering users.
```
 <UserFiltering> 
        <ShowDisplayName>false</ShowDisplayName>
</UserFiltering>
```

Search for the display name of users only if the configuration is set to true.

The default value of the config is false.

Resolve - https://github.com/wso2/product-is/issues/6937