### PR TITLE
Improve error logging

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/java/org/wso2/carbon/user/mgt/ui/UserAdminClient.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/java/org/wso2/carbon/user/mgt/ui/UserAdminClient.java
@@ -317,7 +317,9 @@ public class UserAdminClient  {
             errorMessage = e.getMessage();
         }
 
-        log.error(errorMessage, e);
+        if (log.isDebugEnabled()) {
+            log.debug("Failed to proceed. " + errorMessage, e);
+        }
         throw new AxisFault(errorMessage, e);
 
     }

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserRealmProxy.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserRealmProxy.java
@@ -954,10 +954,14 @@ public class UserRealmProxy {
                 throw new UserAdminException("Read only user store or Role creation is disabled");
             }
         } catch (UserStoreException e) {
-            log.error(e.getMessage(), e);
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Failed to add the role: %s, to the user store", roleName), e);
+            }
             throw new UserAdminException(e.getMessage(), e);
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Failed to add the role: %s", roleName), e);
+            }
             throw new UserAdminException(e.getMessage(), e);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/7513.

When adding duplicate users, the backend server prints two error logs which are redundant as this is a client error. This PR converts these two error logs in to debug logs.