### PR TITLE
Fix SCIM2 roles claim mapping

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -2177,7 +2177,7 @@
 				<Description>Roles</Description>
 				<DisplayOrder>5</DisplayOrder>
 				<SupportedByDefault />
-				<MappedLocalClaim>http://wso2.org/claims/role</MappedLocalClaim>
+				<MappedLocalClaim>http://wso2.org/claims/roles</MappedLocalClaim>
 			</Claim>
 			<Claim>
 				<ClaimURI>urn:ietf:params:scim:schemas:core:2.0:User:x509Certificates.default</ClaimURI>

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -406,6 +406,8 @@
 				<DisplayName>Groups</DisplayName>
 				<AttributeID>groups</AttributeID>
 				<Description>Groups</Description>
+				<SupportedByDefault />
+				<ReadOnly />
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/identity/verifyEmail</ClaimURI>


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/11347.

Set default SCIM2 roles claim mapped to the wso2.roles claim.