### PR TITLE
Add support to invalidate cookies during authentication flow failure

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -179,7 +179,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                         log.debug("Session data key is null in the request and not a logout request.");
                     }
 
-                    FrameworkUtils.sendToRetryPage(request, response);
+                    FrameworkUtils.sendToRetryPage(request, response, null, null, context);
                 }
 
                 // if there is a cache entry, wrap the original request with params in cache entry
@@ -221,7 +221,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                                     "Request Headers: " + getHeaderString(request) + "\n" +
                                     "Thread Id: " + Thread.currentThread().getId());
                         }
-                        FrameworkUtils.sendToRetryPage(request, responseWrapper);
+                        FrameworkUtils.sendToRetryPage(request, responseWrapper, null, null, context);
                         return;
                     }
                 }
@@ -281,7 +281,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                         ":" + request.getRequestURI() + ", User-Agent: " + userAgent + " , Referer: " + referer;
 
                 log.error("Context does not exist. Probably due to invalidated cache. " + message);
-                FrameworkUtils.sendToRetryPage(request, responseWrapper);
+                FrameworkUtils.sendToRetryPage(request, responseWrapper, null, null, context);
             }
         } catch (JsFailureException e) {
             if (log.isDebugEnabled()) {
@@ -293,8 +293,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                 log.debug("User will be redirected to retry page or the error page provided by script.");
             }
         } catch (MisconfigurationException e) {
-            FrameworkUtils.sendToRetryPage(request, responseWrapper, "misconfiguration.error","something.went.wrong.contact" +
-                    ".admin");
+            FrameworkUtils.sendToRetryPage(request, responseWrapper, "misconfiguration.error",
+                    "something.went.wrong.contact.admin", context);
         } catch (PostAuthenticationFailedException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error occurred while evaluating post authentication", e);
@@ -304,7 +304,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
             publishAuthenticationFailure(request, context, context.getSequenceConfig().getAuthenticatedUser(),
                     e.getErrorCode());
             FrameworkUtils
-                    .sendToRetryPage(request, responseWrapper, "Authentication attempt failed.", e.getErrorCode());
+                    .sendToRetryPage(request, responseWrapper, "Authentication attempt failed.",
+                            e.getErrorCode(), context);
         } catch (Throwable e) {
             log.error("Exception in Authentication Framework", e);
             if ((e instanceof FrameworkException)
@@ -313,9 +314,9 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     log.debug(e.getMessage(), e);
                 }
                 FrameworkUtils.sendToRetryPage(request, response, "suspicious.authentication.attempts",
-                        "suspicious.authentication.attempts.description");
+                        "suspicious.authentication.attempts.description", context);
             } else {
-                FrameworkUtils.sendToRetryPage(request, responseWrapper);
+                FrameworkUtils.sendToRetryPage(request, responseWrapper, null, null, context);
             }
         } finally {
             UserCoreUtil.setDomainInThreadLocal(null);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -179,7 +179,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                         log.debug("Session data key is null in the request and not a logout request.");
                     }
 
-                    FrameworkUtils.sendToRetryPage(request, response, null, null, context);
+                    FrameworkUtils.sendToRetryPage(request, response, context);
                 }
 
                 // if there is a cache entry, wrap the original request with params in cache entry
@@ -221,7 +221,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                                     "Request Headers: " + getHeaderString(request) + "\n" +
                                     "Thread Id: " + Thread.currentThread().getId());
                         }
-                        FrameworkUtils.sendToRetryPage(request, responseWrapper, null, null, context);
+                        FrameworkUtils.sendToRetryPage(request, responseWrapper, context);
                         return;
                     }
                 }
@@ -281,7 +281,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                         ":" + request.getRequestURI() + ", User-Agent: " + userAgent + " , Referer: " + referer;
 
                 log.error("Context does not exist. Probably due to invalidated cache. " + message);
-                FrameworkUtils.sendToRetryPage(request, responseWrapper, null, null, context);
+                FrameworkUtils.sendToRetryPage(request, responseWrapper, context);
             }
         } catch (JsFailureException e) {
             if (log.isDebugEnabled()) {
@@ -293,8 +293,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                 log.debug("User will be redirected to retry page or the error page provided by script.");
             }
         } catch (MisconfigurationException e) {
-            FrameworkUtils.sendToRetryPage(request, responseWrapper, "misconfiguration.error",
-                    "something.went.wrong.contact.admin", context);
+            FrameworkUtils.sendToRetryPage(request, responseWrapper, context, "misconfiguration.error",
+                    "something.went.wrong.contact.admin");
         } catch (PostAuthenticationFailedException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error occurred while evaluating post authentication", e);
@@ -304,8 +304,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
             publishAuthenticationFailure(request, context, context.getSequenceConfig().getAuthenticatedUser(),
                     e.getErrorCode());
             FrameworkUtils
-                    .sendToRetryPage(request, responseWrapper, "Authentication attempt failed.",
-                            e.getErrorCode(), context);
+                    .sendToRetryPage(request, responseWrapper, context, "Authentication attempt failed.",
+                            e.getErrorCode());
         } catch (Throwable e) {
             log.error("Exception in Authentication Framework", e);
             if ((e instanceof FrameworkException)
@@ -313,10 +313,10 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                 if (log.isDebugEnabled()) {
                     log.debug(e.getMessage(), e);
                 }
-                FrameworkUtils.sendToRetryPage(request, response, "suspicious.authentication.attempts",
-                        "suspicious.authentication.attempts.description", context);
+                FrameworkUtils.sendToRetryPage(request, response, context, "suspicious.authentication.attempts",
+                        "suspicious.authentication.attempts.description");
             } else {
-                FrameworkUtils.sendToRetryPage(request, responseWrapper, null, null, context);
+                FrameworkUtils.sendToRetryPage(request, responseWrapper, context);
             }
         } finally {
             UserCoreUtil.setDomainInThreadLocal(null);

--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -123,6 +123,7 @@ public class IdentityConstants {
     public final static String COOKIE_SECURE = "secure";
     public final static String COOKIE_HTTP_ONLY = "httpOnly";
     public final static String COOKIE_SAME_SITE = "sameSite";
+    public final static String COOKIES_TO_INVALIDATE_CONFIG = "CookiesToInvalidate";
 
     // HTTP headers which may contain IP address of the client in the order of priority
     public static final String[] HEADERS_WITH_IP = {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityConfigParser.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityConfigParser.java
@@ -215,15 +215,18 @@ public class IdentityConfigParser {
     private void buildCookiesToInvalidateConfig() {
 
         OMElement cookiesToInvalidate = this.getConfigElement(IdentityConstants.COOKIES_TO_INVALIDATE_CONFIG);
-        Iterator<OMElement> cookies = cookiesToInvalidate.getChildrenWithName(
-                new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, IdentityConstants.COOKIE));
+        Iterator<OMElement> cookies = null;
+        if (cookiesToInvalidate != null) {
+            cookies = cookiesToInvalidate.getChildrenWithName(
+                    new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, IdentityConstants.COOKIE));
+        }
         if (cookies != null) {
             while (cookies.hasNext()) {
                 OMElement cookie = cookies.next();
                 String cookieName = cookie.getAttributeValue(new QName(IdentityConstants.COOKIE_NAME));
 
                 if (StringUtils.isBlank(cookieName)) {
-                    throw IdentityRuntimeException.error("Cookie name not defined correctly");
+                    throw IdentityRuntimeException.error("Invalid configuration. Cookie name is not defined correctly.");
                 }
 
                 cookiesToInvalidateConfigurationHolder.add(cookieName);

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityConfigParser.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityConfigParser.java
@@ -44,6 +44,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Stack;
@@ -58,6 +59,7 @@ public class IdentityConfigParser {
     private static Map<String, IdentityCookieConfig> identityCookieConfigurationHolder = new HashMap<>();
     private static Map<String, ReverseProxyConfig> reverseProxyConfigurationHolder = new HashMap<>();
     private static Map<String, LegacyFeatureConfig> legacyFeatureConfigurationHolder = new HashMap<>();
+    private static List<String> cookiesToInvalidateConfigurationHolder = new ArrayList<>();
     public final static String IS_DISTRIBUTED_CACHE = "isDistributed";
     public static final String IS_TEMPORARY = "isTemporary";
     private static final String SERVICE_PROVIDER_CACHE = "ServiceProviderCache";
@@ -111,6 +113,11 @@ public class IdentityConfigParser {
     public static Map<String, ReverseProxyConfig> getReverseProxyConfigurationHolder() {
 
         return reverseProxyConfigurationHolder;
+    }
+
+    public List<String> getCookiesToInvalidateConfigurationHolder() {
+
+        return cookiesToInvalidateConfigurationHolder;
     }
 
     /**
@@ -190,6 +197,7 @@ public class IdentityConfigParser {
             buildCookieConfig();
             buildLegacyFeatureConfig();
             buildReverseProxyConfig();
+            buildCookiesToInvalidateConfig();
 
         } catch ( IOException | XMLStreamException e ) {
             throw IdentityRuntimeException.error("Error occurred while building configuration from identity.xml", e);
@@ -200,6 +208,25 @@ public class IdentityConfigParser {
                 }
             } catch ( IOException e ) {
                 log.error("Error closing the input stream for identity.xml", e);
+            }
+        }
+    }
+
+    private void buildCookiesToInvalidateConfig() {
+
+        OMElement cookiesToInvalidate = this.getConfigElement(IdentityConstants.COOKIES_TO_INVALIDATE_CONFIG);
+        Iterator<OMElement> cookies = cookiesToInvalidate.getChildrenWithName(
+                new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, IdentityConstants.COOKIE));
+        if (cookies != null) {
+            while (cookies.hasNext()) {
+                OMElement cookie = cookies.next();
+                String cookieName = cookie.getAttributeValue(new QName(IdentityConstants.COOKIE_NAME));
+
+                if (StringUtils.isBlank(cookieName)) {
+                    throw IdentityRuntimeException.error("Cookie name not defined correctly");
+                }
+
+                cookiesToInvalidateConfigurationHolder.add(cookieName);
             }
         }
     }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -70,6 +70,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -119,6 +120,7 @@ public class IdentityUtil {
     private static Map<String, IdentityCookieConfig> identityCookiesConfigurationHolder = new HashMap<>();
     private static Map<String, LegacyFeatureConfig> legacyFeatureConfigurationHolder = new HashMap<>();
     private static Map<String, ReverseProxyConfig> reverseProxyConfigurationHolder = new HashMap<>();
+    private static List<String> cookiesToInvalidateConfigurationHolder = new ArrayList<>();
     private static Document importerDoc = null;
     private static ThreadLocal<IdentityErrorMsgContext> IdentityError = new ThreadLocal<IdentityErrorMsgContext>();
     private static final int ENTITY_EXPANSION_LIMIT = 0;
@@ -218,6 +220,11 @@ public class IdentityUtil {
         return identityCookiesConfigurationHolder;
     }
 
+    public static List<String> getCookiesToInvalidateConfigurationHolder() {
+
+        return cookiesToInvalidateConfigurationHolder;
+    }
+
     /**
      * This method can use to check whether the legacy feature for the given legacy feature id is enabled or not
      *
@@ -289,6 +296,8 @@ public class IdentityUtil {
         identityCookiesConfigurationHolder = IdentityConfigParser.getIdentityCookieConfigurationHolder();
         legacyFeatureConfigurationHolder = IdentityConfigParser.getLegacyFeatureConfigurationHolder();
         reverseProxyConfigurationHolder = IdentityConfigParser.getInstance().getReverseProxyConfigurationHolder();
+        cookiesToInvalidateConfigurationHolder =
+                IdentityConfigParser.getInstance().getCookiesToInvalidateConfigurationHolder();
     }
 
     public static String getPPIDDisplayValue(String value) throws Exception {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/resources/identity.xml
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/resources/identity.xml
@@ -577,4 +577,12 @@
             <ProxyContext>/logout</ProxyContext>
         </ReverseProxy>
     </ReverseProxyConfig>
+
+    <CookiesToInvalidate>
+        <Cookie name="commonAuthId"/>
+        <Cookie name="opbs"/>
+        <Cookie name="pastr"/>
+        <Cookie name="sessionNonceCookie"/>
+        <Cookie name="ALOR"/>
+    </CookiesToInvalidate>
 </Server>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2626,4 +2626,16 @@
         <DefaultUrl>{{common_auth_caller_path.default_url}}</DefaultUrl>
         {% endif %}
     </CommonAuthCallerPath>
+
+    <!-- Cookies to invalidate during authentication flow failures. -->
+    <CookiesToInvalidate>
+        	<Cookie name="commonAuthId"/>
+        	<Cookie name="opbs"/>
+        	<Cookie name="pastr"/>
+        	<Cookie name="sessionNonceCookie"/>
+        	<Cookie name="ALOR"/>
+        	{% for cookie in cookies_to_invalidate.cookie_names %}
+        	<Cookie name="{{cookie}}"/>
+        	{% endfor %}
+    </CookiesToInvalidate>
 </Server>


### PR DESCRIPTION
### Proposed changes in this pull request
- This PR adds support to invalidate cookies that are used in authentication flow, when an user is redirected to `retry.do` due to an server or client error.
- Partially fixes : https://github.com/wso2-enterprise/asgardeo-product/issues/1643