### PR TITLE
Incoperate code expiration detail.

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/CodeIntrospectResponse.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/CodeIntrospectResponse.java
@@ -30,6 +30,8 @@ public class CodeIntrospectResponse {
 
     private String recoveryStep = null;
 
+    private boolean isExpired = false;
+
     /**
      *
      **/
@@ -72,6 +74,20 @@ public class CodeIntrospectResponse {
         this.recoveryStep = recoveryStep;
     }
 
+    /**
+     *
+     **/
+    @JsonProperty("isExpired")
+    public boolean isExpired() {
+
+        return isExpired;
+    }
+
+    public void setIsExpired(boolean isExpired) {
+
+        this.isExpired = isExpired;
+    }
+
     @Override
     public String toString() {
 
@@ -81,6 +97,7 @@ public class CodeIntrospectResponse {
         sb.append("  user: ").append(user).append("\n");
         sb.append("  recoveryScenario: ").append(recoveryScenario).append("\n");
         sb.append("  recoveryStep: ").append(recoveryStep).append("\n");
+        sb.append("  isExpired: ").append(isExpired).append("\n");
         sb.append("}\n");
         return sb.toString();
     }


### PR DESCRIPTION
### Proposed changes in this pull request

Incorporate the improvement done to get expired details in the API call, as 
`{"user":{"username":"4453@wso2.com","tenant-domain":"carbon.super","realm":"PRIMARY"},"recoveryScenario":"LITE_SIGN_UP","recoveryStep":"CONFIRM_LITE_SIGN_UP","isExpired":true}`