### PR TITLE
Fix Concurrent SSO requests fail with primary key violation

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -688,7 +688,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
         try {
             // AppId is the auto generated id for the applications and it should be a positive integer.
             if (appId > 0) {
-                UserSessionStore.getInstance().storeAppSessionDataIfNotExist(sessionContextKey, subject, appId, inboundAuth);
+                UserSessionStore.getInstance().storeAppSessionData(sessionContextKey, subject, appId, inboundAuth);
             }
         } catch (DataAccessException e) {
             throw new UserSessionException("Error while storing Application session data in the database.", e);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
@@ -77,8 +77,37 @@ public class SQLQueries {
     // Retrieve application id given the name and the tenant id.
     public static final String SQL_SELECT_APP_ID_OF_APP = "SELECT ID FROM SP_APP WHERE APP_NAME =? AND TENANT_ID =?";
 
-    public static final String SQL_STORE_IDN_AUTH_SESSION_APP_INFO =
-            "INSERT INTO IDN_AUTH_SESSION_APP_INFO(SESSION_ID,SUBJECT,APP_ID,INBOUND_AUTH_TYPE)VALUES (?,?,?,?)";
+    public static final String SQL_STORE_IDN_AUTH_SESSION_APP_INFO_H2 =
+            "MERGE INTO IDN_AUTH_SESSION_APP_INFO KEY(SESSION_ID,SUBJECT,APP_ID,INBOUND_AUTH_TYPE) VALUES(?, ?, ?, ?)";
+
+    public static final String SQL_STORE_IDN_AUTH_SESSION_APP_INFO_MSSQL_OR_DB2 =
+            "MERGE INTO IDN_AUTH_SESSION_APP_INFO T USING " +
+                    "(VALUES(?, ?, ?, ?)) S (SESSION_ID,SUBJECT,APP_ID,INBOUND_AUTH_TYPE) " +
+                    "ON (T.SESSION_ID = S.SESSION_ID AND " +
+                    "T.SUBJECT = S.SUBJECT AND " +
+                    "T.APP_ID = S.APP_ID AND " +
+                    "T.INBOUND_AUTH_TYPE = S.INBOUND_AUTH_TYPE ) " +
+                    "WHEN NOT MATCHED THEN INSERT (SESSION_ID,SUBJECT,APP_ID,INBOUND_AUTH_TYPE) " +
+                    "VALUES (S.SESSION_ID,S.SUBJECT,S.APP_ID,S.INBOUND_AUTH_TYPE);";
+
+    public static final String SQL_STORE_IDN_AUTH_SESSION_APP_INFO_MYSQL_OR_MARIADB =
+            "INSERT INTO IDN_AUTH_SESSION_APP_INFO(SESSION_ID,SUBJECT,APP_ID,INBOUND_AUTH_TYPE)VALUES " +
+                    "(?, ?, ?, ?) " +
+                    "ON DUPLICATE KEY UPDATE " +
+                    "SESSION_ID= VALUES(SESSION_ID), SUBJECT= VALUES(SUBJECT), APP_ID = VALUES(APP_ID), " +
+                    "INBOUND_AUTH_TYPE = VALUES(INBOUND_AUTH_TYPE);";
+
+    public static final String SQL_STORE_IDN_AUTH_SESSION_APP_INFO_POSTGRES =
+            "INSERT INTO IDN_AUTH_SESSION_APP_INFO(SESSION_ID,SUBJECT,APP_ID,INBOUND_AUTH_TYPE)VALUES (?, ?, ?, ?) " +
+                    "ON CONFLICT(SESSION_ID,SUBJECT,APP_ID,INBOUND_AUTH_TYPE) DO UPDATE SET " +
+                    "SESSION_ID = EXCLUDED.SESSION_ID, SUBJECT = EXCLUDED.SUBJECT, APP_ID = EXCLUDED.APP_ID, " +
+                    "INBOUND_AUTH_TYPE = EXCLUDED.INBOUND_AUTH_TYPE;";
+
+    public static final String SQL_STORE_IDN_AUTH_SESSION_APP_INFO_ORACLE =
+            "MERGE INTO IDN_AUTH_SESSION_APP_INFO USING dual ON " +
+                    "(SESSION_ID = ? AND SUBJECT = ? AND APP_ID = ? AND INBOUND_AUTH_TYPE = ?) " +
+                    "WHEN NOT MATCHED THEN INSERT (SESSION_ID, SUBJECT, APP_ID, INBOUND_AUTH_TYPE) " +
+                    "VALUES (?, ?, ?, ?)";
 
     public static final String SQL_CHECK_IDN_AUTH_SESSION_APP_INFO =
             "SELECT 1 FROM IDN_AUTH_SESSION_APP_INFO WHERE SESSION_ID =? AND SUBJECT =? AND APP_ID =? AND " +

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -142,6 +142,17 @@ public abstract class FrameworkConstants {
 
     public static final String USER_TENANT_DOMAIN = "user-tenant-domain";
 
+    // DB product names.
+    public static final String MY_SQL = "MySQL";
+    public static final String MARIA_DB = "MariaDB";
+    public static final String POSTGRE_SQL = "PostgreSQL";
+    public static final String DB2 = "DB2";
+    public static final String MICROSOFT = "Microsoft";
+    public static final String S_MICROSOFT = "microsoft";
+    public static final String INFORMIX = "Informix";
+    public static final String H2 = "H2";
+    public static final String ORACLE = "Oracle";
+
     private FrameworkConstants() {
 
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/JdbcUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/JdbcUtils.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.application.authentication.framework.util;
 
 import org.wso2.carbon.database.utils.jdbc.JdbcTemplate;
+import org.wso2.carbon.database.utils.jdbc.exceptions.DataAccessException;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 
 import javax.sql.DataSource;
@@ -37,5 +38,96 @@ public class JdbcUtils {
 
         DataSource dataSource = IdentityDatabaseUtil.getDataSource();
         return new JdbcTemplate(dataSource);
+    }
+
+
+    /**
+     * Check whether the DB type string contains in the driver name or db product name.
+     *
+     * @param dbType database type string.
+     * @return true if the database type matches the driver type, false otherwise.
+     * @throws DataAccessException if error occurred while checking the DB metadata.
+     */
+    private static boolean isDBTypeOf(String dbType) throws DataAccessException {
+
+        JdbcTemplate jdbcTemplate = JdbcUtils.getNewTemplate();
+        return jdbcTemplate.getDriverName().contains(dbType) || jdbcTemplate.getDatabaseProductName().contains(dbType);
+    }
+
+    /**
+     * Check if the DB is H2.
+     *
+     * @return true if DB is H2.
+     * @throws DataAccessException if error occurred while checking the DB metadata.
+     */
+    public static boolean isH2() throws DataAccessException {
+
+        return isDBTypeOf(FrameworkConstants.H2);
+    }
+
+    /**
+     * Check if the DB is MySQL.
+     *
+     * @return true if DB is MySQL.
+     * @throws DataAccessException if error occurred while checking the DB metadata.
+     */
+    public static boolean isMySQLDB() throws DataAccessException {
+
+        return isDBTypeOf(FrameworkConstants.MY_SQL);
+    }
+
+    /**
+     * Check if the DB is Maria DB.
+     *
+     * @return true if DB is Maria DB.
+     * @throws DataAccessException if error occurred while checking the DB metadata.
+     */
+    public static boolean isMariaDB() throws DataAccessException {
+
+        return isDBTypeOf(FrameworkConstants.MARIA_DB);
+    }
+
+    /**
+     * Check if the DB is DB2.
+     *
+     * @return true if DB2, false otherwise.
+     * @throws DataAccessException if error occurred while checking the DB metadata.
+     */
+    public static boolean isDB2DB() throws DataAccessException {
+
+        return isDBTypeOf(FrameworkConstants.DB2);
+    }
+
+    /**
+     * Check if the DB is PostgreSQL.
+     *
+     * @return true if DB is PostgreSQL, false otherwise.
+     * @throws DataAccessException if error occurred while checking the DB metadata.
+     */
+    public static boolean isPostgreSQLDB() throws DataAccessException {
+
+        return isDBTypeOf(FrameworkConstants.POSTGRE_SQL);
+    }
+
+    /**
+     * Check if the DB is MSSql.
+     *
+     * @return true if DB is MSSql, false otherwise.
+     * @throws DataAccessException if error occurred while checking the DB metadata.
+     */
+    public static boolean isMSSqlDB() throws DataAccessException {
+
+        return isDBTypeOf(FrameworkConstants.MICROSOFT) || isDBTypeOf(FrameworkConstants.S_MICROSOFT);
+    }
+
+    /**
+     * Check if the DB is Oracle.
+     *
+     * @return true if DB is Oracle, false otherwise.
+     * @throws DataAccessException if error occurred while checking the DB metadata.
+     */
+    public static boolean isOracleDB() throws DataAccessException {
+
+        return isDBTypeOf(FrameworkConstants.ORACLE);
     }
 }


### PR DESCRIPTION
Fixes :  https://github.com/wso2/product-is/issues/9945

**Issue** : 
When two SSO requests come to IS at the same time, a primary key violation occurs while trying to insert a record into IDN_AUTH_SESSION_APP_INFO table. 

**Cause** : 

- IDN_AUTH_SESSION_APP_INFO has 4 columns and all 4 are PRIMARY KEY (SESSION_ID, SUBJECT, APP_ID, INBOUND_AUTH_TYPE).
- When 2 Concurrent SSO request comes, due to our existing flow it tries to read if there any data for corresponding (SESSION_ID, SUBJECT, APP_ID, INBOUND_AUTH_TYPE) in the database in a transaction and write the data using another transaction. 
- Problem is Since we are using 2 transactions, this is not a **thread safe**. 

**Fix** : 

- Rather than using 2 traction,  we can use one with insert/update queries.

**Tested DB**

- MSSQL
- MySQL
- Oracle
- DB2
- H2
- Postgres

**Note** : 

- storeAppSessionDataIfNotExist method, s deleted to  protect the flow from Primary Key violation in future.