### PR TITLE
Add support to publish the active session count if configured

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -335,6 +335,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             SessionContext sessionContext = null;
             String commonAuthCookie = null;
             String sessionContextKey = null;
+            String analyticsSessionAction = null;
             // Force authentication requires the creation of a new session. Therefore skip using the existing session
             if (FrameworkUtils.getAuthCookie(request) != null && !context.isForceAuthenticate()) {
 
@@ -349,6 +350,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             String applicationTenantDomain = getApplicationTenantDomain(context);
             // session context may be null when cache expires therefore creating new cookie as well.
             if (sessionContext != null) {
+                analyticsSessionAction = FrameworkConstants.AnalyticsAttributes.SESSION_UPDATE;
                 sessionContext.getAuthenticatedSequences().put(appConfig.getApplicationName(),
                         sequenceConfig);
                 sessionContext.getAuthenticatedIdPs().putAll(context.getCurrentAuthenticatedIdPs());
@@ -421,10 +423,8 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                 // TODO add to cache?
                 // store again. when replicate  cache is used. this may be needed.
                 FrameworkUtils.addSessionContextToCache(sessionContextKey, sessionContext, applicationTenantDomain);
-                FrameworkUtils.publishSessionEvent(sessionContextKey, request, context, sessionContext, sequenceConfig
-                        .getAuthenticatedUser(), FrameworkConstants.AnalyticsAttributes.SESSION_UPDATE);
-
             } else {
+                analyticsSessionAction = FrameworkConstants.AnalyticsAttributes.SESSION_CREATE;
                 sessionContext = new SessionContext();
                 // To identify first login
                 context.setProperty(FrameworkConstants.AnalyticsAttributes.IS_INITIAL_LOGIN, true);
@@ -455,9 +455,6 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
 
                 FrameworkUtils.addSessionContextToCache(sessionContextKey, sessionContext, applicationTenantDomain);
                 setAuthCookie(request, response, context, sessionKey, applicationTenantDomain);
-                FrameworkUtils.publishSessionEvent(sessionContextKey, request, context, sessionContext, sequenceConfig
-                        .getAuthenticatedUser(), FrameworkConstants.AnalyticsAttributes.SESSION_CREATE);
-
                 if (FrameworkServiceDataHolder.getInstance().isUserSessionMappingEnabled()) {
                     try {
                         storeSessionMetaData(sessionContextKey, request);
@@ -470,7 +467,6 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             if (authenticatedUserTenantDomain == null) {
                 PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
             }
-            publishAuthenticationSuccess(request, context, sequenceConfig.getAuthenticatedUser());
 
             if (FrameworkServiceDataHolder.getInstance().isUserSessionMappingEnabled()) {
                 try {
@@ -497,6 +493,9 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                     }
                 }
             }
+            FrameworkUtils.publishSessionEvent(sessionContextKey, request, context, sessionContext, sequenceConfig
+                        .getAuthenticatedUser(), analyticsSessionAction);
+            publishAuthenticationSuccess(request, context, sequenceConfig.getAuthenticatedUser());
         }
 
         // Checking weather inbound protocol is an already cache removed one, request come from federated or other

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
@@ -123,4 +123,13 @@ public class SQLQueries {
     // Remove federated authentication session details of a given session context key.
     public static final String SQL_DELETE_FEDERATED_AUTH_SESSION_INFO = "DELETE FROM IDN_FED_AUTH_SESSION_MAPPING"
             + " WHERE SESSION_ID=?";
+
+    public static final String SQL_GET_ACTIVE_SESSION_COUNT_BY_TENANT =
+            "SELECT COUNT( DISTINCT IDN_AUTH_SESSION_META_DATA.SESSION_ID) " +
+                    "FROM IDN_AUTH_SESSION_META_DATA INNER JOIN IDN_AUTH_USER_SESSION_MAPPING " +
+                    "ON IDN_AUTH_SESSION_META_DATA.SESSION_ID = IDN_AUTH_USER_SESSION_MAPPING.SESSION_ID " +
+                    "INNER JOIN IDN_AUTH_SESSION_STORE " +
+                    "ON IDN_AUTH_USER_SESSION_MAPPING.SESSION_ID = IDN_AUTH_SESSION_STORE.SESSION_ID " +
+                    "WHERE IDN_AUTH_SESSION_META_DATA.PROPERTY_TYPE = ? AND IDN_AUTH_SESSION_META_DATA.VALUE " +
+                    "BETWEEN ? AND ? AND IDN_AUTH_SESSION_STORE.TENANT_ID = ? ";
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -226,6 +226,11 @@ public abstract class FrameworkConstants {
         public static final String USER_SESSION_MAPPING_ENABLED =
                 "JDBCPersistenceManager.SessionDataPersist.UserSessionMapping.Enable";
 
+        /**
+         * Configuration to enable publishing the active session count in analytics event.
+         */
+        public static final String PUBLISH_ACTIVE_SESSION_COUNT = "Analytics.PublishActiveSessionCount";
+
         private Config() {
         }
 
@@ -334,6 +339,7 @@ public abstract class FrameworkConstants {
         public static final String SESSION_CREATE = "sessionCreated";
         public static final String SESSION_UPDATE = "sessionUpdated";
         public static final String SESSION_TERMINATE = "sessionTerminated";
+        public static final String ACTIVE_SESSION_COUNT = "activeSessionCount";
     }
 
     public static class JSAttributes {

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1251,6 +1251,17 @@
         {% endfor %}
     </EventListeners>
 
+    {% if analytics.publish_active_session_count is defined %}
+    <Analytics>
+        <!-- By default value of analytics.publish_active_session_count is set to false so that the identity server
+        publishes session data to the stream org.wso2.is.analytics.stream.OverallSession:1.0.0.
+        When this configuration is enabled, the stream definition org.wso2.is.analytics.stream.OverallSession:1.0.1
+        is used and the current active session count of the identity server will be added as an attribute. Enable it
+        by setting analytics.publish_active_session_count = true -->
+        <PublishActiveSessionCount>{{analytics.publish_active_session_count}}</PublishActiveSessionCount>
+    </Analytics>
+    {% endif %}
+
     <!-- These recorders are used to write user delete information to specific sources. Default event recorder is CSV
      file recorder. This recorder is disabled by default. Enable it by setting enable="true". To run these recorders,
      EventListener "rg.wso2.carbon.user.mgt.listeners.UserDeletionEventListener" also should be enabled. Which is


### PR DESCRIPTION
Fix wso2/product-is#9398

This PR,

1. Stores the session related information in the identity database before publishing the event to analytics. 
2. Clears the session information from the session tables when the user is logged out 
3. Query the identity tables to get the active session count and send to the session data publisher
4. Make the feature configurable
5.Add required config to the identity.xml.j2