### PR TITLE
Delete all the associated provisioned users when IDP deletes

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/JITProvisionedUserDeleteThread.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/JITProvisionedUserDeleteThread.java
@@ -42,7 +42,7 @@ import java.util.List;
  */
 public class JITProvisionedUserDeleteThread implements Runnable {
 
-    private static final Log log = LogFactory.getLog(SessionCleanUpService.class);
+    private static final Log log = LogFactory.getLog(JITProvisionedUserDeleteThread.class);
 
     private final String resourceId;
     private final String tenantDomain;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/ProvisionedUserDeleteThread.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/ProvisionedUserDeleteThread.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.authentication.framework.handler.provisioning;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceComponent;
@@ -68,10 +69,12 @@ public class ProvisionedUserDeleteThread implements Runnable {
             int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
             UserRealm userRealm = realmService.getTenantUserRealm(tenantId);
             String[] userList =
-                    ((AbstractUserStoreManager)userRealm.getUserStoreManager()).
-                            getUserList(FrameworkConstants.PROVISIONED_SOURCE_CLAIM, resourceId, null);
-            for (String username : userList) {
-                ((AbstractUserStoreManager) userRealm.getUserStoreManager()).deleteUser(username);
+                    ((AbstractUserStoreManager) userRealm.getUserStoreManager()).
+                            getUserList(FrameworkConstants.PROVISIONED_SOURCE_ID_CLAIM, resourceId, null);
+            if (ArrayUtils.isNotEmpty(userList)) {
+                for (String username : userList) {
+                    ((AbstractUserStoreManager) userRealm.getUserStoreManager()).deleteUser(username);
+                }
             }
         } catch (UserStoreException e) {
             log.error("Error occurred while deleting the provisioned users from IDP: " + resourceId, e);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/ProvisionedUserDeleteThread.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/ProvisionedUserDeleteThread.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.handler.provisioning;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceComponent;
+import org.wso2.carbon.identity.application.authentication.framework.store.SessionCleanUpService;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * Thread to perform JIT provisioned users deletion task based on provisioned IDP delete.
+ */
+public class ProvisionedUserDeleteThread implements Runnable {
+
+    private static final Log log = LogFactory.getLog(SessionCleanUpService.class);
+    private static final Log diagnosticLog = LogFactory.getLog("diagnostics");
+
+    private final String resourceId;
+    private final String tenantDomain;
+
+    public ProvisionedUserDeleteThread(String resourceId, String tenantDomain) {
+
+        this.resourceId = resourceId;
+        this.tenantDomain = tenantDomain;
+    }
+
+    @Override
+    public void run() {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Start running the JIT provisioned user delete task.");
+        }
+        diagnosticLog.info("Start running the JIT provisioned user delete task.");
+        provisionedUserDelete();
+        if (log.isDebugEnabled()) {
+            log.debug("Stop running the JIT provisioned user delete task.");
+        }
+        diagnosticLog.info("Stop running the JIT provisioned user delete task.");
+    }
+
+    private void provisionedUserDelete() {
+
+        try {
+            FrameworkUtils.startTenantFlow(tenantDomain);
+            RealmService realmService = FrameworkServiceComponent.getRealmService();
+            int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
+            UserRealm userRealm = realmService.getTenantUserRealm(tenantId);
+            String[] userList =
+                    ((AbstractUserStoreManager)userRealm.getUserStoreManager()).
+                            getUserList(FrameworkConstants.PROVISIONED_SOURCE_CLAIM, resourceId, null);
+            for (String username : userList) {
+                ((AbstractUserStoreManager) userRealm.getUserStoreManager()).deleteUser(username);
+            }
+        } catch (UserStoreException e) {
+            log.error("Error occurred while deleting the provisioned users from IDP: " + resourceId, e);
+        } finally {
+            FrameworkUtils.endTenantFlow();
+        }
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -220,7 +220,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                     need to write a provisioning handler extending the "DefaultProvisioningHandler".
                      */
                     UserCoreUtil.setSkipPasswordPatternValidationThreadLocal(true);
-                    if (FrameworkUtils.isJitProvisionEnhancedFeatureEnabled()) {
+                    if (FrameworkUtils.isJITProvisionEnhancedFeatureEnabled()) {
                         setJitProvisionedSource(tenantDomain, idp, userClaims);
                     }
                     userStoreManager.addUser(username, password, null, userClaims, null);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/listener/JITProvisioningIdentityProviderMgtListener.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/listener/JITProvisioningIdentityProviderMgtListener.java
@@ -38,20 +38,21 @@ import java.util.concurrent.Executors;
 public class JITProvisioningIdentityProviderMgtListener extends AbstractIdentityProviderMgtListener {
 
     private static final Log log = LogFactory.getLog(JITProvisioningIdentityProviderMgtListener.class);
+    private static final Log diagnosticLog = LogFactory.getLog("diagnostics");
     private static ExecutorService threadPool = Executors.newFixedThreadPool(2);
 
     @Override
     public boolean doPostDeleteIdPByResourceId(String resourceId, IdentityProvider identityProvider,
                                                String tenantDomain) throws IdentityProviderManagementException {
 
-        if (log.isDebugEnabled()) {
-            log.debug("doPostDeleteIdPByResourceId executed for idp: " + resourceId + " of tenant domain: " +
-                    tenantDomain);
-        }
-
-        if (!FrameworkUtils.isEnhancedFeature()) {
+        if (!FrameworkUtils.isJITProvisionedEnhancedFeatureEnabled()) {
             // JIT provisioning enhanced feature is not enabled. Hence returning.
             return true;
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("The doPostDeleteIdPByResourceId executed for idp: %s of tenant domain: %s",
+                    resourceId, tenantDomain));
         }
 
         ProvisionedUserDeleteThread provisionedUserDeleteThread =
@@ -63,7 +64,7 @@ public class JITProvisioningIdentityProviderMgtListener extends AbstractIdentity
     @Override
     public boolean doPreDeleteIdP(String idPName, String tenantDomain) throws IdentityProviderManagementException {
 
-        if (!FrameworkUtils.isEnhancedFeature()) {
+        if (!FrameworkUtils.isJITProvisionedEnhancedFeatureEnabled()) {
             // JIT provisioning enhanced feature is not enabled. Hence returning.
             return true;
         }
@@ -77,13 +78,14 @@ public class JITProvisioningIdentityProviderMgtListener extends AbstractIdentity
     @Override
     public boolean doPostDeleteIdP(String idPName, String tenantDomain) throws IdentityProviderManagementException {
 
-        if (log.isDebugEnabled()) {
-            log.debug("doPostDeleteIdp executed for idp: " + idPName + " of tenant domain: " + tenantDomain);
-        }
-
-        if (!FrameworkUtils.isEnhancedFeature()) {
+        if (!FrameworkUtils.isJITProvisionedEnhancedFeatureEnabled()) {
             // JIT provisioning enhanced feature is not enabled. Hence returning.
             return true;
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("The doPostDeleteIdp executed for idp: %s of tenant domain: %s.",
+                    idPName, tenantDomain));
         }
 
         try {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/listener/JITProvisioningIdentityProviderMgtListener.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/listener/JITProvisioningIdentityProviderMgtListener.java
@@ -20,7 +20,7 @@ package org.wso2.carbon.identity.application.authentication.framework.handler.pr
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.identity.application.authentication.framework.handler.provisioning.ProvisionedUserDeleteThread;
+import org.wso2.carbon.identity.application.authentication.framework.handler.provisioning.JITProvisionedUserDeleteThread;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
@@ -55,8 +55,8 @@ public class JITProvisioningIdentityProviderMgtListener extends AbstractIdentity
                     resourceId, tenantDomain));
         }
 
-        ProvisionedUserDeleteThread provisionedUserDeleteThread =
-                new ProvisionedUserDeleteThread(resourceId, tenantDomain);
+        JITProvisionedUserDeleteThread provisionedUserDeleteThread =
+                new JITProvisionedUserDeleteThread(resourceId, tenantDomain);
         threadPool.submit(provisionedUserDeleteThread);
         return true;
     }
@@ -69,6 +69,7 @@ public class JITProvisioningIdentityProviderMgtListener extends AbstractIdentity
             return true;
         }
 
+        IdentityUtil.threadLocalProperties.get().remove(FrameworkConstants.IDP_RESOURCE_ID);
         String idpId = IdentityProviderManager.getInstance().getIdPByName(idPName, tenantDomain,
                 true).getResourceId();
         IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.IDP_RESOURCE_ID, idpId);
@@ -90,9 +91,9 @@ public class JITProvisioningIdentityProviderMgtListener extends AbstractIdentity
 
         try {
             String idpId = (String) IdentityUtil.threadLocalProperties.get().get(FrameworkConstants.IDP_RESOURCE_ID);
-            ProvisionedUserDeleteThread provisionedUserDeleteThread =
-                    new ProvisionedUserDeleteThread(idpId, tenantDomain);
-            threadPool.submit(provisionedUserDeleteThread);
+            JITProvisionedUserDeleteThread JITProvisionedUserDeleteThread =
+                    new JITProvisionedUserDeleteThread(idpId, tenantDomain);
+            threadPool.submit(JITProvisionedUserDeleteThread);
         } finally {
             IdentityUtil.threadLocalProperties.get().remove(FrameworkConstants.IDP_RESOURCE_ID);
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/listener/JITProvisioningIdentityProviderMgtListener.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/listener/JITProvisioningIdentityProviderMgtListener.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.handler.provisioning.listener;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.handler.provisioning.ProvisionedUserDeleteThread;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManager;
+import org.wso2.carbon.idp.mgt.listener.AbstractIdentityProviderMgtListener;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Listener to perform JIT provisioning related Identity Provider management operations.
+ */
+public class JITProvisioningIdentityProviderMgtListener extends AbstractIdentityProviderMgtListener {
+
+    private static final Log log = LogFactory.getLog(JITProvisioningIdentityProviderMgtListener.class);
+    private static ExecutorService threadPool = Executors.newFixedThreadPool(2);
+
+    @Override
+    public boolean doPostDeleteIdPByResourceId(String resourceId, IdentityProvider identityProvider,
+                                               String tenantDomain) throws IdentityProviderManagementException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("doPostDeleteIdPByResourceId executed for idp: " + resourceId + " of tenant domain: " +
+                    tenantDomain);
+        }
+
+        if (!FrameworkUtils.isEnhancedFeature()) {
+            // JIT provisioning enhanced feature is not enabled. Hence returning.
+            return true;
+        }
+
+        ProvisionedUserDeleteThread provisionedUserDeleteThread =
+                new ProvisionedUserDeleteThread(resourceId, tenantDomain);
+        threadPool.submit(provisionedUserDeleteThread);
+        return true;
+    }
+
+    @Override
+    public boolean doPreDeleteIdP(String idPName, String tenantDomain) throws IdentityProviderManagementException {
+
+        if (!FrameworkUtils.isEnhancedFeature()) {
+            // JIT provisioning enhanced feature is not enabled. Hence returning.
+            return true;
+        }
+
+        String idpId = IdentityProviderManager.getInstance().getIdPByName(idPName, tenantDomain,
+                true).getResourceId();
+        IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.IDP_RESOURCE_ID, idpId);
+        return true;
+    }
+
+    @Override
+    public boolean doPostDeleteIdP(String idPName, String tenantDomain) throws IdentityProviderManagementException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("doPostDeleteIdp executed for idp: " + idPName + " of tenant domain: " + tenantDomain);
+        }
+
+        if (!FrameworkUtils.isEnhancedFeature()) {
+            // JIT provisioning enhanced feature is not enabled. Hence returning.
+            return true;
+        }
+
+        try {
+            String idpId = (String) IdentityUtil.threadLocalProperties.get().get(FrameworkConstants.IDP_RESOURCE_ID);
+            ProvisionedUserDeleteThread provisionedUserDeleteThread =
+                    new ProvisionedUserDeleteThread(idpId, tenantDomain);
+            threadPool.submit(provisionedUserDeleteThread);
+        } finally {
+            IdentityUtil.threadLocalProperties.get().remove(FrameworkConstants.IDP_RESOURCE_ID);
+        }
+        return true;
+    }
+
+    @Override
+    public int getDefaultOrderId() {
+
+        return 36;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/listener/JITProvisioningIdentityProviderMgtListener.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/listener/JITProvisioningIdentityProviderMgtListener.java
@@ -45,7 +45,7 @@ public class JITProvisioningIdentityProviderMgtListener extends AbstractIdentity
     public boolean doPostDeleteIdPByResourceId(String resourceId, IdentityProvider identityProvider,
                                                String tenantDomain) throws IdentityProviderManagementException {
 
-        if (!FrameworkUtils.isJITProvisionedEnhancedFeatureEnabled()) {
+        if (!FrameworkUtils.isJITProvisionEnhancedFeatureEnabled()) {
             // JIT provisioning enhanced feature is not enabled. Hence returning.
             return true;
         }
@@ -64,7 +64,7 @@ public class JITProvisioningIdentityProviderMgtListener extends AbstractIdentity
     @Override
     public boolean doPreDeleteIdP(String idPName, String tenantDomain) throws IdentityProviderManagementException {
 
-        if (!FrameworkUtils.isJITProvisionedEnhancedFeatureEnabled()) {
+        if (!FrameworkUtils.isJITProvisionEnhancedFeatureEnabled()) {
             // JIT provisioning enhanced feature is not enabled. Hence returning.
             return true;
         }
@@ -79,7 +79,7 @@ public class JITProvisioningIdentityProviderMgtListener extends AbstractIdentity
     @Override
     public boolean doPostDeleteIdP(String idPName, String tenantDomain) throws IdentityProviderManagementException {
 
-        if (!FrameworkUtils.isJITProvisionedEnhancedFeatureEnabled()) {
+        if (!FrameworkUtils.isJITProvisionEnhancedFeatureEnabled()) {
             // JIT provisioning enhanced feature is not enabled. Hence returning.
             return true;
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -333,7 +333,7 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
 
         String username;
         // If JIT provisioning enhanced feature is enabled set the federated ID as the federated username.
-        if (FrameworkUtils.isJitProvisionEnhancedFeatureEnabled()) {
+        if (FrameworkUtils.isJITProvisionEnhancedFeatureEnabled()) {
             username = getFederatedUsername(sequenceConfig.getAuthenticatedUser().getUserName(),
                     externalIdPConfigName, context);
         } else {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.eclipse.equinox.http.helper.ContextPathServletAdaptor;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -45,6 +46,7 @@ import org.wso2.carbon.identity.application.authentication.framework.ServerSessi
 import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
 import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.handler.provisioning.listener.JITProvisioningIdentityProviderMgtListener;
 import org.wso2.carbon.identity.application.authentication.framework.internal.impl.ServerSessionManagementServiceImpl;
 import org.wso2.carbon.identity.application.authentication.framework.internal.impl.UserSessionManagementServiceImpl;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
@@ -98,6 +100,8 @@ import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.functions.library.mgt.FunctionLibraryManagementService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
+import org.wso2.carbon.idp.mgt.listener.IDPMgtAuditLogger;
+import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -291,7 +295,10 @@ public class FrameworkServiceComponent {
         bundleContext.registerService(SSOConsentService.class.getName(), ssoConsentService, null);
         dataHolder.setSSOConsentService(ssoConsentService);
         bundleContext.registerService(PostAuthenticationHandler.class.getName(), consentMgtPostAuthnHandler, null);
-
+        JITProvisioningIdentityProviderMgtListener jitProvisioningIDPMgtListener =
+                new JITProvisioningIdentityProviderMgtListener();
+        bundleContext.registerService(IdentityProviderMgtListener.class.getName(),
+                jitProvisioningIDPMgtListener, null);
         bundleContext.registerService(ClaimFilter.class.getName(), new DefaultClaimFilter(), null);
 
         //this is done to load SessionDataStore class and start the cleanup tasks.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -39,6 +39,7 @@ public abstract class FrameworkConstants {
     public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
     public static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
     public static final String PROVISIONED_SOURCE_ID_CLAIM = "http://wso2.org/claims/identity/userSourceId";
+    public static final String PROVISIONED_SOURCE_CLAIM = "http://wso2.org/claims/identity/userSourceId";
     public static final String UNFILTERED_LOCAL_CLAIM_VALUES = "UNFILTERED_LOCAL_CLAIM_VALUES";
     public static final String UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES = "UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES";
     public static final String UNFILTERED_IDP_CLAIM_VALUES = "UNFILTERED_IDP_CLAIM_VALUES";
@@ -104,11 +105,6 @@ public abstract class FrameworkConstants {
     public static final String MAPPED_ATTRIBUTES = "MappedAttributes";
     public static final String IDP_ID = "idpId";
     public static final String ASSOCIATED_ID = "associatedID";
-
-    public static final String SECRET_KEY_CLAIM_URL = "http://wso2.org/claims/identity/secretkey";
-    public static final String ENABLE_JIT_PROVISION_ENHANCE_FEATURE = "JITProvisioning.EnableEnhancedFeature";
-
-    public static final String JIT_PROVISIONING_FLOW = "JITProvisioningFlow";
 
     // Error details sent from authenticators
     public static final String AUTH_ERROR_CODE = "AuthErrorCode";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -105,8 +105,10 @@ public abstract class FrameworkConstants {
     public static final String IDP_ID = "idpId";
     public static final String ASSOCIATED_ID = "associatedID";
 
+    public static final String JIT_PROVISIONING_FLOW = "JITProvisioningFlow";
+    public static final String SECRET_KEY_CLAIM_URL = "http://wso2.org/claims/identity/secretkey";
     public static final String IDP_RESOURCE_ID = "IDPResourceID";
-    public static final String ENABLE_ENHANCE_FEATURE = "JITProvisioning.EnableEnhancedFeature";
+    public static final String ENABLE_JIT_PROVISION_ENHANCE_FEATURE = "JITProvisioning.EnableEnhancedFeature";
 
     // Error details sent from authenticators
     public static final String AUTH_ERROR_CODE = "AuthErrorCode";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -39,7 +39,6 @@ public abstract class FrameworkConstants {
     public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
     public static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
     public static final String PROVISIONED_SOURCE_ID_CLAIM = "http://wso2.org/claims/identity/userSourceId";
-    public static final String PROVISIONED_SOURCE_CLAIM = "http://wso2.org/claims/identity/userSourceId";
     public static final String UNFILTERED_LOCAL_CLAIM_VALUES = "UNFILTERED_LOCAL_CLAIM_VALUES";
     public static final String UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES = "UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES";
     public static final String UNFILTERED_IDP_CLAIM_VALUES = "UNFILTERED_IDP_CLAIM_VALUES";
@@ -105,6 +104,9 @@ public abstract class FrameworkConstants {
     public static final String MAPPED_ATTRIBUTES = "MappedAttributes";
     public static final String IDP_ID = "idpId";
     public static final String ASSOCIATED_ID = "associatedID";
+
+    public static final String IDP_RESOURCE_ID = "IDPResourceID";
+    public static final String ENABLE_ENHANCE_FEATURE = "JITProvisioning.EnableEnhancedFeature";
 
     // Error details sent from authenticators
     public static final String AUTH_ERROR_CODE = "AuthErrorCode";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -3038,7 +3038,7 @@ public class FrameworkUtils {
      *
      * @return true if the JIT provisioning enhanced features is enabled else return false.
      */
-    public static boolean isJitProvisionEnhancedFeatureEnabled() {
+    public static boolean isJITProvisionEnhancedFeatureEnabled() {
 
         return Boolean.parseBoolean(IdentityUtil.
                     getProperty(FrameworkConstants.ENABLE_JIT_PROVISION_ENHANCE_FEATURE));


### PR DESCRIPTION
### Description

Delete all the associated provisioned users when IDP deletes

### Approach

Assign thread to perform associated provisioned users delete task asynchronously from the IDP delete operation.
