### PR TITLE
[Eventr Handler] [AdminForcedPasswordResetHandler] Handle Update Credentials By Admin

### DIFF
--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -70,7 +70,8 @@
   "identity_mgt.events.schemes.adminForcedPasswordReset.module_index": "9",
   "identity_mgt.events.schemes.adminForcedPasswordReset.subscriptions": [
     "PRE_SET_USER_CLAIMS",
-    "PRE_AUTHENTICATION"
+    "PRE_AUTHENTICATION",
+    "POST_UPDATE_CREDENTIAL_BY_ADMIN"
   ],
   "identity_mgt.events.schemes.'suspension.notification'.module_index": "10",
   "identity_mgt.events.schemes.'suspension.notification'.subscriptions": [


### PR DESCRIPTION
sibling PR:

https://github.com/wso2-extensions/identity-governance/pull/493

Reason to add config:
- Allow AdminForcedPasswordResetHandler to handle in order to invalidate the recovery data.