### PR TITLE
Improve TokenPersistenceProcessor configuration template

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -239,7 +239,11 @@
         {% if oauth.extensions.token_persistence_processor is defined %}
         <TokenPersistenceProcessor>{{oauth.extensions.token_persistence_processor}}</TokenPersistenceProcessor>
         {% else %}
+        {% if oauth.hash_tokens_and_secrets is sameas true %}
+        <TokenPersistenceProcessor>org.wso2.carbon.identity.oauth.tokenprocessor.HashingPersistenceProcessor</TokenPersistenceProcessor>
+        {% else %}
         <TokenPersistenceProcessor>org.wso2.carbon.identity.oauth.tokenprocessor.PlainTextPersistenceProcessor</TokenPersistenceProcessor>
+        {% endif %}
         {% endif %}
 
         <HashAlgorithm>{{oauth.hash_token_algorithm}}</HashAlgorithm>


### PR DESCRIPTION
### Proposed changes in this pull request

Change configuration template for TokenPersistenceProcessor in the identity.xml.j2 to 

- If defined in the deployment.toml, use the configured value.
- if NOT defined in the deployment.toml and if token encryption is enabled, then use `org.wso2.carbon.identity.oauth.tokenprocessor. HashingPersistenceProcessor `
- if NOT defined in the deployment.toml and if token encryption is NOT enabled, then use `org.wso2.carbon.identity.oauth.tokenprocessor.PlainTextPersistenceProcessor`

Fix : https://github.com/wso2/product-is/issues/9307