### PR TITLE
Make all the caches as local cache by default

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/cache/BaseCache.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/cache/BaseCache.java
@@ -71,11 +71,11 @@ public abstract class BaseCache<K extends Serializable, V extends Serializable> 
     public BaseCache(String cacheName, boolean isTemp,
                      List<AbstractCacheListener<K, V>> cacheListeners) {
 
-        this.cacheName = cacheName;
+        this.cacheName = CachingConstants.LOCAL_CACHE_PREFIX + cacheName;
         identityCacheConfig = IdentityUtil.getIdentityCacheConfig(CACHE_MANAGER_NAME, cacheName);
         if (identityCacheConfig != null) {
-            if (!identityCacheConfig.isDistributed()) {
-                this.cacheName = CachingConstants.LOCAL_CACHE_PREFIX + cacheName;
+            if (identityCacheConfig.isDistributed()) {
+                this.cacheName = cacheName;
             }
             identityCacheConfig.setTemporary(isTemp);
         }


### PR DESCRIPTION
### Proposed changes in this pull request

- The Identity caches need to be local caches. We don't recommend distributed caches. 

This change will make all the created caches extending the identity base cache will be local cache by default.