### PR TITLE
Revert "Fix tenant issue in "/validate-username" and "/claims" endpoints."

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
@@ -38,7 +38,6 @@ import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.mgt.endpoint.util.client.ApiException;
 import org.wso2.carbon.identity.mgt.endpoint.util.client.model.Claim;
 import org.wso2.carbon.identity.mgt.endpoint.util.client.model.Error;
@@ -618,17 +617,6 @@ public class IdentityManagementEndpointUtil {
             log.error("Exception while retrieving error details from original exception. Original exception:", e);
             return buildUnexpectedRetryError();
         }
-    }
-
-    /**
-     * Get configurations from the identity.xml.
-     *
-     * @param key Configuration key.
-     * @return Boolean value of the configuration.
-     */
-    public static boolean getConfiguration(String key) {
-
-        return Boolean.parseBoolean(IdentityUtil.getProperty(key));
     }
 
     public static void authenticate(ServiceClient client) throws Exception {

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/SelfRegistrationMgtClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/SelfRegistrationMgtClient.java
@@ -41,12 +41,10 @@ import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants;
 import org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil;
 import org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementServiceUtil;
 import org.wso2.carbon.identity.mgt.endpoint.util.client.model.User;
-import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -143,18 +141,9 @@ public class SelfRegistrationMgtClient {
         return getEndpoint(tenantDomain, CONSENT_API_RELATIVE_PATH + PURPOSES_CATEGORIES_ENDPOINT_RELATIVE_PATH);
     }
 
-    private String getUserAPIEndpoint(String tenantDomain) throws SelfRegistrationMgtClientException {
+    private String getUserAPIEndpoint() throws SelfRegistrationMgtClientException {
 
-        // Added to maintain backward compatibility.
-        if (!IdentityManagementEndpointUtil.getConfiguration(IdentityCoreConstants.ENABLE_TENANT_QUALIFIED_URLS)) {
-            return IdentityManagementEndpointUtil.buildEndpointUrl(USERNAME_VALIDATE_API_RELATIVE_PATH);
-        }
-
-        if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
-            return IdentityManagementEndpointUtil.buildEndpointUrl("t/" + tenantDomain +
-                    USERNAME_VALIDATE_API_RELATIVE_PATH);
-        }
-        return IdentityManagementEndpointUtil.buildEndpointUrl(USERNAME_VALIDATE_API_RELATIVE_PATH);
+        return getEndpoint(null, USERNAME_VALIDATE_API_RELATIVE_PATH);
     }
 
     private String getEndpoint(String tenantDomain, String context) throws SelfRegistrationMgtClientException {
@@ -267,8 +256,7 @@ public class SelfRegistrationMgtClient {
 
             userObject.put(PROPERTIES, properties);
 
-            String tenantDomain = MultitenantUtils.getTenantDomain(user.getUsername());
-            HttpPost post = new HttpPost(getUserAPIEndpoint(tenantDomain));
+            HttpPost post = new HttpPost(getUserAPIEndpoint());
             setAuthorizationHeader(post);
 
             post.setEntity(new StringEntity(userObject.toString(), ContentType.create(HTTPConstants


### PR DESCRIPTION
Reverts wso2/carbon-identity-framework#3172 due to test failures


```
org.wso2.identity.integration.test.consent.SelfSignUpConsentTest.testPurposesWithoutConfiguredPurposes
org.wso2.identity.integration.test.consent.SelfSignUpConsentTest.testWithPurposes
org.wso2.identity.integration.test.consent.SelfSignUpConsentTest.selfSignUpWithConsents
org.wso2.identity.integration.test.consent.SelfSignUpConsentTest.testForAnInvalidTenant
org.wso2.identity.integration.test.consent.SelfSignUpConsentTest.testForCrossTenantWithoutEnabling
```