### PR TITLE
Defining ajaxProcessor output to be text/plain

### DIFF
--- a/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/resources/web/entitlement/prettyPrinter_ajaxprocessor.jsp
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/resources/web/entitlement/prettyPrinter_ajaxprocessor.jsp
@@ -14,6 +14,7 @@
     if (rawXML.startsWith("\n")) {
         rawXML = rawXML.substring(1);
     }
+    response.setContentType("text/plain");
 
 
 %><%=rawXML%>

--- a/components/policy-editor/org.wso2.carbon.policyeditor.ui/src/main/resources/web/policyeditor/prettyPrinter_ajaxprocessor.jsp
+++ b/components/policy-editor/org.wso2.carbon.policyeditor.ui/src/main/resources/web/policyeditor/prettyPrinter_ajaxprocessor.jsp
@@ -19,5 +19,6 @@
     if (rawXML.startsWith("\n")) {
         rawXML = rawXML.substring(1);
     }
+    response.setContentType("text/plain");
 %>
 <%=rawXML%>


### PR DESCRIPTION
### Proposed changes in this pull request

By default ajaxProcessor returned with content`text/html`. This PR changes send Content-Type to `text/plain` instead of `text/html` with the responses generated by the relevant ajaxProcessor.

For more information refer to `Document No: V10013` mail thread.

