### PR TITLE
Add configuration to define the disallowed character regex master fix

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2179,4 +2179,11 @@
 
     <!-- Configuration for allowing an uninterrupted token building flow upon facing claim handling errors. -->
     <ContinueOnClaimHandlingError>{{continue_on_claim_handling_error}}</ContinueOnClaimHandlingError>
+
+    <!--Disallowed characters regEx property-->
+    {% if user_identifier.disallowed.characters.regex is defined %}
+    <UserIdentifier>
+        <DisallowedCharacters>{{user_identifier.disallowed.characters.regex}}</DisallowedCharacters>
+    </UserIdentifier>
+    {% endif %}
 </Server>


### PR DESCRIPTION
### Proposed changes in this pull request

* Added the configuration to define the disallowed character regex for username search in management console.
* For this disallowed characters, the default value will be set inside the code if this configuration is not defined in deployment.toml file.