### PR TITLE
Add default property get TOTP re-enrollment valid time period to TOTP authenticator config properties

### DIFF
--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -165,6 +165,7 @@
   "authentication.authenticator.totp.parameters.useEventHandlerBasedEmailSender": true,
   "authentication.authenticator.totp.parameters.encodingMethod": "Base32",
   "authentication.authenticator.totp.parameters.timeStepSize": "30",
+  "authentication.authenticator.totp.parameters.reEnrollmentValidityPeriod": "300",
   "authentication.authenticator.totp.parameters.windowSize": "3",
   "authentication.authenticator.totp.parameters.authenticationMandatory": true,
   "authentication.authenticator.totp.parameters.enrolUserInAuthenticationFlow": true,


### PR DESCRIPTION
### Proposed changes in this pull request

Add default property to TOTP authenticator config properties get TOTP re-enrollment valid time period to expire the WR code scan option based on that.

This can be configured through deployment.toml file as follows.
```
[authentication.authenticator.totp.parameters]
reEnrollmentValidityPeriod = 120
```
Related issue: https://github.com/wso2-enterprise/asgardeo-product/issues/3838
Related PR: https://github.com/wso2-extensions/identity-outbound-auth-totp/pull/100