### PR TITLE
Make sure pre-requisites are done before registering application management services

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponent.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponent.java
@@ -85,6 +85,16 @@ public class ApplicationManagementServiceComponent {
     @Activate
     protected void activate(ComponentContext context) {
         try {
+            buildFileBasedSPList();
+            if (log.isDebugEnabled()) {
+                log.debug("File based SP building completed");
+            }
+
+            loadAuthenticationTemplates();
+            if (log.isDebugEnabled()) {
+                log.debug("Authentication templates are loaded");
+            }
+
             bundleContext = context.getBundleContext();
             // Registering Application management service as a OSGIService
             bundleContext.registerService(ApplicationManagementService.class.getName(),
@@ -107,10 +117,6 @@ public class ApplicationManagementServiceComponent {
             // Register the ApplicationValidator.
             context.getBundleContext().registerService(ApplicationValidator.class,
                     new DefaultApplicationValidator(), null);
-
-            buildFileBasedSPList();
-            loadAuthenticationTemplates();
-
             if (log.isDebugEnabled()) {
                 log.debug("Identity ApplicationManagementComponent bundle is activated");
             }


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/11506.

Make sure file-based SPs and authentication templates are loaded before registering any of the OSGi services.