### PR TITLE
Add support for defining IDP Issuer Name for federated IDPs

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
@@ -92,6 +92,8 @@ public class IdentityApplicationConstants {
     public static final String TEMPLATE_ID_SP_PROPERTY_NAME = "templateId";
     public static final String TEMPLATE_ID_SP_PROPERTY_DISPLAY_NAME = "Template Id";
 
+    public static final String IDP_ISSUER_NAME = "idpIssuerName";
+
     /**
      * Config elements.
      */

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/java/org/wso2/carbon/idp/mgt/ui/util/IdPManagementUIUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/java/org/wso2/carbon/idp/mgt/ui/util/IdPManagementUIUtil.java
@@ -964,6 +964,15 @@ public class IdPManagementUIUtil {
             jwksProperty.setDisplayName("Identity Provider's JWKS Endpoint");
             fedIdp.addIdpProperties(jwksProperty);
         }
+
+        // Set idpIssuerName of the identity provider.
+        String idpIssuerName = paramMap.get(IdentityApplicationConstants.IDP_ISSUER_NAME);
+        if (StringUtils.isNotBlank(idpIssuerName)) {
+            IdentityProviderProperty idpIssuerNameProperty = new IdentityProviderProperty();
+            idpIssuerNameProperty.setName(IdentityApplicationConstants.IDP_ISSUER_NAME);
+            idpIssuerNameProperty.setValue(idpIssuerName);
+            fedIdp.addIdpProperties(idpIssuerNameProperty);
+        }
     }
 
     private static String handleCertificateDeletion(String oldCertificateValues, String deletedCertificateValues) {

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/org/wso2/carbon/idp/mgt/ui/i18n/Resources.properties
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/org/wso2/carbon/idp/mgt/ui/i18n/Resources.properties
@@ -426,4 +426,6 @@ idp.search.pattern=Enter Identity Provider pattern (* for all)
 identity.provider.search=search
 enter.identity.provider.name.pattern=Enter Identity provider name pattern (* for all)
 error.while.reading.app.info=Error while reading identity providers
+idp.issuer.name=Identity Provider's Issuer Name
+idp.issuer.name.help=If the issuer name is different from the Identity Provider Name specify it
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit.jsp
@@ -76,6 +76,7 @@
     HashMap<String, String> certificateWithRawIdMap = new HashMap<String, String>();
     String jwksUri = null;
     boolean hasJWKSUri = false;
+    String idpIssuerName = null;
     Claim[] identityProviderClaims = null;
     String userIdClaimURI = null;
     String roleClaimURI = null;
@@ -261,6 +262,9 @@
                 if (IdPManagementUIUtil.JWKS_URI.equals(idpProperty.getName())) {
                     hasJWKSUri = true;
                     jwksUri = idpProperty.getValue();
+                }
+                if (IdentityApplicationConstants.IDP_ISSUER_NAME.equals(idpProperty.getName())) {
+                    idpIssuerName = idpProperty.getValue();
                 }
             }
         }
@@ -807,6 +811,10 @@
 
     if (jwksUri == null) {
         jwksUri = "";
+    }
+    
+    if (idpIssuerName == null) {
+        idpIssuerName = "";
     }
 
     if (idpDisplayName == null) {
@@ -3248,7 +3256,18 @@
                                 </div>
                             </td>
                         </tr>
-
+    
+                        <tr>
+                            <td class="leftCol-med labelField"><fmt:message key='idp.issuer.name'/>:</td>
+                            <td>
+                                <input id="idpIssuerName" name="idpIssuerName" type="text"
+                                       value="<%=Encode.forHtmlAttribute(idpIssuerName)%>" autofocus/>
+            
+                                <div class="sectionHelp">
+                                    <fmt:message key='idp.issuer.name.help'/>
+                                </div>
+                            </td>
+                        </tr>
                     </table>
                 </div>
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdpManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdpManager.java
@@ -460,4 +460,22 @@ public interface IdpManager {
         return null;
     }
 
+    /**
+     * Retrieves the first matching IDP for the given metadata property.
+     * Intended to ony be used to retrieve IDP based on a unique metadata property.
+     *
+     * @param property     IDP metadata property name.
+     * @param value        Value associated with given Property.
+     * @param tenantDomain Tenant domain whose information is requested.
+     * @param ignoreFileBasedIdps Whether to ignore file based idps or not.
+     * @return <code>IdentityProvider</code> Identity Provider information.
+     * @throws IdentityProviderManagementException Error when getting Identity Provider
+     *                                                information by IdP name.
+     */
+    default IdentityProvider getIdPByMetadataProperty(String property, String value, String tenantDomain,
+                                                      boolean ignoreFileBasedIdps)
+            throws IdentityProviderManagementException {
+
+        return null;
+    }
 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/cache/IdPCacheByMetadataProperty.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/cache/IdPCacheByMetadataProperty.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.idp.mgt.cache;
+
+import org.wso2.carbon.identity.application.common.cache.BaseCache;
+import org.wso2.carbon.utils.CarbonUtils;
+
+/**
+ * IDP name cache by IDP metadata.
+ */
+public class IdPCacheByMetadataProperty extends BaseCache<IdPMetadataPropertyCacheKey, String> {
+
+    private static final String CACHE_NAME = "IdPCacheByMetadataProperty";
+
+    private static final IdPCacheByMetadataProperty instance = new IdPCacheByMetadataProperty();
+
+    private IdPCacheByMetadataProperty() {
+        super(CACHE_NAME);
+    }
+
+    public static IdPCacheByMetadataProperty getInstance() {
+
+        CarbonUtils.checkSecurity();
+        return instance;
+    }
+}

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/cache/IdPMetadataPropertyCacheKey.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/cache/IdPMetadataPropertyCacheKey.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.idp.mgt.cache;
+
+import org.wso2.carbon.identity.application.common.cache.CacheKey;
+
+/**
+ * Cache key for IDP metadata property.
+ * Used to cache IDP name against a IDP metadata property.
+ */
+public class IdPMetadataPropertyCacheKey extends CacheKey {
+
+    private static final long serialVersionUID = 5800275605577468290L;
+
+    private String name;
+    private String value;
+
+    public IdPMetadataPropertyCacheKey(String name, String value, String tenantDomain) {
+        this.name = name;
+        this.value = value;
+        this.tenantDomain = tenantDomain.toLowerCase();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        IdPMetadataPropertyCacheKey that = (IdPMetadataPropertyCacheKey) o;
+
+        if (!name.equals(that.name)) {
+            return false;
+        }
+        if (!tenantDomain.equals(that.tenantDomain)) {
+            return false;
+        }
+        if (!value.equals(that.value)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + name.hashCode();
+        result = 31 * result + value.hashCode();
+        result = 31 * result + tenantDomain.hashCode();
+        return result;
+    }
+}

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/FileBasedIdPMgtDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/FileBasedIdPMgtDAO.java
@@ -18,8 +18,10 @@
 
 package org.wso2.carbon.idp.mgt.dao;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.IdentityProviderProperty;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
@@ -97,4 +99,27 @@ public class FileBasedIdPMgtDAO {
         return null;
     }
 
+    /**
+     * Retrieves the first matching IDP for the given metadata property.
+     * Intended to ony be used to retrieve IDP name based on a unique metadata property.
+     *
+     * @param property IDP metadata property name.
+     * @param value Value associated with given Property.
+     * @return Identity Provider name.
+     */
+    public String getIdPNameByMetadataProperty(String property, String value) {
+
+        Map<String, IdentityProvider> identityProviders = IdPManagementServiceComponent.getFileBasedIdPs();
+        for (Entry<String, IdentityProvider> entry : identityProviders.entrySet()) {
+            IdentityProviderProperty[] identityProviderProperties = entry.getValue().getIdpProperties();
+            if (!ArrayUtils.isEmpty(identityProviderProperties)) {
+                for (IdentityProviderProperty prop : identityProviderProperties) {
+                    if (prop != null && property.equals(prop.getName()) && value.equals(prop.getValue())) {
+                        return entry.getValue().getIdentityProviderName();
+                    }
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -3956,4 +3956,51 @@ public class IdPManagementDAO {
         }
         return propertiesFromConnectors;
     }
+
+    /**
+     * Retrieves the first matching IDP for the given metadata property.
+     * Intended to ony be used to retrieve IDP name based on a unique metadata property.
+     *
+     * @param dbConnection Optional. DB connection.
+     * @param property IDP metadata property name.
+     * @param value Value associated with given Property.
+     * @param tenantId Tenant id whose information is requested.
+     * @return Identity Provider name.
+     * @throws IdentityProviderManagementException IdentityProviderManagementException.
+     */
+    public String getIdPNameByMetadataProperty(Connection dbConnection, String property, String value, int tenantId)
+            throws IdentityProviderManagementException {
+
+        PreparedStatement prepStmt = null;
+        ResultSet rs = null;
+        boolean dbConnectionInitialized = true;
+        if (dbConnection == null) {
+            dbConnection = IdentityDatabaseUtil.getDBConnection(false);
+        } else {
+            dbConnectionInitialized = false;
+        }
+        try {
+            String sqlStmt = IdPManagementConstants.SQLQueries.GET_IDP_NAME_BY_METADATA;
+            prepStmt = dbConnection.prepareStatement(sqlStmt);
+            prepStmt.setString(1, property);
+            prepStmt.setString(2, value);
+            prepStmt.setInt(3, tenantId);
+            rs = prepStmt.executeQuery();
+            String idPName = null;
+
+            if (rs.next()) {
+                idPName = rs.getString(1);
+            }
+            return idPName;
+        } catch (SQLException e) {
+            throw new IdentityProviderManagementException("Error occurred while retrieving Identity Provider " +
+                    "information for IDP metadata property name: " + property + " value: " + value, e);
+        } finally {
+            if (dbConnectionInitialized) {
+                IdentityDatabaseUtil.closeAllConnections(dbConnection, rs, prepStmt);
+            } else {
+                IdentityDatabaseUtil.closeAllConnections(null, rs, prepStmt);
+            }
+        }
+    }
 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
@@ -409,6 +409,9 @@ public class IdPManagementConstants {
                 " ID FROM IDP WHERE UUID = ?)) UNION SELECT SP_APP.UUID FROM SP_PROVISIONING_CONNECTOR INNER JOIN " +
                 "SP_APP ON SP_PROVISIONING_CONNECTOR.APP_ID = SP_APP.ID INNER JOIN IDP ON IDP_NAME = IDP.NAME WHERE " +
                 "IDP.UUID = ?) APP";
+        public static final String GET_IDP_NAME_BY_METADATA = "SELECT IDP.NAME FROM IDP INNER JOIN IDP_METADATA ON " +
+                "IDP.ID = IDP_METADATA.IDP_ID WHERE IDP_METADATA.NAME = ? AND IDP_METADATA.VALUE = ? AND " +
+                "IDP_METADATA.TENANT_ID = ?";
     }
 
     public enum ErrorMessage {


### PR DESCRIPTION
Provides the needed capability to resolve https://github.com/wso2/product-is/issues/4672

This PR adds a new property to the Identity Provider configuration name "**Identity Provider's Issuer Name**". This is an optional property which can be used mentioned the IDP Issuer Name when it is different from the IDP Name.

The property gets updated in the IDP_METADATA table.

<img width="871" alt="Screen Shot 2020-08-14 at 9 00 32 AM" src="https://user-images.githubusercontent.com/11583571/90221404-cb0dee00-de27-11ea-89c8-f4f83fda5db6.png">

Soap API property
```
 <xsd:idpProperties>
         <xsd:name>idpIssuerName</xsd:name>
         <xsd:value>https://www.idp.com</xsd:value>
</xsd:idpProperties>
```
