### PR TITLE
Add back consent-mgt and oauth webapp to the rewrite context

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -513,8 +513,11 @@
   "user.enable_per_user_functionality_locking": false,
   "tenant_context.enable_tenant_qualified_urls": false,
   "tenant_context.rewrite.webapps": [
+    "/api/identity/consent-mgt/v1.0/",
     "/oauth2/",
     "/scim2/",
+    "/api/identity/oauth2/dcr/v1.1/",
+    "/api/identity/oauth2/v1.0/",
     "/api/identity/media/v1.0/",
     "/api/",
     "/myaccount/",


### PR DESCRIPTION
### Proposed changes in this pull request

Add back which are removed with https://github.com/wso2/carbon-identity-framework/commit/83d3a657b56db2ff158fbc245b9903fa282ae7a5 