### PR TITLE
Config to disable editing the provisioned user's attribute values

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -150,9 +150,9 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                         + userStoreDomain + "'");
                 /*
                 Set PROVISIONED_USER thread local property to true, to identify already provisioned
-                user claim updates.
+                user claim update scenario.
                  */
-                IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.PROVISIONED_USER, true);
+                IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.JIT_PROVISIONING_FLOW, true);
                 if (!userClaims.isEmpty()) {
                     userClaims.remove(FrameworkConstants.PASSWORD);
                     userClaims.remove(USERNAME_CLAIM);
@@ -326,7 +326,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
             throw new FrameworkException("Error while provisioning user : " + subject, e);
         } finally {
             IdentityUtil.clearIdentityErrorMsg();
-            IdentityUtil.threadLocalProperties.get().remove(FrameworkConstants.PROVISIONED_USER);
+            IdentityUtil.threadLocalProperties.get().remove(FrameworkConstants.JIT_PROVISIONING_FLOW);
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -148,6 +148,11 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
             if (userStoreManager.isExistingUser(username)) {
                 diagnosticLog.info("User with username: '" + username + "' already exists in userstore: '"
                         + userStoreDomain + "'");
+                /*
+                Set PROVISIONED_USER thread local property to true, to identify already provisioned
+                user claim updates.
+                 */
+                IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.PROVISIONED_USER, true);
                 if (!userClaims.isEmpty()) {
                     userClaims.remove(FrameworkConstants.PASSWORD);
                     userClaims.remove(USERNAME_CLAIM);
@@ -321,6 +326,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
             throw new FrameworkException("Error while provisioning user : " + subject, e);
         } finally {
             IdentityUtil.clearIdentityErrorMsg();
+            IdentityUtil.threadLocalProperties.get().remove(FrameworkConstants.PROVISIONED_USER);
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -104,6 +104,8 @@ public abstract class FrameworkConstants {
     public static final String IDP_ID = "idpId";
     public static final String ASSOCIATED_ID = "associatedID";
 
+    public static final String PROVISIONED_USER = "provisionedUser";
+
     // Error details sent from authenticators
     public static final String AUTH_ERROR_CODE = "AuthErrorCode";
     public static final String AUTH_ERROR_MSG = "AuthErrorMessage";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -104,7 +104,7 @@ public abstract class FrameworkConstants {
     public static final String IDP_ID = "idpId";
     public static final String ASSOCIATED_ID = "associatedID";
 
-    public static final String PROVISIONED_USER = "provisionedUser";
+    public static final String JIT_PROVISIONING_FLOW = "JITProvisioningFlow";
 
     // Error details sent from authenticators
     public static final String AUTH_ERROR_CODE = "AuthErrorCode";

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -969,6 +969,7 @@
     <JITProvisioning>
         <UserNameProvisioningUI>/accountrecoveryendpoint/register.do</UserNameProvisioningUI>
         <PasswordProvisioningUI>/accountrecoveryendpoint/signup.do</PasswordProvisioningUI>
+        <EnableSyncedAttributeEditing>true</EnableSyncedAttributeEditing>
     </JITProvisioning>
 
     <OutboundProvisioning>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -969,7 +969,7 @@
     <JITProvisioning>
         <UserNameProvisioningUI>/accountrecoveryendpoint/register.do</UserNameProvisioningUI>
         <PasswordProvisioningUI>/accountrecoveryendpoint/signup.do</PasswordProvisioningUI>
-        <EnableSyncedAttributeEditing>true</EnableSyncedAttributeEditing>
+        <EnableEnhancedFeature>false</EnableEnhancedFeature>
     </JITProvisioning>
 
     <OutboundProvisioning>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1266,6 +1266,7 @@
     <JITProvisioning>
         <UserNameProvisioningUI>{{authentication.jit_provisioning.username_provisioning_url}}</UserNameProvisioningUI>
         <PasswordProvisioningUI>{{authentication.jit_provisioning.password_provisioning_url}}</PasswordProvisioningUI>
+        <EnableSyncedAttributeEditing>{{authentication.jit_provisioning.enable_synced_attribute_editing}}</EnableSyncedAttributeEditing>
     </JITProvisioning>
 
     <!--Application management service configurations-->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1266,7 +1266,7 @@
     <JITProvisioning>
         <UserNameProvisioningUI>{{authentication.jit_provisioning.username_provisioning_url}}</UserNameProvisioningUI>
         <PasswordProvisioningUI>{{authentication.jit_provisioning.password_provisioning_url}}</PasswordProvisioningUI>
-        <EnableSyncedAttributeEditing>{{authentication.jit_provisioning.enable_synced_attribute_editing}}</EnableSyncedAttributeEditing>
+        <EnableEnhancedFeature>{{authentication.jit_provisioning.enable_enhanced_feature}}</EnableEnhancedFeature>
     </JITProvisioning>
 
     <!--Application management service configurations-->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -364,7 +364,7 @@
   "authentication_policy.check_account_exist": true,
   "authentication.jit_provisioning.username_provisioning_url": "/accountrecoveryendpoint/register.do",
   "authentication.jit_provisioning.password_provisioning_url": "/accountrecoveryendpoint/signup.do",
-  "authentication.jit_provisioning.enable_synced_attribute_editing":true,
+  "authentication.jit_provisioning.enable_enhanced_feature": false,
 
   "application_mgt.enable_role_validation": false,
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -364,6 +364,7 @@
   "authentication_policy.check_account_exist": true,
   "authentication.jit_provisioning.username_provisioning_url": "/accountrecoveryendpoint/register.do",
   "authentication.jit_provisioning.password_provisioning_url": "/accountrecoveryendpoint/signup.do",
+  "authentication.jit_provisioning.enable_synced_attribute_editing":true,
 
   "application_mgt.enable_role_validation": false,
 


### PR DESCRIPTION
### Proposed changes in this pull request

With the introduced following config, provisioned user's synced attributes will not be allowed to update.

```
[authentication.jit_provisioning]
enable_enhanced_feature = "true"
```

Related issue: https://github.com/wso2/product-is/issues/12010
Related PR: https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/367