### PR TITLE
Add multi attribute login configurations

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1391,6 +1391,11 @@
                        name="org.wso2.carbon.user.mgt.listeners.UserMgtFailureAuditLogger"
                        orderId="{{event.default_listener.user_failure_audit_logger.priority}}"
                        enable="{{event.default_listener.user_failure_audit_logger.enable}}"/>
+       <EventListener id="unique_claim_user_operation_event_listener"
+                      type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
+                      name="org.wso2.carbon.identity.unique.claim.mgt.listener.UniqueClaimUserOperationEventListener"
+                      orderId="{{event.default_listener.unique_claim_user_operation_event_listener.priority}}"
+                      enable="{{event.default_listener.unique_claim_user_operation_event_listener.enable}}"/>
         <EventListener id="user_claim_audit_logger"
                        type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
                        name="org.wso2.carbon.user.mgt.listeners.UserClaimsAuditLogger"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -411,6 +411,9 @@
   "event.default_listener.userid_resolver.priority": "15",
   "event.default_listener.userid_resolver.enable": true,
 
+  "event.default_listener.unique_claim_user_operation_event_listener.priority": "101",
+  "event.default_listener.unique_claim_user_operation_event_listener.enable": false,
+
   "event.default_recorder.user_delete_event.name": "org.wso2.carbon.user.mgt.recorder.DefaultUserDeletionEventRecorder",
   "event.default_recorder.user_delete_event.enable": false,
   "event.default_recorder.user_delete_event.write_to_separate_csv.enable": false,

--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -177,5 +177,12 @@
     "POST_UPDATE_CREDENTIAL",
     "POST_UPDATE_CREDENTIAL_BY_ADMIN",
     "POST_SET_USER_CLAIMS"
+  ],
+  "identity_mgt.events.schemes.'multiattribute.login.handler'.module_index": "30",
+  "identity_mgt.events.schemes.'multiattribute.login.handler'.subscriptions": [
+    "PRE_AUTHENTICATION",
+    "POST_AUTHENTICATION",
+    "PRE_SET_USER_CLAIMS",
+    "POST_SET_USER_CLAIMS"
   ]
 }


### PR DESCRIPTION
Resolves: wso2/product-is#8899
## Purpose
This is the configurations to activate MultiAttributeLoginHandler and UniqueClaimUserOperationEventListener.
 If we activate these feature from deployment.toml we need to add following configurations. 

`[[event_listener]]
id = "unique_claim_user_operation_event_listener"  
type = "org.wso2.carbon.user.core.listener.UserOperationEventListener" 
name = "org.wso2.carbon.identity.unique.claim.mgt.listener.UniqueClaimUserOperationEventListener"
order = 2
enable = true`

`[[event_handler]]
name= "multiattribute.login.handler"  
subscriptions=["PRE_AUTHENTICATION","POST_AUTHENTICATION","PRE_SET_USER_CLAIMS","POST_SET_USER_CLAIMS"]`