### PR TITLE
Fix validate reset password code from email for tenants

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
@@ -767,7 +767,12 @@ public class IdentityManagementEndpointUtil {
                     }
                 }
             } else {
-                basePath = serverUrl + context;
+                if (StringUtils.isNotBlank(tenantDomain) && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME
+                        .equalsIgnoreCase(tenantDomain) && isEndpointTenantAware) {
+                    basePath = serverUrl + "/t/" + tenantDomain + context;
+                } else {
+                    basePath = serverUrl + context;
+                }
             }
         } catch (URLBuilderException e) {
             throw new ApiException("Error while building url for context: " + context);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/test/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtilTest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/test/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtilTest.java
@@ -165,13 +165,13 @@ public class IdentityManagementEndpointUtilTest extends PowerMockTestCase {
                   "https://foo.com",
                   "test.com",
                   IdentityManagementEndpointConstants.UserInfoRecovery.RECOVERY_API_RELATIVE_PATH,
-                  "https://foo.com/api/identity/recovery/v0.9"
+                  "https://foo.com/t/test.com/api/identity/recovery/v0.9"
                 },
                 { false,
                   "https://foo.com",
                   "test.com",
                   IdentityManagementEndpointConstants.UserInfoRecovery.RECOVERY_API_RELATIVE_PATH,
-                  "https://foo.com/api/identity/recovery/v0.9"
+                  "https://foo.com/t/test.com/api/identity/recovery/v0.9"
                 },
                 { false,
                   null,
@@ -223,7 +223,7 @@ public class IdentityManagementEndpointUtilTest extends PowerMockTestCase {
                   "test.com",
                   true,
                   IdentityManagementEndpointConstants.UserInfoRecovery.RECOVERY_API_RELATIVE_PATH,
-                  "https://foo.com/api/identity/recovery/v0.9"
+                  "https://foo.com/t/test.com/api/identity/recovery/v0.9"
                 },
                 { true,
                   "https://foo.com",
@@ -237,7 +237,7 @@ public class IdentityManagementEndpointUtilTest extends PowerMockTestCase {
                   "test.com",
                   true,
                   IdentityManagementEndpointConstants.UserInfoRecovery.RECOVERY_API_RELATIVE_PATH,
-                  "https://foo.com/api/identity/recovery/v0.9"
+                  "https://foo.com/t/test.com/api/identity/recovery/v0.9"
                 },
                 { false,
                   "https://foo.com",


### PR DESCRIPTION
**Purpose**
When we configure a service URL, the tenant domain is not considered when deriving the basePath hence, password recovery fails when trying the flow with the tenanted user.

fixes https://github.com/wso2/product-is/issues/12138