### PR TITLE
Manadatory claim update in social login flow

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthnMissingClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthnMissingClaimHandler.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.user.profile.mgt.UserProfileAdmin;
 import org.wso2.carbon.identity.user.profile.mgt.UserProfileException;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
@@ -308,6 +309,11 @@ public class PostAuthnMissingClaimHandler extends AbstractPostAuthnHandler {
                 UserRealm realm = getUserRealm(user.getTenantDomain());
                 AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) realm.getUserStoreManager();
 
+                /*
+                Set MANDATORY_CLAIM_UPDATE_FLOW thread local property to true, to identify
+                the mandatory claim update flow.
+                 */
+                IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.MANDATORY_CLAIM_UPDATE_FLOW, true);
                 userStoreManager.setUserClaimValuesWithID(user.getUserId(), localIdpClaims, null);
             } catch (UserStoreException e) {
                 if (e instanceof UserStoreClientException) {
@@ -320,6 +326,8 @@ public class PostAuthnMissingClaimHandler extends AbstractPostAuthnHandler {
                 throw new PostAuthenticationFailedException(
                         "User id not found",
                         "User id not found for local user. Could not update profile", e);
+            } finally {
+                IdentityUtil.threadLocalProperties.get().remove(FrameworkConstants.MANDATORY_CLAIM_UPDATE_FLOW);
             }
         }
         context.getSequenceConfig().getAuthenticatedUser().setUserAttributes(authenticatedUserAttributes);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -106,6 +106,7 @@ public abstract class FrameworkConstants {
     public static final String ASSOCIATED_ID = "associatedID";
 
     public static final String JIT_PROVISIONING_FLOW = "JITProvisioningFlow";
+    public static final String MANDATORY_CLAIM_UPDATE_FLOW = "MandatoryClaimUpdateFlow";
     public static final String SECRET_KEY_CLAIM_URL = "http://wso2.org/claims/identity/secretkey";
     public static final String IDP_RESOURCE_ID = "IDPResourceID";
     public static final String ENABLE_JIT_PROVISION_ENHANCE_FEATURE = "JITProvisioning.EnableEnhancedFeature";


### PR DESCRIPTION
### Proposed changes in this pull request

With this PR changes, MANDATORY_CLAIM_UPDATE_FLOW thread-local was introduced to capture the mandatory claim update flow for social login.
Resolves: https://github.com/wso2/product-is/issues/12222

### When should this PR be merged
This PR should be merged before https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/381
