### PR TITLE
Add new config for password reset with challenge questions feature.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -796,6 +796,7 @@
                 <Forced>
                     <Enable>false</Enable>
                 </Forced>
+                <SkipOnInsufficientAnswers>true</SkipOnInsufficientAnswers>
             </Password>
             <Answer>
                 <Regex>.*</Regex>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -975,6 +975,7 @@
                 <Forced>
                     <Enable>{{identity_mgt.forced_challenge_questions.enable_forced_challenge_questions}}</Enable>
                 </Forced>
+                <SkipOnInsufficientAnswers>{{identity_mgt.password_reset_challenge_questions.skip_on_insufficient_answers}}</SkipOnInsufficientAnswers>
             </Password>
             <Answer>
                 <Regex>{{identity_mgt.password_reset_challenge_questions.answer_regex}}</Regex>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -271,6 +271,7 @@
   "identity_mgt.recovery.challenge_question.answer_regex": ".*",
   "identity_mgt.recovery.challenge_question.enforce_answer_uniqueness": false,
   "identity_mgt.password_reset_challenge_questions.question_separator": "!",
+  "identity_mgt.password_reset_challenge_questions.skip_on_insufficient_answers": true,
 
   "identity_mgt.forced_challenge_questions.enable_forced_challenge_questions": false,
   "identity_mgt.challenge_questions.min_required_answers": "",


### PR DESCRIPTION
Issue: https://github.com/wso2/product-is/issues/8905

The improvement done with PR [1] will be enabled by default in the product. The config is introduced if anyone wishes to have the old behaviour.

[1] https://github.com/wso2-extensions/identity-governance/pull/405