### PR TITLE
Tenant qualify /identity endpoint

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -81,6 +81,8 @@ import static org.wso2.carbon.identity.application.common.util.IdentityApplicati
 public class DefaultAuthenticationRequestHandler implements AuthenticationRequestHandler {
 
     public static final String AUTHZ_FAIL_REASON = "AUTHZ_FAIL_REASON";
+    private static final String CHECK_REMEMBER = "chkRemember";
+    private static final String CHECK_REMEMBER_ON = "on";
     private static final Log log = LogFactory.getLog(DefaultAuthenticationRequestHandler.class);
     private static final Log AUDIT_LOG = CarbonConstants.AUDIT_LOG;
     private static volatile DefaultAuthenticationRequestHandler instance;
@@ -773,7 +775,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                 }
 
                 if (context.isRequestAuthenticated() && context.isRememberMe()) {
-                    serviceURLBuilder.addParameter("chkRemember", "on");
+                    serviceURLBuilder.addParameter(CHECK_REMEMBER, CHECK_REMEMBER_ON);
                 }
 
                 try {
@@ -790,7 +792,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                 String rememberMeParam = "";
 
                 if (context.isRequestAuthenticated() && context.isRememberMe()) {
-                    rememberMeParam = rememberMeParam + "chkRemember=on";
+                    rememberMeParam = CHECK_REMEMBER + "=" + CHECK_REMEMBER_ON;
                 }
 
                 if (StringUtils.isNotEmpty(rememberMeParam)) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityProcessor.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityProcessor.java
@@ -28,6 +28,8 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationResult;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.handler.AbstractIdentityHandler;
 import org.wso2.carbon.identity.core.handler.InitConfig;
 import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
@@ -180,7 +182,17 @@ public abstract class IdentityProcessor extends AbstractIdentityHandler {
         responseBuilder.setRelyingParty(getRelyingPartyId(context));
         //type parameter is using since framework checking it, but future it'll use AUTH_NAME
         responseBuilder.setAuthType(getType(context));
-        String commonAuthURL = IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, true, true);
+        String commonAuthURL;
+        try {
+            ServiceURLBuilder serviceURLBuilder = ServiceURLBuilder.create().addPath(FrameworkConstants.COMMONAUTH);
+            commonAuthURL = serviceURLBuilder.build().getAbsolutePublicURL();
+        } catch (URLBuilderException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error occurred when building URL.", e);
+            }
+            // Fallback to old way, for error scenarios.
+            commonAuthURL = IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, true, true);
+        }
         responseBuilder.setRedirectURL(commonAuthURL);
         return responseBuilder;
     }
@@ -229,8 +241,17 @@ public abstract class IdentityProcessor extends AbstractIdentityHandler {
         responseBuilder.setCallbackPath(getCallbackPath(context));
         responseBuilder.setRelyingParty(getRelyingPartyId(context));
         //type parameter is using since framework checking it, but future it'll use AUTH_NAME
-        responseBuilder.setAuthType(getType(context));
-        String commonAuthURL = IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, true, true);
+        String commonAuthURL;
+        try {
+            ServiceURLBuilder serviceURLBuilder = ServiceURLBuilder.create().addPath(FrameworkConstants.COMMONAUTH);
+            commonAuthURL = serviceURLBuilder.build().getAbsolutePublicURL();
+        } catch (URLBuilderException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error occurred when building URL.", e);
+            }
+            // Fallback to old way, for error scenarios.
+            commonAuthURL = IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, true, true);
+        }
         responseBuilder.setRedirectURL(commonAuthURL);
         return responseBuilder;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityProcessor.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityProcessor.java
@@ -187,11 +187,7 @@ public abstract class IdentityProcessor extends AbstractIdentityHandler {
             ServiceURLBuilder serviceURLBuilder = ServiceURLBuilder.create().addPath(FrameworkConstants.COMMONAUTH);
             commonAuthURL = serviceURLBuilder.build().getAbsolutePublicURL();
         } catch (URLBuilderException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Error occurred when building URL.", e);
-            }
-            // Fallback to old way, for error scenarios.
-            commonAuthURL = IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, true, true);
+            throw new RuntimeException("Error occurred when building URL.", e);
         }
         responseBuilder.setRedirectURL(commonAuthURL);
         return responseBuilder;
@@ -246,11 +242,7 @@ public abstract class IdentityProcessor extends AbstractIdentityHandler {
             ServiceURLBuilder serviceURLBuilder = ServiceURLBuilder.create().addPath(FrameworkConstants.COMMONAUTH);
             commonAuthURL = serviceURLBuilder.build().getAbsolutePublicURL();
         } catch (URLBuilderException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Error occurred when building URL.", e);
-            }
-            // Fallback to old way, for error scenarios.
-            commonAuthURL = IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, true, true);
+            throw new RuntimeException("Error occurred when building URL.", e);
         }
         responseBuilder.setRedirectURL(commonAuthURL);
         return responseBuilder;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -120,6 +120,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -2572,5 +2573,26 @@ public class FrameworkUtils {
 
         // If config is empty or not a boolean value, the property must be set to the default value which is true.
         return !Boolean.FALSE.toString().equalsIgnoreCase(continueOnClaimHandlingErrorValue);
+    }
+
+    public static boolean isAbsoluteURI(String uri) {
+
+        if (StringUtils.isBlank(uri)) {
+            if (log.isDebugEnabled()) {
+                log.debug("URI is empty.");
+            }
+            return true;
+        }
+
+        try {
+            final URI uriObj = new URI(uri);
+            return uriObj.isAbsolute();
+        } catch (URISyntaxException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Unable to process the URI: " + uri, e);
+            }
+        }
+        // Default behavior of a URI is expected to be absolute;
+        return true;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2581,18 +2581,14 @@ public class FrameworkUtils {
             if (log.isDebugEnabled()) {
                 log.debug("URI is empty.");
             }
-            return true;
+            return false;
         }
 
         try {
             final URI uriObj = new URI(uri);
             return uriObj.isAbsolute();
         } catch (URISyntaxException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Unable to process the URI: " + uri, e);
-            }
+            throw new RuntimeException("Unable to process the URI :" + uri, e);
         }
-        // Default behavior of a URI is expected to be absolute;
-        return true;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandlerTest.java
@@ -47,6 +47,9 @@ import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthent
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.ServiceURL;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.internal.DefaultServiceURLBuilder;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -70,7 +73,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-@PrepareForTest(FrameworkUtils.class)
+@PrepareForTest({FrameworkUtils.class, ServiceURLBuilder.class})
 @WithCarbonHome
 public class DefaultAuthenticationRequestHandlerTest {
 
@@ -81,6 +84,12 @@ public class DefaultAuthenticationRequestHandlerTest {
     HttpServletResponse response;
 
     DefaultAuthenticationRequestHandler authenticationRequestHandler;
+
+    @Mock
+    DefaultServiceURLBuilder serviceURLBuilder;
+
+    @Mock
+    ServiceURL serviceURL;
 
     @ObjectFactory
     public IObjectFactory getObjectFactory() {
@@ -93,6 +102,10 @@ public class DefaultAuthenticationRequestHandlerTest {
 
         initMocks(this);
         authenticationRequestHandler = new DefaultAuthenticationRequestHandler();
+        mockStatic(ServiceURLBuilder.class);
+        when(ServiceURLBuilder.create()).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.addPath(anyString())).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.build()).thenReturn(serviceURL);
     }
 
     @AfterMethod
@@ -243,7 +256,7 @@ public class DefaultAuthenticationRequestHandlerTest {
 
         DefaultAuthenticationRequestHandler requestHandler = spy(new DefaultAuthenticationRequestHandler());
         doNothing().when(requestHandler).populateErrorInformation(request, response, context);
-
+        when(serviceURL.getAbsolutePublicURL()).thenReturn(expectedRedirectUrl);
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         requestHandler.sendResponse(request, response, context);
         verify(response).sendRedirect(captor.capture());
@@ -337,6 +350,7 @@ public class DefaultAuthenticationRequestHandlerTest {
         when(request.getCookies()).thenReturn(cookies);
         when(FrameworkUtils.getCookie(any(HttpServletRequest.class), anyString())).thenReturn
                 (cookies[0]);
+        when(FrameworkUtils.isAbsoluteURI(anyString())).thenReturn(true);
         authenticationRequestHandler.handle(request, response, context);
         assertTrue(Boolean.parseBoolean(context.getProperty(
                 FrameworkConstants.POST_AUTHENTICATION_EXTENSION_COMPLETED).toString()));


### PR DESCRIPTION
Addresses https://github.com/wso2/product-is/issues/8626

Currently in some outbound authenticators, absolute call back is set from the authenticator itself see: https://github.com/wso2-extensions/identity-outbound-auth-samlsso/blob/master/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/logout/processor/SAMLLogoutResponseProcessor.java#L73. This can cause complications in tenant qualified scenarios. Hence as a solution we have moved the absolute URL creation logic to the framework whereever it is being used, and from the authenticator level only respective URL context is expected.

This PR also fixes the issue where DefaultServiceURLBuilder unncessarily encoding the query param string of a URL. As a result call back URL is getting as :
https://localhost:9443/samlsso?sessionDataKey%3Dac584d70-8453-426c-945c-8d8b097387da

Expected one should be  :
https://localhost:9443/samlsso?sessionDataKey=ac584d70-8453-426c-945c-8d8b097387da