### PR TITLE
Adding new events to capture failed login attempts

### DIFF
--- a/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
@@ -190,8 +190,6 @@ public class IdentityEventConstants {
         public static final String POST_ADD_EXTERNAL_CLAIM = "POST_ADD_EXTERNAL_CLAIM";
         public static final String POST_UPDATE_EXTERNAL_CLAIM = "POST_UPDATE_EXTERNAL_CLAIM";
         public static final String POST_DELETE_EXTERNAL_CLAIM = "POST_DELETE_EXTERNAL_CLAIM";
-        public static final String FAILED_LOGIN_ATTEMPT = "FAILED_LOGIN_ATTEMPT";
-        public static final String SUCCESSFUL_LOGIN_ATTEMPT = "SUCCESSFUL_LOGIN_ATTEMPT";
     }
 
     /**

--- a/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
@@ -190,6 +190,8 @@ public class IdentityEventConstants {
         public static final String POST_ADD_EXTERNAL_CLAIM = "POST_ADD_EXTERNAL_CLAIM";
         public static final String POST_UPDATE_EXTERNAL_CLAIM = "POST_UPDATE_EXTERNAL_CLAIM";
         public static final String POST_DELETE_EXTERNAL_CLAIM = "POST_DELETE_EXTERNAL_CLAIM";
+        public static final String FAILED_LOGIN_ATTEMPT = "FAILED_LOGIN_ATTEMPT";
+        public static final String SUCCESSFUL_LOGIN_ATTEMPT = "SUCCESSFUL_LOGIN_ATTEMPT";
     }
 
     /**
@@ -297,6 +299,8 @@ public class IdentityEventConstants {
         public static final String OLD_CLAIM_DIALECT_URI = "oldClaimDialectUri";
         public static final String NEW_CLAIM_DIALECT_URI = "newClaimDialectUri";
         public static final String EXTERNAL_CLAIM_PROPERTIES = "externalClaimProperties";
+        public static final String PROPERTY_FAILED_LOGIN_ATTEMPTS_CLAIM = "PropertyFailedLoginAttemptsClaim";
+        public static final String AUTHENTICATOR_NAME = "authenticatorName";
     }
 
     public class ErrorMessage {


### PR DESCRIPTION
### Proposed changes in this pull request
Adding two new events to capture the failed scenario in MF authenticators such as EMAIL OTP etc.

### Follow up actions
- [ ] Bump framework version in IS
- [ ] Bump framewrok version in account lock handler via https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/92 and merge the PR