### PR TITLE
Add Configuration for allowed scopes

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -155,7 +155,7 @@
     </RemoteFetch>
 
     <OAuth>
-        <!-- Configuration to pass a list of scopes which are allowed without any validation -->
+        <!-- Configuration to pass a list of scopes which are allowed without any validation. -->
         <AllowedScopes>
              {%for scope in oauth.allowed_scopes%}
                   <Scope>{{scope}}</Scope>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -155,12 +155,6 @@
     </RemoteFetch>
 
     <OAuth>
-        <!-- Configuration to pass a list of scopes which are allowed without any validation. -->
-        <AllowedScopes>
-             {%for scope in oauth.allowed_scopes%}
-                  <Scope>{{scope}}</Scope>
-             {% endfor %}
-        </AllowedScopes>
         <!-- Token cleanup feature config to clean IDN_OAUTH2_ACCESS_TOKEN table-->
         <TokenCleanup>
             <!--If true old access token cleaning feature is enabled -->
@@ -773,6 +767,15 @@
         Default value: true
         -->
         <EnableJWTTokenValidationDuringIntrospection>{{oauth.enable_jwt_token_validation_during_introspection}}</EnableJWTTokenValidationDuringIntrospection>
+
+        {% if oauth.allowed_scopes is defined %}
+        <!-- Configuration to pass a list of scopes which are allowed without any validation. -->
+        <AllowedScopes>
+            {%for scope in oauth.allowed_scopes%}
+                <Scope>{{scope}}</Scope>
+            {% endfor %}
+        </AllowedScopes>
+        {% endif %}
     </OAuth>
 
     <MultifactorAuthentication>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -155,6 +155,7 @@
     </RemoteFetch>
 
     <OAuth>
+        <!-- Configuration to pass a list of scopes which are allowed without any validation -->
         <AllowedScopes>
              {%for scope in oauth.allowed_scopes%}
                   <Scope>{{scope}}</Scope>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -155,6 +155,11 @@
     </RemoteFetch>
 
     <OAuth>
+        <AllowedScopes>
+             {%for scope in oauth.allowed_scopes%}
+                  <Scope>{{scope}}</Scope>
+             {% endfor %}
+        </AllowedScopes>
         <!-- Token cleanup feature config to clean IDN_OAUTH2_ACCESS_TOKEN table-->
         <TokenCleanup>
             <!--If true old access token cleaning feature is enabled -->


### PR DESCRIPTION
The PR provided the capablilty to add a set of scopes as approved/allowed scopes where it will be considered as approved scopes without any validation.
The scopes could be provided in the deployment.toml as follows
[oauth]
allowed_scopes = ["scope1", "scope2"]

Introduced with related to https://github.com/wso2/product-is/issues/8245