### PR TITLE
Ignore empty query params in the callback url

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/pom.xml
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/pom.xml
@@ -301,7 +301,7 @@
 
                             org.wso2.carbon.base; version="${carbon.base.imp.pkg.version.range}",
                             org.wso2.carbon.captcha.mgt.beans.xsd;
-                            version="${carbon.identity.package.export.version}",
+                            version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.utils.multitenancy; version="${carbon.kernel.package.import.version.range}",
 


### PR DESCRIPTION
resolves https://github.com/wso2/product-is/issues/11361

## Approach
This fix improves the fix introduce by https://github.com/wso2/carbon-identity-framework/pull/3427 but not throwing an exception and ignoring the empty query params.