### PR TITLE
Prevent policy creation with a null value

### DIFF
--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/pap/store/PAPPolicyStore.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/pap/store/PAPPolicyStore.java
@@ -158,9 +158,9 @@ public class PAPPolicyStore {
             log.debug("Creating or updating entitlement policy");
         }
 
-        if (policy == null || policyId == null) {
+        if (policy == null || policy.getPolicy() == null || policyId == null) {
             log.error("Error while creating or updating entitlement policy: " +
-                      "Policy DTO or Policy Id can not be null");
+                      "Policy DTO or the policy included in Policy DTO or Policy Id can not be null");
             throw new EntitlementException("Invalid Entitlement Policy. Policy or policyId can not be Null");
         }
 
@@ -207,7 +207,7 @@ public class PAPPolicyStore {
                 }
             }
 
-            if (policy.getPolicy() != null && policy.getPolicy().trim().length() > 0) {
+            if (policy.getPolicy().trim().length() > 0) {
                 resource.setContent(policy.getPolicy());
                 newPolicy = true;
                 PolicyAttributeBuilder policyAttributeBuilder = new PolicyAttributeBuilder(policy.getPolicy());

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/policy/store/RegistryPolicyStoreManageModule.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/policy/store/RegistryPolicyStoreManageModule.java
@@ -77,7 +77,17 @@ public class RegistryPolicyStoreManageModule extends AbstractPolicyFinderModule
         Resource resource;
         int tenantId = CarbonContext.getThreadLocalCarbonContext().getTenantId();
 
-        if (policy == null || policy.getPolicyId() == null || policy.getPolicyId().trim().length() == 0) {
+        if (policy == null || policy.getPolicyId() == null || policy.getPolicy() == null || policy.getPolicyId()
+                .trim().length() == 0) {
+            if (log.isDebugEnabled()) {
+                if (policy == null) {
+                    log.debug("PolicyStoreDTO: " + policy + ", is null.");
+                } else {
+                    log.debug("Either PolicyStoreDTO's Id: " + policy.getPolicyId() + ", or it's policy: " + policy.
+                            getPolicy() + ", is null. Or else, the mentioned policy Id: " + policy.getPolicyId()
+                            + ", is empty.");
+                }
+            }
             throw new EntitlementException("Policy can not be null");
         }
 
@@ -101,7 +111,7 @@ public class RegistryPolicyStoreManageModule extends AbstractPolicyFinderModule
                 resource = registry.newResource();
             }
 
-            if (policy.getPolicy() != null && policy.getPolicy().trim().length() != 0) {
+            if (policy.getPolicy().trim().length() != 0) {
                 resource.setContent(policy.getPolicy());
                 resource.setMediaType(PDPConstants.REGISTRY_MEDIA_TYPE);
                 AttributeDTO[] attributeDTOs = policy.getAttributeDTOs();

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/policy/store/RegistryPolicyStoreManageModule.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/policy/store/RegistryPolicyStoreManageModule.java
@@ -83,9 +83,9 @@ public class RegistryPolicyStoreManageModule extends AbstractPolicyFinderModule
                 if (policy == null) {
                     log.debug("PolicyStoreDTO: " + policy + ", is null.");
                 } else {
-                    log.debug("Either PolicyStoreDTO's Id: " + policy.getPolicyId() + ", or it's policy: " + policy.
-                            getPolicy() + ", is null. Or else, the mentioned policy Id: " + policy.getPolicyId()
-                            + ", is empty.");
+                    log.debug(String.format("Either PolicyStoreDTO's Id: %s, or it's policy: %s, is null. Or " +
+                            "else, the mentioned policy Id: %s, is empty.", policy.getPolicyId(), policy.getPolicy(),
+                            policy.getPolicyId()));
                 }
             }
             throw new EntitlementException("Policy can not be null");


### PR DESCRIPTION
Fix wso2/product-is#8371.

This fix does not allow adding null policies. If a null policy add is attempted, the scenario is considered the same as adding a policy without it's Id.