### PR TITLE
Config for breaking token building flow on error when obtaining claims

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -168,6 +168,11 @@ public class FrameworkUtils {
     private static final String REQUEST_PARAM_APPLICATION = "application";
     private static final String ALREADY_WRITTEN_PROPERTY = "AlreadyWritten";
 
+    private static final String CONTINUE_ON_CLAIM_HANDLING_ERROR = "ContinueOnClaimHandlingError";
+    private static final String CONTINUE_ON_CLAIM_HANDLING_ERROR_DEFAULT = "true";
+    private static final String TRUE = "true";
+    private static final String FALSE = "false";
+
 
     private FrameworkUtils() {
     }
@@ -2545,5 +2550,22 @@ public class FrameworkUtils {
                     "manager: " + userStoreManager.getClass() + ", from the realm.");
         }
         return userStoreManager;
+    }
+
+    /**
+     * Check whether the authentication flow should continue upon facing a claim handling error.
+     *
+     * @return true/false Continue or break flow when facing claim handling errors.
+     */
+    public static boolean isContinueOnClaimHandlingErrorAllowed() {
+
+        String continueOnClaimHandlingErrorValue = IdentityUtil.getProperty(CONTINUE_ON_CLAIM_HANDLING_ERROR);
+
+        // If config is empty or not a boolean value, the property must be set to the default value which is true.
+        if (StringUtils.isBlank(continueOnClaimHandlingErrorValue) ||
+                !(TRUE.equals(continueOnClaimHandlingErrorValue) || FALSE.equals(continueOnClaimHandlingErrorValue))) {
+            continueOnClaimHandlingErrorValue = CONTINUE_ON_CLAIM_HANDLING_ERROR_DEFAULT;
+        }
+        return Boolean.parseBoolean(continueOnClaimHandlingErrorValue);
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -169,10 +169,6 @@ public class FrameworkUtils {
     private static final String ALREADY_WRITTEN_PROPERTY = "AlreadyWritten";
 
     private static final String CONTINUE_ON_CLAIM_HANDLING_ERROR = "ContinueOnClaimHandlingError";
-    private static final String CONTINUE_ON_CLAIM_HANDLING_ERROR_DEFAULT = "true";
-    private static final String TRUE = "true";
-    private static final String FALSE = "false";
-
 
     private FrameworkUtils() {
     }
@@ -2562,11 +2558,6 @@ public class FrameworkUtils {
         String continueOnClaimHandlingErrorValue = IdentityUtil.getProperty(CONTINUE_ON_CLAIM_HANDLING_ERROR);
 
         // If config is empty or not a boolean value, the property must be set to the default value which is true.
-        if (StringUtils.isBlank(continueOnClaimHandlingErrorValue) ||
-                !(TRUE.equalsIgnoreCase(continueOnClaimHandlingErrorValue) ||
-                        FALSE.equalsIgnoreCase(continueOnClaimHandlingErrorValue))) {
-            continueOnClaimHandlingErrorValue = CONTINUE_ON_CLAIM_HANDLING_ERROR_DEFAULT;
-        }
-        return Boolean.parseBoolean(continueOnClaimHandlingErrorValue);
+        return !Boolean.FALSE.toString().equalsIgnoreCase(continueOnClaimHandlingErrorValue);
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2563,7 +2563,8 @@ public class FrameworkUtils {
 
         // If config is empty or not a boolean value, the property must be set to the default value which is true.
         if (StringUtils.isBlank(continueOnClaimHandlingErrorValue) ||
-                !(TRUE.equals(continueOnClaimHandlingErrorValue) || FALSE.equals(continueOnClaimHandlingErrorValue))) {
+                !(TRUE.equalsIgnoreCase(continueOnClaimHandlingErrorValue) ||
+                        FALSE.equalsIgnoreCase(continueOnClaimHandlingErrorValue))) {
             continueOnClaimHandlingErrorValue = CONTINUE_ON_CLAIM_HANDLING_ERROR_DEFAULT;
         }
         return Boolean.parseBoolean(continueOnClaimHandlingErrorValue);

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2120,4 +2120,7 @@
     <MutualTLS>
         <ClientCertificateHeader>{{oauth.mutualtls.client_certificate_header}}</ClientCertificateHeader>
     </MutualTLS>
+
+    <!-- Configuration for allowing an uninterrupted token building flow upon facing claim handling errors. -->
+    <ContinueOnClaimHandlingError>{{continue_on_claim_handling_error}}</ContinueOnClaimHandlingError>
 </Server>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -532,5 +532,7 @@
     {
       "class": "org.wso2.carbon.user.core.ldap.UniqueIDReadWriteLDAPUserStoreManager"
     }
-  ]
+  ],
+
+  "continue_on_claim_handling_error": true
 }


### PR DESCRIPTION
#### Description:
This config is used to check whether to break the normal authentication flow upon facing claim handling errors. Currently an empty claim map is returned and the flow continues. This config is used to decide which action to take in such a scenario. 

#### Related issues:
https://github.com/wso2/product-is/issues/8168

#### Related PRs:
https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1381