### PR TITLE
Introduce configuration for primary login identifier

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -876,6 +876,11 @@
         </AskPassword>
     </TenantRegistrationVerification>
 
+    <!--<LoginIdentifiers>
+        <Enable>false</Enable>
+        <PrimaryLoginIdentifier>http://wso2.org/claims/userType</PrimaryLoginIdentifier>
+    </LoginIdentifiers>-->
+
     <AccountSuspension>
         <UseIdentityClaims>true</UseIdentityClaims>
     </AccountSuspension>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1120,6 +1120,11 @@
         <ResendConfirmationReCaptcha>{{identity_mgt.user_self_registration.enable_resend_confirmation_recaptcha}}</ResendConfirmationReCaptcha>
     </SelfRegistration>
 
+    <LoginIdentifiers>
+        <Enable>{{identity_mgt.login_identifiers.enable}}</Enable>
+        <PrimaryLoginIdentifier>{{identity_mgt.login_identifiers.primary_claim}}</PrimaryLoginIdentifier>
+    </LoginIdentifiers>
+
     <UserClaimUpdate>
         <Claim uri = "http://wso2.org/claims/emailaddress">
             <VerificationOnUpdate>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -304,6 +304,9 @@
 
   "identity_mgt.password_update.preserve_logged_in_session": false,
 
+  "identity_mgt.login_identifiers.enable" : false,
+  "identity_mgt.login_identifiers.primary_claim" : "http://wso2.org/claims/username",
+
   "identity_mgt.username_recovery.email.enable_username_recovery": false,
   "identity_mgt.username_recovery.email.enable_recaptcha": false,
 


### PR DESCRIPTION
### Proposed changes in this pull request
Resolves wso2/product-is#10631
In SCIM 2.0 get user method, currently we are setting org.wso2.carbon.user.core.common.User.getUserName() for the urn:ietf:params:scim:schemas:core:2.0:User:userName attribute.

If we have a requirement to get the value in another claim to the urn:ietf:params:scim:schemas:core:2.0:User:userName in scim response, that is not possible.
If we want to rename the username, also having a sperate claim to store the human readable username is helpful.
So, when creating the user, we should generate a unique user id and pass it as the immutable identifire to the user core, while passing the configurable claim with the human readable username.

We can define, a configuration as a primary login identifier, and give a preferred claim for that.
Ex:
```
<LoginIdentifiers> 
    <Enable>true</Enable>
    <PrimaryLoginIdentifier>http://wso2.org/claims/userType</PrimaryLoginIdentifier> 
</LoginIdentifiers>
```
In the scim component, check for this configuration, and if available, generate a UUID and provide it as the immutable username and pass this claim in the claims set.

In the get user part of the scim component, when the above configuration is enabled, the human readable scim username can be set by retrieving the value of the above defined claim.