### PR TITLE
Fix SSO to console through myaccount

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -296,8 +296,8 @@ public class DefaultStepHandler implements StepHandler {
                 // Are there multiple authenticators?
                 if (authConfigList.size() > 1) {
                     sendToPage = true;
-                    // To identify whether the multi-option is available including an authentication flow handler.
-                    // If it is available it will directly redirect to that.
+                    /* To identify whether the multi-option is available including an authentication flow handler.
+                    If it is available it will directly redirect to that. */
                     for (AuthenticatorConfig config : authConfigList) {
                         if ((config.getApplicationAuthenticator() instanceof AuthenticationFlowHandler)) {
                             authenticatorConfig = config;
@@ -361,14 +361,14 @@ public class DefaultStepHandler implements StepHandler {
         diagnosticLog.info("Sending to the Multi Option page");
         Map<String, String> parameterMap = getAuthenticatorConfig().getParameterMap();
         String showAuthFailureReason = null;
-        if (parameterMap != null) {
+        if (MapUtils.isNotEmpty(parameterMap)) {
             showAuthFailureReason = parameterMap.get(FrameworkConstants.SHOW_AUTHFAILURE_RESON_CONFIG);
             if (log.isDebugEnabled()) {
                 log.debug("showAuthFailureReason has been set as : " + showAuthFailureReason);
             }
         }
         diagnosticLog.info("showAuthFailureReason has been set as : " + showAuthFailureReason);
-        String retryParam = "";
+        String retryParam = StringUtils.EMPTY;
 
         if (stepConfig.isRetrying()) {
             context.setCurrentAuthenticator(null);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -290,7 +290,7 @@ public class DefaultStepHandler implements StepHandler {
                 // Find if step contains only a single authenticator with a single
                 // IdP. If yes, don't send to the multi-option page. Call directly.
                 boolean sendToPage = false;
-                boolean isAuthenticationFlowHandler = false;
+                boolean isAuthenticationFlowHandlerInMultiStep = false;
                 AuthenticatorConfig authenticatorConfig = null;
 
                 // Are there multiple authenticators?
@@ -301,7 +301,7 @@ public class DefaultStepHandler implements StepHandler {
                     for (AuthenticatorConfig config : authConfigList) {
                         if ((config.getApplicationAuthenticator() instanceof AuthenticationFlowHandler)) {
                             authenticatorConfig = config;
-                            isAuthenticationFlowHandler = true;
+                            isAuthenticationFlowHandlerInMultiStep = true;
                             sendToPage = false;
                             break;
                         }
@@ -333,11 +333,10 @@ public class DefaultStepHandler implements StepHandler {
                     }
 
                     doAuthentication(request, response, context, authenticatorConfig);
-                    /* If an authentication flow handler is redirected with incomplete, it will redirect to
-                    multi option page, as multi-option is available */
-                    if (context.getParameter(FrameworkConstants.REDIRECTED_AUTHENTICATOR) ==
-                            authenticatorConfig.getApplicationAuthenticator().getName()
-                            && isAuthenticationFlowHandler) {
+                    /* If an authentication flow handler is redirected with incomplete status,
+                    it will redirect to multi option page, as multi-option is available */
+                    if ((request.getAttribute(FrameworkConstants.RequestParams.FLOW_STATUS)) ==
+                            AuthenticatorFlowStatus.INCOMPLETE && isAuthenticationFlowHandlerInMultiStep) {
                         sendToMultiOptionPage(stepConfig, request, context, response, authenticatorNames);
                     }
                     return;
@@ -628,7 +627,6 @@ public class DefaultStepHandler implements StepHandler {
 
             if (status == AuthenticatorFlowStatus.INCOMPLETE) {
                 context.setCurrentAuthenticator(authenticator.getName());
-                context.setProperty(FrameworkConstants.REDIRECTED_AUTHENTICATOR, authenticator.getName());
                 if (log.isDebugEnabled()) {
                     log.debug(authenticator.getName() + " is redirecting");
                 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -142,6 +142,8 @@ public abstract class FrameworkConstants {
 
     public static final String USER_TENANT_DOMAIN = "user-tenant-domain";
 
+    public static final String REDIRECTED_AUTHENTICATOR = "redirectedAuthenticator";
+
     private FrameworkConstants() {
 
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -142,8 +142,6 @@ public abstract class FrameworkConstants {
 
     public static final String USER_TENANT_DOMAIN = "user-tenant-domain";
 
-    public static final String REDIRECTED_AUTHENTICATOR = "redirectedAuthenticator";
-
     private FrameworkConstants() {
 
     }


### PR DESCRIPTION
### Purpose
With these PR changes, SSO to console through Myaccount issue will be resolved.

### Approach
With the previous implementation, it will check the already authenticated authenticator list and if the current step is already authenticated it will SSO to the application. But in the console, as we have configured, multi-option for the first step along with identifier-first, GitHub and Google and since we didn't authenticate from any of these from MyAccount it will prompt for multi-option page. Even though from My account, it will authenticate from the basic authenticator, the identifier first step will not include for the already authenticated category. Therefore identifier first will prompt the user along with the multi-option page.

With the PR changes, it will check whether the multi-option is available including an authentication flow handler. If so it will give priority to identifier first and execute, and if the authentication status is incomplete with identifier-first it will re-prompt for the multi-option page.

### Related issue
https://github.com/wso2-enterprise/asgardeo-product/issues/3717