### PR TITLE
Resolving the internal service URL for internal API calls

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/repository/conf/identity/identity.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/repository/conf/identity/identity.xml
@@ -71,6 +71,9 @@
         <TrustManagerType>SunX509</TrustManagerType>
     </Security>
 
+    <!--This configuration is to resolve the internal service URL for internal API calls-->
+    <ServerHostName>localhost</ServerHostName>
+
     <Identity>
         <IssuerPolicy>SelfAndManaged</IssuerPolicy>
         <TokenValidationPolicy>CertValidate</TokenValidationPolicy>

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURL.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURL.java
@@ -37,7 +37,7 @@ public interface ServiceURL {
      *
      * @return String of the host name.
      */
-    String getHostName();
+    String getProxyHostName();
 
     /**
      * Returns the port of Service URL.

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
@@ -240,7 +240,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
     private String fetchInternalHostName() throws URLBuilderException {
 
         String internalHostName = ServerConfiguration.getInstance().
-                getFirstProperty(IdentityCoreConstants.INTERNAL_HOST_NAME);
+                getFirstProperty(IdentityCoreConstants.SERVER_HOST_NAME);
         try {
             if (StringUtils.isBlank(internalHostName)) {
                 internalHostName = NetworkUtils.getLocalHostname();

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
@@ -80,7 +80,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
     public ServiceURL build() throws URLBuilderException {
 
         String protocol = fetchProtocol();
-        String hostName = fetchHostName();
+        String proxyHostName = fetchProxyHostName();
         String internalHostName = fetchInternalHostName();
         int port = fetchPort();
         String tenantDomain = resolveTenantDomain();
@@ -88,7 +88,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         String resolvedFragment = buildFragment(fragment, fragmentParams);
         String urlPath = getResolvedUrlPath(tenantDomain);
 
-        return new ServiceURLImpl(protocol, hostName, internalHostName, port, tenantDomain, proxyContextPath, urlPath,
+        return new ServiceURLImpl(protocol, proxyHostName, internalHostName, port, tenantDomain, proxyContextPath, urlPath,
                 parameters, resolvedFragment);
     }
 
@@ -220,10 +220,10 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         return CarbonUtils.getManagementTransport();
     }
 
-    private String fetchHostName() throws URLBuilderException {
+    private String fetchProxyHostName() throws URLBuilderException {
 
-        String hostName = ServerConfiguration.getInstance().getFirstProperty(IdentityCoreConstants.HOST_NAME);
-        return resolveHostName(hostName);
+        String proxyHostName = ServerConfiguration.getInstance().getFirstProperty(IdentityCoreConstants.HOST_NAME);
+        return resolveHostName(proxyHostName);
     }
 
     private String fetchInternalHostName() throws URLBuilderException {
@@ -264,7 +264,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
     private class ServiceURLImpl implements ServiceURL {
 
         private String protocol;
-        private String hostName;
+        private String proxyHostName;
         private String internalHostName;
         private int port;
         private String tenantDomain;
@@ -277,12 +277,12 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         private String relativePublicUrl;
         private String relativeInternalUrl;
 
-        private ServiceURLImpl(String protocol, String hostName, String internalHostName, int port, String tenantDomain,
+        private ServiceURLImpl(String protocol, String proxyHostName, String internalHostName, int port, String tenantDomain,
                                String proxyContextPath, String urlPath, Map<String, String> parameters, String fragment)
                 throws URLBuilderException {
 
             this.protocol = protocol;
-            this.hostName = hostName;
+            this.proxyHostName = proxyHostName;
             this.internalHostName = internalHostName;
             this.port = port;
             this.tenantDomain = tenantDomain;
@@ -313,9 +313,9 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
          * @return String of the host name.
          */
         @Override
-        public String getHostName() {
+        public String getProxyHostName() {
 
-            return hostName;
+            return proxyHostName;
         }
 
         /**
@@ -441,11 +441,11 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
             if (StringUtils.isBlank(protocol)) {
                 throw new URLBuilderException("Protocol of service URL is not available");
             }
-            if (StringUtils.isBlank(hostName)) {
+            if (StringUtils.isBlank(proxyHostName)) {
                 throw new URLBuilderException("Hostname of service URL is not available");
             }
             absolutePublicUrl.append(protocol).append("://");
-            absolutePublicUrl.append(hostName.toLowerCase());
+            absolutePublicUrl.append(proxyHostName.toLowerCase());
             // If it's well known HTTPS port, skip adding port.
             if (port != IdentityCoreConstants.DEFAULT_HTTPS_PORT) {
                 absolutePublicUrl.append(":").append(port);

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.NetworkUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -239,8 +240,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
 
     private String fetchInternalHostName() throws URLBuilderException {
 
-        String internalHostName = ServerConfiguration.getInstance().
-                getFirstProperty(IdentityCoreConstants.SERVER_HOST_NAME);
+        String internalHostName = IdentityUtil.getProperty(IdentityCoreConstants.SERVER_HOST_NAME);
         try {
             if (StringUtils.isBlank(internalHostName)) {
                 internalHostName = NetworkUtils.getLocalHostname();
@@ -444,15 +444,15 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
 
         private String fetchAbsolutePublicUrl() throws URLBuilderException {
 
-            StringBuilder absoluteUrl = new StringBuilder();
-            absoluteUrl.append(protocol).append("://");
-            absoluteUrl.append(hostName.toLowerCase());
+            StringBuilder absolutePublicUrl = new StringBuilder();
+            absolutePublicUrl.append(protocol).append("://");
+            absolutePublicUrl.append(hostName.toLowerCase());
             // If it's well known HTTPS port, skip adding port.
             if (port != IdentityCoreConstants.DEFAULT_HTTPS_PORT) {
-                absoluteUrl.append(":").append(port);
+                absolutePublicUrl.append(":").append(port);
             }
-            absoluteUrl.append(fetchRelativePublicUrl());
-            return absoluteUrl.toString();
+            absolutePublicUrl.append(fetchRelativePublicUrl());
+            return absolutePublicUrl.toString();
         }
 
         private String fetchAbsoluteInternalUrl() throws URLBuilderException {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
@@ -223,6 +223,17 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
     private String fetchHostName() throws URLBuilderException {
 
         String hostName = ServerConfiguration.getInstance().getFirstProperty(IdentityCoreConstants.HOST_NAME);
+        return resolveHostName(hostName);
+    }
+
+    private String fetchInternalHostName() throws URLBuilderException {
+
+        String internalHostName = IdentityUtil.getProperty(IdentityCoreConstants.SERVER_HOST_NAME);
+        return resolveHostName(internalHostName);
+    }
+
+    private String resolveHostName(String hostName) throws URLBuilderException {
+
         try {
             if (StringUtils.isBlank(hostName)) {
                 hostName = NetworkUtils.getLocalHostname();
@@ -236,24 +247,6 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
             hostName = hostName.substring(0, hostName.length() - 1);
         }
         return hostName;
-    }
-
-    private String fetchInternalHostName() throws URLBuilderException {
-
-        String internalHostName = IdentityUtil.getProperty(IdentityCoreConstants.SERVER_HOST_NAME);
-        try {
-            if (StringUtils.isBlank(internalHostName)) {
-                internalHostName = NetworkUtils.getLocalHostname();
-            }
-        } catch (SocketException e) {
-            throw new URLBuilderException(String.format("Error while trying to resolve the internal " +
-                    "hostname %s from the system", internalHostName), e);
-        }
-
-        if (StringUtils.isNotBlank(internalHostName) && internalHostName.endsWith("/")) {
-            internalHostName = internalHostName.substring(0, internalHostName.length() - 1);
-        }
-        return internalHostName;
     }
 
     private Integer fetchPort() {
@@ -445,6 +438,12 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         private String fetchAbsolutePublicUrl() throws URLBuilderException {
 
             StringBuilder absolutePublicUrl = new StringBuilder();
+            if (StringUtils.isBlank(protocol)) {
+                throw new URLBuilderException("Protocol of service URL is not available");
+            }
+            if (StringUtils.isBlank(hostName)) {
+                throw new URLBuilderException("Hostname of service URL is not available");
+            }
             absolutePublicUrl.append(protocol).append("://");
             absolutePublicUrl.append(hostName.toLowerCase());
             // If it's well known HTTPS port, skip adding port.
@@ -458,6 +457,12 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         private String fetchAbsoluteInternalUrl() throws URLBuilderException {
 
             StringBuilder absoluteInternalUrl = new StringBuilder();
+            if (StringUtils.isBlank(protocol)) {
+                throw new URLBuilderException("Protocol of service URL is not available");
+            }
+            if (StringUtils.isBlank(hostName)) {
+                throw new URLBuilderException("Hostname of service URL is not available");
+            }
             absoluteInternalUrl.append(protocol).append("://");
             absoluteInternalUrl.append(internalHostName.toLowerCase());
             // If it's well known HTTPS port, skip adding port.

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
@@ -460,8 +460,8 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
             if (StringUtils.isBlank(protocol)) {
                 throw new URLBuilderException("Protocol of service URL is not available");
             }
-            if (StringUtils.isBlank(hostName)) {
-                throw new URLBuilderException("Hostname of service URL is not available");
+            if (StringUtils.isBlank(internalHostName)) {
+                throw new URLBuilderException("Internal hostname of service URL is not available");
             }
             absoluteInternalUrl.append(protocol).append("://");
             absoluteInternalUrl.append(internalHostName.toLowerCase());

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -25,6 +25,7 @@ public class IdentityCoreConstants {
     public static final String IDENTITY_CONFIG = "identity.xml";
     public static final String IDENTITY_DEFAULT_NAMESPACE = "http://wso2.org/projects/carbon/carbon.xml";
     public static final String HOST_NAME = "HostName";
+    public static final String INTERNAL_HOST_NAME = "InternalHostName";
     public static final String FILE_NAME_REGEX = "FileNameRegEx";
     public static final String PORTS_OFFSET = "Ports.Offset";
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -25,7 +25,7 @@ public class IdentityCoreConstants {
     public static final String IDENTITY_CONFIG = "identity.xml";
     public static final String IDENTITY_DEFAULT_NAMESPACE = "http://wso2.org/projects/carbon/carbon.xml";
     public static final String HOST_NAME = "HostName";
-    public static final String INTERNAL_HOST_NAME = "InternalHostName";
+    public static final String SERVER_HOST_NAME = "ServerHostName";
     public static final String FILE_NAME_REGEX = "FileNameRegEx";
     public static final String PORTS_OFFSET = "Ports.Offset";
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
@@ -106,6 +106,7 @@ public class DefaultServiceURLBuilderTest {
 
         String testPath = "/testPath";
         String urlPath = null;
+        when(CarbonUtils.getManagementTransport()).thenReturn("https");
         try {
             urlPath = ServiceURLBuilder.create().addPath(testPath).build().getPath();
         } catch (URLBuilderException e) {
@@ -122,6 +123,7 @@ public class DefaultServiceURLBuilderTest {
         String testPath2 = "testPath2/";
         String testPath3 = "/testPath3/";
         String urlPath = null;
+        when(CarbonUtils.getManagementTransport()).thenReturn("https");
         try {
             urlPath = ServiceURLBuilder.create().addPath(testPath1, testPath2, testPath3).build().getPath();
         } catch (URLBuilderException e) {
@@ -135,6 +137,7 @@ public class DefaultServiceURLBuilderTest {
     public void testAddParameter() {
 
         String parameterValue = null;
+        when(CarbonUtils.getManagementTransport()).thenReturn("https");
         try {
             parameterValue = ServiceURLBuilder.create().addParameter("key", "value").build().getParameter("key");
         } catch (URLBuilderException e) {
@@ -147,8 +150,8 @@ public class DefaultServiceURLBuilderTest {
     @Test
     public void testAddParameters() {
 
+        when(CarbonUtils.getManagementTransport()).thenReturn("https");
         Map<String, String> parameters = new HashMap<>();
-
         Map<String, String> expected = new HashMap<String, String>() {
             {
                 put("key1", "value1");
@@ -184,7 +187,7 @@ public class DefaultServiceURLBuilderTest {
     public void testAddFragmentParameter() {
 
         String fragment = null;
-
+        when(CarbonUtils.getManagementTransport()).thenReturn("https");
         try {
             fragment =
                     ServiceURLBuilder.create().addFragmentParameter("key1", "value1").addFragmentParameter("key2",
@@ -200,7 +203,7 @@ public class DefaultServiceURLBuilderTest {
     public void testAddFragmentParameters() {
 
         String fragment = null;
-
+        when(CarbonUtils.getManagementTransport()).thenReturn("https");
         try {
             fragment =
                     ServiceURLBuilder.create().addFragmentParameter("key1", "value1").addFragmentParameter("key2",
@@ -223,6 +226,7 @@ public class DefaultServiceURLBuilderTest {
         String[] valuesList = {"value1", "value2", "value3"};
         when(ServerConfiguration.getInstance().getFirstProperty(IdentityCoreConstants
                 .PROXY_CONTEXT_PATH)).thenReturn("proxyContextPath");
+        when(CarbonUtils.getManagementTransport()).thenReturn("https");
         when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(true);
         when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()).thenReturn("carbon.super");
 
@@ -238,7 +242,7 @@ public class DefaultServiceURLBuilderTest {
         }
 
         assertEquals(absoluteUrl,
-                "null://localhost:0/proxyContextPath/testPath1/testPath2/testPath3?key1%3Dvalue1%26key2%3Dvalue2" +
+                "https://localhost:0/proxyContextPath/testPath1/testPath2/testPath3?key1%3Dvalue1%26key2%3Dvalue2" +
                         "%26key3%3Dvalue3#key1%3Dvalue1%26key2%3Dvalue2%26key3%3Dvalue3");
     }
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
@@ -371,7 +371,7 @@ public class DefaultServiceURLBuilderTest {
             }
 
         } catch (URLBuilderException e) {
-            //Mock behaviour, hence ignored
+            // Mock behaviour, hence ignored.
         }
 
         assertEquals(absoluteUrl, expected);

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
@@ -231,7 +231,7 @@ public class DefaultServiceURLBuilderTest {
                             valuesList[0]).addParameter(keysList[1], valuesList[1]).addParameter(keysList[2],
                             valuesList[2]).addFragmentParameter(keysList[0], valuesList[0])
                             .addFragmentParameter(keysList[1], valuesList[1])
-                            .addFragmentParameter(keysList[2], valuesList[2]).build().getAbsoluteInternalURL();
+                            .addFragmentParameter(keysList[2], valuesList[2]).build().getAbsolutePublicURL();
         } catch (URLBuilderException e) {
             // Mock behaviour, hence ignored
         }
@@ -311,20 +311,20 @@ public class DefaultServiceURLBuilderTest {
                                 "fragment").addFragmentParameter("key2", "fragment").addFragmentParameter("key3",
                                 "fragment").addFragmentParameter("key4", "fragment").addParameter("key1", "v")
                                 .addParameter("key2", "v").addParameter("key3", "v").addParameter("key4", "v").build()
-                                .getAbsoluteInternalURL();
+                                .getAbsolutePublicURL();
             } else if (MapUtils.isNotEmpty(fragmentParams)){
                 absoluteUrl =
                         ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment).addFragmentParameter("key1",
                                 "fragment").addFragmentParameter("key2", "fragment").addFragmentParameter("key3",
-                                "fragment").addFragmentParameter("key4", "fragment").build().getAbsoluteInternalURL();
+                                "fragment").addFragmentParameter("key4", "fragment").build().getAbsolutePublicURL();
             } else if (MapUtils.isNotEmpty(parameters)){
                 absoluteUrl =
                         ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment).addParameter("key1", "v")
                                 .addParameter("key2", "v").addParameter("key3", "v").addParameter("key4", "v").build()
-                                .getAbsoluteInternalURL();
+                                .getAbsolutePublicURL();
             } else {
                 absoluteUrl =
-                        ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment).build().getAbsoluteInternalURL();
+                        ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment).build().getAbsolutePublicURL();
             }
 
         } catch (URLBuilderException e) {

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -73,6 +73,9 @@
         <UserStorePasswordEncryption>InternalKeyStore</UserStorePasswordEncryption>
     </Security>
 
+    <!-- This configuration is to resolve the internal service URL for internal API calls -->
+    <ServerHostName>localhost</ServerHostName>
+
     <Identity>
         <IssuerPolicy>SelfAndManaged</IssuerPolicy>
         <TokenValidationPolicy>CertValidate</TokenValidationPolicy>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -70,6 +70,9 @@
         <TrustManagerType>{{key_mgt.trust_manager_type}}</TrustManagerType>
     </Security>
 
+    <!--This configuration is to resolve the internal service URL for internal API calls-->
+    <ServerHostName>{{server.internal_hostname}}</ServerHostName>
+
     <Identity>
         <IssuerPolicy>{{identity.issuer_policy}}</IssuerPolicy>
         <TokenValidationPolicy>{{identity.token_validation_policy}}</TokenValidationPolicy>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -70,7 +70,7 @@
         <TrustManagerType>{{key_mgt.trust_manager_type}}</TrustManagerType>
     </Security>
 
-    <!--This configuration is to resolve the internal service URL for internal API calls-->
+    <!-- This configuration is to resolve the internal service URL for internal API calls -->
     <ServerHostName>{{server.internal_hostname}}</ServerHostName>
 
     <Identity>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -25,6 +25,8 @@
   "identity.issuer_policy": "SelfAndManaged",
   "identity.token_validation_policy": "CertValidate",
 
+  "server.internal_hostname": "localhost",
+
   "service_provider.sp_name_regex": "^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$",
 
   "remotefetch.enable":false,


### PR DESCRIPTION
### Proposed changes in this pull request
This PR changes will resolve the internal service URL for internal API calls. An optional config is introduced in “identity.xml” for the internal hostname as “<ServerHostName>”  with the default value “localhost”. It will be configurable from deployment.toml if necessary.

Relates to https://github.com/wso2/product-is/issues/8194

**Sample configurations are as follows,**
- Configuration in identity.xml.j2 file
`<ServerHostName>{{server.internal_hostname}}</ServerHostName>
`
- Configuration in deployment.toml
`[server]`
`internal_hostname = “internal.wso2.is”`

This configuration will be utilized at the service url builder utility to build the internal absolute url of a service endpoint, that will be consumed at places that will generate internal calls. As at now, we have accountrecoveryendpoint invoking internal API calls. 