### PR TITLE
Fix behaviour of return_only_mapped_local_roles property

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -311,6 +311,10 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
                         extAttibutesValueMap.put(idpRoleClaimUri, serviceProviderMappedUserRoles);
                     }
 
+                    if (returnOnlyMappedLocalRoles && StringUtils.isBlank(serviceProviderMappedUserRoles)) {
+                        extAttibutesValueMap.put(idpRoleClaimUri, serviceProviderMappedUserRoles);
+                    }
+
                     if (mappedAttrs == null || mappedAttrs.isEmpty()) {
                         // do claim handling
                         mappedAttrs = handleClaimMappings(stepConfig, context,

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2013,7 +2013,7 @@ public class FrameworkUtils {
             Map<String, String> extAttributesValueMap, String idpRoleClaimUri, Boolean excludeUnmapped) {
 
         if (idpRoleClaimUri == null) {
-            // Since idpRoleCalimUri is not defined cannot do role mapping.
+            // Since idpRoleClaimUri is not defined cannot do role mapping.
             if (log.isDebugEnabled()) {
                 log.debug("Role claim uri is not configured for the external IDP: " + externalIdPConfig.getIdPName()
                         + ", in Domain: " + externalIdPConfig.getDomain() + ".");


### PR DESCRIPTION
### Proposed changes in this pull request
When the property idp_role_management.return_only_mapped_local_roles is added, the expectation would be to only send the IDP mapped roles to SP at all times. But at the moment, if a role mapping is not added or at least one matching mapping is not found, we're sending all IDP roles to SP. This PR fixes that issue.

Refers https://github.com/wso2/product-is/issues/11941
