### PR TITLE
Add config related to dropping unregistered scopes

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -595,7 +595,14 @@
 
         Default value: true
         -->
-        <EnableJWTTokenValidationDuringIntrospection>{{oauth.enable_jwt_token_validation_during_introspection}}</EnableJWTTokenValidationDuringIntrospection>
+        <EnableJWTTokenValidationDuringIntrospection>true</EnableJWTTokenValidationDuringIntrospection>
+
+        <!--
+        By enabling this config, any unregistered scopes(excluding internal scopes and allowed scopes)
+        passed in a OAuth based authz request will be dropped.
+        Default value : false
+        -->
+        <!--<DropUnregisteredScopes>true</DropUnregisteredScopes>-->
     </OAuth>
 
     <MultifactorAuthentication>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -804,6 +804,15 @@
             {% endfor %}
         </AllowedScopes>
         {% endif %}
+
+        {% if oauth.drop_unregistered_scopes is defined %}
+        <!--
+        By enabling this config, any unregistered scopes(excluding internal scopes and allowed scopes)
+        passed in a OAuth based authz request will be dropped.
+        Default value : false
+        -->
+        <DropUnregisteredScopes>{{oauth.drop_unregistered_scopes}}</DropUnregisteredScopes>
+        {% endif %}
     </OAuth>
 
     <MultifactorAuthentication>


### PR DESCRIPTION
Config pr related to https://github.com/wso2/product-is/issues/11207 https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1540

Configuration required to drop unregistered scopes.
```
[oauth]
drop_unregistered_scopes = "true"
```

By enabling above config, any unregistered scopes(excluding internal scopes and allowed scopes) passed in a OAuth based authz request will be dropped.
Default value : false