### PR TITLE
Add systemRoles configuration to identify read only roles

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/pom.xml
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/pom.xml
@@ -108,6 +108,7 @@
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${import.package.version.commons.logging}",
                             org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
+                            org.apache.axiom.*; version="${axiom.osgi.version.range}",
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.wso2.carbon; version="${carbon.kernel.package.import.version.range}",

--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/RoleConstants.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/RoleConstants.java
@@ -51,6 +51,9 @@ public class RoleConstants {
     // Group related constants.
     public static final String ID_URI = "urn:ietf:params:scim:schemas:core:2.0:id";
 
+    // System roles config element.
+    public static final String SYSTEM_ROLES_CONFIG_ELEMENT = "SystemRoles";
+    public static final String ROLE_NAME_CONFIG_ELEMENT = "RoleName";
     /**
      * Grouping of constants related to database table names.
      */

--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/RoleManagementService.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/RoleManagementService.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.role.mgt.core;
 import org.apache.commons.lang.NotImplementedException;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * OSGi service interface which use to manage roles.
@@ -191,5 +192,15 @@ public interface RoleManagementService {
             NotImplementedException {
 
         throw new NotImplementedException("isExistingRoleName method is not implemented");
+    }
+
+    /**
+     * Get the list of system roles.
+     *
+     * @return A set of system roles.
+     */
+    default Set<String> getSystemRoles() throws NotImplementedException {
+
+        throw new NotImplementedException("getSystemRoles method is not implemented");
     }
 }

--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/dao/RoleDAO.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/dao/RoleDAO.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.role.mgt.core.dao;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.wso2.carbon.identity.role.mgt.core.GroupBasicInfo;
 import org.wso2.carbon.identity.role.mgt.core.IdentityRoleManagementException;
 import org.wso2.carbon.identity.role.mgt.core.Role;
@@ -25,6 +26,7 @@ import org.wso2.carbon.identity.role.mgt.core.RoleBasicInfo;
 import org.wso2.carbon.identity.role.mgt.core.UserBasicInfo;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * RoleDAO interface.
@@ -229,4 +231,14 @@ public interface RoleDAO {
      * @throws IdentityRoleManagementException IdentityRoleManagementException.
      */
     String getRoleNameByID(String roleID, String tenantDomain) throws IdentityRoleManagementException;
+
+    /**
+     * Get the list of system roles.
+     *
+     * @return A set of system roles.
+     */
+    default Set<String> getSystemRoles() throws NotImplementedException {
+
+        throw new NotImplementedException("getSystemRoles method is not implemented");
+    }
 }

--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/internal/RoleManagementServiceImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/internal/RoleManagementServiceImpl.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.identity.role.mgt.core.dao.RoleMgtDAOFactory;
 import org.wso2.carbon.user.core.UserCoreConstants;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.wso2.carbon.identity.role.mgt.core.RoleConstants.Error.INVALID_REQUEST;
 
@@ -147,5 +148,11 @@ public class RoleManagementServiceImpl implements RoleManagementService {
             NotImplementedException {
 
         return roleDAO.isExistingRoleName(roleName, tenantDomain);
+    }
+
+    @Override
+    public Set<String> getSystemRoles() {
+
+        return roleDAO.getSystemRoles();
     }
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2517,6 +2517,15 @@
     </SystemApplications>
     {% endif %}
 
+    <!-- System Roles -->
+    {% if system_roles.read_only_roles is defined %}
+    <SystemRoles>
+        {% for role in system_roles.read_only_roles %}
+        <RoleName>{{role}}</RoleName>
+        {% endfor %}
+    </SystemRoles>
+    {% endif %}
+
     <MutualTLS>
         <ClientCertificateHeader>{{oauth.mutualtls.client_certificate_header}}</ClientCertificateHeader>
     </MutualTLS>


### PR DESCRIPTION
### Proposed changes in this pull request

- Resolves https://github.com/wso2/product-is/issues/11645
- Following configuration can be added to `deployment.toml` in order to enable read-only roles.

```
[system_roles]
read_only_roles = ["role1", "role2", "role3"]
```