### PR TITLE
Fix syntax error while searching roles in oracle db

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/dao/SQLQueries.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/dao/SQLQueries.java
@@ -121,9 +121,9 @@ public class SQLQueries {
             + ":OFFSET;, :LIMIT;";
 
     public static final String GET_ROLES_BY_TENANT_AND_ROLE_NAME_ORACLE =
-            "SELECT UM_ROLE_NAME FROM (SELECT UM_ROLE_NAME rownum AS "
-                    + "rnum FROM (SELECT UM_ROLE_NAME FROM UM_HYBRID_ROLE ORDER BY UM_ID DESC) WHERE "
-                    + "UM_TENANT_ID=:UM_TENANT_ID; AND UM_ROLE_NAME LIKE :UM_ROLE_NAME; AND rownum <= :END_INDEX;) "
+            "SELECT UM_ROLE_NAME FROM (SELECT UM_ROLE_NAME, rownum AS "
+                    + "rnum FROM (SELECT UM_ROLE_NAME FROM UM_HYBRID_ROLE WHERE UM_TENANT_ID=:UM_TENANT_ID;"
+                    + " ORDER BY UM_ID DESC) WHERE UM_ROLE_NAME LIKE :UM_ROLE_NAME; AND rownum <= :END_INDEX;) "
                     + "WHERE rnum > :ZERO_BASED_START_INDEX;";
 
     public static final String GET_ROLES_BY_TENANT_AND_ROLE_NAME_MSSQL =


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/10439

Earlier the oracle sql query was like 

```
SELECT UM_ROLE_NAME FROM 
	(SELECT UM_ROLE_NAME  rownum AS rnum FROM 
		(SELECT UM_ROLE_NAME FROM UM_HYBRID_ROLE ORDER BY UM_ID DESC) 

WHERE UM_TENANT_ID=:UM_TENANT_ID;
AND UM_ROLE_NAME LIKE :UM_ROLE_NAME; 
AND rownum <= :END_INDEX;
        ) 
WHERE rnum > :ZERO_BASED_START_INDEX;
```

- Here the select query has two attributes`SELECT UM_ROLE_NAME rownum AS rnum`. They need to be splitted by `,` 

- And  `WHERE UM_TENANT_ID=:UM_TENANT_ID;` part is outside the `(SELECT UM_ROLE_NAME FROM UM_HYBRID_ROLE ORDER BY UM_ID DESC) ` query. So the `UM_TENANT_ID` column was not available outside the select query. So moved it inside the select query
