### PR TITLE
Change CACHE_MANAGER_NAME to IdentityApplicationManagementCacheManager

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/cache/BaseCache.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/cache/BaseCache.java
@@ -47,7 +47,7 @@ import javax.cache.Caching;
 public abstract class BaseCache<K extends Serializable, V extends Serializable> {
 
     private static final Log log = LogFactory.getLog(BaseCache.class);
-    private static final String CACHE_MANAGER_NAME = "IdentityCacheManager";
+    private static final String CACHE_MANAGER_NAME = "IdentityApplicationManagementCacheManager";
     private CacheBuilder<K, V> cacheBuilder;
     private final List<AbstractCacheListener<K, V>> cacheListeners;
     private String cacheName;


### PR DESCRIPTION
### Proposed changes in this pull request

- Change CACHE_MANAGER_NAME to IdentityApplicationManagementCacheManager
- This is because we still have the cache manager name as IdentityApplicationManagementCacheManager https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2#L1517

