### PR TITLE
Override Console version label to "BETA"

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -806,9 +806,6 @@
   "myaccount.overview.enabled": true,
   "myaccount.personal_info.enabled": true,
   "myaccount.security.enabled": true,
-  "myaccount.product_version.configs": {
-    "versionOverride": "BETA"
-  },
   "myaccount.operations.scopes": {
     "create": [],
     "read": [

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -627,6 +627,9 @@
   "console.session.params.sessionRefreshTimeOut": 300,
   "console.session.params.checkSessionInterval": 3,
   "console.applications.enabled": true,
+  "console.product_version.configs": {
+    "versionOverride": "BETA"
+  },
   "console.applications.scopes": {
     "create": [
       "internal_application_mgt_create"
@@ -803,7 +806,9 @@
   "myaccount.overview.enabled": true,
   "myaccount.personal_info.enabled": true,
   "myaccount.security.enabled": true,
-
+  "myaccount.product_version.configs": {
+    "versionOverride": "BETA"
+  },
   "myaccount.operations.scopes": {
     "create": [],
     "read": [


### PR DESCRIPTION
### Purpose

- Change the default config to override the portal version label to `BETA`

### Goals
Fixes https://github.com/wso2/product-is/issues/10195