### PR TITLE
Remove tenant qualified url from webfinger endpoint

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1465,7 +1465,8 @@
             <Scopes>internal_identity_mgt_create</Scopes>
             <Scopes>internal_identity_mgt_delete</Scopes>
         </Resource>
-        <Resource context="(.*)/.well-known(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/.well-known/openid-configuration(.*)" secured="false" http-method="all"/>
+        <Resource context="/.well-known/webfinger(.*)" secured="false" http-method="all"/>
         <Resource context="(.*)/api/identity/oauth2/dcr/v1.1/register(.*)" secured="true" http-method="POST">
             <Permissions>/permission/admin/manage/identity/applicationmgt/create</Permissions>
             <Scopes>internal_application_mgt_create</Scopes>


### PR DESCRIPTION
### Proposed changes in this pull request
This PR will remove tenant qualified url from webfinger endpoint. This will fix the issue of calling web finger endpoint in a tenant specific way. The expected behaviour can be found in the documentation: [OpenID Connect Discovery](https://is.docs.wso2.com/en/latest/learn/openid-connect-discovery/#openid-provider-issuer-discovery)
