### PR TITLE
Disable saving old access tokens in audit table by default. 

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -154,7 +154,7 @@
             <!--If true old access token cleaning feature is enabled -->
             <EnableTokenCleanup>true</EnableTokenCleanup>
             <!--If true  old access token retained in audit table  -->
-            <RetainOldAccessToken>true</RetainOldAccessToken>
+            <RetainOldAccessToken>false</RetainOldAccessToken>
         </TokenCleanup>
         <!-- Specify the Token issuer class to be used.
              Default: org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImpl.

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -46,7 +46,7 @@
   "remote_fetch.working_directory": "${carbon.home}/tmp/",
 
   "oauth.token_cleanup.enable": true,
-  "oauth.token_cleanup.retain_access_tokens_for_auditing": true,
+  "oauth.token_cleanup.retain_access_tokens_for_auditing": false,
 
   "oauth.use_entityid_as_issuer_in_oidc_discovery": true,
   "oauth.token_validation.authorization_code_validity": "5m",


### PR DESCRIPTION
 **Purpose**
Related Issue -[ #5274](https://github.com/wso2/product-is/issues/5274)

