### PR TITLE
Adding missing IntermediateCertValidation enable config

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1765,7 +1765,7 @@
     </AdaptiveAuth>
 
     <!--Intermediate certificate validation for certificate based requests-->
-    <IntermediateCertValidation enable="false">
+    <IntermediateCertValidation enable="{{intermediate_cert_validation.enable}}">
         <IntermediateCerts>
             <!--Add intermediate certificate CN. Multiple <CertCN> elements can be used for multiple certificates.-->
             {% for cert in intermediate_cert_validation.cert_cns %}

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -440,6 +440,7 @@
   "tenant_context.rewrite.overwrite.dispatch": [
     "/user-portal/"
   ],
+  "intermediate_cert_validation.enable":false,
   "intermediate_cert_validation.cert_cns": [
     "localhost"
   ],


### PR DESCRIPTION
### Proposed changes in this pull request
Adding missing IntermediateCertValidation enable config to the `j2` template and `default.json`.

To configure add the following config to the `toml`.
```
[intermediate_cert_validation]
enable=true
```

Resolves : https://github.com/wso2/product-is/issues/6779

### After Merging

Update the documentation [1] as described in https://github.com/wso2/product-is/issues/6779 and https://github.com/wso2/docs-is/issues/747

[1] - https://is.docs.wso2.com/en/5.9.0/develop/authenticating-and-authorizing-rest-apis/