### PR TITLE
Add new claim 'verifyMobile' used to enable mobile verification flow.

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -737,6 +737,14 @@
 				<Description>To store newly updated mobile number until it is verified.</Description>
 				<ReadOnly/>
 			</Claim>
+			<Claim>
+				<ClaimURI>http://wso2.org/claims/identity/verifyMobile</ClaimURI>
+				<DisplayName>Verify Mobile</DisplayName>
+				<!-- If user store based identity store is used, a proper mapped attribute
+				in your user store must be configured for this. -->
+				<AttributeID>verifyMobile</AttributeID>
+				<Description>Temporary claim to invoke mobile verification feature</Description>
+			</Claim>
 		</Dialect>
 
 		<Dialect dialectURI="http://schemas.xmlsoap.org/ws/2005/05/identity">
@@ -2550,6 +2558,16 @@
 				<DisplayOrder>1</DisplayOrder>
 				<SupportedByDefault />
 				<MappedLocalClaim>http://wso2.org/claims/oneTimePassword</MappedLocalClaim>
+			</Claim>
+			<Claim>
+				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyMobile</ClaimURI>
+				<DisplayName>Verify Mobile</DisplayName>
+				<AttributeID>verifyMobile</AttributeID>
+				<Description>Temporary claim to invoke mobile verification feature</Description>
+				<Required />
+				<DisplayOrder>1</DisplayOrder>
+				<SupportedByDefault />
+				<MappedLocalClaim>http://wso2.org/claims/identity/verifyMobile</MappedLocalClaim>
 			</Claim>
 		</Dialect>
 		<Dialect dialectURI="http://eidas.europa.eu/attributes/naturalperson">

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1131,8 +1131,8 @@
         </Claim>
         <!-- When updating the claim value, the verification notification can be controlled by sending an additional
         temporary claim ('verifyEmail'/'verifyMobile') along with the update request. To enable this option,
-        'CheckForVerifyClaimOnUpdate' should be set to true. -->
-        <CheckForVerifyClaimOnUpdate>{{identity_mgt.user_claim_update.check_verify_claim_on_update}}</CheckForVerifyClaimOnUpdate>
+        'UseVerifyClaim' should be set to true. -->
+        <UseVerifyClaim>{{identity_mgt.user_claim_update.use_verify_claim}}</UseVerifyClaim>
     </UserClaimUpdate>
 
      <AccountSuspension>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1129,6 +1129,10 @@
                 </VerificationCode>
              </VerificationOnUpdate>
         </Claim>
+        <!-- When adding a new claim value instead of updating an exiting value, the verification notification can be
+            controlled by sending an additional temporary claim ('verifyEmail'/'verifyMobile') along with the update
+            request. To enable this option, 'CheckForVerifyClaimOnAddition' should be set to true. -->
+        <CheckForVerifyClaimOnAddition>{{identity_mgt.user_claim_update.check_verify_claim_on_addition}}</CheckForVerifyClaimOnAddition>
     </UserClaimUpdate>
 
      <AccountSuspension>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1129,10 +1129,10 @@
                 </VerificationCode>
              </VerificationOnUpdate>
         </Claim>
-        <!-- When adding a new claim value instead of updating an exiting value, the verification notification can be
-            controlled by sending an additional temporary claim ('verifyEmail'/'verifyMobile') along with the update
-            request. To enable this option, 'CheckForVerifyClaimOnAddition' should be set to true. -->
-        <CheckForVerifyClaimOnAddition>{{identity_mgt.user_claim_update.check_verify_claim_on_addition}}</CheckForVerifyClaimOnAddition>
+        <!-- When updating the claim value, the verification notification can be controlled by sending an additional
+        temporary claim ('verifyEmail'/'verifyMobile') along with the update request. To enable this option,
+        'CheckForVerifyClaimOnUpdate' should be set to true. -->
+        <CheckForVerifyClaimOnUpdate>{{identity_mgt.user_claim_update.check_verify_claim_on_update}}</CheckForVerifyClaimOnUpdate>
     </UserClaimUpdate>
 
      <AccountSuspension>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -328,7 +328,7 @@
   "identity_mgt.user_claim_update.email.verification_email_validity": "$ref{identity_mgt.default_mail_validity_period}",
   "identity_mgt.user_claim_update.mobile.enable_verification": false,
   "identity_mgt.user_claim_update.mobile.verification_sms_otp_validity": "5",
-  "identity_mgt.user_claim_update.check_verify_claim_on_addition": true,
+  "identity_mgt.user_claim_update.check_verify_claim_on_update": true,
 
   "identity_mgt_account_suspension.use_identity_claims": true,
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -818,6 +818,7 @@
   "myaccount.session.params.userIdleWarningTimeOut": 580,
   "myaccount.session.params.sessionRefreshTimeOut": 300,
   "myaccount.session.params.checkSessionInterval": 3,
+  "myaccount.personal_info.disabled_features": ["profileInfo.mobileVerification"],
   "cors.allow_generic_http_requests": true,
   "cors.allow_any_origin": true,
   "cors.allowed_origins": [],

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -328,7 +328,7 @@
   "identity_mgt.user_claim_update.email.verification_email_validity": "$ref{identity_mgt.default_mail_validity_period}",
   "identity_mgt.user_claim_update.mobile.enable_verification": false,
   "identity_mgt.user_claim_update.mobile.verification_sms_otp_validity": "5",
-  "identity_mgt.user_claim_update.check_verify_claim_on_update": true,
+  "identity_mgt.user_claim_update.use_verify_claim": true,
 
   "identity_mgt_account_suspension.use_identity_claims": true,
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -328,6 +328,7 @@
   "identity_mgt.user_claim_update.email.verification_email_validity": "$ref{identity_mgt.default_mail_validity_period}",
   "identity_mgt.user_claim_update.mobile.enable_verification": false,
   "identity_mgt.user_claim_update.mobile.verification_sms_otp_validity": "5",
+  "identity_mgt.user_claim_update.check_verify_claim_on_addition": true,
 
   "identity_mgt_account_suspension.use_identity_claims": true,
 


### PR DESCRIPTION
### Proposed changes in this pull request

This PR, 
- introduces a new identity claim 'verifyMobile' which is used to enable the mobile verification feature. (Part of the fix for : https://github.com/wso2/product-is/issues/10358)
- adds a default configuration to disable mobile verification feature from my-account by default (Related to : https://github.com/wso2/identity-apps/pull/1275)



