### PR TITLE
Fix get tenant context from static method

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -205,10 +205,10 @@ public class IdentityProviderManager implements IdpManager {
 
         // If sts url is configured in file, change it according to tenant domain. If not configured, add a default url
         if (StringUtils.isNotBlank(stsUrl)) {
-            stsUrl = stsUrl.replace(IdentityConstants.STS.WSO2_CARBON_STS, IdPManagementUtil.getTenantContext() +
+            stsUrl = stsUrl.replace(IdentityConstants.STS.WSO2_CARBON_STS, getTenantContextFromTenantDomain(tenantDomain) +
                     IdentityConstants.STS.WSO2_CARBON_STS);
         } else {
-            stsUrl = IdentityUtil.getServerURL("services/" + IdPManagementUtil.getTenantContext() +
+            stsUrl = IdentityUtil.getServerURL("services/" + getTenantContextFromTenantDomain(tenantDomain) +
                     IdentityConstants.STS.WSO2_CARBON_STS, true, true);
         }
 
@@ -3037,5 +3037,20 @@ public class IdentityProviderManager implements IdpManager {
 
         return !Stream.of(INTERNAL_DOMAIN, APPLICATION_DOMAIN, WORKFLOW_DOMAIN).anyMatch(domain -> localRoleName
                 .toUpperCase().startsWith((domain + UserCoreConstants.DOMAIN_SEPARATOR).toUpperCase()));
+    }
+
+    /**
+     * Get tenant context using tenant domain.
+     *
+     * @param tenantDomain tenant domain of the tenant
+     * @return tenant context
+     */
+    private String getTenantContextFromTenantDomain(String tenantDomain) {
+
+        if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
+            return MultitenantConstants.TENANT_AWARE_URL_PREFIX + "/" + tenantDomain + "/";
+        } else {
+            return "";
+        }
     }
 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -3042,15 +3042,14 @@ public class IdentityProviderManager implements IdpManager {
     /**
      * Get tenant context using tenant domain.
      *
-     * @param tenantDomain tenant domain of the tenant
-     * @return tenant context
+     * @param tenantDomain Tenant domain of the tenant
+     * @return Tenant context
      */
     private String getTenantContextFromTenantDomain(String tenantDomain) {
 
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
             return MultitenantConstants.TENANT_AWARE_URL_PREFIX + "/" + tenantDomain + "/";
-        } else {
-            return "";
         }
+        return "";
     }
 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -3042,8 +3042,8 @@ public class IdentityProviderManager implements IdpManager {
     /**
      * Get tenant context using tenant domain.
      *
-     * @param tenantDomain Tenant domain of the tenant
-     * @return Tenant context
+     * @param tenantDomain Tenant domain of the tenant.
+     * @return Tenant context of the tenant.
      */
     private String getTenantContextFromTenantDomain(String tenantDomain) {
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
@@ -161,8 +161,12 @@ public class IdPManagementUtil {
     /**
      * Set tenantContext and tenantParameter specific to the tenant domain.
      *
+     * @deprecated Setting tenant context and tenant parameter in static method will replace already set value with
+     * new value for two concurrent logins in different tenant domains.
+     * Can use local parameters to resolve this.
      * @param tenantDomain of requested resident IdP
      */
+    @Deprecated
     public static void setTenantSpecifiers(String tenantDomain) {
 
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
@@ -177,8 +181,10 @@ public class IdPManagementUtil {
     /**
      * Get the tenant context specific to the resident IdP tenant domain.
      *
+     * @deprecated Setter is deprecated.
      * @return the tenantContext
      */
+//    @Deprecated
     public static String getTenantContext() {
 
         return tenantContext;
@@ -187,8 +193,10 @@ public class IdPManagementUtil {
     /**
      * Get the tenant parameter specific to the resident IdP tenant domain to be appended with the endpoint URL.
      *
+     * @deprecated Setter is deprecated.
      * @return the tenantParameter
      */
+    @Deprecated
     public static String getTenantParameter() {
 
         return tenantParameter;

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
@@ -184,7 +184,7 @@ public class IdPManagementUtil {
      * @deprecated Setter is deprecated.
      * @return the tenantContext
      */
-//    @Deprecated
+    @Deprecated
     public static String getTenantContext() {
 
         return tenantContext;


### PR DESCRIPTION
**Purpose**
Setting tenant context and tenant parameter in static method will replace already set value with new value for two concurrent logins in different tenant domains.

fix https://github.com/wso2/product-is/issues/11898 

Related PRs 
https://github.com/wso2-support/carbon-identity-framework/pull/1648
https://github.com/wso2-support/carbon-identity-framework/pull/1647
