### PR TITLE
[Config] Enable by default of client_certificate_authentication_handler  

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -411,7 +411,7 @@
   "event.default_listener.user_claim_audit_logger.enable": false,
   "event.default_listener.user_claim_audit_logger.LogUpdatedClaimsOnly": false,
   "event.default_listener.client_certificate_authentication_handler.priority": "10",
-  "event.default_listener.client_certificate_authentication_handler.enable": false,
+  "event.default_listener.client_certificate_authentication_handler.enable": true,
   "event.default_listener.username_resolver.priority": "14",
   "event.default_listener.username_resolver.enable": true,
   "event.default_listener.userid_resolver.priority": "15",


### PR DESCRIPTION
Enable by default

Revert the effect of https://github.com/wso2/carbon-identity-framework/pull/3477