### PR TITLE
Userstore add UI default userstore config set to UniqueIDReadWriteLDAPUserStoreManager

### DIFF
--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration.ui/src/main/java/org/wso2/carbon/identity/user/store/configuration/ui/UserStoreUIConstants.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration.ui/src/main/java/org/wso2/carbon/identity/user/store/configuration/ui/UserStoreUIConstants.java
@@ -23,6 +23,8 @@ public final class UserStoreUIConstants {
 
     public static final String RWLDAP_USERSTORE_MANAGER = "org.wso2.carbon.user.core.ldap.ReadWriteLDAPUserStoreManager";
     public static final String ROLDAP_USERSTORE_MANAGER = "org.wso2.carbon.user.core.ldap.ReadOnlyLDAPUserStoreManager";
+    public static final String UROLDAP_USERSTORE_MANAGER = "org.wso2.carbon.user.core.ldap" +
+            ".UniqueIDReadOnlyLDAPUserStoreManager";
     public static final String ACTIVEDIRECTORY_USERSTORE_MANAGER = "org.wso2.carbon.user.core.ldap.ActiveDirectoryUserStoreManager";
     public static final String JDABC_USERSTORE_MANAGER = "org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager";
     public static final String CASSANDRA_USERSTORE_MANAGER = "org.wso2.carbon.user.cassandra.CassandraUserStoreManager";

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration.ui/src/main/java/org/wso2/carbon/identity/user/store/configuration/ui/UserStoreUIConstants.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration.ui/src/main/java/org/wso2/carbon/identity/user/store/configuration/ui/UserStoreUIConstants.java
@@ -22,9 +22,9 @@ public final class UserStoreUIConstants {
     }
 
     public static final String RWLDAP_USERSTORE_MANAGER = "org.wso2.carbon.user.core.ldap.ReadWriteLDAPUserStoreManager";
+    public static final String URWLDAP_USERSTORE_MANAGER = "org.wso2.carbon.user.core.ldap" +
+            ".UniqueIDReadWriteLDAPUserStoreManager";
     public static final String ROLDAP_USERSTORE_MANAGER = "org.wso2.carbon.user.core.ldap.ReadOnlyLDAPUserStoreManager";
-    public static final String UROLDAP_USERSTORE_MANAGER = "org.wso2.carbon.user.core.ldap" +
-            ".UniqueIDReadOnlyLDAPUserStoreManager";
     public static final String ACTIVEDIRECTORY_USERSTORE_MANAGER = "org.wso2.carbon.user.core.ldap.ActiveDirectoryUserStoreManager";
     public static final String JDABC_USERSTORE_MANAGER = "org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager";
     public static final String CASSANDRA_USERSTORE_MANAGER = "org.wso2.carbon.user.cassandra.CassandraUserStoreManager";

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration.ui/src/main/resources/web/userstore_config/userstore-config.jsp
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration.ui/src/main/resources/web/userstore_config/userstore-config.jsp
@@ -85,6 +85,8 @@
         return propertyMap;
     }
 %><%
+    domain = "0";
+    className = "0";
     if (SecondaryUserStoreConfigurationUtil.isUserStoreRepositorySeparationEnabled()) {
         repository = request.getParameter("repositoryName");
     }
@@ -111,7 +113,7 @@
 
 
     if (selectedClassApplied == null || selectedClassApplied.trim().length() == 0) {
-        selectedClassApplied = UserStoreUIConstants.UROLDAP_USERSTORE_MANAGER;
+        selectedClassApplied = UserStoreUIConstants.URWLDAP_USERSTORE_MANAGER;
     } else {
 
     }

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration.ui/src/main/resources/web/userstore_config/userstore-config.jsp
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration.ui/src/main/resources/web/userstore_config/userstore-config.jsp
@@ -85,8 +85,6 @@
         return propertyMap;
     }
 %><%
-    domain = "0";
-    className = "0";
     if (SecondaryUserStoreConfigurationUtil.isUserStoreRepositorySeparationEnabled()) {
         repository = request.getParameter("repositoryName");
     }
@@ -113,7 +111,7 @@
 
 
     if (selectedClassApplied == null || selectedClassApplied.trim().length() == 0) {
-        selectedClassApplied = UserStoreUIConstants.RWLDAP_USERSTORE_MANAGER;
+        selectedClassApplied = UserStoreUIConstants.UROLDAP_USERSTORE_MANAGER;
     } else {
 
     }


### PR DESCRIPTION
**Fixes: https://github.com/wso2/product-is/issues/9623**

**Description:**
The default userstore config in the Userstore Add page was the ReadWriteLDAPUserStoreManager which is no longer supported by IS. Non-uniqueID userstores did not require a mandatory userID attribute. Hence, setting the default userstore config to UniqueIDReadWriteLDAPUserStoreManager fixes the mentioned issue.