### PR TITLE
Add support to update template name

### DIFF
--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/constant/SQLConstants.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/constant/SQLConstants.java
@@ -87,7 +87,7 @@ public class SQLConstants {
             "LAST_MODIFIED = VALUES(LAST_MODIFIED), HAS_FILE = VALUES(HAS_FILE), HAS_ATTRIBUTE = VALUES" +
             "(HAS_ATTRIBUTE), TYPE_ID = VALUES(TYPE_ID)";
     public static final String UPDATE_RESOURCE =
-            "UPDATE IDN_CONFIG_RESOURCE SET LAST_MODIFIED = ?, HAS_FILE = ?, HAS_ATTRIBUTE = ? WHERE ID = ?";
+            "UPDATE IDN_CONFIG_RESOURCE SET NAME = ?, LAST_MODIFIED = ?, HAS_FILE = ?, HAS_ATTRIBUTE = ? WHERE ID = ?";
     public static final String UPDATE_RESOURCE_H2 =
             "UPDATE IDN_CONFIG_RESOURCE SET TENANT_ID = ?, NAME = ?, LAST_MODIFIED = ?, HAS_FILE = ?, " +
                     "HAS_ATTRIBUTE = ?, TYPE_ID = ? WHERE ID = ?";

--- a/components/template-mgt/org.wso2.carbon.identity.template.mgt/src/main/java/org/wso2/carbon/identity/template/mgt/TemplateManagerImpl.java
+++ b/components/template-mgt/org.wso2.carbon.identity.template.mgt/src/main/java/org/wso2/carbon/identity/template/mgt/TemplateManagerImpl.java
@@ -391,6 +391,10 @@ public class TemplateManagerImpl implements TemplateManager {
                     e.getErrorCode())) {
                 throw handleClientException(TemplateMgtConstants.ErrorMessages.ERROR_CODE_TEMPLATE_NOT_FOUND, e,
                         templateId, getTenantDomainFromCarbonContext());
+            } else if (ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_ALREADY_EXISTS.getCode().equals(
+                    e.getErrorCode())) {
+                throw handleClientException(TemplateMgtConstants.ErrorMessages.ERROR_CODE_TEMPLATE_ALREADY_EXIST, e,
+                        templateId, getTenantDomainFromCarbonContext());
             }
             throw handleServerException(TemplateMgtConstants.ErrorMessages.ERROR_CODE_UPDATE_TEMPLATE, e,
                     templateId, getTenantDomainFromCarbonContext());


### PR DESCRIPTION
This PR will enable updating the name of the template. If that name already exists in the database, an exception is thrown