### PR TITLE
Skip current session from being terminated at password update

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/UserSessionManagementServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/UserSessionManagementServiceImpl.java
@@ -49,6 +49,11 @@ import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.
+        CURRENT_SESSION_IDENTIFIER;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Config.
+        PRESERVE_LOGGED_IN_SESSION_AT_PASSWORD_UPDATE;
+
 /**
  * This a service class used to manage user sessions.
  */
@@ -56,8 +61,6 @@ public class UserSessionManagementServiceImpl implements UserSessionManagementSe
 
     private static final Log log = LogFactory.getLog(UserSessionManagementServiceImpl.class);
     private SessionManagementService sessionManagementService = new SessionManagementService();
-    private static final String PRESERVE_SESSION_WHEN_PASSWORD_UPDATE = "PasswordUpdate.PreserveCurrentSessionAndToken";
-    private static final String CURRENT_SESSION_IDENTIFIER = "currentSessionIdentifier";
 
     @Override
     public void terminateSessionsOfUser(String username, String userStoreDomain, String tenantDomain) throws
@@ -181,7 +184,7 @@ public class UserSessionManagementServiceImpl implements UserSessionManagementSe
         List<String> sessionIdList = getSessionIdListByUserId(userId);
 
         boolean isSessionPreservingAtPasswordUpdateEnabled =
-                Boolean.parseBoolean(IdentityUtil.getProperty(PRESERVE_SESSION_WHEN_PASSWORD_UPDATE));
+                Boolean.parseBoolean(IdentityUtil.getProperty(PRESERVE_LOGGED_IN_SESSION_AT_PASSWORD_UPDATE));
         String currentSessionId = "";
         boolean isSessionTerminationSkipped = false;
         if (isSessionPreservingAtPasswordUpdateEnabled) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -133,6 +133,9 @@ public abstract class FrameworkConstants {
     public static final String FEDERATED_IDP_ROLE_CLAIM_VALUE_SEPARATOR =
             "FederatedIDPRoleClaimValueAttributeSeparator";
 
+    // Current session thread local identifier.
+    public static final String CURRENT_SESSION_IDENTIFIER = "currentSessionIdentifier";
+
     private FrameworkConstants() {
 
     }
@@ -230,6 +233,13 @@ public abstract class FrameworkConstants {
          * Configuration to enable publishing the active session count in analytics event.
          */
         public static final String PUBLISH_ACTIVE_SESSION_COUNT = "Analytics.PublishActiveSessionCount";
+
+        /**
+         * Configuration to enable preserving user from being logged out at password update by skipping current
+         * session and token from being terminated.
+         */
+        public static final String PRESERVE_LOGGED_IN_SESSION_AT_PASSWORD_UPDATE =
+                "PasswordUpdate.PreserveLoggedInSession";
 
         private Config() {
         }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2344,4 +2344,9 @@
         {% endfor %}
     </ReverseProxyConfig>
     {% endif %}
+
+    <!-- Configuration for preserving the current session and token when updating the password. -->
+    <PasswordUpdate>
+        <PreserveCurrentSessionAndToken>{{password_update.preserve_current_session_and_token}}</PreserveCurrentSessionAndToken>
+    </PasswordUpdate>
 </Server>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2347,6 +2347,6 @@
 
     <!-- Configuration for preserving the current session and token when updating the password. -->
     <PasswordUpdate>
-        <PreserveLoggedInSession>{{password_update.preserve_logged_in_session}}</PreserveLoggedInSession>
+        <PreserveLoggedInSession>{{identity_mgt.password_update.preserve_logged_in_session}}</PreserveLoggedInSession>
     </PasswordUpdate>
 </Server>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2347,6 +2347,6 @@
 
     <!-- Configuration for preserving the current session and token when updating the password. -->
     <PasswordUpdate>
-        <PreserveCurrentSessionAndToken>{{password_update.preserve_current_session_and_token}}</PreserveCurrentSessionAndToken>
+        <PreserveLoggedInSession>{{password_update.preserve_logged_in_session}}</PreserveLoggedInSession>
     </PasswordUpdate>
 </Server>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -290,6 +290,8 @@
   "identity_mgt.password_reset_by_admin.enable_emailed_otp_based_reset": false,
   "identity_mgt.password_reset_by_admin.enable_offline_otp_based_reset": false,
 
+  "identity_mgt.password_update.preserve_logged_in_session": false,
+
   "identity_mgt.username_recovery.email.enable_username_recovery": false,
   "identity_mgt.username_recovery.email.enable_recaptcha": false,
 
@@ -821,7 +823,5 @@
   "cors.supports_credentials": true,
   "cors.max_age": -1,
   "cors.tag_requests": false,
-  "audit.log.contextual_param.params": [],
-
-  "password_update.preserve_logged_in_session": false
+  "audit.log.contextual_param.params": []
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -821,5 +821,7 @@
   "cors.supports_credentials": true,
   "cors.max_age": -1,
   "cors.tag_requests": false,
-  "audit.log.contextual_param.params": []
+  "audit.log.contextual_param.params": [],
+
+  "password_update.preserve_current_session_and_token": false
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -823,5 +823,5 @@
   "cors.tag_requests": false,
   "audit.log.contextual_param.params": [],
 
-  "password_update.preserve_current_session_and_token": false
+  "password_update.preserve_logged_in_session": false
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.key-mappings.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.key-mappings.json
@@ -3,5 +3,6 @@
   "scim.authentication_handler.oauth.properties.priority": "scim.authentication_handler.oauth.properties.Priority",
   "scim.authentication_handler.oauth.properties.authorization_server": "scim.authentication_handler.oauth.properties.AuthorizationServer",
   "scim.authentication_handler.oauth.properties.username": "scim.authentication_handler.oauth.properties.UserName",
-  "scim.authentication_handler.oauth.properties.password": "scim.authentication_handler.oauth.properties.Password"
+  "scim.authentication_handler.oauth.properties.password": "scim.authentication_handler.oauth.properties.Password",
+  "password_update.preserve_logged_in_session": "identity_mgt.password_update.preserve_logged_in_session"
 }


### PR DESCRIPTION
Resolves session preserving part of - https://github.com/wso2/product-is/issues/9461

With this improvement, it is possible to skip the current session/token from being terminated/revoked at password update, which stops the user from being logged out from the current session. This feature can be enabled the following configuration in deployment.toml

```
[identity_mgt]
password_update.preserve_logged_in_session=true
```