### PR TITLE
Add missing EnforceCertificateExpiryTimeValidity config to identity.xml

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1343,6 +1343,7 @@
     <!-- JWT validator configurations -->
     <JWTValidatorConfigs>
         <Enable>true</Enable>
+        <EnforceCertificateExpiryTimeValidity>true</EnforceCertificateExpiryTimeValidity>
         <JWKSEndpoint>
             <HTTPConnectionTimeout>1000</HTTPConnectionTimeout>
             <HTTPReadTimeout>1000</HTTPReadTimeout>


### PR DESCRIPTION
### Proposed changes in this pull request
Add missing EnforceCertificateExpiryTimeValidity config to identity.xml

Related to https://github.com/wso2/carbon-identity-framework/pull/2701