### PR TITLE
Add account locked error code to IdentityCoreConstants

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -61,6 +61,7 @@ public class IdentityCoreConstants {
     public static final String USER_ACCOUNT_DISABLED = " User account is disabled";
 
     //UserCoreConstants class define the rest of the relevant error codes.
+    public static final String USER_ACCOUNT_LOCKED_ERROR_CODE = "17003";
     public static final String USER_ACCOUNT_DISABLED_ERROR_CODE = "17004";
     public static final String USER_ACCOUNT_NOT_CONFIRMED_ERROR_CODE = "17005";
     public static final String ADMIN_FORCED_USER_PASSWORD_RESET_VIA_EMAIL_LINK_ERROR_CODE = "17006";


### PR DESCRIPTION
### Proposed changes in this pull request

Added the account locked error code  to IdentityCoreConstants for use at the authentication endpoint.

### Related issue
wso2/product-is/issues/12175

### Related PR
wso2/identity-apps/pull/2257
wso2-extensions/identity-local-auth-basicauth/pull/113