### PR TITLE
Remove credential null check from IdentityMgtEventListener

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/IdentityMgtEventListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/IdentityMgtEventListener.java
@@ -517,10 +517,6 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
                                 UserStoreManager userStoreManager) throws UserStoreException {
 
         if (!isEnable()) {
-            if (credential == null || StringUtils.isBlank(credential.toString())) {
-                log.error("Identity Management listener is disabled");
-                throw new UserStoreException(PASSWORD_INVALID + ASK_PASSWORD_FEATURE_IS_DISABLED);
-            }
             return true;
         }
 


### PR DESCRIPTION
### Proposed changes in this pull request
> Following removed logic was added assuming that credentials will be provided as empty/null during the ask password flow. Since old IdentityMgtEventListener needs to be enabled if ask password option is enabled. If IdentityMgtEventListener is disabled it throws an exception if credentials are null/empty. Since old IdentityMgtEventListener is no longer used following logic is causing errors if credentials are null/empty. Hence that logic is removed by this PR. 