### PR TITLE
Add a method to check EmailUsernameEnable status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 *.class
 .classpath
+.factorypath
 .settings
 .project
 *.iml

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -1076,7 +1076,7 @@ public class IdentityUtil {
      * @return true if the EnableEmailUserName. False if it doesnt
      */
     public static boolean isEmailUsernameEnabled() {
-        String enableEmailUsernameProperty = getProperty(ENABLE_EMAIL_USERNAME);
+        String enableEmailUsernameProperty = ServerConfiguration.getInstance().getFirstProperty(ENABLE_EMAIL_USERNAME);
         if (StringUtils.isNotBlank(enableEmailUsernameProperty)) {
             return Boolean.parseBoolean(enableEmailUsernameProperty);
         }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -1050,11 +1050,9 @@ public class IdentityUtil {
      * @return true if the EnableRecoveryEndpoint. False if it doesnt
      */
     public static boolean isRecoveryEPAvailable() {
+
         String enableRecoveryEPUrlProperty = getProperty(ENABLE_RECOVERY_ENDPOINT);
-        if (StringUtils.isNotBlank(enableRecoveryEPUrlProperty)) {
-            return Boolean.parseBoolean(enableRecoveryEPUrlProperty);
-        }
-        return false;
+        return Boolean.parseBoolean(enableRecoveryEPUrlProperty);
     }
 
     /**
@@ -1063,11 +1061,9 @@ public class IdentityUtil {
      * @return true if the EnableSelfSignUpEndpoint. False if it doesnt
      */
     public static boolean isSelfSignUpEPAvailable() {
+
         String enableSelfSignEPUpUrlProperty = getProperty(ENABLE_SELF_SIGN_UP_ENDPOINT);
-        if (StringUtils.isNotBlank(enableSelfSignEPUpUrlProperty)) {
-            return Boolean.parseBoolean(enableSelfSignEPUpUrlProperty);
-        }
-        return false;
+        return Boolean.parseBoolean(enableSelfSignEPUpUrlProperty);
     }
 
     /**
@@ -1076,11 +1072,9 @@ public class IdentityUtil {
      * @return true if the EnableEmailUserName. False if it doesnt
      */
     public static boolean isEmailUsernameEnabled() {
+
         String enableEmailUsernameProperty = ServerConfiguration.getInstance().getFirstProperty(ENABLE_EMAIL_USERNAME);
-        if (StringUtils.isNotBlank(enableEmailUsernameProperty)) {
-            return Boolean.parseBoolean(enableEmailUsernameProperty);
-        }
-        return false;
+        return Boolean.parseBoolean(enableEmailUsernameProperty);
     }
 
      /**

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -1044,6 +1044,11 @@ public class IdentityUtil {
         return isOperationSupported;
     }
 
+    /**
+     * Returns whether the recovery endpoint is available or not
+     *
+     * @return true if the EnableRecoveryEndpoint. False if it doesnt
+     */
     public static boolean isRecoveryEPAvailable() {
         String enableRecoveryEPUrlProperty = getProperty(ENABLE_RECOVERY_ENDPOINT);
         if (StringUtils.isNotBlank(enableRecoveryEPUrlProperty)) {
@@ -1052,6 +1057,11 @@ public class IdentityUtil {
         return false;
     }
 
+    /**
+     * Returns whether the self signup endpoint is available or not
+     *
+     * @return true if the EnableSelfSignUpEndpoint. False if it doesnt
+     */
     public static boolean isSelfSignUpEPAvailable() {
         String enableSelfSignEPUpUrlProperty = getProperty(ENABLE_SELF_SIGN_UP_ENDPOINT);
         if (StringUtils.isNotBlank(enableSelfSignEPUpUrlProperty)) {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -1045,7 +1045,7 @@ public class IdentityUtil {
     }
 
     /**
-     * Returns whether the recovery endpoint is available or not
+     * Returns whether the recovery endpoint is available or not.
      *
      * @return true if the EnableRecoveryEndpoint. False if it doesnt
      */
@@ -1058,7 +1058,7 @@ public class IdentityUtil {
     }
 
     /**
-     * Returns whether the self signup endpoint is available or not
+     * Returns whether the self signup endpoint is available or not.
      *
      * @return true if the EnableSelfSignUpEndpoint. False if it doesnt
      */
@@ -1071,7 +1071,7 @@ public class IdentityUtil {
     }
 
     /**
-     * Returns whether the email based username is enabled or not
+     * Returns whether the email based username is enabled or not.
      *
      * @return true if the EnableEmailUserName. False if it doesnt
      */

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -107,6 +107,7 @@ public class IdentityUtil {
             "[^<>:\"/\\\\|?*\\x00-\\x1F]*[^<>:\"/\\\\|?*\\x00-\\x1F\\ .]$";
     private static final String ENABLE_RECOVERY_ENDPOINT = "EnableRecoveryEndpoint";
     private static final String ENABLE_SELF_SIGN_UP_ENDPOINT = "EnableSelfSignUpEndpoint";
+    private static final String ENABLE_EMAIL_USERNAME = "EnableEmailUserName";
     private static Log log = LogFactory.getLog(IdentityUtil.class);
     private static Map<String, Object> configuration = new HashMap<>();
     private static Map<IdentityEventListenerConfigKey, IdentityEventListenerConfig> eventListenerConfiguration = new
@@ -1055,6 +1056,19 @@ public class IdentityUtil {
         String enableSelfSignEPUpUrlProperty = getProperty(ENABLE_SELF_SIGN_UP_ENDPOINT);
         if (StringUtils.isNotBlank(enableSelfSignEPUpUrlProperty)) {
             return Boolean.parseBoolean(enableSelfSignEPUpUrlProperty);
+        }
+        return false;
+    }
+
+    /**
+     * Returns whether the email based username is enabled or not
+     *
+     * @return true if the EnableEmailUserName. False if it doesnt
+     */
+    public static boolean isEmailUsernameEnabled() {
+        String enableEmailUsernameProperty = getProperty(ENABLE_EMAIL_USERNAME);
+        if (StringUtils.isNotBlank(enableEmailUsernameProperty)) {
+            return Boolean.parseBoolean(enableEmailUsernameProperty);
         }
         return false;
     }


### PR DESCRIPTION
### Proposed changes in this pull request
- Add a method to check EmailUsernameEnable status in carbon.xml. Which is required in the basic login page

### When should this PR be merged

For the IS v5.10.0 release. https://github.com/wso2/identity-apps/pull/487 can't merge without this.