### PR TITLE
[Fix] Adding error codes to the error messages

### DIFF
--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/dao/impl/FileBasedUserStoreDAOImpl.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/dao/impl/FileBasedUserStoreDAOImpl.java
@@ -525,7 +525,9 @@ public class FileBasedUserStoreDAOImpl extends AbstractUserStoreDAO {
     private boolean isDomainNameExists(String domainName) throws IdentityUserStoreMgtException {
 
         if (StringUtils.isEmpty(domainName)) {
-            throw new IdentityUserStoreClientException(" User store domain name should not be empty.");
+            throw new IdentityUserStoreClientException(
+                    UserStoreConfigurationConstant.ErrorMessage.ERROR_CODE_EMPTY_USERSTORE_DOMAIN_NAME.getCode(),
+                    UserStoreConfigurationConstant.ErrorMessage.ERROR_CODE_EMPTY_USERSTORE_DOMAIN_NAME.getMessage());
         }
 
         if (!getDomainNames().contains(domainName)) {

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/UserStoreConfigurationConstant.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/utils/UserStoreConfigurationConstant.java
@@ -62,7 +62,8 @@ public class UserStoreConfigurationConstant {
         ERROR_CODE_USER_STORE_DOMAIN_ALREADY_EXISTS("SUS-60002",
                 "User store domain already exists with same domain name."),
         ERROR_CODE_USER_STORE_DOMAIN_NOT_FOUND("SUS-60001",
-                "Unable to find any user store's domain id with the provided identifier.");
+                "Unable to find any user store's domain id with the provided identifier."),
+        ERROR_CODE_EMPTY_USERSTORE_DOMAIN_NAME("SUS-60008", "Userstore domain name cannot be emtpy.");
 
         private final String code;
         private final String message;


### PR DESCRIPTION
This PR is sent as a part of the fix for https://github.com/wso2/product-is/issues/9558

### Proposed changes in this pull request
In the existing implementation, when an invalid userstore domain is sent, a `BAD_REQUEST` was returned by the API as expected. This is a client-error. But the API response had a server error code (650xx). This is due to not setting an error code from the DAO side.

Related PR https://github.com/wso2/identity-api-server/pull/209