### PR TITLE
Feature decouple session data layer

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
@@ -178,6 +178,14 @@
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -251,6 +259,9 @@
                             version="${carbon.identity.package.export.version}"
                         </Export-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
+                        <Embed-Dependency>
+                            commons-lang
+                        </Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -32,6 +32,8 @@ import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.idp.mgt.util.IdPManagementUtil;
+import redis.clients.jedis.BinaryJedis;
+import org.apache.commons.lang.SerializationUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -44,11 +46,14 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.*;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.nio.IOUtil.toByteArray;
 
 /**
  * Data will be persisted or stored date will be removed from the store. These two events are considered as STORE operation
@@ -145,6 +150,7 @@ public class SessionDataStore {
     private boolean sessionDataCleanupEnabled = true;
     private boolean operationDataCleanupEnabled = false;
     private static boolean tempDataCleanupEnabled = false;
+    private static BinaryJedis jedis;
 
     static {
         try {
@@ -288,12 +294,23 @@ public class SessionDataStore {
         return instance;
     }
 
+    //Return Jedis object
+    private static BinaryJedis returnjedis() {
+        if (jedis != null)
+            return jedis;
+        return new BinaryJedis("127.0.0.1", 6379);
+    }
+
     public Object getSessionData(String key, String type) {
+
         SessionContextDO sessionContextDO = getSessionContextData(key, type);
         return sessionContextDO != null ? sessionContextDO.getEntry() : null;
     }
 
     public SessionContextDO getSessionContextData(String key, String type) {
+        //modify to get data
+          jedis=returnjedis();
+
         if (!enablePersist) {
             return null;
         }
@@ -330,9 +347,25 @@ public class SessionDataStore {
             preparedStatement.setString(1, key);
             preparedStatement.setString(2, type);
             resultSet = preparedStatement.executeQuery();
-            if (resultSet.next()) {
+            //if(resultSet.next()) {
+            byte[] bObject = jedis.get(key.getBytes());
+            if (bObject != null) {
+                HashMap hash = (HashMap) deserialize(bObject);
+                String operation = (String) hash.get("operation");
+                long nanoTime = ((Long) hash.get("nanoTime"));
+
+                if ((OPERATION_STORE.equals(operation))) {
+                    log.info("redis working");
+                    Object blobObject = hash.get("BlobObj");
+                    //Object blobObject = getBlobObject(resultSet.getBinaryStream(2));
+                    return new SessionContextDO(key, type, blobObject, nanoTime);
+
+                }
+
+            } else {
                 String operation = resultSet.getString(1);
                 long nanoTime = resultSet.getLong(3);
+
                 if ((OPERATION_STORE.equals(operation))) {
                     return new SessionContextDO(key, type, getBlobObject(resultSet.getBinaryStream(2)), nanoTime);
                 }
@@ -489,6 +522,7 @@ public class SessionDataStore {
     }
 
     public void persistSessionData(String key, String type, Object entry, long nanoTime, int tenantId) {
+
         if (!enablePersist) {
             return;
         }
@@ -522,6 +556,21 @@ public class SessionDataStore {
             preparedStatement.setLong(6, nanoTime + validityPeriodNano);
             preparedStatement.setInt(7, tenantId);
             preparedStatement.executeUpdate();
+
+            //code for redis hashmap
+            Map hm= new HashMap();
+            hm.put("type",type);
+            hm.put("operation",OPERATION_STORE);
+            hm.put("BlobObj",(entry));
+            hm.put("nanoTime",nanoTime);
+            hm.put("time",(nanoTime + validityPeriodNano));
+            hm.put("tenantId",tenantId);
+
+            byte[] obj=serialize((Serializable) hm);
+            jedis=returnjedis();
+            jedis.set(key.getBytes(),obj);
+            //jedis.hmset(key,hm);
+
             IdentityDatabaseUtil.commitTransaction(connection);
         } catch (SQLException | IOException e) {
             IdentityDatabaseUtil.rollbackTransaction(connection);
@@ -530,6 +579,15 @@ public class SessionDataStore {
             IdentityDatabaseUtil.closeAllConnections(connection, null, preparedStatement);
         }
 
+    }
+    //Serializes an Object to byte array
+    private static byte[] serialize(Serializable obj) {
+        return SerializationUtils.serialize(obj);
+    }
+
+    //Deserializes a byte array back to Object
+    private static Object deserialize(byte[] bytes) {
+        return SerializationUtils.deserialize(bytes);
     }
 
     public void removeSessionData(String key, String type, long nanoTime) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.authentication.framework.store;
 
+import org.apache.commons.lang.SerializationUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -33,7 +34,6 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.idp.mgt.util.IdPManagementUtil;
 import redis.clients.jedis.BinaryJedis;
-import org.apache.commons.lang.SerializationUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -42,18 +42,25 @@ import java.io.InputStream;
 import java.io.ObjectInput;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInput;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
-
-import static com.hazelcast.nio.IOUtil.toByteArray;
 
 /**
  * Data will be persisted or stored date will be removed from the store. These two events are considered as STORE operation
@@ -63,8 +70,18 @@ import static com.hazelcast.nio.IOUtil.toByteArray;
  * All expired operations will be deleted by SessionCleanUpService task.
  */
 public class SessionDataStore {
-    private static final Log log = LogFactory.getLog(SessionDataStore.class);
 
+    public static final String DEFAULT_SESSION_STORE_TABLE_NAME = "IDN_AUTH_SESSION_STORE";
+    public static final String DEFAULT_TEMP_SESSION_STORE_TABLE_NAME = "IDN_AUTH_TEMP_SESSION_STORE";
+    public static final String OPERATION = "operation";
+    public static final String NANO_TIME = "nanoTime";
+    public static final String BLOB_OBJ = "BlobObj";
+    public static final String TYPE = "type";
+    public static final String TIME = "time";
+    public static final String TENANT_ID = "tenantId";
+    public static final String HOST = "127.0.0.1";
+    public static final int PORT = 6379;
+    private static final Log log = LogFactory.getLog(SessionDataStore.class);
     private static final String OPERATION_DELETE = "DELETE";
     private static final String OPERATION_STORE = "STORE";
     private static final String SQL_INSERT_STORE_OPERATION =
@@ -86,7 +103,6 @@ public class SessionDataStore {
             "DELETE FROM IDN_AUTH_SESSION_STORE WHERE OPERATION = '" + OPERATION_DELETE + "' AND  EXPIRY_TIME < ?";
     private static final String SQL_DELETE_TEMP_RECORDS =
             "DELETE FROM IDN_AUTH_TEMP_SESSION_STORE WHERE SESSION_ID = ? AND  SESSION_TYPE = ?";
-
     private static final String SQL_DESERIALIZE_OBJECT_MYSQL =
             "SELECT OPERATION, SESSION_OBJECT, TIME_CREATED FROM IDN_AUTH_SESSION_STORE WHERE SESSION_ID =? AND" +
                     " SESSION_TYPE=? ORDER BY TIME_CREATED DESC LIMIT 1";
@@ -105,7 +121,6 @@ public class SessionDataStore {
     private static final String SQL_DESERIALIZE_OBJECT_ORACLE =
             "SELECT * FROM (SELECT OPERATION, SESSION_OBJECT, TIME_CREATED FROM IDN_AUTH_SESSION_STORE WHERE SESSION_ID =? AND" +
                     " SESSION_TYPE=? ORDER BY TIME_CREATED DESC) WHERE ROWNUM < 2";
-
     private static final String SQL_DELETE_EXPIRED_DATA_TASK_MYSQL =
             "DELETE FROM IDN_AUTH_SESSION_STORE WHERE EXPIRY_TIME < ? LIMIT %d";
     private static final String SQL_DELETE_EXPIRED_DATA_TASK_MSSQL =
@@ -128,27 +143,13 @@ public class SessionDataStore {
     private static final String MICROSOFT_DATABASE = "Microsoft";
     private static final String POSTGRESQL_DATABASE = "PostgreSQL";
     private static final String INFORMIX_DATABASE = "Informix";
-
     private static final int DEFAULT_DELETE_LIMIT = 50000;
-    public static final String DEFAULT_SESSION_STORE_TABLE_NAME = "IDN_AUTH_SESSION_STORE";
     private static final String CACHE_MANAGER_NAME = "IdentityApplicationManagementCacheManager";
-    public static final String DEFAULT_TEMP_SESSION_STORE_TABLE_NAME = "IDN_AUTH_TEMP_SESSION_STORE";
     private static int maxSessionDataPoolSize = 100;
     private static int maxTempDataPoolSize = 50;
-    private static BlockingDeque<SessionContextDO> sessionContextQueue = new LinkedBlockingDeque();
-    private static BlockingDeque<SessionContextDO> tempAuthnContextDataDeleteQueue = new LinkedBlockingDeque();
+    private static final BlockingDeque<SessionContextDO> sessionContextQueue = new LinkedBlockingDeque();
+    private static final BlockingDeque<SessionContextDO> tempAuthnContextDataDeleteQueue = new LinkedBlockingDeque();
     private static volatile SessionDataStore instance;
-    private boolean enablePersist;
-    private String sqlInsertSTORE;
-    private String sqlInsertDELETE;
-    private String sqlDeleteSTORETask;
-    private String sqlDeleteTempDataTask;
-    private String sqlDeleteDELETETask;
-    private String sqlSelect;
-    private String sqlDeleteExpiredDataTask;
-    private int deleteChunkSize = DEFAULT_DELETE_LIMIT;
-    private boolean sessionDataCleanupEnabled = true;
-    private boolean operationDataCleanupEnabled = false;
     private static boolean tempDataCleanupEnabled = false;
     private static BinaryJedis jedis;
 
@@ -197,12 +198,33 @@ public class SessionDataStore {
         }
     }
 
+    private boolean enablePersist;
+    private final String sqlInsertSTORE;
+    private final String sqlInsertDELETE;
+    private String sqlDeleteSTORETask;
+    private final String sqlDeleteTempDataTask;
+    private final String sqlDeleteDELETETask;
+    private String sqlSelect;
+    private String sqlDeleteExpiredDataTask;
+    private int deleteChunkSize = DEFAULT_DELETE_LIMIT;
+    private boolean sessionDataCleanupEnabled = true;
+    private boolean operationDataCleanupEnabled = false;
+    private boolean redisEnabled = true;
+
     private SessionDataStore() {
+
         String enablePersistVal = IdentityUtil.getProperty("JDBCPersistenceManager.SessionDataPersist.Enable");
         enablePersist = true;
         if (enablePersistVal != null) {
             enablePersist = Boolean.parseBoolean(enablePersistVal);
         }
+
+        String redisEnabledVal = IdentityUtil.getProperty("JDBCPersistenceManager.SessionDataPersist.RedisEnable");
+        if (redisEnabledVal != null) {
+            log.info("checking");
+            redisEnabled = Boolean.parseBoolean(redisEnabledVal);
+        }
+
         String insertSTORESQL = IdentityUtil
                 .getProperty("JDBCPersistenceManager.SessionDataPersist.SQL.InsertSTORE");
         String insertDELETESQL = IdentityUtil
@@ -284,6 +306,7 @@ public class SessionDataStore {
     }
 
     public static SessionDataStore getInstance() {
+
         if (instance == null) {
             synchronized (SessionDataStore.class) {
                 if (instance == null) {
@@ -294,11 +317,24 @@ public class SessionDataStore {
         return instance;
     }
 
-    //Return Jedis object
-    private static BinaryJedis returnjedis() {
+    // Return Jedis object.
+    private static BinaryJedis getJedisInstance() {
+
         if (jedis != null)
             return jedis;
-        return new BinaryJedis("127.0.0.1", 6379);
+        return new BinaryJedis(HOST, PORT);
+    }
+
+    // Serializes an Object to byte array.
+    private static byte[] serialize(Serializable obj) {
+
+        return SerializationUtils.serialize(obj);
+    }
+
+    // Deserializes a byte array back to Object.
+    private static Object deserialize(byte[] bytes) {
+
+        return SerializationUtils.deserialize(bytes);
     }
 
     public Object getSessionData(String key, String type) {
@@ -307,84 +343,13 @@ public class SessionDataStore {
         return sessionContextDO != null ? sessionContextDO.getEntry() : null;
     }
 
-    public SessionContextDO getSessionContextData(String key, String type) {
-        //modify to get data
-          jedis=returnjedis();
-
-        if (!enablePersist) {
-            return null;
-        }
-        Connection connection = null;
-        try {
-            connection = IdentityDatabaseUtil.getDBConnection(false);
-        } catch (IdentityRuntimeException e) {
-            log.error(e.getMessage(), e);
-            return null;
-        }
-        PreparedStatement preparedStatement = null;
-        ResultSet resultSet = null;
-        try {
-            if (StringUtils.isBlank(sqlSelect)) {
-                String driverName = connection.getMetaData().getDriverName();
-                if (driverName.contains(MYSQL_DATABASE) || driverName.contains(MARIA_DATABASE)
-                        || driverName.contains(H2_DATABASE)) {
-                    sqlSelect = SQL_DESERIALIZE_OBJECT_MYSQL;
-                } else if (connection.getMetaData().getDatabaseProductName().contains(DB2_DATABASE)) {
-                    sqlSelect = SQL_DESERIALIZE_OBJECT_DB2SQL;
-                } else if (driverName.contains(MS_SQL_DATABASE)
-                        || driverName.contains(MICROSOFT_DATABASE)) {
-                    sqlSelect = SQL_DESERIALIZE_OBJECT_MSSQL;
-                } else if (driverName.contains(POSTGRESQL_DATABASE)) {
-                    sqlSelect = SQL_DESERIALIZE_OBJECT_POSTGRESQL;
-                } else if (driverName.contains(INFORMIX_DATABASE)) {
-                    // Driver name = "IBM Informix JDBC Driver for IBM Informix Dynamic Server"
-                    sqlSelect = SQL_DESERIALIZE_OBJECT_INFORMIX;
-                } else {
-                    sqlSelect = SQL_DESERIALIZE_OBJECT_ORACLE;
-                }
-            }
-            preparedStatement = connection.prepareStatement(getSessionStoreDBQuery(sqlSelect, type));
-            preparedStatement.setString(1, key);
-            preparedStatement.setString(2, type);
-            resultSet = preparedStatement.executeQuery();
-            //if(resultSet.next()) {
-            byte[] bObject = jedis.get(key.getBytes());
-            if (bObject != null) {
-                HashMap hash = (HashMap) deserialize(bObject);
-                String operation = (String) hash.get("operation");
-                long nanoTime = ((Long) hash.get("nanoTime"));
-
-                if ((OPERATION_STORE.equals(operation))) {
-                    log.info("redis working");
-                    Object blobObject = hash.get("BlobObj");
-                    //Object blobObject = getBlobObject(resultSet.getBinaryStream(2));
-                    return new SessionContextDO(key, type, blobObject, nanoTime);
-
-                }
-
-            } else {
-                String operation = resultSet.getString(1);
-                long nanoTime = resultSet.getLong(3);
-
-                if ((OPERATION_STORE.equals(operation))) {
-                    return new SessionContextDO(key, type, getBlobObject(resultSet.getBinaryStream(2)), nanoTime);
-                }
-            }
-        } catch (ClassNotFoundException | IOException | SQLException |
-                IdentityApplicationManagementException e) {
-            log.error("Error while retrieving session data", e);
-        } finally {
-            IdentityDatabaseUtil.closeAllConnections(connection, resultSet, preparedStatement);
-        }
-        return null;
-    }
-
     public void storeSessionData(String key, String type, Object entry) {
 
         storeSessionData(key, type, entry, MultitenantConstants.INVALID_TENANT_ID);
     }
 
     public void storeSessionData(String key, String type, Object entry, int tenantId) {
+
         if (!enablePersist) {
             return;
         }
@@ -397,6 +362,7 @@ public class SessionDataStore {
     }
 
     public void clearSessionData(String key, String type) {
+
         if (!enablePersist) {
             return;
         }
@@ -521,16 +487,80 @@ public class SessionDataStore {
 
     }
 
+    public SessionContextDO getSessionContextData(String key, String type) {
+        // Modify to get data.
+        jedis = getJedisInstance();
+
+        if (!enablePersist) {
+            return null;
+        }
+        if (redisEnabled) {
+            byte[] sessionObject = jedis.get(key.getBytes());
+            if (sessionObject != null) {
+                HashMap hash = (HashMap) deserialize(sessionObject);
+                String operation = (String) hash.get(OPERATION);
+                long nanoTime = ((Long) hash.get(NANO_TIME));
+
+                if ((OPERATION_STORE.equals(operation))) {
+                    Object blobObject = hash.get(BLOB_OBJ);
+                    return new SessionContextDO(key, type, blobObject, nanoTime);
+                }
+            }
+        } else {
+            Connection connection = null;
+            try {
+                connection = IdentityDatabaseUtil.getDBConnection(false);
+            } catch (IdentityRuntimeException e) {
+                log.error(e.getMessage(), e);
+                return null;
+            }
+            PreparedStatement preparedStatement = null;
+            ResultSet resultSet = null;
+
+            try {
+                if (StringUtils.isBlank(sqlSelect)) {
+                    if (connection.getMetaData().getDriverName().contains(MYSQL_DATABASE)
+                            || connection.getMetaData().getDriverName().contains(H2_DATABASE)) {
+                        sqlSelect = SQL_DESERIALIZE_OBJECT_MYSQL;
+                    } else if (connection.getMetaData().getDatabaseProductName().contains(DB2_DATABASE)) {
+                        sqlSelect = SQL_DESERIALIZE_OBJECT_DB2SQL;
+                    } else if (connection.getMetaData().getDriverName().contains(MS_SQL_DATABASE)
+                            || connection.getMetaData().getDriverName().contains(MICROSOFT_DATABASE)) {
+                        sqlSelect = SQL_DESERIALIZE_OBJECT_MSSQL;
+                    } else if (connection.getMetaData().getDriverName().contains(POSTGRESQL_DATABASE)) {
+                        sqlSelect = SQL_DESERIALIZE_OBJECT_POSTGRESQL;
+                    } else if (connection.getMetaData().getDriverName().contains(INFORMIX_DATABASE)) {
+                        // Driver name = "IBM Informix JDBC Driver for IBM Informix Dynamic Server"
+                        sqlSelect = SQL_DESERIALIZE_OBJECT_INFORMIX;
+                    } else {
+                        sqlSelect = SQL_DESERIALIZE_OBJECT_ORACLE;
+                    }
+                }
+                preparedStatement = connection.prepareStatement(getSessionStoreDBQuery(sqlSelect, type));
+                preparedStatement.setString(1, key);
+                preparedStatement.setString(2, type);
+                resultSet = preparedStatement.executeQuery();
+                if (resultSet.next()) {
+                    String operation = resultSet.getString(1);
+                    long nanoTime = resultSet.getLong(3);
+                    if ((OPERATION_STORE.equals(operation))) {
+                        return new SessionContextDO(key, type, getBlobObject(resultSet.getBinaryStream(2)), nanoTime);
+                    }
+                }
+            } catch (ClassNotFoundException | IOException | SQLException |
+                    IdentityApplicationManagementException e) {
+                log.error("Error while retrieving session data", e);
+            } finally {
+                IdentityDatabaseUtil.closeAllConnections(connection, resultSet, preparedStatement);
+            }
+            return null;
+        }
+        return null;
+    }
+
     public void persistSessionData(String key, String type, Object entry, long nanoTime, int tenantId) {
 
         if (!enablePersist) {
-            return;
-        }
-        Connection connection = null;
-        try {
-            connection = IdentityDatabaseUtil.getDBConnection();
-        } catch (IdentityRuntimeException e) {
-            log.error(e.getMessage(), e);
             return;
         }
 
@@ -544,53 +574,89 @@ public class SessionDataStore {
             validityPeriodNano = getCleanupTimeout(type, tenantId);
         }
 
-        PreparedStatement preparedStatement = null;
-        try {
-            String sqlQuery = getSessionStoreDBQuery(sqlInsertSTORE, type);
-            preparedStatement = connection.prepareStatement(sqlQuery);
-            preparedStatement.setString(1, key);
-            preparedStatement.setString(2, type);
-            preparedStatement.setString(3, OPERATION_STORE);
-            setBlobObject(preparedStatement, entry, 4);
-            preparedStatement.setLong(5, nanoTime);
-            preparedStatement.setLong(6, nanoTime + validityPeriodNano);
-            preparedStatement.setInt(7, tenantId);
-            preparedStatement.executeUpdate();
+        if (redisEnabled) {
+            // Code for redis hashmap.
+            Map sessionEntry = new HashMap();
+            sessionEntry.put(TYPE, type);
+            sessionEntry.put(OPERATION, OPERATION_STORE);
+            sessionEntry.put(BLOB_OBJ, entry);
+            sessionEntry.put(NANO_TIME, nanoTime);
+            sessionEntry.put(TIME, nanoTime + validityPeriodNano);
+            sessionEntry.put(TENANT_ID, tenantId);
 
-            //code for redis hashmap
-            Map hm= new HashMap();
-            hm.put("type",type);
-            hm.put("operation",OPERATION_STORE);
-            hm.put("BlobObj",(entry));
-            hm.put("nanoTime",nanoTime);
-            hm.put("time",(nanoTime + validityPeriodNano));
-            hm.put("tenantId",tenantId);
+            byte[] serializedSessionEntry = serialize((Serializable) sessionEntry);
 
-            byte[] obj=serialize((Serializable) hm);
-            jedis=returnjedis();
-            jedis.set(key.getBytes(),obj);
-            //jedis.hmset(key,hm);
-
-            IdentityDatabaseUtil.commitTransaction(connection);
-        } catch (SQLException | IOException e) {
-            IdentityDatabaseUtil.rollbackTransaction(connection);
-            log.error("Error while storing session data", e);
-        } finally {
-            IdentityDatabaseUtil.closeAllConnections(connection, null, preparedStatement);
+            jedis = getJedisInstance();
+            jedis.set(key.getBytes(), serializedSessionEntry);
+        } else {
+            Connection connection = null;
+            try {
+                connection = IdentityDatabaseUtil.getDBConnection();
+            } catch (IdentityRuntimeException e) {
+                log.error(e.getMessage(), e);
+                return;
+            }
+            PreparedStatement preparedStatement = null;
+            try {
+                String sqlQuery = getSessionStoreDBQuery(sqlInsertSTORE, type);
+                preparedStatement = connection.prepareStatement(sqlQuery);
+                preparedStatement.setString(1, key);
+                preparedStatement.setString(2, type);
+                preparedStatement.setString(3, OPERATION_STORE);
+                setBlobObject(preparedStatement, entry, 4);
+                preparedStatement.setLong(5, nanoTime);
+                preparedStatement.setLong(6, nanoTime + validityPeriodNano);
+                preparedStatement.setInt(7, tenantId);
+                preparedStatement.executeUpdate();
+                IdentityDatabaseUtil.commitTransaction(connection);
+            } catch (SQLException | IOException e) {
+                IdentityDatabaseUtil.rollbackTransaction(connection);
+                log.error("Error while storing session data", e);
+            } finally {
+                IdentityDatabaseUtil.closeAllConnections(connection, null, preparedStatement);
+            }
         }
-
-    }
-    //Serializes an Object to byte array
-    private static byte[] serialize(Serializable obj) {
-        return SerializationUtils.serialize(obj);
     }
 
-    //Deserializes a byte array back to Object
-    private static Object deserialize(byte[] bytes) {
-        return SerializationUtils.deserialize(bytes);
+    private Object getBlobObject(InputStream is)
+            throws IdentityApplicationManagementException, IOException, ClassNotFoundException {
+
+        if (is != null) {
+            ObjectInput ois = null;
+            try {
+                ois = new ObjectInputStream(is);
+                return ois.readObject();
+            } finally {
+                if (ois != null) {
+                    try {
+                        ois.close();
+                    } catch (IOException e) {
+                        log.error("IOException while trying to close ObjectInputStream.", e);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private void setBlobObject(PreparedStatement prepStmt, Object value, int index)
+            throws SQLException, IOException {
+
+        if (value != null) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(value);
+            oos.flush();
+            oos.close();
+            InputStream inputStream = new ByteArrayInputStream(baos.toByteArray());
+            prepStmt.setBinaryStream(index, inputStream, inputStream.available());
+        } else {
+            prepStmt.setBinaryStream(index, null, 0);
+        }
     }
 
     public void removeSessionData(String key, String type, long nanoTime) {
+
         if (!enablePersist) {
             return;
         }
@@ -661,45 +727,11 @@ public class SessionDataStore {
         }
     }
 
-    private void setBlobObject(PreparedStatement prepStmt, Object value, int index)
-            throws SQLException, IOException {
-        if (value != null) {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ObjectOutputStream oos = new ObjectOutputStream(baos);
-            oos.writeObject(value);
-            oos.flush();
-            oos.close();
-            InputStream inputStream = new ByteArrayInputStream(baos.toByteArray());
-            prepStmt.setBinaryStream(index, inputStream, inputStream.available());
-        } else {
-            prepStmt.setBinaryStream(index, null, 0);
-        }
-    }
-
-    private Object getBlobObject(InputStream is)
-            throws IdentityApplicationManagementException, IOException, ClassNotFoundException {
-        if (is != null) {
-            ObjectInput ois = null;
-            try {
-                ois = new ObjectInputStream(is);
-                return ois.readObject();
-            } finally {
-                if (ois != null) {
-                    try {
-                        ois.close();
-                    } catch (IOException e) {
-                        log.error("IOException while trying to close ObjectInputStream.", e);
-                    }
-                }
-            }
-        }
-        return null;
-    }
-
     /**
      * Removes STORE records related to DELETE records in IDN_AUTH_SESSION_STORE table
      */
     private void removeInvalidatedSTOREOperations() {
+
         Connection connection = null;
         PreparedStatement statement = null;
         try {
@@ -757,6 +789,7 @@ public class SessionDataStore {
     }
 
     private long getCleanupTimeout(String type, int tenantId) {
+
         if (isTempCache(type)) {
             return TimeUnit.MINUTES.toNanos(IdentityUtil.getTempDataCleanUpTimeout());
         } else if (tenantId != MultitenantConstants.INVALID_TENANT_ID) {

--- a/pom.xml
+++ b/pom.xml
@@ -1719,6 +1719,16 @@
                 <artifactId>spring-web</artifactId>
                 <version>${springframework.spring-web.version}</version>
             </dependency>
+            <dependency>
+                <groupId>redis.clients</groupId>
+                <artifactId>jedis</artifactId>
+                <version>${redis.clients.jedis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons-lang.version}</version>
+            </dependency>
         </dependencies>
 
     </dependencyManagement>
@@ -1738,6 +1748,8 @@
         <codehaus.jettison.version>1.4.0</codehaus.jettison.version>
         <springframework.spring-web.version>5.1.1.RELEASE</springframework.spring-web.version>
         <jaxrx.jsr311.api.version>1.1.1</jaxrx.jsr311.api.version>
+        <redis.clients.jedis.version>3.3.0</redis.clients.jedis.version>
+        <commons-lang.version>2.6</commons-lang.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
### Proposed changes in this pull request

Currently, the identity server user session implementation is backed by relational databases. That implementation will affect the performance in large scale implementations. This pull request contains POC to the session data is backed by Redis server. Here Both Redis and RDMS support is given.

#### Code

The persistSessionData, getSessionContextData methods in the Session store class are modified for the change. redisEnabled variable is used to select either the Redis implementation or RDMS implementation.

