### PR TITLE
Add a configuration to enable the publish password grant events to analytics

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -535,6 +535,8 @@
             <EnableDataProviders>false</EnableDataProviders>
         </Introspection-->
 
+        <PublishPasswordGrantLogin>false</PublishPasswordGrantLogin>
+
     </OAuth>
 
     <MultifactorAuthentication>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -688,6 +688,8 @@
         <RedirectToRequestedRedirectUri>false</RedirectToRequestedRedirectUri>
         {% endif %}
 
+        <PublishPasswordGrantLogin>{{analytics.publish_password_grant_logins}}</PublishPasswordGrantLogin>
+
     </OAuth>
 
     <MultifactorAuthentication>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -495,5 +495,7 @@
   "pagination.max_items_per_page": "100",
   "pagination.default_items_per_page": "15",
 
-  "user_filtering.show_display_name_of_user": false
+  "user_filtering.show_display_name_of_user": false,
+
+  "analytics.publish_password_grant_logins": false
 }


### PR DESCRIPTION
### Proposed changes in this pull request

* Fix : https://github.com/wso2/product-is/issues/5065
* Added a configuration which can enable the publishing of password grant events to analytics.
* Templated the configuration with default value as `false`.