### PR TITLE
Remove comments from auth script before checking for loops

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/DefaultApplicationValidatorTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/DefaultApplicationValidatorTest.java
@@ -90,6 +90,35 @@ public class DefaultApplicationValidatorTest {
                 "    executeStep(1);\n" +
                 "};\n";
 
+        String scriptEight = "// This script will only allow for login to application while the user's age is over " +
+                "configured value\n// The user will  be redirected to an error page if the date of birth is not " +
+                "present or user is below configured var onLoginRequest = function(context) {for(var step = 0;" +
+                " step < 5; step++) {Log.info('Walking east one step');} executeStep(1);} value\n\nvar ageLimit" +
+                " = 18;\n\n// Error page to redirect " +
+                "unauthorized users,\n// can be either an absolute url or relative url to server root, or " +
+                "empty/null\n// null/empty value will redirect to the default error page\nvar errorPage = '';\n\n// " +
+                "Additional query params to be added to the above url.\n// Hint: Use i18n keys for error " +
+                "messages\nvar errorPageParameters = {\n    'status': 'Unauthorized',\n    'statusMsg': 'You need to " +
+                "be over ' + ageLimit + ' years to login to this application.'\n};\n\n/*\nHi am a multi line comment " +
+                "1\n*/\n// Date of birth attribute at the client side\nvar dateOfBirthClaim = 'http://wso2" +
+                ".org/claims/dob';\n\n// The validator function for DOB. Default validation check if the DOB is in " +
+                "YYYY-MM-dd format\nvar validateDOB = function (dob) {\n    return dob.match(/^(\\d{4})-(\\d{2})-" +
+                "(\\d{2})$/);\n};\n\nvar onLoginRequest = function(context) {\n    executeStep(1, {\n        " +
+                "onSuccess: function (context) {\n            var underAge = true;\n            // Extracting user " +
+                "store domain of authenticated subject from the first step\n            var dob = context" +
+                ".currentKnownSubject.localClaims[dateOfBirthClaim];// Adding a single line comment with for while " +
+                "foreach \n            Log.debug('DOB of user ' + context.currentKnownSubject.identifier + ' is : ' +" +
+                " dob);\n            if (dob && validateDOB(dob)) {\n                var birthDate = new Date(dob);\n" +
+                "                if (getAge(birthDate) >= ageLimit) {\n                    underAge = false;\n       " +
+                "         }\n            }\n            if (underAge === true) {\n                Log.debug('User ' +" +
+                " context.currentKnownSubject.identifier + ' is under aged. Hence denied to login.');\n              " +
+                "  sendError(errorPage, errorPageParameters);\n            }\n        }\n    });\n};\n/*\n* Hi am a " +
+                "multi line comment 2\n*/\nvar getAge = function(birthDate) {\n    var /*Adding a multiline comment " +
+                "with for while foreach*/today = new Date();\n    var age = today.getFullYear() - birthDate" +
+                ".getFullYear();\n    var m = today.getMonth()/* Adding a multiline comment with for while foreach */" +
+                " - birthDate.getMonth();\n    if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {\n  " +
+                "      age--;\n    }\n    return age;\n};";
+
         return new String[][]{
                 // isValidationFailScenario, isLoopsAllowed, script
                 {"true", "false", scripOne},
@@ -102,6 +131,7 @@ public class DefaultApplicationValidatorTest {
                 {"false", "false", scripSix},
                 {"false", "true", scripOne},
                 {"false", "true", scriptFive},
+                {"false", "false", scriptEight}
         };
     }
 


### PR DESCRIPTION
The capability to disallow loops were added in https://github.com/wso2/carbon-identity-framework/pull/3632. This PR does an improvement to it by removing comments from the script before checking for loops