### PR TITLE
Federated user id as the username of the provisioned user

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -220,7 +220,9 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                     need to write a provisioning handler extending the "DefaultProvisioningHandler".
                      */
                     UserCoreUtil.setSkipPasswordPatternValidationThreadLocal(true);
-                    setSource(tenantDomain, idp, userClaims);
+                    if (FrameworkUtils.isEnhancedFeature()) {
+                        setSource(tenantDomain, idp, userClaims);
+                    }
                     userStoreManager.addUser(username, password, null, userClaims, null);
                 } catch (UserStoreException e) {
                     // Add user operation will fail if a user operation workflow is already defined for the same user.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -66,7 +66,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.InternalRoleDomains.APPLICATION_DOMAIN;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.InternalRoleDomains.WORKFLOW_DOMAIN;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USERNAME_CLAIM;
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.PROVISIONED_SOURCE_CLAIM;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.PROVISIONED_SOURCE_ID_CLAIM;
 
 public class DefaultProvisioningHandler implements ProvisioningHandler {
 
@@ -220,8 +220,8 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                     need to write a provisioning handler extending the "DefaultProvisioningHandler".
                      */
                     UserCoreUtil.setSkipPasswordPatternValidationThreadLocal(true);
-                    if (FrameworkUtils.isEnhancedFeature()) {
-                        setSource(tenantDomain, idp, userClaims);
+                    if (FrameworkUtils.isJitProvisionEnhancedFeature()) {
+                        setJitProvisionedSource(tenantDomain, idp, userClaims);
                     }
                     userStoreManager.addUser(username, password, null, userClaims, null);
                 } catch (UserStoreException e) {
@@ -600,13 +600,13 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
      * @param userClaims   User claims.
      * @throws FrameworkException If an error occurs while retrieving the resource id of the identity provider.
      */
-    private void setSource(String tenantDomain, String idpName, Map<String, String> userClaims)
+    private void setJitProvisionedSource(String tenantDomain, String idpName, Map<String, String> userClaims)
             throws FrameworkException {
 
         try {
             String idpId = IdentityProviderManager.getInstance().getIdPByName(idpName, tenantDomain,
                     true).getResourceId();
-            userClaims.put(PROVISIONED_SOURCE_CLAIM, idpId);
+            userClaims.put(PROVISIONED_SOURCE_ID_CLAIM, idpId);
         } catch (IdentityProviderManagementException e) {
             throw new FrameworkException("Error while getting the federated IDP name of the IDP: "
                     + idpName + "in the tenant: " + tenantDomain, e);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -40,6 +40,8 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.constant.FederatedAssociationConstants;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.exception.FederatedAssociationManagerException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
@@ -64,6 +66,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.InternalRoleDomains.APPLICATION_DOMAIN;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.InternalRoleDomains.WORKFLOW_DOMAIN;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USERNAME_CLAIM;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.PROVISIONED_SOURCE_CLAIM;
 
 public class DefaultProvisioningHandler implements ProvisioningHandler {
 
@@ -217,6 +220,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                     need to write a provisioning handler extending the "DefaultProvisioningHandler".
                      */
                     UserCoreUtil.setSkipPasswordPatternValidationThreadLocal(true);
+                    setSource(tenantDomain, idp, userClaims);
                     userStoreManager.addUser(username, password, null, userClaims, null);
                 } catch (UserStoreException e) {
                     // Add user operation will fail if a user operation workflow is already defined for the same user.
@@ -584,6 +588,27 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
         deletingRoles.remove(realm.getRealmConfiguration().getEveryOneRoleName());
 
         return deletingRoles;
+    }
+
+    /**
+     * Set the identity provider's resource id as the source of the provisioned user.
+     *
+     * @param tenantDomain Tenant domain.
+     * @param idpName      Identity provider name.
+     * @param userClaims   User claims.
+     * @throws FrameworkException If an error occurs while retrieving the resource id of the identity provider.
+     */
+    private void setSource(String tenantDomain, String idpName, Map<String, String> userClaims)
+            throws FrameworkException {
+
+        try {
+            String idpId = IdentityProviderManager.getInstance().getIdPByName(idpName, tenantDomain,
+                    true).getResourceId();
+            userClaims.put(PROVISIONED_SOURCE_CLAIM, idpId);
+        } catch (IdentityProviderManagementException e) {
+            throw new FrameworkException("Error while getting the federated IDP name of the IDP: "
+                    + idpName + "in the tenant: " + tenantDomain, e);
+        }
     }
 
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -220,7 +220,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                     need to write a provisioning handler extending the "DefaultProvisioningHandler".
                      */
                     UserCoreUtil.setSkipPasswordPatternValidationThreadLocal(true);
-                    if (FrameworkUtils.isJitProvisionEnhancedFeature()) {
+                    if (FrameworkUtils.isJitProvisionEnhancedFeatureEnabled()) {
                         setJitProvisionedSource(tenantDomain, idp, userClaims);
                     }
                     userStoreManager.addUser(username, password, null, userClaims, null);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -333,7 +333,7 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
 
         String username;
         // If JIT provisioning enhanced feature is enabled set the federated ID as the federated username.
-        if (FrameworkUtils.isJitProvisionEnhancedFeature()) {
+        if (FrameworkUtils.isJitProvisionEnhancedFeatureEnabled()) {
             username = getFederatedUsername(sequenceConfig.getAuthenticatedUser().getUserName(),
                     externalIdPConfigName, context);
         } else {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.client.utils.URIBuilder;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.wso2.carbon.consent.mgt.core.ConsentManager;
@@ -60,8 +59,6 @@ import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
-import org.wso2.carbon.identity.user.profile.mgt.UserProfileAdmin;
-import org.wso2.carbon.identity.user.profile.mgt.UserProfileException;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.exception.FederatedAssociationManagerException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
@@ -70,12 +67,9 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.user.core.service.RealmService;
-import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
-import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -84,7 +78,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.application.authentication.framework.handler.request.PostAuthnHandlerFlowStatus.SUCCESS_COMPLETED;
-import static org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.constant.SSOConsentConstants.USERNAME_CLAIM;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Config.SEND_ONLY_LOCALLY_MAPPED_ROLES_OF_IDP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_GETTING_IDP_BY_NAME;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_GETTING_REALM_IN_POST_AUTHENTICATION;
@@ -196,8 +189,7 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                         combinedLocalClaims
                                 .put(FrameworkConstants.PASSWORD, request.getParameter(FrameworkConstants.PASSWORD));
                     }
-                    String username;
-                    username = getUsernameFederatedUser(sequenceConfig, externalIdPConfigName, context);
+                    String username = getUsernameFederatedUser(sequenceConfig, externalIdPConfigName, context);
                     if (context.getProperty(FrameworkConstants.CHANGING_USERNAME_ALLOWED) != null) {
                         username = request.getParameter(FrameworkConstants.USERNAME);
                     }
@@ -320,7 +312,9 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                             return PostAuthnHandlerFlowStatus.INCOMPLETE;
                         }
                     }
-                    username = getUsernameFederatedUser(sequenceConfig, externalIdPConfigName, context);
+                    if (StringUtils.isEmpty(username)) {
+                        username = getUsernameFederatedUser(sequenceConfig, externalIdPConfigName, context);
+                    }
                     if (log.isDebugEnabled()) {
                         log.debug("User : " + sequenceConfig.getAuthenticatedUser().getLoggableUserId()
                                 + " coming from " + externalIdPConfig.getIdPName()
@@ -339,7 +333,7 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
 
         String username;
         // If JIT provisioning enhanced feature is enabled set the federated ID as the federated username.
-        if (FrameworkUtils.isEnhancedFeature()) {
+        if (FrameworkUtils.isJitProvisionEnhancedFeature()) {
             username = getFederatedUsername(sequenceConfig.getAuthenticatedUser().getUserName(),
                     externalIdPConfigName, context);
         } else {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -197,12 +197,7 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                                 .put(FrameworkConstants.PASSWORD, request.getParameter(FrameworkConstants.PASSWORD));
                     }
                     String username;
-                    if (FrameworkUtils.isEnhancedFeature()) {
-                        username = getFederatedUsername(sequenceConfig.getAuthenticatedUser().getUserName(),
-                                externalIdPConfigName, context);
-                    } else {
-                        username = sequenceConfig.getAuthenticatedUser().getUserName();
-                    }
+                    username = getUsernameFederatedUser(sequenceConfig, externalIdPConfigName, context);
                     if (context.getProperty(FrameworkConstants.CHANGING_USERNAME_ALLOWED) != null) {
                         username = request.getParameter(FrameworkConstants.USERNAME);
                     }
@@ -317,16 +312,7 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                         }
 
                         if (externalIdPConfig.isPromptConsentEnabled()) {
-                            /*
-                            If JIT provisioning enhanced feature is enabled set the federated ID as the
-                            federated username.
-                             */
-                            if (FrameworkUtils.isEnhancedFeature()) {
-                                username = getFederatedUsername(sequenceConfig.getAuthenticatedUser().getUserName(),
-                                        externalIdPConfigName, context);
-                            } else {
-                                username = sequenceConfig.getAuthenticatedUser().getUserName();
-                            }
+                            username = getUsernameFederatedUser(sequenceConfig, externalIdPConfigName, context);
                             redirectToAccountCreateUI(externalIdPConfig, context, localClaimValues, response,
                                     username, request);
                             // Set the property to make sure the request is a returning one.
@@ -334,6 +320,7 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                             return PostAuthnHandlerFlowStatus.INCOMPLETE;
                         }
                     }
+                    username = getUsernameFederatedUser(sequenceConfig, externalIdPConfigName, context);
                     if (log.isDebugEnabled()) {
                         log.debug("User : " + sequenceConfig.getAuthenticatedUser().getLoggableUserId()
                                 + " coming from " + externalIdPConfig.getIdPName()
@@ -345,6 +332,20 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
             }
         }
         return SUCCESS_COMPLETED;
+    }
+
+    private String getUsernameFederatedUser(SequenceConfig sequenceConfig, String externalIdPConfigName,
+                                            AuthenticationContext context) throws PostAuthenticationFailedException {
+
+        String username;
+        // If JIT provisioning enhanced feature is enabled set the federated ID as the federated username.
+        if (FrameworkUtils.isEnhancedFeature()) {
+            username = getFederatedUsername(sequenceConfig.getAuthenticatedUser().getUserName(),
+                    externalIdPConfigName, context);
+        } else {
+            username = sequenceConfig.getAuthenticatedUser().getUserName();
+        }
+        return username;
     }
     
     private String getFederatedUsername(String username, String idpName, AuthenticationContext context)

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -38,6 +38,7 @@ public abstract class FrameworkConstants {
     public static final String ACCOUNT_DISABLED_CLAIM_URI = "http://wso2.org/claims/identity/accountDisabled";
     public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
     public static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
+    public static final String PROVISIONED_SOURCE_CLAIM = "http://wso2.org/claims/identity/userSource";
     public static final String UNFILTERED_LOCAL_CLAIM_VALUES = "UNFILTERED_LOCAL_CLAIM_VALUES";
     public static final String UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES = "UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES";
     public static final String UNFILTERED_IDP_CLAIM_VALUES = "UNFILTERED_IDP_CLAIM_VALUES";
@@ -103,6 +104,8 @@ public abstract class FrameworkConstants {
     public static final String MAPPED_ATTRIBUTES = "MappedAttributes";
     public static final String IDP_ID = "idpId";
     public static final String ASSOCIATED_ID = "associatedID";
+
+    public static final String SECRET_KEY_CLAIM_URL = "http://wso2.org/claims/identity/secretkey";
 
     public static final String JIT_PROVISIONING_FLOW = "JITProvisioningFlow";
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -106,6 +106,7 @@ public abstract class FrameworkConstants {
     public static final String ASSOCIATED_ID = "associatedID";
 
     public static final String SECRET_KEY_CLAIM_URL = "http://wso2.org/claims/identity/secretkey";
+    public static final String ENABLE_ENHANCE_FEATURE = "JITProvisioning.EnableEnhancedFeature";
 
     public static final String JIT_PROVISIONING_FLOW = "JITProvisioningFlow";
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -38,7 +38,7 @@ public abstract class FrameworkConstants {
     public static final String ACCOUNT_DISABLED_CLAIM_URI = "http://wso2.org/claims/identity/accountDisabled";
     public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
     public static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
-    public static final String PROVISIONED_SOURCE_CLAIM = "http://wso2.org/claims/identity/userSource";
+    public static final String PROVISIONED_SOURCE_ID_CLAIM = "http://wso2.org/claims/identity/userSourceId";
     public static final String UNFILTERED_LOCAL_CLAIM_VALUES = "UNFILTERED_LOCAL_CLAIM_VALUES";
     public static final String UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES = "UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES";
     public static final String UNFILTERED_IDP_CLAIM_VALUES = "UNFILTERED_IDP_CLAIM_VALUES";
@@ -106,7 +106,7 @@ public abstract class FrameworkConstants {
     public static final String ASSOCIATED_ID = "associatedID";
 
     public static final String SECRET_KEY_CLAIM_URL = "http://wso2.org/claims/identity/secretkey";
-    public static final String ENABLE_ENHANCE_FEATURE = "JITProvisioning.EnableEnhancedFeature";
+    public static final String ENABLE_JIT_PROVISION_ENHANCE_FEATURE = "JITProvisioning.EnableEnhancedFeature";
 
     public static final String JIT_PROVISIONING_FLOW = "JITProvisioningFlow";
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkErrorConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkErrorConstants.java
@@ -56,6 +56,7 @@ public class FrameworkErrorConstants {
         ERROR_WHILE_SETTING_IDP_DATA("80015", "Error while setting IDP data for tenant domain, %s"),
         ERROR_WHILE_SETTING_IDP_DATA_IDP_IS_NULL("80016", "Resident IDP is null for the tenant domain, %s"),
         ERROR_WHILE_HANDLING_CLAIM_MAPPINGS("80017", "Error while handling claim mappings"),
+        ERROR_WHILE_GETTING_FEDERATED_USERNAME("80018", "Error while getting the federated username"),
         MISMATCHING_TENANT_DOMAIN("AFW-60001",
                 "Service Provider tenant domain must be equal to user tenant domain for non-SaaS applications"),
         SYSTEM_ERROR_WHILE_AUTHENTICATING("AFW-65001", "System error while authenticating");

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -3038,10 +3038,12 @@ public class FrameworkUtils {
      *
      * @return true if the JIT provisioning enhanced features is enabled else return false.
      */
-    public static boolean isEnhancedFeature() {
+    public static boolean isJitProvisionEnhancedFeature() {
 
-        if (StringUtils.isNotBlank(IdentityUtil.getProperty(FrameworkConstants.ENABLE_ENHANCE_FEATURE))) {
-            return Boolean.parseBoolean(IdentityUtil.getProperty(FrameworkConstants.ENABLE_ENHANCE_FEATURE));
+        if (StringUtils.isNotBlank(IdentityUtil.
+                getProperty(FrameworkConstants.ENABLE_JIT_PROVISION_ENHANCE_FEATURE))) {
+            return Boolean.parseBoolean(IdentityUtil.
+                    getProperty(FrameworkConstants.ENABLE_JIT_PROVISION_ENHANCE_FEATURE));
         }
         return false;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -3032,4 +3032,17 @@ public class FrameworkUtils {
         context.setRetrying(false);
         context.setCurrentAuthenticator(null);
     }
+
+    /**
+     * Check whether the JIT provisioning enhanced feature is enabled.
+     *
+     * @return true if the JIT provisioning enhanced features is enabled else return false.
+     */
+    public static boolean isEnhancedFeature() {
+
+        if (StringUtils.isNotBlank(IdentityUtil.getProperty(FrameworkConstants.ENABLE_ENHANCE_FEATURE))) {
+            return Boolean.parseBoolean(IdentityUtil.getProperty(FrameworkConstants.ENABLE_ENHANCE_FEATURE));
+        }
+        return false;
+    }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -3038,13 +3038,9 @@ public class FrameworkUtils {
      *
      * @return true if the JIT provisioning enhanced features is enabled else return false.
      */
-    public static boolean isJitProvisionEnhancedFeature() {
+    public static boolean isJitProvisionEnhancedFeatureEnabled() {
 
-        if (StringUtils.isNotBlank(IdentityUtil.
-                getProperty(FrameworkConstants.ENABLE_JIT_PROVISION_ENHANCE_FEATURE))) {
-            return Boolean.parseBoolean(IdentityUtil.
+        return Boolean.parseBoolean(IdentityUtil.
                     getProperty(FrameworkConstants.ENABLE_JIT_PROVISION_ENHANCE_FEATURE));
-        }
-        return false;
     }
 }


### PR DESCRIPTION
### Description

With these PR changes, federated id from the IDN_AUTH_USER will be set as the username of the JIT provisioned users.
Related issue: https://github.com/wso2/product-is/issues/11991