### PR TITLE
Add authenticated user null check before assign to JsClamis attributes

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsClaims.java
@@ -87,10 +87,12 @@ public class JsClaims extends AbstractJSContextMemberObject {
     public void initializeContext(AuthenticationContext context) {
 
         super.initializeContext(context);
-        if (StringUtils.isNotBlank(idp) && getContext().getCurrentAuthenticatedIdPs().containsKey(idp)) {
-            this.authenticatedUser = getContext().getCurrentAuthenticatedIdPs().get(idp).getUser();
-        } else {
-            this.authenticatedUser = getAuthenticatedUserFromSubjectIdentifierStep();
+        if (this.authenticatedUser == null) {
+            if (StringUtils.isNotBlank(idp) && getContext().getCurrentAuthenticatedIdPs().containsKey(idp)) {
+                this.authenticatedUser = getContext().getCurrentAuthenticatedIdPs().get(idp).getUser();
+            } else {
+                this.authenticatedUser = getAuthenticatedUserFromSubjectIdentifierStep();
+            }
         }
     }
 


### PR DESCRIPTION


Fixes https://github.com/wso2/product-is/issues/11777

If a federated user in secondary user store, taking authenticated from step config is wrong,(it will give federated user without proper user domain, will fail for secondary user domain).

Fix- add a null check before reassigning the class attribute.