### PR TITLE
Change default values of API deprecation config

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -551,11 +551,11 @@
     {
       "id": "oauth",
       "version": "1.0",
-      "enable": true
+      "enable": false
     },
     {
       "id": "identity/connect/dcr",
-      "enable": true
+      "enable": false
     }
   ],
 


### PR DESCRIPTION
### Proposed changes in this pull request
Set default value of API deprecation config to false as "identity/connect/dcr" and "oauth" APIs are disabled by default. To enable add the following configs to deployment.toml.
```
[[legacy_feature]]
id = "identity/connect/dcr"
enable = true

[[legacy_feature]]
id = "oauth"
version = "1.0"
enable = true
```

### Related PR
https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1407