### PR TITLE
Add the capability to disallow loops in a adaptive auth script

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/validator/DefaultApplicationValidator.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/validator/DefaultApplicationValidator.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.common.model.script.AuthenticationScriptConfig;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.dao.ApplicationDAO;
@@ -60,6 +61,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -90,6 +93,13 @@ public class DefaultApplicationValidator implements ApplicationValidator {
     private static final String GROUPS_ARE_PROHIBITED_FOR_ROLE_MAPPING = "Groups including: %s, are " +
             "prohibited for role mapping. Use roles instead.";
     public static final String IS_HANDLER = "IS_HANDLER";
+    private static final String CONF_ADAPTIVE_AUTH_ALLOW_LOOPS = "AdaptiveAuth.AllowLoops";
+    private static Pattern loopPattern;
+
+    public DefaultApplicationValidator() {
+
+        loopPattern = Pattern.compile("\\b(for|while)\\b");
+    }
 
     @Override
     public int getOrderId() {
@@ -116,7 +126,10 @@ public class DefaultApplicationValidator implements ApplicationValidator {
                         .getLocalAndOutBoundAuthenticationConfig().getSubjectClaimUri() : null,
                 tenantDomain, serviceProvider.getApplicationName());
         validateRoleConfigs(validationErrors, serviceProvider.getPermissionAndRoleConfig(), tenantDomain);
-
+        if (isAuthenticationScriptAvailableConfig(serviceProvider)) {
+            validateAdaptiveAuthScript(validationErrors,
+                    serviceProvider.getLocalAndOutBoundAuthenticationConfig().getAuthenticationScriptConfig());
+        }
         return validationErrors;
     }
 
@@ -472,5 +485,56 @@ public class DefaultApplicationValidator implements ApplicationValidator {
 
         return !Stream.of(INTERNAL_DOMAIN, APPLICATION_DOMAIN, WORKFLOW_DOMAIN).anyMatch(domain -> localRoleName
                 .toUpperCase().startsWith((domain + UserCoreConstants.DOMAIN_SEPARATOR).toUpperCase()));
+    }
+
+    private void validateAdaptiveAuthScript(List<String> validationErrors,
+                                            AuthenticationScriptConfig authenticationScriptConfig) {
+
+        String script = getAdaptiveAuthScript(authenticationScriptConfig);
+        if (StringUtils.isBlank(script)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Provided authentication script is empty.");
+            }
+            return;
+        }
+
+        if (!isLoopsInAdaptiveAuthScriptAllowed()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Loops are not allowed in the authentication script. " +
+                        "Therefore checking whether loops are present in the provided script.");
+            }
+            Matcher matcher = loopPattern.matcher(script);
+            if (matcher.find()) {
+                validationErrors.add("Loops are not allowed in the adaptive authentication script, " +
+                        "but loops are available in the provided script.");
+            }
+        }
+    }
+
+    private boolean isLoopsInAdaptiveAuthScriptAllowed() {
+
+        String confAllowLoops = IdentityUtil.getProperty(CONF_ADAPTIVE_AUTH_ALLOW_LOOPS);
+
+        // By default allow loops.
+        if (StringUtils.isBlank(confAllowLoops)) {
+            return true;
+        }
+
+        return Boolean.parseBoolean(confAllowLoops);
+    }
+
+    private String getAdaptiveAuthScript(AuthenticationScriptConfig scriptConfig) {
+
+        if (scriptConfig != null) {
+            return scriptConfig.getContent();
+        }
+
+        return null;
+    }
+
+    private boolean isAuthenticationScriptAvailableConfig(ServiceProvider serviceProvider) {
+
+        return serviceProvider.getLocalAndOutBoundAuthenticationConfig() != null &&
+                serviceProvider.getLocalAndOutBoundAuthenticationConfig().getAuthenticationScriptConfig() != null;
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/DefaultApplicationValidatorTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/DefaultApplicationValidatorTest.java
@@ -1,0 +1,134 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.carbon.identity.application.mgt;
+
+import org.apache.commons.lang.StringUtils;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.model.script.AuthenticationScriptConfig;
+import org.wso2.carbon.identity.application.mgt.validator.DefaultApplicationValidator;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Test class for DefaultApplicationValidator.
+ */
+public class DefaultApplicationValidatorTest {
+
+    @DataProvider(name = "validateAdaptiveAuthScriptDataProvider")
+    public Object[][] validateAdaptiveAuthScriptDataProvider() {
+
+        String scripOne = "var onLoginRequest = function(context) {\n" +
+                "    \tfor (var step = 0; step < 5; step++) {\n" +
+                "  \t\tLog.info('Walking east one step');\n" +
+                "\t} \n" +
+                "    executeStep(1);\n" +
+                "};\n";
+        String scripTwo = "var onLoginRequest = function(context) {for(var step = 0; step < 5; step++) {\n" +
+                "  \t\tLog.info('Walking east one step');\n" +
+                "\t} \n" +
+                "    executeStep(1);\n" +
+                "};\n";
+        String scripThree = "var onLoginRequest = function(context) {for(var step = 0; step < 5; step++) {" +
+                "Log.info('Walking east one step');} executeStep(1);};";
+        String scriptFour = "var onLoginRequest = function(context) {\n" +
+                "    var n = 0;\n" +
+                "\tvar x = 0;\n" +
+                "\twhile (n < 3) {\n" +
+                "\t  n++;\n" +
+                "\t  x += n;\n" +
+                "\t}\n" +
+                "    executeStep(1);\n" +
+                "};\n";
+        String scriptFive = "var onLoginRequest = function(context) {\n" +
+                "var i = 0;\n" +
+                "do {\n" +
+                "  i += 1;\n" +
+                "  console.log(i);\n" +
+                "}while(i < 5);\n" +
+                "    executeStep(1);\n" +
+                "};\n";
+        String scripSix = "var onLoginRequest = function(context) {\n" +
+                "    var forceAuth = true;\n" +
+                "    var therefore = true;\n" +
+                "    var fivefor = true;\n" +
+                "    var for_auth = true;\n" +
+                "    var whilefor = true;\n" +
+                "    var forwhile = true;\n" +
+                "    var some_whiles = true;\n" +
+                "    executeStep(1);\n" +
+                "};\n";
+
+        return new String[][]{
+                // isValidationFailScenario, isLoopsAllowed, script
+                {"true", "false", scripOne},
+                {"true", "false", scripTwo},
+                {"true", "false", scripThree},
+                {"true", "false", scriptFour},
+                {"true", "false", scriptFive},
+                {"true", "false", scriptFour},
+                {"false", "false", scripSix},
+                {"false", "true", scripOne},
+                {"false", "true", scriptFive},
+        };
+    }
+
+    @Test(dataProvider = "validateAdaptiveAuthScriptDataProvider")
+    public void validateAdaptiveAuthScriptTest(String isValidationFailScenario, String isLoopsAllowed, String script)
+            throws Exception {
+
+        DefaultApplicationValidator defaultApplicationValidator = new DefaultApplicationValidator();
+
+        Field configuration = IdentityUtil.class.getDeclaredField("configuration");
+        configuration.setAccessible(true);
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("AdaptiveAuth.AllowLoops", isLoopsAllowed);
+        configuration.set(IdentityUtil.class, configMap);
+
+        Method validateAdaptiveAuthScript = DefaultApplicationValidator.class.getDeclaredMethod(
+                "validateAdaptiveAuthScript", List.class, AuthenticationScriptConfig.class);
+        validateAdaptiveAuthScript.setAccessible(true);
+
+        AuthenticationScriptConfig scriptConfig = new AuthenticationScriptConfig();
+        scriptConfig.setContent(script);
+
+        List<String> validationErrors = new ArrayList<>();
+        validateAdaptiveAuthScript.invoke(defaultApplicationValidator, validationErrors, scriptConfig);
+
+        if (Boolean.parseBoolean(isValidationFailScenario)) {
+            Assert.assertFalse(validationErrors.isEmpty(), "This is an invalid scenario. There should be " +
+                    "validation messages.");
+
+            List<String> filtered = validationErrors.stream()
+                    .filter(error -> StringUtils.containsIgnoreCase(error, "loop"))
+                    .collect(Collectors.toList());
+            Assert.assertFalse(filtered.isEmpty(), "There should be a validation message related to loops");
+        } else {
+            Assert.assertTrue(validationErrors.isEmpty(), "There are validation messages. This is a valid case " +
+                    "there should not be any validation messages. Validation messages: " +
+                    String.join("|", validationErrors));
+        }
+    }
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/resources/testng.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/resources/testng.xml
@@ -21,6 +21,7 @@
         <classes>
             <class name="org.wso2.carbon.identity.application.mgt.ApplicationMgtUtilTest"/>
             <class name="org.wso2.carbon.identity.application.mgt.ApplicationManagementServiceImplTest"/>
+            <class name="org.wso2.carbon.identity.application.mgt.DefaultApplicationValidatorTest"/>
         </classes>
     </test>
 </suite>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2531,6 +2531,10 @@
 
         <!--Timeout in milliseconds for the waiting external calls-->
         <LongWaitTimeout>{{authentication.adaptive.long_wait.timout}}</LongWaitTimeout>
+
+        {% if authentication.adaptive.allow_loops is defined %}
+            <AllowLoops>{{authentication.adaptive.allow_loops}}</AllowLoops>
+        {% endif %}
     </AdaptiveAuth>
 
     <!--Intermediate certificate validation for certificate based requests-->


### PR DESCRIPTION
### Proposed changes in this pull request

This PR provides  the capability to disallow loops in an adaptive auth script. 
If loops are not allowed and an authentication script is added with a loop an error message will be shown.

Add the below config to deployment.toml to disallow loops
```
[authentication.adaptive]
allow_loops = false
```
Default value: true (loops are allowed)

