### PR TITLE
Add method to get public Absolute URL.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
@@ -282,7 +282,7 @@ public class ConfigurationFacade {
     private String buildTenantQualifiedUrl(String context) {
 
         try {
-            return ServiceURLBuilder.create().addPath(context).build().getInternalAbsoluteURL();
+            return ServiceURLBuilder.create().addPath(context).build().getAbsolutePublicURL();
         } catch (URLBuilderException e) {
             throw new IdentityRuntimeException("Error while building url for context: " + context);
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
@@ -282,7 +282,7 @@ public class ConfigurationFacade {
     private String buildTenantQualifiedUrl(String context) {
 
         try {
-            return ServiceURLBuilder.create().addPath(context).build().getAbsoluteURL();
+            return ServiceURLBuilder.create().addPath(context).build().getInternalAbsoluteURL();
         } catch (URLBuilderException e) {
             throw new IdentityRuntimeException("Error while building url for context: " + context);
         }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURL.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURL.java
@@ -83,12 +83,22 @@ public interface ServiceURL {
     String getTenantDomain();
 
     /**
+     * Returns the absolute URL used for Identity Server internal calls.
      * Concatenate the protocol, host name, port, proxy context path, web context root, url context, query params and
-     * the fragment to return the absolute URL.
+     * the fragment to return the internal absolute URL.
      *
-     * @return The absolute URL from the Service URL instance.
+     * @return The internal absolute URL from the Service URL instance.
      */
-    String getAbsoluteURL();
+    String getInternalAbsoluteURL();
+
+    /**
+     * Returns the proxy server url when the Identity Server is fronted with a proxy.
+     * Concatenate the protocol, host name, port, proxy context path, web context root, url context, query params and
+     * the fragment to return the public absolute URL.
+     *
+     * @return The public absolute URL from the Service URL instance.
+     */
+    String getPublicAbsoluteURL();
 
     /**
      * Concatenate the url context, query params and the fragment to return the relative URL.

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURL.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURL.java
@@ -89,7 +89,7 @@ public interface ServiceURL {
      *
      * @return The internal absolute URL from the Service URL instance.
      */
-    String getInternalAbsoluteURL();
+    String getAbsoluteInternalURL();
 
     /**
      * Returns the proxy server url when the Identity Server is fronted with a proxy.
@@ -98,7 +98,7 @@ public interface ServiceURL {
      *
      * @return The public absolute URL from the Service URL instance.
      */
-    String getPublicAbsoluteURL();
+    String getAbsolutePublicURL();
 
     /**
      * Concatenate the url context, query params and the fragment to return the relative URL.

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
@@ -171,13 +171,27 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         }
 
         /**
-         * Concatenate the protocol, host name, port, proxy context path, web context root, url context, query params
-         * and the fragment to return the absolute URL.
+         * Returns the absolute URL used for Identity Server internal calls.
+         * Concatenate the protocol, host name, port, proxy context path, web context root, url context, query params and
+         * the fragment to return the internal absolute URL.
          *
-         * @return The absolute URL from the Service URL instance.
+         * @return The internal absolute URL from the Service URL instance.
          */
         @Override
-        public String getAbsoluteURL() {
+        public String getInternalAbsoluteURL() {
+
+            return absoluteUrl;
+        }
+
+        /**
+         * Returns the proxy server url when the Identity Server is fronted with a proxy.
+         * Concatenate the protocol, host name, port, proxy context path, web context root, url context, query params and
+         * the fragment to return the public absolute URL.
+         *
+         * @return The public absolute URL from the Service URL instance.
+         */
+        @Override
+        public String getPublicAbsoluteURL() {
 
             return absoluteUrl;
         }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
@@ -178,7 +178,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
          * @return The internal absolute URL from the Service URL instance.
          */
         @Override
-        public String getInternalAbsoluteURL() {
+        public String getAbsoluteInternalURL() {
 
             return absoluteUrl;
         }
@@ -191,7 +191,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
          * @return The public absolute URL from the Service URL instance.
          */
         @Override
-        public String getPublicAbsoluteURL() {
+        public String getAbsolutePublicURL() {
 
             return absoluteUrl;
         }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
@@ -232,7 +232,7 @@ public class DefaultServiceURLBuilderTest {
                             valuesList[0]).addParameter(keysList[1], valuesList[1]).addParameter(keysList[2],
                             valuesList[2]).addFragmentParameter(keysList[0], valuesList[0])
                             .addFragmentParameter(keysList[1], valuesList[1])
-                            .addFragmentParameter(keysList[2], valuesList[2]).build().getInternalAbsoluteURL();
+                            .addFragmentParameter(keysList[2], valuesList[2]).build().getAbsoluteInternalURL();
         } catch (URLBuilderException e) {
             // Mock behaviour, hence ignored
         }
@@ -313,20 +313,20 @@ public class DefaultServiceURLBuilderTest {
                                 "fragment").addFragmentParameter("key2", "fragment").addFragmentParameter("key3",
                                 "fragment").addFragmentParameter("key4", "fragment").addParameter("key1", "v")
                                 .addParameter("key2", "v").addParameter("key3", "v").addParameter("key4", "v").build()
-                                .getInternalAbsoluteURL();
+                                .getAbsoluteInternalURL();
             } else if (MapUtils.isNotEmpty(fragmentParams)){
                 absoluteUrl =
                         ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment).addFragmentParameter("key1",
                                 "fragment").addFragmentParameter("key2", "fragment").addFragmentParameter("key3",
-                                "fragment").addFragmentParameter("key4", "fragment").build().getInternalAbsoluteURL();
+                                "fragment").addFragmentParameter("key4", "fragment").build().getAbsoluteInternalURL();
             } else if (MapUtils.isNotEmpty(parameters)){
                 absoluteUrl =
                         ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment).addParameter("key1", "v")
                                 .addParameter("key2", "v").addParameter("key3", "v").addParameter("key4", "v").build()
-                                .getInternalAbsoluteURL();
+                                .getAbsoluteInternalURL();
             } else {
                 absoluteUrl =
-                        ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment).build().getInternalAbsoluteURL();
+                        ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment).build().getAbsoluteInternalURL();
             }
 
         } catch (URLBuilderException e) {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
@@ -232,7 +232,7 @@ public class DefaultServiceURLBuilderTest {
                             valuesList[0]).addParameter(keysList[1], valuesList[1]).addParameter(keysList[2],
                             valuesList[2]).addFragmentParameter(keysList[0], valuesList[0])
                             .addFragmentParameter(keysList[1], valuesList[1])
-                            .addFragmentParameter(keysList[2], valuesList[2]).build().getAbsoluteURL();
+                            .addFragmentParameter(keysList[2], valuesList[2]).build().getInternalAbsoluteURL();
         } catch (URLBuilderException e) {
             // Mock behaviour, hence ignored
         }
@@ -313,20 +313,20 @@ public class DefaultServiceURLBuilderTest {
                                 "fragment").addFragmentParameter("key2", "fragment").addFragmentParameter("key3",
                                 "fragment").addFragmentParameter("key4", "fragment").addParameter("key1", "v")
                                 .addParameter("key2", "v").addParameter("key3", "v").addParameter("key4", "v").build()
-                                .getAbsoluteURL();
+                                .getInternalAbsoluteURL();
             } else if (MapUtils.isNotEmpty(fragmentParams)){
                 absoluteUrl =
                         ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment).addFragmentParameter("key1",
                                 "fragment").addFragmentParameter("key2", "fragment").addFragmentParameter("key3",
-                                "fragment").addFragmentParameter("key4", "fragment").build().getAbsoluteURL();
+                                "fragment").addFragmentParameter("key4", "fragment").build().getInternalAbsoluteURL();
             } else if (MapUtils.isNotEmpty(parameters)){
                 absoluteUrl =
                         ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment).addParameter("key1", "v")
                                 .addParameter("key2", "v").addParameter("key3", "v").addParameter("key4", "v").build()
-                                .getAbsoluteURL();
+                                .getInternalAbsoluteURL();
             } else {
                 absoluteUrl =
-                        ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment).build().getAbsoluteURL();
+                        ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment).build().getInternalAbsoluteURL();
             }
 
         } catch (URLBuilderException e) {

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -2519,7 +2519,7 @@ public class IdentityProviderManager implements IdpManager {
 
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
             try {
-                return ServiceURLBuilder.create().addPath(urlContext).build().getInternalAbsoluteURL();
+                return ServiceURLBuilder.create().addPath(urlContext).build().getAbsoluteInternalURL();
             } catch (URLBuilderException e) {
                 throw IdentityProviderManagementException.error(IdentityProviderManagementServerException.class,
                         "Error while building URL: " + urlContext, e);

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -2519,7 +2519,7 @@ public class IdentityProviderManager implements IdpManager {
 
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
             try {
-                return ServiceURLBuilder.create().addPath(urlContext).build().getAbsoluteURL();
+                return ServiceURLBuilder.create().addPath(urlContext).build().getInternalAbsoluteURL();
             } catch (URLBuilderException e) {
                 throw IdentityProviderManagementException.error(IdentityProviderManagementServerException.class,
                         "Error while building URL: " + urlContext, e);


### PR DESCRIPTION
### Proposed changes in this pull request

Rename getAbsoluteURL() to getAbsoluteURLInternal().
Add new method to get the public absolute URL.

improvement for #2851.