### PR TITLE
Expose endpoint params to JS authentication context

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsAuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsAuthenticationContext.java
@@ -81,6 +81,8 @@ public class JsAuthenticationContext extends AbstractJSObjectWrapper<Authenticat
                 }
             case FrameworkConstants.JSAttributes.JS_RETRY_STEP:
                 return getWrapped().isRetrying();
+            case FrameworkConstants.JSAttributes.JS_ENDPOINT_PARAMS:
+                return new JsWritableParameters(getContext().getEndpointParams());
             default:
                 return super.getMember(name);
         }
@@ -104,6 +106,8 @@ public class JsAuthenticationContext extends AbstractJSObjectWrapper<Authenticat
                 return hasTransientValueInParameters(FrameworkConstants.RequestAttribute.HTTP_RESPONSE);
             case FrameworkConstants.JSAttributes.JS_STEPS:
                 return !getWrapped().getSequenceConfig().getStepMap().isEmpty();
+            case FrameworkConstants.JSAttributes.JS_ENDPOINT_PARAMS:
+                return getWrapped().getEndpointParams() != null;
             default:
                 return super.hasMember(name);
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -417,6 +417,7 @@ public abstract class FrameworkConstants {
         public static final String JS_RETRY_STEP = "retry";
         public static final String JS_FUNC_LOAD_FUNC_LIB = "loadLocalLibrary";
         public static final String JS_AUTH_FAILURE = "fail";
+        public static final String JS_ENDPOINT_PARAMS = "endpointParams";
 
         public static final String IDP = "idp";
         public static final String AUTHENTICATOR = "authenticator";


### PR DESCRIPTION
### Proposed changes in this pull request
Fixes https://github.com/wso2/product-is/issues/11588
Expose the endpoint params that have been added to the authentication context, to use in the adaptive authentication scripts
