### PR TITLE
Trigger SESSION_EXPIRE event when a timed out session is found

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.TransientObjectWrapper;
+import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.JsFailureException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.MisconfigurationException;
@@ -641,13 +642,15 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
             }
 
             String sessionContextKey = DigestUtils.sha256Hex(cookie.getValue());
-            SessionContext sessionContext;
+            SessionContext sessionContext = null;
             // get the authentication details from the cache
             try {
                 //Starting tenant-flow as tenant domain is retrieved downstream from the carbon-context to get the
                 // tenant wise session expiry time
                 FrameworkUtils.startTenantFlow(context.getTenantDomain());
-                sessionContext = FrameworkUtils.getSessionContextFromCache(sessionContextKey);
+                sessionContext = FrameworkUtils.getSessionContextFromCache(request, context, sessionContextKey);
+            } catch (AuthenticationFailedException e) {
+                log.error("Error in finding the previous authenticated session.", e);
             } finally {
                 FrameworkUtils.endTenantFlow();
             }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -34,7 +34,6 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.TransientObjectWrapper;
-import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.JsFailureException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.MisconfigurationException;
@@ -649,8 +648,6 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                 // tenant wise session expiry time
                 FrameworkUtils.startTenantFlow(context.getTenantDomain());
                 sessionContext = FrameworkUtils.getSessionContextFromCache(request, context, sessionContextKey);
-            } catch (AuthenticationFailedException e) {
-                log.error("Error in finding the previous authenticated session.", e);
             } finally {
                 FrameworkUtils.endTenantFlow();
             }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -56,6 +56,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.SerializableJsFunction;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.InvalidCredentialsException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
@@ -101,6 +102,10 @@ import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
@@ -949,6 +954,79 @@ public class FrameworkUtils {
             }
         }
         return sessionContext;
+    }
+
+    /**
+     * Retrieve session context from the session cache.
+     *
+     * @param request           HttpServletRequest.
+     * @param context           Authentication context.
+     * @param sessionContextKey Session context key.
+     * @return Session context key.
+     * @throws AuthenticationFailedException Error in triggering session expire event.
+     */
+    public static SessionContext getSessionContextFromCache(HttpServletRequest request, AuthenticationContext context
+            , String sessionContextKey) throws AuthenticationFailedException {
+
+        SessionContext sessionContext = null;
+        if (StringUtils.isNotBlank(sessionContextKey)) {
+            SessionContextCacheKey cacheKey = new SessionContextCacheKey(sessionContextKey);
+            SessionContextCache sessionContextCache = SessionContextCache.getInstance();
+            SessionContextCacheEntry cacheEntry = sessionContextCache.getSessionContextCacheEntry(cacheKey);
+
+            if (cacheEntry != null) {
+                sessionContext = cacheEntry.getContext();
+                boolean isSessionExpired = sessionContextCache.isSessionExpired(cacheKey, cacheEntry);
+                if (isSessionExpired) {
+                    triggerSessionExpireEvent(request, context, sessionContext);
+                    if (log.isDebugEnabled()) {
+                        log.debug("A SESSION_EXPIRE event was fired for the expired session found corresponding " +
+                                "to the key: " + cacheKey.getContextId());
+                    }
+                    return null;
+                }
+            }
+        }
+        return sessionContext;
+    }
+
+    /**
+     * Trigger SESSION_EXPIRE event on session expiry due to a session idle timeout or a remember me session time out.
+     *
+     * @param request        HttpServletRequest.
+     * @param context        Authentication context.
+     * @param sessionContext Session context.
+     * @throws AuthenticationFailedException Error in triggering the session expiry event.
+     */
+    private static void triggerSessionExpireEvent(HttpServletRequest request, AuthenticationContext context,
+                                                  SessionContext sessionContext) throws AuthenticationFailedException {
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        if (sessionContext != null) {
+            Object authenticatedUserObj = sessionContext.getProperty(FrameworkConstants.AUTHENTICATED_USER);
+            if (authenticatedUserObj instanceof AuthenticatedUser) {
+                authenticatedUser = (AuthenticatedUser) authenticatedUserObj;
+            }
+            context.setSubject(authenticatedUser);
+
+            IdentityEventService eventService = FrameworkServiceDataHolder.getInstance().getIdentityEventService();
+            try {
+                Map<String, Object> eventProperties = new HashMap<>();
+                eventProperties.put(IdentityEventConstants.EventProperty.REQUEST, request);
+                eventProperties.put(IdentityEventConstants.EventProperty.CONTEXT, context);
+                eventProperties.put(IdentityEventConstants.EventProperty.SESSION_CONTEXT, sessionContext);
+                Map<String, Object> paramMap = new HashMap<>();
+                paramMap.put(FrameworkConstants.AnalyticsAttributes.USER, authenticatedUser);
+                paramMap.put(FrameworkConstants.AnalyticsAttributes.SESSION_ID, context.getSessionIdentifier());
+                Map<String, Object> unmodifiableParamMap = Collections.unmodifiableMap(paramMap);
+                eventProperties.put(IdentityEventConstants.EventProperty.PARAMS, unmodifiableParamMap);
+
+                Event event = new Event(IdentityEventConstants.EventName.SESSION_EXPIRE.name(), eventProperties);
+                eventService.handleEvent(event);
+            } catch (IdentityEventException e) {
+                throw new AuthenticationFailedException("Error in triggering the session expire event.", e);
+            }
+        }
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -56,7 +56,6 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.SerializableJsFunction;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
-import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.InvalidCredentialsException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
@@ -963,10 +962,10 @@ public class FrameworkUtils {
      * @param context           Authentication context.
      * @param sessionContextKey Session context key.
      * @return Session context key.
-     * @throws AuthenticationFailedException Error in triggering session expire event.
+     * @throws FrameworkException Error in triggering session expire event.
      */
     public static SessionContext getSessionContextFromCache(HttpServletRequest request, AuthenticationContext context
-            , String sessionContextKey) throws AuthenticationFailedException {
+            , String sessionContextKey) throws FrameworkException {
 
         SessionContext sessionContext = null;
         if (StringUtils.isNotBlank(sessionContextKey)) {
@@ -996,10 +995,10 @@ public class FrameworkUtils {
      * @param request        HttpServletRequest.
      * @param context        Authentication context.
      * @param sessionContext Session context.
-     * @throws AuthenticationFailedException Error in triggering the session expiry event.
+     * @throws FrameworkException Error in triggering the session expiry event.
      */
     private static void triggerSessionExpireEvent(HttpServletRequest request, AuthenticationContext context,
-                                                  SessionContext sessionContext) throws AuthenticationFailedException {
+                                                  SessionContext sessionContext) throws FrameworkException {
 
         AuthenticatedUser authenticatedUser = new AuthenticatedUser();
         if (sessionContext != null) {
@@ -1024,7 +1023,8 @@ public class FrameworkUtils {
                 Event event = new Event(IdentityEventConstants.EventName.SESSION_EXPIRE.name(), eventProperties);
                 eventService.handleEvent(event);
             } catch (IdentityEventException e) {
-                throw new AuthenticationFailedException("Error in triggering the session expire event.", e);
+                throw new FrameworkException("Error in triggering session expire event for the session: " +
+                        context.getSessionIdentifier() + " of user: " + authenticatedUser.toFullQualifiedUsername(), e);
             }
         }
     }

--- a/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
@@ -154,7 +154,8 @@ public class IdentityEventConstants {
         AUTHENTICATION_FAILURE,
         SESSION_CREATE,
         SESSION_UPDATE,
-        SESSION_TERMINATE
+        SESSION_TERMINATE,
+        SESSION_EXPIRE
     }
 
     public class EventProperty {

--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -140,7 +140,8 @@
   "identity_mgt.events.schemes.TokenBindingExpiryEventHandler.properties.enable": true,
   "identity_mgt.events.schemes.TokenBindingExpiryEventHandler.module_index": "24",
   "identity_mgt.events.schemes.TokenBindingExpiryEventHandler.subscriptions": [
-    "SESSION_TERMINATE"
+    "SESSION_TERMINATE",
+    "SESSION_EXPIRE"
   ],
   "identity_mgt.events.schemes.'default.notification.sender'.properties.'subscription.TRIGGER_SMS_NOTIFICATION.stream'":"id_gov_sms_notify_stream:1.0.0",
   "identity_mgt.events.schemes.'default.notification.sender'.properties.'subscription.TRIGGER_SMS_NOTIFICATION.claim.mobile'":"http://wso2.org/claims/mobile",


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9312

**Description**
With this PR a SESSION_EXPIRE event is fired for a session expiry due to session idle time out or timed out remember-me session. An expired session can be found if a user tries to SSO, log in again or tries to logout from an application after an idle time out. 