### PR TITLE
[FIX] Encoding password regex

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/user/add-step1.jsp
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/user/add-step1.jsp
@@ -59,6 +59,9 @@
     boolean isAskPasswordEnabled = false;
     boolean isUserOnBoardingEnabled = false;
 
+    String GREATER_THAN_CHARACTER = ">";
+    String GREATER_THAN_ENCODING_STRING = "&gt;";
+
     String BUNDLE = "org.wso2.carbon.userstore.ui.i18n.Resources";
     ResourceBundle resourceBundle = ResourceBundle.getBundle(BUNDLE, request.getLocale());
 
@@ -343,9 +346,11 @@
             <form method="post" action="add-finish-ajaxprocessor.jsp" name="dataForm" onsubmit="return doValidation();">
 
                 <input type="hidden" id="pwd_primary_null" name="pwd_primary_null"
-                       value=<%=Encode.forHtmlAttribute(userRealmInfo.getPrimaryUserStoreInfo().getPasswordRegEx())%>>
+                       value=<%=Encode.forHtmlAttribute(userRealmInfo.getPrimaryUserStoreInfo().getPasswordRegEx())
+                       .replace(GREATER_THAN_CHARACTER, GREATER_THAN_ENCODING_STRING)%>>
                 <input type="hidden" id="usr_primary_null" name="usr_primary_null"
-                       value=<%=Encode.forHtmlAttribute(userRealmInfo.getPrimaryUserStoreInfo().getUserNameRegEx())%>>
+                       value=<%=Encode.forHtmlAttribute(userRealmInfo.getPrimaryUserStoreInfo().getUserNameRegEx())
+                       .replace(GREATER_THAN_CHARACTER, GREATER_THAN_ENCODING_STRING)%>>
 
                 <%
 
@@ -360,11 +365,13 @@
                 <input type="hidden"
                        id="pwd_<%=Encode.forHtmlAttribute(allUserStoreInfo[i].getDomainName().toUpperCase())%>"
                        name="pwd_<%=Encode.forHtmlAttribute(allUserStoreInfo[i].getDomainName().toUpperCase())%>"
-                       value=<%=Encode.forHtmlAttribute(pwdRegEx)%>>
+                       value=<%=Encode.forHtmlAttribute(pwdRegEx).replace(GREATER_THAN_CHARACTER,
+                       GREATER_THAN_ENCODING_STRING)%>>
                 <input type="hidden"
                        id="usr_<%=Encode.forHtmlAttribute(allUserStoreInfo[i].getDomainName().toUpperCase())%>"
                        name="usr_<%=Encode.forHtmlAttribute(allUserStoreInfo[i].getDomainName().toUpperCase())%>"
-                       value=<%=Encode.forHtmlAttribute(usrRegEx)%>>
+                       value=<%=Encode.forHtmlAttribute(usrRegEx).replace(GREATER_THAN_CHARACTER,
+                       GREATER_THAN_ENCODING_STRING)%>>
 
                 <% }
 

--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/user/add-step1.jsp
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/user/add-step1.jsp
@@ -59,9 +59,6 @@
     boolean isAskPasswordEnabled = false;
     boolean isUserOnBoardingEnabled = false;
 
-    String GREATER_THAN_CHARACTER = ">";
-    String GREATER_THAN_ENCODING_STRING = "&gt;";
-
     String BUNDLE = "org.wso2.carbon.userstore.ui.i18n.Resources";
     ResourceBundle resourceBundle = ResourceBundle.getBundle(BUNDLE, request.getLocale());
 
@@ -346,11 +343,9 @@
             <form method="post" action="add-finish-ajaxprocessor.jsp" name="dataForm" onsubmit="return doValidation();">
 
                 <input type="hidden" id="pwd_primary_null" name="pwd_primary_null"
-                       value=<%=Encode.forHtmlAttribute(userRealmInfo.getPrimaryUserStoreInfo().getPasswordRegEx())
-                       .replace(GREATER_THAN_CHARACTER, GREATER_THAN_ENCODING_STRING)%>>
+                       value=<%=Encode.forHtml(userRealmInfo.getPrimaryUserStoreInfo().getPasswordRegEx())%>>
                 <input type="hidden" id="usr_primary_null" name="usr_primary_null"
-                       value=<%=Encode.forHtmlAttribute(userRealmInfo.getPrimaryUserStoreInfo().getUserNameRegEx())
-                       .replace(GREATER_THAN_CHARACTER, GREATER_THAN_ENCODING_STRING)%>>
+                       value=<%=Encode.forHtml(userRealmInfo.getPrimaryUserStoreInfo().getUserNameRegEx())%>>
 
                 <%
 
@@ -365,13 +360,11 @@
                 <input type="hidden"
                        id="pwd_<%=Encode.forHtmlAttribute(allUserStoreInfo[i].getDomainName().toUpperCase())%>"
                        name="pwd_<%=Encode.forHtmlAttribute(allUserStoreInfo[i].getDomainName().toUpperCase())%>"
-                       value=<%=Encode.forHtmlAttribute(pwdRegEx).replace(GREATER_THAN_CHARACTER,
-                       GREATER_THAN_ENCODING_STRING)%>>
+                       value=<%=Encode.forHtml(pwdRegEx)%>>
                 <input type="hidden"
                        id="usr_<%=Encode.forHtmlAttribute(allUserStoreInfo[i].getDomainName().toUpperCase())%>"
                        name="usr_<%=Encode.forHtmlAttribute(allUserStoreInfo[i].getDomainName().toUpperCase())%>"
-                       value=<%=Encode.forHtmlAttribute(usrRegEx).replace(GREATER_THAN_CHARACTER,
-                       GREATER_THAN_ENCODING_STRING)%>>
+                       value=<%=Encode.forHtml(usrRegEx)%>>
 
                 <% }
 


### PR DESCRIPTION
Resolves wso2/product-is#7505

### Proposed changes in this pull request
The issue is due to not encoding `>` character properly. This PR encodes `>` to `&gt;`.

## Related PRs
Support Fix : https://github.com/wso2-support/carbon-identity-framework/pull/950