### PR TITLE
[Config] Make enable property of client_certificate_authentication_handler configurable 

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1431,6 +1431,11 @@
                        enable="{{event.default_listener.user_claim_audit_logger.enable}}">
             <Property name="LogUpdatedClaimsOnly">{{event.default_listener.user_claim_audit_logger.LogUpdatedClaimsOnly}}</Property>
         </EventListener>
+        <EventListener id="client_certificate_authentication_handler"
+                       type="org.wso2.carbon.identity.core.handler.AbstractIdentityMessageHandler"
+                       name="org.wso2.carbon.identity.auth.service.handler.impl.ClientCertificateBasedAuthenticationHandler"
+                       orderId="{{event.default_listener.client_certificate_authentication_handler.priority}}"
+                       enable="{{event.default_listener.client_certificate_authentication_handler.enable}}"/>
         <!-- Custom Audit Loggers-->
         {% for listener in event_listener %}
         <EventListener id="{{listener.id}}"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -410,6 +410,8 @@
   "event.default_listener.user_claim_audit_logger.priority": "9",
   "event.default_listener.user_claim_audit_logger.enable": false,
   "event.default_listener.user_claim_audit_logger.LogUpdatedClaimsOnly": false,
+  "event.default_listener.client_certificate_authentication_handler.priority": "10",
+  "event.default_listener.client_certificate_authentication_handler.enable": false,
   "event.default_listener.username_resolver.priority": "14",
   "event.default_listener.username_resolver.enable": true,
   "event.default_listener.userid_resolver.priority": "15",


### PR DESCRIPTION
Fix https://github.com/wso2/product-is/issues/11604

Fix : 

- Add separate config for client_certificate_authentication_handler event handler

Priority default value:

- https://github.com/wso2-extensions/identity-carbon-auth-rest/blob/master/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/ClientCertificateBasedAuthenticationHandler.java#L70

