### PR TITLE
Add config to enable deprecated APIs

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -92,6 +92,11 @@
         <!--<SPNameRegex>^[a-zA-Z0-9._-]*$</SPNameRegex>-->
     <!--</ServiceProviders>-->
 
+    <LegacyFeatures>
+        <EnableOAuth1>false</EnableOAuth1>
+        <EnableIdentityConnectDCR>false</EnableIdentityConnectDCR>
+    </LegacyFeatures>
+
     <OpenID>
         <!--
             Default values for OpenIDServerUrl and OpenIDUSerPattern are built in following format

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -93,8 +93,8 @@
     </ServiceProviders>
 
     <LegacyFeatures>
-        <EnableOAuth1>{{legacy_feature.enable_oauth1}}</EnableOAuth1>
-        <EnableIdentityConnectDCR>{{legacy_feature.enable_identity_connect_dcr}}</EnableIdentityConnectDCR>
+        <EnableOAuth1>{{legacy_features.enable_oauth1}}</EnableOAuth1>
+        <EnableIdentityConnectDCR>{{legacy_features.enable_identity_connect_dcr}}</EnableIdentityConnectDCR>
     </LegacyFeatures>
 
     <OpenID>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -92,6 +92,11 @@
         {% endif %}
     </ServiceProviders>
 
+    <LegacyFeatures>
+        <EnableOAuth1>{LegacyFeatures.EnableOAuth1}</EnableOAuth1>
+        <EnableIdentityConnectDCR>{LegacyFeatures.EnableIdentityConnectDCR}</EnableIdentityConnectDCR>
+    </LegacyFeatures>
+
     <OpenID>
         <!--
             Default values for OpenIDServerUrl and OpenIDUSerPattern are built in following format

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -93,8 +93,8 @@
     </ServiceProviders>
 
     <LegacyFeatures>
-        <EnableOAuth1>{LegacyFeatures.EnableOAuth1}</EnableOAuth1>
-        <EnableIdentityConnectDCR>{LegacyFeatures.EnableIdentityConnectDCR}</EnableIdentityConnectDCR>
+        <EnableOAuth1>{{legacy_feature.enable_oauth1}}</EnableOAuth1>
+        <EnableIdentityConnectDCR>{{legacy_feature.enable_identity_connect_dcr}}</EnableIdentityConnectDCR>
     </LegacyFeatures>
 
     <OpenID>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -314,6 +314,9 @@
   "authentication.jit_provisioning.username_provisioning_url": "/accountrecoveryendpoint/register.do",
   "authentication.jit_provisioning.password_provisioning_url": "/accountrecoveryendpoint/signup.do",
 
+  "LegacyFeatures.EnableOAuth1": false,
+  "LegacyFeatures.EnableIdentityConnectDCR": false,
+
   "event.default_listener.workflow.priority": "10",
   "event.default_listener.workflow.enable": true,
   "event.default_listener.identity_mgt.priority": "50",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -314,8 +314,8 @@
   "authentication.jit_provisioning.username_provisioning_url": "/accountrecoveryendpoint/register.do",
   "authentication.jit_provisioning.password_provisioning_url": "/accountrecoveryendpoint/signup.do",
 
-  "LegacyFeatures.EnableOAuth1": false,
-  "LegacyFeatures.EnableIdentityConnectDCR": false,
+  "legacy_feature.enable_oauth1": false,
+  "legacy_feature.enable_identity_connect_dcr": false,
 
   "event.default_listener.workflow.priority": "10",
   "event.default_listener.workflow.enable": true,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -314,8 +314,8 @@
   "authentication.jit_provisioning.username_provisioning_url": "/accountrecoveryendpoint/register.do",
   "authentication.jit_provisioning.password_provisioning_url": "/accountrecoveryendpoint/signup.do",
 
-  "legacy_feature.enable_oauth1": false,
-  "legacy_feature.enable_identity_connect_dcr": false,
+  "legacy_features.enable_oauth1": false,
+  "legacy_features.enable_identity_connect_dcr": false,
 
   "event.default_listener.workflow.priority": "10",
   "event.default_listener.workflow.enable": true,


### PR DESCRIPTION
### Proposed changes in this pull request

This PR will add config to disable deprecated APIs.

The following config will have to add to the deployment.toml file to enable the /identity/connect/register API and the OAuth 1.0 API.

```
[legacy_features]
enable_oauth1 = true
enable_identity_connect_dcr = true
```

### When should this PR be merged
This PR should be merged before https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1407

