### PR TITLE
Skip considering unauthenticated flow handler in passive authentication.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -129,8 +129,7 @@ public class DefaultStepHandler implements StepHandler {
         // check passive authentication
         if (context.isPassiveAuthenticate()) {
             if (authenticatedStepIdps.isEmpty()) {
-
-                if (isOnlyFlowHandlersInStep(stepConfig)) {
+                if (authenticatedIdPs.keySet().size() > 0 && isOnlyFlowHandlersInStep(stepConfig)) {
                     // During Passive authentication, if the authenticatedStepIdps empty and contain only flow handlers.
                     // Then considering as authenticated.
                     String authenticatedIdP = authenticatedIdPs.keySet().iterator().next();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -62,6 +62,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.Authenticator.SAML2SSO.FED_AUTH_NAME;
 import static org.wso2.carbon.identity.base.IdentityConstants.FEDERATED_IDP_SESSION_ID;
+import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.RESIDENT_IDP;
 
 public class DefaultStepHandler implements StepHandler {
 
@@ -132,7 +133,10 @@ public class DefaultStepHandler implements StepHandler {
                 if (authenticatedIdPs.keySet().size() > 0 && isOnlyFlowHandlersInStep(stepConfig)) {
                     // During Passive authentication, if the authenticatedStepIdps empty and contain only flow handlers.
                     // Then considering as authenticated.
-                    String authenticatedIdP = authenticatedIdPs.keySet().iterator().next();
+                    String authenticatedIdP = RESIDENT_IDP;
+                    if (authenticatedIdPs.get(authenticatedIdP) == null) {
+                        authenticatedIdP = authenticatedIdPs.keySet().iterator().next();
+                    }
                     AuthenticatedIdPData authenticatedIdPData = authenticatedIdPs.get(authenticatedIdP);
                     populateStepConfigWithAuthenticationDetails(stepConfig, authenticatedIdPData,
                             stepConfig.getAuthenticatorList().get(0));


### PR DESCRIPTION
### Proposed changes in this pull request
In the authentication script if we have something like below (This is to support auto login after password reset  with identifier-first and basic auth),

Step 1: identifier-first 
Step 2: basic
```
var executeNormalLoginFlow = function (context) {
    executeStep(1, {
        onSuccess: function (context) {
                executeStep(2);
        }
    });  
};

var executeAutoLoginFlow = function(context) {
    executeStep(2);
};

var onLoginRequest = function(context) {
    var autoLoginCookieValue = context.request.cookies.ALOR;
    if(autoLoginCookieValue != null) {
        Log.info("Executing auto login flow.");
        executeAutoLoginFlow(context);
    } else {
        executeNormalLoginFlow(context);
    }
};
```
After the AutoLoginFlow, the ALOR cookie will be cleared. So when there is a prompt=none request from the client, it will be executed in the NormalLoginFlow, in this flow the identifier-first will not be in the already executed steps. So the none prompt call will fail.

As the fix,
In the passive authentication flow, if unauthenticated step have only flow handlers then consider it as authenticated and use the session user details.