### PR TITLE
Add UserAccountStateWithUsername constant

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -63,6 +63,7 @@ public class IdentityCoreConstants {
     public static final String ADMIN_FORCED_USER_PASSWORD_RESET_VIA_OTP_MISMATCHED_ERROR_CODE = "17008";
 
     public static final String USER_ACCOUNT_STATE = "UserAccountState";
+    public static final String USER_ACCOUNT_STATE_WITH_USERNAME = "UserAccountStateWithUsername";
 
     // Pagination constants.
     public static final int DEFAULT_MAXIMUM_ITEMS_PRE_PAGE = 100;


### PR DESCRIPTION
### Proposed changes in this pull request

Frontport https://github.com/wso2-support/carbon-identity-framework/pull/1279
Add USER_ACCOUNT_STATE_WITH_USERNAME constant it keeps track of the error code when the account is disabled or locked.

