### PR TITLE
Introduce System roles based console scopes config structure

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -543,4 +543,18 @@ public class IdentityConstants {
         public final static String PROXY_CONTEXT = "ProxyContext";
         public final static String DEFAULT_CONTEXT = "DefaultContext";
     }
+
+    /**
+     * Contains the constants related to System roles configs elements.
+     */
+    public static class SystemRoles {
+
+        // System roles config element.
+        public static final String SYSTEM_ROLES_CONFIG_ELEMENT = "SystemRoles";
+        public static final String SYSTEM_ROLES_ENABLED_CONFIG_ELEMENT = "SystemRoles.Enabled";
+        public static final String ROLE_CONFIG_ELEMENT = "Role";
+        public static final String ROLE_NAME_CONFIG_ELEMENT = "Name";
+        public static final String ROLE_MANDATORY_SCOPES_CONFIG_ELEMENT = "MandatoryScopes";
+        public static final String ROLE_SCOPE_CONFIG_ELEMENT = "Scope";
+    }
 }

--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/RoleConstants.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/RoleConstants.java
@@ -51,9 +51,6 @@ public class RoleConstants {
     // Group related constants.
     public static final String ID_URI = "urn:ietf:params:scim:schemas:core:2.0:id";
 
-    // System roles config element.
-    public static final String SYSTEM_ROLES_CONFIG_ELEMENT = "SystemRoles";
-    public static final String ROLE_NAME_CONFIG_ELEMENT = "RoleName";
     /**
      * Grouping of constants related to database table names.
      */

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2610,10 +2610,18 @@
     {% endif %}
 
     <!-- System Roles -->
-    {% if system_roles.read_only_roles is defined %}
+    {% if system_roles is defined %}
     <SystemRoles>
+        <Enabled>{{system_roles.enable}}</Enabled>
         {% for role in system_roles.read_only_roles %}
-        <RoleName>{{role}}</RoleName>
+        <Role>
+            <Name>{{role.name}}</Name>
+            <MandatoryScopes>
+                {% for scope in role.scopes %}
+                <Scope>{{scope}}</Scope>
+                {% endfor %}
+            </MandatoryScopes>
+        </Role>
         {% endfor %}
     </SystemRoles>
     {% endif %}


### PR DESCRIPTION
### Proposed changes in this pull request

- Resolves https://github.com/wso2/product-is/issues/11696

- Below config structure has been introduced with this PR to configure the console scopes based on the system roles:
```
[system_roles]
enable = true
[[system_roles.read_only_roles]]
name ="Administrator"
scopes =["console:full"]
[[system_roles.read_only_roles]]
name ="Application Developer"
scopes =["console:applications", "console:idps"]
```
