### PR TITLE
Avoid possible deadlock when deleting IDP associated JIT provisioned users

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/listener/JITProvisioningIdentityProviderMgtListener.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/listener/JITProvisioningIdentityProviderMgtListener.java
@@ -38,7 +38,7 @@ import java.util.concurrent.Executors;
 public class JITProvisioningIdentityProviderMgtListener extends AbstractIdentityProviderMgtListener {
 
     private static final Log log = LogFactory.getLog(JITProvisioningIdentityProviderMgtListener.class);
-    private static ExecutorService threadPool = Executors.newFixedThreadPool(2);
+    private static final ExecutorService threadPool = Executors.newFixedThreadPool(1);
 
     @Override
     public boolean doPostDeleteIdPByResourceId(String resourceId, IdentityProvider identityProvider,


### PR DESCRIPTION
### Proposed changes in this pull request
Avoid a possible deadlock when deleting IDP associated JIT provisioned users

Related PR: https://github.com/wso2/carbon-identity-framework/pull/3597