### PR TITLE
Add improvement to UserClaimsAuditLogger to log only updated claims

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1093,7 +1093,9 @@
                        type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
                        name="org.wso2.carbon.user.mgt.listeners.UserClaimsAuditLogger"
                        orderId="{{event.default_listener.user_claim_audit_logger.priority}}"
-                       enable="{{event.default_listener.user_claim_audit_logger.enable}}"/>
+                       enable="{{event.default_listener.user_claim_audit_logger.enable}}">
+            <Property name="LogUpdatedClaimsOnly">{{event.default_listener.user_claim_audit_logger.LogUpdatedClaimsOnly}}</Property>
+        </EventListener>
         <!-- Custom Audit Loggers-->
         {% for listener in event_listener %}
         <EventListener id="{{listener.id}}"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -318,6 +318,7 @@
   "event.default_listener.user_failure_audit_logger.enable": true,
   "event.default_listener.user_claim_audit_logger.priority": "9",
   "event.default_listener.user_claim_audit_logger.enable": false,
+  "event.default_listener.user_claim_audit_logger.LogUpdatedClaimsOnly": false,
   "event.default_listener.username_resolver.priority": "14",
   "event.default_listener.username_resolver.enable": true,
   "event.default_listener.userid_resolver.priority": "15",


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/7443

This PR is to add improvement to audit logs so that whenever any claim of a user got updated, it will log only the information of which claim got updated with what value.

To enable this requirement 'LogUpdatedClaimsOnly' property should be enabled in the deployment.toml file as follows.

```
[event.default_listener.user_claim_audit_logger]     
priority = 9
enable = true
LogUpdatedClaimsOnly = true
```

Following is a sample log printed when the above property is enabled. 

`TID: [-1234] [2020-02-07 16:11:29,555] [b8140222-378d-404a-a60e-4b2e97979b7f]  INFO {AUDIT_LOG} - Initiator : admin@carbon.super | Action : doPreSetUserClaimValues | Target : sam | Added Claims : { "http://wso2.org/claims/mobile" : "012345678" } | Updated Claims : { "http://wso2.org/claims/emailaddress" : "sam1234@gmail.com" } | Removed Claims : { "http://wso2.org/claims/country" : "Sri Lanka" }`
