### PR TITLE
Add SuperTenantFlowInitializer filter

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/filter/SuperTenantFlowInitializer.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/filter/SuperTenantFlowInitializer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.core.filter;
+
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_ID;
+
+/**
+ * Once registered to a web app, this servlet filter will initiate a super tenant flow when accessing the web app.
+ *
+ * Used to pass the session validation when accessing super tenant web app jsp files through a tenant's context
+ * eg: /t/{tenant-domain}/.
+ */
+public class SuperTenantFlowInitializer implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+
+        // Nothing to implement
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+
+        try {
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(SUPER_TENANT_ID, true);
+
+            filterChain.doFilter(servletRequest, servletResponse);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
+    @Override
+    public void destroy() {
+
+        // Nothing to implement
+    }
+}


### PR DESCRIPTION
This filter is used to pass the session validation when accessing super tenant web app jsp files through a tenant's context eg: /t/{tenant-domain}/.