### PR TITLE
[Improvement] Extending the expiry time of commonAuth Cookie

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -51,6 +51,7 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authentication.framework.util.LoginContextManagementUtil;
 import org.wso2.carbon.identity.application.authentication.framework.util.SessionMgtConstants;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.idp.mgt.util.IdPManagementUtil;
@@ -82,7 +83,6 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
     private static final Log log = LogFactory.getLog(DefaultAuthenticationRequestHandler.class);
     private static final Log AUDIT_LOG = CarbonConstants.AUDIT_LOG;
     private static volatile DefaultAuthenticationRequestHandler instance;
-    private static final String EXTEND_REMEMBER_ME_SESSION_ON_AUTH = "TimeConfig.ExtendRememberMeSessionTimeoutOnAuth";
 
     public static DefaultAuthenticationRequestHandler getInstance() {
 
@@ -425,7 +425,8 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                  * option is selected. With this config, the expiry time will increase at every authentication.
                  */
                 if (sessionContext.isRememberMe() &&
-                        Boolean.parseBoolean(IdentityUtil.getProperty(EXTEND_REMEMBER_ME_SESSION_ON_AUTH))) {
+                        Boolean.parseBoolean(IdentityUtil.getProperty(
+                                IdentityConstants.ServerConfig.EXTEND_REMEMBER_ME_SESSION_ON_AUTH))) {
                     context.setRememberMe(sessionContext.isRememberMe());
                     setAuthCookie(request, response, context, commonAuthCookie, applicationTenantDomain);
                 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -82,6 +82,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
     private static final Log log = LogFactory.getLog(DefaultAuthenticationRequestHandler.class);
     private static final Log AUDIT_LOG = CarbonConstants.AUDIT_LOG;
     private static volatile DefaultAuthenticationRequestHandler instance;
+    private static String EXTEND_REMEMBER_ME_SESSION_ON_AUTH = "TimeConfig.ExtendRememberMeSessionTimeoutOnAuth";
 
     public static DefaultAuthenticationRequestHandler getInstance() {
 
@@ -418,6 +419,15 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                     } catch (UserSessionException e) {
                         log.error("Updating session meta data failed.", e);
                     }
+                }
+                /*
+                 * In the default configuration, the expiry time of the commonAuthCookie is fixed when rememberMe
+                 * option is selected. With this config, the expiry time will increase at every authentication.
+                 */
+                if (sessionContext.isRememberMe() &&
+                        Boolean.parseBoolean(IdentityUtil.getProperty(EXTEND_REMEMBER_ME_SESSION_ON_AUTH))) {
+                    context.setRememberMe(sessionContext.isRememberMe());
+                    setAuthCookie(request, response, context, commonAuthCookie, applicationTenantDomain);
                 }
 
                 // TODO add to cache?

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -82,7 +82,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
     private static final Log log = LogFactory.getLog(DefaultAuthenticationRequestHandler.class);
     private static final Log AUDIT_LOG = CarbonConstants.AUDIT_LOG;
     private static volatile DefaultAuthenticationRequestHandler instance;
-    private static String EXTEND_REMEMBER_ME_SESSION_ON_AUTH = "TimeConfig.ExtendRememberMeSessionTimeoutOnAuth";
+    private static final String EXTEND_REMEMBER_ME_SESSION_ON_AUTH = "TimeConfig.ExtendRememberMeSessionTimeoutOnAuth";
 
     public static DefaultAuthenticationRequestHandler getInstance() {
 

--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -261,6 +261,8 @@ public class IdentityConstants {
         //Timeout Configurations
         public static final String SESSION_IDLE_TIMEOUT = "TimeConfig.SessionIdleTimeout";
         public static final String REMEMBER_ME_TIME_OUT = "TimeConfig.RememberMeTimeout";
+        public static final String EXTEND_REMEMBER_ME_SESSION_ON_AUTH =
+                "TimeConfig.ExtendRememberMeSessionTimeoutOnAuth";
 
         public static final String CLEAN_UP_PERIOD = "JDBCPersistenceManager.SessionDataPersist.SessionDataCleanUp.CleanUpPeriod";
         public static final String CLEAN_UP_TIMEOUT = "JDBCPersistenceManager.SessionDataPersist.SessionDataCleanUp.CleanUpTimeout";

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -62,6 +62,11 @@
     <TimeConfig>
         <SessionIdleTimeout>15</SessionIdleTimeout>
         <RememberMeTimeout>20160</RememberMeTimeout>
+        <!--
+        Setting ExtendRememberMeSessionTimeoutOnAuth to TRUE will change the expiry time of the commonAuth cookie
+        during the authentication. The default value will be TRUE and the expiry time of the commonAuth cookie
+        will change.
+        -->
         <ExtendRememberMeSessionTimeoutOnAuth>true</ExtendRememberMeSessionTimeoutOnAuth>
     </TimeConfig>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -62,6 +62,7 @@
     <TimeConfig>
         <SessionIdleTimeout>15</SessionIdleTimeout>
         <RememberMeTimeout>20160</RememberMeTimeout>
+        <ExtendRememberMeSessionTimeoutOnAuth>true</ExtendRememberMeSessionTimeoutOnAuth>
     </TimeConfig>
 
     <!-- Security configurations -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -60,6 +60,12 @@
     <TimeConfig>
         <SessionIdleTimeout>{{session.timeout.idle_session_timeout}}</SessionIdleTimeout>
         <RememberMeTimeout>{{session.timeout.remember_me_session_timeout}}</RememberMeTimeout>
+        <!--
+        Setting ExtendRememberMeSessionTimeoutOnAuth to TRUE will change the expiry time of the commonAuth cookie
+        during the authentication. The default value will be FALSE and the expiry time of the commonAuth cookie
+        will not change.
+        -->
+        <ExtendRememberMeSessionTimeoutOnAuth>{{session.timeout.extend_remember_me_session_timeout_on_auth}}</ExtendRememberMeSessionTimeoutOnAuth>
     </TimeConfig>
 
     <!-- Security configurations -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -62,8 +62,8 @@
         <RememberMeTimeout>{{session.timeout.remember_me_session_timeout}}</RememberMeTimeout>
         <!--
         Setting ExtendRememberMeSessionTimeoutOnAuth to TRUE will change the expiry time of the commonAuth cookie
-        during the authentication. The default value will be FALSE and the expiry time of the commonAuth cookie
-        will not change.
+        during the authentication. The default value will be TRUE and the expiry time of the commonAuth cookie
+        will change.
         -->
         <ExtendRememberMeSessionTimeoutOnAuth>{{session.timeout.extend_remember_me_session_timeout_on_auth}}</ExtendRememberMeSessionTimeoutOnAuth>
     </TimeConfig>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -19,6 +19,7 @@
   "session_data.cleanup.pre_session_data_cleanup_thread_pool_size": "20",
   "session.timeout.idle_session_timeout": "15m",
   "session.timeout.remember_me_session_timeout": "14d",
+  "session.timeout.extend_remember_me_session_timeout_on_auth": true,
   "key_mgt.keystore_dir": "${carbon.home}/conf/keystores",
   "key_mgt.key_manager_type": "SunX509",
   "key_mgt.trust_manager_type": "SunX509",


### PR DESCRIPTION
Resolves wso2/product-is#9411
### Proposed changes in this pull request
Setting the commonAuth cookie of the session context has rememberMe option selected. 
Since this introduces a behavioural change, a new config was introduced to the identity.xml to turn the feature off when needed. It can be configured in the toml as follows.

```
[session.timeout]
extend_remember_me_session_timeout_on_auth=false
```

### Follow up actions

- [ ] Create a migration issue and add it to the migration documentation.
- [ ] Specify in the WSO2 documentation [1], on `How to turn extending commonAuth Cookie expiry time`.

Update the documentation [1] with the above configurations.

[1] - https://is.docs.wso2.com/en/latest/learn/configuring-session-timeout/