### PR TITLE
Fix same sql query executed more than one time in single flow 

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
@@ -171,6 +171,13 @@ public class SSOConsentServiceImpl implements SSOConsentService {
 
         ClaimMapping[] claimMappings = getSpClaimMappings(serviceProvider);
 
+        if (claimMappings == null || claimMappings.length == 0) {
+            if (log.isDebugEnabled()) {
+                log.debug("No claim mapping configured from the application. Hence skipping getting consent.");
+            }
+            return new ConsentClaimsData();
+        }
+
         List<String> requestedClaims = new ArrayList<>();
         List<String> mandatoryClaims = new ArrayList<>();
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
@@ -358,10 +358,13 @@ public class SSOConsentServiceImpl implements SSOConsentService {
         List<ClaimMetaData> claimsWithConsent;
         List<ClaimMetaData> claimsDeniedConsent;
         if (!overrideExistingConsent) {
+            String spName = serviceProvider.getApplicationName();
+            String spTenantDomain = getSPTenantDomain(serviceProvider);
+            Receipt receipt = getConsentReceiptOfUser(serviceProvider, authenticatedUser, spName, spTenantDomain, subject);
             claimsWithConsent =
-                    getUserRequestedClaims(serviceProvider, authenticatedUser, userConsent, true);
+                    getUserRequestedClaims(receipt, userConsent, true);
             claimsDeniedConsent =
-                    getUserRequestedClaims(serviceProvider, authenticatedUser, userConsent, false);
+                    getUserRequestedClaims(receipt, userConsent, false);
         } else {
             claimsWithConsent = userConsent.getApprovedClaims();
             claimsDeniedConsent = userConsent.getDisapprovedClaims();
@@ -733,10 +736,8 @@ public class SSOConsentServiceImpl implements SSOConsentService {
         return userConsent;
     }
 
-    private List<ClaimMetaData> getUserRequestedClaims(ServiceProvider serviceProvider,
-                                                       AuthenticatedUser authenticatedUser,
-                                                       UserConsent userConsent, boolean isConsented)
-            throws SSOConsentServiceException {
+    private List<ClaimMetaData> getUserRequestedClaims(Receipt receipt,
+                                                       UserConsent userConsent, boolean isConsented) {
 
         List<ClaimMetaData> requestedClaims = new ArrayList<>();
         if (isConsented) {
@@ -744,11 +745,6 @@ public class SSOConsentServiceImpl implements SSOConsentService {
         } else {
             requestedClaims.addAll(userConsent.getDisapprovedClaims());
         }
-
-        String spName = serviceProvider.getApplicationName();
-        String spTenantDomain = getSPTenantDomain(serviceProvider);
-        String subject = buildSubjectWithUserStoreDomain(authenticatedUser);
-        Receipt receipt = getConsentReceiptOfUser(serviceProvider, authenticatedUser, spName, spTenantDomain, subject);
         if (receipt == null) {
             return requestedClaims;
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
@@ -353,6 +353,13 @@ public class SSOConsentServiceImpl implements SSOConsentService {
             logDebug("User: " + authenticatedUser.getAuthenticatedSubjectIdentifier() + " has approved consent.");
         }
         UserConsent userConsent = processUserConsent(consentApprovedClaimIds, consentClaimsData);
+        if (isEmpty(userConsent.getApprovedClaims()) && isEmpty(userConsent.getDisapprovedClaims())) {
+            if (isDebugEnabled()) {
+                logDebug("User: " + authenticatedUser.getAuthenticatedSubjectIdentifier() + " has not provided new " +
+                        "approved/disapproved consent. Hence skipping the consent progress.");
+            }
+            return;
+        }
         String subject = buildSubjectWithUserStoreDomain(authenticatedUser);
 
         List<ClaimMetaData> claimsWithConsent;


### PR DESCRIPTION
### Proposed changes in this pull request

- Fix same SQL query executed more than one time in a single flow 

The following query was executed 2 times inside processConsent method,
```
SELECT CONSENT_RECEIPT_ID, LANGUAGE, PII_PRINCIPAL_ID, PRINCIPAL_TENANT_ID, STATE, SP_DISPLAY_NAME, SP_DESCRIPTION FROM (SELECT R.CONSENT_RECEIPT_ID, R.LANGUAGE, R.PII_PRINCIPAL_ID, R.PRINCIPAL_TENANT_ID, R.STATE, RS.SP_DISPLAY_NAME, RS.SP_DESCRIPTION, ROW_NUMBER() OVER ( ORDER BY R.CONSENT_RECEIPT_ID) AS ROWNUM FROM CM_RECEIPT R INNER JOIN CM_RECEIPT_SP_ASSOC RS ON R.CONSENT_RECEIPT_ID = RS.CONSENT_RECEIPT_ID WHERE PII_PRINCIPAL_ID LIKE 'CONSUMER/istestuser_1' AND PRINCIPAL_TENANT_ID = 3 AND SP_NAME LIKE 'app_1dummyperftenant1' AND SP_TENANT_ID LIKE 3 AND STATE LIKE 'ACTIVE') AS RES WHERE RES.ROWNUM BETWEEN 1 AND 2
```
Fix https://github.com/wso2/product-is/issues/11886

This PR has the following improvement
- If the SP did not have the claim mapping configured skip getting the consent from the DB
- If there is no newly added approved/disapproved consent skip processing the consent

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
