### PR TITLE
Fix user provision with domain separator for federated login

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
@@ -162,6 +162,9 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
 
         Map<String, Object> eventProperties = new HashMap<>();
         String username = MultitenantUtils.getTenantAwareUsername(context.getSubject().toFullQualifiedUsername());
+        if(context.getSubject().isFederatedUser()) {
+            username = UserCoreUtil.removeDomainFromName(username);
+        }
         String tenantDomain = context.getTenantDomain();
         IdentityEventService identityEventService = FrameworkServiceDataHolder.getInstance().getIdentityEventService();
         RealmService realmService = FrameworkServiceDataHolder.getInstance().getRealmService();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
@@ -162,7 +162,7 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
 
         Map<String, Object> eventProperties = new HashMap<>();
         String username = MultitenantUtils.getTenantAwareUsername(context.getSubject().toFullQualifiedUsername());
-        if(context.getSubject().isFederatedUser()) {
+        if (context.getSubject().isFederatedUser()) {
             username = UserCoreUtil.removeDomainFromName(username);
         }
         String tenantDomain = context.getTenantDomain();


### PR DESCRIPTION
**Purpose**
The federated login fails when the subject identifier is having a slash.

Fixes - wso2/product-is#12121