### PR TITLE
Revert "Fix application and internal role count from framework level"

### DIFF
--- a/components/user-store/org.wso2.carbon.identity.user.store.count/src/main/java/org/wso2/carbon/identity/user/store/count/UserStoreCountService.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.count/src/main/java/org/wso2/carbon/identity/user/store/count/UserStoreCountService.java
@@ -86,10 +86,13 @@ public class UserStoreCountService {
             roleCounts[i] = new PairDTO(userStoreDomain, Long.toString(count));
             i++;
         }
-        roleCounts[i] =  new PairDTO(UserCoreConstants.INTERNAL_DOMAIN, String.valueOf(
-                UserStoreCountUtils.getInternalRoleCount(filter)));
-        roleCounts[++i] =  new PairDTO(InternalStoreCountConstants.APPLICATION_DOMAIN, String.valueOf(
-                UserStoreCountUtils.getApplicationRoleCount(filter)));
+        String internalDomainFilter = UserCoreConstants.INTERNAL_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + filter;
+        String applicationDomainFilter = InternalStoreCountConstants.APPLICATION_DOMAIN +
+                UserCoreConstants.DOMAIN_SEPARATOR + filter;
+        roleCounts[i] = new PairDTO(UserCoreConstants.INTERNAL_DOMAIN, String.valueOf(
+                getRoleCount(internalDomainFilter)));
+        roleCounts[++i] = new PairDTO(InternalStoreCountConstants.APPLICATION_DOMAIN, String.valueOf(
+                getRoleCount(applicationDomainFilter)));
 
         return roleCounts;
     }


### PR DESCRIPTION
Reverts wso2/carbon-identity-framework#2725, because this is fixed in the user core level with https://github.com/wso2/carbon-kernel/pull/2590.

> Resolves https://github.com/wso2/product-is/issues/7470.