### PR TITLE
Fix service url builder unnecessarily encoding query param string

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
@@ -501,13 +501,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
                 serverUrl.setLength(serverUrl.length() - 1);
             }
             if (StringUtils.isNotBlank(resolvedParamsString)) {
-                try {
-                    serverUrl.append(delimiter).append(URLEncoder.encode(resolvedParamsString,
-                            StandardCharsets.UTF_8.name()));
-                } catch (UnsupportedEncodingException e) {
-                    throw new URLBuilderException(String.format("Error while trying to build url. %s is not supported" +
-                            ".", StandardCharsets.UTF_8.name()), e);
-                }
+                serverUrl.append(delimiter).append(resolvedParamsString);
             }
         }
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilder.java
@@ -171,7 +171,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         return tenantDomain;
     }
 
-    private String buildFragment(String fragment, Map<String, String> fragmentParams) {
+    private String buildFragment(String fragment, Map<String, String> fragmentParams) throws URLBuilderException {
 
         if (StringUtils.isNotBlank(fragment)) {
             return fragment;
@@ -180,13 +180,19 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         }
     }
 
-    private String getResolvedParamString(Map<String, String> parameters) {
+    private String getResolvedParamString(Map<String, String> parameters) throws URLBuilderException {
 
         StringJoiner joiner = new StringJoiner("&");
         if (MapUtils.isNotEmpty(parameters)) {
             for (Map.Entry<String, String> entry : parameters.entrySet()) {
                 StringBuilder paramBuilder = new StringBuilder();
-                paramBuilder.append(entry.getKey()).append("=").append(entry.getValue());
+                try {
+                    paramBuilder.append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8.name())).append("=")
+                            .append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.name()));
+                } catch (UnsupportedEncodingException e) {
+                    throw new URLBuilderException(String.format("Error while trying to build url. %s is not supported" +
+                            ".", StandardCharsets.UTF_8.name()), e);
+                }
                 joiner.add(paramBuilder.toString());
             }
         }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
@@ -250,6 +250,7 @@ public class DefaultServiceURLBuilderTest {
     public Object[][] getAbsolutePublicURLData() {
 
         Map<String, String> parameters = new HashMap<>();
+        Map<String, String> unencodedParameters = new HashMap<>();
         Map<String, String> fragmentParams = new HashMap<>();
 
         ArrayList<String> keys = new ArrayList<String>(Arrays.asList("key1", "key2", "key3", "key4"));
@@ -257,6 +258,7 @@ public class DefaultServiceURLBuilderTest {
             parameters.put(key, "v");
             fragmentParams.put(key, "fragment");
         }
+        unencodedParameters.put("key5", " v ");
 
         return new Object[][]{
                 {"https", "www.wso2.com", 9443, "/proxyContext", "abc", false, null, "", fragmentParams,
@@ -282,6 +284,9 @@ public class DefaultServiceURLBuilderTest {
                         "https://www.wso2.com:9443/samlsso#fragment", "samlsso/"},
                 {"https", "www.wso2.com", 9443, "", "", true, parameters, "", fragmentParams,
                         "https://www.wso2.com:9443?key1=v&key2=v&key3=v&key4=v#key1=fragment&key2=fragment&key3" +
+                                "=fragment&key4=fragment", null},
+                {"https", "www.wso2.com", 9443, "", "", true, unencodedParameters, "", fragmentParams,
+                        "https://www.wso2.com:9443?key5=+v+#key1=fragment&key2=fragment&key3" +
                                 "=fragment&key4=fragment", null},
                 {"https", "www.wso2.com", 9443, "/proxyContext", "", false, null, "", fragmentParams,
                         "https://www.wso2.com:9443/proxyContext#key1=fragment&key2=fragment&key3=fragment&key4" +
@@ -349,12 +354,14 @@ public class DefaultServiceURLBuilderTest {
 
         try {
             if (MapUtils.isNotEmpty(parameters) && MapUtils.isNotEmpty(fragmentParams)) {
-                absoluteUrl =
-                        ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment).addFragmentParameter("key1",
-                                "fragment").addFragmentParameter("key2", "fragment").addFragmentParameter("key3",
-                                "fragment").addFragmentParameter("key4", "fragment").addParameter("key1", "v")
-                                .addParameter("key2", "v").addParameter("key3", "v").addParameter("key4", "v").build()
-                                .getAbsolutePublicURL();
+                ServiceURLBuilder serviceURLBuilder = ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment);
+                for (String paramKey : parameters.keySet()) {
+                    serviceURLBuilder.addParameter(paramKey, parameters.get(paramKey));
+                }
+                for (String fragmentKey : fragmentParams.keySet()) {
+                    serviceURLBuilder.addFragmentParameter(fragmentKey, fragmentParams.get(fragmentKey));
+                }
+                absoluteUrl = serviceURLBuilder.build().getAbsolutePublicURL();
             } else if (MapUtils.isNotEmpty(fragmentParams)){
                 absoluteUrl =
                         ServiceURLBuilder.create().addPath(urlPath).setFragment(fragment).addFragmentParameter("key1",

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
@@ -242,7 +242,7 @@ public class DefaultServiceURLBuilderTest {
         }
 
         assertEquals(absoluteUrl,
-                "null://localhost:0/proxyContextPath/testPath1/testPath2/testPath3?key1=value1&key2=value2&key3" +
+                "https://localhost:0/proxyContextPath/testPath1/testPath2/testPath3?key1=value1&key2=value2&key3" +
                         "=value3#key1=value1&key2=value2&key3=value3");
     }
 
@@ -303,20 +303,19 @@ public class DefaultServiceURLBuilderTest {
 
         return new Object[][]{
                 {"https", "internal.wso2.is", 9443, "abc", false, null, "", fragmentParams,
-                        "https://internal.wso2.is:9443#key1%3Dfragment%26key2%3Dfragment%26key3%3Dfragment" +
-                                "%26key4%3Dfragment", ""},
+                        "https://internal.wso2.is:9443#key1=fragment&key2=fragment&key3=fragment&key4=fragment", ""},
                 {"https", "internal.wso2.is", 9443, "", false, null, "fragment", fragmentParams,
                         "https://internal.wso2.is:9443/samlsso#fragment", "/samlsso"},
                 {"https", "internal.wso2.is", 9443, "", true, null, "", fragmentParams,
-                        "https://internal.wso2.is:9443/samlsso#key1%3Dfragment%26key2%3D" +
-                                "fragment%26key3%3Dfragment%26key4%3Dfragment", "/samlsso/"},
+                        "https://internal.wso2.is:9443/samlsso#key1=fragment&key2=fragment&key3=fragment&key4" +
+                                "=fragment", "/samlsso/"},
                 {"https", null, 9443, "abc", false, null, "fragment", fragmentParams,
                         "https://localhost:9443/samlsso#fragment", "samlsso"},
                 {"https", "internal.wso2.is", 9443, "abc", true, parameters, "fragment", fragmentParams,
-                        "https://internal.wso2.is:9443/t/abc/samlsso?key1%3Dv%26key2%3Dv%26key3%3Dv%26key4%3Dv#fragment",
+                        "https://internal.wso2.is:9443/t/abc/samlsso?key1=v&key2=v&key3=v&key4=v#fragment",
                         "/samlsso"},
                 {"https", "internal.wso2.is", 9443, "abc", false, parameters, "", null,
-                        "https://internal.wso2.is:9443/samlsso?key1%3Dv%26key2%3Dv%26key3%3Dv%26key4%3Dv", "/samlsso/"},
+                        "https://internal.wso2.is:9443/samlsso?key1=v&key2=v&key3=v&key4=v", "/samlsso/"},
                 {"https", "internal.wso2.is", 9443, "abc", true, null, "fragment", fragmentParams,
                         "https://internal.wso2.is:9443/t/abc/samlsso#fragment", "/samlsso"},
                 {"https", "internal.wso2.is", 9443, "abc", true, null, "", null,
@@ -324,12 +323,10 @@ public class DefaultServiceURLBuilderTest {
                 {"https", "internal.wso2.is", 9443, "", true, null, "fragment", fragmentParams,
                         "https://internal.wso2.is:9443/samlsso#fragment", "samlsso/"},
                 {"https", "internal.wso2.is", 9443, "", true, parameters, "", fragmentParams,
-                        "https://internal.wso2.is:9443?key1%3Dv%26key2%3Dv%26key3%3Dv%26key4%3Dv#key1" +
-                                "%3Dfragment%26key2%3Dfragment%26key3%3Dfragment%26key4%3Dfragment",
-                        null},
+                        "https://internal.wso2.is:9443?key1=v&key2=v&key3=v&key4=v#key1=fragment&key2=fragment&key3" +
+                                "=fragment&key4=fragment", null},
                 {"https", null, 9443, "", false, null, "", fragmentParams,
-                        "https://localhost:9443#key1%3Dfragment%26key2%3Dfragment%26key3%3Dfragment" +
-                                "%26key4%3Dfragment", null}
+                        "https://localhost:9443#key1=fragment&key2=fragment&key3=fragment&key4=fragment", null}
         };
     }
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/internal/DefaultServiceURLBuilderTest.java
@@ -242,8 +242,8 @@ public class DefaultServiceURLBuilderTest {
         }
 
         assertEquals(absoluteUrl,
-                "https://localhost:0/proxyContextPath/testPath1/testPath2/testPath3?key1%3Dvalue1%26key2%3Dvalue2" +
-                        "%26key3%3Dvalue3#key1%3Dvalue1%26key2%3Dvalue2%26key3%3Dvalue3");
+                "null://localhost:0/proxyContextPath/testPath1/testPath2/testPath3?key1=value1&key2=value2&key3" +
+                        "=value3#key1=value1&key2=value2&key3=value3");
     }
 
     @DataProvider
@@ -260,20 +260,20 @@ public class DefaultServiceURLBuilderTest {
 
         return new Object[][]{
                 {"https", "www.wso2.com", 9443, "/proxyContext", "abc", false, null, "", fragmentParams,
-                        "https://www.wso2.com:9443/proxyContext#key1%3Dfragment%26key2%3Dfragment%26key3%3Dfragment" +
-                                "%26key4%3Dfragment", ""},
+                        "https://www.wso2.com:9443/proxyContext#key1=fragment&key2=fragment&key3=fragment&key4" +
+                                "=fragment", ""},
                 {"https", "www.wso2.com", 9443, "/proxyContext/", "", false, null, "fragment", fragmentParams,
                         "https://www.wso2.com:9443/proxyContext/samlsso#fragment", "/samlsso"},
                 {"https", "www.wso2.com", 9443, "proxyContext", "", true, null, "", fragmentParams,
-                        "https://www.wso2.com:9443/proxyContext/samlsso#key1%3Dfragment%26key2%3D" +
-                                "fragment%26key3%3Dfragment%26key4%3Dfragment", "/samlsso/"},
+                        "https://www.wso2.com:9443/proxyContext/samlsso#key1=fragment&key2=fragment&key3=fragment" +
+                                "&key4=fragment", "/samlsso/"},
                 {"https", "www.wso2.com", 9443, "", "abc", false, null, "fragment", fragmentParams,
                         "https://www.wso2.com:9443/samlsso#fragment", "samlsso"},
                 {"https", "www.wso2.com", 9443, null, "abc", true, parameters, "fragment", fragmentParams,
-                        "https://www.wso2.com:9443/t/abc/samlsso?key1%3Dv%26key2%3Dv%26key3%3Dv%26key4%3Dv#fragment",
+                        "https://www.wso2.com:9443/t/abc/samlsso?key1=v&key2=v&key3=v&key4=v#fragment",
                         "/samlsso"},
                 {"https", "www.wso2.com", 9443, null, "abc", false, parameters, "", null,
-                        "https://www.wso2.com:9443/samlsso?key1%3Dv%26key2%3Dv%26key3%3Dv%26key4%3Dv", "/samlsso/"},
+                        "https://www.wso2.com:9443/samlsso?key1=v&key2=v&key3=v&key4=v", "/samlsso/"},
                 {"https", "www.wso2.com", 9443, "proxyContext/", "abc", true, null, "fragment", fragmentParams,
                         "https://www.wso2.com:9443/proxyContext/t/abc/samlsso#fragment", "/samlsso"},
                 {"https", "www.wso2.com", 9443, "/proxyContext", "abc", true, null, "", null,
@@ -281,12 +281,11 @@ public class DefaultServiceURLBuilderTest {
                 {"https", "www.wso2.com", 9443, "", "", true, null, "fragment", fragmentParams,
                         "https://www.wso2.com:9443/samlsso#fragment", "samlsso/"},
                 {"https", "www.wso2.com", 9443, "", "", true, parameters, "", fragmentParams,
-                        "https://www.wso2.com:9443?key1%3Dv%26key2%3Dv%26key3%3Dv%26key4%3Dv#key1" +
-                                "%3Dfragment%26key2%3Dfragment%26key3%3Dfragment%26key4%3Dfragment",
-                        null},
+                        "https://www.wso2.com:9443?key1=v&key2=v&key3=v&key4=v#key1=fragment&key2=fragment&key3" +
+                                "=fragment&key4=fragment", null},
                 {"https", "www.wso2.com", 9443, "/proxyContext", "", false, null, "", fragmentParams,
-                        "https://www.wso2.com:9443/proxyContext#key1%3Dfragment%26key2%3Dfragment%26key3%3Dfragment" +
-                                "%26key4%3Dfragment", null}
+                        "https://www.wso2.com:9443/proxyContext#key1=fragment&key2=fragment&key3=fragment&key4" +
+                                "=fragment", null}
         };
     }
 


### PR DESCRIPTION

This PR fixes the issue where DefaultServiceURLBuilder unncessarily encoding the query param string of a URL. As a result URL is getting as :
https://localhost:9443/samlsso?sessionDataKey%3Dac584d70-8453-426c-945c-8d8b097387da

Expected one should be  :
https://localhost:9443/samlsso?sessionDataKey=ac584d70-8453-426c-945c-8d8b097387da