### PR TITLE
Remove unwanted script

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-get-ridp-metadata-finish-ajaxprocessor.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-get-ridp-metadata-finish-ajaxprocessor.jsp
@@ -37,6 +37,3 @@
     } finally {
     }
 %>
-<script type="text/javascript">
-    location.href = "idp-mgt-edit-local.jsp";
-</script>


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/11392

This can introduce below script tag in the metadata file, if load balancer or some entity in the middle change the `Content-Length` header. This script tag should not be needed to this jsp file.

```
<script type="text/javascript">
    location.href = "idp-mgt-edit-local.jsp";
</script>
```
