### PR TITLE
Revert "Tenant qualify /identity endpoint"

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
@@ -45,8 +45,6 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Commo
 import org.wso2.carbon.identity.application.authentication.framework.store.UserSessionStore;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
-import org.wso2.carbon.identity.core.ServiceURLBuilder;
-import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 
 import java.io.IOException;
@@ -207,13 +205,7 @@ public class DefaultLogoutRequestHandler implements LogoutRequestHandler {
         // attributes
         request.setAttribute(FrameworkConstants.ResponseParams.LOGGED_OUT, isLoggedOut);
 
-        String redirectURL = null;
-        ServiceURLBuilder serviceURLBuilder = ServiceURLBuilder.create();
-        if (FrameworkUtils.isAbsoluteURI(context.getCallerPath())) {
-            redirectURL = context.getCallerPath();
-        } else {
-            serviceURLBuilder = serviceURLBuilder.addPath(context.getCallerPath());
-        }
+        String redirectURL;
 
         if(context.getCallerSessionKey() != null) {
             request.setAttribute(FrameworkConstants.SESSION_DATA_KEY, context.getCallerSessionKey());
@@ -234,20 +226,12 @@ public class DefaultLogoutRequestHandler implements LogoutRequestHandler {
             } else {
                 FrameworkUtils.addAuthenticationResultToCache(context.getCallerSessionKey(), authenticationResult);
             }
-            if (FrameworkUtils.isAbsoluteURI(context.getCallerPath())) {
-                String sessionDataKeyParam = FrameworkConstants.SESSION_DATA_KEY + "=" +
-                        URLEncoder.encode(context.getCallerSessionKey(), "UTF-8");
-                redirectURL = FrameworkUtils.appendQueryParamsStringToUrl(context.getCallerPath(), sessionDataKeyParam);
 
-            } else {
-                serviceURLBuilder.addParameter(FrameworkConstants.SESSION_DATA_KEY, URLEncoder.encode(context
-                        .getCallerSessionKey(), "UTF-8"));
-                try {
-                    redirectURL = serviceURLBuilder.build().getAbsolutePublicURL();
-                } catch (URLBuilderException e) {
-                    throw new ServletException(e.getMessage(), e);
-                }
-            }
+            String sessionDataKeyParam = FrameworkConstants.SESSION_DATA_KEY + "=" +
+                    URLEncoder.encode(context.getCallerSessionKey(), "UTF-8");
+            redirectURL = FrameworkUtils.appendQueryParamsStringToUrl(context.getCallerPath(), sessionDataKeyParam);
+        } else {
+            redirectURL = context.getCallerPath();
         }
 
         /*

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityProcessor.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityProcessor.java
@@ -28,8 +28,6 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationResult;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
-import org.wso2.carbon.identity.core.ServiceURLBuilder;
-import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.handler.AbstractIdentityHandler;
 import org.wso2.carbon.identity.core.handler.InitConfig;
 import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
@@ -182,13 +180,7 @@ public abstract class IdentityProcessor extends AbstractIdentityHandler {
         responseBuilder.setRelyingParty(getRelyingPartyId(context));
         //type parameter is using since framework checking it, but future it'll use AUTH_NAME
         responseBuilder.setAuthType(getType(context));
-        String commonAuthURL;
-        try {
-            ServiceURLBuilder serviceURLBuilder = ServiceURLBuilder.create().addPath(FrameworkConstants.COMMONAUTH);
-            commonAuthURL = serviceURLBuilder.build().getAbsolutePublicURL();
-        } catch (URLBuilderException e) {
-            throw new RuntimeException("Error occurred when building URL.", e);
-        }
+        String commonAuthURL = IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, true, true);
         responseBuilder.setRedirectURL(commonAuthURL);
         return responseBuilder;
     }
@@ -237,13 +229,8 @@ public abstract class IdentityProcessor extends AbstractIdentityHandler {
         responseBuilder.setCallbackPath(getCallbackPath(context));
         responseBuilder.setRelyingParty(getRelyingPartyId(context));
         //type parameter is using since framework checking it, but future it'll use AUTH_NAME
-        String commonAuthURL;
-        try {
-            ServiceURLBuilder serviceURLBuilder = ServiceURLBuilder.create().addPath(FrameworkConstants.COMMONAUTH);
-            commonAuthURL = serviceURLBuilder.build().getAbsolutePublicURL();
-        } catch (URLBuilderException e) {
-            throw new RuntimeException("Error occurred when building URL.", e);
-        }
+        responseBuilder.setAuthType(getType(context));
+        String commonAuthURL = IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, true, true);
         responseBuilder.setRedirectURL(commonAuthURL);
         return responseBuilder;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -120,7 +120,6 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -2573,22 +2572,5 @@ public class FrameworkUtils {
 
         // If config is empty or not a boolean value, the property must be set to the default value which is true.
         return !Boolean.FALSE.toString().equalsIgnoreCase(continueOnClaimHandlingErrorValue);
-    }
-
-    public static boolean isAbsoluteURI(String uri) {
-
-        if (StringUtils.isBlank(uri)) {
-            if (log.isDebugEnabled()) {
-                log.debug("URI is empty.");
-            }
-            return false;
-        }
-
-        try {
-            final URI uriObj = new URI(uri);
-            return uriObj.isAbsolute();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException("Unable to process the URI :" + uri, e);
-        }
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandlerTest.java
@@ -47,9 +47,6 @@ import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthent
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
-import org.wso2.carbon.identity.core.ServiceURL;
-import org.wso2.carbon.identity.core.ServiceURLBuilder;
-import org.wso2.carbon.identity.core.internal.DefaultServiceURLBuilder;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -73,7 +70,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-@PrepareForTest({FrameworkUtils.class, ServiceURLBuilder.class})
+@PrepareForTest(FrameworkUtils.class)
 @WithCarbonHome
 public class DefaultAuthenticationRequestHandlerTest {
 
@@ -84,12 +81,6 @@ public class DefaultAuthenticationRequestHandlerTest {
     HttpServletResponse response;
 
     DefaultAuthenticationRequestHandler authenticationRequestHandler;
-
-    @Mock
-    DefaultServiceURLBuilder serviceURLBuilder;
-
-    @Mock
-    ServiceURL serviceURL;
 
     @ObjectFactory
     public IObjectFactory getObjectFactory() {
@@ -102,10 +93,6 @@ public class DefaultAuthenticationRequestHandlerTest {
 
         initMocks(this);
         authenticationRequestHandler = new DefaultAuthenticationRequestHandler();
-        mockStatic(ServiceURLBuilder.class);
-        when(ServiceURLBuilder.create()).thenReturn(serviceURLBuilder);
-        when(serviceURLBuilder.addPath(anyString())).thenReturn(serviceURLBuilder);
-        when(serviceURLBuilder.build()).thenReturn(serviceURL);
     }
 
     @AfterMethod
@@ -256,7 +243,7 @@ public class DefaultAuthenticationRequestHandlerTest {
 
         DefaultAuthenticationRequestHandler requestHandler = spy(new DefaultAuthenticationRequestHandler());
         doNothing().when(requestHandler).populateErrorInformation(request, response, context);
-        when(serviceURL.getAbsolutePublicURL()).thenReturn(expectedRedirectUrl);
+
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         requestHandler.sendResponse(request, response, context);
         verify(response).sendRedirect(captor.capture());
@@ -350,7 +337,6 @@ public class DefaultAuthenticationRequestHandlerTest {
         when(request.getCookies()).thenReturn(cookies);
         when(FrameworkUtils.getCookie(any(HttpServletRequest.class), anyString())).thenReturn
                 (cookies[0]);
-        when(FrameworkUtils.isAbsoluteURI(anyString())).thenReturn(true);
         authenticationRequestHandler.handle(request, response, context);
         assertTrue(Boolean.parseBoolean(context.getProperty(
                 FrameworkConstants.POST_AUTHENTICATION_EXTENSION_COMPLETED).toString()));


### PR DESCRIPTION
Reverts wso2/carbon-identity-framework#2995

Reverting since we decided to change the approach for tenant qualifying /identity endpoint.