### PR TITLE
Add auth script execution supervisor

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JSExecutionSupervisor.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JSExecutionSupervisor.java
@@ -1,0 +1,177 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.config.model.graph;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Supervises the execution of any script engine, and kills the thread if the time taken is too much.
+ */
+public class JSExecutionSupervisor {
+
+    private static final Log LOG = LogFactory.getLog(JSExecutionSupervisor.class);
+    private static final String JS_EXECUTION_MONITOR = "JS-Exec-Monitor";
+    private final long TIMEOUT_IN_MILLIS;
+    private long taskExecutionRateInMillis = 100L;
+    private Map<String, TaskHolder> currentScriptExecutions = new HashMap<>();
+    private ScheduledExecutorService monitoringService;
+
+    public JSExecutionSupervisor(int threadCount, long timeoutInMillis) {
+
+        this.TIMEOUT_IN_MILLIS = timeoutInMillis;
+
+        if (taskExecutionRateInMillis > timeoutInMillis) {
+            taskExecutionRateInMillis = timeoutInMillis;
+        }
+
+        monitoringService = new ScheduledThreadPoolExecutor(threadCount, r -> new Thread(r, JS_EXECUTION_MONITOR));
+    }
+
+    /**
+     * Shutdown the execution supervisor.
+     */
+    public void shutdown() {
+
+        monitoringService.shutdown();
+    }
+
+    /**
+     * Start monitoring an adaptive auth execution.
+     *
+     * @param identifier          Monitoring task identifier.
+     * @param serviceProvider     Service provider of the adaptive auth script.
+     * @param tenantDomain        Tenant domain.
+     * @param elapsedTimeInMillis Elapsed time in milliseconds if a previous
+     *                            adaptive auth execution happened in the same thread.
+     */
+    public void monitor(String identifier, String serviceProvider, String tenantDomain, long elapsedTimeInMillis) {
+
+        MonitoringTask monitoringTask = new MonitoringTask(Thread.currentThread(), identifier, serviceProvider,
+                tenantDomain, elapsedTimeInMillis);
+        ScheduledFuture<?> monitoredFuture = monitoringService.
+                scheduleAtFixedRate(monitoringTask, taskExecutionRateInMillis, taskExecutionRateInMillis,
+                        TimeUnit.MILLISECONDS);
+        currentScriptExecutions.put(identifier, new TaskHolder(monitoringTask, monitoredFuture));
+    }
+
+    /**
+     * Mark adaptive auth script execution as complete and stop monitoring.
+     *
+     * @param identifier Monitoring task identifier.
+     * @return Total elapsed time of adaptive auth execution in the current thread.
+     */
+    public long completed(String identifier) {
+
+        TaskHolder taskHolder = currentScriptExecutions.remove(identifier);
+        long elapsedTime = 0L;
+        if (taskHolder == null) {
+            // Nothing to be done as there was no such task with the given identifier.
+            return elapsedTime;
+        }
+
+        ScheduledFuture<?> monitoredFuture = taskHolder.getScheduledFuture();
+        if (taskHolder.getScheduledFuture() != null) {
+            monitoredFuture.cancel(true);
+        }
+
+        MonitoringTask task = taskHolder.getMonitoringTask();
+        if (task != null) {
+            elapsedTime = task.getTotalElapsedTime();
+        }
+        return elapsedTime;
+    }
+
+    private class TaskHolder {
+
+        private MonitoringTask monitoringTask;
+        private ScheduledFuture<?> scheduledFuture;
+
+        public TaskHolder(MonitoringTask monitoringTask, ScheduledFuture<?> scheduledFuture) {
+
+            this.monitoringTask = monitoringTask;
+            this.scheduledFuture = scheduledFuture;
+        }
+
+        public MonitoringTask getMonitoringTask() {
+
+            return monitoringTask;
+        }
+
+        public ScheduledFuture<?> getScheduledFuture() {
+
+            return scheduledFuture;
+        }
+    }
+
+    private class MonitoringTask implements Runnable {
+
+        private Thread originalThread;
+        private long timeCreated;
+        private long elapsedTimeInMillis;
+        private String id;
+        private String serviceProvider;
+        private String tenantDomain;
+
+        public MonitoringTask(Thread originalThread, String id, String serviceProvider, String tenantDomain,
+                              long elapsedTimeInMillis) {
+
+            this.originalThread = originalThread;
+            this.id = id;
+            this.serviceProvider = serviceProvider;
+            this.tenantDomain = tenantDomain;
+            this.timeCreated = System.currentTimeMillis();
+            this.elapsedTimeInMillis = elapsedTimeInMillis;
+        }
+
+        @Override
+        public void run() {
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("JS execution monitoring task running. Thread: %s, service " +
+                        "provider: %s, tenant: %s.", originalThread.getName(), serviceProvider, tenantDomain));
+            }
+
+            long elapsedTime = getTotalElapsedTime();
+            if (elapsedTime > TIMEOUT_IN_MILLIS) {
+                StackTraceElement[] stackTraceElements = originalThread.getStackTrace();
+                Throwable throwable = new Throwable();
+                throwable.setStackTrace(stackTraceElements);
+                LOG.warn(String.format("The script took too much time to execute. Thread: %s, service " +
+                                "provider: %s, tenant: %s, execution duration: %s(ms).", originalThread.getName(),
+                        serviceProvider, tenantDomain, elapsedTime), throwable);
+                originalThread.interrupt();
+                originalThread.stop();
+
+                // Marking current monitoring task as complete.
+                completed(id);
+            }
+        }
+
+        private long getTotalElapsedTime() {
+
+            return (System.currentTimeMillis() - timeCreated) + elapsedTimeInMillis;
+        }
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
@@ -50,6 +50,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -172,8 +173,18 @@ public class JsGraphBuilder {
             engine.eval(FrameworkServiceDataHolder.getInstance().getCodeForRequireFunction());
             removeDefaultFunctions(engine);
             engine.eval(script);
-            invocable.invokeFunction(FrameworkConstants.JSAttributes.JS_FUNC_ON_LOGIN_REQUEST,
-                    new JsAuthenticationContext(authenticationContext));
+
+            String identifier = UUID.randomUUID().toString();
+            long elapsedTime;
+            try {
+                getJSExecutionSupervisor().monitor(identifier, authenticationContext.getServiceProviderName(),
+                        authenticationContext.getTenantDomain(), 0L);
+                invocable.invokeFunction(FrameworkConstants.JSAttributes.JS_FUNC_ON_LOGIN_REQUEST,
+                        new JsAuthenticationContext(authenticationContext));
+            } finally {
+                elapsedTime = getJSExecutionSupervisor().completed(identifier);
+            }
+            setAuthScriptExecutionElapsedTime(authenticationContext, elapsedTime);
             JsGraphBuilderFactory.persistCurrentContext(authenticationContext, engine);
         } catch (ScriptException e) {
             result.setBuildSuccessful(false);
@@ -929,6 +940,28 @@ public class JsGraphBuilder {
         engine.eval(REMOVE_FUNCTIONS);
     }
 
+    private JSExecutionSupervisor getJSExecutionSupervisor() {
+
+        return FrameworkServiceDataHolder.getInstance().getJsExecutionSupervisor();
+    }
+
+    private void setAuthScriptExecutionElapsedTime(AuthenticationContext context, long elapsedTime) {
+
+        context.setProperty(FrameworkConstants.AdaptiveAuthentication.PROP_EXECUTION_SUPERVISOR_ELAPSED_TIME,
+                elapsedTime);
+    }
+
+    private long getAuthScriptExecutionElapsedTime(AuthenticationContext context) {
+
+        long elapsedTime = 0L;
+        Object elapsedTimeObj = context.getProperty(
+                FrameworkConstants.AdaptiveAuthentication.PROP_EXECUTION_SUPERVISOR_ELAPSED_TIME);
+        if (elapsedTimeObj != null) {
+            elapsedTime = (Long) elapsedTimeObj;
+        }
+        return elapsedTime;
+    }
+
     /**
      * Javascript based Decision Evaluator implementation.
      * This is used to create the Authentication Graph structure dynamically on the fly while the authentication flow
@@ -983,8 +1016,18 @@ public class JsGraphBuilder {
 
                     CompiledScript compiledScript = compilable.compile(jsFunction.getSource());
                     JSObject builderFunction = (JSObject) compiledScript.eval();
-                    result = jsConsumer.apply(builderFunction);
 
+                    String identifier = UUID.randomUUID().toString();
+                    long elapsedTime = getAuthScriptExecutionElapsedTime(authenticationContext);
+                    try {
+                        getJSExecutionSupervisor().monitor(identifier, authenticationContext.getServiceProviderName(),
+                                authenticationContext.getTenantDomain(), elapsedTime);
+                        result = jsConsumer.apply(builderFunction);
+                    } finally {
+                        elapsedTime = getJSExecutionSupervisor().completed(identifier);
+                    }
+
+                    setAuthScriptExecutionElapsedTime(authenticationContext, elapsedTime);
                     JsGraphBuilderFactory.persistCurrentContext(authenticationContext, scriptEngine);
 
                     AuthGraphNode executingNode = (AuthGraphNode) authenticationContext

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -19,11 +19,11 @@
 package org.wso2.carbon.identity.application.authentication.framework.internal;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.eclipse.equinox.http.helper.ContextPathServletAdaptor;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -44,13 +44,11 @@ import org.wso2.carbon.identity.application.authentication.framework.LocalApplic
 import org.wso2.carbon.identity.application.authentication.framework.RequestPathApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.ServerSessionManagementService;
 import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
-import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
-import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
-import org.wso2.carbon.identity.application.authentication.framework.handler.provisioning.listener.JITProvisioningIdentityProviderMgtListener;
-import org.wso2.carbon.identity.application.authentication.framework.internal.impl.ServerSessionManagementServiceImpl;
-import org.wso2.carbon.identity.application.authentication.framework.internal.impl.UserSessionManagementServiceImpl;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
+import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.config.loader.UIBasedConfigurationLoader;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JSExecutionSupervisor;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsFunctionRegistryImpl;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsGraphBuilderFactory;
 import org.wso2.carbon.identity.application.authentication.framework.dao.impl.CacheBackedLongWaitStatusDAO;
@@ -58,6 +56,7 @@ import org.wso2.carbon.identity.application.authentication.framework.dao.impl.Lo
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.claims.ClaimFilter;
 import org.wso2.carbon.identity.application.authentication.framework.handler.claims.impl.DefaultClaimFilter;
+import org.wso2.carbon.identity.application.authentication.framework.handler.provisioning.listener.JITProvisioningIdentityProviderMgtListener;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.PostAuthenticationHandler;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.JITProvisioningPostAuthenticationHandler;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.PostAuthAssociationHandler;
@@ -74,6 +73,8 @@ import org.wso2.carbon.identity.application.authentication.framework.inbound.Htt
 import org.wso2.carbon.identity.application.authentication.framework.inbound.IdentityProcessor;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.IdentityServlet;
 import org.wso2.carbon.identity.application.authentication.framework.internal.impl.AuthenticationMethodNameTranslatorImpl;
+import org.wso2.carbon.identity.application.authentication.framework.internal.impl.ServerSessionManagementServiceImpl;
+import org.wso2.carbon.identity.application.authentication.framework.internal.impl.UserSessionManagementServiceImpl;
 import org.wso2.carbon.identity.application.authentication.framework.listener.AuthenticationEndpointTenantActivityListener;
 import org.wso2.carbon.identity.application.authentication.framework.listener.SessionContextMgtListener;
 import org.wso2.carbon.identity.application.authentication.framework.services.PostAuthenticationMgtService;
@@ -103,7 +104,6 @@ import org.wso2.carbon.identity.functions.library.mgt.FunctionLibraryManagementS
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
-import org.wso2.carbon.idp.mgt.listener.IDPMgtAuditLogger;
 import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
@@ -115,6 +115,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+
 import javax.servlet.Servlet;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.promptOnLongWait;
@@ -227,6 +228,7 @@ public class FrameworkServiceComponent {
         bundleContext.registerService(ServerSessionManagementService.class.getName(),
                 serverSessionManagementService, null);
         dataHolder.setServerSessionManagementService(serverSessionManagementService);
+        setAdaptiveAuthExecutionSupervisor();
 
         boolean tenantDropdownEnabled = ConfigurationFacade.getInstance().getTenantDropdownEnabled();
 
@@ -355,6 +357,36 @@ public class FrameworkServiceComponent {
         }
     }
 
+    private void setAdaptiveAuthExecutionSupervisor() {
+
+        String threadCountString = IdentityUtil.getProperty(
+                FrameworkConstants.AdaptiveAuthentication.CONF_EXECUTION_SUPERVISOR_THREAD_COUNT);
+        int threadCount = FrameworkConstants.AdaptiveAuthentication.DEFAULT_EXECUTION_SUPERVISOR_THREAD_COUNT;
+        if (StringUtils.isNotBlank(threadCountString)) {
+            try {
+                threadCount = Integer.parseInt(threadCountString);
+            } catch (NumberFormatException e) {
+                log.error("Error while parsing adaptive authentication execution supervisor thread count config: "
+                        + threadCountString + ", setting thread count to default value: " + threadCount, e);
+            }
+        }
+
+        String timeoutString = IdentityUtil.getProperty(
+                FrameworkConstants.AdaptiveAuthentication.CONF_EXECUTION_SUPERVISOR_TIMEOUT);
+        long timeoutInMillis = FrameworkConstants.AdaptiveAuthentication.DEFAULT_EXECUTION_SUPERVISOR_TIMEOUT;
+        if (StringUtils.isNotBlank(timeoutString)) {
+            try {
+                timeoutInMillis = Long.parseLong(timeoutString);
+            } catch (NumberFormatException e) {
+                log.error("Error while parsing adaptive authentication execution supervisor timeout config: "
+                        + timeoutString + ", setting timeout to default value: " + timeoutInMillis, e);
+            }
+        }
+
+        FrameworkServiceDataHolder.getInstance()
+                .setJsExecutionSupervisor(new JSExecutionSupervisor(threadCount, timeoutInMillis));
+    }
+
     @Deactivate
     protected void deactivate(ComponentContext ctxt) {
 
@@ -364,6 +396,7 @@ public class FrameworkServiceComponent {
 
         FrameworkServiceDataHolder.getInstance().setBundleContext(null);
         SessionDataStore.getInstance().stopService();
+        FrameworkServiceDataHolder.getInstance().getJsExecutionSupervisor().shutdown();
     }
 
     @Reference(

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.application.authentication.framework.Authenticat
 import org.wso2.carbon.identity.application.authentication.framework.JsFunctionRegistry;
 import org.wso2.carbon.identity.application.authentication.framework.ServerSessionManagementService;
 import org.wso2.carbon.identity.application.authentication.framework.config.loader.SequenceLoader;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JSExecutionSupervisor;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsGraphBuilderFactory;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.claims.ClaimFilter;
@@ -96,6 +97,7 @@ public class FrameworkServiceDataHolder {
     private SessionSerializer sessionSerializer;
 
     private AccountLockService accountLockService;
+    private JSExecutionSupervisor jsExecutionSupervisor;
 
     private FrameworkServiceDataHolder() {
 
@@ -537,6 +539,16 @@ public class FrameworkServiceDataHolder {
             ServerSessionManagementService sessionManagementService) {
 
         this.serverSessionManagementService = sessionManagementService;
+    }
+
+    public JSExecutionSupervisor getJsExecutionSupervisor() {
+
+        return jsExecutionSupervisor;
+    }
+
+    public void setJsExecutionSupervisor(JSExecutionSupervisor jsExecutionSupervisor) {
+
+        this.jsExecutionSupervisor = jsExecutionSupervisor;
     }
 
     public SessionContextMgtListener getSessionContextMgtListener(String inboundType) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -491,6 +491,14 @@ public abstract class FrameworkConstants {
     public static class AdaptiveAuthentication {
 
         public static final String ADAPTIVE_AUTH_LONG_WAIT_TIMEOUT = "AdaptiveAuth.LongWaitTimeout";
+        public static final String CONF_EXECUTION_SUPERVISOR_THREAD_COUNT =
+                "AdaptiveAuth.ExecutionSupervisor.ThreadCount";
+        public static final String CONF_EXECUTION_SUPERVISOR_TIMEOUT =
+                "AdaptiveAuth.ExecutionSupervisor.Timeout";
+        public static final int DEFAULT_EXECUTION_SUPERVISOR_THREAD_COUNT = 1;
+        public static final long DEFAULT_EXECUTION_SUPERVISOR_TIMEOUT = 500L;
+        public static final String PROP_EXECUTION_SUPERVISOR_ELAPSED_TIME
+                = "AdaptiveAuthExecutionSupervisorElapsedTime";
     }
 
     public static class ResidentIdpPropertyName {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JSExecutionSupervisorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JSExecutionSupervisorTest.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.config.model.graph;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+import java.util.UUID;
+
+/**
+ * Test class for JSExecutionSupervisor.
+ */
+public class JSExecutionSupervisorTest {
+
+    private static final Log LOG = LogFactory.getLog(JSExecutionSupervisor.class);
+
+    @Test
+    public void testMonitor() {
+
+        JSExecutionSupervisor supervisor = new JSExecutionSupervisor(1, 100L);
+        try {
+            String identifier = UUID.randomUUID().toString();
+            supervisor.monitor(identifier, "dummySP", "dummyTenant", 0L);
+            long executionDuration = 50L;
+            Thread.sleep(executionDuration);
+
+            long elapsedTime = supervisor.completed(identifier);
+            Assert.assertTrue("Elapsed time should equal or greater than " + executionDuration
+                    + " but the recorded elapsed time is: " + elapsedTime, elapsedTime >= executionDuration);
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+            Assert.fail("This is within the valid execution period but the monitor has killed the thread. " +
+                    "Error message: " + e.getMessage());
+        } finally {
+            supervisor.shutdown();
+        }
+    }
+
+    @Test
+    public void testMonitorNegative() throws InterruptedException {
+
+        final JSExecutionSupervisor supervisor = new JSExecutionSupervisor(1, 50L);
+        try {
+            Thread testExecutionThread = new Thread(() -> {
+                try {
+                    String identifier = UUID.randomUUID().toString();
+                    supervisor.monitor(identifier, "dummySP", "dummyTenant", 0L);
+                    Thread.sleep(2000L);
+                } catch (InterruptedException ignored) {
+                    // We are expecting that a exception will be thrown as the monitor will kill the thread.
+                }
+            });
+            testExecutionThread.start();
+
+            // Sleeping until the test completes.
+            Thread.sleep(300L);
+
+            Assert.assertFalse("The monitor should have killed the testExecutionThread but it didn't happen.",
+                    testExecutionThread.isAlive());
+        } finally {
+            supervisor.shutdown();
+        }
+    }
+
+    @Test
+    public void testMonitorWithAlreadyElapsedTime() {
+
+        JSExecutionSupervisor supervisor = new JSExecutionSupervisor(1, 2000L);
+        try {
+            String identifier = UUID.randomUUID().toString();
+            long elapsedTime = 1000L;
+            supervisor.monitor(identifier, "dummySP", "dummyTenant", elapsedTime);
+            long executionDuration = 50L;
+            Thread.sleep(executionDuration);
+
+            long totalElapsedTime = supervisor.completed(identifier);
+            long totalExecutionDuration = elapsedTime + executionDuration;
+            Assert.assertTrue("Elapsed time should be equal or greater than " + executionDuration
+                    + " but the recorded elapsed time is: " + elapsedTime, totalElapsedTime >= totalExecutionDuration);
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+            Assert.fail("This is within the valid execution period but the monitor has killed the thread. " +
+                    "Error message: " + e.getMessage());
+        } finally {
+            supervisor.shutdown();
+        }
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilderTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilderTest.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.application.authentication.framework.config.model.graph;
 
 import org.mockito.Mock;
+import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -28,6 +29,7 @@ import org.wso2.carbon.identity.application.authentication.framework.LocalApplic
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
 import org.wso2.carbon.identity.application.common.ApplicationAuthenticatorService;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
@@ -70,6 +72,14 @@ public class JsGraphBuilderTest extends AbstractFrameworkTest {
         initMocks(this);
         jsGraphBuilderFactory = new JsGraphBuilderFactory();
         jsGraphBuilderFactory.init();
+        JSExecutionSupervisor jsExecutionSupervisor = new JSExecutionSupervisor(1, 5000L);
+        FrameworkServiceDataHolder.getInstance().setJsExecutionSupervisor(jsExecutionSupervisor);
+    }
+
+    @AfterTest
+    public void teardown() {
+
+        FrameworkServiceDataHolder.getInstance().getJsExecutionSupervisor().shutdown();
     }
 
     @Test

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerAcrTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerAcrTest.java
@@ -18,13 +18,17 @@
 
 package org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl;
 
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JSExecutionSupervisor;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthHistory;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.common.testng.WithAxisConfiguration;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
@@ -49,6 +53,19 @@ import static org.testng.Assert.assertNotNull;
 @WithRealmService
 @WithAxisConfiguration
 public class GraphBasedSequenceHandlerAcrTest extends GraphBasedSequenceHandlerAbstractTest {
+
+    @BeforeTest
+    public void init() {
+
+        JSExecutionSupervisor jsExecutionSupervisor = new JSExecutionSupervisor(1, 5000L);
+        FrameworkServiceDataHolder.getInstance().setJsExecutionSupervisor(jsExecutionSupervisor);
+    }
+
+    @AfterTest
+    public void teardown() {
+
+        FrameworkServiceDataHolder.getInstance().getJsExecutionSupervisor().shutdown();
+    }
 
     @Test(dataProvider = "staticAcrDataProvider")
     public void testHandleStaticJavascriptAcr(String spFileName, String[] acrArray, int authHistoryCount) throws

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerClaimMappingsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerClaimMappingsTest.java
@@ -20,9 +20,12 @@ package org.wso2.carbon.identity.application.authentication.framework.handler.se
 
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JSExecutionSupervisor;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
@@ -57,6 +60,19 @@ import static org.testng.Assert.assertEquals;
 @WithCarbonHome
 @WithRealmService
 public class GraphBasedSequenceHandlerClaimMappingsTest extends GraphBasedSequenceHandlerAbstractTest {
+
+    @BeforeTest
+    public void init() {
+
+        JSExecutionSupervisor jsExecutionSupervisor = new JSExecutionSupervisor(1, 5000L);
+        FrameworkServiceDataHolder.getInstance().setJsExecutionSupervisor(jsExecutionSupervisor);
+    }
+
+    @AfterTest
+    public void teardown() {
+
+        FrameworkServiceDataHolder.getInstance().getJsExecutionSupervisor().shutdown();
+    }
 
     public void testHandleClaimHandling() throws Exception {
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerClaimsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerClaimsTest.java
@@ -20,9 +20,12 @@ package org.wso2.carbon.identity.application.authentication.framework.handler.se
 
 import org.powermock.api.mockito.PowerMockito;
 import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JSExecutionSupervisor;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
@@ -36,7 +39,6 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.Collections;
 
-import java.util.Collections;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -53,6 +55,19 @@ import static org.mockito.Mockito.when;
 @WithH2Database(jndiName = "jdbc/WSO2IdentityDB", files = {"dbScripts/h2.sql"})
 @WithRealmService
 public class GraphBasedSequenceHandlerClaimsTest extends GraphBasedSequenceHandlerAbstractTest {
+
+    @BeforeTest
+    public void init() {
+
+        JSExecutionSupervisor jsExecutionSupervisor = new JSExecutionSupervisor(1, 5000L);
+        FrameworkServiceDataHolder.getInstance().setJsExecutionSupervisor(jsExecutionSupervisor);
+    }
+
+    @AfterTest
+    public void teardown() {
+
+        FrameworkServiceDataHolder.getInstance().getJsExecutionSupervisor().shutdown();
+    }
 
     public void testHandleClaimHandling() throws Exception {
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerCustomFunctionsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerCustomFunctionsTest.java
@@ -22,12 +22,15 @@ import org.apache.commons.lang3.SerializationUtils;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
 import org.wso2.carbon.identity.application.authentication.framework.JsFunctionRegistry;
 import org.wso2.carbon.identity.application.authentication.framework.MockAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JSExecutionSupervisor;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsFunctionRegistryImpl;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsAuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthHistory;
@@ -65,6 +68,19 @@ import static org.testng.Assert.assertTrue;
 @WithCarbonHome
 @WithRealmService
 public class GraphBasedSequenceHandlerCustomFunctionsTest extends GraphBasedSequenceHandlerAbstractTest {
+
+    @BeforeTest
+    public void init() {
+
+        JSExecutionSupervisor jsExecutionSupervisor = new JSExecutionSupervisor(1, 5000L);
+        FrameworkServiceDataHolder.getInstance().setJsExecutionSupervisor(jsExecutionSupervisor);
+    }
+
+    @AfterTest
+    public void teardown() {
+
+        FrameworkServiceDataHolder.getInstance().getJsExecutionSupervisor().shutdown();
+    }
 
     @Test
     public void testHandleDynamicJavascript1() throws Exception {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerExceptionRetryTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerExceptionRetryTest.java
@@ -19,12 +19,15 @@
 package org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl;
 
 import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
 import org.wso2.carbon.identity.application.authentication.framework.JsFunctionRegistry;
 import org.wso2.carbon.identity.application.authentication.framework.MockAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JSExecutionSupervisor;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsFunctionRegistryImpl;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsAuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
@@ -56,6 +59,19 @@ import static org.mockito.Mockito.mock;
 public class GraphBasedSequenceHandlerExceptionRetryTest extends GraphBasedSequenceHandlerAbstractTest {
 
     private static final String CONTEXT_ATTRIBUTE_NAME_CURRENT_FAIL_TRIES = "RetriesOnTest";
+
+    @BeforeTest
+    public void init() {
+
+        JSExecutionSupervisor jsExecutionSupervisor = new JSExecutionSupervisor(1, 5000L);
+        FrameworkServiceDataHolder.getInstance().setJsExecutionSupervisor(jsExecutionSupervisor);
+    }
+
+    @AfterTest
+    public void teardown() {
+
+        FrameworkServiceDataHolder.getInstance().getJsExecutionSupervisor().shutdown();
+    }
 
     public void testExceptionRetry() throws Exception {
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerFailTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerFailTest.java
@@ -18,12 +18,16 @@
 
 package org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl;
 
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JSExecutionSupervisor;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthHistory;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
@@ -46,6 +50,19 @@ import static org.testng.Assert.assertNotNull;
 @WithH2Database(jndiName = "jdbc/WSO2CarbonDB", files = {"dbScripts/h2.sql"})
 @WithCarbonHome
 public class GraphBasedSequenceHandlerFailTest extends GraphBasedSequenceHandlerAbstractTest {
+
+    @BeforeTest
+    public void init() {
+
+        JSExecutionSupervisor jsExecutionSupervisor = new JSExecutionSupervisor(1, 5000L);
+        FrameworkServiceDataHolder.getInstance().setJsExecutionSupervisor(jsExecutionSupervisor);
+    }
+
+    @AfterTest
+    public void teardown() {
+
+        FrameworkServiceDataHolder.getInstance().getJsExecutionSupervisor().shutdown();
+    }
 
     @Test
     public void handleFailMethodWithParamsTest() throws Exception {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerLongWaitTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerLongWaitTest.java
@@ -18,11 +18,14 @@
 
 package org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl;
 
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.AsyncProcess;
 import org.wso2.carbon.identity.application.authentication.framework.JsFunctionRegistry;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JSExecutionSupervisor;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsFunctionRegistryImpl;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsGraphBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
@@ -47,6 +50,19 @@ import static org.mockito.Mockito.mock;
 @WithH2Database(jndiName = "jdbc/WSO2IdentityDB", files = {"dbScripts/h2.sql"})
 @WithRealmService
 public class GraphBasedSequenceHandlerLongWaitTest extends GraphBasedSequenceHandlerAbstractTest {
+
+    @BeforeTest
+    public void init() {
+
+        JSExecutionSupervisor jsExecutionSupervisor = new JSExecutionSupervisor(1, 5000L);
+        FrameworkServiceDataHolder.getInstance().setJsExecutionSupervisor(jsExecutionSupervisor);
+    }
+
+    @AfterTest
+    public void teardown() {
+
+        FrameworkServiceDataHolder.getInstance().getJsExecutionSupervisor().shutdown();
+    }
 
     @Test
     public void testHandleLongWait() throws Exception {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/testng.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/testng.xml
@@ -55,6 +55,7 @@
             <class name="org.wso2.carbon.identity.application.authentication.framework.config.loader.UIBasedConfigurationLoaderTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsAuthenticationContextTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsGraphBuilderTest"/>
+            <class name="org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JSExecutionSupervisorTest"/>
 
             <class name="org.wso2.carbon.identity.application.authentication.framework.session.extender.processor.SessionExtenderProcessorTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.session.extender.request.SessionExtenderRequestTest"/>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2548,6 +2548,10 @@
         {% if authentication.adaptive.allow_loops is defined %}
             <AllowLoops>{{authentication.adaptive.allow_loops}}</AllowLoops>
         {% endif %}
+        <ExecutionSupervisor>
+            <ThreadCount>{{authentication.adaptive.execution_supervisor.thread_count}}</ThreadCount>
+            <Timeout>{{authentication.adaptive.execution_supervisor.timeout}}</Timeout>
+        </ExecutionSupervisor>
     </AdaptiveAuth>
 
     <!--Intermediate certificate validation for certificate based requests-->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -577,6 +577,8 @@
   "authentication.adaptive.long_wait.page_refresh_interval": "500ms",
   "authentication.adaptive.long_wait.timout": "10s",
   "authentication.adaptive.long_wait.prompt": false,
+  "authentication.adaptive.execution_supervisor.thread_count": "1",
+  "authentication.adaptive.execution_supervisor.timeout": "500ms",
 
   "federated.idp.role_claim_value_attribute_separator": ",",
   "configuration.store.query_length.max": "4194304",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.unit-resolve.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.unit-resolve.json
@@ -81,6 +81,7 @@
     "authentication.adaptive.http_connections.read_timeout": "ms",
     "authentication.adaptive.http_connections.request_timeout": "ms",
     "authentication.adaptive.long_wait.page_refresh_interval": "ms",
-    "authentication.adaptive.long_wait.timout": "ms"
+    "authentication.adaptive.long_wait.timout": "ms",
+    "authentication.adaptive.execution_supervisor.timeout": "ms"
   }
 }


### PR DESCRIPTION
This PR introduces an adaptive auth script execution supervisor that is capable of limiting the execution time of the script.


If required the following can be configured (in the deployment.toml);
Number of threads for the supervisor:
Default:1
```
[authentication.adaptive.execution_supervisor]
thread_count = "1"
```

Allowed script execution time in milliseconds:
Default:500ms
```
[authentication.adaptive.execution_supervisor]
timeout = "500ms"
```