### PR TITLE
Set tenant domain from thread local context if available

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -51,6 +51,7 @@ import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
 import org.wso2.carbon.user.api.Tenant;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -68,6 +69,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -562,7 +564,12 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
 
     private String getTenantDomain(HttpServletRequest request) throws FrameworkException {
 
-        String tenantDomain = request.getParameter(FrameworkConstants.RequestParams.TENANT_DOMAIN);
+        // We give precedence to the tenant domain set in the thread local.
+        String tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+        if (IdentityUtil.isBlank(tenantDomain)) {
+            // Fall back to the tenant domain in the request param.
+            tenantDomain = request.getParameter(FrameworkConstants.RequestParams.TENANT_DOMAIN);
+        }
 
         if (tenantDomain == null || tenantDomain.isEmpty() || "null".equals(tenantDomain)) {
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -566,9 +566,16 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
 
         // We give precedence to the tenant domain set in the thread local.
         String tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
-        if (IdentityUtil.isBlank(tenantDomain)) {
+        if (StringUtils.isNotBlank(tenantDomain)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Tenant domain resolved from the thread local context: " + tenantDomain);
+            }
+        } else {
             // Fall back to the tenant domain in the request param.
             tenantDomain = request.getParameter(FrameworkConstants.RequestParams.TENANT_DOMAIN);
+            if (log.isDebugEnabled()) {
+                log.debug("Tenant domain resolved from request parameter: " + tenantDomain);
+            }
         }
 
         if (tenantDomain == null || tenantDomain.isEmpty() || "null".equals(tenantDomain)) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
@@ -1,0 +1,76 @@
+package org.wso2.carbon.identity.application.authentication.framework.handler.request.impl;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.testutil.IdentityBaseTest;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.LOGOUT;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.TENANT_DOMAIN;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.TYPE;
+import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.TENANT_NAME_FROM_CONTEXT;
+import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+
+/**
+ * Unit tests for {@link DefaultRequestCoordinator}.
+ */
+@WithCarbonHome
+public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
+
+    private DefaultRequestCoordinator requestCoordinator;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        requestCoordinator = new DefaultRequestCoordinator();
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+
+    }
+
+    @DataProvider(name = "tenantDomainProvider")
+    public Object[][] provideTenantDomain() {
+
+        return new Object[][]{
+                {null, null, SUPER_TENANT_DOMAIN_NAME},
+                {"foo.com", "xyz.com", "foo.com"},
+                {null, "xyz.com", "xyz.com"},
+        };
+    }
+
+    @Test(dataProvider = "tenantDomainProvider")
+    public void testTenantDomainInAuthenticationContext(String tenantDomainInThreadLocal,
+                                                        String tenantDomainInRequestParam,
+                                                        String expected) throws Exception {
+
+        setTenantDomainInThreadLocalContext(tenantDomainInThreadLocal);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter(TYPE)).thenReturn("oauth");
+        when(request.getParameter(LOGOUT)).thenReturn("true");
+        when(request.getParameter(TENANT_DOMAIN)).thenReturn(tenantDomainInRequestParam);
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        AuthenticationContext context = requestCoordinator.initializeFlow(request, response);
+
+        assertEquals(context.getTenantDomain(), expected);
+    }
+
+    private void setTenantDomainInThreadLocalContext(String tenantDomainInThreadLocalContext) {
+
+        IdentityUtil.threadLocalProperties.get().put(TENANT_NAME_FROM_CONTEXT, tenantDomainInThreadLocalContext);
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.application.authentication.framework.handler.request.impl;
 
 import org.testng.annotations.AfterMethod;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/testng.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/testng.xml
@@ -26,6 +26,8 @@
             <class name="org.wso2.carbon.identity.application.authentication.framework.handler.hrd.impl.DefaultHomeRealmDiscovererTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultAuthenticationRequestHandlerTest"/>
             <class
+                    name="org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultRequestCoordinatorTest"/>
+            <class
                     name="org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.JITProvisioningPostAuthenticationHandlerTest"/>
            <class
                    name="org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.PostAuthAssociationHandlerTest"/>


### PR DESCRIPTION
### Proposed changes in this pull request
Relates to https://github.com/wso2/product-is/issues/8197

- In the tenant qualified URL mode, the tenant domain will be sent as a path param. The tenant domain value will be set in a thread-local. 

We need to pick the tenant domain from this thread-local if available. We will fallback to other tenant domain resolving methods if the thread-local value is not available.