### PR TITLE
Add the capability to disallow loops in a adaptive auth script

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/validator/DefaultApplicationValidator.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/validator/DefaultApplicationValidator.java
@@ -98,7 +98,7 @@ public class DefaultApplicationValidator implements ApplicationValidator {
 
     public DefaultApplicationValidator() {
 
-        loopPattern = Pattern.compile("\\b(for|while)\\b");
+        loopPattern = Pattern.compile("\\b(for|while|forEach)\\b");
     }
 
     @Override

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/DefaultApplicationValidatorTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/DefaultApplicationValidatorTest.java
@@ -78,6 +78,15 @@ public class DefaultApplicationValidatorTest {
                 "    var whilefor = true;\n" +
                 "    var forwhile = true;\n" +
                 "    var some_whiles = true;\n" +
+                "    var fore = true;\n" +
+                "    var foreach = true;\n" +
+                "    var foreaches = true;\n" +
+                "    executeStep(1);\n" +
+                "};\n";
+
+        String scriptSeven = "var onLoginRequest = function(context) {\n" +
+                "    var array1 = ['a', 'b', 'c'];\n" +
+                "    array1.forEach(element => console.log(element));\n" +
                 "    executeStep(1);\n" +
                 "};\n";
 
@@ -89,6 +98,7 @@ public class DefaultApplicationValidatorTest {
                 {"true", "false", scriptFour},
                 {"true", "false", scriptFive},
                 {"true", "false", scriptFour},
+                {"true", "false", scriptSeven},
                 {"false", "false", scripSix},
                 {"false", "true", scripOne},
                 {"false", "true", scriptFive},


### PR DESCRIPTION
### Proposed changes in this pull request

Related to https://github.com/wso2/carbon-identity-framework/pull/3627 additionally disallows forEach loops 