### PR TITLE
Make SP name javascript regex configurable

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/java/org/wso2/carbon/identity/application/mgt/ui/util/ApplicationMgtUIUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/java/org/wso2/carbon/identity/application/mgt/ui/util/ApplicationMgtUIUtil.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.application.mgt.ui.util;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ui.ApplicationBean;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,6 +39,8 @@ public class ApplicationMgtUIUtil {
     private static final String SP_UNIQUE_ID_MAP = "spUniqueIdMap";
     public static final String JWKS_URI = IdentityApplicationConstants.JWKS_URI_SP_PROPERTY_NAME;
     public static final String JWKS_DISPLAYNAME = "JWKS Endpoint";
+    public static final String APP_NAME_JAVASCRIPT_VALIDATING_REGEX = "^[a-zA-Z0-9\\s.+_-]*$";
+    private static final String SERVICE_PROVIDERS_NAME_JAVASCRIPT_REGEX = "ServiceProviders.SPNameJavascriptRegex";
 
     /**
      * Get related application bean from the session.
@@ -116,4 +119,17 @@ public class ApplicationMgtUIUtil {
         }
     }
 
+    /**
+     * Return the Service Provider javascript validation regex if configured in the deployment.toml.
+     *
+     * @return regex.
+     */
+    public static String getSPValidatorJavascriptRegex() {
+
+        String spValidatorJavascriptRegex = IdentityUtil.getProperty(SERVICE_PROVIDERS_NAME_JAVASCRIPT_REGEX);
+        if (StringUtils.isBlank(spValidatorJavascriptRegex)) {
+            spValidatorJavascriptRegex = APP_NAME_JAVASCRIPT_VALIDATING_REGEX;
+        }
+        return spValidatorJavascriptRegex;
+    }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/add-service-provider.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/add-service-provider.jsp
@@ -25,6 +25,7 @@
 <%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
 <%@ page import="static org.wso2.carbon.identity.application.mgt.ui.util.ApplicationMgtUIConstants.*" %>
 <%@ page import="org.wso2.carbon.identity.application.common.model.xsd.SpTemplate" %>
+<%@ page import="org.wso2.carbon.identity.application.mgt.ui.util.ApplicationMgtUIUtil" %>
 
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="carbon" uri="http://wso2.org/projects/carbon/taglibs/carbontags.jar"%>
@@ -205,7 +206,7 @@ window.onload = function() {
                     <tr>
                         <td style="width:15%" class="leftCol-med labelField"><fmt:message key='config.application.info.basic.name'/>:<span class="required">*</span></td>
                         <td>
-                            <input id="spName" name="spName" type="text" value="" white-list-patterns="^[a-zA-Z0-9\s.+_-]*$" autofocus/>
+                            <input id="spName" name="spName" type="text" value="" white-list-patterns="<%=Encode.forHtmlContent(ApplicationMgtUIUtil.getSPValidatorJavascriptRegex())%>" autofocus/>
                             <div class="sectionHelp">
                                 <fmt:message key='help.name'/>
                             </div>

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider.jsp
@@ -1370,7 +1370,7 @@
                             <td>
                                 <input style="width:50%" id="spName" name="spName" type="text"
                                        value="<%=Encode.forHtmlAttribute(spName)%>"
-                                       white-list-patterns="^[a-zA-Z0-9\s.+_-]*$" autofocus/>
+                                       white-list-patterns="<%=Encode.forHtmlContent(ApplicationMgtUIUtil.getSPValidatorJavascriptRegex())%>" autofocus/>
                                 <div class="sectionHelp">
                                     <fmt:message key='help.name'/>
                                 </div>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -93,6 +93,9 @@
     <!--This configuration is used to define the Service Provider name regex in DCR and IdentityApplicationManagementService-->
     <ServiceProviders>
         <SPNameRegex>{{service_provider.sp_name_regex}}</SPNameRegex>
+        {% if service_provider.sp_name_java_script_regex is defined %}
+        <SPNameJavascriptRegex>{{service_provider.sp_name_java_script_regex}}</SPNameJavascriptRegex>
+        {% endif %}
         {% if service_provider.fetch_chunk_size is defined %}
         <FetchChunkSize>{{service_provider.fetch_chunk_size}}</FetchChunkSize>
         {% endif %}


### PR DESCRIPTION
Fix https://github.com/wso2/product-is/issues/10353

To configure the javascript regex to validate the service provider name, add the following configuration to the `<IS_HOME>/repository/conf/deployment.toml` file.


```
[service_provider]
sp_name_java_script_regex = '<required_javascript_regex>'
```