### PR TITLE
Fix OIDC issuer ID in resident IdP

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-local.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-local.jsp
@@ -26,6 +26,7 @@
 <%@ page import="org.wso2.carbon.identity.application.common.model.idp.xsd.Property" %>
 <%@ page import="org.wso2.carbon.identity.application.common.model.idp.xsd.ProvisioningConnectorConfig" %>
 <%@ page import="org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityTenantUtil" %>
 <%@ page import="org.wso2.carbon.identity.governance.stub.bean.ConnectorConfig" %>
 <%@ page import="org.wso2.carbon.idp.mgt.ui.client.IdentityGovernanceAdminClient" %>
 <%@ page import="org.wso2.carbon.idp.mgt.ui.util.IdPManagementUIUtil" %>
@@ -654,14 +655,24 @@ function removeDefaultAuthSeq() {
                     <table class="carbonFormTable">
                         <tr>
                             <td class="leftCol-med labelField"><fmt:message key='idp.entity.id'/>:</td>
-                            <td>
-                                <input id="oidcIdPEntityId" name="oidcIdPEntityId" type="text"
-                                       value="<%=Encode.forHtmlAttribute(oidcIdpEntityId)%>"/>
+                            <%
+                                if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+                            %>
+                                    <td><%=Encode.forHtmlContent(tokenUrl)%></td>
+                            <%
+                                } else {
+                            %>
+                                    <td>
+                                        <input id="oidcIdPEntityId" name="oidcIdPEntityId" type="text"
+                                               value="<%=Encode.forHtmlAttribute(oidcIdpEntityId)%>"/>
 
-                                <div class="sectionHelp">
-                                    <fmt:message key='idp.entity.id.help'/>
-                                </div>
-                            </td>
+                                        <div class="sectionHelp">
+                                            <fmt:message key='idp.entity.id.help'/>
+                                        </div>
+                                    </td>
+                            <%
+                                }
+                            %>
                         </tr>
                         <tr>
                             <td class="leftCol-med labelField"><fmt:message key='authz.endpoint'/>:</td>

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -206,6 +206,7 @@ public class IdentityProviderManager implements IdpManager {
         if (StringUtils.isBlank(oauth2TokenEPUrl)) {
             oauth2TokenEPUrl = IdentityUtil.getServerURL(IdentityConstants.OAuth.TOKEN, true, false);
         }
+        oauth2TokenEPUrl = resolveAbsoluteURL(IdentityConstants.OAuth.TOKEN, oauth2TokenEPUrl);
 
         if (StringUtils.isBlank(oauth2RevokeEPUrl)) {
             oauth2RevokeEPUrl = IdentityUtil.getServerURL(IdentityConstants.OAuth.REVOKE, true, false);

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -203,9 +203,6 @@ public class IdentityProviderManager implements IdpManager {
             oauth2AuthzEPUrl = IdentityUtil.getServerURL(IdentityConstants.OAuth.AUTHORIZE, true, false);
         }
 
-        if (StringUtils.isBlank(oauth2TokenEPUrl)) {
-            oauth2TokenEPUrl = IdentityUtil.getServerURL(IdentityConstants.OAuth.TOKEN, true, false);
-        }
         oauth2TokenEPUrl = resolveAbsoluteURL(IdentityConstants.OAuth.TOKEN, oauth2TokenEPUrl);
 
         if (StringUtils.isBlank(oauth2RevokeEPUrl)) {
@@ -2516,17 +2513,31 @@ public class IdentityProviderManager implements IdpManager {
         }
     }
 
-    private String resolveAbsoluteURL(String urlContext, String resolvedUrl) throws IdentityProviderManagementServerException {
+    /**
+     * Resolves the public service url given the default context and the url picked from the configuration based on
+     * the 'tenant_context.enable_tenant_qualified_urls' mode set in deployment.toml.
+     *
+     * @param defaultUrlContext default url context path
+     * @param urlFromConfig     url picked from the file configuration
+     * @return absolute public url of the service if 'enable_tenant_qualified_urls' is 'true', else returns the url
+     * from the file config
+     * @throws IdentityProviderManagementServerException when fail to build the absolute public url
+     */
+    private String resolveAbsoluteURL(String defaultUrlContext, String urlFromConfig) throws IdentityProviderManagementServerException {
 
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-            try {
-                return ServiceURLBuilder.create().addPath(urlContext).build().getAbsoluteInternalURL();
-            } catch (URLBuilderException e) {
-                throw IdentityProviderManagementException.error(IdentityProviderManagementServerException.class,
-                        "Error while building URL: " + urlContext, e);
+        if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && StringUtils.isNotBlank(urlFromConfig)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Resolved URL:" + urlFromConfig + " from file configuration for default url context: " +
+                        defaultUrlContext);
             }
-        } else {
-            return resolvedUrl;
+            return urlFromConfig;
+        }
+
+        try {
+            return ServiceURLBuilder.create().addPath(defaultUrlContext).build().getAbsolutePublicURL();
+        } catch (URLBuilderException e) {
+            throw IdentityProviderManagementException.error(IdentityProviderManagementServerException.class,
+                    "Error while building URL: " + defaultUrlContext, e);
         }
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

In tenant-qualified URLs mode, the OIDC Identity Provider Entity ID would be set to the token EP and would not be configurable.

-

### When should this PR be merged

ASAP
