### PR TITLE
Clear only the username from runtime params when Back to first step by use a different account

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -260,7 +260,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                         context.setProperty(BACK_TO_FIRST_STEP, true);
                         Map<String, String> runtimeParams =
                                 context.getAuthenticatorParams(FrameworkConstants.JSAttributes.JS_COMMON_OPTIONS);
-                        runtimeParams.clear();
+                        runtimeParams.put(FrameworkConstants.JSAttributes.JS_OPTIONS_USERNAME, null);
                         FrameworkUtils.resetAuthenticationContext(context);
                         returning = false;
 


### PR DESCRIPTION
### Proposed changes in this pull request
Fixes https://github.com/wso2-enterprise/asgardeo-product/issues/4050

`runtimeParams` contains authenticatorParams like `skipIdentifierPreProcess`, `allowSuperTenantUserLogin` which will be populated only when building the `JsGraphBuilder` creation.

Those shouldn't be removed from this step.
Username is set at Identifier first execution. It is used to display the username in basic authentication step. So https://github.com/wso2-extensions/identity-local-auth-basicauth/blob/8837d39352cf5d102bcb36472ef3ed7932bf1604/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java#L456

