### PR TITLE
[FIX] Throwing an error when the user count is failed

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/role/role-mgt.jsp
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/role/role-mgt.jsp
@@ -219,7 +219,13 @@
                 if (selectedCountDomain.equalsIgnoreCase(UserAdminUIConstants.ALL_DOMAINS)) {
                     roleCount = countClient.countRoles(countFilter);
                 } else {
-                    roleCount.put(selectedCountDomain, String.valueOf(countClient.countRolesInDomain(countFilter, selectedCountDomain)));
+                    try {
+                        roleCount.put(selectedCountDomain, String.valueOf(countClient.countRolesInDomain(countFilter,
+                            selectedCountDomain)));
+                    } catch (Exception e) {
+                        // In this scenario an error should be shown in the count results section.
+                        roleCount.put(selectedCountDomain, "Error while getting the role count");
+                    }
                 }
             }
 
@@ -509,9 +515,18 @@
                     <tr>
                         <td class="leftCol-big" style="padding-right: 0 !important;"><%=Encode.forHtml(key)%></td>
                         <td>
+                            <%
+                            if (StringUtils.isNumeric(value)) {
+                            %>
                             <input type="text" readonly=true name="<%=UserAdminUIConstants.ROLE_COUNT%>"
                                    value="<%=Encode.forHtmlAttribute(value)%>" />
-
+                            <%
+                            } else {
+                            %>
+                            <p>Error occurred while getting the count</p>
+                            <%
+                            }
+                            %>
                         </td>
                     </tr>
 

--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/user/user-mgt.jsp
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/user/user-mgt.jsp
@@ -245,14 +245,25 @@
                     if (selectedCountDomain.equalsIgnoreCase(UserAdminUIConstants.ALL_DOMAINS)) {
                         userCount = countClient.countUsers(countFilter);
                     } else {
-                        userCount.put(selectedCountDomain, String.valueOf(countClient.countUsersInDomain(countFilter, selectedCountDomain)));
+                        try {
+                            userCount.put(selectedCountDomain, String.valueOf(countClient.countUsersInDomain(countFilter,
+                                selectedCountDomain)));
+                        } catch (Exception e) {
+                            // In this scenario an error should be shown in the count results section.
+                            userCount.put(selectedCountDomain, "Error while getting user count");
+                        }
                     }
                 } else {                //this is a claim based search
                     if (selectedCountDomain.equalsIgnoreCase(UserAdminUIConstants.ALL_DOMAINS)) {
                         userCount = countClient.countByClaim(countClaimUri, countFilter);
                     } else {
-                        userCount.put(selectedCountDomain, String.valueOf(countClient.countByClaimInDomain(countClaimUri,
-                                countFilter, selectedCountDomain)));
+                        try {
+                            userCount.put(selectedCountDomain, String.valueOf(countClient.countByClaimInDomain
+                                (countClaimUri, countFilter, selectedCountDomain)));
+                        } catch (Exception e) {
+                            // In this scenario an error should be shown in the count results section.
+                            userCount.put(selectedCountDomain, "Error while getting user count");
+                        }
                     }
                 }
             }
@@ -595,9 +606,18 @@
                         <td class="leftCol-big" style="padding-right: 0 !important;"><%=Encode.forHtml(key)%>
                         </td>
                         <td>
+                            <%
+                            if (StringUtils.isNumeric(value)) {
+                            %>
                             <input type="text" readonly=true name="<%=UserAdminUIConstants.USER_COUNT%>"
-                                   value="<%=Encode.forHtmlAttribute(value)%>"/>
-
+                                                               value="<%=Encode.forHtmlAttribute(value)%>"/>
+                            <%
+                            } else {
+                            %>
+                            <p>Error occurred while getting the count</p>
+                            <%
+                            }
+                            %>
                         </td>
                     </tr>
 

--- a/components/user-store/org.wso2.carbon.identity.user.store.count/src/main/java/org/wso2/carbon/identity/user/store/count/UserStoreCountService.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.count/src/main/java/org/wso2/carbon/identity/user/store/count/UserStoreCountService.java
@@ -56,11 +56,11 @@ public class UserStoreCountService {
             long count = -1L;
             try {
                 count = getUserCountWithClaims(UserStoreCountUtils.USERNAME_CLAIM, filterWithDomain);
+                userCounts[i] = new PairDTO(userStoreDomain, Long.toString(count));
             } catch (UserStoreCounterException e) {
-                String errorMsg = "Error while getting user count from user store domain : " + userStoreDomain;
-                throw new UserStoreCounterException(errorMsg, e);
+                userCounts[i] = new PairDTO(userStoreDomain, "Error while getting user count");
+                log.error("Error while getting user count from user store domain : " + userStoreDomain, e);
             }
-            userCounts[i] = new PairDTO(userStoreDomain, Long.toString(count));
             i++;
         }
         return userCounts;
@@ -82,8 +82,13 @@ public class UserStoreCountService {
         for (String userStoreDomain : userStoreDomains) {
             long count = -1L;
             String filterWithDomain = getFilterWithDomain(userStoreDomain, filter);
-            count = getRoleCount(filterWithDomain);
-            roleCounts[i] = new PairDTO(userStoreDomain, Long.toString(count));
+            try {
+                count = getRoleCount(filterWithDomain);
+                roleCounts[i] = new PairDTO(userStoreDomain, Long.toString(count));
+            } catch (UserStoreCounterException e) {
+                roleCounts[i] = new PairDTO(userStoreDomain, "Error while getting role count");
+                log.error("Error while getting role count from user store domain : " + userStoreDomain, e);
+            }
             i++;
         }
         String internalDomainFilter = UserCoreConstants.INTERNAL_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + filter;


### PR DESCRIPTION
Resolve wso2/product-is#9907

### Proposed changes in this pull request
An error message will be displayed if an error occurred while getting the user count. Therefore, the user listing flow will not be affected due to this.