### PR TITLE
Improving cookie configurations

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1259,9 +1259,13 @@
         </CacheManager>
     </CacheConfig>
 
-    <!--Cookies>
-        <Cookie name="commonAuthId" domain="localhost" httpOnly="true" secure="true" />
-    </Cookies-->
+    {% if identity.cookies is defined %}
+    <Cookies>
+    {% for cookie in identity.cookies %}
+        <Cookie name="{{cookie.name}}" domain="{{cookie.domain}}" httpOnly="{{cookie.httpOnly}}" secure="{{cookie.secure}}" />
+    {% endfor %}
+    </Cookies>
+    {% endif %}
 
 
     {% if resource_access_control.default_access_allow is sameas true %}


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/7473

## Approach

This PR introduces a `for loop` to read the configs from the `deployment.toml`.

To configure the cookies in the `toml` config file, follow the given sample.

```
[identity.cookies.commonAuthId]
name = "commonAuthId"
domain = "localhost"
httpOnly = "true"
secure = "true"

[identity.cookies.samlssoTokenId]
name = "samlssoTokenId"
domain = "wso2.com"
httpOnly = "true"
secure = "true"
```

## Related PRs
Support Fix: https://github.com/wso2-support/carbon-identity-framework/pull/943