### PR TITLE
Fix invalid error message shown for idle session timeout field in idp-mgt-edit-local.jsp

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-local.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-local.jsp
@@ -272,7 +272,7 @@ function idpMgtCancel(){
             CARBON.showWarningDialog("Resident IdP Entity ID cannot be empty");
             return false;
         }
-        var isSessionTimeoutValidated = doValidateInput(document.getElementById('sessionIdleTimeout'), "Resident IdP Idle Session Timeout must be numeric value greater than 0");
+        var isSessionTimeoutValidated = doValidateInput(document.getElementById('sessionIdleTimeout'), "Resident IdP Idle Session Timeout must be numeric value greater than 0 and cannot be empty");
         if (!isSessionTimeoutValidated) {
             return false;
         }


### PR DESCRIPTION
Resolves wso2/product-is#4826

**Proposed changes in this pull request**
Change the error message to "Resident IdP Idle Session Timeout must be a numeric value greater than 0 and cannot be empty".

**Reviewers**
@darshanasbg @gayashanbc