### PR TITLE
Handle role claim URI in role mapping

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
@@ -63,6 +63,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
+import static org.wso2.carbon.identity.core.util.IdentityUtil.getLocalGroupsClaimURI;
 
 public class DefaultClaimHandler implements ClaimHandler {
 
@@ -986,13 +987,13 @@ public class DefaultClaimHandler implements ClaimHandler {
      */
     private void handleRoleClaim(AuthenticationContext context, Map<String, String> mappedAttrs) {
 
-        if (mappedAttrs.containsKey(FrameworkConstants.LOCAL_ROLE_CLAIM_URI)) {
-            String[] groups = mappedAttrs.get(FrameworkConstants.LOCAL_ROLE_CLAIM_URI).split(Pattern
+        if (mappedAttrs.containsKey(getLocalGroupsClaimURI())) {
+            String[] groups = mappedAttrs.get(getLocalGroupsClaimURI()).split(Pattern
                     .quote(FrameworkUtils.getMultiAttributeSeparator()));
             SequenceConfig sequenceConfig = context.getSequenceConfig();
             // Execute only if it has allowed removing userstore domain from the sp level configurations.
             if (isRemoveUserDomainInRole(sequenceConfig)) {
-                mappedAttrs.put(FrameworkConstants.LOCAL_ROLE_CLAIM_URI, FrameworkUtils
+                mappedAttrs.put(getLocalGroupsClaimURI(), FrameworkUtils
                         .removeDomainFromNamesExcludeHybrid(Arrays.asList(groups)));
             }
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -671,7 +671,7 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
 
         if (claimMapping != null) {
             //Ex. Standard dialects like OIDC.
-            idpRoleClaimUri = claimMapping.get(FrameworkConstants.LOCAL_ROLE_CLAIM_URI);
+            idpRoleClaimUri = claimMapping.get(IdentityUtil.getLocalGroupsClaimURI());
         } else if (idPStandardDialect == null && !useDefaultIdpDialect) {
             //Ex. SAML custom claims.
             idpRoleClaimUri = FrameworkUtils.getIdpRoleClaimUri(externalIdPConfig);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultRequestPathBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultRequestPathBasedSequenceHandler.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -241,7 +242,7 @@ public class DefaultRequestPathBasedSequenceHandler implements RequestPathBasedS
             if (spToLocalClaimMapping != null && !spToLocalClaimMapping.isEmpty()) {
 
                 for (Entry<String, String> entry : spToLocalClaimMapping.entrySet()) {
-                    if (FrameworkConstants.LOCAL_ROLE_CLAIM_URI.equals(entry.getValue())) {
+                    if (IdentityUtil.getLocalGroupsClaimURI().equals(entry.getValue())) {
                         return entry.getKey();
                     }
                 }
@@ -249,7 +250,7 @@ public class DefaultRequestPathBasedSequenceHandler implements RequestPathBasedS
         }
 
         if (spRoleClaimUri == null) {
-            spRoleClaimUri = FrameworkConstants.LOCAL_ROLE_CLAIM_URI;
+            spRoleClaimUri = IdentityUtil.getLocalGroupsClaimURI();
             if (log.isDebugEnabled()) {
                 String serviceProvider = appConfig.getApplicationName();
                 log.debug("Service Provider Role Claim URI not configured for SP: " + serviceProvider +

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultSequenceHandlerUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultSequenceHandlerUtils.java
@@ -42,7 +42,7 @@ import java.util.regex.Pattern;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.InternalRoleDomains.APPLICATION_DOMAIN;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.InternalRoleDomains.WORKFLOW_DOMAIN;
-
+import static org.wso2.carbon.identity.core.util.IdentityUtil.getLocalGroupsClaimURI;
 
 /**
  * Common utility used by Default Sequence Handlers.
@@ -242,10 +242,9 @@ public class DefaultSequenceHandlerUtils {
     private static String getStandardRoleClaimURI(String standardDialect, String tenantDomain)
             throws FrameworkException {
 
-        String roleClaim = getStandardClaimURIFromLocal(standardDialect, tenantDomain, FrameworkConstants
-                .LOCAL_ROLE_CLAIM_URI);
+        String roleClaim = getStandardClaimURIFromLocal(standardDialect, tenantDomain, getLocalGroupsClaimURI());
         if (StringUtils.isBlank(roleClaim)) {
-            return FrameworkConstants.LOCAL_ROLE_CLAIM_URI;
+            return getLocalGroupsClaimURI();
         }
         return roleClaim;
     }
@@ -295,7 +294,7 @@ public class DefaultSequenceHandlerUtils {
                 }
             }
         }
-        return FrameworkConstants.LOCAL_ROLE_CLAIM_URI;
+        return getLocalGroupsClaimURI();
     }
 
     /**
@@ -317,7 +316,7 @@ public class DefaultSequenceHandlerUtils {
 
             if (MapUtils.isNotEmpty(spToLocalClaimMapping)) {
                 for (Map.Entry<String, String> entry : spToLocalClaimMapping.entrySet()) {
-                    if (FrameworkConstants.LOCAL_ROLE_CLAIM_URI.equals(entry.getValue())) {
+                    if (getLocalGroupsClaimURI().equals(entry.getValue())) {
                         spRoleClaimUri = entry.getKey();
                         break;
                     }
@@ -326,7 +325,7 @@ public class DefaultSequenceHandlerUtils {
         }
 
         if (StringUtils.isEmpty(spRoleClaimUri)) {
-            spRoleClaimUri = FrameworkConstants.LOCAL_ROLE_CLAIM_URI;
+            spRoleClaimUri = getLocalGroupsClaimURI();
             if (log.isDebugEnabled()) {
                 String serviceProvider = appConfig.getApplicationName();
                 log.debug("Service Provider Role Claim URI not configured for SP: " + serviceProvider +

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -168,6 +168,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.REQUEST_PARAM_SP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.USER_TENANT_DOMAIN_HINT;
 import static org.wso2.carbon.identity.core.util.IdentityTenantUtil.isLegacySaaSAuthenticationEnabled;
+import static org.wso2.carbon.identity.core.util.IdentityUtil.getLocalGroupsClaimURI;
 
 public class FrameworkUtils {
 
@@ -2086,7 +2087,7 @@ public class FrameworkUtils {
             ClaimMapping[] idpToLocalClaimMapping = externalIdPConfig.getClaimMappings();
             if (idpToLocalClaimMapping != null && idpToLocalClaimMapping.length > 0) {
                 for (ClaimMapping mapping : idpToLocalClaimMapping) {
-                    if (FrameworkConstants.LOCAL_ROLE_CLAIM_URI.equals(mapping.getLocalClaim().getClaimUri())
+                    if (getLocalGroupsClaimURI().equals(mapping.getLocalClaim().getClaimUri())
                             && mapping.getRemoteClaim() != null) {
                         return mapping.getRemoteClaim().getClaimUri();
                     }
@@ -2149,8 +2150,8 @@ public class FrameworkUtils {
 
     /**
      * Returns the local claim uri that is mapped for the IdP role claim uri configured.
-     * If no role claim uri is configured for the IdP returns the local role claim 'http://wso2.org/claims/role'.
-     *
+     * If no role claim uri is configured for the IdP returns the local claim by calling 'IdentityUtils
+     * .#getLocalGroupsClaimURI()'.
      * @param externalIdPConfig IdP configurations
      * @return local claim uri mapped for the IdP role claim uri.
      */
@@ -2170,7 +2171,7 @@ public class FrameworkUtils {
                 }
             }
         }
-        return FrameworkConstants.LOCAL_ROLE_CLAIM_URI;
+        return getLocalGroupsClaimURI();
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthAssociationHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthAssociationHandlerTest.java
@@ -26,6 +26,7 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.core.util.AdminServicesUtil;
 import org.wso2.carbon.identity.application.authentication.framework.AbstractFrameworkTest;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.FederatedApplicationAuthenticator;
@@ -66,11 +67,12 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.wso2.carbon.identity.core.util.IdentityUtil.getLocalGroupsClaimURI;
 
 /**
  * This is a test class for {@link PostAuthAssociationHandler}.
  */
-@PrepareForTest({FrameworkUtils.class, ConfigurationFacade.class, ClaimMetadataHandler.class})
+@PrepareForTest({FrameworkUtils.class, ConfigurationFacade.class, ClaimMetadataHandler.class, AdminServicesUtil.class})
 @PowerMockIgnore({"javax.xml.*"})
 public class PostAuthAssociationHandlerTest extends AbstractFrameworkTest {
 
@@ -133,6 +135,8 @@ public class PostAuthAssociationHandlerTest extends AbstractFrameworkTest {
     public void testHandleWithAuthenticatedUserWithFederatedIdpAssociatedToSecondaryUserStore(boolean hasSpRoleMapping)
             throws Exception {
 
+        PowerMockito.spy(AdminServicesUtil.class);
+        PowerMockito.doReturn(null).when(AdminServicesUtil.class, "getUserRealm");
         AuthenticationContext context = processAndGetAuthenticationContext(sp, true, true, hasSpRoleMapping);
         FederatedAssociationManager federatedAssociationManager = mock(FederatedAssociationManagerImpl.class);
         when(FrameworkUtils.getFederatedAssociationManager()).thenReturn(federatedAssociationManager);
@@ -205,8 +209,8 @@ public class PostAuthAssociationHandlerTest extends AbstractFrameworkTest {
         }
 
         if (withSpRoleMapping) {
-            sequenceConfig.getApplicationConfig().getClaimMappings().put(FrameworkConstants.LOCAL_ROLE_CLAIM_URI,
-                    FrameworkConstants.LOCAL_ROLE_CLAIM_URI);
+            sequenceConfig.getApplicationConfig().getClaimMappings().put(getLocalGroupsClaimURI(),
+                    getLocalGroupsClaimURI());
             sequenceConfig.getApplicationConfig().getServiceProvider().getClaimConfig().setLocalClaimDialect(true);
             sequenceConfig.getApplicationConfig().getRoleMappings().put(ORI_ROLE_1, SP_MAPPED_ROLE_1);
             sequenceConfig.getApplicationConfig().getRoleMappings().put(ORI_ROLE_2, SP_MAPPED_ROLE_2);
@@ -218,7 +222,7 @@ public class PostAuthAssociationHandlerTest extends AbstractFrameworkTest {
     private boolean isSpRoleMappingSuccessful(Map<ClaimMapping, String> authenticatedUserAttributes) {
 
         for (Map.Entry<ClaimMapping, String> entry : authenticatedUserAttributes.entrySet()) {
-            if (FrameworkConstants.LOCAL_ROLE_CLAIM_URI.equals(entry.getKey().getLocalClaim().getClaimUri())) {
+            if (getLocalGroupsClaimURI().equals(entry.getKey().getLocalClaim().getClaimUri())) {
                 List<String> roles = Arrays.asList(entry.getValue().split(","));
                 return roles.size() == 2 && roles.contains(SP_MAPPED_ROLE_1) && roles.contains(SP_MAPPED_ROLE_2);
             }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultRequestPathBasedSequenceHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultRequestPathBasedSequenceHandlerTest.java
@@ -70,6 +70,7 @@ import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.wso2.carbon.identity.core.util.IdentityUtil.getLocalGroupsClaimURI;
 
 @PrepareForTest({FrameworkUtils.class, ApplicationMgtSystemConfig.class, IdentityTenantUtil.class})
 public class DefaultRequestPathBasedSequenceHandlerTest {
@@ -267,7 +268,7 @@ public class DefaultRequestPathBasedSequenceHandlerTest {
                         }},
                         new HashMap<Object, Object>() {
                             {
-                                put(FrameworkConstants.LOCAL_ROLE_CLAIM_URI, "localRole1,localRole2");
+                                put(getLocalGroupsClaimURI(), "localRole1,localRole2");
                             }
                         },
                         SUBJECT_CLAIM_URI,
@@ -281,7 +282,7 @@ public class DefaultRequestPathBasedSequenceHandlerTest {
                         }},
                         new HashMap<Object, Object>() {
                             {
-                                put(FrameworkConstants.LOCAL_ROLE_CLAIM_URI, "localRole1,localRole2");
+                                put(getLocalGroupsClaimURI(), "localRole1,localRole2");
                                 put(SUBJECT_CLAIM_URI, "mapped_attribute_claim_subject");
                             }
                         }, SUBJECT_CLAIM_URI,
@@ -292,7 +293,7 @@ public class DefaultRequestPathBasedSequenceHandlerTest {
                         null,
                         new HashMap<Object, Object>() {
                             {
-                                put(FrameworkConstants.LOCAL_ROLE_CLAIM_URI, "localRole1,localRole2");
+                                put(getLocalGroupsClaimURI(), "localRole1,localRole2");
                                 put(SUBJECT_CLAIM_URI, "mapped_attribute_claim_subject");
                             }
                         }, SUBJECT_CLAIM_URI,
@@ -379,7 +380,7 @@ public class DefaultRequestPathBasedSequenceHandlerTest {
     private Object[][] getSpRoleClaimUriData() {
         return new Object[][]{
                 {"SP_ROLE_CLAIM", "SP_ROLE_CLAIM"},
-                {null, FrameworkConstants.LOCAL_ROLE_CLAIM_URI}
+                {null, getLocalGroupsClaimURI()}
         };
     }
 
@@ -400,7 +401,7 @@ public class DefaultRequestPathBasedSequenceHandlerTest {
         return new Object[][]{
                 {       // SP mapped role claim
                         new HashMap<String, String>() {{
-                            put("SP_ROLE_CLAIM", FrameworkConstants.LOCAL_ROLE_CLAIM_URI);
+                            put("SP_ROLE_CLAIM", getLocalGroupsClaimURI());
                         }},
                         "SP_ROLE_CLAIM"
                 },
@@ -408,13 +409,13 @@ public class DefaultRequestPathBasedSequenceHandlerTest {
                         new HashMap<String, String>() {{
                             put("SP_CLAIM", "LOCAL_CLAIM");
                         }},
-                        FrameworkConstants.LOCAL_ROLE_CLAIM_URI
+                        getLocalGroupsClaimURI()
                 },
                 {      // No SP mapped claims
-                        new HashMap<>(), FrameworkConstants.LOCAL_ROLE_CLAIM_URI
+                        new HashMap<>(), getLocalGroupsClaimURI()
                 },
                 {
-                        null, FrameworkConstants.LOCAL_ROLE_CLAIM_URI
+                        null, getLocalGroupsClaimURI()
                 }
         };
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandlerTest.java
@@ -87,6 +87,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import static org.wso2.carbon.identity.core.util.IdentityUtil.getLocalGroupsClaimURI;
 
 @PrepareForTest({
                         FrameworkUtils.class, IdentityApplicationManagementUtil.class, ApplicationMgtSystemConfig.class,
@@ -174,8 +175,8 @@ public class DefaultStepBasedSequenceHandlerTest {
     private Object[][] getSpRoleClaimUriData() {
         return new Object[][]{
                 {"SP_ROLE_CLAIM", "SP_ROLE_CLAIM"},
-                {null, FrameworkConstants.LOCAL_ROLE_CLAIM_URI},
-                {"", FrameworkConstants.LOCAL_ROLE_CLAIM_URI}
+                {null, getLocalGroupsClaimURI()},
+                {"", getLocalGroupsClaimURI()}
         };
     }
 
@@ -195,7 +196,7 @@ public class DefaultStepBasedSequenceHandlerTest {
         return new Object[][]{
                 {       // SP mapped role claim
                         new HashMap<String, String>() {{
-                            put("SP_ROLE_CLAIM", FrameworkConstants.LOCAL_ROLE_CLAIM_URI);
+                            put("SP_ROLE_CLAIM", getLocalGroupsClaimURI());
                         }},
                         "SP_ROLE_CLAIM"
                 },
@@ -203,13 +204,13 @@ public class DefaultStepBasedSequenceHandlerTest {
                         new HashMap<String, String>() {{
                             put("SP_CLAIM", "LOCAL_CLAIM");
                         }},
-                        FrameworkConstants.LOCAL_ROLE_CLAIM_URI
+                        getLocalGroupsClaimURI()
                 },
                 {      // No SP mapped claims
-                        new HashMap<>(), FrameworkConstants.LOCAL_ROLE_CLAIM_URI
+                        new HashMap<>(), getLocalGroupsClaimURI()
                 },
                 {
-                        null, FrameworkConstants.LOCAL_ROLE_CLAIM_URI
+                        null, getLocalGroupsClaimURI()
                 }
         };
     }
@@ -252,7 +253,7 @@ public class DefaultStepBasedSequenceHandlerTest {
         return new Object[][]{
                 {       // SP mapped role claim
                         new ClaimMapping[]{
-                                ClaimMapping.build(FrameworkConstants.LOCAL_ROLE_CLAIM_URI, "IDP_ROLE_CLAIM", "", true)
+                                ClaimMapping.build(getLocalGroupsClaimURI(), "IDP_ROLE_CLAIM", "", true)
                         },
                         "IDP_ROLE_CLAIM"
                 },
@@ -264,7 +265,7 @@ public class DefaultStepBasedSequenceHandlerTest {
                 },
                 {       // Role claim among claim mappings but remote claim is null
                         new ClaimMapping[]{
-                                ClaimMapping.build(FrameworkConstants.LOCAL_ROLE_CLAIM_URI, null, null, true)
+                                ClaimMapping.build(getLocalGroupsClaimURI(), null, null, true)
                         },
                         null
                 },

--- a/components/claim-mgt/org.wso2.carbon.claim.mgt.ui/src/main/java/org/wso2/carbon/claim/mgt/ui/client/ClaimAdminClient.java
+++ b/components/claim-mgt/org.wso2.carbon.claim.mgt.ui/src/main/java/org/wso2/carbon/claim/mgt/ui/client/ClaimAdminClient.java
@@ -111,6 +111,14 @@ public class ClaimAdminClient {
             role.setClaimUri("http://wso2.org/claims/role");
             mapping.setClaim(role);
             newClaims[i] = mapping;
+
+            // If role group separation is enabled, we need to send the roles claim also as UI might need that.
+            ClaimMappingDTO rolesMapping = new ClaimMappingDTO();
+            ClaimDTO roles = new ClaimDTO();
+            roles.setClaimUri("http://wso2.org/claims/roles");
+            rolesMapping.setClaim(roles);
+            newClaims[i] = rolesMapping;
+
             claims.setClaimMappings(newClaims);
             return claims;
         } catch (Exception e) {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -75,9 +75,12 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.Base64;
@@ -1419,5 +1422,36 @@ public class IdentityUtil {
             log.warn("Property value parsing error: GroupAndRoleSeparationEnabled, thus considered as FALSE");
             return Boolean.FALSE;
         }
+    }
+
+    /**
+     * With group role separation, user roles are separated into groups and internal roles and, to support backward
+     * compatibility, the legacy wso2.role claim still returns both groups and internal roles. This method provides
+     * claim URIs of these group, role claims.
+     *
+     * @return An unmodifiable set of claim URIs which contain user groups, roles, or both.
+     */
+    public static Set<String> getRoleGroupClaims() {
+
+        Set<String> roleGroupClaimURIs = new HashSet<>();
+        roleGroupClaimURIs.add(UserCoreConstants.ROLE_CLAIM);
+        if (IdentityUtil.isGroupsVsRolesSeparationImprovementsEnabled()) {
+            roleGroupClaimURIs.add(UserCoreConstants.INTERNAL_ROLES_CLAIM);
+            roleGroupClaimURIs.add(UserCoreConstants.USER_STORE_GROUPS_CLAIM);
+        }
+        return Collections.unmodifiableSet(roleGroupClaimURIs);
+    }
+
+    /**
+     * With group role separation, user roles are separated into groups and internal roles and, to support backward
+     * compatibility, the legacy wso2.role claim still returns both groups and internal roles. This method provides
+     * the claim URI which contain internal roles, or both groups and roles in a backward compatible manner.
+     *
+     * @return Claim URI for the user groups, or both groups and roles based on the backward compatibility.
+     */
+    public static String getLocalGroupsClaimURI() {
+
+        return IdentityUtil.isGroupsVsRolesSeparationImprovementsEnabled() ?
+                UserCoreConstants.INTERNAL_ROLES_CLAIM : UserCoreConstants.ROLE_CLAIM;
     }
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1895,6 +1895,7 @@
     <!--<LoggableUserClaims>-->
         <!--<LoggableUserClaim>http://wso2.org/claims/identity/accountLocked</LoggableUserClaim>-->
         <!--<LoggableUserClaim>http://wso2.org/claims/role</LoggableUserClaim>-->
+        <!--<LoggableUserClaim>http://wso2.org/claims/roles</LoggableUserClaim>-->
     <!--</LoggableUserClaims>-->
 
     <!--Configuration Store properties-->


### PR DESCRIPTION
Fixes wso2/product-is#11330.

- Add validation for SP and IdP role mapping to stop adding groups during role mapping
- Switch to the wso2.roles claim as the claim URI to represent roles in the Identity Framework