### PR TITLE
Add configs to enable account lock/unlock notification during forced password reset

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -828,6 +828,8 @@
             <Offline>false</Offline>
             <OTP>false</OTP>
             <RecoveryLink>false</RecoveryLink>
+            <AccountLockNotification>false</AccountLockNotification>
+            <AccountUnlockNotification>false</AccountUnlockNotification>
         </AdminPasswordReset>
         <CallbackRegex>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/login.do</CallbackRegex>
         <NotifyUserExistence>false</NotifyUserExistence>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1034,6 +1034,8 @@
             <Offline>{{identity_mgt.password_reset_by_admin.enable_offline_otp_based_reset}}</Offline>
             <OTP>{{identity_mgt.password_reset_by_admin.enable_emailed_otp_based_reset}}</OTP>
             <RecoveryLink>{{identity_mgt.password_reset_by_admin.enable_emailed_link_based_reset}}</RecoveryLink>
+            <AccountLockNotification>{{identity_mgt.password_reset_by_admin.enable_account_lock_notification}}</AccountLockNotification>
+            <AccountUnlockNotification>{{identity_mgt.password_reset_by_admin.enable_account_unlock_notification}}</AccountUnlockNotification>
         </AdminPasswordReset>
         <NotifyUserExistence>{{identity_mgt.recovery.notify_user_existence}}</NotifyUserExistence>
         <CallbackRegex>{{identity_mgt.recovery.callback_url}}</CallbackRegex>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -297,6 +297,8 @@
   "identity_mgt.password_reset_by_admin.enable_emailed_link_based_reset": false,
   "identity_mgt.password_reset_by_admin.enable_emailed_otp_based_reset": false,
   "identity_mgt.password_reset_by_admin.enable_offline_otp_based_reset": false,
+  "identity_mgt.password_reset_by_admin.enable_account_lock_notification": false,
+  "identity_mgt.password_reset_by_admin.enable_account_unlock_notification": false,
 
   "identity_mgt.password_update.preserve_logged_in_session": false,
 


### PR DESCRIPTION
### Proposed changes in this pull request
> $subject
> Fixing https://github.com/wso2/product-is/issues/9708
> In the public fix, account lock/unlock notifications during admin forced password reset are disabled by default.