### PR TITLE
Support SMS OTP pattern and length configurable in account recovery

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -778,6 +778,9 @@
         <Notification>
             <Password>
                 <Enable>false</Enable>
+                <smsOtp>
+                    <Regex>[a-zA-Z0-9]{6}</Regex>
+                </smsOtp>
             </Password>
             <Username>
                 <Enable>false</Enable>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -957,6 +957,9 @@
                 <ExpiryTime>
                     <smsOtp>{{identity_mgt.password_reset_sms.sms_otp_validity}}</smsOtp>
                 </ExpiryTime>
+                <smsOtp>
+                    <Regex>{{identity_mgt.password_reset_sms.sms_otp_regex}}</Regex>
+                </smsOtp>
             </Password>
             <Username>
                 <Enable>{{identity_mgt.username_recovery.email.enable_username_recovery}}</Enable>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -258,6 +258,7 @@
   "identity_mgt.endpoint.enable_self_signup_endpoint": true,
   "identity_mgt.password_reset_email.enable_password_reset_email": false,
   "identity_mgt.password_reset_sms.sms_otp_validity": "1m",
+  "identity_mgt.password_reset_sms.sms_otp_regex": "[a-zA-Z0-9]{6}",
   "identity_mgt.password_reset_email.enable_recaptcha": false,
   "identity_mgt.password_reset_email.reset_mail_validity": "$ref{identity_mgt.default_mail_validity_period}",
   "identity_mgt.notification_channel_recovery.recovery_code_validity": "1m",


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9087
Depends on https://github.com/wso2-extensions/identity-governance/pull/415

This PR is to introduce the toml configurations for the configurable SMS OTP pattern and length for account recovery.