### PR TITLE
Add support for including tenant domain as a parameter in URLResolverService

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultURLResolverService.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultURLResolverService.java
@@ -40,6 +40,22 @@ import static org.wso2.carbon.identity.core.util.IdentityTenantUtil.isTenantQual
 public class DefaultURLResolverService implements URLResolverService {
 
     @Override
+    public String resolveUrl(String url, boolean addProxyContextPath, boolean addWebContextRoot,
+                             Map<String, Object> properties) throws URLResolverException {
+
+        return resolveUrl(url, null, addProxyContextPath, addWebContextRoot, false, false, properties);
+    }
+
+    @Override
+    public String resolveUrl(String url, boolean addProxyContextPath, boolean addWebContextRoot,
+                             boolean addTenantQueryParamInLegacyMode, boolean addTenantPathParamInLegacyMode,
+                             Map<String, Object> properties) throws URLResolverException {
+
+        return resolveUrl(url, null, addProxyContextPath, addWebContextRoot, addTenantQueryParamInLegacyMode,
+                addTenantPathParamInLegacyMode, properties);
+    }
+
+    @Override
     public String resolveUrl(String url, String tenantDomain, boolean addProxyContextPath, boolean addWebContextRoot,
                              boolean addTenantQueryParamInLegacyMode, boolean addTenantPathParamInLegacyMode,
                              Map<String, Object> properties) throws URLResolverException {
@@ -58,6 +74,22 @@ public class DefaultURLResolverService implements URLResolverService {
         } catch (MalformedURLException e) {
             throw new URLResolverException("Error while parsing the URL: " + url, e);
         }
+    }
+
+    @Override
+    public String resolveUrlContext(String urlContext, boolean addProxyContextPath, boolean addWebContextRoot,
+                                    Map<String, Object> properties) throws URLResolverException {
+
+        return resolveUrlContext(urlContext, null, addProxyContextPath, addWebContextRoot, false, false, properties);
+    }
+
+    @Override
+    public String resolveUrlContext(String urlContext, boolean addProxyContextPath, boolean addWebContextRoot,
+                                    boolean addTenantQueryParamInLegacyMode, boolean addTenantPathParamInLegacyMode,
+                                    Map<String, Object> properties) throws URLResolverException {
+
+        return resolveUrlContext(urlContext, null, addProxyContextPath, addWebContextRoot,
+                addTenantQueryParamInLegacyMode, addTenantPathParamInLegacyMode, properties);
     }
 
     @Override

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultURLResolverService.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultURLResolverService.java
@@ -170,12 +170,7 @@ public class DefaultURLResolverService implements URLResolverService {
 
     private void appendTenantAsPathParam(StringBuilder serverUrl, String tenantDomain) {
 
-        if (StringUtils.isBlank(tenantDomain)) {
-            tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
-            if (StringUtils.isBlank(tenantDomain)) {
-                tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-            }
-        }
+        tenantDomain = resolveTenantDomain(tenantDomain);
         if (StringUtils.isNotBlank(tenantDomain)) {
             if (serverUrl.toString().endsWith("/")) {
                 serverUrl.append("t/").append(tenantDomain);
@@ -187,12 +182,7 @@ public class DefaultURLResolverService implements URLResolverService {
 
     private void appendTenantPathParamInLegacyMode(StringBuilder serverUrl, String tenantDomain) {
 
-        if (StringUtils.isBlank(tenantDomain)) {
-            tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
-            if (StringUtils.isBlank(tenantDomain)) {
-                tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-            }
-        }
+        tenantDomain = resolveTenantDomain(tenantDomain);
         if (StringUtils.isNotBlank(tenantDomain) &&
                 !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
             if (serverUrl.toString().endsWith("/")) {
@@ -215,6 +205,17 @@ public class DefaultURLResolverService implements URLResolverService {
         }
     }
 
+    private String resolveTenantDomain(String tenantDomain) {
+
+        if (StringUtils.isBlank(tenantDomain)) {
+            tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+            if (StringUtils.isBlank(tenantDomain)) {
+                tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+            }
+        }
+        return tenantDomain;
+    }
+
     private void appendURLContext(StringBuilder serverUrl, String urlContext) {
 
         if (!serverUrl.toString().endsWith("/") && urlContext.trim().charAt(0) != '/') {
@@ -227,9 +228,8 @@ public class DefaultURLResolverService implements URLResolverService {
     }
 
     private void appendContextToUri(String urlContext, String tenantDomain, boolean addProxyContextPath,
-                                    boolean addWebContextRoot,
-                                    StringBuilder serverUrl, boolean addTenantQueryParamInLegacyMode,
-                                    boolean addTenantPathParamInLegacyMode) {
+                                    boolean addWebContextRoot, StringBuilder serverUrl,
+                                    boolean addTenantQueryParamInLegacyMode, boolean addTenantPathParamInLegacyMode) {
 
         if (addProxyContextPath) {
             appendProxyContextPath(serverUrl);

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultURLResolverService.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultURLResolverService.java
@@ -195,13 +195,10 @@ public class DefaultURLResolverService implements URLResolverService {
 
     private void appendTenantQueryParamInLegacyMode(StringBuilder serverUrl, String tenantDomain) {
 
-        if (StringUtils.isBlank(tenantDomain)) {
-            tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
-        }
-        if (StringUtils.isNotBlank(tenantDomain)) {
-            if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
-                serverUrl.append("?").append(MultitenantConstants.TENANT_DOMAIN).append("=").append(tenantDomain);
-            }
+        tenantDomain = resolveTenantDomain(tenantDomain);
+        if (StringUtils.isNotBlank(tenantDomain) &&
+                !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
+            serverUrl.append("?").append(MultitenantConstants.TENANT_DOMAIN).append("=").append(tenantDomain);
         }
     }
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/URLResolverService.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/URLResolverService.java
@@ -29,6 +29,39 @@ public interface URLResolverService {
      * This method is used to return a URL with a proxy context path, a web context root and the tenant domain (If
      * required) when provided with a URL.
      *
+     * @param url                 URL.
+     * @param addProxyContextPath Add proxy context path to the URL.
+     * @param addWebContextRoot   Add web context path to the URL.
+     * @param properties          Properties.
+     * @return Resolved URL for the given URL.
+     * @throws URLResolverException If error occurred while constructing the URL.
+     */
+    String resolveUrl(String url, boolean addProxyContextPath, boolean addWebContextRoot,
+                      Map<String, Object> properties)
+            throws URLResolverException;
+
+    /**
+     * This method is used to return a URL with a proxy context path, a web context root and the tenant domain (If
+     * required) when provided with a URL.
+     *
+     * @param url                             URL.
+     * @param addProxyContextPath             Add proxy context path to the URL.
+     * @param addWebContextRoot               Add web context path to the URL.
+     * @param addTenantQueryParamInLegacyMode Add tenant as a query parameter to the URL during legacy mode operation.
+     * @param addTenantPathParamInLegacyMode  Add tenant as a path parameter to the URL during legacy mode operation.
+     * @param properties                      Properties.
+     * @return Resolved URL for the given URL.
+     * @throws URLResolverException If error occurred while constructing the URL.
+     */
+    String resolveUrl(String url, boolean addProxyContextPath, boolean addWebContextRoot,
+                      boolean addTenantQueryParamInLegacyMode, boolean addTenantPathParamInLegacyMode,
+                      Map<String, Object> properties)
+            throws URLResolverException;
+
+    /**
+     * This method is used to return a URL with a proxy context path, a web context root and the tenant domain (If
+     * required) when provided with a URL.
+     *
      * @param url                             URL.
      * @param tenantDomain                    Tenant domain.
      * @param addProxyContextPath             Add proxy context path to the URL.
@@ -42,6 +75,39 @@ public interface URLResolverService {
     String resolveUrl(String url, String tenantDomain, boolean addProxyContextPath, boolean addWebContextRoot,
                       boolean addTenantQueryParamInLegacyMode, boolean addTenantPathParamInLegacyMode,
                       Map<String, Object> properties)
+            throws URLResolverException;
+
+    /**
+     * This method is used to return a URL with a proxy context path, a web context root and the tenant domain (If
+     * required) when provided with a URL context.
+     *
+     * @param urlContext                      URL context.
+     * @param addProxyContextPath             Add proxy context path to the URL.
+     * @param addWebContextRoot               Add web context path to the URL.
+     * @param properties                      Properties.
+     * @return Complete URL for the given URL context.
+     * @throws URLResolverException If error occurred while constructing the URL.
+     */
+    String resolveUrlContext(String urlContext, boolean addProxyContextPath,
+                             boolean addWebContextRoot, Map<String, Object> properties)
+            throws URLResolverException;
+
+    /**
+     * This method is used to return a URL with a proxy context path, a web context root and the tenant domain (If
+     * required) when provided with a URL context.
+     *
+     * @param urlContext                      URL context.
+     * @param addProxyContextPath             Add proxy context path to the URL.
+     * @param addWebContextRoot               Add web context path to the URL.
+     * @param addTenantQueryParamInLegacyMode Add tenant as a query parameter to the URL during legacy mode operation.
+     * @param addTenantPathParamInLegacyMode  Add tenant as a path parameter to the URL during legacy mode operation.
+     * @param properties                      Properties.
+     * @return Complete URL for the given URL context.
+     * @throws URLResolverException If error occurred while constructing the URL.
+     */
+    String resolveUrlContext(String urlContext, boolean addProxyContextPath,
+                             boolean addWebContextRoot, boolean addTenantQueryParamInLegacyMode,
+                             boolean addTenantPathParamInLegacyMode, Map<String, Object> properties)
             throws URLResolverException;
 
     /**

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/URLResolverService.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/URLResolverService.java
@@ -29,16 +29,17 @@ public interface URLResolverService {
      * This method is used to return a URL with a proxy context path, a web context root and the tenant domain (If
      * required) when provided with a URL.
      *
-     * @param url                 URL.
-     * @param addProxyContextPath Add proxy context path to the URL.
-     * @param addWebContextRoot   Add web context path to the URL.
+     * @param url                             URL.
+     * @param tenantDomain                    Tenant domain.
+     * @param addProxyContextPath             Add proxy context path to the URL.
+     * @param addWebContextRoot               Add web context path to the URL.
      * @param addTenantQueryParamInLegacyMode Add tenant as a query parameter to the URL during legacy mode operation.
-     * @param addTenantPathParamInLegacyMode Add tenant as a path parameter to the URL during legacy mode operation.
-     * @param properties          Properties.
+     * @param addTenantPathParamInLegacyMode  Add tenant as a path parameter to the URL during legacy mode operation.
+     * @param properties                      Properties.
      * @return Resolved URL for the given URL.
      * @throws URLResolverException If error occurred while constructing the URL.
      */
-    String resolveUrl(String url, boolean addProxyContextPath, boolean addWebContextRoot,
+    String resolveUrl(String url, String tenantDomain, boolean addProxyContextPath, boolean addWebContextRoot,
                       boolean addTenantQueryParamInLegacyMode, boolean addTenantPathParamInLegacyMode,
                       Map<String, Object> properties)
             throws URLResolverException;
@@ -48,16 +49,17 @@ public interface URLResolverService {
      * required) when provided with a URL context.
      *
      * @param urlContext                      URL context.
+     * @param tenantDomain                    Tenant domain.
      * @param addProxyContextPath             Add proxy context path to the URL.
      * @param addWebContextRoot               Add web context path to the URL.
      * @param addTenantQueryParamInLegacyMode Add tenant as a query parameter to the URL during legacy mode operation.
-     * @param addTenantPathParamInLegacyMode Add tenant as a path parameter to the URL during legacy mode operation.
+     * @param addTenantPathParamInLegacyMode  Add tenant as a path parameter to the URL during legacy mode operation.
      * @param properties                      Properties.
      * @return Complete URL for the given URL context.
      * @throws URLResolverException If error occurred while constructing the URL.
      */
-    String resolveUrlContext(String urlContext, boolean addProxyContextPath, boolean addWebContextRoot,
-                             boolean addTenantQueryParamInLegacyMode, boolean addTenantPathParamInLegacyMode,
-                             Map<String, Object> properties)
+    String resolveUrlContext(String urlContext, String tenantDomain, boolean addProxyContextPath,
+                             boolean addWebContextRoot, boolean addTenantQueryParamInLegacyMode,
+                             boolean addTenantPathParamInLegacyMode, Map<String, Object> properties)
             throws URLResolverException;
 }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -404,7 +404,32 @@ public class IdentityUtil {
 
         URLResolverService urlResolverService = IdentityCoreServiceComponent.getURLResolverService();
         try {
-            return urlResolverService.resolveUrl(url, addProxyContextPath, addWebContextRoot,
+            return urlResolverService.resolveUrl(url, null, addProxyContextPath, addWebContextRoot,
+                    addTenantQueryParamInLegacyMode, addTenantPathParamInLegacyMode, null);
+        } catch (URLResolverException e) {
+            throw IdentityRuntimeException.error("Error while resolving URL: " + url, e);
+        }
+    }
+
+    /**
+     * This method is used to return a URL with a proxy context path, a web context root and the tenant domain (If
+     * required) when provided with a URL.
+     *
+     * @param url                             URL.
+     * @param tenantDomain                    Tenant Domain.
+     * @param addProxyContextPath             Add proxy context path to the URL.
+     * @param addWebContextRoot               Add web context path to the URL.
+     * @param addTenantQueryParamInLegacyMode Add tenant domain as a query parameter in legacy mode.
+     * @param addTenantPathParamInLegacyMode  Add tenant domain as a path parameter in legacy mode.
+     * @return Resolved URL for the given URL.
+     */
+    public static String resolveURL(String url, String tenantDomain, boolean addProxyContextPath,
+                                    boolean addWebContextRoot, boolean addTenantQueryParamInLegacyMode,
+                                    boolean addTenantPathParamInLegacyMode) {
+
+        URLResolverService urlResolverService = IdentityCoreServiceComponent.getURLResolverService();
+        try {
+            return urlResolverService.resolveUrl(url, tenantDomain, addProxyContextPath, addWebContextRoot,
                     addTenantQueryParamInLegacyMode, addTenantPathParamInLegacyMode, null);
         } catch (URLResolverException e) {
             throw IdentityRuntimeException.error("Error while resolving URL: " + url, e);
@@ -428,8 +453,35 @@ public class IdentityUtil {
 
         URLResolverService urlResolverService = IdentityCoreServiceComponent.getURLResolverService();
         try {
-            return urlResolverService.resolveUrlContext(urlContext, addProxyContextPath, addWebContextRoot,
+            return urlResolverService.resolveUrlContext(urlContext, null, addProxyContextPath, addWebContextRoot,
                     addTenantQueryParamInLegacyMode, addTenantPathParamInLegacyMode, null);
+        } catch (URLResolverException e) {
+            throw IdentityRuntimeException.error("Error while resolving URL: " + urlContext, e);
+        }
+    }
+
+    /**
+     * This util method is used to construct a complete URL out of the given URL context.
+     *
+     * @param urlContext                      URL context.
+     * @param tenantDomain                    Tenant Domain.
+     * @param addProxyContextPath             Add proxy context path to the URL.
+     * @param addWebContextRoot               Add web context path to the URL.
+     * @param addTenantQueryParamInLegacyMode Add tenant domain as a query parameter in legacy mode.
+     * @param addTenantPathParamInLegacyMode  Add tenant domain as a path parameter in legacy mode.
+     * @return Complete URL for the given URL context.
+     * @throws IdentityRuntimeException If error occurred while constructing the URL.
+     */
+    public static String getServerURL(String urlContext, String tenantDomain, boolean addProxyContextPath,
+                                      boolean addWebContextRoot, boolean addTenantQueryParamInLegacyMode,
+                                      boolean addTenantPathParamInLegacyMode)
+            throws IdentityRuntimeException {
+
+        URLResolverService urlResolverService = IdentityCoreServiceComponent.getURLResolverService();
+        try {
+            return urlResolverService
+                    .resolveUrlContext(urlContext, tenantDomain, addProxyContextPath, addWebContextRoot,
+                            addTenantQueryParamInLegacyMode, addTenantPathParamInLegacyMode, null);
         } catch (URLResolverException e) {
             throw IdentityRuntimeException.error("Error while resolving URL: " + urlContext, e);
         }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/util/IdentityUtilTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/util/IdentityUtilTest.java
@@ -510,6 +510,33 @@ public class IdentityUtilTest {
                         addWebContextRoot, addTenantQueryParamInLegacyMode, addTenantPathParamInLegacyMode));
     }
 
+    @Test(dataProvider = "getServerURLData")
+    public void testGetServerURLWithTenantParam(String host, String tenantDomain, boolean enableTenantURLSupport,
+                                         int port,
+                                 String proxyCtx, String ctxRoot, String endpoint, boolean addProxyContextPath,
+                                 boolean addWebContextRoot, boolean addTenantQueryParamInLegacyMode,
+                                 boolean addTenantPathParamInLegacyMode, String expected) throws Exception {
+
+        when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()).thenReturn("carbon.super");
+        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(enableTenantURLSupport);
+        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(null);
+        when(CarbonUtils.getTransportPort(any(AxisConfiguration.class), anyString())).thenReturn(9443);
+        when(CarbonUtils.getTransportProxyPort(any(AxisConfiguration.class), anyString())).thenReturn(port);
+        when(CarbonUtils.getManagementTransport()).thenReturn("https");
+        when(mockServerConfiguration.getFirstProperty(IdentityCoreConstants.HOST_NAME)).thenReturn(host);
+        when(mockServerConfiguration.getFirstProperty(IdentityCoreConstants.WEB_CONTEXT_ROOT)).thenReturn(ctxRoot);
+        when(mockServerConfiguration.getFirstProperty(IdentityCoreConstants.PROXY_CONTEXT_PATH)).thenReturn(proxyCtx);
+
+        assertEquals(IdentityUtil.getServerURL(endpoint, tenantDomain, addProxyContextPath, addWebContextRoot,
+                addTenantQueryParamInLegacyMode, addTenantPathParamInLegacyMode), expected, String
+                .format("Generated server url doesn't match the expected for input: host = %s, tenantDomain = %s" +
+                                "enableTenantURLSupport = %b, port = %d, proxyCtx = %s, ctxRoot = %s, endpoint = %s, " +
+                                "addProxyContextPath = %b, addWebContextRoot = %b, addTenantQueryParamInLegacyMode = " +
+                                "%b, addTenantQueryParamInLegacyMode = %b", host, tenantDomain,
+                        enableTenantURLSupport, port, proxyCtx, ctxRoot, endpoint, addProxyContextPath,
+                        addWebContextRoot, addTenantQueryParamInLegacyMode, addTenantPathParamInLegacyMode));
+    }
+
     @DataProvider
     public Object[][] resolveURLData() {
 
@@ -539,6 +566,18 @@ public class IdentityUtilTest {
         when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantFromContext);
 
         assertEquals(IdentityUtil.resolveURL(url, false, false, addTenantQueryParamInLegacyMode,
+                addTenantPathParamInLegacyMode), expected);
+    }
+
+    @Test(dataProvider = "resolveURLData")
+    public void testResolveURLwithTenantParam(String url, String tenantDomain, Boolean enableTenantURLSupport,
+                               boolean addTenantQueryParamInLegacyMode, boolean addTenantPathParamInLegacyMode,
+                               String expected) {
+        when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()).thenReturn("carbon.super");
+        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(enableTenantURLSupport);
+        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(null);
+
+        assertEquals(IdentityUtil.resolveURL(url, tenantDomain, false, false, addTenantQueryParamInLegacyMode,
                 addTenantPathParamInLegacyMode), expected);
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

Overload the current method implementations to accommodate tenant domain as a parameter in URLResolverService. 

Improvement for: https://github.com/wso2/carbon-identity-framework/pull/2828
Related to: https://github.com/wso2/product-is/issues/7902