### PR TITLE
Omit role claim from UI

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -64,11 +64,13 @@ import org.wso2.carbon.identity.application.mgt.defaultsequence.DefaultAuthSeqMg
 import org.wso2.carbon.identity.application.mgt.defaultsequence.DefaultAuthSeqMgtService;
 import org.wso2.carbon.identity.application.mgt.defaultsequence.DefaultAuthSeqMgtServiceImpl;
 import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponent;
+import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponentHolder;
 import org.wso2.carbon.identity.application.mgt.internal.ApplicationMgtListenerServiceComponent;
 import org.wso2.carbon.identity.application.mgt.listener.AbstractApplicationMgtListener;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationResourceManagementListener;
 import org.wso2.carbon.identity.application.mgt.validator.ApplicationValidatorManager;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -843,12 +845,21 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
         try {
             startTenantFlow(tenantDomain);
             String claimDialect = ApplicationMgtSystemConfig.getInstance().getClaimDialect();
-            ClaimMapping[] claimMappings = CarbonContext.getThreadLocalCarbonContext().getUserRealm().getClaimManager()
-                    .getAllClaimMappings(claimDialect);
+
             List<String> claimUris = new ArrayList<>();
-            for (ClaimMapping claimMap : claimMappings) {
-                claimUris.add(claimMap.getClaim().getClaimUri());
+            if (UserCoreConstants.DEFAULT_CARBON_DIALECT.equalsIgnoreCase(claimDialect)) {
+                // Local claims are retrieved via ClaimMetadataManagement service for consistency.
+                List<LocalClaim> localClaims = ApplicationManagementServiceComponentHolder.getInstance()
+                        .getClaimMetadataManagementService().getLocalClaims(tenantDomain);
+                claimUris = getLocalClaimURIs(localClaims);
+            } else {
+                ClaimMapping[] claimMappings = CarbonContext.getThreadLocalCarbonContext().getUserRealm()
+                        .getClaimManager().getAllClaimMappings(claimDialect);
+                for (ClaimMapping claimMap : claimMappings) {
+                    claimUris.add(claimMap.getClaim().getClaimUri());
+                }
             }
+
             String[] allLocalClaimUris = (claimUris.toArray(new String[claimUris.size()]));
             if (ArrayUtils.isNotEmpty(allLocalClaimUris)) {
                 Arrays.sort(allLocalClaimUris);
@@ -2557,6 +2568,17 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
                 }
             }
         }
+    }
+
+    private ArrayList<String> getLocalClaimURIs(List<LocalClaim> localClaims) {
+
+        // Using Java 8 streams to do the mapping will result in breaking at the axis level thus using the following
+        // approach.
+        ArrayList<String> localClaimsArray = new ArrayList<String>();
+        for (LocalClaim localClaim : localClaims) {
+            localClaimsArray.add(localClaim.getClaimURI());
+        }
+        return localClaimsArray;
     }
 }
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponent.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponent.java
@@ -53,6 +53,7 @@ import org.wso2.carbon.identity.application.mgt.listener.ApplicationResourceMana
 import org.wso2.carbon.identity.application.mgt.listener.DefaultApplicationResourceMgtListener;
 import org.wso2.carbon.identity.application.mgt.validator.ApplicationValidator;
 import org.wso2.carbon.identity.application.mgt.validator.DefaultApplicationValidator;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -343,5 +344,23 @@ public class ApplicationManagementServiceComponent {
         objForUncategorized.put(ApplicationConstants.CATEGORY_ORDER, ApplicationConstants.ORDER_FOR_UNCATEGORIZED);
         categoriesObj.put(ApplicationConstants.UNCATEGORIZED, objForUncategorized);
         return categoriesObj;
+    }
+
+    @Reference(
+            name = "claim.meta.mgt.service",
+            service = ClaimMetadataManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetClaimMetaMgtService"
+    )
+    protected void setClaimMetaMgtService(ClaimMetadataManagementService claimMetaMgtService) {
+
+        ApplicationManagementServiceComponentHolder.getInstance().setClaimMetadataManagementService(
+                claimMetaMgtService);
+    }
+
+    protected void unsetClaimMetaMgtService(ClaimMetadataManagementService claimMetaMgtService) {
+
+        ApplicationManagementServiceComponentHolder.getInstance().setClaimMetadataManagementService(null);
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponentHolder.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponentHolder.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.identity.application.mgt.internal;
 
 import org.wso2.carbon.consent.mgt.core.ConsentManager;
 import org.wso2.carbon.identity.application.mgt.AbstractInboundAuthenticatorConfig;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.registry.api.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
@@ -47,6 +48,8 @@ public class ApplicationManagementServiceComponentHolder {
     private boolean databaseBackedCertificateStoringSupportAvailable;
 
     private ConsentManager consentManager;
+
+    private ClaimMetadataManagementService claimMetadataManagementService;
 
     private ApplicationManagementServiceComponentHolder() {
 
@@ -169,5 +172,16 @@ public class ApplicationManagementServiceComponentHolder {
     public ConsentManager getConsentManager() {
 
         return consentManager;
+    }
+
+    public ClaimMetadataManagementService getClaimMetadataManagementService() {
+
+        return claimMetadataManagementService;
+    }
+
+    public void setClaimMetadataManagementService(
+            ClaimMetadataManagementService claimMetadataManagementService) {
+
+        this.claimMetadataManagementService = claimMetadataManagementService;
     }
 }

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementServiceImpl.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementServiceImpl.java
@@ -34,7 +34,9 @@ import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.List;
@@ -171,8 +173,9 @@ public class ClaimMetadataManagementServiceImpl implements ClaimMetadataManageme
 
         // Add listener
 
-
-        return localClaims;
+        return IdentityUtil.isGroupsVsRolesSeparationImprovementsEnabled() ? localClaims.stream().filter(
+                localClaim -> !UserCoreConstants.ROLE_CLAIM.equals(localClaim.getClaimURI())).collect(
+                Collectors.toList()) : localClaims;
     }
 
     @Override

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/DefaultClaimMetadataStore.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/DefaultClaimMetadataStore.java
@@ -481,6 +481,10 @@ public class DefaultClaimMetadataStore implements ClaimMetadataStore {
                 List<ClaimMapping> claimMappings = new ArrayList<>();
 
                 for (LocalClaim localClaim : localClaims) {
+                    if (isFilterableClaim(localClaim)) {
+                        continue;
+                    }
+
                     ClaimMapping claimMapping = ClaimMetadataUtils.convertLocalClaimToClaimMapping(localClaim, this
                             .tenantId);
                     claimMappings.add(claimMapping);
@@ -546,6 +550,10 @@ public class DefaultClaimMetadataStore implements ClaimMetadataStore {
             List<ClaimMapping> claimMappings = new ArrayList<>();
 
             for (LocalClaim localClaim : localClaims) {
+                if (isFilterableClaim(localClaim)) {
+                    continue;
+                }
+
                 ClaimMapping claimMapping = ClaimMetadataUtils.convertLocalClaimToClaimMapping(localClaim, this
                         .tenantId);
 
@@ -582,5 +590,22 @@ public class DefaultClaimMetadataStore implements ClaimMetadataStore {
         } catch (ClaimMetadataException e) {
             throw new UserStoreException(e.getMessage(), e);
         }
+    }
+
+    private boolean isFilterableClaim(LocalClaim localClaim) {
+
+        // Filter the local claim `role` when groups vs roles separation is enabled. This claim is
+        // considered as a legacy claim going forward, thus `roles` and `groups` claims should be used
+        // instead.
+        if (IdentityUtil.isGroupsVsRolesSeparationImprovementsEnabled() && UserCoreConstants.ROLE_CLAIM.
+                equals(localClaim.getClaimURI())) {
+            if (log.isDebugEnabled()) {
+                log.debug("Skipping the legacy role claim: " + localClaim.getClaimURI() + ", when getting " +
+                        "local claims");
+            }
+            return true;
+        }
+
+        return false;
     }
 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/pom.xml
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/pom.xml
@@ -66,6 +66,10 @@
             <groupId>org.json.wso2</groupId>
             <artifactId>json</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.claim.metadata.mgt</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -110,6 +114,7 @@
                             org.wso2.carbon.identity.base;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.role.mgt.core;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.persistence;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.claim.metadata.mgt.*;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon;version="${carbon.kernel.package.import.version.range}",
                             org.apache.commons.codec.binary; version="${commons-codec.wso2.osgi.version.range}",
                             org.json;version="${json.wso2.version.range}",

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/internal/IdPManagementServiceComponent.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/internal/IdPManagementServiceComponent.java
@@ -35,6 +35,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.core.ConnectorConfig;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -465,5 +466,22 @@ public class IdPManagementServiceComponent {
     protected void unsetGovernanceConnector(ConnectorConfig identityConnectorConfig) {
 
         IdpMgtServiceComponentHolder.getInstance().unsetGovernanceConnector(identityConnectorConfig);
+    }
+
+    @Reference(
+            name = "claim.meta.mgt.service",
+            service = ClaimMetadataManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetClaimMetaMgtService"
+    )
+    protected void setClaimMetaMgtService(ClaimMetadataManagementService claimMetaMgtService) {
+
+        IdpMgtServiceComponentHolder.getInstance().setClaimMetadataManagementService(claimMetaMgtService);
+    }
+
+    protected void unsetClaimMetaMgtService(ClaimMetadataManagementService claimMetaMgtService) {
+
+        IdpMgtServiceComponentHolder.getInstance().setClaimMetadataManagementService(null);
     }
 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/internal/IdpMgtServiceComponentHolder.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/internal/IdpMgtServiceComponentHolder.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.application.common.util.IdentityApplicationConst
 import org.wso2.carbon.identity.core.ConnectorConfig;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.role.mgt.core.RoleManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.dao.CacheBackedIdPMgtDAO;
 import org.wso2.carbon.idp.mgt.dao.IdPManagementDAO;
@@ -50,6 +51,7 @@ public class IdpMgtServiceComponentHolder {
     private volatile List<ConnectorConfig> identityConnectorConfigList = new ArrayList<>();
     private RegistryService registryService;
     private RoleManagementService roleManagementService;
+    private ClaimMetadataManagementService claimMetadataManagementService;
 
     private List<MetadataConverter> metadataConverters = new ArrayList<>();
 
@@ -138,5 +140,15 @@ public class IdpMgtServiceComponentHolder {
     public void setRoleManagementService(RoleManagementService roleManagementService) {
 
         this.roleManagementService = roleManagementService;
+    }
+
+    public ClaimMetadataManagementService getClaimMetadataManagementService() {
+
+        return claimMetadataManagementService;
+    }
+
+    public void setClaimMetadataManagementService(ClaimMetadataManagementService claimMetadataManagementService) {
+
+        this.claimMetadataManagementService = claimMetadataManagementService;
     }
 }

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -117,10 +117,9 @@
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/role</ClaimURI>
-				<DisplayName>Role</DisplayName>
+				<DisplayName>Roles and groups</DisplayName>
 				<AttributeID>role</AttributeID>
-				<Description>Role</Description>
-				<SupportedByDefault/>
+				<Description>Include both userstore groups and internal roles</Description>
 				<ReadOnly />
 			</Claim>
 			<Claim>


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/11341.

- Skip wso2.role claim from `getLocalClaimURIs` method in the claim metadata management service
- Fix mgt console to read local claim URI list from the claim metadata management service
- Omit the same role from the edit.jsp for user profile due to the underline backend service call change might break backward compatibility.
- Set role claim as not supported by default to hide from the user profile, and update display name and description.

