### PR TITLE
fix null pointer exception when the DATA_MAP is not initialized

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
@@ -588,8 +588,12 @@ public class AuthenticationContext extends MessageContext implements Serializabl
      */
     public Serializable getAnalyticsData(String key) {
 
-        Map<String, Serializable> analyticsData =
-                (HashMap<String, Serializable>) this.getParameter(FrameworkConstants.AnalyticsData.DATA_MAP);
-        return analyticsData.get(key);
+        if (this.getParameters().containsKey(FrameworkConstants.AnalyticsData.DATA_MAP)) {
+            Map<String, Serializable> analyticsData =
+                    (HashMap<String, Serializable>) this.getParameter(FrameworkConstants.AnalyticsData.DATA_MAP);
+            return analyticsData.get(key);
+        } else {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Resolves: wso2/product-is#9076

Fix includes :
Check for the Null pointer scenario on the Data map in the context.