### PR TITLE
Use unique userid for session management

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -67,6 +67,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -590,7 +591,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                     userId = UserSessionStore.getInstance().getUserId(userName, tenantId, userStoreDomain, idpId);
                     try {
                         if (userId == null) {
-                            userId = UUIDGenerator.generateUUID();
+                            userId = UUID.randomUUID().toString();
                             UserSessionStore.getInstance().storeUserData(userId, userName, tenantId, userStoreDomain,
                                     idpId);
                         }
@@ -608,7 +609,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                         }
                     }
                 } else {
-                    userId = FrameworkUtils.resolveUserIdFromUsername(tenantDomain, userStoreDomain, userName);
+                    userId = FrameworkUtils.resolveUserIdFromUsername(tenantId, userStoreDomain, userName);
                 }
                 if (StringUtils.isNotEmpty(userId)) {
                     if (persistUserToSessionMapping && !UserSessionStore.getInstance().isExistingMapping(userId,

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
@@ -48,6 +48,9 @@ public class SQLQueries {
     public static final String SQL_SELECT_USER_IDS_OF_USER_STORE =
             "SELECT USER_ID FROM IDN_AUTH_USER WHERE DOMAIN_NAME = ? AND TENANT_ID =?";
 
+    public static final String SQL_SELECT_INFO_OF_USER_ID =
+            "SELECT USER_ID FROM IDN_AUTH_USER WHERE USER_ID = ?";
+
     /**
      * Queries to retrieve session ID.
      */

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -749,8 +749,6 @@ public class UserSessionStore {
                         isExisting = true;
                     }
                 }
-            } catch (SQLException e1) {
-                throw new UserSessionException("Error while retrieving information of user id: " + userId, e1);
             }
         } catch (SQLException e) {
             throw new UserSessionException("Error while retrieving information of user id: " + userId, e);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -729,4 +729,32 @@ public class UserSessionStore {
                     "the session index:" + sessionContextKey, e);
         }
     }
+
+    /**
+     * Method to check whether the user id is available in the IDN_AUTH_USER table.
+     *
+     * @param userId    Id of the user
+     * @return the boolean decision
+     * @throws UserSessionException if an error occurs when retrieving the mapping from the database
+     */
+    public boolean isExistingUser(String userId) throws UserSessionException {
+
+        Boolean isExisting = false;
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
+            try (PreparedStatement preparedStatement = connection
+                    .prepareStatement(SQLQueries.SQL_SELECT_INFO_OF_USER_ID)) {
+                preparedStatement.setString(1, userId);
+                try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                    if (resultSet.next()) {
+                        isExisting = true;
+                    }
+                }
+            } catch (SQLException e1) {
+                throw new UserSessionException("Error while retrieving information of user id: " + userId, e1);
+            }
+        } catch (SQLException e) {
+            throw new UserSessionException("Error while retrieving information of user id: " + userId, e);
+        }
+        return isExisting;
+    }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2441,8 +2441,8 @@ public class FrameworkUtils {
                 if (userStoreManager instanceof AbstractUserStoreManager) {
                     String userId = ((AbstractUserStoreManager) userStoreManager).getUserIDFromUserName(username);
 
-                    // If only the user store is not read-only, update the user-id claim with the unique id.
-                    // Otherwise there will be no permission to update the userstore.
+                    // If the user id is not present in the userstore, we need to add it to the userstore. But if the
+                    // userstore is read-only, we cannot add the id and empty user id will returned.
                     if (StringUtils.isBlank(userId) && !userStoreManager.isReadOnly()) {
                         userId = addUserId(username, userStoreManager);
                     }
@@ -2457,17 +2457,18 @@ public class FrameworkUtils {
                 if (log.isDebugEnabled()) {
                     log.debug("Error occurred while resolving Id for the user: " + username, e);
                 }
-                throw new UserSessionException("Error occurred while resolving Id for the user: " + username);
+                throw new UserSessionException("Error occurred while resolving Id for the user: " + username, e);
             }
         } catch (UserStoreException e) {
-            throw new UserSessionException("Error occurred while retrieving the userstore manager to resolve Id for the user: " + username);
+            throw new UserSessionException("Error occurred while retrieving the userstore manager to resolve Id for " +
+                    "the user: " + username, e);
         }
     }
 
     private static String addUserId(String username, UserStoreManager userStoreManager) {
 
         String userId;
-        userId = UUIDGenerator.generateUUID();
+        userId = UUID.randomUUID().toString();
         Map<String, String> claims = new HashMap<>();
         claims.put(UserCoreClaimConstants.USER_ID_CLAIM_URI, userId);
         try {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2460,7 +2460,7 @@ public class FrameworkUtils {
                 throw new UserSessionException("Error occurred while resolving Id for the user: " + username);
             }
         } catch (UserStoreException e) {
-            throw new UserSessionException("Unable to retrieve Id for the user: " + username);
+            throw new UserSessionException("Error occurred while retrieving the userstore manager to resolve Id for the user: " + username);
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2455,7 +2455,7 @@ public class FrameworkUtils {
                 throw new UserSessionException("Unable to get the unique id of the user: " + username + ".");
             } catch (org.wso2.carbon.user.core.UserStoreException e) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Error occurred while retrieving Id for the user: " + username, e);
+                    log.debug("Error occurred while resolving Id for the user: " + username, e);
                 }
                 throw new UserSessionException("Unable to retrieve Id for the user: " + username);
             }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2457,7 +2457,7 @@ public class FrameworkUtils {
                 if (log.isDebugEnabled()) {
                     log.debug("Error occurred while resolving Id for the user: " + username, e);
                 }
-                throw new UserSessionException("Unable to retrieve Id for the user: " + username);
+                throw new UserSessionException("Error occurred while resolving Id for the user: " + username);
             }
         } catch (UserStoreException e) {
             throw new UserSessionException("Unable to retrieve Id for the user: " + username);


### PR DESCRIPTION
### Proposed changes in this pull request

Fix https://github.com/wso2/product-is/issues/7725

### Approach
According to the previous implementation, for all the logged in users, a unique id is generated and added to the IDN_AUTH_USER table. Session details are mapped using this unique id.
Since now there is a unique identifier for each user, there's no need to generate a new id during authentication.
Therefore, for the local users, the unique user id given from the user store level is used for the session information storing. If the unique id is not available, an id is generated and the userid claim is updated. For the federated users, an id generated and added to the IDN_AUTH_USER table.