### PR TITLE
adding SCIM2 TenantMgtListener config to enable and disable the listener

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1218,6 +1218,11 @@
                        name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListener"
                        orderId="{{event.default_listener.scim2.priority}}"
                        enable="{{event.default_listener.scim2.enable}}"/>
+        <EventListener id="scim2"
+                       type="org.wso2.carbon.stratos.common.listeners.TenantMgtListener"
+                       name="org.wso2.carbon.identity.scim2.common.listener.SCIMTenantMgtListener"
+                       orderId="{{event.default_listener.scim2_tenant_mgt.priority}}"
+                       enable="{{event.default_listener.scim2_tenant_mgt.enable}}"/>
         <EventListener id="governance_identity_mgt"
                        type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
                        name="org.wso2.carbon.identity.governance.listener.IdentityMgtEventListener"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -355,6 +355,8 @@
   "event.default_listener.scim.enable": false,
   "event.default_listener.scim_tenant_mgt.priority": "-1",
   "event.default_listener.scim_tenant_mgt.enable": true,
+  "event.default_listener.scim2_tenant_mgt.priority": "-1",
+  "event.default_listener.scim2_tenant_mgt.enable": true,
   "event.default_listener.scim2.priority": "93",
   "event.default_listener.scim2.enable": true,
   "event.default_listener.governance_identity_mgt.priority": "95",


### PR DESCRIPTION
### Proposed changes in this pull request

Toml config to disable the listener.
```
[event.default_listener.scim2_tenant_mgt]
enable="false"
```

**NOTE:** order id was set to `-1` to maintain backward compatibility.