### PR TITLE
Add configuration to enable sending notification emails on every account lockout cycle

### DIFF
--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -13,6 +13,7 @@
   "identity_mgt.events.schemes.'account.lock.handler'.properties.'On.Failure.Max.Attempts'": "5",
   "identity_mgt.events.schemes.'account.lock.handler'.properties.Time": "5m",
   "identity_mgt.events.schemes.'account.lock.handler'.properties.'notification.manageInternally'": true,
+  "identity_mgt.events.schemes.'account.lock.handler'.properties.'notification.notifyOnLockIncrement'": false,
   "identity_mgt.events.schemes.emailSend.module_index": "2",
   "identity_mgt.events.schemes.emailSend.subscriptions": [
     "TRIGGER_NOTIFICATION"


### PR DESCRIPTION
### Proposed changes in this pull request

A new config is introduced to the existing account lock handler to enable/disable sending notification emails on every account lockout cycle (Every time the lock duration increments due to further failed login attempts after the initial lockout)
