### PR TITLE
XACML standard policy editor does not work as expected for 'equals-with-regexp-match

### DIFF
--- a/components/entitlement/org.wso2.carbon.identity.entitlement.common/src/main/java/org/wso2/carbon/identity/entitlement/common/util/PolicyEditorUtil.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.common/src/main/java/org/wso2/carbon/identity/entitlement/common/util/PolicyEditorUtil.java
@@ -966,6 +966,8 @@ public class PolicyEditorUtil {
                     designatorDTO);
         } else if (PolicyConstants.Functions.FUNCTION_EQUAL.equals(rowDTO.getFunction())) {
             applyElementDTO = processEqualFunctions(function, dataType, attributeValue, designatorDTO);
+        } else if (PolicyConstants.Functions.FUNCTION_EQUAL_MATCH_REGEXP.equals(rowDTO.getFunction())) {
+            applyElementDTO = processRegexpFunctions(function, dataType, attributeValue, designatorDTO);
         } else {
             applyElementDTO = processBagFunction(function, dataType, attributeValue, designatorDTO);
         }
@@ -1262,6 +1264,37 @@ public class PolicyEditorUtil {
             return applyElementDTO;
 
         }
+    }
+
+    /**
+     * Process regexp-match functions.
+     *
+     * @param function       Function name.
+     * @param dataType       Data type.
+     * @param attributeValue Attribute Value.
+     * @param designatorDTO  AttributeDesignator information.
+     * @return ApplyElementDTO.
+     */
+    public static ApplyElementDTO processRegexpFunctions(String function, String dataType, String attributeValue,
+                                                         AttributeDesignatorDTO designatorDTO) {
+
+        if (PolicyConstants.Functions.FUNCTION_EQUAL_MATCH_REGEXP.equals(function)) {
+            ApplyElementDTO applyElementDTO = new ApplyElementDTO();
+            applyElementDTO.setFunctionId(PolicyConstants.XACMLData.FUNCTION_ANY_OF);
+            if (applyElementMap.containsKey(attributeValue)) {
+                applyElementDTO.setApplyElement(applyElementMap.get(attributeValue));
+            } else {
+                AttributeValueElementDTO valueElementDTO = new AttributeValueElementDTO();
+                valueElementDTO.setAttributeDataType(dataType);
+                valueElementDTO.setAttributeValue(attributeValue);
+                applyElementDTO.setAttributeValueElementDTO(valueElementDTO);
+            }
+            applyElementDTO.setFunctionFunctionId(
+                    processFunction(PolicyConstants.Functions.FUNCTION_EQUAL_MATCH_REGEXP, dataType));
+            applyElementDTO.setAttributeDesignators(designatorDTO);
+            return applyElementDTO;
+        }
+        return null;
     }
 
     /**

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/java/org/wso2/carbon/identity/entitlement/ui/util/PolicyEditorUtil.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/java/org/wso2/carbon/identity/entitlement/ui/util/PolicyEditorUtil.java
@@ -972,6 +972,8 @@ public class PolicyEditorUtil {
                     designatorDTO);
         } else if (PolicyConstants.Functions.FUNCTION_EQUAL.equals(rowDTO.getFunction())) {
             applyElementDTO = processEqualFunctions(function, dataType, attributeValue, designatorDTO);
+        } else if (PolicyConstants.Functions.FUNCTION_EQUAL_MATCH_REGEXP.equals(rowDTO.getFunction())) {
+            applyElementDTO = processRegexpFunctions(function, dataType, attributeValue, designatorDTO);
         } else {
             applyElementDTO = processBagFunction(function, dataType, attributeValue, designatorDTO);
         }
@@ -1268,6 +1270,37 @@ public class PolicyEditorUtil {
             return applyElementDTO;
 
         }
+    }
+
+    /**
+     * Process regexp-match functions.
+     *
+     * @param function       Function name.
+     * @param dataType       Data type.
+     * @param attributeValue Attribute Value.
+     * @param designatorDTO  AttributeDesignator information.
+     * @return ApplyElementDTO.
+     */
+    public static ApplyElementDTO processRegexpFunctions(String function, String dataType, String attributeValue,
+                                                         AttributeDesignatorDTO designatorDTO) {
+
+        if (PolicyConstants.Functions.FUNCTION_EQUAL_MATCH_REGEXP.equals(function)) {
+            ApplyElementDTO applyElementDTO = new ApplyElementDTO();
+            applyElementDTO.setFunctionId(PolicyConstants.XACMLData.FUNCTION_ANY_OF);
+            if (applyElementMap.containsKey(attributeValue)) {
+                applyElementDTO.setApplyElement(applyElementMap.get(attributeValue));
+            } else {
+                AttributeValueElementDTO valueElementDTO = new AttributeValueElementDTO();
+                valueElementDTO.setAttributeDataType(dataType);
+                valueElementDTO.setAttributeValue(attributeValue);
+                applyElementDTO.setAttributeValueElementDTO(valueElementDTO);
+            }
+            applyElementDTO.setFunctionFunctionId(
+                    processFunction(PolicyConstants.Functions.FUNCTION_EQUAL_MATCH_REGEXP, dataType));
+            applyElementDTO.setAttributeDesignators(designatorDTO);
+            return applyElementDTO;
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Fixes wso2/product-is#7479

As per the specification [1] for regular expressions (Match evaluations) in the rule's condition element, the match semantics can be expressed as an element in a condition by using the “urn:oasis:names:tc:xacml:3.0:function:any-of” function, as follows:

```
<Apply FunctionId=”urn:oasis:names:tc:xacml:3.0:function:any-of”>

    <Function

FunctionId=”urn:oasis:names:tc:xacml:1.0:function:string-regexp-match”/>

    <AttributeValue DataType=”http://www.w3.org/2001/XMLSchema#string”>

        John.*

    </AttributeValue>

    <AttributeDesignator

         Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject"

         AttributeId=”urn:oasis:names:tc:xacml:1.0:subject:subject-id”

         DataType=”http://www.w3.org/2001/XMLSchema#string”/>

</Apply>
```

Currently we support Match evaluations only in the rule's target element. This PR provides provides support for applying the same on rule's condition element by following the above semantics.

This works successfully using the Write Policy in XML option. However since our Try It tool provides some limited set of capabilities (e.g. currently it allows to specify multiple AttributeValues using the comma seperator in a single field. Therefore using commas in the attribute value is currently not supported. We will consider this as an improvement to our Try It tool to add support to provide multiple attribute value fields. Therefore for testing purposes we can use the editor to create XACML requests using the 'Create Request Using Editor' option.

[1] http://docs.oasis-open.org/xacml/3.0/xacml-3.0-core-spec-os-en.html#_Toc325047249