### PR TITLE
Fix password pattern validation error in Provision silently JIT mode. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1742,7 +1742,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.6.1-alpha3</carbon.kernel.version>
+        <carbon.kernel.version>4.6.2-m4</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>


### PR DESCRIPTION
### Proposed changes in this pull request

In JIT provisioning flow, there are few ways the user is provisioned. In **Prompt for consent**
 and **Provision silently** modes, Identity server internally generates the password for the user. 

With this fix, it will ignore the password policy validation for generated passwords. 

Fix https://github.com/wso2/product-is/issues/10597