### PR TITLE
Template configs to configure customer userstores

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2474,6 +2474,11 @@
         {% for allowed_user_store in user_store_mgt.allowed_user_stores %}
         <AllowedUserstore>{{allowed_user_store}}</AllowedUserstore>
         {% endfor %}
+        {% if user_store_mgt.custom_user_stores is defined %}
+        {% for custom_user_store in user_store_mgt.custom_user_stores %}
+        <AllowedUserstore>{{custom_user_store}}</AllowedUserstore>
+        {% endfor %}
+        {% endif %}
     </AllowedUserstores>
     {% endif %}
 


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/10582

After adding this fix, you can enable the custom user stores that are being deployed by adding the following configuration in the <IS_HOME>/repository/conf/deployment.toml file.

```
[user_store_mgt]
custom_user_stores=["org.sample1.custom.CustomUniqueIDJDBCUserStoreManager", "org.sample2.custom.CustomUniqueIDJDBCUserStoreManager"]
```