### PR TITLE
Update Yahoo UserInfo Endpoint

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
@@ -60,7 +60,10 @@ public class IdentityApplicationConstants {
 
     public static final String YAHOO_OAUTH2_URL = "https://api.login.yahoo.com/oauth2/request_auth";
     public static final String YAHOO_TOKEN_URL = "https://api.login.yahoo.com/oauth2/get_token";
+    @Deprecated
+    /** @deprecated Please use {@link #YAHOO_OPENID_CONNECT_USERINFO_URL instead. */
     public static final String YAHOO_USERINFO_URL = "https://social.yahooapis.com/v1/user/";
+    public static final String YAHOO_OPENID_CONNECT_USERINFO_URL = "https://api.login.yahoo.com/openid/v1/userinfo";
 
     public static final String SESSION_IDLE_TIME_OUT = "SessionIdleTimeout";
     public static final String REMEMBER_ME_TIME_OUT = "RememberMeTimeout";

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
@@ -61,7 +61,7 @@ public class IdentityApplicationConstants {
     public static final String YAHOO_OAUTH2_URL = "https://api.login.yahoo.com/oauth2/request_auth";
     public static final String YAHOO_TOKEN_URL = "https://api.login.yahoo.com/oauth2/get_token";
     @Deprecated
-    /** @deprecated Please use {@link #YAHOO_OPENID_CONNECT_USERINFO_URL instead. */
+    /** @deprecated Please use {@link #YAHOO_OIDC_USERINFO_URL instead. */
     public static final String YAHOO_USERINFO_URL = "https://social.yahooapis.com/v1/user/";
     public static final String YAHOO_OPENID_CONNECT_USERINFO_URL = "https://api.login.yahoo.com/openid/v1/userinfo";
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/org/wso2/carbon/identity/application/authentication/framework/config/builder/application-authentication-multi-chain.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/org/wso2/carbon/identity/application/authentication/framework/config/builder/application-authentication-multi-chain.xml
@@ -122,7 +122,7 @@
         <AuthenticatorConfig name="YahooOAuth2Authenticator" enabled="true">
             <Parameter name="YahooTokenEndpoint">https://api.login.yahoo.com/oauth2/get_token</Parameter>
             <Parameter name="YahooOAuthzEndpoint">https://api.login.yahoo.com/oauth2/request_auth</Parameter>
-            <Parameter name="YahooUserInfoEndpoint">https://social.yahooapis.com/v1/user/</Parameter>
+            <Parameter name="YahooUserInfoEndpoint">https://api.login.yahoo.com/openid/v1/userinfo</Parameter>
         </AuthenticatorConfig>
         <AuthenticatorConfig name="MobileConnectAuthenticator" enabled="true">
             <Parameter name="MobileConnectKey">mobileConnectClientId</Parameter>

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/org/wso2/carbon/identity/application/authentication/framework/config/builder/application-authentication-multi-step-1.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/org/wso2/carbon/identity/application/authentication/framework/config/builder/application-authentication-multi-step-1.xml
@@ -122,7 +122,7 @@
         <AuthenticatorConfig name="YahooOAuth2Authenticator" enabled="true">
             <Parameter name="YahooTokenEndpoint">https://api.login.yahoo.com/oauth2/get_token</Parameter>
             <Parameter name="YahooOAuthzEndpoint">https://api.login.yahoo.com/oauth2/request_auth</Parameter>
-            <Parameter name="YahooUserInfoEndpoint">https://social.yahooapis.com/v1/user/</Parameter>
+            <Parameter name="YahooUserInfoEndpoint">https://api.login.yahoo.com/openid/v1/userinfo</Parameter>
         </AuthenticatorConfig>
         <AuthenticatorConfig name="MobileConnectAuthenticator" enabled="true">
             <Parameter name="MobileConnectKey">mobileConnectClientId</Parameter>

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/application-authentication-GraphStepHandlerTest.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/application-authentication-GraphStepHandlerTest.xml
@@ -122,7 +122,7 @@
         <AuthenticatorConfig name="YahooOAuth2Authenticator" enabled="true">
             <Parameter name="YahooTokenEndpoint">https://api.login.yahoo.com/oauth2/get_token</Parameter>
             <Parameter name="YahooOAuthzEndpoint">https://api.login.yahoo.com/oauth2/request_auth</Parameter>
-            <Parameter name="YahooUserInfoEndpoint">https://social.yahooapis.com/v1/user/</Parameter>
+            <Parameter name="YahooUserInfoEndpoint">https://api.login.yahoo.com/openid/v1/userinfo</Parameter>
         </AuthenticatorConfig>
         <AuthenticatorConfig name="MobileConnectAuthenticator" enabled="true">
             <Parameter name="MobileConnectKey">mobileConnectClientId</Parameter>

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/application-authentication-AdaptiveStepHandlerTest.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/application-authentication-AdaptiveStepHandlerTest.xml
@@ -122,7 +122,7 @@
         <AuthenticatorConfig name="YahooOAuth2Authenticator" enabled="true">
             <Parameter name="YahooTokenEndpoint">https://api.login.yahoo.com/oauth2/get_token</Parameter>
             <Parameter name="YahooOAuthzEndpoint">https://api.login.yahoo.com/oauth2/request_auth</Parameter>
-            <Parameter name="YahooUserInfoEndpoint">https://social.yahooapis.com/v1/user/</Parameter>
+            <Parameter name="YahooUserInfoEndpoint">https://api.login.yahoo.com/openid/v1/userinfo</Parameter>
         </AuthenticatorConfig>
         <AuthenticatorConfig name="MobileConnectAuthenticator" enabled="true">
             <Parameter name="MobileConnectKey">mobileConnectClientId</Parameter>

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml
@@ -129,7 +129,7 @@
         <AuthenticatorConfig name="YahooOAuth2Authenticator" enabled="true">
             <Parameter name="YahooTokenEndpoint">https://api.login.yahoo.com/oauth2/get_token</Parameter>
             <Parameter name="YahooOAuthzEndpoint">https://api.login.yahoo.com/oauth2/request_auth</Parameter>
-            <Parameter name="YahooUserInfoEndpoint">https://social.yahooapis.com/v1/user/</Parameter>
+            <Parameter name="YahooUserInfoEndpoint">https://api.login.yahoo.com/openid/v1/userinfo</Parameter>
         </AuthenticatorConfig>
         <AuthenticatorConfig name="MobileConnectAuthenticator" enabled="true">
                        <Parameter name="MCAuthenticationEndpointURL">mobileconnectauthenticationendpoint/mobileconnect.jsp</Parameter>

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -108,7 +108,7 @@
   "authentication.authenticator.yahoo.enable": true,
   "authentication.authenticator.yahoo.parameters.YahooTokenEndpoint": "https://api.login.yahoo.com/oauth2/get_token",
   "authentication.authenticator.yahoo.parameters.YahooOAuthzEndpoint": "https://api.login.yahoo.com/oauth2/request_auth",
-  "authentication.authenticator.yahoo.parameters.YahooUserInfoEndpoint": "https://social.yahooapis.com/v1/user/",
+  "authentication.authenticator.yahoo.parameters.YahooUserInfoEndpoint": "https://api.login.yahoo.com/openid/v1/userinfo",
 
   "authentication.authenticator.fido.name": "FIDOAuthenticator",
   "authentication.authenticator.fido.enable": true,


### PR DESCRIPTION
### Proposed changes in this pull request

Issue: https://github.com/wso2/product-is/issues/8339

The Social Directory API which provides profile (identity) information about Yahoo users is deprecated and completely shut down on June 30, 2020 [1].This PR adds the new Yahoo OpenId Connect UserInfo API.

[1] https://developer.yahoo.com/oauth/social-directory-eol/