### PR TITLE
Make the number unique for theuserMobileVerification  module.

### DIFF
--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/identity-event.properties
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/identity-event.properties
@@ -125,6 +125,6 @@ analyticsLoginDataPublisherV110.subscription.2=AUTHENTICATION_STEP_FAILURE
 analyticsLoginDataPublisherV110.subscription.3=AUTHENTICATION_SUCCESS
 analyticsLoginDataPublisherV110.subscription.4=AUTHENTICATION_FAILURE
 analyticsLoginDataPublisherV110.enable=false
-module.name.24=userMobileVerification
+module.name.25=userMobileVerification
 userMobileVerification.subscription.1=PRE_SET_USER_CLAIMS
 userMobileVerification.subscription.2=POST_SET_USER_CLAIMS

--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -146,7 +146,7 @@
   "identity_mgt.events.schemes.'default.notification.sender'.properties.'subscription.TRIGGER_SMS_NOTIFICATION.stream'":"id_gov_sms_notify_stream:1.0.0",
   "identity_mgt.events.schemes.'default.notification.sender'.properties.'subscription.TRIGGER_SMS_NOTIFICATION.claim.mobile'":"http://wso2.org/claims/mobile",
   "identity_mgt.events.schemes.OIDCLogoutEventHandler.properties.enable": true,
-  "identity_mgt.events.schemes.userMobileVerification.module_index": "24",
+  "identity_mgt.events.schemes.userMobileVerification.module_index": "25",
   "identity_mgt.events.schemes.userMobileVerification.subscriptions": [
     "PRE_SET_USER_CLAIMS",
     "POST_SET_USER_CLAIMS"


### PR DESCRIPTION
### Proposed changes in this pull request

Make the userMobileVerification index unique.

Sharing the index with multiple modules confuses the flow of the handlers engaged afterward.
