### PR TITLE
Issue 5365: rename cookie for manage multi tenant session

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -335,9 +335,11 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             String commonAuthCookie = null;
             String sessionContextKey = null;
             // Force authentication requires the creation of a new session. Therefore skip using the existing session
-            if (FrameworkUtils.getAuthCookie(request) != null && !context.isForceAuthenticate()) {
+            //if (FrameworkUtils.getAuthCookie(request) != null && !context.isForceAuthenticate()) {
+            if (FrameworkUtils.getAuthCookieTenant(request, context.getTenantDomain()) != null && !context.isForceAuthenticate()) {
 
-                commonAuthCookie = FrameworkUtils.getAuthCookie(request).getValue();
+                //commonAuthCookie = FrameworkUtils.getAuthCookie(request).getValue();
+            	commonAuthCookie = FrameworkUtils.getAuthCookieTenant(request, context.getTenantDomain()).getValue();
 
                 if (commonAuthCookie != null) {
                     sessionContextKey = DigestUtils.sha256Hex(commonAuthCookie);
@@ -711,7 +713,9 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             authCookieAge = IdPManagementUtil.getRememberMeTimeout(tenantDomain);
         }
 
-        FrameworkUtils.storeAuthCookie(request, response, sessionKey, authCookieAge);
+        //FrameworkUtils.storeAuthCookie(request, response, sessionKey, authCookieAge);
+        FrameworkUtils.storeAuthCookieTenant(request, response, sessionKey, authCookieAge, tenantDomain);
+        
     }
 
     private String getAuthenticatedUserTenantDomain(AuthenticationContext context,

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -505,7 +505,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     log.debug("relyingParty param is null. This is a possible logout scenario.");
                 }
 
-                Cookie cookie = FrameworkUtils.getAuthCookie(request);
+                // Cookie cookie = FrameworkUtils.getAuthCookie(request);
+                Cookie cookie = FrameworkUtils.getAuthCookieTenant(request,tenantDomain);
 
                 String sessionContextKey = null;
                 if (cookie != null) {
@@ -603,7 +604,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
             }
         }
 
-        Cookie cookie = FrameworkUtils.getAuthCookie(request);
+        //Cookie cookie = FrameworkUtils.getAuthCookie(request);
+        Cookie cookie = FrameworkUtils.getAuthCookieTenant(request,context.getTenantDomain());
 
         // if cookie exists user has previously authenticated
         if (cookie != null) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -718,6 +718,11 @@ public class FrameworkUtils {
 
         setCookie(req, resp, FrameworkConstants.COMMONAUTH_COOKIE, id, age, SameSiteCookie.NONE);
     }
+    
+    public static void storeAuthCookieTenant(HttpServletRequest req, HttpServletResponse resp, String id, Integer age, String tenantDomain) {
+
+        setCookie(req, resp, FrameworkConstants.COMMONAUTH_COOKIE+"-"+tenantDomain, id, age, SameSiteCookie.NONE);
+    }
 
     /**
      * Stores a cookie to the response taking configurations from identity.xml file.
@@ -788,6 +793,11 @@ public class FrameworkUtils {
     public static Cookie getAuthCookie(HttpServletRequest req) {
 
         return getCookie(req, FrameworkConstants.COMMONAUTH_COOKIE);
+    }
+    
+    public static Cookie getAuthCookieTenant(HttpServletRequest req, String tenantDomain) {
+
+        return getCookie(req, FrameworkConstants.COMMONAUTH_COOKIE+"-"+tenantDomain);
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

Fix issue https://github.com/wso2/product-is/issues/5365:
- custom cookie session name adding tenant name for mange multi tenant session
- inserted new methods to return new cookie name depending from tenant (storeAuthCookieTenant and getAuthCookieTenant)
uses this new methods where are call the olds

### When should this PR be merged

Modify from tag v5.17.5

### Follow up actions

Check multi session user of different tenant in same browser

### Checklist (for reviewing)

I left old code commented, remove them after merge.

