### PR TITLE
Add config to keep non-jit provisioned roles of a user during jit update

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/ProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/ProvisioningHandler.java
@@ -35,4 +35,21 @@ public interface ProvisioningHandler {
      */
     public void handle(List<String> roles, String subject, Map<String, String> attributes,
                        String provisioningUserStoreId, String tenantDomain) throws FrameworkException;
+
+    /**
+     * Default implementation to validate idp role mappings by keeping backward compatibility.
+     *
+     * @param roles
+     * @param subject
+     * @param attributes
+     * @param provisioningUserStoreId
+     * @param tenantDomain
+     * @param idpToLocalRoleMapping
+     * @throws FrameworkException
+     */
+    default void handle(List<String> roles, String subject, Map<String, String> attributes,
+            String provisioningUserStoreId, String tenantDomain, List<String> idpToLocalRoleMapping)
+            throws FrameworkException {
+        throw new FrameworkException("Operation is not supported.");
+    }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -57,7 +57,10 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Config.SEND_MANUALLY_ADDED_LOCAL_ROLES_OF_IDP;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Config.SEND_ONLY_LOCALLY_MAPPED_ROLES_OF_IDP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.InternalRoleDomains.APPLICATION_DOMAIN;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.InternalRoleDomains.WORKFLOW_DOMAIN;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USERNAME_CLAIM;
@@ -83,7 +86,16 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
 
     @Override
     public void handle(List<String> roles, String subject, Map<String, String> attributes,
-                       String provisioningUserStoreId, String tenantDomain) throws FrameworkException {
+            String provisioningUserStoreId, String tenantDomain) throws FrameworkException {
+
+        handle(roles, subject, attributes, provisioningUserStoreId, tenantDomain, null);
+
+    }
+
+    @Override
+    public void handle(List<String> roles, String subject, Map<String, String> attributes,
+            String provisioningUserStoreId, String tenantDomain, List<String> idpToLocalRoleMapping)
+            throws FrameworkException {
 
         RegistryService registryService = FrameworkServiceComponent.getRegistryService();
         RealmService realmService = FrameworkServiceComponent.getRealmService();
@@ -220,6 +232,30 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                 // Update user with roles
                 List<String> currentRolesList = Arrays.asList(userStoreManager.getRoleListOfUser(username));
                 Collection<String> deletingRoles = retrieveRolesToBeDeleted(realm, currentRolesList, rolesToAdd);
+
+                if (idpToLocalRoleMapping != null && !idpToLocalRoleMapping.isEmpty()) {
+                    boolean excludeUnmappedRoles = true;
+                    boolean includeManuallyAddedLocalRoles = false;
+                    if (StringUtils.isNotEmpty(IdentityUtil.getProperty(SEND_ONLY_LOCALLY_MAPPED_ROLES_OF_IDP))) {
+                        excludeUnmappedRoles = Boolean
+                                .parseBoolean(IdentityUtil.getProperty(SEND_ONLY_LOCALLY_MAPPED_ROLES_OF_IDP));
+                    }
+
+                    if (StringUtils.isNotEmpty(IdentityUtil.getProperty(SEND_MANUALLY_ADDED_LOCAL_ROLES_OF_IDP))) {
+                        includeManuallyAddedLocalRoles = Boolean
+                                .parseBoolean(IdentityUtil.getProperty(SEND_MANUALLY_ADDED_LOCAL_ROLES_OF_IDP));
+                    }
+
+
+                    /* Get the intersection of current deletingList with idpRoleMappings,deletingRoles will be equal to
+                    mapped idp roles.Here we assume only the mapped idp roles with federated idp.
+                    */
+                    if (excludeUnmappedRoles && includeManuallyAddedLocalRoles) {
+                        deletingRoles = deletingRoles.stream().distinct().filter(idpToLocalRoleMapping::contains)
+                                .collect(Collectors.toSet());
+                    }
+                }
+
                 rolesToAdd.removeAll(currentRolesList);
                 List<String> nonExistingUnmappedIdpRoles = new ArrayList<>();
                 for (String role : rolesToAdd) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -234,7 +234,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                 Collection<String> deletingRoles = retrieveRolesToBeDeleted(realm, currentRolesList, rolesToAdd);
 
                 if (idpToLocalRoleMapping != null && !idpToLocalRoleMapping.isEmpty()) {
-                    boolean excludeUnmappedRoles = true;
+                    boolean excludeUnmappedRoles = false;
                     boolean includeManuallyAddedLocalRoles = false;
                     if (StringUtils.isNotEmpty(IdentityUtil.getProperty(SEND_ONLY_LOCALLY_MAPPED_ROLES_OF_IDP))) {
                         excludeUnmappedRoles = Boolean

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -48,6 +48,7 @@ import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -543,9 +544,12 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
             if (MapUtils.isNotEmpty(localUnfilteredClaimsForNullValues)) {
                 extAttributesValueMap.putAll(localUnfilteredClaimsForNullValues);
             }
+            List<String> idpToLocalRoleMapping = new ArrayList<String>(
+                    context.getExternalIdP().getRoleMappings().values());
 
-            FrameworkUtils.getProvisioningHandler().handle(mappedRoles, subjectIdentifier,
-                    extAttributesValueMap, userStoreDomain, context.getTenantDomain());
+            FrameworkUtils.getProvisioningHandler()
+                    .handle(mappedRoles, subjectIdentifier, extAttributesValueMap, userStoreDomain,
+                            context.getTenantDomain(), idpToLocalRoleMapping);
 
         } catch (FrameworkException e) {
             log.error("User provisioning failed!", e);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -166,6 +166,8 @@ public abstract class FrameworkConstants {
         public static final String REMOVE_PARAM_ON_CONSUME = "removeOnConsumeFromAPI";
         public static final String SEND_ONLY_LOCALLY_MAPPED_ROLES_OF_IDP = "FederatedRoleManagement"
                 + ".ReturnOnlyMappedLocalRoles";
+        public static final String SEND_MANUALLY_ADDED_LOCAL_ROLES_OF_IDP = "FederatedRoleManagement"
+                + ".ReturnManuallyAddedLocalRoles";
 
         /**
          * Configuration name for setting the url for receiving tenant list upon any modification to a tenant

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandlerTest.java
@@ -537,14 +537,15 @@ public class DefaultStepBasedSequenceHandlerTest {
 
         // Mock the provisioning handler
         ProvisioningHandler provisioningHandler = mock(ProvisioningHandler.class);
-        doNothing().when(provisioningHandler).handle(anyList(), anyString(), anyMap(), captor.capture(), anyString());
+        doNothing().when(provisioningHandler)
+                .handle(anyList(), anyString(), anyMap(), captor.capture(), anyString(), anyList());
 
         // Mock framework util to returned mocked provisoning handler
         returnMockProvisioningHandler(provisioningHandler);
         mockHandlerThreadLocalProvisioningServiceProvider();
 
         stepBasedSequenceHandler.handleJitProvisioning(subjectIdentifier, context, mappedRoles, externalAttributeValues);
-        verify(provisioningHandler).handle(anyList(), anyString(), anyMap(), captor.capture(), anyString());
+        verify(provisioningHandler).handle(anyList(), anyString(), anyMap(), captor.capture(), anyString(), anyList());
 
         // check whether the user is provisioned to correct user store
         assertEquals(captor.getValue(), expectedUserStoreToBeProvisioned);
@@ -598,8 +599,8 @@ public class DefaultStepBasedSequenceHandlerTest {
         context = getMockedContextForJitProvisioning(null, null, null);
         // Mock the provisioning handler
         ProvisioningHandler provisioningHandler = mock(ProvisioningHandler.class);
-        doThrow(new FrameworkException("Provisioning Failed"))
-                .when(provisioningHandler).handle(anyList(), anyString(), anyMap(), anyString(), anyString());
+        doThrow(new FrameworkException("Provisioning Failed")).when(provisioningHandler)
+                .handle(anyList(), anyString(), anyMap(), anyString(), anyString(), anyList());
 
         returnMockProvisioningHandler(provisioningHandler);
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1240,6 +1240,9 @@
     {% if idp_role_management.return_only_mapped_local_roles is defined %}
         <FederatedRoleManagement>
             <ReturnOnlyMappedLocalRoles>{{idp_role_management.return_only_mapped_local_roles}}</ReturnOnlyMappedLocalRoles>
+            {% if idp_role_management.return_manually_added_local_roles is defined %}
+            <ReturnManuallyAddedLocalRoles>{{idp_role_management.return_manually_added_local_roles}}</ReturnManuallyAddedLocalRoles>
+            {% endif %}
         </FederatedRoleManagement>
     {% endif %}
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -356,6 +356,7 @@
 
   "sp_role_management.return_only_mapped_local_roles": false,
   "idp_role_management.return_only_mapped_local_roles": false,
+  "idp_role_management.return_manually_added_local_roles": false,
   "outbound_provisioning_management.reset_provisioning_entities_on_config_update": true,
 
   "authentication_policy.check_account_exist": true,


### PR DESCRIPTION
**Resolves** : wso2/product-is#7203

**Approach** : Considered idp role mappings and allow any local role which is not mapped to an external role not to be touched during JIT provisioning.

To enable this following configuration need to be added in deployment.toml file.

```
[idp_role_management]
return_only_mapped_local_roles = true
return_manually_added_local_roles = true
```