### PR TITLE
Fix issue of displaying local authenticator names as null 

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.application.mgt;
 
 import org.apache.axiom.om.OMElement;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -190,30 +191,7 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
 
         int appId = doAddApplication(serviceProvider, tenantDomain, username, appDAO::createApplication);
         serviceProvider.setApplicationID(appId);
-        LocalAuthenticatorConfig[] localAuthenticatorConfigs = this.getAllLocalAuthenticators(tenantDomain);
-        if (serviceProvider.getLocalAndOutBoundAuthenticationConfig() == null) {
-            continue;
-        }
-        AuthenticationStep[] authSteps =
-                serviceProvider.getLocalAndOutBoundAuthenticationConfig().getAuthenticationSteps();
-        if (authSteps == null || authSteps.length == 0) {
-            continue;
-        }
-        for (AuthenticationStep authStep : authSteps) {
-            if (authStep.getLocalAuthenticatorConfigs() != null
-                    && authStep.getLocalAuthenticatorConfigs().length > 0) {
-                LocalAuthenticatorConfig localAuthenticatorConfig = authStep.getLocalAuthenticatorConfigs();
-                if (localAuthenticatorConfig.getName() != null && localAuthenticatorConfigs != null &&
-                        localAuthenticatorConfig.getDisplayName() == null) {
-                    for (LocalAuthenticatorConfig config : localAuthenticatorConfigs) {
-                        if (config.getName().equals(localAuthenticatorConfig.getName())) {
-                            localAuthenticatorConfig.setDisplayName(config.getDisplayName());
-                            break;
-                        }
-                    }
-                }
-            }
-        }
+        setDisplayNamesOfLocalAuthenticators(serviceProvider, tenantDomain);
         SpTemplate spTemplate = this.getApplicationTemplate(templateName, tenantDomain);
         if (spTemplate != null) {
             updateSpFromTemplate(serviceProvider, tenantDomain, spTemplate);
@@ -2216,7 +2194,7 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
         validateApplicationConfigurations(updatedApp, tenantDomain, username);
 
         updatedApp.setApplicationResourceId(resourceId);
-
+        setDisplayNamesOfLocalAuthenticators(updatedApp, tenantDomain);
         Collection<ApplicationResourceManagementListener> listeners =
                 ApplicationMgtListenerServiceComponent.getApplicationResourceMgtListeners();
         for (ApplicationResourceManagementListener listener : listeners) {
@@ -2534,6 +2512,42 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
     private Collection<ApplicationMgtListener> getApplicationMgtListeners() {
 
         return ApplicationMgtListenerServiceComponent.getApplicationMgtListeners();
+    }
+
+    /**
+     * Set displayName of configured localAuthenticators in the service provider, if displayName is null.
+     *
+     * @param serviceProvider Service provider,
+     * @param tenantDomain    Tenant domain.
+     * @throws IdentityApplicationManagementException If an error occur while retrieving local authenticator configs.
+     */
+    private void setDisplayNamesOfLocalAuthenticators(ServiceProvider serviceProvider, String tenantDomain)
+            throws IdentityApplicationManagementException {
+
+        // Set displayName of local authenticators if displayNames are null.
+        LocalAuthenticatorConfig[] localAuthenticatorConfigs = getAllLocalAuthenticators(tenantDomain);
+        if (serviceProvider.getLocalAndOutBoundAuthenticationConfig() == null || localAuthenticatorConfigs == null) {
+            return;
+        }
+        AuthenticationStep[] authSteps =
+                serviceProvider.getLocalAndOutBoundAuthenticationConfig().getAuthenticationSteps();
+        if (CollectionUtils.isEmpty(Arrays.asList(authSteps))) {
+            return;
+        }
+        for (AuthenticationStep authStep : authSteps) {
+            if (CollectionUtils.isEmpty(Arrays.asList(authStep.getLocalAuthenticatorConfigs()))) {
+                return;
+            }
+            for (LocalAuthenticatorConfig localAuthenticator : authStep.getLocalAuthenticatorConfigs()) {
+                if (localAuthenticator.getDisplayName() == null) {
+                    Arrays.stream(localAuthenticatorConfigs).forEach(config -> {
+                        if (StringUtils.equals(localAuthenticator.getName(), config.getName())) {
+                            localAuthenticator.setDisplayName(config.getDisplayName());
+                        }
+                    });
+                }
+            }
+        }
     }
 }
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -2517,7 +2517,7 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
     /**
      * Set displayName of configured localAuthenticators in the service provider, if displayName is null.
      *
-     * @param serviceProvider Service provider,
+     * @param serviceProvider Service provider.
      * @param tenantDomain    Tenant domain.
      * @throws IdentityApplicationManagementException If an error occur while retrieving local authenticator configs.
      */

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -190,7 +190,30 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
 
         int appId = doAddApplication(serviceProvider, tenantDomain, username, appDAO::createApplication);
         serviceProvider.setApplicationID(appId);
-
+        LocalAuthenticatorConfig[] localAuthenticatorConfigs = this.getAllLocalAuthenticators(tenantDomain);
+        if (serviceProvider.getLocalAndOutBoundAuthenticationConfig() == null) {
+            continue;
+        }
+        AuthenticationStep[] authSteps =
+                serviceProvider.getLocalAndOutBoundAuthenticationConfig().getAuthenticationSteps();
+        if (authSteps == null || authSteps.length == 0) {
+            continue;
+        }
+        for (AuthenticationStep authStep : authSteps) {
+            if (authStep.getLocalAuthenticatorConfigs() != null
+                    && authStep.getLocalAuthenticatorConfigs().length > 0) {
+                LocalAuthenticatorConfig localAuthenticatorConfig = authStep.getLocalAuthenticatorConfigs();
+                if (localAuthenticatorConfig.getName() != null && localAuthenticatorConfigs != null &&
+                        localAuthenticatorConfig.getDisplayName() == null) {
+                    for (LocalAuthenticatorConfig config : localAuthenticatorConfigs) {
+                        if (config.getName().equals(localAuthenticatorConfig.getName())) {
+                            localAuthenticatorConfig.setDisplayName(config.getDisplayName());
+                            break;
+                        }
+                    }
+                }
+            }
+        }
         SpTemplate spTemplate = this.getApplicationTemplate(templateName, tenantDomain);
         if (spTemplate != null) {
             updateSpFromTemplate(serviceProvider, tenantDomain, spTemplate);


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves https://github.com/wso2/product-is/issues/10830

### Approach
https://github.com/wso2/product-is/issues/10830 occurs if a local authenticator is first time used to configure a service provider via the console app/ REST API. 

If the SP is configured via mgt console, the local authenticator's display name is set at ApplicationBean class. https://github.com/wso2/carbon-identity-framework/blob/2eacea41b5f993bbdd3ebe9f045b7a46e7b0eee6/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/java/org/wso2/carbon/identity/application/mgt/ui/ApplicationBean.java#L1015 
When configuring the SP via REST API we only pass the authenticator's name but the displayname is not set at admin service/DAO level. Therefore, the authenticator is saved in `IDP_AUTHENTICATOR` with `DISPLAY_NAME = null`.
https://github.com/wso2/carbon-identity-framework/blob/2eacea41b5f993bbdd3ebe9f045b7a46e7b0eee6/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java#L1518

This issue is fixed by setting the display name of the local authenticators at the admin services `createApplicationWithTemplate` and `updateApplicationByResourceId`  if displayname is null.