### PR TITLE
JIT Provisioning able to update local claim value to null/empty on th…

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -507,6 +507,12 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
             serviceProvider.setClaimDialect(ApplicationConstants.LOCAL_IDP_DEFAULT_CLAIM_DIALECT);
             serviceProvider.setTenantDomain(context.getTenantDomain());
             IdentityApplicationManagementUtil.setThreadLocalProvisioningServiceProvider(serviceProvider);
+            Map<String, String> localUnfilteredClaimsForNullValues =
+                    (Map<String, String>) context
+                            .getProperty(FrameworkConstants.UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES);
+            if (MapUtils.isNotEmpty(localUnfilteredClaimsForNullValues)) {
+                extAttributesValueMap.putAll(localUnfilteredClaimsForNullValues);
+            }
 
             FrameworkUtils.getProvisioningHandler().handle(mappedRoles, subjectIdentifier,
                     extAttributesValueMap, userStoreDomain, context.getTenantDomain());

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -39,6 +39,7 @@ public abstract class FrameworkConstants {
     public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
     public static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
     public static final String UNFILTERED_LOCAL_CLAIM_VALUES = "UNFILTERED_LOCAL_CLAIM_VALUES";
+    public static final String UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES = "UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES";
     public static final String UNFILTERED_IDP_CLAIM_VALUES = "UNFILTERED_IDP_CLAIM_VALUES";
     public static final String UNFILTERED_SP_CLAIM_VALUES = "UNFILTERED_SP_CLAIM_VALUES";
     public static final String SP_TO_CARBON_CLAIM_MAPPING = "SP_TO_CARBON_CLAIM_MAPPING";


### PR DESCRIPTION
Public Issue : https://github.com/wso2/product-is/issues/10656

Earlier Flaw
- Implement a null check for claim values in two points.
1 - **claim mapping**
2 - before adding as user claim

The flaw in the pervious flow 
- During JIT Provisioning when we try to update an existing claim with a null/empty value, that change is not getting represented in the IS PRIMARY user store.
- The above use case is valid if we have any custom JIT provision handler.

Fix :
- Unable to remove Null check for incoming claims in **claim mapping**
  - Because there are several other values like context property, sp claims and user attributes depending on this result claim mapping after null check.
  -  Rather than removing null check, we add to another new claim mapping to store null value claims **(localUnfilteredClaimsForNullValues)** and save to new context property, for this specific use case.
 -  Then we retireve this **localUnfilteredClaimsForNullValues** just before calling JIT provision handler and add null value claim mapping to user attributes.


- Keep separate arrays for null claims(**toBeDeletedUserClaims**) and not null claims(**userClaims**).


We have two use cases for JIT provisioning
1 - First time provisioning (user not in user store)
    - Here won't apply this fix cause the existing flow will work fine. (**userClaims** will be added as user properties)

2 - User already in the user store (addressed issue)

  - First, we add all not null claims from **userClaims**.
  - Then. we get all active claims for the corresponding user.
  - Added null or empty claims as **toBeDeletedClaims**
 - Finally, we remove toBeDeletedUserClaims from active claims.



Test case:
- Test cases conducted for both primary userstore (LDAP) and secondary user store (Unique JDBC - MSSQL)
- Test case is to set a claim value as null/empty in extAttrs[1] and track the process through the flow.


[1]  - [https://github.com/wso2-support/carbon-identity-framework/blob/4ea6157369ec69c402837e2f608874066d702e17/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java#L289](https://github.com/wso2-support/carbon-identity-framework/blob/4ea6157369ec69c402837e2f608874066d702e17/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java#L289)
