### PR TITLE
Feature session persistence redis

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
@@ -161,6 +161,14 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.functions.library.mgt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -233,6 +241,9 @@
                             version="${carbon.identity.package.export.version}"
                         </Export-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
+                        <Embed-Dependency>
+                            commons-lang
+                        </Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -340,7 +340,7 @@ public class SessionDataStore {
             preparedStatement.setString(1, key);
             preparedStatement.setString(2, type);
             resultSet = preparedStatement.executeQuery();
-            //if(resultSet.next()) {
+
             byte[] bObject = jedis.get(key.getBytes());
             if (bObject != null) {
                 HashMap hash = (HashMap) deserialize(bObject);
@@ -350,15 +350,15 @@ public class SessionDataStore {
                 if ((OPERATION_STORE.equals(operation))) {
                     log.info("redis working");
                     Object blobObject = hash.get("BlobObj");
-                    //Object blobObject = getBlobObject(resultSet.getBinaryStream(2));
                     return new SessionContextDO(key, type, blobObject, nanoTime);
 
                 }
 
-            } else {
+            }
+            else {
                 String operation = resultSet.getString(1);
                 long nanoTime = resultSet.getLong(3);
-
+                log.info("h2 is working");
                 if ((OPERATION_STORE.equals(operation))) {
                     return new SessionContextDO(key, type, getBlobObject(resultSet.getBinaryStream(2)), nanoTime);
 
@@ -366,7 +366,6 @@ public class SessionDataStore {
 
             }
 
-           // }
         } catch (ClassNotFoundException | IOException | SQLException |
                 IdentityApplicationManagementException e) {
             log.error("Error while retrieving session data", e);

--- a/pom.xml
+++ b/pom.xml
@@ -1757,6 +1757,16 @@
                 <artifactId>spring-web</artifactId>
                 <version>${springframework.spring-web.version}</version>
             </dependency>
+            <dependency>
+                <groupId>redis.clients</groupId>
+                <artifactId>jedis</artifactId>
+                <version>${redis.clients.jedis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons-lang.version}</version>
+            </dependency>
         </dependencies>
 
     </dependencyManagement>
@@ -1776,6 +1786,8 @@
         <codehaus.jettison.version>1.4.0</codehaus.jettison.version>
         <springframework.spring-web.version>5.1.1.RELEASE</springframework.spring-web.version>
         <jaxrx.jsr311.api.version>1.1.1</jaxrx.jsr311.api.version>
+        <redis.clients.jedis.version>3.3.0</redis.clients.jedis.version>
+        <commons-lang.version>2.6</commons-lang.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
### Proposed changes in this pull request

Currently, the identity server user session implementation is backed by relational databases. That implementation will affect the performance in large scale implementations. This pull request contains POC to the session data is backed by Redis server. Here Both Redis and RDMS support is given.


### Checklist (for reviewing)

#### Code
The persistSessionData,  getSessionContextData methods in the Session store class are modified for the change. enableRedis variable is used to select either the Redis implementation or RDMS implementation.

