### PR TITLE
Add Config to get allowed userstore types

### DIFF
--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/pom.xml
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/pom.xml
@@ -122,7 +122,8 @@
                             org.wso2.carbon.utils; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.base; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.package.import.version.range}",
-                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}"
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.apache.axiom.om
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.user.store.configuration.internal,

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/pom.xml
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/pom.xml
@@ -123,7 +123,7 @@
                             org.wso2.carbon.identity.base; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.package.import.version.range}",
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
-                            org.apache.axiom.om
+                            org.apache.axiom.om; version="${axiom.osgi.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.user.store.configuration.internal,

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/UserStoreConfigServiceImpl.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/UserStoreConfigServiceImpl.java
@@ -249,7 +249,18 @@ public class UserStoreConfigServiceImpl implements UserStoreConfigService {
     @Override
     public Set<String> getAvailableUserStoreClasses() throws IdentityUserStoreMgtException {
 
-        return UserStoreManagerRegistry.getUserStoreManagerClasses();
+        return getAllowedUserstoreClasses(UserStoreManagerRegistry.getUserStoreManagerClasses());
+    }
+
+    private Set<String> getAllowedUserstoreClasses(Set<String> userstores) {
+
+        Set<String> allowedUserstores = UserStoreConfigListenersHolder.getInstance().getAllowedUserstores();
+        // Preserving the old behavior, if the 'AllowedUserstores' config is not set.
+        if (allowedUserstores == null) {
+            return userstores;
+        }
+        userstores.retainAll(allowedUserstores);
+        return userstores;
     }
 
     @Override

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/internal/UserStoreConfigComponent.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/internal/UserStoreConfigComponent.java
@@ -17,6 +17,8 @@
 */
 package org.wso2.carbon.identity.user.store.configuration.internal;
 
+import org.apache.axiom.om.OMElement;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.framework.BundleContext;
@@ -29,6 +31,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.user.store.configuration.UserStoreConfigService;
 import org.wso2.carbon.identity.user.store.configuration.UserStoreConfigServiceImpl;
@@ -36,8 +39,13 @@ import org.wso2.carbon.identity.user.store.configuration.dao.AbstractUserStoreDA
 import org.wso2.carbon.identity.user.store.configuration.dao.impl.DatabaseBasedUserStoreDAOFactory;
 import org.wso2.carbon.identity.user.store.configuration.dao.impl.FileBasedUserStoreDAOFactory;
 import org.wso2.carbon.identity.user.store.configuration.listener.UserStoreConfigListener;
+import org.wso2.carbon.identity.user.store.configuration.utils.UserStoreConfigurationConstant;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.service.RealmService;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 
 /**
  * User store configuration service OSGi component.
@@ -126,6 +134,7 @@ public class UserStoreConfigComponent {
             } else {
                 log.error("FileBasedUserStoreDAOFactory could not be registered.");
             }
+            readAllowedUserstoreConfiguration();
 
         } catch (Throwable e) {
             log.error("Failed to load user store org.wso2.carbon.identity.user.store.configuration details.", e);
@@ -218,5 +227,39 @@ public class UserStoreConfigComponent {
     protected void unsetUserStoreConfigListenerService(UserStoreConfigListener userStoreConfigListener) {
 
         UserStoreConfigListenersHolder.getInstance().unsetUserStoreConfigListenerService(userStoreConfigListener);
+    }
+
+    private void readAllowedUserstoreConfiguration() {
+
+        IdentityConfigParser configParser = IdentityConfigParser.getInstance();
+        // Read allowed userstore configurations in identity.xml.
+        OMElement userstoresConfig = configParser.getConfigElement(UserStoreConfigurationConstant.ALLOWED_USERSTORES);
+        if (userstoresConfig == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("'" + UserStoreConfigurationConstant.ALLOWED_USERSTORES + "' config not found.");
+            }
+            return;
+        }
+        Set<String> allowedUserstores = new HashSet<>();
+        Iterator userstoreItr = userstoresConfig.getChildrenWithLocalName(UserStoreConfigurationConstant
+                .ALLOWED_USERSTORE);
+        int allowedUserstoreCount = 0;
+        if (userstoreItr != null) {
+            while (userstoreItr.hasNext()) {
+                OMElement userstoreConfig = (OMElement) userstoreItr.next();
+                String allowedUserstore = userstoreConfig.getText();
+                if (StringUtils.isNotBlank(allowedUserstore)) {
+                    allowedUserstores.add(allowedUserstore);
+                    allowedUserstoreCount++;
+                }
+            }
+        }
+        if (allowedUserstoreCount == 0) {
+            if (log.isDebugEnabled()) {
+                log.debug("No userstores have been configured under the '" + UserStoreConfigurationConstant
+                        .ALLOWED_USERSTORE + "' config.");
+            }
+        }
+        UserStoreConfigListenersHolder.getInstance().setAllowedUserstores(allowedUserstores);
     }
 }

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/internal/UserStoreConfigListenersHolder.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/internal/UserStoreConfigListenersHolder.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Service holder for required OSGi services.
@@ -35,6 +36,7 @@ public class UserStoreConfigListenersHolder {
     private List<UserStoreConfigListener> listeners = new ArrayList<>();
     private Map<String, AbstractUserStoreDAOFactory> userStoreDAOFactory = new HashMap<>();
     private UserStoreConfigService userStoreConfigService;
+    private Set<String> allowedUserstores = null;
 
 
     private UserStoreConfigListenersHolder() {
@@ -67,6 +69,16 @@ public class UserStoreConfigListenersHolder {
 
     public UserStoreConfigService getUserStoreConfigService() {
         return userStoreConfigService;
+    }
+
+    public Set<String> getAllowedUserstores() {
+
+        return allowedUserstores;
+    }
+
+    public void setAllowedUserstores(Set<String> allowedUserstores) {
+
+        this.allowedUserstores = allowedUserstores;
     }
 
 }

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/UserStoreConfigurationConstant.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/UserStoreConfigurationConstant.java
@@ -43,6 +43,8 @@ public class UserStoreConfigurationConstant {
     public static final String PERIOD = ".";
     public static final String DISABLED = "Disabled";
     public static final String FILE_EXTENSION_XML = ".xml";
+    public static final String ALLOWED_USERSTORES = "AllowedUserstores";
+    public static final String ALLOWED_USERSTORE = "AllowedUserstore";
 
     private UserStoreConfigurationConstant() {
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2044,4 +2044,10 @@
         <ShowDisplayName>{{user_filtering.show_display_name_of_user}}</ShowDisplayName>
     </UserFiltering>
 
+    <!-- Allowed Userstores -->
+        <AllowedUserstores>
+            {% for userstore in allowed_userstore %}
+            <AllowedUserstore>{{userstore.class}}</AllowedUserstore>
+            {% endfor %}
+        </AllowedUserstores>
 </Server>


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/8022

Following config needs to be introduced to identity.xml

```
<AllowedUserstores>
  <AllowedUserstore>org.wso2.carbon.user.core.jdbc.UniqueIDJDBCUserStoreManager</AllowedUserstore>
  <AllowedUserstore>org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager</AllowedUserstore>
</AllowedUserstores>
```

Need to configure the templated config from deployment.toml as follows.

```
[[allowed_userstore]]
class = "org.wso2.carbon.user.core.jdbc.UniqueIDJDBCUserStoreManager"
[[allowed_userstore]]  
class = "org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager"
```
