### PR TITLE
Add oidc roles claim

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -1631,6 +1631,15 @@
 				<MappedLocalClaim>http://wso2.org/claims/role</MappedLocalClaim>
 			</Claim>
 			<Claim>
+				<ClaimURI>roles</ClaimURI>
+				<DisplayName>User Roles</DisplayName>
+				<AttributeID>roles</AttributeID>
+				<Description>List of role names that have been assigned to the principal. This typically will require a mapping at the application container level to application deployment roles.</Description>
+				<DisplayOrder>13</DisplayOrder>
+				<SupportedByDefault />
+				<MappedLocalClaim>http://wso2.org/claims/roles</MappedLocalClaim>
+			</Claim>
+			<Claim>
 				<ClaimURI>email</ClaimURI>
 				<DisplayName>Email</DisplayName>
 				<AttributeID>mail</AttributeID>


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/11327.

Introduce new 'roles' claim to the OIDC claim dialect. This claim is mapped to the local wso2.roles claim and will bring users internal roles to the application.