### PR TITLE
Handle duplicate CORS origin entries

### DIFF
--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/constant/ErrorMessages.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/constant/ErrorMessages.java
@@ -147,7 +147,14 @@ public enum ErrorMessages {
      */
     ERROR_CODE_BAD_HEADER("60009",
             "Bad header name.",
-            "%s is an invalid header name.");
+            "%s is an invalid header name."),
+
+    /**
+     * Duplicate origin input.
+     */
+    ERROR_CODE_DUPLICATE_ORIGINS("60010",
+                                      "Duplicate origins found in the origin list.",
+                                      "Duplicate origin values are found in the request.");
 
     /**
      * The error prefix.

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/constant/ErrorMessages.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/constant/ErrorMessages.java
@@ -153,8 +153,8 @@ public enum ErrorMessages {
      * Duplicate origin input.
      */
     ERROR_CODE_DUPLICATE_ORIGINS("60010",
-                                      "Duplicate origins found in the origin list.",
-                                      "Duplicate origin values are found in the request.");
+                                      "Found duplicate origins.",
+                                      "Duplicate entries are found in the allowed origins list.");
 
     /**
      * The error prefix.

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/util/CORSConfigurationUtils.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/util/CORSConfigurationUtils.java
@@ -25,7 +25,9 @@ import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.cors.mgt.core.constant.ErrorMessages;
+import org.wso2.carbon.identity.cors.mgt.core.exception.CORSManagementServiceClientException;
 import org.wso2.carbon.identity.cors.mgt.core.model.CORSConfiguration;
+import org.wso2.carbon.identity.cors.mgt.core.model.Origin;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,6 +36,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.wso2.carbon.identity.cors.mgt.core.constant.ErrorMessages.ERROR_CODE_DUPLICATE_ORIGINS;
+import static org.wso2.carbon.identity.cors.mgt.core.internal.util.ErrorUtils.handleClientException;
 
 /**
  * Utility class for CORS configuration operations.
@@ -130,5 +135,33 @@ public class CORSConfigurationUtils {
         } else {
             return new ArrayList<>(Collections.singletonList((String) value));
         }
+    }
+
+    /**
+     * Check for duplicate entries of origins.
+     *
+     * @param origins List of the origin names.
+     * @return Whether the list has duplicate entries or not.
+     */
+    public static boolean hasDuplicates(List<String> origins) {
+
+        Set<String> originsHashSet = new HashSet<>(origins);
+        return origins.size() != originsHashSet.size();
+    }
+
+    /**
+     * Convert origin strings to Origin instances.
+     *
+     * @param originNames List of origin names.
+     * @return Origins as a list.
+     * @throws CORSManagementServiceClientException
+     */
+    public static List<Origin> createOriginList(List<String> originNames) throws CORSManagementServiceClientException {
+
+        List<Origin> originList = new ArrayList<>();
+        for (String origin : originNames) {
+            originList.add(new Origin(origin));
+        }
+        return originList;
     }
 }

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/util/CORSConfigurationUtils.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/util/CORSConfigurationUtils.java
@@ -37,9 +37,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.wso2.carbon.identity.cors.mgt.core.constant.ErrorMessages.ERROR_CODE_DUPLICATE_ORIGINS;
-import static org.wso2.carbon.identity.cors.mgt.core.internal.util.ErrorUtils.handleClientException;
-
 /**
  * Utility class for CORS configuration operations.
  */

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/util/ErrorUtils.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/util/ErrorUtils.java
@@ -39,7 +39,7 @@ public class ErrorUtils {
      */
     public static CORSManagementServiceServerException handleServerException(ErrorMessages error, String... data) {
 
-        return new CORSManagementServiceServerException(error.getCode(), String.format(error.getDescription(), data));
+        return new CORSManagementServiceServerException(String.format(error.getDescription(), data), error.getCode());
     }
 
     /**
@@ -53,7 +53,7 @@ public class ErrorUtils {
     public static CORSManagementServiceServerException handleServerException(ErrorMessages error, Throwable e,
                                                                              String... data) {
 
-        return new CORSManagementServiceServerException(error.getCode(), String.format(error.getDescription(), data),
+        return new CORSManagementServiceServerException(String.format(error.getDescription(), data), error.getCode(),
                 e);
     }
 
@@ -66,7 +66,7 @@ public class ErrorUtils {
      */
     public static CORSManagementServiceClientException handleClientException(ErrorMessages error, String... data) {
 
-        return new CORSManagementServiceClientException(error.getCode(), String.format(error.getDescription(), data));
+        return new CORSManagementServiceClientException(String.format(error.getDescription(), data), error.getCode());
     }
 
     /**
@@ -80,7 +80,7 @@ public class ErrorUtils {
     public static CORSManagementServiceClientException handleClientException(ErrorMessages error, Throwable e,
                                                                              String... data) {
 
-        return new CORSManagementServiceClientException(error.getCode(), String.format(error.getDescription(), data),
+        return new CORSManagementServiceClientException(String.format(error.getDescription(), data), error.getCode(),
                 e);
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
Handle the errors when duplicate origin values are found when setting and adding CORS Origins.

Related: wso2/product-is#11098