### PR TITLE
Always use the super tenant cache for the authentication flow.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/AuthenticationBaseCache.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/AuthenticationBaseCache.java
@@ -105,19 +105,20 @@ public class AuthenticationBaseCache<K extends Serializable, V extends Serializa
 
     private static String getTenantDomainFromContext() {
 
+        // Due to the SaaS application use cases, we are reverting this.
         // We use the tenant domain set in context only in tenant qualified URL mode.
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-            String tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
-            if (StringUtils.isNotBlank(tenantDomain)) {
-                return tenantDomain;
-            } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("TenantQualifiedUrlsEnabled is enabled, but the tenant domain is not set to the" +
-                            " context. Hence using the tenant domain from the carbon context.");
-                }
-                return PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-            }
-        }
+//        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+//            String tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+//            if (StringUtils.isNotBlank(tenantDomain)) {
+//                return tenantDomain;
+//            } else {
+//                if (log.isDebugEnabled()) {
+//                    log.debug("TenantQualifiedUrlsEnabled is enabled, but the tenant domain is not set to the" +
+//                            " context. Hence using the tenant domain from the carbon context.");
+//                }
+//                return PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+//            }
+//        }
         return SUPER_TENANT_DOMAIN_NAME;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

Always use the super tenant cache for the authentication flow.