### PR TITLE
Recaptcha params added to basic authenticator in multi option page

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -143,6 +143,12 @@ public abstract class FrameworkConstants {
 
     public static final String USER_TENANT_DOMAIN = "user-tenant-domain";
 
+    public static final String BASIC_AUTH_MECHANISM = "basic";
+    public static final String RECAPTCHA_PARAM = "reCaptcha";
+    public static final String RECAPTCHA_RESEND_CONFIRMATION_PARAM = "reCaptchaResend";
+    public static final String RECAPTCHA_KEY_PARAM = "reCaptchaKey";
+    public static final String RECAPTCHA_API_PARAM = "reCaptchaAPI";
+
     // DB product names.
     public static final String MY_SQL = "MySQL";
     public static final String MARIA_DB = "MariaDB";


### PR DESCRIPTION
### Proposed changes in this pull request

> Fixes https://github.com/wso2/product-is/issues/12077
> reCaptcha validation would fail when trying to log in using the basic authenticator in a login page with multiple options. This PR fixes this issue by manually adding the recaptcha params to the auhentication endpoint redirect URL when basic authenticator is present as a option in a multi option authenticator scenario.
