### PR TITLE
Add tenant loading at userstore create and update

### DIFF
--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/pom.xml
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/pom.xml
@@ -119,6 +119,7 @@
                             org.wso2.carbon.ndatasource.rdbms; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.core.multitenancy.utils;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.utils; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.base; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.package.import.version.range}",

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/internal/UserStoreConfigComponent.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/internal/UserStoreConfigComponent.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.user.store.configuration.listener.UserStoreConfi
 import org.wso2.carbon.identity.user.store.configuration.utils.UserStoreConfigurationConstant;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.utils.ConfigurationContextService;
 
 import java.util.HashSet;
 import java.util.Iterator;
@@ -261,5 +262,28 @@ public class UserStoreConfigComponent {
             }
         }
         UserStoreConfigListenersHolder.getInstance().setAllowedUserstores(allowedUserstores);
+    }
+
+    @Reference(
+            name = "config.context.service",
+            service = ConfigurationContextService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetConfigurationContextService"
+    )
+    protected void setConfigurationContextService(ConfigurationContextService configurationContextService) {
+
+        UserStoreConfigListenersHolder.getInstance().setConfigurationContextService(configurationContextService);
+        if (log.isDebugEnabled()) {
+            log.debug("ConfigurationContextService Instance was set.");
+        }
+    }
+
+    protected void unsetConfigurationContextService(ConfigurationContextService configurationContextService) {
+
+        UserStoreConfigListenersHolder.getInstance().setConfigurationContextService(null);
+        if (log.isDebugEnabled()) {
+            log.debug("ConfigurationContextService Instance was unset.");
+        }
     }
 }

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/internal/UserStoreConfigListenersHolder.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/internal/UserStoreConfigListenersHolder.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.user.store.configuration.internal;
 import org.wso2.carbon.identity.user.store.configuration.UserStoreConfigService;
 import org.wso2.carbon.identity.user.store.configuration.dao.AbstractUserStoreDAOFactory;
 import org.wso2.carbon.identity.user.store.configuration.listener.UserStoreConfigListener;
+import org.wso2.carbon.utils.ConfigurationContextService;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,6 +38,7 @@ public class UserStoreConfigListenersHolder {
     private Map<String, AbstractUserStoreDAOFactory> userStoreDAOFactory = new HashMap<>();
     private UserStoreConfigService userStoreConfigService;
     private Set<String> allowedUserstores = null;
+    private ConfigurationContextService configurationContextService;
 
 
     private UserStoreConfigListenersHolder() {
@@ -79,6 +81,16 @@ public class UserStoreConfigListenersHolder {
     public void setAllowedUserstores(Set<String> allowedUserstores) {
 
         this.allowedUserstores = allowedUserstores;
+    }
+
+    public ConfigurationContextService getConfigurationContextService() {
+
+        return configurationContextService;
+    }
+
+    public void setConfigurationContextService(ConfigurationContextService configurationContextService) {
+
+        this.configurationContextService = configurationContextService;
     }
 
 }


### PR DESCRIPTION
When the tenant is unloaded some userstore actions does not get fully completed in tenant mode.
With this PR if a userstore action is called in tenant mode and the tenant is not loaded it will trigger a tenant loading.

Resolves https://github.com/wso2/product-is/issues/9868
Resolves https://github.com/wso2/product-is/issues/9621
Resolves https://github.com/wso2/product-is/issues/9721
Resolves https://github.com/wso2/product-is/issues/9971