### PR TITLE
Introduce a new UserSessionStore.getIdPId method by deprecating existing method.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -644,7 +644,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             boolean persistUserToSessionMapping = true;
             String userId;
             try {
-                int idpId = UserSessionStore.getInstance().getIdPId(idpName);
+                int idpId = UserSessionStore.getInstance().getIdPId(idpName, appTenantId);
 
                 // If the user is federated, generate a unique ID for the user and add an entry to the IDN_AUTH_USER
                 // table with the tenant id as -1 and user store domain as FEDERATED.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
@@ -72,6 +72,8 @@ public class SQLQueries {
      */
     public static final String SQL_SELECT_IDP_ID_OF_IDP = "SELECT IDP.ID FROM IDP WHERE NAME = ?";
 
+    public static final String SQL_SELECT_IDP_WITH_TENANT = "SELECT IDP.ID FROM IDP WHERE NAME = ? AND TENANT_ID = ?";
+
     // Retrieve application id given the name and the tenant id.
     public static final String SQL_SELECT_APP_ID_OF_APP = "SELECT ID FROM SP_APP WHERE APP_NAME =? AND TENANT_ID =?";
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -266,6 +266,38 @@ public class UserSessionStore {
     }
 
     /**
+     * Retrieve IDP ID from the IDP table using IDP name and tenant ID.
+     *
+     * @param idpName   IDP name.
+     * @param tenantId  Tenant ID.
+     * @return          IDP ID.
+     * @throws UserSessionException
+     */
+    public int getIdPId(String idpName, int tenantId) throws UserSessionException {
+
+        int idPId = -1;
+        if (idpName.equals("LOCAL")) {
+            return idPId;
+        }
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
+            try (PreparedStatement preparedStatement = connection
+                    .prepareStatement(SQLQueries.SQL_SELECT_IDP_WITH_TENANT)) {
+                preparedStatement.setString(1, idpName);
+                preparedStatement.setInt(2, tenantId);
+                try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                    if (resultSet.next()) {
+                        idPId = resultSet.getInt(1);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            throw new UserSessionException("Error while retrieving the IdP id of: " + idpName + " and tenant ID: " +
+                    tenantId, e);
+        }
+        return idPId;
+    }
+
+    /**
      * Method to store user id and session id mapping in the database table IDN_AUTH_USER_SESSION_STORE.
      *
      * @param userId    Id of the user


### PR DESCRIPTION
### Proposed changes in this pull request
> IDP name is not unique across all the tenants. 
> Deprecate the current `UserSessionStore.getIdPId(String idpName)` and introduce a new `UserSessionStore.getIdPId(String idpName, int tenantId)` method.