### PR TITLE
[Improvement] Enable self registration confirmation on creation

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1108,6 +1108,7 @@
             <EnableDetailedResponseBody>{{identity_mgt.user_self_registration.enable_detailed_api_response}}</EnableDetailedResponseBody>
         </API>
         <LockOnCreation>{{identity_mgt.user_self_registration.lock_on_creation}}</LockOnCreation>
+        <SendConfirmationOnCreation>{{identity_mgt.user_self_registration.send_confirmation_on_creation}}</SendConfirmationOnCreation>
         <NotifyAccountConfirmation>{{identity_mgt.user_self_registration.notify_account_confirmation}}</NotifyAccountConfirmation>
         <Notification>
             <InternallyManage>{{identity_mgt.user_self_registration.notification.manage_internally}}</InternallyManage>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -323,6 +323,7 @@
   "identity_mgt.user_self_registration.enable_account_lock_for_verified_preferred_channel" : true,
   "identity_mgt.user_self_registration.enable_detailed_api_response" : false,
   "identity_mgt.user_self_registration.lock_on_creation": true,
+  "identity_mgt.user_self_registration.send_confirmation_on_creation": false,
   "identity_mgt.user_self_registration.notify_account_confirmation": false,
   "identity_mgt.user_self_registration.enable_recaptcha": true,
   "identity_mgt.user_self_registration.verification_email_validity": "$ref{identity_mgt.default_mail_validity_period}",


### PR DESCRIPTION
Resolves: wso2/product-is/issues/10356
### Purpose				
In self registration, there is no option to enable send verification notification to the user if disable account lock on creation. 
And also sometimes users may have to access the self registered account without verifying the account. 

### Describe the improvement
After a user creates an account, the user gets access to the account without verifying. 
And also the user has an option to verify the account by clicking verification notification. 
The client application has the ability to determine the user account state whether it is verified or not. (using accountState claim ). Then the client application can limit the user access according to the user account state. 

### Additional context
Application can be configured to enable send verification notification even if disable “Account Lock On Creation” option.
accountState claim value:
 Before verify the account : PENDING_SR
After verified the account : UNLOCK
### Product Version
Wso2 IS 5.10.0
### How to reproduce
Identity -> Identity Providers and then click Resident
Expand the Account Management Policies section, and then expand the User Self Registration section
enable “Enable Account Confirmation On Creation”
