### PR TITLE
Fix wso2/product-is#9531: SaaS app authentication with tenant qualified URLs

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -156,6 +156,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.InternalRoleDomains.APPLICATION_DOMAIN;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.InternalRoleDomains.WORKFLOW_DOMAIN;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.REQUEST_PARAM_SP;
+import static org.wso2.carbon.identity.core.util.IdentityTenantUtil.isLegacySaaSAuthenticationEnabled;
 
 public class FrameworkUtils {
 
@@ -2609,14 +2610,21 @@ public class FrameworkUtils {
      */
     public static String preprocessUsername(String username, AuthenticationContext context) {
 
-        if (context.getSequenceConfig().getApplicationConfig().isSaaSApp()) {
+        boolean isSaaSApp = context.getSequenceConfig().getApplicationConfig().isSaaSApp();
+
+        if (isLegacySaaSAuthenticationEnabled() && isSaaSApp) {
             return username;
         }
+
         if (IdentityUtil.isEmailUsernameEnabled()) {
             if (StringUtils.countMatches(username, "@") == 1) {
                 return username + "@" + context.getTenantDomain();
             }
         } else if (!username.endsWith(context.getTenantDomain())) {
+
+            if (isSaaSApp && StringUtils.countMatches(username, "@") == 1) {
+                return username;
+            }
             return username + "@" + context.getTenantDomain();
         }
         return username;

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -36,6 +36,7 @@ public class IdentityCoreConstants {
     public static final String UTF_8 = "UTF-8";
     public static final String UTC = "UTC";
     public static final int EVENT_LISTENER_ORDER_ID = -1;
+    public static final String ENABLE_LEGACY_SAAS_AUTHENTICATION = "EnableLegacySaaSAuthentication";
 
     public static final String CASE_INSENSITIVE_USERNAME = "CaseInsensitiveUsername";
     public static final String USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS = "UseCaseSensitiveUsernameForCacheKeys";

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
@@ -340,4 +340,23 @@ public class IdentityTenantUtil {
 
         return Boolean.parseBoolean(IdentityUtil.getProperty(IdentityCoreConstants.ENABLE_TENANT_QUALIFIED_URLS));
     }
+
+    /**
+     *
+     * Checks whether legacy SaaS authentication is enabled.
+     *
+     * If enabled and if the username provided during the SaaS application authentication does not have a tenant
+     * domain appended, the user will be treated as a super tenant user and will be authenticated against the super
+     * tenant domain.
+     *
+     * If disabled and if the username provided during the SaaS application authentication does not have a tenant
+     * domain appended, the user will be treated as a application tenant domain user and will be authenticated
+     * against the application tenant domain.
+     *
+     * @return true if legacy SaaS authentication is enabled, false otherwise.
+     */
+    public static boolean isLegacySaaSAuthenticationEnabled() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(IdentityCoreConstants.ENABLE_LEGACY_SAAS_AUTHENTICATION));
+    }
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2123,6 +2123,18 @@
 
     <EnableTenantQualifiedUrls>{{tenant_context.enable_tenant_qualified_urls}}</EnableTenantQualifiedUrls>
 
+
+    <!--
+        When this property is set to 'true', if the username provided during the SaaS application authentication does
+        not have a tenant domain appended, the user will be treated as a super tenant user and will be authenticated
+        against the super tenant domain.
+
+        When this property is set to 'false', if the username provided during the SaaS application authentication does
+        not have a tenant domain appended, the user will be treated as a application tenant domain user and will be
+        authenticated against the application tenant domain.
+    -->
+    <EnableLegacySaaSAuthentication>{{authentication.enable_legacy_saas_mode | default(false)}}</EnableLegacySaaSAuthentication>
+
     <EnablePerUserFunctionalityLocking>{{user.enable_per_user_functionality_locking}}</EnablePerUserFunctionalityLocking>
 
     <TenantContextsToRewrite>


### PR DESCRIPTION
Fixes wso2/product-is#9531

With this fix, during SaaS app authentication, we consider the tenant domain in the authentication context by default. As a result if the login identifier of the user does not contain the tenant domain, the user will be authenticated against the application tenant domain.

The default behavior for SaaS app authentication will be changed with the fix. However the below configuration in deployment.toml will enable the previous authentication behavior where we considered login identifier without tenant domain are from super tenant.

```toml
[authentication]
enable_legacy_saas_mode = true
```