### PR TITLE
Fix newline in config template (.j2) issue in

### DIFF
--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml.j2
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml.j2
@@ -153,8 +153,7 @@
     </AuthenticationEndpointRedirectParams>
 
     {% if authentication.endpoint.enable_custom_claim_mappings is defined %}
-    <AllowCustomClaimMappingsForAuthenticators>{{authentication.endpoint.enable_custom_claim_mappings}}
-    </AllowCustomClaimMappingsForAuthenticators>
+    <AllowCustomClaimMappingsForAuthenticators>{{authentication.endpoint.enable_custom_claim_mappings}}</AllowCustomClaimMappingsForAuthenticators>
     {% endif %}
 
     {% if tenant.domain_drop_down.enable is defined %}


### PR DESCRIPTION
### Proposed changes in this pull request

Due to the  new line in  AllowCustomClaimMappingsForAuthenticators config , it's not applying correctly

- Remove the newline character in between closing tag (`</AllowCustomClaimMappingsForAuthenticators>`) and the opening tag

Related issue: https://github.com/wso2/product-is/issues/8086
### When should this PR be merged

- ASAP

### Follow up actions

- N/A


### Checklist (for reviewing)

#### General

- [x] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [x] **Is the PR labeled correctly?**

#### Functionality

- [x] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [x] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [x] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [x] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [x] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).
