### PR TITLE
Set files related to a resource instead of resource type when creating resources in getResourcesByType method

### DIFF
--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/dao/impl/ConfigurationDAOImpl.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/dao/impl/ConfigurationDAOImpl.java
@@ -1509,6 +1509,9 @@ public class ConfigurationDAOImpl implements ConfigurationDAO {
 
         JdbcTemplate jdbcTemplate = JdbcUtils.getNewTemplate();
         try {
+            String resourceTypeName = jdbcTemplate.fetchSingleRecord(SQLConstants.GET_RESOURCE_TYPE_BY_ID_SQL,
+                    (resultSet, rowNumber) -> resultSet.getString(DB_SCHEMA_COLUMN_NAME_NAME),
+                    preparedStatement -> preparedStatement.setString(1, resourceTypeId));
             return jdbcTemplate.executeQuery(GET_RESOURCES_BY_RESOURCE_TYPE_ID_SQL,
                     (LambdaExceptionUtils.rethrowRowMapper((resultSet, rowNumber) -> {
                         String resourceId = resultSet.getString(DB_SCHEMA_COLUMN_NAME_ID);
@@ -1528,7 +1531,7 @@ public class ConfigurationDAOImpl implements ConfigurationDAO {
                         resource.setLastModified(resourceLastModified);
                         resource.setHasFile(Boolean.valueOf(resourceHasFile));
                         resource.setTenantDomain(IdentityTenantUtil.getTenantDomain(tenantId));
-                        resource.setFiles(getFilesByResourceType(resourceTypeId, tenantId));
+                        resource.setFiles(getFiles(resourceId, resourceTypeName, resourceName));
                         resource.setAttributes(getAttributesByResourceId(resourceId));
                         return resource;
                     })),


### PR DESCRIPTION
### Proposed changes in this pull request

Fixes https://github.com/wso2/product-is/issues/10777

In the previous implementation, the file set of a resource type is set as a specific resource's file set mistakenly. This PR fix that bug.