### PR TITLE
Prompt postAuthMissing claim handler on userstore client exception

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthnMissingClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthnMissingClaimHandler.java
@@ -178,7 +178,7 @@ public class PostAuthnMissingClaimHandler extends AbstractPostAuthnHandler {
                 uriBuilder.addParameter(FrameworkConstants.REQUEST_PARAM_SP,
                         context.getSequenceConfig().getApplicationConfig().getApplicationName());
                 if (context.getProperty(POST_AUTH_MISSING_CLAIMS_ERROR) != null) {
-                    uriBuilder.addParameter(POST_AUTH_MISSING_CLAIMS_ERROR,
+                    uriBuilder.addParameter("errorMessage",
                             context.getProperty(POST_AUTH_MISSING_CLAIMS_ERROR).toString());
                     context.removeProperty(POST_AUTH_MISSING_CLAIMS_ERROR);
                 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthnMissingClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthnMissingClaimHandler.java
@@ -43,6 +43,7 @@ import org.wso2.carbon.identity.user.profile.mgt.association.federation.Federate
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.exception.FederatedAssociationManagerException;
 import org.wso2.carbon.user.api.Claim;
 import org.wso2.carbon.user.api.ClaimManager;
+import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
@@ -60,6 +61,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.hand
         .PostAuthnHandlerFlowStatus.UNSUCCESS_COMPLETED;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants
         .POST_AUTHENTICATION_REDIRECTION_TRIGGERED;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.POST_AUTH_MISSING_CLAIMS_ERROR;
 
 public class PostAuthnMissingClaimHandler extends AbstractPostAuthnHandler {
 
@@ -113,7 +115,15 @@ public class PostAuthnMissingClaimHandler extends AbstractPostAuthnHandler {
                     context);
             return flowStatus;
         } else {
-            handlePostAuthenticationForMissingClaimsResponse(request, response, context);
+            try {
+                handlePostAuthenticationForMissingClaimsResponse(request, response, context);
+            } catch (PostAuthenticationFailedException e) {
+                if (context.getProperty(POST_AUTH_MISSING_CLAIMS_ERROR) != null) {
+                    PostAuthnHandlerFlowStatus flowStatus =
+                            handlePostAuthenticationForMissingClaimsRequest(request, response, context);
+                    return flowStatus;
+                }
+            }
             if (log.isDebugEnabled()) {
                 log.debug("Successfully returning from missing claim handler");
             }
@@ -167,6 +177,11 @@ public class PostAuthnMissingClaimHandler extends AbstractPostAuthnHandler {
                         context.getContextIdentifier());
                 uriBuilder.addParameter(FrameworkConstants.REQUEST_PARAM_SP,
                         context.getSequenceConfig().getApplicationConfig().getApplicationName());
+                if (context.getProperty(POST_AUTH_MISSING_CLAIMS_ERROR) != null) {
+                    uriBuilder.addParameter(POST_AUTH_MISSING_CLAIMS_ERROR,
+                            context.getProperty(POST_AUTH_MISSING_CLAIMS_ERROR).toString());
+                    context.removeProperty(POST_AUTH_MISSING_CLAIMS_ERROR);
+                }
                 response.sendRedirect(uriBuilder.build().toString());
                 context.setProperty(POST_AUTHENTICATION_REDIRECTION_TRIGGERED, true);
 
@@ -294,6 +309,9 @@ public class PostAuthnMissingClaimHandler extends AbstractPostAuthnHandler {
 
                 userStoreManager.setUserClaimValues(user.getUserName(), localIdpClaims, null);
             } catch (UserStoreException e) {
+                if (e instanceof UserStoreClientException) {
+                    context.setProperty(POST_AUTH_MISSING_CLAIMS_ERROR, e.getMessage());
+                }
                 throw new PostAuthenticationFailedException(
                         "Error while handling missing mandatory claims",
                         "Error while updating claims for local user. Could not update profile", e);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -97,6 +97,7 @@ public abstract class FrameworkConstants {
     public static final String CHANGING_USERNAME_ALLOWED = "changingUserNameAllowed";
     public static final String MISSING_CLAIMS = "missingClaims";
     public static final String MISSING_CLAIMS_DISPLAY_NAME = "missingClaimsDisplayName";
+    public static final String POST_AUTH_MISSING_CLAIMS_ERROR = "postAuthMissingClaimsError";
 
     public static final String REQUEST_PARAM_SP = "sp";
     public static final String MAPPED_ATTRIBUTES = "MappedAttributes";


### PR DESCRIPTION
### Proposed changes in this pull request

Fixes part of : https://github.com/wso2/product-is/issues/11226
If the user enters an invlid input and if it validates in the backend and sends a userStoreClientException, the user will be prompted the same page to provide claim values with the error message as follows.

![Screenshot from 2021-02-11 20-24-45](https://user-images.githubusercontent.com/25483865/107655339-7e598180-6ca9-11eb-9986-fdd59c7c0ae0.png)

![Screenshot from 2021-02-11 20-22-04](https://user-images.githubusercontent.com/25483865/107655276-68e45780-6ca9-11eb-85ca-8384cdc5920d.png)


### Depends on
https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/333