### PR TITLE
Fix possible null pointer error when updating the secondary user store from management console

### DIFF
--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/SecondaryUserStoreConfigurationUtil.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/SecondaryUserStoreConfigurationUtil.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.user.store.configuration.utils;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.Attr;
@@ -343,10 +344,17 @@ public class SecondaryUserStoreConfigurationUtil {
 
         Map<String, String> secondaryUserStoreProperties = null;
         try {
-            UserStoreManager secondaryUserStoreManager = getSecondaryUserStoreManager(userStoreDomain);
-            if (secondaryUserStoreManager != null) {
-                secondaryUserStoreProperties = secondaryUserStoreManager.getRealmConfiguration()
-                        .getUserStoreProperties();
+            RealmConfiguration realmConfiguration = UserStoreConfigComponent.getRealmService().getTenantUserRealm(
+                    getTenantIdInTheCurrentContext()).getRealmConfiguration();
+            while (realmConfiguration != null) {
+                String domainName = realmConfiguration.getUserStoreProperty(UserCoreConstants.RealmConfig
+                        .PROPERTY_DOMAIN_NAME);
+                if (StringUtils.equalsIgnoreCase(domainName, userStoreDomain)) {
+                    secondaryUserStoreProperties = realmConfiguration.getUserStoreProperties();
+                    break;
+                } else {
+                    realmConfiguration = realmConfiguration.getSecondaryRealmConfig();
+                }
             }
         } catch (UserStoreException e) {
             String errorMessage = "Error while retrieving user store configurations for user store domain: "


### PR DESCRIPTION
Fix for issue [1]. We need to use the realm configuration to retrieve the user store properties.

[1] wso2/product-is#7565