### PR TITLE
Fix application and internal role count from framework level

### DIFF
--- a/components/user-store/org.wso2.carbon.identity.user.store.count/src/main/java/org/wso2/carbon/identity/user/store/count/UserStoreCountService.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.count/src/main/java/org/wso2/carbon/identity/user/store/count/UserStoreCountService.java
@@ -86,13 +86,10 @@ public class UserStoreCountService {
             roleCounts[i] = new PairDTO(userStoreDomain, Long.toString(count));
             i++;
         }
-        String internalDomainFilter = UserCoreConstants.INTERNAL_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + filter;
-        String applicationDomainFilter = InternalStoreCountConstants.APPLICATION_DOMAIN +
-                UserCoreConstants.DOMAIN_SEPARATOR + filter;
-        roleCounts[i] = new PairDTO(UserCoreConstants.INTERNAL_DOMAIN, String.valueOf(
-                getRoleCount(internalDomainFilter)));
-        roleCounts[++i] = new PairDTO(InternalStoreCountConstants.APPLICATION_DOMAIN, String.valueOf(
-                getRoleCount(applicationDomainFilter)));
+        roleCounts[i] =  new PairDTO(UserCoreConstants.INTERNAL_DOMAIN, String.valueOf(
+                UserStoreCountUtils.getInternalRoleCount(filter)));
+        roleCounts[++i] =  new PairDTO(InternalStoreCountConstants.APPLICATION_DOMAIN, String.valueOf(
+                UserStoreCountUtils.getApplicationRoleCount(filter)));
 
         return roleCounts;
     }


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes https://github.com/wso2/product-is/issues/7470.


### Approach taken
- The newly implemented `getRoleCount` method delegates counting logic to the user store manager. But for internal or application roles, counting should be done with the corresponding tables in the identity database, not with the user store manager. Therefore, the logic to retrieve internal user role count from the user store manager is removed, and the previous implementation is restored.