### PR TITLE
Re-initiate authentication flow if session nonce cookie is missing 

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/LoginContextManagementUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/LoginContextManagementUtil.java
@@ -84,6 +84,9 @@ public class LoginContextManagementUtil {
         AuthenticationContext context = FrameworkUtils.getAuthenticationContextFromCache(sessionDataKey);
         // Valid Request
         if (isValidRequest(request, context)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Setting response for the valid request.");
+            }
             // If the context is valid and at the first step.
             if (isStepHasMultiOption(context)) {
                 context.setCurrentAuthenticator(null);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/LoginContextManagementUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/LoginContextManagementUtil.java
@@ -36,6 +36,7 @@ import java.net.URLDecoder;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -47,6 +48,8 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.REQUEST_PARAM_APPLICATION;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.getConsoleURL;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.getMyAccountURL;
+import static org.wso2.carbon.identity.application.authentication.framework.util.SessionNonceCookieUtil.getNonceCookieName;
+import static org.wso2.carbon.identity.application.authentication.framework.util.SessionNonceCookieUtil.isNonceCookieEnabled;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.DEFAULT_SP_CONFIG;
 
 /**
@@ -80,7 +83,7 @@ public class LoginContextManagementUtil {
 
         AuthenticationContext context = FrameworkUtils.getAuthenticationContextFromCache(sessionDataKey);
         // Valid Request
-        if (context != null) {
+        if (isValidRequest(request, context)) {
             // If the context is valid and at the first step.
             if (isStepHasMultiOption(context)) {
                 context.setCurrentAuthenticator(null);
@@ -315,5 +318,15 @@ public class LoginContextManagementUtil {
             }
         }
         return stepHasMultiOption;
+    }
+
+    private static boolean isValidRequest(HttpServletRequest request, AuthenticationContext context) {
+
+        boolean isValidRequest = context != null;
+        if (isNonceCookieEnabled() && isValidRequest) {
+            Cookie nonceCookie = FrameworkUtils.getCookie(request, getNonceCookieName(context));
+            isValidRequest = nonceCookie != null && StringUtils.isNotBlank(nonceCookie.getValue());
+        }
+        return isValidRequest;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionNonceCookieUtilTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionNonceCookieUtilTest.java
@@ -18,32 +18,54 @@
 
 package org.wso2.carbon.identity.application.authentication.framework.util;
 
+import com.google.gson.JsonObject;
+import jdk.nashorn.internal.parser.JSONParser;
+import org.json.JSONObject;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.REQUEST_PARAM_APPLICATION;
 import static org.wso2.carbon.identity.application.authentication.framework.util.SessionNonceCookieUtil.NONCE_COOKIE;
 import static org.wso2.carbon.identity.application.authentication.framework.util.SessionNonceCookieUtil.NONCE_COOKIE_CONFIG;
 
-@PrepareForTest({IdentityUtil.class})
+@PrepareForTest({IdentityUtil.class, IdentityTenantUtil.class, FrameworkUtils.class, LoginContextManagementUtil.class})
 public class SessionNonceCookieUtilTest {
 
     private static final String SESSION_DATA_KEY_VALUE = "SessionDataKeyValue";
+    private static final String SESSION_DATA_KEY_NAME = "sessionDataKey";
+    private static final String RELYING_PARTY_NAME = "relyingParty";
+    private static final String RELYING_PARTY_VALUE = "relyingPartyValue";
+    private static final String TENANT_DOMAIN_NAME = "tenantDomain";
+    private static final String TENANT_DOMAIN_VALUE = "carbon.super";
+    private static final String APP_ACCESS_URL = "https://test.mock.relyingParty.com";
+
     @Mock
     private HttpServletRequest request;
 
@@ -56,18 +78,17 @@ public class SessionNonceCookieUtilTest {
     @Captor
     ArgumentCaptor<Cookie> cookieCaptor;
 
+    @Captor
+    ArgumentCaptor<String> responseCaptor;
+
     @Test
     public void nonceCookieTest() {
 
-        mockStatic(IdentityUtil.class);
-        Mockito.when(IdentityUtil.getProperty(NONCE_COOKIE_CONFIG)).thenReturn("true");
-        Mockito.when(IdentityUtil.getTempDataCleanUpTimeout()).thenReturn(Long.parseLong("40"));
+        mockNonceCookieUtils("true", "40");
         assertTrue(SessionNonceCookieUtil.isNonceCookieEnabled());
 
         // Creating old session nonce and authentication cookie.
-        Cookie[] cookies = new Cookie[2];
-        cookies[0] = new Cookie(FrameworkConstants.COMMONAUTH_COOKIE, "commonAuthIdValue");
-        cookies[1] = new Cookie(NONCE_COOKIE + "-" + SESSION_DATA_KEY_VALUE, "sessionNonceValue");
+        Cookie[] cookies = getAuthenticationCookies();
         Mockito.when(request.getCookies()).thenReturn(cookies);
         Mockito.when(context.getContextIdentifier()).thenReturn(SESSION_DATA_KEY_VALUE);
 
@@ -87,5 +108,63 @@ public class SessionNonceCookieUtilTest {
         Cookie removedOldSessionNonce = capturedCookies.get(0);
         assertEquals(removedOldSessionNonce.getName(), NONCE_COOKIE + "-" + SESSION_DATA_KEY_VALUE);
         assertEquals(removedOldSessionNonce.getMaxAge(), TimeUnit.MINUTES.toSeconds(40) * 2);
+    }
+
+    @Test
+    public void missingNonceCookieTest() throws Exception {
+
+        mockUtils();
+        Cookie[] cookies = getAuthenticationCookies();
+        Mockito.when(request.getCookies()).thenReturn(cookies);
+        Mockito.when(request.getParameter(SESSION_DATA_KEY_NAME)).thenReturn(SESSION_DATA_KEY_VALUE);
+        Mockito.when(request.getParameter(RELYING_PARTY_NAME)).thenReturn(RELYING_PARTY_VALUE);
+        Mockito.when(request.getParameter(REQUEST_PARAM_APPLICATION)).thenReturn(RELYING_PARTY_VALUE);
+        Mockito.when(request.getParameter(TENANT_DOMAIN_NAME)).thenReturn(TENANT_DOMAIN_VALUE);
+        Mockito.when(context.getContextIdentifier()).thenReturn(SESSION_DATA_KEY_VALUE);
+
+        PrintWriter mockPrintWriter = Mockito.mock(PrintWriter.class);
+        Mockito.when(response.getWriter()).thenReturn(mockPrintWriter);
+
+        // Request contains an authentication contex but missing the session nonce cookie.
+        LoginContextManagementUtil.handleLoginContext(request, response);
+
+        Mockito.verify(mockPrintWriter).write(responseCaptor.capture());
+        List<String> responses = responseCaptor.getAllValues();
+        Assert.assertNotNull(responses.get(0));
+
+        JSONObject response = new JSONObject(responses.get(0));
+        Assert.assertEquals(response.get("status"), "redirect");
+        Assert.assertEquals(response.get("redirectUrl"), APP_ACCESS_URL);
+    }
+
+    private Cookie[] getAuthenticationCookies() {
+
+        Cookie[] cookies = new Cookie[2];
+        cookies[0] = new Cookie(FrameworkConstants.COMMONAUTH_COOKIE, "commonAuthIdValue");
+        cookies[1] = new Cookie(NONCE_COOKIE + "-" + SESSION_DATA_KEY_VALUE, "sessionNonceValue");
+        return cookies;
+    }
+
+    private void mockUtils() throws Exception {
+
+        mockNonceCookieUtils("true", "40");
+
+        mockStatic(IdentityTenantUtil.class);
+        Mockito.when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(false);
+
+        mockStatic(FrameworkUtils.class);
+        Mockito.when(FrameworkUtils.getAuthenticationContextFromCache(any())).thenReturn(context);
+        Mockito.when(FrameworkUtils.getCookie(any(), any())).thenReturn(null);
+
+        PowerMockito.spy(LoginContextManagementUtil.class);
+        PowerMockito.doReturn(APP_ACCESS_URL).when(LoginContextManagementUtil.class, "getAccessURLFromApplication",
+                anyString(), anyString());
+    }
+
+    private void mockNonceCookieUtils(String isNonceCookieEnabled, String tempDataCleanupTimeout) {
+
+        mockStatic(IdentityUtil.class);
+        Mockito.when(IdentityUtil.getProperty(NONCE_COOKIE_CONFIG)).thenReturn(isNonceCookieEnabled);
+        Mockito.when(IdentityUtil.getTempDataCleanUpTimeout()).thenReturn(Long.parseLong(tempDataCleanupTimeout));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/wso2-enterprise/asgardeo-product/issues/2488.

Even though an authentication context exists, a session nonce cookie related to a particular request could be missing if a user intentionally misses it or if the cookie timeout out and expired in the browser session. 

In such cases, the authentication request is considered invalid and the request is redirected to the access URL.
