### PR TITLE
Add missing licenses

### DIFF
--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/constant/SQLQueries.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/constant/SQLQueries.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * NOTE: The code/logic in this class is copied from https://bitbucket.org/thetransactioncompany/cors-filter.
+ * All credits goes to the original authors of the project https://bitbucket.org/thetransactioncompany/cors-filter.
+ */
+
 package org.wso2.carbon.identity.cors.mgt.core.constant;
 
 /**

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/constant/SchemaConstants.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/constant/SchemaConstants.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * NOTE: The code/logic in this class is copied from https://bitbucket.org/thetransactioncompany/cors-filter.
+ * All credits goes to the original authors of the project https://bitbucket.org/thetransactioncompany/cors-filter.
+ */
+
 package org.wso2.carbon.identity.cors.mgt.core.constant;
 
 /**

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/util/ErrorUtils.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/util/ErrorUtils.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * NOTE: The code/logic in this class is copied from https://bitbucket.org/thetransactioncompany/cors-filter.
+ * All credits goes to the original authors of the project https://bitbucket.org/thetransactioncompany/cors-filter.
+ */
+
 package org.wso2.carbon.identity.cors.mgt.core.internal.util;
 
 import org.wso2.carbon.identity.cors.mgt.core.constant.ErrorMessages;

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/model/CORSApplication.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/model/CORSApplication.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * NOTE: The code/logic in this class is copied from https://bitbucket.org/thetransactioncompany/cors-filter.
+ * All credits goes to the original authors of the project https://bitbucket.org/thetransactioncompany/cors-filter.
+ */
+
 package org.wso2.carbon.identity.cors.mgt.core.model;
 
 /**


### PR DESCRIPTION
### Proposed changes in this pull request
This PR adds the WSO2 license header to some files in the CORS component that are missing the license. 
