### PR TITLE
Set Correct Application ID when Fetching SP Application Details

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtDBQueries.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtDBQueries.java
@@ -90,7 +90,7 @@ public class ApplicationMgtDBQueries {
     public static final String LOAD_APP_NAMES_BY_TENANT = "SELECT ID, APP_NAME, DESCRIPTION FROM SP_APP WHERE " +
             "TENANT_ID = ? AND APP_NAME != ? ORDER BY ID DESC";
     public static final String LOAD_APP_NAMES_BY_TENANT_AND_APP_NAME =
-            "SELECT APP_NAME, DESCRIPTION FROM SP_APP WHERE " +
+            "SELECT ID, APP_NAME, DESCRIPTION FROM SP_APP WHERE " +
             "TENANT_ID = ? AND APP_NAME LIKE ? AND APP_NAME != ? ORDER BY ID DESC";
     public static final String LOAD_APP_COUNT_BY_TENANT = "SELECT COUNT(*) FROM SP_APP WHERE TENANT_ID = ? AND " +
             "APP_NAME != ? ";

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -3358,8 +3358,9 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
 
             while (appNameResultSet.next()) {
                 ApplicationBasicInfo basicInfo = new ApplicationBasicInfo();
-                basicInfo.setApplicationName(appNameResultSet.getString(1));
-                basicInfo.setDescription(appNameResultSet.getString(2));
+                basicInfo.setApplicationId(appNameResultSet.getInt("ID"));
+                basicInfo.setApplicationName(appNameResultSet.getString("APP_NAME"));
+                basicInfo.setDescription(appNameResultSet.getString("DESCRIPTION"));
                 appInfo.add(basicInfo);
             }
         } catch (SQLException e) {


### PR DESCRIPTION
## Purpose
Set correct application ID when fetching Service Prover application details
Related Issue: https://github.com/wso2/product-apim/issues/11537

## Approach
Update database query to fetch application ID as well from SP_APP table and set the ID to the ApplicationBasicInfo object when fetching SP application details.

## Related PRs
https://github.com/wso2-support/carbon-identity-framework/pull/1729
https://github.com/wso2-support/carbon-identity-framework/pull/1730