### PR TITLE
Remote fetch working directory default value updated

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -151,7 +151,7 @@
 <!--Remote Fetch Core Configuration-->
     <RemoteFetch>
         <FetchEnabled>{{remotefetch.enable}}</FetchEnabled>
-        <WorkingDirectory>{{remotefetch.workingdirectory}}</WorkingDirectory>
+        <WorkingDirectory>{{remotefetch.working_directory}}</WorkingDirectory>
     </RemoteFetch>
 
     <OAuth>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -150,8 +150,8 @@
 
 <!--Remote Fetch Core Configuration-->
     <RemoteFetch>
-        <FetchEnabled>{{remotefetch.enable}}</FetchEnabled>
-        <WorkingDirectory>{{remotefetch.working_directory}}</WorkingDirectory>
+        <FetchEnabled>{{remote_fetch.enable}}</FetchEnabled>
+        <WorkingDirectory>{{remote_fetch.working_directory}}</WorkingDirectory>
     </RemoteFetch>
 
     <OAuth>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -36,8 +36,8 @@
 
   "service_provider.sp_name_regex": "^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$",
 
-  "remotefetch.enable":false,
-  "remotefetch.working_directory":"${carbon.home}/tmp/",
+  "remote_fetch.enable": false,
+  "remote_fetch.working_directory": "${carbon.home}/tmp/",
 
   "oauth.token_cleanup.enable": true,
   "oauth.token_cleanup.retain_access_tokens_for_auditing": true,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -37,7 +37,7 @@
   "service_provider.sp_name_regex": "^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$",
 
   "remotefetch.enable":false,
-  "remotefetch.workingdirectory":"/tmp/",
+  "remotefetch.workingdirectory":"${carbon.home}/tmp/",
 
   "oauth.token_cleanup.enable": true,
   "oauth.token_cleanup.retain_access_tokens_for_auditing": true,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -37,7 +37,7 @@
   "service_provider.sp_name_regex": "^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$",
 
   "remotefetch.enable":false,
-  "remotefetch.workingdirectory":"${carbon.home}/tmp/",
+  "remotefetch.working_directory":"${carbon.home}/tmp/",
 
   "oauth.token_cleanup.enable": true,
   "oauth.token_cleanup.retain_access_tokens_for_auditing": true,


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/9675

## Approach
> The default value for the Remote Fetch working directory was given as `/tmp/`. This would only work with Unix filesystems, thereby, causing the server to throw errors in a Windows environment. Changing the default to `${carbon.home}/tmp` resolves this issue as the server obtains its root path correctly regardless of the environment.

## Related PRs
> https://github.com/wso2-extensions/identity-fetch-remote/pull/47