### PR TITLE
Introduce new claim to store the mutability of user

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -712,6 +712,14 @@
 				<AttributeID>isLiteUser</AttributeID>
 				<Description>Claim to store if this is a lite user account.</Description>
 			</Claim>
+			<Claim>
+				<ClaimURI>http://wso2.org/claims/identity/isReadOnlyUser</ClaimURI>
+				<DisplayName>Read Only User</DisplayName>
+				<!-- If user store based identity store is used, a proper mapped attribute
+				in your user store must be configured for this. -->
+				<AttributeID>isReadOnlyUser</AttributeID>
+				<Description>Claim to store if the user is read only</Description>
+			</Claim>
 		</Dialect>
 
 		<Dialect dialectURI="http://schemas.xmlsoap.org/ws/2005/05/identity">
@@ -2485,6 +2493,16 @@
 				<DisplayOrder>1</DisplayOrder>
 				<SupportedByDefault />
 				<MappedLocalClaim>http://wso2.org/claims/dob</MappedLocalClaim>
+			</Claim>
+			<Claim>
+				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:isReadOnlyUser</ClaimURI>
+				<DisplayName>Read Only User</DisplayName>
+				<AttributeID>isReadOnlyUser</AttributeID>
+				<Description>Claim to store if the user is read only</Description>
+				<Required />
+				<DisplayOrder>1</DisplayOrder>
+				<SupportedByDefault />
+				<MappedLocalClaim>http://wso2.org/claims/identity/isReadOnlyUser</MappedLocalClaim>
 			</Claim>
 		</Dialect>
 		<Dialect dialectURI="http://eidas.europa.eu/attributes/naturalperson">


### PR DESCRIPTION
Fixes wso2/product-is#6101

This PR introduces a new claim `http://wso2.org/claims/identity/isReadOnlyUser` to the WSO2 claim dialect to indicates whether the user is from a read-only user-store or not. If the user-store is read-only, the value of this claim is set as _True_.

This PR also introduces a new SCIM attribute to the SCIM2.0 enterprise user schema. The claim URI is `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:isReadOnlyUser` and it is mapped to the above mentioned WSO2 claim. The SCIM attribute is defined to be returned only when it is requested.

Related PRs: https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/273