### PR TITLE
Service provider cache cleared when updating connected IDPs

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
@@ -252,4 +252,16 @@ public interface ApplicationDAO {
 
         return 0;
     }
+
+    /**
+     * Method that can be run after updating components related to the service provider. Contains post application
+     * dependency update tasks.
+     *
+     * @param serviceProvider   Service provider application.
+     * @param tenantDomain      Tenant domain of the service provider.
+     */
+    default void clearApplicationFromCache(ServiceProvider serviceProvider, String tenantDomain)
+            throws IdentityApplicationManagementException {
+
+    }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/CacheBackedApplicationDAO.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/CacheBackedApplicationDAO.java
@@ -185,6 +185,11 @@ public class CacheBackedApplicationDAO extends ApplicationDAOImpl {
         appDAO.updateApplication(serviceProvider, tenantDomain);
     }
 
+    public void clearApplicationFromCache(ServiceProvider serviceProvider, String tenantDomain) {
+
+        clearAllAppCache(serviceProvider, tenantDomain);
+    }
+
     public void deleteApplication(String applicationName) throws IdentityApplicationManagementException {
 
         String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/12283
> With this PR, when an IDP is updated, it triggers a cache clear of all service providers connected to the relevant IDP. When a subsequent GET request to the service provider is made, the server pulls info directly from the database, not the stale info that was in the cache.