### PR TITLE
Redundant tenant flow initiation removed when setting permission in the scim2/Roles endpoint

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/dao/RoleDAOImpl.java
@@ -1081,18 +1081,11 @@ public class RoleDAOImpl implements RoleDAO {
             return new RoleBasicInfo(roleID, roleName);
         }
         try {
-            String loggedInUser = CarbonContext.getThreadLocalCarbonContext().getUsername();
-            PrivilegedCarbonContext.startTenantFlow();
-            PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
-            carbonContext.setTenantDomain(tenantDomain, true);
-            carbonContext.setUsername(loggedInUser);
             getUserAdminProxy().setRoleUIPermission(roleName, permissions.toArray(new String[0]));
             return new RoleBasicInfo(roleID, roleName);
         } catch (UserAdminException e) {
             throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(),
                     "An error occurred when setting permissions for the role: " + roleName, e);
-        } finally {
-            PrivilegedCarbonContext.endTenantFlow();
         }
     }
 

--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/dao/RoleDAOImpl.java
@@ -1081,9 +1081,11 @@ public class RoleDAOImpl implements RoleDAO {
             return new RoleBasicInfo(roleID, roleName);
         }
         try {
+            String loggedInUser = CarbonContext.getThreadLocalCarbonContext().getUsername();
             PrivilegedCarbonContext.startTenantFlow();
             PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
             carbonContext.setTenantDomain(tenantDomain, true);
+            carbonContext.setUsername(loggedInUser);
             getUserAdminProxy().setRoleUIPermission(roleName, permissions.toArray(new String[0]));
             return new RoleBasicInfo(roleID, roleName);
         } catch (UserAdminException e) {

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserRealmProxy.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserRealmProxy.java
@@ -82,7 +82,9 @@ public class UserRealmProxy {
 
     public static final String FALSE = "false";
     public static final String PERMISSION = "/permission";
+    public static final String PERMISSION_TREE = "/permission/";
     public static final String PERMISSION_ADMIN = "/permission/admin";
+    public static final String PERMISSION_PROTECTED = "/permission/protected";
     private UserRealm realm = null;
 
     public UserRealmProxy(UserRealm userRealm) {
@@ -2148,8 +2150,10 @@ public class UserRealmProxy {
                     !adminUser.equalsIgnoreCase(loggedInUserName)) {
                 Arrays.sort(rawResources);
                 if (Arrays.binarySearch(rawResources, PERMISSION_ADMIN) > -1 ||
-                        Arrays.binarySearch(rawResources, "/permission/protected") > -1 ||
-                        Arrays.binarySearch(rawResources, PERMISSION) > -1) {
+                        Arrays.binarySearch(rawResources, PERMISSION_PROTECTED) > -1 ||
+                        Arrays.binarySearch(rawResources, PERMISSION) > -1 ||
+                        Arrays.binarySearch(rawResources, PERMISSION_TREE) > -1) {
+
                     log.warn("An attempt to Assign admin permission for role by user : " +
                             loggedInUserName);
                     throw new UserStoreException("Can not assign Admin for permission role");


### PR DESCRIPTION
#### Purpose
> Resolves https://github.com/wso2/product-is/issues/9874

#### Approach
> The set role permissions method fails when setting admin permissions as the logged in user is not passed to the new tenant flow started for the purpose. Starting a new tenant flow is not necessary in this instance as the context does not change from the previous one. 