### PR TITLE
Enable application certificate expiry validation by default.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -209,7 +209,7 @@
   "saml.enable_user_domain_crpto": false,
   "saml.enable_request_validity_period": false,
   "saml.request_validity_period": "5m",
-  "saml.enable_saml_sp_certificate_expiry_validation": false,
+  "saml.enable_saml_sp_certificate_expiry_validation": true,
 
   "saml.endpoints.idp_url": "$ref{server.base_path}/samlsso",
   "saml.endpoints.logout": "$ref{server.base_path}/authenticationendpoint/samlsso_logout.do",


### PR DESCRIPTION
### Proposed changes in this pull request

Enable application certificate expiry validation by default.