### PR TITLE
[Fix] Claim mapping not deleted upon userstore deletion

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>org.wso2.carbon.user.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.user.store.configuration</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
@@ -119,6 +123,7 @@
                             org.wso2.carbon.identity.base; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.model;
                             version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.user.store.configuration.*;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
                         <Export-Package>

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementService.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementService.java
@@ -140,4 +140,15 @@ public interface ClaimMetadataManagementService {
      */
     void removeExternalClaim(String externalClaimDialectURI, String externalClaimURI, String tenantDomain) throws
             ClaimMetadataException;
+
+    /**
+     * Remove attribute claim mappings related to a tenant domain.
+     *
+     * @param tenantId        Tenant Id
+     * @param userstoreDomain Tenant domain
+     * @throws ClaimMetadataException If an error occurred while removing local claim mappings
+     */
+    default void removeClaimMappingAttributes(int tenantId, String userstoreDomain) throws ClaimMetadataException {
+
+    }
 }

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementServiceImpl.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementServiceImpl.java
@@ -27,11 +27,13 @@ import org.wso2.carbon.identity.claim.metadata.mgt.dao.ExternalClaimDAO;
 import org.wso2.carbon.identity.claim.metadata.mgt.dao.LocalClaimDAO;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataClientException;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataServerException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ClaimDialect;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.user.api.UserStoreException;
 
 import java.util.List;
 
@@ -332,5 +334,24 @@ public class ClaimMetadataManagementServiceImpl implements ClaimMetadataManageme
         this.externalClaimDAO.removeExternalClaim(externalClaimDialectURI, externalClaimURI, tenantId);
 
         // Add listener
+    }
+
+    @Override
+    public void removeClaimMappingAttributes(int tenantId, String userstoreDomain) throws ClaimMetadataException {
+
+        if (StringUtils.isEmpty(userstoreDomain)) {
+            throw new ClaimMetadataClientException(ClaimConstants.ErrorMessage.ERROR_CODE_EMPTY_TENANT_DOMAIN.getCode(),
+                    ClaimConstants.ErrorMessage.ERROR_CODE_EMPTY_TENANT_DOMAIN.getMessage());
+        }
+        try {
+            this.localClaimDAO.removeClaimMappingAttributes(tenantId, userstoreDomain);
+        } catch (UserStoreException e) {
+            String errorMessage = String.format(
+                    ClaimConstants.ErrorMessage.ERROR_CODE_SERVER_ERROR_DELETING_CLAIM_MAPPINGS.getMessage(),
+                    tenantId, userstoreDomain);
+            throw new ClaimMetadataServerException(
+                    ClaimConstants.ErrorMessage.ERROR_CODE_SERVER_ERROR_DELETING_CLAIM_MAPPINGS.getCode(),
+                    errorMessage, e);
+        }
     }
 }

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/CacheBackedLocalClaimDAO.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/CacheBackedLocalClaimDAO.java
@@ -16,19 +16,20 @@
 
 package org.wso2.carbon.identity.claim.metadata.mgt.dao;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.claim.metadata.mgt.cache.LocalClaimCache;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
+import org.wso2.carbon.user.api.UserStoreException;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- *
  * Caching wrapper for org.wso2.carbon.identity.claim.metadata.mgt.dao.LocalClaimDAO
- *
  */
 public class CacheBackedLocalClaimDAO {
 
@@ -77,6 +78,26 @@ public class CacheBackedLocalClaimDAO {
     public void removeLocalClaim(String localClaimURI, int tenantId) throws ClaimMetadataException {
 
         localClaimDAO.removeLocalClaim(localClaimURI, tenantId);
+        localClaimInvalidationCache.clearCacheEntry(tenantId);
+    }
+
+    /**
+     * Remove attribute claim mappings related to tenant id and domain.
+     *
+     * @param tenantId        Tenant Id
+     * @param userstoreDomain Domain name
+     * @throws UserStoreException If an error occurred while removing local claims
+     */
+    public void removeClaimMappingAttributes(int tenantId, String userstoreDomain) throws UserStoreException {
+
+        if (StringUtils.isEmpty(userstoreDomain)) {
+            String message = ClaimConstants.ErrorMessage.ERROR_CODE_EMPTY_TENANT_DOMAIN.getMessage();
+            if (log.isDebugEnabled()) {
+                log.debug(message);
+            }
+            throw new UserStoreException(message);
+        }
+        localClaimDAO.deleteClaimMappingAttributes(tenantId, userstoreDomain);
         localClaimInvalidationCache.clearCacheEntry(tenantId);
     }
 }

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/LocalClaimDAO.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/LocalClaimDAO.java
@@ -159,22 +159,18 @@ public class LocalClaimDAO extends ClaimDAO {
             throw new UserStoreException(message);
         }
         userstoreDomain = userstoreDomain.toUpperCase();
-        Connection dbConnection = IdentityDatabaseUtil.getDBConnection(true);
-        PreparedStatement preparedStatement = null;
-        try {
-            preparedStatement = dbConnection.prepareStatement(SQLConstants.DELETE_IDN_CLAIM_MAPPED_ATTRIBUTE);
+        try (Connection dbConnection = IdentityDatabaseUtil.getDBConnection(true);
+             PreparedStatement preparedStatement = dbConnection
+                     .prepareStatement(SQLConstants.DELETE_IDN_CLAIM_MAPPED_ATTRIBUTE)) {
             preparedStatement.setString(1, userstoreDomain);
             preparedStatement.setInt(2, tenantId);
             preparedStatement.executeUpdate();
             IdentityDatabaseUtil.commitTransaction(dbConnection);
         } catch (SQLException e) {
-            IdentityDatabaseUtil.rollbackTransaction(dbConnection);
             String message =
                     String.format(ClaimConstants.ErrorMessage.ERROR_CODE_DELETE_IDN_CLAIM_MAPPED_ATTRIBUTE.getMessage(),
                             userstoreDomain, tenantId);
             throw new UserStoreException(message, e);
-        } finally {
-            IdentityDatabaseUtil.closeAllConnections(dbConnection, null, preparedStatement);
         }
     }
 

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/exception/ClaimMetadataException.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/exception/ClaimMetadataException.java
@@ -26,6 +26,7 @@ public class ClaimMetadataException extends IdentityException {
     private static final long serialVersionUID = -1228322936730202713L;
 
     public ClaimMetadataException(String errorDescription) {
+
         super(errorDescription);
     }
 
@@ -35,6 +36,19 @@ public class ClaimMetadataException extends IdentityException {
     }
 
     public ClaimMetadataException(String message, Throwable e) {
+
         super(message, e);
+    }
+
+    /**
+     * Constructs a new exception with an error code, detail message and throwable.
+     *
+     * @param errorCode The error code
+     * @param message   The detail message
+     * @param cause     Throwable
+     */
+    public ClaimMetadataException(String errorCode, String message, Throwable cause) {
+
+        super(errorCode, message, cause);
     }
 }

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/exception/ClaimMetadataServerException.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/exception/ClaimMetadataServerException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.claim.metadata.mgt.exception;
+
+/**
+ * Exception class that represents server exceptions thrown by ClaimMetadataManagementService.
+ */
+public class ClaimMetadataServerException extends ClaimMetadataException {
+
+    /**
+     * Constructs a new exception with an error code, detail message and throwable.
+     *
+     * @param errorCode The error code
+     * @param message   The detail message
+     * @param cause     Throwable
+     */
+    public ClaimMetadataServerException(String errorCode, String message, Throwable cause) {
+
+        super(errorCode, message, cause);
+    }
+}

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/listener/ClaimConfigListener.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/listener/ClaimConfigListener.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.claim.metadata.mgt.listener;
+
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.claim.metadata.mgt.internal.IdentityClaimManagementServiceDataHolder;
+import org.wso2.carbon.identity.user.store.configuration.listener.UserStoreConfigListener;
+import org.wso2.carbon.user.api.UserStoreException;
+
+/**
+ * Class which contains the implementation of a listener for claim configurations. This listener is responsible for
+ * actions related to claim configurations when the user store change happens.
+ */
+public class ClaimConfigListener implements UserStoreConfigListener {
+
+    @Override
+    public void onUserStoreNamePreUpdate(int tenantId, String currentUserStoreName, String newUserStoreName) throws
+            UserStoreException {
+
+        // Not Implemented.
+    }
+
+    @Override
+    public void onUserStoreNamePostUpdate(int tenantId, String currentUserStoreName, String newUserStoreName) throws
+            UserStoreException {
+
+        // Not Implemented.
+    }
+
+    @Override
+    public void onUserStorePreDelete(int tenantId, String userstoreDomain) throws UserStoreException {
+
+        try {
+            IdentityClaimManagementServiceDataHolder.getInstance().getClaimManagementService()
+                    .removeClaimMappingAttributes(tenantId, userstoreDomain);
+        } catch (ClaimMetadataException e) {
+            throw new UserStoreException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void onUserStorePostDelete(int tenantId, String userStoreName) throws UserStoreException {
+
+        // Not implemented.
+    }
+}

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
@@ -19,7 +19,7 @@ package org.wso2.carbon.identity.claim.metadata.mgt.util;
 import org.wso2.carbon.user.core.UserCoreConstants;
 
 /**
- * Holds the claim metadata related constants
+ * Holds the claim metadata related constants.
  */
 public class ClaimConstants {
 
@@ -61,7 +61,12 @@ public class ClaimConstants {
         ERROR_CODE_MAPPED_TO_EMPTY_LOCAL_CLAIM_URI("100008",
                 "Mapped local claim URI cannot be empty"),
         ERROR_CODE_MAPPED_TO_INVALID_LOCAL_CLAIM_URI("100009",
-                "Invalid Claim URI : %s for Claim Dialect : %s");
+                "Invalid Claim URI : %s for Claim Dialect : %s"),
+        ERROR_CODE_EMPTY_TENANT_DOMAIN("60000", "Empty tenant domain in the request"),
+        ERROR_CODE_DELETE_IDN_CLAIM_MAPPED_ATTRIBUTE("65001", "Error occurred while deleting claim " +
+                "mapped attributes for domain : %s with tenant Id : %s from table : IDN_CLAIM_MAPPED_ATTRIBUTE"),
+        ERROR_CODE_SERVER_ERROR_DELETING_CLAIM_MAPPINGS("65001", "Error occurred while deleting the " +
+                "claim mapping for the tenant : %s with domain : %s");
 
         private final String code;
         private final String message;

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/SQLConstants.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/SQLConstants.java
@@ -17,7 +17,7 @@
 package org.wso2.carbon.identity.claim.metadata.mgt.util;
 
 /**
- * Holds the SQL queries and related constants
+ * Holds the SQL queries and related constants.
  */
 public class SQLConstants {
 
@@ -85,4 +85,8 @@ public class SQLConstants {
     public static final String IS_CLAIM_MAPPING = "SELECT MAPPED_LOCAL_CLAIM_ID FROM IDN_CLAIM_MAPPING WHERE " +
             "MAPPED_LOCAL_CLAIM_ID=(SELECT ID FROM IDN_CLAIM WHERE DIALECT_ID=(SELECT ID FROM IDN_CLAIM_DIALECT WHERE" +
             " DIALECT_URI=? AND TENANT_ID=?) AND CLAIM_URI=? AND TENANT_ID=?) AND TENANT_ID=?";
+
+    // Delete claim mapped attributes.
+    public static final String DELETE_IDN_CLAIM_MAPPED_ATTRIBUTE = "DELETE FROM IDN_CLAIM_MAPPED_ATTRIBUTE WHERE " +
+            "USER_STORE_DOMAIN_NAME=? AND TENANT_ID=?";
 }


### PR DESCRIPTION
## Proposed Changes

A listener with a method `onUserStorePreDelete` has been introduced. This listener carries the implementation of deleting mapped claims in `IDN_CLAIM_MAPPED_ATTRIBUTE` attribute.

This listener will be invoked upon userstore deletion as UserStorePreDelete function.

Resolves https://github.com/wso2/product-is/issues/7313

Support fix: 
 - https://github.com/wso2-support/carbon-identity-framework/pull/931
 - https://github.com/wso2-support/carbon-identity-framework/pull/937 