### PR TITLE
Add configs for custom scope handlers

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -523,6 +523,9 @@
         handler class. Therefor not supporting additional scope handlers. -->
         <ScopeHandlers>
             <ScopeHandler class="org.wso2.carbon.identity.oauth2.validators.OIDCScopeHandler" />
+        {% for scope_handler in oauth.custom_scope_handler%}
+            <ScopeHandler class="{{scope_handler.class}}" />
+        {% endfor %}
         </ScopeHandlers>
 
         <!-- Assertions can be used to embedd parameters into access token. -->


### PR DESCRIPTION
**Resolves** : wso2/product-is#11460

This PR adds the following templated configuration support.

- Adding a new custom ScopeHandler in identity.xml

To add a custom ScopeHandler, add the following configuration in deployment.toml

```
[[oauth.custom_scope_handler]]
class="org.wso2.carbon.identity.oauth2.custom.validator1"
[[oauth.custom_scope_handler]]
class= "org.wso2.carbon.identity.oauth2.custom.validator2"
```
This will add the following custom ScopeHandler configuration in identity.xml.

```
<ScopeHandlers>
    <ScopeHandler class="org.wso2.carbon.identity.oauth2.validators.OIDCScopeHandler" />
    <ScopeHandler class="org.wso2.carbon.identity.oauth2.custom.validator1" />
    <ScopeHandler class="org.wso2.carbon.identity.oauth2.custom.validator2" />
</ScopeHandlers>
```