### PR TITLE
Add capability to configure retry from authenticator level when an ad…

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
@@ -58,6 +58,7 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
 
     private static final long serialVersionUID = -4406878411547612129L;
     private static final Log log = LogFactory.getLog(AbstractApplicationAuthenticator.class);
+    public static final String ENABLE_RETRY_FROM_AUTHENTICATOR = "enableRetryFromAuthenticator";
 
     @Override
     public AuthenticatorFlowStatus process(HttpServletRequest request,
@@ -138,7 +139,12 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
     protected boolean retryAuthenticationEnabled(AuthenticationContext context) {
         SequenceConfig sequenceConfig = context.getSequenceConfig();
         AuthenticationGraph graph = sequenceConfig.getAuthenticationGraph();
-        if (graph == null || !graph.isEnabled()) {
+        boolean isRetryAuthenticatorEnabled = false;
+        Map<String, String> authParams = context.getAuthenticatorParams(context.getCurrentAuthenticator());
+        if (MapUtils.isNotEmpty(authParams)) {
+            isRetryAuthenticatorEnabled = Boolean.parseBoolean(authParams.get(ENABLE_RETRY_FROM_AUTHENTICATOR));
+        }
+        if (graph == null || !graph.isEnabled() || isRetryAuthenticatorEnabled) {
             return retryAuthenticationEnabled();
         }
         return false;


### PR DESCRIPTION
Fixes wso2/product-is#9970

With the fix in the PR, we can use the below adaptive script to set 'enableRetryFromAuthenticator' from authenticator level whenever an authentication graph is configured.

```
var onLoginRequest = function(context) {
    executeStep(1);
    executeStep(2,{
   authenticationOptions:[
      {idp:'smsotp'},{idp:'emailotp'}
   ], authenticatorParams: { federated: { smsotp:
{ enableRetryFromAuthenticator: 'true' }
}}}, {});
};
```