### PR TITLE
Implement deletion of all consents of a tenant on tenant deletion

### DIFF
--- a/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/listener/TenantConsentMgtListener.java
+++ b/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/listener/TenantConsentMgtListener.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.consent.mgt.listener;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.consent.mgt.core.PrivilegedConsentManager;
 import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementException;
 import org.wso2.carbon.consent.mgt.core.model.PurposeCategory;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
@@ -29,7 +30,7 @@ import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
 import org.wso2.carbon.stratos.common.exception.StratosException;
 
 /**
- * Tenant listener which adds default purpose category for a tenant
+ * Tenant listener which adds default purpose category for a tenant.
  */
 public class TenantConsentMgtListener extends AbstractIdentityTenantMgtListener {
 
@@ -41,6 +42,41 @@ public class TenantConsentMgtListener extends AbstractIdentityTenantMgtListener 
 
         if (isSsoConsentManagementEnabled()) {
             addDefaultPurposeCategory(tenantInfoBean);
+        }
+    }
+
+    /**
+     * Delete all consents belongs to a given tenant before deleting the tenant.
+     *
+     * @param tenantId Id of the tenant
+     * @throws StratosException
+     */
+    @Override
+    public void onPreDelete(int tenantId) throws StratosException {
+
+        if (log.isDebugEnabled()) {
+            log.info("Deleting all consents of the tenant: " + tenantId);
+        }
+        deleteAllConsents(tenantId);
+    }
+
+    /**
+     * Delete all consents belongs to a given tenant id.
+     *
+     * @param tenantId Id of the tenant
+     * @throws StratosException
+     */
+    protected void deleteAllConsents(int tenantId) throws StratosException {
+
+        try {
+            PrivilegedConsentManager privilegedConsentManager =
+                    IdentityConsentDataHolder.getInstance().getPrivilegedConsentManager();
+            privilegedConsentManager.deletePurposeCategories(tenantId);
+            privilegedConsentManager.deletePIICategories(tenantId);
+            privilegedConsentManager.deletePurposes(tenantId);
+            privilegedConsentManager.deleteReceipts(tenantId);
+        } catch (ConsentManagementException e) {
+            throw new StratosException("Error in deleting consents of tenant:" + tenantId, e);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -2014,7 +2014,7 @@
         <ehcache.version>1.5.0.wso2v3</ehcache.version>
         <com.fasterxml.core.version2>2.5.4</com.fasterxml.core.version2>
         <io.swagger.version>1.5.20</io.swagger.version>
-        <carbon.consent.mgt.version>2.2.4</carbon.consent.mgt.version>
+        <carbon.consent.mgt.version>2.2.10</carbon.consent.mgt.version>
 
         <javax.xml.range>[0.0.0,1.0.0)</javax.xml.range>
         <org.apache.xml.security.range>[0.0.0,2.0.0)</org.apache.xml.security.range>


### PR DESCRIPTION
### Proposed changes in this pull request
All Purposes, Purposes Categories, PII Categories, and Receipts created under a tenant should get deleted in the tenant deletion process.

Closes #2914

### Prerequisites
wso2/carbon-consent-management#175