### PR TITLE
Use Federation association manager service

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -24,18 +24,24 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.CarbonException;
+import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.core.util.AnonymousSessionUtil;
 import org.wso2.carbon.core.util.PermissionUpdateUtil;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.provisioning.ProvisioningHandler;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceComponent;
+import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.user.profile.mgt.UserProfileAdmin;
 import org.wso2.carbon.identity.user.profile.mgt.UserProfileException;
+import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
+import org.wso2.carbon.identity.user.profile.mgt.association.federation.constant.FederatedAssociationConstants;
+import org.wso2.carbon.identity.user.profile.mgt.association.federation.exception.FederatedAssociationManagerException;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
@@ -149,10 +155,9 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                     userClaims.remove(USERNAME_CLAIM);
                     userStoreManager.setUserClaimValues(UserCoreUtil.removeDomainFromName(username), userClaims, null);
                 }
-
-                UserProfileAdmin userProfileAdmin = UserProfileAdmin.getInstance();
-
-                if (StringUtils.isEmpty(userProfileAdmin.getNameAssociatedWith(idp, subjectVal))) {
+                String associatedUserName = FrameworkUtils.getFederatedAssociationManager()
+                        .getUserForFederatedAssociation(tenantDomain, idp, subjectVal);
+                if (StringUtils.isEmpty(associatedUserName)) {
                     // Associate User
                     associateUser(username, userStoreDomain, tenantDomain, subjectVal, idp);
                 }
@@ -179,7 +184,8 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
 
             PermissionUpdateUtil.updatePermissionTree(tenantId);
 
-        } catch (org.wso2.carbon.user.api.UserStoreException | CarbonException | UserProfileException e) {
+        } catch (org.wso2.carbon.user.api.UserStoreException | CarbonException |
+                FederatedAssociationManagerException e) {
             throw new FrameworkException("Error while provisioning user : " + subject, e);
         } finally {
             IdentityUtil.clearIdentityErrorMsg();
@@ -196,8 +202,10 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(usernameWithUserstoreDomain);
 
             if (!StringUtils.isEmpty(idp) && !StringUtils.isEmpty(subject)) {
-                UserProfileAdmin userProfileAdmin = UserProfileAdmin.getInstance();
-                userProfileAdmin.associateID(idp, subject);
+                FederatedAssociationManager federatedAssociationManager = FrameworkUtils
+                        .getFederatedAssociationManager();
+                User user = getAssociatedUser(tenantDomain, userStoreDomain, username);
+                federatedAssociationManager.createFederatedAssociation(user, idp, subject);
 
                 if (log.isDebugEnabled()) {
                     log.debug("Associated local user: " + usernameWithUserstoreDomain + " in tenant: " +
@@ -207,7 +215,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                 throw new FrameworkException("Error while associating local user: " + usernameWithUserstoreDomain +
                         " in tenant: " + tenantDomain + " to the federated subject : " + subject + " in IdP: " + idp);
             }
-        } catch (UserProfileException e) {
+        } catch (FederatedAssociationManagerException e) {
             if (isUserAlreadyAssociated(e)) {
                 log.info("An association already exists for user: " + subject + ". Skip association while JIT " +
                         "provisioning");
@@ -221,8 +229,19 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
         }
     }
 
-    private boolean isUserAlreadyAssociated(UserProfileException e) {
-        return e.getMessage() != null && e.getMessage().contains(ALREADY_ASSOCIATED_MESSAGE);
+    private User getAssociatedUser(String tenantDomain, String userStoreDomain, String username) {
+
+        User user = new User();
+        user.setTenantDomain(tenantDomain);
+        user.setUserStoreDomain(userStoreDomain);
+        user.setUserName(MultitenantUtils.getTenantAwareUsername(username));
+        return user;
+    }
+
+    private boolean isUserAlreadyAssociated(FederatedAssociationManagerException e) {
+
+        return e.getMessage() != null && e.getMessage().contains(FederatedAssociationConstants.ErrorMessages
+                .FEDERATED_ASSOCIATION_ALREADY_EXISTS.getDescription());
     }
 
     private void updateUserWithNewRoleSet(String username, UserStoreManager userStoreManager, List<String> rolesToAdd,
@@ -249,7 +268,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                                                                    Collection<String> deletingRoles)
             throws UserStoreException, FrameworkException {
         if (userStoreManager.getRealmConfiguration().isPrimary()
-            && username.equals(realm.getRealmConfiguration().getAdminUserName())) {
+                && username.equals(realm.getRealmConfiguration().getAdminUserName())) {
             if (log.isDebugEnabled()) {
                 log.debug("Federated user's username is equal to super admin's username of local IdP.");
             }
@@ -259,11 +278,11 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                     .contains(realm.getRealmConfiguration().getAdminRoleName())) {
                 if (log.isDebugEnabled()) {
                     log.debug("Federated user doesn't have super admin role. Unable to sync roles, since" +
-                              " super admin role cannot be unassigned from super admin user");
+                            " super admin role cannot be unassigned from super admin user");
                 }
                 throw new FrameworkException(
                         "Federated user which having same username to super admin username of local IdP," +
-                        " trying login without having super admin role assigned");
+                                " trying login without having super admin role assigned");
             }
         }
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -57,6 +57,8 @@ import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataExcept
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.user.profile.mgt.UserProfileAdmin;
 import org.wso2.carbon.identity.user.profile.mgt.UserProfileException;
+import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
+import org.wso2.carbon.identity.user.profile.mgt.association.federation.exception.FederatedAssociationManagerException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -460,17 +462,15 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                                                                 String tenantDomain)
             throws PostAuthenticationFailedException {
 
-        FrameworkUtils.startTenantFlow(tenantDomain);
         String username = null;
         try {
-            UserProfileAdmin userProfileAdmin = UserProfileAdmin.getInstance();
-            username = userProfileAdmin.getNameAssociatedWith(idpName, authenticatedSubjectIdentifier);
-        } catch (UserProfileException e) {
+            FederatedAssociationManager federatedAssociationManager = FrameworkUtils.getFederatedAssociationManager();
+            username = federatedAssociationManager.getUserForFederatedAssociation(tenantDomain, idpName,
+                    authenticatedSubjectIdentifier);
+        } catch (FederatedAssociationManagerException | FrameworkException e) {
             handleExceptions(
                     String.format(ErrorMessages.ERROR_WHILE_GETTING_USERNAME_ASSOCIATED_WITH_IDP.getMessage(), idpName),
                     ErrorMessages.ERROR_WHILE_GETTING_USERNAME_ASSOCIATED_WITH_IDP.getCode(), e);
-        } finally {
-            FrameworkUtils.endTenantFlow();
         }
         return username;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -89,6 +89,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.functions.library.mgt.FunctionLibraryManagementService;
 import org.wso2.carbon.identity.template.mgt.TemplateManager;
+import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -735,5 +736,32 @@ public class FrameworkServiceComponent {
             log.error("Failed to read require.js file. Therefore, require() function doesn't support in" +
                     "adaptive authentication scripts.", e);
         }
+    }
+
+    @Reference(
+            name = "identity.user.profile.mgt.component",
+            service = FederatedAssociationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetFederatedAssociationManagerService"
+    )
+    protected void setFederatedAssociationManagerService(FederatedAssociationManager
+                                                                     federatedAssociationManagerService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Federated Association Manager Service is set in the Application Authentication Framework " +
+                    "bundle");
+        }
+        FrameworkServiceDataHolder.getInstance().setFederatedAssociationManager(federatedAssociationManagerService);
+    }
+
+    protected void unsetFederatedAssociationManagerService(FederatedAssociationManager
+                                                                   federatedAssociationManagerService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Federated Association Manager Service is unset in the Application Authentication Framework " +
+                    "bundle");
+        }
+        FrameworkServiceDataHolder.getInstance().setFederatedAssociationManager(null);
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.identity.core.handler.HandlerComparator;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.functions.library.mgt.FunctionLibraryManagementService;
 import org.wso2.carbon.identity.template.mgt.TemplateManager;
+import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -83,6 +84,7 @@ public class FrameworkServiceDataHolder {
     private FunctionLibraryManagementService functionLibraryManagementService = null;
     private String requireCode = "";
     private boolean userSessionMappingEnabled;
+    private FederatedAssociationManager federatedAssociationManager;
 
     private FrameworkServiceDataHolder() {
 
@@ -503,5 +505,15 @@ public class FrameworkServiceDataHolder {
         }
 
         this.userSessionMappingEnabled = userSessionMappingEnabled;
+    }
+
+    public FederatedAssociationManager getFederatedAssociationManager() {
+
+        return federatedAssociationManager;
+    }
+
+    public void setFederatedAssociationManager(FederatedAssociationManager federatedAssociationManager) {
+
+        this.federatedAssociationManager = federatedAssociationManager;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -98,6 +98,7 @@ import org.wso2.carbon.identity.core.model.IdentityCookieConfig;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.idp.mgt.IdpManager;
@@ -2395,6 +2396,23 @@ public class FrameworkUtils {
             }
         }
         return String.join(FrameworkUtils.getMultiAttributeSeparator(), roleList);
+    }
+
+    /**
+     * This method returns the Federated Association Manager service registered during OSGi deployement.
+     *
+     * @return FederatedAssociationManger service.
+     * @throws FrameworkException
+     */
+    public static FederatedAssociationManager getFederatedAssociationManager() throws FrameworkException {
+
+        FederatedAssociationManager federatedAssociationManager = FrameworkServiceDataHolder.getInstance()
+                .getFederatedAssociationManager();
+
+        if (federatedAssociationManager == null) {
+            throw new FrameworkException("Federated Association Manager service is not available.");
+        }
+        return federatedAssociationManager;
     }
 }
 


### PR DESCRIPTION
Fix : https://github.com/wso2/product-is/issues/7658

## Approach
The federated user association was done in the authentication-framework by calling the UserProfileAdmin service. But there is a separate service class, **`FederatedAssociationManager`**  implemented for executing the user association functionalities.

This PR has changed the implementation of JIT provisioning to use the FederatedAssociationManager service.