### PR TITLE
Block role creation with system_ prefix

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserAdmin.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserAdmin.java
@@ -301,6 +301,16 @@ public class UserAdmin {
      */
     public void addInternalRole(String roleName, String[] userList, String[] permissions)
             throws UserAdminException {
+
+        /* Block the role names with the prefix 'system_' as it is used for the special roles created by the system in
+        order to maintain the backward compatibility. */
+        if (getUserAdminProxy().isRoleAndGroupSeparationEnabled() && StringUtils
+                .startsWithIgnoreCase(roleName, UserCoreConstants.INTERNAL_SYSTEM_ROLE_PREFIX)) {
+            String errorMessage = String.format("Invalid role name: %s. Role names with the prefix: %s, is not allowed"
+                            + " to be created from externally in the system.", roleName,
+                    UserCoreConstants.INTERNAL_SYSTEM_ROLE_PREFIX);
+            throw new UserAdminException(errorMessage);
+        }
         addUserRole(roleName, userList, permissions, false, true);
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Block the role names with the prefix `system_` as it is used for the special roles created by the system in order to maintain the backward compatibility.

- Resolves https://github.com/wso2/product-is/issues/9640
