### PR TITLE
Skip password pattern validation when provisioning users

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -161,11 +161,9 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                     associateUser(username, userStoreDomain, tenantDomain, subjectVal, idp);
                 }
             } else {
-                boolean isUserProvidedPassword = false;
                 String password = generatePassword();
                 String passwordFromUser = userClaims.get(FrameworkConstants.PASSWORD);
                 if (StringUtils.isNotEmpty(passwordFromUser)) {
-                    isUserProvidedPassword = true;
                     password = passwordFromUser;
                 }
 
@@ -178,10 +176,12 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                 userClaims.remove(FrameworkConstants.PASSWORD);
                 boolean userWorkflowEngaged = false;
                 try {
-                    // This thread local is set to skip the password pattern validation if it is a generated one.
-                    if (!isUserProvidedPassword) {
-                        UserCoreUtil.setSkipPasswordPatternValidationThreadLocal(true);
-                    }
+                    /*
+                    This thread local is set to skip the password pattern validation even if the password
+                    is generated, or user entered one. If it is required to check password pattern validation,
+                    need to write a provisioning handler extending the "DefaultProvisioningHandler".
+                     */
+                    UserCoreUtil.setSkipPasswordPatternValidationThreadLocal(true);
                     userStoreManager.addUser(username, password, null, userClaims, null);
                 } catch (UserStoreException e) {
                     // Add user operation will fail if a user operation workflow is already defined for the same user.
@@ -195,9 +195,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                         throw e;
                     }
                 } finally {
-                    if (!isUserProvidedPassword) {
-                        UserCoreUtil.removeSkipPasswordPatternValidationThreadLocal();
-                    }
+                    UserCoreUtil.removeSkipPasswordPatternValidationThreadLocal();
                 }
 
                 if (userWorkflowEngaged ||


### PR DESCRIPTION
### Proposed changes in this pull request
Fix https://github.com/wso2/product-is/issues/10961

If we validate the password pattern violation similar to https://github.com/wso2-extensions/identity-governance/blob/c579fea49208010e85ddc81f9d5b205d2412cd61/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java#L584-L589, 
need to add a governance dependency to the framework. To avoid that, we normally skip the password pattern validation in this DefaultProvisioingHandler. 

If it is required to check password pattern validation, need to write a provisioning handler extending the "DefaultProvisioningHandler".

Git issue for the proper fix: https://github.com/wso2/product-is/issues/11004