### PR TITLE
Remove redundant usage of 'callbackURL' query param

### DIFF
--- a/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/resources/web/entitlement/policy-view.jsp
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/resources/web/entitlement/policy-view.jsp
@@ -82,9 +82,7 @@
         <input type="hidden" name="visited" id="visited">
         <textarea id="txtPolicy" rows="50" cols="50"><%=Encode.forHtmlContent(policy)%>
         </textarea>
-
-        <input type="hidden" name="callbackURL"
-               value="../entitlement/update-policy-submit.jsp?policyid=<%=Encode.forUriComponent(policyId)%>"/>
+        <input type="hidden" name="policyid" value="<%=Encode.forUriComponent(policyId)%>"/>
         <input type="hidden" name="<csrf:tokenname/>" value="<csrf:tokenvalue/>"/>
     </form>
 </div>

--- a/components/policy-editor/org.wso2.carbon.policyeditor.ui/src/main/resources/web/policyeditor/index.jsp
+++ b/components/policy-editor/org.wso2.carbon.policyeditor.ui/src/main/resources/web/policyeditor/index.jsp
@@ -136,8 +136,7 @@
 
     <!-- This div will contain the hidden form, which will do the POST back when saving a Policy -->
     <div id="post-back-content" style="display: none;">
-        <form name="postbackForm" id="post-back-form" action="" method="post">
-
+        <form name="postbackForm" id="post-back-form" action="../entitlement/update-policy-submit.jsp" method="post">
         </form>
     </div>
 </div>
@@ -146,14 +145,14 @@
     String policyURL = request.getParameter("url");
 
     String policyText = "";
-    String callbackURL = "";
+    String policyId = "";
 
     if (policyURL == null) {
         if (request.getParameter("policy") != null) {
             policyText = request.getParameter("policy").replaceAll("\r\n", "")
                     .replaceAll("\n", "");
             policyText=policyText.replace("'", "\"");
-            callbackURL = request.getParameter("callbackURL");
+            policyId = request.getParameter("policyid");
         }
     }
 %>
@@ -173,7 +172,7 @@
 
     // If the policy is posted to the editor with additional meta-data
     var policyText = '<%=Encode.forJavaScriptBlock(policyText)%>';
-    var callbackURL = '<%=Encode.forJavaScriptBlock(callbackURL)%>';
+    var policyId = '<%=Encode.forJavaScriptBlock(policyId)%>';
 
     // Create design and source view tabs
     var tabView = new YAHOO.widget.TabView('editor-canvas');

--- a/components/policy-editor/org.wso2.carbon.policyeditor.ui/src/main/resources/web/policyeditor/js/policy-editor.js
+++ b/components/policy-editor/org.wso2.carbon.policyeditor.ui/src/main/resources/web/policyeditor/js/policy-editor.js
@@ -429,7 +429,7 @@ function savePolicyXML() {
             var callURL = serviceBaseURL + "PolicyEditorService";
 
             new wso2.wsf.WSRequest(callURL, "savePolicyXML", body_xml, savePolicyXMLCallback);
-        } else if (callbackURL != "") {
+        } else {
             postbackUpdatedPolicy();
         }
     }
@@ -445,31 +445,11 @@ function savePolicyXMLCallback() {
  */
 function postbackUpdatedPolicy() {
     var formEl = document.getElementById("post-back-form");
-    
-    // Break down the call back URL into operation and parameters
-    var parts = callbackURL.split("?");
-    var endpoint = parts[0];
-    formEl.setAttribute("action", endpoint);
-
     var formContentHTML = formEl.innerHTML;
 
-    if (parts.length > 1) {
-        var params = parts[1].split("&");
-        if (params.length > 0) {
-            for (var x = 0; x < params.length; x++) {
-                // Break into key and value
-                var pair = params[x].split("=");
-                var key = pair[0];
-                var value = pair[1];
-
-                formContentHTML =
-                formContentHTML + '<input type="hidden" name="' + key + '" value="' + value + '"/>'
-            }
-        }
-    }
-
     formEl.innerHTML =
-    formContentHTML + '<input type="hidden" name="policy" id="policy-content"/>';
+        formContentHTML + '<input type="hidden" name="policy" id="policy-content"/>'
+        + '<input type="hidden" name="policyid" value="' + policyId + '"/>';
 
     YAHOO.util.Event.onDOMReady(function() {
         document.getElementById("policy-content").value = currentPolicyDoc.toString();
@@ -483,45 +463,12 @@ function postbackUpdatedPolicy() {
  *  
  */
 function goBack() {
-    var parts = callbackURL.split("?");
-    var backURL = parts[0] + "?";
-    var backUrlParams = "";
-
-    if (parts.length > 1) {
-        var params = parts[1].split("&");
-        if (params.length > 0) {
-            for (var x = 0; x < params.length; x++) {
-                // Break into key and value
-                var pair = params[x].split("=");
-                var key = pair[0];
-                var value = pair[1];
-
-                if ((key == "serviceName") && (value != "null")) {
-                    backUrlParams = key + "=" + value;
-                    break;
-                } else if ((key == "moduleName") && (value != "null")) {
-                    backURL = "../modulemgt/module_info.jsp?"
-                    if (backUrlParams != "") {
-                        backUrlParams = backUrlParams + "&" + key + "=" + value;
-                    } else {
-                        backUrlParams = key + "=" + value;
-                    }
-                } else if ((key == "moduleVersion") && (value != "null")) {
-                    backURL = "../modulemgt/module_info.jsp?"
-                    if (backUrlParams != "") {
-                        backUrlParams = backUrlParams + "&" + key + "=" + value;
-                    } else {
-                        backUrlParams = key + "=" + value;
-                    }
-                }
-            }
-        }
-    }
+    var redirectURL = document.getElementById("post-back-form").getAttribute("action");
 
     cleanBreadCrumb();
     
     // Redirecting to the url
-    location.href = backURL + backUrlParams;
+    location.href = redirectURL;
 }
 
 /**


### PR DESCRIPTION
### Description
Goal of this is PR to remove redundant usage of the 'callbackURL' query parameter in the XACML Policy Editor.