### PR TITLE
Add support to configure portal hostnames and paths when tenant qualified urls enabled

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -26,6 +26,10 @@ public class IdentityCoreConstants {
     public static final String IDENTITY_DEFAULT_NAMESPACE = "http://wso2.org/projects/carbon/carbon.xml";
     public static final String HOST_NAME = "HostName";
     public static final String SERVER_HOST_NAME = "ServerHostName";
+    public static final String AUTHENTICATION_ENDPOINT_HOST_NAME = "AuthenticationEndpoint.HostName";
+    public static final String AUTHENTICATION_ENDPOINT_PATH = "AuthenticationEndpoint.Path";
+    public static final String RECOVERY_ENDPOINT_HOST_NAME = "RecoveryEndpoint.HostName";
+    public static final String RECOVERY_ENDPOINT_PATH = "RecoveryEndpoint.Path";
     public static final String FILE_NAME_REGEX = "FileNameRegEx";
     public static final String PORTS_OFFSET = "Ports.Offset";
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -79,6 +79,20 @@
     <!-- This configuration is to resolve the internal service URL for internal API calls. -->
     <ServerHostName>{{server.internal_hostname}}</ServerHostName>
 
+    <!--
+        Following configuration adds support to change hostnames and paths of authentication and recovery portals.
+        Note : These configurations works only when tenant qualified URLs are enabled. Otherwise use configurations
+        provided in application-authentication.xml
+    -->
+    <AuthenticationEndpoint>
+        <HostName>{{authenticationendpoint.hostname}}</HostName>
+        <Path>{{authenticationendpoint.path}}</Path>
+    </AuthenticationEndpoint>
+    <RecoveryEndpoint>
+        <HostName>{{recoveryendpoint.hostname}}</HostName>
+        <Path>{{recoveryendpoint.path}}</Path>
+    </RecoveryEndpoint>
+
     <Identity>
         <IssuerPolicy>{{identity.issuer_policy}}</IssuerPolicy>
         <TokenValidationPolicy>{{identity.token_validation_policy}}</TokenValidationPolicy>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -35,6 +35,10 @@
   "identity.token_validation_policy": "CertValidate",
 
   "server.internal_hostname": "localhost",
+  "authenticationendpoint.hostname": "$ref{server.hostname}",
+  "authenticationendpoint.path": "/authenticationendpoint",
+  "recoveryendpoint.hostname" : "$ref{server.hostname}",
+  "recoveryendpoint.path" : "/recoveryendpoint",
 
   "service_provider.sp_name_regex": "^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$",
 


### PR DESCRIPTION
### Proposed changes in this pull request
This PR adds support to configure hostname and path for authentication-portal and recovery-portal when tenant qualified URLs are enabled. Following deployment.toml configurations can be used to change the hostnames and paths of authentication-portal and recovery-portal.

```
[authenticationendpoint]
hostname ="local.accounts.wso2.com"
path ="/authenticationendpoint"

[recoveryendpoint]
hostname ="local.accounts.wso2.com"
path ="/recoveryendpoint"
```