### PR TITLE
Fix SAML metadata URLs in tenant qualified URL mode

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -79,6 +79,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -115,10 +116,6 @@ public class IdentityProviderManager implements IdpManager {
         IdPManagementUtil.setTenantSpecifiers(tenantDomain);
 
         String openIdUrl;
-        String samlSSOUrl;
-        String samlLogoutUrl;
-        String samlECPUrl;
-        String samlArtifactUrl;
         String oauth1RequestTokenUrl;
         String oauth1AuthorizeUrl;
         String oauth1AccessTokenUrl;
@@ -141,9 +138,6 @@ public class IdentityProviderManager implements IdpManager {
         String scim2GroupsEndpoint;
 
         openIdUrl = IdentityUtil.getProperty(IdentityConstants.ServerConfig.OPENID_SERVER_URL);
-        samlSSOUrl = IdentityUtil.getProperty(IdentityConstants.ServerConfig.SSO_IDP_URL);
-        samlECPUrl = IdentityUtil.getProperty(IdentityConstants.ServerConfig.SAML_ECP_URL);
-        samlArtifactUrl = IdentityUtil.getProperty(IdentityConstants.ServerConfig.SSO_ARTIFACT_URL);
         oauth1RequestTokenUrl = IdentityUtil.getProperty(IdentityConstants.OAuth.OAUTH1_REQUEST_TOKEN_URL);
         oauth1AuthorizeUrl = IdentityUtil.getProperty(IdentityConstants.OAuth.OAUTH1_AUTHORIZE_URL);
         oauth1AccessTokenUrl = IdentityUtil.getProperty(IdentityConstants.OAuth.OAUTH1_ACCESSTOKEN_URL);
@@ -168,24 +162,6 @@ public class IdentityProviderManager implements IdpManager {
         if (StringUtils.isBlank(openIdUrl)) {
             openIdUrl = IdentityUtil.getServerURL(IdentityConstants.OpenId.OPENID, true, true);
         }
-
-        if (StringUtils.isBlank(samlSSOUrl)) {
-            samlSSOUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true);
-        }
-        samlSSOUrl += IdPManagementUtil.getTenantParameter();
-        samlSSOUrl = resolveAbsoluteURL(IdPManagementConstants.SAMLSSO, samlSSOUrl);
-
-        samlLogoutUrl = samlSSOUrl;
-
-        if (StringUtils.isBlank(samlArtifactUrl)) {
-            samlArtifactUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true);
-        }
-        samlArtifactUrl = resolveAbsoluteURL(IdPManagementConstants.SSO_ARTIFACT_URL, samlArtifactUrl);
-
-        if (StringUtils.isBlank(samlECPUrl)) {
-            samlECPUrl = IdentityUtil.getServerURL(IdentityConstants.ServerConfig.SAMLSSO, true, true);
-        }
-        samlECPUrl = resolveAbsoluteURL(IdPManagementConstants.SAML_ECP_URL, samlECPUrl);
 
         if (StringUtils.isBlank(oauth1RequestTokenUrl)) {
             oauth1RequestTokenUrl = IdentityUtil.getServerURL(IdentityConstants.OAuth.REQUEST_TOKEN, true, true);
@@ -331,108 +307,8 @@ public class IdentityProviderManager implements IdpManager {
         openIdFedAuthn.setProperties(propertiesList.toArray(new Property[propertiesList.size()]));
         fedAuthnCofigs.add(openIdFedAuthn);
 
-        FederatedAuthenticatorConfig saml2SSOFedAuthn = IdentityApplicationManagementUtil
-                .getFederatedAuthenticator(identityProvider.getFederatedAuthenticatorConfigs(),
-                        IdentityApplicationConstants.Authenticator.SAML2SSO.NAME);
-        if (saml2SSOFedAuthn == null) {
-            saml2SSOFedAuthn = new FederatedAuthenticatorConfig();
-            saml2SSOFedAuthn.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.NAME);
-        }
-
-        propertiesList = new ArrayList<>();
-        Property samlSSOUrlProperty = IdentityApplicationManagementUtil.getProperty(saml2SSOFedAuthn.getProperties(),
-                IdentityApplicationConstants.Authenticator.SAML2SSO.SSO_URL);
-        if (samlSSOUrlProperty == null) {
-            samlSSOUrlProperty = new Property();
-            samlSSOUrlProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.SSO_URL);
-            // Set the generated saml sso endpoint value.
-            samlSSOUrlProperty.setValue(samlSSOUrl);
-        }
-        propertiesList.add(samlSSOUrlProperty);
-
-        Property samlLogoutUrlProperty = IdentityApplicationManagementUtil.getProperty(saml2SSOFedAuthn.getProperties(),
-                IdentityApplicationConstants.Authenticator.SAML2SSO.LOGOUT_REQ_URL);
-        if (samlLogoutUrlProperty == null) {
-            samlLogoutUrlProperty = new Property();
-            samlLogoutUrlProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.LOGOUT_REQ_URL);
-            // Set the generated saml slo endpoint value.
-            samlLogoutUrlProperty.setValue(samlLogoutUrl);
-        }
-        propertiesList.add(samlLogoutUrlProperty);
-
-        Property samlECPUrlProperty = IdentityApplicationManagementUtil.getProperty(saml2SSOFedAuthn.getProperties(),
-                IdentityApplicationConstants.Authenticator.SAML2SSO.ECP_URL);
-        if (samlECPUrlProperty == null) {
-            samlECPUrlProperty = new Property();
-            samlECPUrlProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.ECP_URL);
-        }
-        //set the generated saml ecp endpoint value
-        samlECPUrlProperty.setValue(samlECPUrl);
-        propertiesList.add(samlECPUrlProperty);
-
-        Property idPEntityIdProperty = IdentityApplicationManagementUtil.getProperty(saml2SSOFedAuthn.getProperties(),
-                IdentityApplicationConstants.Authenticator.SAML2SSO.IDP_ENTITY_ID);
-        if (idPEntityIdProperty == null) {
-            idPEntityIdProperty = new Property();
-            idPEntityIdProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IDP_ENTITY_ID);
-            idPEntityIdProperty.setValue(IdPManagementUtil.getResidentIdPEntityId());
-        }
-        propertiesList.add(idPEntityIdProperty);
-
-        Property samlArtifactUrlProperty =
-                IdentityApplicationManagementUtil.getProperty(saml2SSOFedAuthn.getProperties(),
-                        IdentityApplicationConstants.Authenticator.SAML2SSO.ARTIFACT_RESOLVE_URL);
-        if (samlArtifactUrlProperty == null) {
-            samlArtifactUrlProperty = new Property();
-            samlArtifactUrlProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.ARTIFACT_RESOLVE_URL);
-        }
-        samlArtifactUrlProperty.setValue(samlArtifactUrl);
-        propertiesList.add(samlArtifactUrlProperty);
-
-        for (Property property : saml2SSOFedAuthn.getProperties()) {
-            if (property != null &&
-                    !IdentityApplicationConstants.Authenticator.SAML2SSO.SSO_URL.equals(property.getName()) &&
-                    !IdentityApplicationConstants.Authenticator.SAML2SSO.LOGOUT_REQ_URL.equals(property.getName()) &&
-                    !IdentityApplicationConstants.Authenticator.SAML2SSO.ECP_URL.equals(property.getName()) &&
-                    !IdentityApplicationConstants.Authenticator.SAML2SSO.IDP_ENTITY_ID.equals(property.getName())) {
-                propertiesList.add(property);
-            }
-        }
-
-        Property samlMetadataValidityPeriodProperty = IdentityApplicationManagementUtil.getProperty(saml2SSOFedAuthn.
-                getProperties(), IdentityApplicationConstants.Authenticator.SAML2SSO.
-                SAML_METADATA_VALIDITY_PERIOD);
-        if (samlMetadataValidityPeriodProperty == null) {
-            samlMetadataValidityPeriodProperty = new Property();
-            samlMetadataValidityPeriodProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.
-                    SAML_METADATA_VALIDITY_PERIOD);
-            samlMetadataValidityPeriodProperty.setValue(IdentityApplicationConstants.Authenticator.SAML2SSO.
-                    SAML_METADATA_VALIDITY_PERIOD_DEFAULT);
-        }
-        propertiesList.add(samlMetadataValidityPeriodProperty);
-        Property samlMetadataSigningEnabledProperty = IdentityApplicationManagementUtil.getProperty(saml2SSOFedAuthn.
-                getProperties(), IdentityApplicationConstants.Authenticator.SAML2SSO.
-                SAML_METADATA_SIGNING_ENABLED);
-        if (samlMetadataSigningEnabledProperty == null) {
-            samlMetadataSigningEnabledProperty = new Property();
-            samlMetadataSigningEnabledProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.
-                    SAML_METADATA_SIGNING_ENABLED);
-            samlMetadataSigningEnabledProperty.setValue(IdentityApplicationConstants.Authenticator.SAML2SSO.
-                    SAML_METADATA_SIGNING_ENABLED_DEFAULT);
-        }
-        propertiesList.add(samlMetadataSigningEnabledProperty);
-        Property samlAuthnRequestSigningProperty = IdentityApplicationManagementUtil.getProperty(saml2SSOFedAuthn.
-                getProperties(), IdentityApplicationConstants.Authenticator.SAML2SSO.
-                SAML_METADATA_AUTHN_REQUESTS_SIGNING_ENABLED);
-        if (samlAuthnRequestSigningProperty == null) {
-            samlAuthnRequestSigningProperty = new Property();
-            samlAuthnRequestSigningProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.
-                    SAML_METADATA_AUTHN_REQUESTS_SIGNING_ENABLED);
-            samlAuthnRequestSigningProperty.setValue(IdentityApplicationConstants.Authenticator.SAML2SSO.
-                    SAML_METADATA_AUTHN_REQUESTS_SIGNING_DEFAULT);
-        }
-        propertiesList.add(samlAuthnRequestSigningProperty);
-        saml2SSOFedAuthn.setProperties(propertiesList.toArray(new Property[propertiesList.size()]));
+        // SAML2 related endpoints.
+        FederatedAuthenticatorConfig saml2SSOFedAuthn = buildSAMLProperties(identityProvider);
         fedAuthnCofigs.add(saml2SSOFedAuthn);
 
         FederatedAuthenticatorConfig oauth1FedAuthn = IdentityApplicationManagementUtil
@@ -700,6 +576,173 @@ public class IdentityProviderManager implements IdpManager {
         identityProvider.setProvisioningConnectorConfigs(new ProvisioningConnectorConfig[]{scimProvConn});
 
         return identityProvider;
+    }
+
+    private String buildSAMLUrl(String urlFromConfigFile, String defaultContext, boolean appendTenantDomainInLegacyMode)
+            throws IdentityProviderManagementServerException {
+
+        String url = urlFromConfigFile;
+        if (StringUtils.isBlank(url)) {
+            url = IdentityUtil.getServerURL(defaultContext, true, true);
+        }
+
+        if (StringUtils.isNotBlank(url) && appendTenantDomainInLegacyMode) {
+            url += IdPManagementUtil.getTenantParameter();
+        }
+        return resolveAbsoluteURL(defaultContext, url);
+    }
+
+    private FederatedAuthenticatorConfig buildSAMLProperties(IdentityProvider identityProvider)
+            throws IdentityProviderManagementServerException {
+
+        String samlSSOUrl = buildSAMLUrl(IdentityUtil.getProperty(IdentityConstants.ServerConfig.SSO_IDP_URL),
+                IdPManagementConstants.SAMLSSO, true);
+
+        String samlLogoutUrl = buildSAMLUrl(IdentityUtil.getProperty(IdentityConstants.ServerConfig.SSO_IDP_URL),
+                IdPManagementConstants.SAMLSSO, true);
+
+        String samlECPUrl = buildSAMLUrl(IdentityUtil.getProperty(IdentityConstants.ServerConfig.SAML_ECP_URL),
+                IdPManagementConstants.SAML_ECP_URL, true);
+
+        String samlArtifactUrl = buildSAMLUrl(IdentityUtil.getProperty(IdentityConstants.ServerConfig.SSO_ARTIFACT_URL),
+                IdPManagementConstants.SSO_ARTIFACT_URL, false);
+
+        FederatedAuthenticatorConfig samlFederatedAuthConfig = IdentityApplicationManagementUtil
+                .getFederatedAuthenticator(identityProvider.getFederatedAuthenticatorConfigs(),
+                        IdentityApplicationConstants.Authenticator.SAML2SSO.NAME);
+        if (samlFederatedAuthConfig == null) {
+            samlFederatedAuthConfig = new FederatedAuthenticatorConfig();
+            samlFederatedAuthConfig.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.NAME);
+        }
+
+        List<Property> propertiesList = new ArrayList<>();
+
+        Property samlSSOUrlProperty = resolveSAMLProperty(samlSSOUrl, samlFederatedAuthConfig,
+                IdentityApplicationConstants.Authenticator.SAML2SSO.SSO_URL);
+        propertiesList.add(samlSSOUrlProperty);
+
+        Property samlLogoutUrlProperty = resolveSAMLProperty(samlLogoutUrl, samlFederatedAuthConfig,
+                IdentityApplicationConstants.Authenticator.SAML2SSO.LOGOUT_REQ_URL);
+        propertiesList.add(samlLogoutUrlProperty);
+
+        Property samlECPUrlProperty = resolveSAMLProperty(samlECPUrl, samlFederatedAuthConfig,
+                IdentityApplicationConstants.Authenticator.SAML2SSO.ECP_URL);
+        propertiesList.add(samlECPUrlProperty);
+
+        Property samlArtifactUrlProperty = resolveSAMLProperty(samlArtifactUrl, samlFederatedAuthConfig,
+                IdentityApplicationConstants.Authenticator.SAML2SSO.ARTIFACT_RESOLVE_URL);
+        propertiesList.add(samlArtifactUrlProperty);
+
+        Property idPEntityIdProperty =
+                IdentityApplicationManagementUtil.getProperty(samlFederatedAuthConfig.getProperties(),
+                        IdentityApplicationConstants.Authenticator.SAML2SSO.IDP_ENTITY_ID);
+        if (idPEntityIdProperty == null) {
+            idPEntityIdProperty = new Property();
+            idPEntityIdProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.IDP_ENTITY_ID);
+            idPEntityIdProperty.setValue(IdPManagementUtil.getResidentIdPEntityId());
+        }
+        propertiesList.add(idPEntityIdProperty);
+
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            // Add SSO URL as a destination URL if not already available.
+            addSSOUrlAsDestinationUrl(samlFederatedAuthConfig, samlSSOUrl, propertiesList);
+        }
+
+        for (Property property : samlFederatedAuthConfig.getProperties()) {
+            if (property != null &&
+                    !IdentityApplicationConstants.Authenticator.SAML2SSO.SSO_URL.equals(property.getName()) &&
+                    !IdentityApplicationConstants.Authenticator.SAML2SSO.LOGOUT_REQ_URL.equals(property.getName()) &&
+                    !IdentityApplicationConstants.Authenticator.SAML2SSO.ECP_URL.equals(property.getName()) &&
+                    !IdentityApplicationConstants.Authenticator.SAML2SSO.IDP_ENTITY_ID.equals(property.getName())) {
+                propertiesList.add(property);
+            }
+        }
+
+        Property samlMetadataValidityPeriodProperty =
+                IdentityApplicationManagementUtil.getProperty(samlFederatedAuthConfig.
+                        getProperties(), IdentityApplicationConstants.Authenticator.SAML2SSO.
+                        SAML_METADATA_VALIDITY_PERIOD);
+        if (samlMetadataValidityPeriodProperty == null) {
+            samlMetadataValidityPeriodProperty = new Property();
+            samlMetadataValidityPeriodProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.
+                    SAML_METADATA_VALIDITY_PERIOD);
+            samlMetadataValidityPeriodProperty.setValue(IdentityApplicationConstants.Authenticator.SAML2SSO.
+                    SAML_METADATA_VALIDITY_PERIOD_DEFAULT);
+        }
+        propertiesList.add(samlMetadataValidityPeriodProperty);
+        Property samlMetadataSigningEnabledProperty =
+                IdentityApplicationManagementUtil.getProperty(samlFederatedAuthConfig.
+                        getProperties(), IdentityApplicationConstants.Authenticator.SAML2SSO.
+                        SAML_METADATA_SIGNING_ENABLED);
+        if (samlMetadataSigningEnabledProperty == null) {
+            samlMetadataSigningEnabledProperty = new Property();
+            samlMetadataSigningEnabledProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.
+                    SAML_METADATA_SIGNING_ENABLED);
+            samlMetadataSigningEnabledProperty.setValue(IdentityApplicationConstants.Authenticator.SAML2SSO.
+                    SAML_METADATA_SIGNING_ENABLED_DEFAULT);
+        }
+        propertiesList.add(samlMetadataSigningEnabledProperty);
+        Property samlAuthnRequestSigningProperty =
+                IdentityApplicationManagementUtil.getProperty(samlFederatedAuthConfig.
+                        getProperties(), IdentityApplicationConstants.Authenticator.SAML2SSO.
+                        SAML_METADATA_AUTHN_REQUESTS_SIGNING_ENABLED);
+        if (samlAuthnRequestSigningProperty == null) {
+            samlAuthnRequestSigningProperty = new Property();
+            samlAuthnRequestSigningProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.
+                    SAML_METADATA_AUTHN_REQUESTS_SIGNING_ENABLED);
+            samlAuthnRequestSigningProperty.setValue(IdentityApplicationConstants.Authenticator.SAML2SSO.
+                    SAML_METADATA_AUTHN_REQUESTS_SIGNING_DEFAULT);
+        }
+        propertiesList.add(samlAuthnRequestSigningProperty);
+        samlFederatedAuthConfig.setProperties(propertiesList.toArray(new Property[propertiesList.size()]));
+        return samlFederatedAuthConfig;
+    }
+
+    private void addSSOUrlAsDestinationUrl(FederatedAuthenticatorConfig federatedAuthenticatorConfig,
+                                           String ssoUrl,
+                                           List<Property> propertiesList) {
+
+        // First find the available configured destination URLs.
+        List<Property> destinationURLs = Arrays.stream(federatedAuthenticatorConfig.getProperties())
+                .filter(property -> property.getName()
+                        .startsWith(IdentityApplicationConstants.Authenticator.SAML2SSO.DESTINATION_URL_PREFIX))
+                .collect(Collectors.toList());
+
+        // Check whether the SSO URL is already available as a destination URL
+        boolean isSAMLSSOUrlNotPresentAsDestination = destinationURLs.stream()
+                .noneMatch(x -> StringUtils.equals(ssoUrl, x.getValue()));
+
+        if (isSAMLSSOUrlNotPresentAsDestination) {
+            // There are no destination properties matching the default SSO URL.
+            int propertyNameIndex = destinationURLs.size() + 1;
+            Property destinationURLProperty = buildDestinationURLProperty(ssoUrl, propertyNameIndex);
+            propertiesList.add(destinationURLProperty);
+        }
+    }
+
+    private Property buildDestinationURLProperty(String destinationURL, int index) {
+
+        Property destinationURLProperty = new Property();
+        destinationURLProperty.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.DESTINATION_URL_PREFIX +
+                IdentityApplicationConstants.MULTIVALUED_PROPERTY_CHARACTER + index);
+        destinationURLProperty.setValue(destinationURL);
+        return destinationURLProperty;
+    }
+
+    private Property resolveSAMLProperty(String samlEpUrl, FederatedAuthenticatorConfig samlFedAuthConfig,
+                                              String propertyName) {
+
+        Property samlProperty =
+                IdentityApplicationManagementUtil.getProperty(samlFedAuthConfig.getProperties(), propertyName);
+
+        if (samlProperty == null || IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            // In tenant qualified mode we have to always give send the calculated URL and not the value stored in DB.
+            samlProperty = new Property();
+            samlProperty.setName(propertyName);
+            // Set the calculated SAML endpoint URL.
+            samlProperty.setValue(samlEpUrl);
+        }
+        return samlProperty;
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

In the tenant qualified URL mode,

- Fixes SAML endpoint URLs build for SAML metadata being overridden by already saved values in the DB.
- Adds the SAML SSO URL as a destination URL by default in addition to already configured ones.