### PR TITLE
Add a constant to define sameSite property of cookies

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -374,6 +374,7 @@ public abstract class FrameworkConstants {
         public static final String JS_COOKIE_SECURE = "secure";
         public static final String JS_COOKIE_VERSION = "version";
         public static final String JS_COOKIE_HTTP_ONLY = "httpOnly";
+        public static final String JS_COOKIE_SAMESITE = "sameSite";
         public static final String JS_LOCAL_ROLES = "roles";
         public static final String JS_CLAIMS = "claims";
         public static final String JS_AUTHENTICATED_IDP = "idp";


### PR DESCRIPTION
### Proposed changes in this pull request
Fixing https://github.com/wso2/product-is/issues/9656
Introduce a new constant to define the SameSite property in the adaptive scripts `setCookie` method.