### PR TITLE
Delete un-updated config props on fed authenticator update

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -1030,8 +1030,30 @@ public class IdPManagementDAO {
             int authnId = getAuthenticatorIdentifier(dbConnection, idpId,
                     newFederatedAuthenticatorConfig.getName());
 
+            List<Property> unUpdatedProperties = new ArrayList<>();
             List<Property> singleValuedProperties = new ArrayList<>();
             List<Property> multiValuedProperties = new ArrayList<>();
+
+            // Checking for old fed auth config properties that are not updated so we can delete them.
+            if (ArrayUtils.isNotEmpty(oldFederatedAuthenticatorConfig.getProperties())) {
+                if (ArrayUtils.isNotEmpty(newFederatedAuthenticatorConfig.getProperties())) {
+                    for (Property propertyOld : oldFederatedAuthenticatorConfig.getProperties()) {
+                        boolean hasProp = false;
+                        for (Property propertyNew : newFederatedAuthenticatorConfig.getProperties()) {
+                            if (StringUtils.equals(propertyOld.getName(), propertyNew.getName())) {
+                                hasProp = true;
+                                break;
+                            }
+                        }
+                        if (!hasProp) {
+                            unUpdatedProperties.add(propertyOld);
+                        }
+                    }
+                } else {
+                    unUpdatedProperties =
+                            new ArrayList<>(Arrays.asList(oldFederatedAuthenticatorConfig.getProperties()));
+                }
+            }
 
             for (Property property : newFederatedAuthenticatorConfig.getProperties()) {
                 if (Pattern.matches(IdPManagementConstants.MULTI_VALUED_PROPERT_IDENTIFIER_PATTERN, property.getName
@@ -1040,6 +1062,10 @@ public class IdPManagementDAO {
                 } else {
                     singleValuedProperties.add(property);
                 }
+            }
+
+            if (CollectionUtils.isNotEmpty(unUpdatedProperties)) {
+                deleteFederatedConfigProperties(dbConnection, authnId, tenantId, unUpdatedProperties);
             }
             if (CollectionUtils.isNotEmpty(singleValuedProperties)) {
                 updateSingleValuedFederatedConfigProperties(dbConnection, authnId, tenantId, singleValuedProperties);
@@ -1192,6 +1218,7 @@ public class IdPManagementDAO {
                     deleteOldValuePrepStmt = dbConnection.prepareStatement(sqlStmt);
                     deleteOldValuePrepStmt.setString(1, property.getName());
                     deleteOldValuePrepStmt.setInt(2, tenantId);
+                    deleteOldValuePrepStmt.setInt(3, authnId);
                     deleteOldValuePrepStmt.executeUpdate();
                 }
             }
@@ -1217,6 +1244,29 @@ public class IdPManagementDAO {
             IdentityDatabaseUtil.closeStatement(addNewPropsPrepStmt);
         }
 
+    }
+
+    private void deleteFederatedConfigProperties(Connection dbConnection, int authnId, int tenantId, List<Property>
+            properties) throws SQLException {
+
+        if (CollectionUtils.isEmpty(properties)) {
+            return;
+        }
+
+        PreparedStatement deletePrepStmt = null;
+        String sqlStmt = IdPManagementConstants.SQLQueries.DELETE_IDP_AUTH_PROP_WITH_KEY_SQL;
+        try {
+            deletePrepStmt = dbConnection.prepareStatement(sqlStmt);
+            for (Property property : properties) {
+                deletePrepStmt.setString(1, property.getName());
+                deletePrepStmt.setInt(2, tenantId);
+                deletePrepStmt.setInt(3, authnId);
+                deletePrepStmt.addBatch();
+            }
+            deletePrepStmt.executeBatch();
+        } finally {
+            IdentityDatabaseUtil.closeStatement(deletePrepStmt);
+        }
     }
 
     /**

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
@@ -214,7 +214,7 @@ public class IdPManagementConstants {
                 "PROPERTY_VALUE = ?, IS_SECRET = ? WHERE AUTHENTICATOR_ID = ? AND PROPERTY_KEY = ?";
 
         public static final String DELETE_IDP_AUTH_PROP_WITH_KEY_SQL = "DELETE FROM IDP_AUTHENTICATOR_PROPERTY "
-                + "WHERE PROPERTY_KEY = ? AND TENANT_ID = ?";
+                + "WHERE PROPERTY_KEY = ? AND TENANT_ID = ? AND AUTHENTICATOR_ID = ?";
 
         public static final String ADD_IDP_CLAIMS_SQL = "INSERT INTO IDP_CLAIM (IDP_ID, TENANT_ID, CLAIM) "
                 + "VALUES (?, ?, ?)";


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9592

When a fed auth config is updated the complete config that needs be added is passed in `newFederatedAuthenticatorConfig `. In this PR the old properties associated with the auth config that is not available in the new config is deleted from the DB.