### PR TITLE
Add method to get the federated user id

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -876,15 +876,15 @@ public class UserSessionStore {
     /**
      * Returns the user id of the federated user.
      *
-     * @param userName - username of the federated user.
-     * @param tenantId
+     * @param subjectIdentifier Subject Identifier of the federated user.
+     * @param tenantId          Id of the tenant domain
      * @param idPId
      * @return
      * @throws UserSessionException
      */
-    public String getFederatedUserId(String userName, int tenantId, int idPId)
+    public String getFederatedUserId(String subjectIdentifier, int tenantId, int idPId)
             throws UserSessionException {
-        
-        return getUserId(userName, tenantId, null, idPId);
+
+        return getUserId(subjectIdentifier, tenantId, null, idPId);
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -877,7 +877,7 @@ public class UserSessionStore {
      * Returns the user id of the federated user.
      *
      * @param subjectIdentifier - Subject Identifier of the federated user.
-     * @param tenantId          - Id of the tenant domain.
+     * @param tenantId          - Id of the service provider's tenant domain.
      * @param idPId             - Id of the identity provider.
      * @return userId - User Id of the federated user.
      * @throws UserSessionException
@@ -885,8 +885,8 @@ public class UserSessionStore {
     public String getFederatedUserId(String subjectIdentifier, int tenantId, int idPId)
             throws UserSessionException {
 
-        //When federated user is stored, the userDomain is passed as null and it is added as "FEDERATED" to the store.
-        //Here null is passed as userDomain to get the userId from the "FEDERATED" userDomain.
+        // When federated user is stored, the userDomain is passed as null and it is added as "FEDERATED" to the store.
+        // Here null is passed as userDomain to get the userId from the "FEDERATED" userDomain.
         return getUserId(subjectIdentifier, tenantId, null, idPId);
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -876,17 +876,15 @@ public class UserSessionStore {
     /**
      * Returns the user id of the federated user.
      *
-     * @param userName
-     * @param tenantDomain
+     * @param userName - username of the federated user.
+     * @param tenantId
      * @param idPId
      * @return
      * @throws UserSessionException
      */
-    public String getFederatedUserId(String userName, String tenantDomain, int idPId)
+    public String getFederatedUserId(String userName, int tenantId, int idPId)
             throws UserSessionException {
-
-        int tenantId = (tenantDomain == null) ? MultitenantConstants.INVALID_TENANT_ID : IdentityTenantUtil
-                .getTenantId(tenantDomain);
+        
         return getUserId(userName, tenantId, null, idPId);
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -34,7 +34,6 @@ import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.idp.mgt.util.IdPManagementUtil;
-import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -871,4 +871,19 @@ public class UserSessionStore {
         }
         return activeSessionCount;
     }
+
+    /**
+     * Returns the user id of the federated user
+     *
+     * @param userName
+     * @param tenantId
+     * @param idPId
+     * @return
+     * @throws UserSessionException
+     */
+    public String getFederatedUserId(String userName, int tenantId, int idPId)
+            throws UserSessionException {
+
+        return getUserId(userName, tenantId, null, idPId);
+    }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -885,8 +885,7 @@ public class UserSessionStore {
     public String getFederatedUserId(String subjectIdentifier, int tenantId, int idPId)
             throws UserSessionException {
 
-        // When federated user is stored, the userDomain is passed as null and it is added as "FEDERATED" to the store.
-        // Here null is passed as userDomain to get the userId from the "FEDERATED" userDomain.
-        return getUserId(subjectIdentifier, tenantId, null, idPId);
+        // When federated user is stored, the userDomain is added as "FEDERATED" to the store.
+        return getUserId(subjectIdentifier, tenantId, FEDERATED_USER_DOMAIN, idPId);
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -876,15 +876,17 @@ public class UserSessionStore {
     /**
      * Returns the user id of the federated user.
      *
-     * @param subjectIdentifier Subject Identifier of the federated user.
-     * @param tenantId          Id of the tenant domain
-     * @param idPId
-     * @return
+     * @param subjectIdentifier - Subject Identifier of the federated user.
+     * @param tenantId          - Id of the tenant domain.
+     * @param idPId             - Id of the identity provider.
+     * @return userId - User Id of the federated user.
      * @throws UserSessionException
      */
     public String getFederatedUserId(String subjectIdentifier, int tenantId, int idPId)
             throws UserSessionException {
 
+        //When federated user is stored, the userDomain is passed as null and it is added as "FEDERATED" to the store.
+        //Here null is passed as userDomain to get the userId from the "FEDERATED" userDomain.
         return getUserId(subjectIdentifier, tenantId, null, idPId);
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.idp.mgt.util.IdPManagementUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -873,17 +874,19 @@ public class UserSessionStore {
     }
 
     /**
-     * Returns the user id of the federated user
+     * Returns the user id of the federated user.
      *
      * @param userName
-     * @param tenantId
+     * @param tenantDomain
      * @param idPId
      * @return
      * @throws UserSessionException
      */
-    public String getFederatedUserId(String userName, int tenantId, int idPId)
+    public String getFederatedUserId(String userName, String tenantDomain, int idPId)
             throws UserSessionException {
 
+        int tenantId = (tenantDomain == null) ? MultitenantConstants.INVALID_TENANT_ID : IdentityTenantUtil
+                .getTenantId(tenantDomain);
         return getUserId(userName, tenantId, null, idPId);
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

Add method to get federated user id from `username`, `tenantId`, `IdpId`.