### PR TITLE
Session data cleanup for session_app_info, session_meta_data tables

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/mysql/sessiondata-cleanup/mysql-session-data-cleanup.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/mysql/sessiondata-cleanup/mysql-session-data-cleanup.sql
@@ -109,6 +109,7 @@ CREATE PROCEDURE `CLEANUP_SESSION_DATA`()
                     INNER JOIN TEMP_SESSION_BATCH AS B ON
                     A.SESSION_ID = B.SESSION_ID;
             SET @sessionMappingsCleanupCount = row_count();
+            SET @deletedUserSessionMappings = @deletedUserSessionMappings + @sessionMappingsCleanupCount;
             COMMIT;
             SELECT 'DELETED USER-SESSION MAPPINGS...!!' AS 'INFO LOG', @sessionMappingsCleanupCount ;
         END IF;
@@ -121,6 +122,7 @@ CREATE PROCEDURE `CLEANUP_SESSION_DATA`()
                      INNER JOIN TEMP_SESSION_BATCH AS B ON
                     A.SESSION_ID = B.SESSION_ID;
             SET @sessionAppInfoCleanupCount = row_count();
+            SET @deletedSessionAppInfo = @deletedSessionAppInfo + @sessionAppInfoCleanupCount;
             COMMIT;
             SELECT 'DELETED SESSION APP INFO...!!' AS 'INFO LOG', @sessionAppInfoCleanupCount ;
         END IF;
@@ -133,6 +135,7 @@ CREATE PROCEDURE `CLEANUP_SESSION_DATA`()
                      INNER JOIN TEMP_SESSION_BATCH AS B ON
                     A.SESSION_ID = B.SESSION_ID;
             SET @sessionMetadataCleanupCount = row_count();
+            SET @deletedSessionMetadata = @deletedSessionMetadata + @sessionMetadataCleanupCount;
             COMMIT;
             SELECT 'DELETED SESSION METADATA...!!' AS 'INFO LOG', @sessionMetadataCleanupCount ;
         END IF;
@@ -149,9 +152,6 @@ CREATE PROCEDURE `CLEANUP_SESSION_DATA`()
 
         IF (tracingEnabled) THEN SET
         @deletedSessions = @deletedSessions + @sessionCleanupCount;
-          SET @deletedUserSessionMappings = @deletedUserSessionMappings + @sessionMappingsCleanupCount;
-          SET @deletedSessionAppInfo = @deletedSessionAppInfo + @sessionAppInfoCleanupCount;
-          SET @deletedSessionMetadata = @deletedSessionMetadata + @sessionMetadataCleanupCount;
           SELECT 'REMOVED SESSIONS: ' AS 'INFO LOG', @deletedSessions AS 'NO OF DELETED ENTRIES', NOW() AS 'TIMESTAMP';
           SELECT 'REMOVED USER-SESSION MAPPINGS: ' AS 'INFO LOG', @deletedUserSessionMappings AS 'NO OF DELETED ENTRIES', NOW() AS 'TIMESTAMP';
           SELECT 'REMOVED SESSION APP INFO: ' AS 'INFO LOG', @deletedSessionAppInfo AS 'NO OF DELETED ENTRIES', NOW() AS 'TIMESTAMP';
@@ -222,6 +222,7 @@ CREATE PROCEDURE `CLEANUP_SESSION_DATA`()
                      INNER JOIN TEMP_SESSION_BATCH AS B ON
                     A.SESSION_ID = B.SESSION_ID;
             SET @operationalSessionMappingsCleanupCount = row_count();
+            SET @deletedOperationUserSessionMappings = @operationalSessionMappingsCleanupCount + @deletedOperationUserSessionMappings;
             COMMIT;
             SELECT 'DELETED OPERATIONAL USER-SESSION MAPPINGS ...!!' AS 'INFO LOG', @operationalSessionMappingsCleanupCount ;
         END IF;
@@ -234,6 +235,7 @@ CREATE PROCEDURE `CLEANUP_SESSION_DATA`()
                      INNER JOIN TEMP_SESSION_BATCH AS B ON
                     A.SESSION_ID = B.SESSION_ID;
             SET @operationalAppInfoCleanupCount = row_count();
+            SET @deletedOperationSessionAppInfo = @operationalAppInfoCleanupCount + @deletedOperationSessionAppInfo;
             COMMIT;
             SELECT 'DELETED OPERATIONAL SESSION APP INFO ...!!' AS 'INFO LOG', @operationalAppInfoCleanupCount ;
         END IF;
@@ -246,6 +248,7 @@ CREATE PROCEDURE `CLEANUP_SESSION_DATA`()
                      INNER JOIN TEMP_SESSION_BATCH AS B ON
                     A.SESSION_ID = B.SESSION_ID;
             SET @operationalMetadataCleanupCount = row_count();
+            SET @deletedOperationalSessionMetadata = @operationalMetadataCleanupCount + @deletedOperationalSessionMetadata;
             COMMIT;
             SELECT 'DELETED OPERATIONAL SESSION METADATA ...!!' AS 'INFO LOG', @operationalMetadataCleanupCount ;
         END IF;
@@ -253,9 +256,6 @@ CREATE PROCEDURE `CLEANUP_SESSION_DATA`()
         IF (tracingEnabled)
         THEN
           SET @deletedDeleteOperations = @operationCleanupCount + @deletedDeleteOperations;
-          SET @deletedOperationUserSessionMappings = @operationalSessionMappingsCleanupCount + @deletedOperationUserSessionMappings;
-          SET @deletedOperationSessionAppInfo = @operationalAppInfoCleanupCount + @deletedOperationSessionAppInfo;
-          SET @deletedOperationalSessionMetadata = @operationalMetadataCleanupCount + @deletedOperationalSessionMetadata;
           SELECT 'REMOVED DELETE OPERATION RECORDS: ' AS 'INFO LOG', @deletedDeleteOperations AS 'NO OF DELETED DELETE ENTRIES', NOW() AS 'TIMESTAMP';
           SELECT 'REMOVED USER-SESSION MAPPINGS RECORDS: ' AS 'INFO LOG', @deletedOperationUserSessionMappings AS 'NO OF DELETED DELETE ENTRIES', NOW() AS 'TIMESTAMP';
           SELECT 'REMOVED SESSION APP INFO RECORDS: ' AS 'INFO LOG', @deletedOperationSessionAppInfo AS 'NO OF DELETED DELETE ENTRIES', NOW() AS 'TIMESTAMP';

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/oracle/sessiondata-cleanup/oracle-sessiondata-cleanup.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/oracle/sessiondata-cleanup/oracle-sessiondata-cleanup.sql
@@ -142,7 +142,6 @@ BEGIN
                 EXECUTE IMMEDIATE 'DELETE FROM IDN_AUTH_USER_SESSION_MAPPING WHERE SESSION_ID IN (SELECT SESSION_ID FROM TEMP_SESSION_BATCH)';
                 sessionmappingcleanupcount := SQL%rowcount;
                 COMMIT;
-
                 IF ( tracingenabled ) THEN
                     deletedmappingsessions := deletedmappingsessions + sessionmappingcleanupcount;
                     EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''DELETED USER-SESSION MAPPINGS COMPLETED WITH '|| sessionmappingcleanupcount||''')';
@@ -157,7 +156,6 @@ BEGIN
                 EXECUTE IMMEDIATE 'DELETE FROM IDN_AUTH_SESSION_APP_INFO WHERE SESSION_ID IN (SELECT SESSION_ID FROM TEMP_SESSION_BATCH)';
                 sessionappinfocleanupcount := SQL%rowcount;
                 COMMIT;
-
                 IF ( tracingenabled ) THEN
                     deletedsessionapppinfo := deletedsessionapppinfo + sessionappinfocleanupcount;
                     EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''DELETED SESSION APP INFO COMPLETED WITH '|| sessionappinfocleanupcount||''')';
@@ -172,7 +170,6 @@ BEGIN
                 EXECUTE IMMEDIATE 'DELETE FROM IDN_AUTH_SESSION_META_DATA WHERE SESSION_ID IN (SELECT SESSION_ID FROM TEMP_SESSION_BATCH)';
                 sessionmetadatacleanupcount := SQL%rowcount;
                 COMMIT;
-
                 IF ( tracingenabled ) THEN
                     deletedsessionmetadata := deletedsessionmetadata + sessionmetadatacleanupcount;
                     EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''DELETED SESSION METADATA COMPLETED WITH '|| sessionmetadatacleanupcount||''')';
@@ -285,7 +282,6 @@ BEGIN
                 EXECUTE IMMEDIATE 'DELETE FROM IDN_AUTH_USER_SESSION_MAPPING WHERE SESSION_ID IN (SELECT SESSION_ID FROM TEMP_SESSION_BATCH)';
                 operationalmappingcleanupcount := SQL%rowcount;
                 COMMIT;
-
                 IF ( tracingenabled ) THEN
                     deletedoperationalsessionmappings := deletedoperationalsessionmappings + operationalmappingcleanupcount;
                     EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''DELETED OPERATIONAL USER-SESSION MAPPINGS COMPLETED WITH '|| operationalmappingcleanupcount||''')';
@@ -300,7 +296,6 @@ BEGIN
                 EXECUTE IMMEDIATE 'DELETE FROM IDN_AUTH_SESSION_APP_INFO WHERE SESSION_ID IN (SELECT SESSION_ID FROM TEMP_SESSION_BATCH)';
                 operationalappinfocleanupcount := SQL%rowcount;
                 COMMIT;
-
                 IF ( tracingenabled ) THEN
                     deletedoperationalsessionapppinfo := deletedoperationalsessionapppinfo + operationalappinfocleanupcount;
                     EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''DELETED OPERATIONAL SESSION APP INFO COMPLETED WITH '|| operationalappinfocleanupcount||''')';

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/oracle/sessiondata-cleanup/oracle-sessiondata-cleanup.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/oracle/sessiondata-cleanup/oracle-sessiondata-cleanup.sql
@@ -7,7 +7,12 @@ CREATE OR REPLACE PROCEDURE wso2_session_cleanup_sp IS
 
     deletedsessions                  INT := 0;
     deletedmappingsessions           INT := 0;
+    deletedsessionapppinfo           INT := 0;
+    deletedsessionmetadata           INT := 0;
     deletedstoreoperations           INT := 0;
+    deletedoperationalsessionmappings   INT := 0;
+    deletedoperationalsessionapppinfo   INT := 0;
+    deletedoperationalsessionmetadata   INT := 0;
     unixtime                         INT := 0;
     rowcount                         INT := 0;
     sessioncleanuptime               INT := 0;
@@ -15,6 +20,11 @@ CREATE OR REPLACE PROCEDURE wso2_session_cleanup_sp IS
     current_schema                   VARCHAR(20);
     sessioncleanupcount              INT := 0;
     sessionmappingcleanupcount       INT := 0;
+    operationalmappingcleanupcount   INT := 0;
+    sessionappinfocleanupcount       INT := 0;
+    operationalappinfocleanupcount   INT := 0;
+    sessionmetadatacleanupcount      INT := 0;
+    operationalmetadatacleanupcount  INT := 0;
     operationcleanupcount            INT := 0;
 
 -- ------------------------------------------
@@ -127,14 +137,49 @@ BEGIN
             END IF;
 
             -- Deleting user-session mappings from 'IDN_AUTH_USER_SESSION_MAPPING' table
-            EXECUTE IMMEDIATE 'DELETE FROM IDN_AUTH_USER_SESSION_MAPPING WHERE SESSION_ID IN (SELECT SESSION_ID FROM TEMP_SESSION_BATCH)';
-            sessionmappingcleanupcount := SQL%rowcount;
-            COMMIT;
+            SELECT COUNT(*) INTO ROWCOUNT from ALL_TABLES where OWNER = CURRENT_SCHEMA AND table_name = upper('IDN_AUTH_USER_SESSION_MAPPING');
+            IF (ROWCOUNT = 1) then
+                EXECUTE IMMEDIATE 'DELETE FROM IDN_AUTH_USER_SESSION_MAPPING WHERE SESSION_ID IN (SELECT SESSION_ID FROM TEMP_SESSION_BATCH)';
+                sessionmappingcleanupcount := SQL%rowcount;
+                COMMIT;
 
-            IF ( tracingenabled ) THEN
-            EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''DELETED USER-SESSION MAPPINGS COMPLETED WITH '|| sessionmappingcleanupcount||''')';
-            COMMIT;
-            END IF;
+                IF ( tracingenabled ) THEN
+                    deletedmappingsessions := deletedmappingsessions + sessionmappingcleanupcount;
+                    EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''DELETED USER-SESSION MAPPINGS COMPLETED WITH '|| sessionmappingcleanupcount||''')';
+                    COMMIT;
+                END IF;
+            END if;
+            -- End of deleting user-session mappings from 'IDN_AUTH_USER_SESSION_MAPPING' table
+
+            -- Deleting session app info from 'IDN_AUTH_SESSION_APP_INFO' table
+            SELECT COUNT(*) INTO ROWCOUNT from ALL_TABLES where OWNER = CURRENT_SCHEMA AND table_name = upper('IDN_AUTH_SESSION_APP_INFO');
+            IF (ROWCOUNT = 1) then
+                EXECUTE IMMEDIATE 'DELETE FROM IDN_AUTH_SESSION_APP_INFO WHERE SESSION_ID IN (SELECT SESSION_ID FROM TEMP_SESSION_BATCH)';
+                sessionappinfocleanupcount := SQL%rowcount;
+                COMMIT;
+
+                IF ( tracingenabled ) THEN
+                    deletedsessionapppinfo := deletedsessionapppinfo + sessionappinfocleanupcount;
+                    EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''DELETED SESSION APP INFO COMPLETED WITH '|| sessionappinfocleanupcount||''')';
+                    COMMIT;
+                END IF;
+            END if;
+            -- End of deleting session app info from 'IDN_AUTH_SESSION_APP_INFO' table
+
+            -- Deleting session metadata from 'IDN_AUTH_SESSION_META_DATA' table
+            SELECT COUNT(*) INTO ROWCOUNT from ALL_TABLES where OWNER = CURRENT_SCHEMA AND table_name = upper('IDN_AUTH_SESSION_META_DATA');
+            IF (ROWCOUNT = 1) then
+                EXECUTE IMMEDIATE 'DELETE FROM IDN_AUTH_SESSION_META_DATA WHERE SESSION_ID IN (SELECT SESSION_ID FROM TEMP_SESSION_BATCH)';
+                sessionmetadatacleanupcount := SQL%rowcount;
+                COMMIT;
+
+                IF ( tracingenabled ) THEN
+                    deletedsessionmetadata := deletedsessionmetadata + sessionmetadatacleanupcount;
+                    EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''DELETED SESSION METADATA COMPLETED WITH '|| sessionmetadatacleanupcount||''')';
+                    COMMIT;
+                END IF;
+            END if;
+            -- End of deleting session metadata from 'IDN_AUTH_SESSION_META_DATA' table
 
             EXECUTE IMMEDIATE 'DELETE FROM IDN_AUTH_SESSION_STORE_TMP WHERE ROW_ID IN (SELECT ROW_ID FROM TEMP_SESSION_BATCH)';
 --            EXECUTE IMMEDIATE 'DELETE FROM IDN_AUTH_SESSION_STORE_TMP WHERE SESSION_ID IN (SELECT SESSION_ID FROM JOIN TEMP_SESSION_BATCH)';
@@ -151,12 +196,6 @@ BEGIN
             COMMIT;
             END IF;
 
-            IF ( tracingenabled ) THEN
-            deletedmappingsessions := deletedmappingsessions + sessionmappingcleanupcount;
-            EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''TOTAL REMOVED USER-SESSION MAPPINGS COMPLETED WITH '|| deletedmappingsessions||''')';
-            COMMIT;
-            END IF;
-
             dbms_lock.sleep(sleeptime);
         END LOOP;
 
@@ -164,6 +203,9 @@ BEGIN
 
     IF ( tracingenabled ) THEN
         EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''SESSION_CLEANUP_TASK COMPLETED REMOVING '||deletedsessions||' SESSIONS'')';
+        EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''SESSION_CLEANUP_TASK COMPLETED REMOVING '||deletedmappingsessions||' USER-SESSION MAPPINGS'')';
+        EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''SESSION_CLEANUP_TASK COMPLETED REMOVING '||deletedsessionapppinfo||' SESSION APP INFO ENTRIES'')';
+        EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''SESSION_CLEANUP_TASK COMPLETED REMOVING '||deletedsessionmetadata||' SESSION METADATA ENTRIES'')';
         COMMIT;
     END IF;
 
@@ -190,10 +232,10 @@ BEGIN
         
 --        EXECUTE IMMEDIATE 'CREATE TABLE IDN_AUTH_SESSION_STORE_TMP AS SELECT SESSION_ID,SESSION_TYPE FROM IDN_AUTH_SESSION_STORE WHERE 1=2';
 
-         EXECUTE IMMEDIATE 'CREATE TABLE IDN_AUTH_SESSION_STORE_TMP (ROW_ID rowid,CONSTRAINT CHNK_IDN_OATH_ACCS_TOK_PRI PRIMARY KEY (ROW_ID)) NOLOGGING';
+         EXECUTE IMMEDIATE 'CREATE TABLE IDN_AUTH_SESSION_STORE_TMP (ROW_ID rowid,SESSION_ID varchar(100),CONSTRAINT CHNK_IDN_OATH_ACCS_TOK_PRI PRIMARY KEY (ROW_ID)) NOLOGGING';
 
 
-        EXECUTE IMMEDIATE 'INSERT INTO IDN_AUTH_SESSION_STORE_TMP SELECT rowid FROM IDN_AUTH_SESSION_STORE WHERE rownum <= :chunkLimit AND OPERATION = ''DELETE'' AND TIME_CREATED < :operationCleanupTime'
+        EXECUTE IMMEDIATE 'INSERT INTO IDN_AUTH_SESSION_STORE_TMP SELECT rowid,SESSION_ID FROM IDN_AUTH_SESSION_STORE WHERE rownum <= :chunkLimit AND OPERATION = ''DELETE'' AND TIME_CREATED < :operationCleanupTime'
         USING chunklimit,operationcleanuptime;
         rowcount := SQL%rowcount;
         
@@ -218,10 +260,10 @@ BEGIN
             END IF;
             
 --            EXECUTE IMMEDIATE 'CREATE TABLE TEMP_SESSION_BATCH AS SELECT SESSION_ID, SESSION_TYPE FROM IDN_AUTH_SESSION_STORE_TMP WHERE 1=2';
-              EXECUTE IMMEDIATE 'CREATE TABLE TEMP_SESSION_BATCH (ROW_ID rowid,CONSTRAINT BATCH_IDN_OATH_ACCS_TOK_PRI PRIMARY KEY (ROW_ID)) NOLOGGING';
+              EXECUTE IMMEDIATE 'CREATE TABLE TEMP_SESSION_BATCH (ROW_ID rowid,SESSION_ID varchar(100),CONSTRAINT BATCH_IDN_OATH_ACCS_TOK_PRI PRIMARY KEY (ROW_ID)) NOLOGGING';
               COMMIT;
 
-            EXECUTE IMMEDIATE 'INSERT INTO TEMP_SESSION_BATCH SELECT ROW_ID FROM IDN_AUTH_SESSION_STORE_TMP WHERE rownum <= :batchSize'
+            EXECUTE IMMEDIATE 'INSERT INTO TEMP_SESSION_BATCH SELECT ROW_ID,SESSION_ID FROM IDN_AUTH_SESSION_STORE_TMP WHERE rownum <= :batchSize'
             USING batchsize;
             rowcount := SQL%rowcount;
             COMMIT;
@@ -236,6 +278,51 @@ BEGIN
                 EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''DELETED  STORE OPERATIONS COMPLETED WITH '||operationcleanupcount||''')';
                 COMMIT;
             END IF;
+
+            -- Deleting operational data related user-session mappings from 'IDN_AUTH_USER_SESSION_MAPPING' table
+            SELECT COUNT(*) INTO ROWCOUNT from ALL_TABLES where OWNER = CURRENT_SCHEMA AND table_name = upper('IDN_AUTH_USER_SESSION_MAPPING');
+            IF (ROWCOUNT = 1) then
+                EXECUTE IMMEDIATE 'DELETE FROM IDN_AUTH_USER_SESSION_MAPPING WHERE SESSION_ID IN (SELECT SESSION_ID FROM TEMP_SESSION_BATCH)';
+                operationalmappingcleanupcount := SQL%rowcount;
+                COMMIT;
+
+                IF ( tracingenabled ) THEN
+                    deletedoperationalsessionmappings := deletedoperationalsessionmappings + operationalmappingcleanupcount;
+                    EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''DELETED OPERATIONAL USER-SESSION MAPPINGS COMPLETED WITH '|| operationalmappingcleanupcount||''')';
+                    COMMIT;
+                END IF;
+            END if;
+            -- End of deleting operational data related user-session mappings from 'IDN_AUTH_USER_SESSION_MAPPING' table
+
+            -- Deleting operational data related session app info from 'IDN_AUTH_SESSION_APP_INFO' table
+            SELECT COUNT(*) INTO ROWCOUNT from ALL_TABLES where OWNER = CURRENT_SCHEMA AND table_name = upper('IDN_AUTH_SESSION_APP_INFO');
+            IF (ROWCOUNT = 1) then
+                EXECUTE IMMEDIATE 'DELETE FROM IDN_AUTH_SESSION_APP_INFO WHERE SESSION_ID IN (SELECT SESSION_ID FROM TEMP_SESSION_BATCH)';
+                operationalappinfocleanupcount := SQL%rowcount;
+                COMMIT;
+
+                IF ( tracingenabled ) THEN
+                    deletedoperationalsessionapppinfo := deletedoperationalsessionapppinfo + operationalappinfocleanupcount;
+                    EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''DELETED OPERATIONAL SESSION APP INFO COMPLETED WITH '|| operationalappinfocleanupcount||''')';
+                    COMMIT;
+                END IF;
+            END if;
+            -- End of deleting operational data related session app info from 'IDN_AUTH_SESSION_APP_INFO' table
+
+            -- Deleting operational data related session metadata from 'IDN_AUTH_SESSION_META_DATA' table
+            SELECT COUNT(*) INTO ROWCOUNT from ALL_TABLES where OWNER = CURRENT_SCHEMA AND table_name = upper('IDN_AUTH_SESSION_META_DATA');
+            IF (ROWCOUNT = 1) then
+                EXECUTE IMMEDIATE 'DELETE FROM IDN_AUTH_SESSION_META_DATA WHERE SESSION_ID IN (SELECT SESSION_ID FROM TEMP_SESSION_BATCH)';
+                operationalmetadatacleanupcount := SQL%rowcount;
+                COMMIT;
+
+                IF ( tracingenabled ) THEN
+                    deletedoperationalsessionmetadata := deletedoperationalsessionmetadata + operationalmetadatacleanupcount;
+                    EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''DELETED OPERATIONAL SESSION METADATA COMPLETED WITH '|| operationalmetadatacleanupcount||''')';
+                    COMMIT;
+                END IF;
+            END if;
+            -- End of deleting operational data related session metadata from 'IDN_AUTH_SESSION_META_DATA' table
 
             EXECUTE IMMEDIATE 'DELETE IDN_AUTH_SESSION_STORE_TMP where ROW_ID in (select ROW_ID from TEMP_SESSION_BATCH)';
             COMMIT;
@@ -269,6 +356,9 @@ BEGIN
     EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),'' '')';
         EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''TOTAL REMOVED SESSIONS COMPLETED WITH '||deletedsessions||''')';
         EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''TOTAL REMOVED OPERATIONS COMPLETED WITH '||deletedstoreoperations||''')';
+        EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''TOTAL REMOVED OPERATION RELATED USER SESSION MAPPINGS COMPLETED WITH '||deletedoperationalsessionmappings||''')';
+        EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''TOTAL REMOVED OPERATION RELATED SESSION APP INFO COMPLETED WITH '||deletedoperationalsessionapppinfo||''')';
+        EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''TOTAL REMOVED OPERATION RELATED SESSION METADATA COMPLETED WITH '||deletedoperationalsessionmetadata||''')';
         EXECUTE IMMEDIATE 'INSERT INTO LOG_WSO2_SESSION_CLEANUP_SP (TIMESTAMP,LOG) VALUES (TO_CHAR( SYSTIMESTAMP, ''DD.MM.YYYY HH24:MI:SS:FF4''),''WSO2_SESSION_CLEANUP_SP COMPLETED .... ! '')';
         COMMIT;
     END IF;

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/postgresql/postgre-11x/sessiondata-cleanup/postgresql_11-session-data-cleanup.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/postgresql/postgre-11x/sessiondata-cleanup/postgresql_11-session-data-cleanup.sql
@@ -241,7 +241,6 @@ LOOP
             notice := 'BATCH DELETE START ON TABLE '||purgingSessionAppInfoTable||' WITH :'||batchCount;
             RAISE NOTICE '%',notice;
             END IF;
-
             EXECUTE 'DELETE from '||quote_ident(purgingSessionAppInfoTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
             GET diagnostics deleteAppInfoCount := ROW_COUNT;
             COMMIT;
@@ -261,7 +260,6 @@ LOOP
             notice := 'BATCH DELETE START ON TABLE '||purgingSessionMetadataTable||' WITH :'||batchCount;
             RAISE NOTICE '%',notice;
             END IF;
-
             EXECUTE 'DELETE from '||quote_ident(purgingSessionMetadataTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
             GET diagnostics deleteMetadataCount := ROW_COUNT;
             COMMIT;
@@ -416,7 +414,6 @@ LOOP
                 notice := 'BATCH DELETE START ON TABLE '||purgingSessionAppInfoTable||' WITH :'||batchCount;
                 RAISE NOTICE '%',notice;
             END IF;
-
             EXECUTE 'DELETE from '||quote_ident(purgingSessionAppInfoTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
             GET diagnostics deleteAppInfoCount := ROW_COUNT;
             COMMIT;
@@ -436,7 +433,6 @@ LOOP
                 notice := 'BATCH DELETE START ON TABLE '||purgingSessionMetadataTable||' WITH :'||batchCount;
                 RAISE NOTICE '%',notice;
             END IF;
-
             EXECUTE 'DELETE from '||quote_ident(purgingSessionMetadataTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
             GET diagnostics deleteMetadataCount := ROW_COUNT;
             COMMIT;

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/postgresql/postgre-11x/sessiondata-cleanup/postgresql_11-session-data-cleanup.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/postgresql/postgre-11x/sessiondata-cleanup/postgresql_11-session-data-cleanup.sql
@@ -19,6 +19,8 @@ sessionCleanupTime bigint :=0;
 operationCleanupTime bigint :=0;
 deleteCount INT := 0;
 deleteMappingCount INT := 0;
+deleteAppInfoCount INT := 0;
+deleteMetadataCount INT := 0;
 chunkCount INT := 0;
 batchCount INT := 0;
 
@@ -27,6 +29,8 @@ tablename  IN ('idn_auth_session_store');
 
 purgingTable text;
 purgingSessionUserMappingTable text;
+purgingSessionAppInfoTable text;
+purgingSessionMetadataTable text;
 purgingChunkTable text;
 purgingBatchTable text;
 purgeBseColmn text;
@@ -54,6 +58,8 @@ unix_timestamp := TRUNC(extract(epoch from now() at time zone 'utc'));
 
 purgingTable := 'idn_auth_session_store';
 purgingSessionUserMappingTable = 'idn_auth_user_session_mapping';
+purgingSessionAppInfoTable = 'idn_auth_session_app_info';
+purgingSessionMetadataTable = 'idn_auth_session_meta_data';
 purgeBseColmn := 'session_id';
 purgeBseColmnType := 'varchar';
 
@@ -208,21 +214,64 @@ LOOP
         END IF;
 
         -- Deleting user-session mappings from 'idn_auth_user_session_mapping' table
-        IF (enableLog AND logLevel IN ('TRACE')) THEN
-        notice := 'BATCH DELETE START ON TABLE '||purgingSessionUserMappingTable||' WITH :'||batchCount;
-        RAISE NOTICE '%',notice;
-        END IF;
+        EXECUTE 'SELECT count(1) from pg_catalog.pg_tables WHERE schemaname = current_schema() AND tablename =  $1' into rowcount USING purgingSessionUserMappingTable;
+        IF (rowcount = 1)
+        THEN
+            IF (enableLog AND logLevel IN ('TRACE')) THEN
+            notice := 'BATCH DELETE START ON TABLE '||purgingSessionUserMappingTable||' WITH :'||batchCount;
+            RAISE NOTICE '%',notice;
+            END IF;
 
-        EXECUTE 'DELETE from '||quote_ident(purgingSessionUserMappingTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
-        GET diagnostics deleteMappingCount := ROW_COUNT;
-        COMMIT;
+            EXECUTE 'DELETE from '||quote_ident(purgingSessionUserMappingTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
+            GET diagnostics deleteMappingCount := ROW_COUNT;
+            COMMIT;
 
-        IF (enableLog AND logLevel IN ('DEBUG','TRACE')) THEN
-        notice := 'BATCH DELETE FINISHED ON TABLE '||purgingSessionUserMappingTable||' WITH :'||deleteMappingCount;
-        RAISE NOTICE '%',notice;
+            IF (enableLog AND logLevel IN ('DEBUG','TRACE')) THEN
+            notice := 'BATCH DELETE FINISHED ON TABLE '||purgingSessionUserMappingTable||' WITH :'||deleteMappingCount;
+            RAISE NOTICE '%',notice;
+            END IF;
         END IF;
         -- End of deleting user-session mappings from 'idn_auth_user_session_mapping' table
 
+        -- Deleting session app info from 'idn_auth_session_app_info' table
+        EXECUTE 'SELECT count(1) from pg_catalog.pg_tables WHERE schemaname = current_schema() AND tablename =  $1' into rowcount USING purgingSessionAppInfoTable;
+        IF (rowcount = 1)
+        THEN
+            IF (enableLog AND logLevel IN ('TRACE')) THEN
+            notice := 'BATCH DELETE START ON TABLE '||purgingSessionAppInfoTable||' WITH :'||batchCount;
+            RAISE NOTICE '%',notice;
+            END IF;
+
+            EXECUTE 'DELETE from '||quote_ident(purgingSessionAppInfoTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
+            GET diagnostics deleteAppInfoCount := ROW_COUNT;
+            COMMIT;
+
+            IF (enableLog AND logLevel IN ('DEBUG','TRACE')) THEN
+            notice := 'BATCH DELETE FINISHED ON TABLE '||purgingSessionAppInfoTable||' WITH :'||deleteAppInfoCount;
+            RAISE NOTICE '%',notice;
+            END IF;
+        END IF;
+        -- End of deleting session app info from 'idn_auth_session_app_info' table
+
+        -- Deleting session metadata from 'idn_auth_session_meta_data' table
+        EXECUTE 'SELECT count(1) from pg_catalog.pg_tables WHERE schemaname = current_schema() AND tablename =  $1' into rowcount USING purgingSessionMetadataTable;
+        IF (rowcount = 1)
+        THEN
+            IF (enableLog AND logLevel IN ('TRACE')) THEN
+            notice := 'BATCH DELETE START ON TABLE '||purgingSessionMetadataTable||' WITH :'||batchCount;
+            RAISE NOTICE '%',notice;
+            END IF;
+
+            EXECUTE 'DELETE from '||quote_ident(purgingSessionMetadataTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
+            GET diagnostics deleteMetadataCount := ROW_COUNT;
+            COMMIT;
+
+            IF (enableLog AND logLevel IN ('DEBUG','TRACE')) THEN
+            notice := 'BATCH DELETE FINISHED ON TABLE '||purgingSessionMetadataTable||' WITH :'||deleteMetadataCount;
+            RAISE NOTICE '%',notice;
+            END IF;
+        END IF;
+        -- End of deleting session metadata from 'idn_auth_session_meta_data' table
 
         EXECUTE ' DELETE from '||quote_ident(purgingChunkTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
         IF (enableLog AND logLevel IN ('TRACE')) THEN
@@ -340,20 +389,64 @@ LOOP
         END IF;
 
         -- Deleting user-session mappings from 'idn_auth_user_session_mapping' table
-        IF (enableLog AND logLevel IN ('TRACE')) THEN
-        notice := 'BATCH DELETE START ON TABLE '||purgingSessionUserMappingTable||' WITH :'||batchCount;
-        RAISE NOTICE '%',notice;
-        END IF;
+        EXECUTE 'SELECT count(1) from pg_catalog.pg_tables WHERE schemaname = current_schema() AND tablename =  $1' into rowcount USING purgingSessionUserMappingTable;
+        IF (rowcount = 1)
+        THEN
+            IF (enableLog AND logLevel IN ('TRACE')) THEN
+                notice := 'BATCH DELETE START ON TABLE '||purgingSessionUserMappingTable||' WITH :'||batchCount;
+                RAISE NOTICE '%',notice;
+            END IF;
 
-        EXECUTE 'DELETE from '||quote_ident(purgingSessionUserMappingTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
-        GET diagnostics deleteMappingCount := ROW_COUNT;
-        COMMIT;
+            EXECUTE 'DELETE from '||quote_ident(purgingSessionUserMappingTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
+            GET diagnostics deleteMappingCount := ROW_COUNT;
+            COMMIT;
 
-        IF (enableLog AND logLevel IN ('DEBUG','TRACE')) THEN
-        notice := 'BATCH DELETE FINISHED ON TABLE '||purgingSessionUserMappingTable||' WITH :'||deleteMappingCount;
-        RAISE NOTICE '%',notice;
+            IF (enableLog AND logLevel IN ('DEBUG','TRACE')) THEN
+                notice := 'BATCH DELETE FINISHED ON TABLE '||purgingSessionUserMappingTable||' WITH :'||deleteMappingCount;
+                RAISE NOTICE '%',notice;
+            END IF;
         END IF;
         -- End of deleting user-session mappings from 'idn_auth_user_session_mapping' table
+
+        -- Deleting session app info from 'idn_auth_session_app_info' table
+        EXECUTE 'SELECT count(1) from pg_catalog.pg_tables WHERE schemaname = current_schema() AND tablename =  $1' into rowcount USING purgingSessionAppInfoTable;
+        IF (rowcount = 1)
+        THEN
+            IF (enableLog AND logLevel IN ('TRACE')) THEN
+                notice := 'BATCH DELETE START ON TABLE '||purgingSessionAppInfoTable||' WITH :'||batchCount;
+                RAISE NOTICE '%',notice;
+            END IF;
+
+            EXECUTE 'DELETE from '||quote_ident(purgingSessionAppInfoTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
+            GET diagnostics deleteAppInfoCount := ROW_COUNT;
+            COMMIT;
+
+            IF (enableLog AND logLevel IN ('DEBUG','TRACE')) THEN
+                notice := 'BATCH DELETE FINISHED ON TABLE '||purgingSessionAppInfoTable||' WITH :'||deleteAppInfoCount;
+                RAISE NOTICE '%',notice;
+            END IF;
+        END IF;
+        -- End of deleting session app info from 'idn_auth_session_app_info' table
+
+        -- Deleting session metadata from 'idn_auth_session_meta_data' table
+        EXECUTE 'SELECT count(1) from pg_catalog.pg_tables WHERE schemaname = current_schema() AND tablename =  $1' into rowcount USING purgingSessionMetadataTable;
+        IF (rowcount = 1)
+        THEN
+            IF (enableLog AND logLevel IN ('TRACE')) THEN
+                notice := 'BATCH DELETE START ON TABLE '||purgingSessionMetadataTable||' WITH :'||batchCount;
+                RAISE NOTICE '%',notice;
+            END IF;
+
+            EXECUTE 'DELETE from '||quote_ident(purgingSessionMetadataTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
+            GET diagnostics deleteMetadataCount := ROW_COUNT;
+            COMMIT;
+
+            IF (enableLog AND logLevel IN ('DEBUG','TRACE')) THEN
+                notice := 'BATCH DELETE FINISHED ON TABLE '||purgingSessionMetadataTable||' WITH :'||deleteMetadataCount;
+                RAISE NOTICE '%',notice;
+            END IF;
+        END IF;
+        -- End of deleting session metadata from 'idn_auth_session_meta_data' table
 
 
         EXECUTE ' DELETE from '||quote_ident(purgingChunkTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/postgresql/postgre-9x/sessiondata-cleanup/postgresql-session-data-cleanup.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/postgresql/postgre-9x/sessiondata-cleanup/postgresql-session-data-cleanup.sql
@@ -21,6 +21,8 @@ sessionCleanupTime bigint :=0;
 operationCleanupTime bigint :=0;
 deleteCount INT := 0;
 deleteMappingCount INT := 0;
+deleteAppInfoCount INT := 0;
+deleteMetadataCount INT := 0;
 chunkCount INT := 0;
 batchCount INT := 0;
 
@@ -29,6 +31,8 @@ tablename  IN ('idn_auth_session_store');
 
 purgingTable text;
 purgingSessionUserMappingTable text;
+purgingSessionAppInfoTable text;
+purgingSessionMetadataTable text;
 purgingChunkTable text;
 purgingBatchTable text;
 purgeBseColmn text;
@@ -63,6 +67,8 @@ IF (operationid = 1 OR operationid = 2)
 THEN
     purgingTable := 'idn_auth_session_store';
     purgingSessionUserMappingTable = 'idn_auth_user_session_mapping';
+    purgingSessionAppInfoTable = 'idn_auth_session_app_info';
+    purgingSessionMetadataTable = 'idn_auth_session_meta_data';
     purgeBseColmn := 'session_id';
 	purgeBseColmnType := 'varchar';
 
@@ -83,6 +89,9 @@ THEN
 ELSIF (operationid = 3 OR operationid = 4)
 THEN
     purgingTable := 'idn_auth_session_store';
+    purgingSessionUserMappingTable = 'idn_auth_user_session_mapping';
+    purgingSessionAppInfoTable = 'idn_auth_session_app_info';
+    purgingSessionMetadataTable = 'idn_auth_session_meta_data';
     purgeBseColmn := 'session_id';
 	purgeBseColmnType := 'varchar';
 
@@ -328,13 +337,14 @@ auditTable :=  purgingTable||'_auditlog';
             GET diagnostics deleteCount := ROW_COUNT;
 
             IF (enableLog AND logLevel IN ('DEBUG','TRACE')) THEN
-            notice := 'BATCH DELETE FINISHED ON TABLE'||purgingTable||' WITH :'||deleteCount;
+            notice := 'BATCH DELETE FINISHED ON TABLE '||purgingTable||' WITH :'||deleteCount;
             RAISE NOTICE '%',notice;
             END IF;
 
-            IF (operationid = 2)
+            -- Deleting user-session mappings from 'idn_auth_user_session_mapping' table
+            EXECUTE 'SELECT count(1) from pg_catalog.pg_tables WHERE schemaname = current_schema() AND tablename =  $1' into rowcount USING purgingSessionUserMappingTable;
+            IF (rowcount = 1)
     		THEN
-	            -- Deleting user-session mappings from 'idn_auth_user_session_mapping' table
 	            IF (enableLog AND logLevel IN ('TRACE')) THEN
 	            notice := 'BATCH DELETE START ON TABLE '||purgingSessionUserMappingTable||' WITH :'||batchCount;
 	            RAISE NOTICE '%',notice;
@@ -344,10 +354,49 @@ auditTable :=  purgingTable||'_auditlog';
 	            GET diagnostics deleteMappingCount := ROW_COUNT;
 
 	            IF (enableLog AND logLevel IN ('DEBUG','TRACE')) THEN
-	            notice := 'BATCH DELETE FINISHED ON TABLE'||purgingSessionUserMappingTable||' WITH :'||deleteMappingCount;
+	            notice := 'BATCH DELETE FINISHED ON TABLE '||purgingSessionUserMappingTable||' WITH :'||deleteMappingCount;
 	            RAISE NOTICE '%',notice;
 	            END IF;
 	        END IF;
+            -- End of deleting user-session mappings from 'idn_auth_user_session_mapping' table
+
+            -- Deleting session app info from 'idn_auth_session_app_info' table
+            EXECUTE 'SELECT count(1) from pg_catalog.pg_tables WHERE schemaname = current_schema() AND tablename =  $1' into rowcount USING purgingSessionAppInfoTable;
+            IF (rowcount = 1)
+            THEN
+                IF (enableLog AND logLevel IN ('TRACE')) THEN
+                    notice := 'BATCH DELETE START ON TABLE '||purgingSessionAppInfoTable||' WITH :'||batchCount;
+                    RAISE NOTICE '%',notice;
+                END IF;
+
+                EXECUTE 'DELETE from '||quote_ident(purgingSessionAppInfoTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
+                GET diagnostics deleteAppInfoCount := ROW_COUNT;
+
+                IF (enableLog AND logLevel IN ('DEBUG','TRACE')) THEN
+                    notice := 'BATCH DELETE FINISHED ON TABLE '||purgingSessionAppInfoTable||' WITH :'||deleteAppInfoCount;
+                    RAISE NOTICE '%',notice;
+                END IF;
+            END IF;
+            -- End of deleting session app info from 'idn_auth_session_app_info' table
+
+            -- Deleting session metadata from 'idn_auth_session_meta_data' table
+            EXECUTE 'SELECT count(1) from pg_catalog.pg_tables WHERE schemaname = current_schema() AND tablename =  $1' into rowcount USING purgingSessionMetadataTable;
+            IF (rowcount = 1)
+            THEN
+                IF (enableLog AND logLevel IN ('TRACE')) THEN
+                    notice := 'BATCH DELETE START ON TABLE '||purgingSessionMetadataTable||' WITH :'||batchCount;
+                    RAISE NOTICE '%',notice;
+                END IF;
+
+                EXECUTE 'DELETE from '||quote_ident(purgingSessionMetadataTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
+                GET diagnostics deleteMetadataCount := ROW_COUNT;
+
+                IF (enableLog AND logLevel IN ('DEBUG','TRACE')) THEN
+                    notice := 'BATCH DELETE FINISHED ON TABLE '||purgingSessionMetadataTable||' WITH :'||deleteMetadataCount;
+                    RAISE NOTICE '%',notice;
+                END IF;
+            END IF;
+            -- End of deleting session metadata from 'idn_auth_session_meta_data' table
 
             EXECUTE ' DELETE from '||quote_ident(purgingChunkTable)||' a USING '||purgingBatchTable||' b where a.'||purgeBseColmn||' = b.'||purgeBseColmn||'';
             IF (enableLog AND logLevel IN ('TRACE')) THEN


### PR DESCRIPTION
This PR
-  Introduces session data clean up for the IDN_AUTH_SESSION_APP_INFO_TABLE, IDN_AUTH_SESSION_META_DATA tables to the existing mysql, postgresql-9, postgresql-11, mssql, oracle session data scripts.
- Adds cleaning up of IDN_AUTH_USER_SESSION_MAPPING table to the operational data clean up section of all scripts.
- Adds a check to verify if the table exists before cleaning up the tables - IDN_AUTH_USER_SESSION_MAPPING, IDN_AUTH_SESSION_APP_INFO_TABLE, IDN_AUTH_SESSION_META_DATA

Resolves : https://github.com/wso2/product-is/issues/9929, https://github.com/wso2/product-is/issues/5287, https://github.com/wso2/product-is/issues/7996
