### PR TITLE
Add configurations to enable application role permission to view the OAuth app in DCRM

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -549,6 +549,9 @@
 
         <PublishPasswordGrantLogin>false</PublishPasswordGrantLogin>
 
+        <DCRM>
+            <ApplicationRolePermissionRequiredToView>{{oauth.dcrm.application_role_permission_required_to_view}}</ApplicationRolePermissionRequiredToView>
+        </DCRM>
     </OAuth>
 
     <MultifactorAuthentication>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -708,6 +708,9 @@
 
         <PublishPasswordGrantLogin>{{analytics.publish_password_grant_logins}}</PublishPasswordGrantLogin>
 
+        <DCRM>
+            <ApplicationRolePermissionRequiredToView>{{oauth.dcrm.application_role_permission_required_to_view}}</ApplicationRolePermissionRequiredToView>
+        </DCRM>
     </OAuth>
 
     <MultifactorAuthentication>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -124,6 +124,8 @@
   "oauth.grant_type.device_code.grant_handler": "org.wso2.carbon.identity.oauth2.device.grant.DeviceFlowGrant",
   "oauth.grant_type.device_code.grant_validator": "org.wso2.carbon.identity.oauth2.device.grant.DeviceFlowGrantValidator",
 
+  "oauth.dcrm.application_role_permission_required_to_view": true,
+
   "oauth.extensions.callback_handlers": [
     {
       "class":"org.wso2.carbon.identity.oauth.callback.DefaultCallbackHandler"


### PR DESCRIPTION
This PR will add configurations to enable application role permission to view the OAuth app in DCRM. To enable this add the following configuration to "_deployment.toml_" file in "_<IS_HOME>/repository/conf_" directory.

`[oauth.dcrm]
application_role_permission_required_to_view = false`

Related PR: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1378