### PR TITLE
Remove checks for SAML Fed IdP

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -533,8 +533,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             // store the saml index with the session context key for the single logout.
             if (context.getAuthenticationStepHistory() != null) {
                 for (AuthHistory authHistory : context.getAuthenticationStepHistory()) {
-                    if (FED_AUTH_NAME.equals(authHistory.getAuthenticatorName()) &&
-                            StringUtils.isNotBlank(authHistory.getIdpSessionIndex()) &&
+                    if (StringUtils.isNotBlank(authHistory.getIdpSessionIndex()) &&
                             StringUtils.isNotBlank(authHistory.getIdpName())) {
                         try {
                             UserSessionStore.getInstance().storeFederatedAuthSessionInfo(sessionContextKey,

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -578,8 +578,7 @@ public class DefaultStepHandler implements StepHandler {
                     idpSessionIndex = idpSessionIndexParamValue.toString();
                 }
             }
-            if (StringUtils.isNotBlank(context.getCurrentAuthenticator()) && StringUtils.isNotBlank(idpSessionIndex)
-                    && FED_AUTH_NAME.equals(context.getCurrentAuthenticator())) {
+            if (StringUtils.isNotBlank(context.getCurrentAuthenticator()) && StringUtils.isNotBlank(idpSessionIndex)) {
                 authHistory.setIdpSessionIndex(idpSessionIndex);
                 authHistory.setRequestType(context.getRequestType());
             }


### PR DESCRIPTION
### Proposed changes in this pull request

- Remove check for SAML Fed IdP before persisting Federated Authentication Session Info to ```UserSessionStore``` 
- Remove check for SAML Fed IdP before adding ```IdPSessionIndex``` and ```RequestType``` to authentication history

---

- Current implementation only allows SAML federated authentication session info to be persisted into `UserSessionStore` during the authentication.
- But a mapping between `sid` claim of the `id token` and session id of the primary is needs to be persisted during the OIDC federated authentication for OIDC single logout. 
- To persist the OIDC session info into `UserSessionStore`, the check for SAML federated idp is removed. 
- Indented behavior of this check was to prevent session data getting stored unnecessarily when using authenticators other than SAML. But removing this check won't affect intended behavior as the `idpSessionIndex` value will be null for other authenticators except for SAML and OIDC.

Issue - https://github.com/wso2/product-is/issues/10714
