### PR TITLE
Fix ClassNotFoundException when using custom password generator.

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/pom.xml
@@ -142,7 +142,7 @@
                             org.wso2.carbon.user.mgt.ui.*;version="${carbon.identity.package.export.version}",
                             org.wso2.carbon.userstore.ui.*,
                          </Export-Package>
-                        <DynamicImport-Package>*</DynamicImport-Package>
+                         <DynamicImport-Package>*</DynamicImport-Package>
                          <Carbon-Component>UIBundle</Carbon-Component>
                      </instructions>
                 </configuration>

--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/pom.xml
@@ -142,6 +142,7 @@
                             org.wso2.carbon.user.mgt.ui.*;version="${carbon.identity.package.export.version}",
                             org.wso2.carbon.userstore.ui.*,
                          </Export-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                          <Carbon-Component>UIBundle</Carbon-Component>
                      </instructions>
                 </configuration>


### PR DESCRIPTION
### Proposed changes in this pull request

Fixes https://github.com/wso2/product-is/issues/4509.

### Approach
Enable dynamic imports for the in the org.wso2.carbon.user.mgt component to load the classes from custom password generator implementations. 