### PR TITLE
Add memory supervision to script execution supervisor

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JSExecutionMonitorData.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JSExecutionMonitorData.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.config.model.graph;
+
+import java.io.Serializable;
+
+/**
+ * Holds the result of a script execution monitor.
+ */
+public class JSExecutionMonitorData implements Serializable {
+
+    private static final long serialVersionUID = 1183234189933783699L;
+    private long elapsedTime;
+    private long consumedMemory;
+
+    public JSExecutionMonitorData(long elapsedTime, long consumedMemory) {
+
+        this.elapsedTime = elapsedTime;
+        this.consumedMemory = consumedMemory;
+    }
+
+    public long getElapsedTime() {
+
+        return elapsedTime;
+    }
+
+    public void setElapsedTime(long elapsedTime) {
+
+        this.elapsedTime = elapsedTime;
+    }
+
+    public long getConsumedMemory() {
+
+        return consumedMemory;
+    }
+
+    public void setConsumedMemory(long consumedMemory) {
+
+        this.consumedMemory = consumedMemory;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JSExecutionSupervisor.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JSExecutionSupervisor.java
@@ -16,9 +16,11 @@
 
 package org.wso2.carbon.identity.application.authentication.framework.config.model.graph;
 
+import com.sun.management.ThreadMXBean;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.lang.management.ManagementFactory;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
@@ -34,16 +36,31 @@ public class JSExecutionSupervisor {
     private static final Log LOG = LogFactory.getLog(JSExecutionSupervisor.class);
     private static final String JS_EXECUTION_MONITOR = "JS-Exec-Monitor";
     private final long timeoutInMillis;
-    private long taskExecutionRateInMillis = 100L;
+    private final long memoryLimitInBytes;
+    private long taskExecutionRateInMillis = 50L;
     private Map<String, TaskHolder> currentScriptExecutions = new HashMap<>();
     private ScheduledExecutorService monitoringService;
+    private final int monitorTypeTime = 0;
+    private final int monitorTypeMemory = 1;
 
     public JSExecutionSupervisor(int threadCount, long timeoutInMillis) {
 
-        this.timeoutInMillis = timeoutInMillis;
+        this(threadCount, timeoutInMillis, 0L);
+    }
+
+    public JSExecutionSupervisor(int threadCount, long timeoutInMillis, long memoryLimit) {
 
         if (taskExecutionRateInMillis > timeoutInMillis) {
             taskExecutionRateInMillis = timeoutInMillis;
+        }
+
+        this.timeoutInMillis = timeoutInMillis;
+
+        if (memoryLimit > 0) {
+            this.memoryLimitInBytes = memoryLimit;
+        } else {
+            // We are not checking for memory usage.
+            memoryLimitInBytes = -1;
         }
 
         monitoringService = new ScheduledThreadPoolExecutor(threadCount, r -> new Thread(r, JS_EXECUTION_MONITOR));
@@ -64,12 +81,29 @@ public class JSExecutionSupervisor {
      * @param serviceProvider     Service provider of the adaptive auth script.
      * @param tenantDomain        Tenant domain.
      * @param elapsedTimeInMillis Elapsed time in milliseconds if a previous
-     *                            adaptive auth execution happened in the same thread.
+     *                            adaptive auth execution happened in the same flow.
      */
     public void monitor(String identifier, String serviceProvider, String tenantDomain, long elapsedTimeInMillis) {
 
+        monitor(identifier, serviceProvider, tenantDomain, elapsedTimeInMillis, 0L);
+    }
+
+    /**
+     * Start monitoring an adaptive auth execution.
+     *
+     * @param identifier            Monitoring task identifier.
+     * @param serviceProvider       Service provider of the adaptive auth script.
+     * @param tenantDomain          Tenant domain.
+     * @param elapsedTimeInMillis   Elapsed time in milliseconds if a previous
+     *                              adaptive auth execution happened in the same flow.
+     * @param consumedMemoryInBytes Consumed memory in bytes if a previous
+     *                              adaptive auth execution happened in the same flow.
+     */
+    public void monitor(String identifier, String serviceProvider, String tenantDomain, long elapsedTimeInMillis,
+                        long consumedMemoryInBytes) {
+
         MonitoringTask monitoringTask = new MonitoringTask(Thread.currentThread(), identifier, serviceProvider,
-                tenantDomain, elapsedTimeInMillis);
+                tenantDomain, elapsedTimeInMillis, consumedMemoryInBytes);
         ScheduledFuture<?> monitoredFuture = monitoringService.
                 scheduleAtFixedRate(monitoringTask, taskExecutionRateInMillis, taskExecutionRateInMillis,
                         TimeUnit.MILLISECONDS);
@@ -82,13 +116,12 @@ public class JSExecutionSupervisor {
      * @param identifier Monitoring task identifier.
      * @return Total elapsed time of adaptive auth execution in the current thread.
      */
-    public long completed(String identifier) {
+    public JSExecutionMonitorData completed(String identifier) {
 
         TaskHolder taskHolder = currentScriptExecutions.remove(identifier);
-        long elapsedTime = 0L;
         if (taskHolder == null) {
             // Nothing to be done as there was no such task with the given identifier.
-            return elapsedTime;
+            return null;
         }
 
         ScheduledFuture<?> monitoredFuture = taskHolder.getScheduledFuture();
@@ -97,10 +130,15 @@ public class JSExecutionSupervisor {
         }
 
         MonitoringTask task = taskHolder.getMonitoringTask();
+        long elapsedTime = 0L;
+        long consumedMemory = 0L;
         if (task != null) {
             elapsedTime = task.getTotalElapsedTime();
+            consumedMemory = task.getTotalConsumedMemory();
+            task.turnOffThreadMemoryCounting();
         }
-        return elapsedTime;
+
+        return new JSExecutionMonitorData(elapsedTime, consumedMemory);
     }
 
     private class TaskHolder {
@@ -128,14 +166,23 @@ public class JSExecutionSupervisor {
     private class MonitoringTask implements Runnable {
 
         private Thread originalThread;
-        private long timeCreated;
-        private long elapsedTimeInMillis;
         private String id;
         private String serviceProvider;
         private String tenantDomain;
+        private long timeCreated;
+        private long elapsedTimeInMillis;
+        private long startMemoryInBytes;
+        private long consumedMemoryInBytes;
+        private ThreadMXBean memoryCounter = null;
 
         public MonitoringTask(Thread originalThread, String id, String serviceProvider, String tenantDomain,
                               long elapsedTimeInMillis) {
+
+            this(originalThread, id, serviceProvider, tenantDomain, elapsedTimeInMillis, 0L);
+        }
+
+        public MonitoringTask(Thread originalThread, String id, String serviceProvider, String tenantDomain,
+                              long elapsedTimeInMillis, long consumedMemoryInBytes) {
 
             this.originalThread = originalThread;
             this.id = id;
@@ -143,6 +190,24 @@ public class JSExecutionSupervisor {
             this.tenantDomain = tenantDomain;
             this.timeCreated = System.currentTimeMillis();
             this.elapsedTimeInMillis = elapsedTimeInMillis;
+            this.consumedMemoryInBytes = consumedMemoryInBytes;
+
+            if (memoryLimitInBytes > 0) {
+                java.lang.management.ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+                if (threadMXBean instanceof com.sun.management.ThreadMXBean) {
+                    memoryCounter = (ThreadMXBean) threadMXBean;
+                    try {
+                        turnOnThreadMemoryCounting();
+                        startMemoryInBytes = getCurrentMemory(originalThread.getId());
+                    } catch (UnsupportedOperationException e) {
+                        LOG.error("Thread allocated memory measurement is not supported by the JVM. Therefore memory " +
+                                "supervision will not be done for adaptive auth script executions.", e);
+                    }
+                } else {
+                    LOG.error("Thread allocated memory measurement is not supported by the JVM. Therefore memory " +
+                            "supervision will not be done for adaptive auth script executions.");
+                }
+            }
         }
 
         @Override
@@ -154,24 +219,71 @@ public class JSExecutionSupervisor {
             }
 
             long elapsedTime = getTotalElapsedTime();
-            if (elapsedTime > timeoutInMillis) {
-                StackTraceElement[] stackTraceElements = originalThread.getStackTrace();
-                Throwable throwable = new Throwable();
-                throwable.setStackTrace(stackTraceElements);
-                LOG.warn(String.format("The script took too much time to execute. Thread: %s, service " +
-                                "provider: %s, tenant: %s, execution duration: %s(ms).", originalThread.getName(),
-                        serviceProvider, tenantDomain, elapsedTime), throwable);
-                originalThread.interrupt();
-                originalThread.stop();
 
-                // Marking current monitoring task as complete.
-                completed(id);
+            if (elapsedTime > timeoutInMillis) {
+                terminateScriptExecutingThread(monitorTypeTime, elapsedTime);
+            } else if (memoryCounter != null) {
+                long consumedMemory = getTotalConsumedMemory();
+                if (consumedMemory > memoryLimitInBytes) {
+                    terminateScriptExecutingThread(monitorTypeMemory, consumedMemory);
+                }
             }
+        }
+
+        private void terminateScriptExecutingThread(int monitorType, long consumedResourceValue) {
+
+            String warnLog;
+            if (monitorTypeTime == monitorType) {
+                warnLog = String.format("The script took too much time to execute. Thread: %s, service provider: %s, " +
+                                "tenant: %s, execution duration: %s(ms).", originalThread.getName(), serviceProvider,
+                        tenantDomain, consumedResourceValue);
+            } else {
+                warnLog = String.format("The script took too much memory to execute. Thread: %s, service provider: " +
+                                "%s, tenant: %s, consumed memory: %s(bytes).", originalThread.getName(),
+                        serviceProvider, tenantDomain, consumedResourceValue);
+            }
+
+            StackTraceElement[] stackTraceElements = originalThread.getStackTrace();
+            Throwable throwable = new Throwable();
+            throwable.setStackTrace(stackTraceElements);
+            LOG.warn(warnLog, throwable);
+            originalThread.interrupt();
+            originalThread.stop();
+
+            // Marking current monitoring task as complete.
+            completed(id);
         }
 
         private long getTotalElapsedTime() {
 
             return (System.currentTimeMillis() - timeCreated) + elapsedTimeInMillis;
+        }
+
+        private long getTotalConsumedMemory() {
+
+            return (getCurrentMemory(originalThread.getId()) - startMemoryInBytes) + consumedMemoryInBytes;
+        }
+
+        private long getCurrentMemory(long threadId) {
+
+            if (memoryCounter != null) {
+                return memoryCounter.getThreadAllocatedBytes(threadId);
+            }
+            return 0L;
+        }
+
+        private void turnOnThreadMemoryCounting() {
+
+            if (memoryCounter != null) {
+                memoryCounter.setThreadAllocatedMemoryEnabled(true);
+            }
+        }
+
+        private void turnOffThreadMemoryCounting() {
+
+            if (memoryCounter != null) {
+                memoryCounter.setThreadAllocatedMemoryEnabled(false);
+            }
         }
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -384,8 +384,22 @@ public class FrameworkServiceComponent {
             }
         }
 
+        String memoryLimitString = IdentityUtil.getProperty(
+                FrameworkConstants.AdaptiveAuthentication.CONF_EXECUTION_SUPERVISOR_MEMORY_LIMIT);
+        long memoryLimitInBytes = FrameworkConstants.AdaptiveAuthentication.DEFAULT_EXECUTION_SUPERVISOR_MEMORY_LIMIT;
+        if (StringUtils.isNotBlank(memoryLimitString)) {
+            try {
+                memoryLimitInBytes = Long.parseLong(memoryLimitString);
+            } catch (NumberFormatException e) {
+                log.error("Error while parsing adaptive authentication execution supervisor memory limit config: "
+                        + memoryLimitString + ", memory consumption will not be monitored.", e);
+            }
+        }
+
+
+
         FrameworkServiceDataHolder.getInstance()
-                .setJsExecutionSupervisor(new JSExecutionSupervisor(threadCount, timeoutInMillis));
+                .setJsExecutionSupervisor(new JSExecutionSupervisor(threadCount, timeoutInMillis, memoryLimitInBytes));
     }
 
     @Deactivate

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -533,10 +533,13 @@ public abstract class FrameworkConstants {
                 "AdaptiveAuth.ExecutionSupervisor.ThreadCount";
         public static final String CONF_EXECUTION_SUPERVISOR_TIMEOUT =
                 "AdaptiveAuth.ExecutionSupervisor.Timeout";
+        public static final String CONF_EXECUTION_SUPERVISOR_MEMORY_LIMIT =
+                "AdaptiveAuth.ExecutionSupervisor.MemoryLimit";
         public static final int DEFAULT_EXECUTION_SUPERVISOR_THREAD_COUNT = 1;
         public static final long DEFAULT_EXECUTION_SUPERVISOR_TIMEOUT = 500L;
-        public static final String PROP_EXECUTION_SUPERVISOR_ELAPSED_TIME
-                = "AdaptiveAuthExecutionSupervisorElapsedTime";
+        public static final long DEFAULT_EXECUTION_SUPERVISOR_MEMORY_LIMIT = -1;
+        public static final String PROP_EXECUTION_SUPERVISOR_RESULT
+                = "AdaptiveAuthExecutionSupervisorResult";
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JSExecutionSupervisorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JSExecutionSupervisorTest.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.Assert;
 import org.testng.annotations.Test;
 
+import java.util.HashMap;
 import java.util.UUID;
 
 /**
@@ -33,16 +34,25 @@ public class JSExecutionSupervisorTest {
     @Test
     public void testMonitor() {
 
-        JSExecutionSupervisor supervisor = new JSExecutionSupervisor(1, 100L);
+        long timeout = 100L;
+        long memoryLimit = 50000L;
+
+        JSExecutionSupervisor supervisor = new JSExecutionSupervisor(1, timeout, memoryLimit);
         try {
             String identifier = UUID.randomUUID().toString();
-            supervisor.monitor(identifier, "dummySP", "dummyTenant", 0L);
+            supervisor.monitor(identifier, "dummySP", "dummyTenant", 0L, 0L);
             long executionDuration = 50L;
             Thread.sleep(executionDuration);
 
-            long elapsedTime = supervisor.completed(identifier);
+            JSExecutionMonitorData result = supervisor.completed(identifier);
+
+            Assert.assertNotNull("The execution monitor result should not be null.", result);
+            long elapsedTime = result.getElapsedTime();
             Assert.assertTrue("Elapsed time should equal or greater than " + executionDuration
                     + " but the recorded elapsed time is: " + elapsedTime, elapsedTime >= executionDuration);
+            long consumedMemory = result.getConsumedMemory();
+            Assert.assertTrue("Conusumed memory should be greater than 0. Consumed memory: " + consumedMemory,
+                    consumedMemory > 0);
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);
             Assert.fail("This is within the valid execution period but the monitor has killed the thread. " +
@@ -53,7 +63,7 @@ public class JSExecutionSupervisorTest {
     }
 
     @Test
-    public void testMonitorNegative() throws InterruptedException {
+    public void testTimeBasedMonitorNegative() throws InterruptedException {
 
         final JSExecutionSupervisor supervisor = new JSExecutionSupervisor(1, 50L);
         try {
@@ -79,7 +89,7 @@ public class JSExecutionSupervisorTest {
     }
 
     @Test
-    public void testMonitorWithAlreadyElapsedTime() {
+    public void testTimeBasedMonitorWithAlreadyElapsedTime() {
 
         JSExecutionSupervisor supervisor = new JSExecutionSupervisor(1, 2000L);
         try {
@@ -89,10 +99,66 @@ public class JSExecutionSupervisorTest {
             long executionDuration = 50L;
             Thread.sleep(executionDuration);
 
-            long totalElapsedTime = supervisor.completed(identifier);
+            JSExecutionMonitorData result = supervisor.completed(identifier);
+            long totalElapsedTime = result.getElapsedTime();
             long totalExecutionDuration = elapsedTime + executionDuration;
             Assert.assertTrue("Elapsed time should be equal or greater than " + executionDuration
                     + " but the recorded elapsed time is: " + elapsedTime, totalElapsedTime >= totalExecutionDuration);
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+            Assert.fail("This is within the valid execution period but the monitor has killed the thread. " +
+                    "Error message: " + e.getMessage());
+        } finally {
+            supervisor.shutdown();
+        }
+    }
+
+    @Test
+    public void testMemoryBasedMonitorNegative() throws InterruptedException {
+
+        final JSExecutionSupervisor supervisor = new JSExecutionSupervisor(1, 5000L, 4000L);
+        Thread testExecutionThread = null;
+        try {
+            testExecutionThread = new Thread(() -> {
+                try {
+                    String identifier = UUID.randomUUID().toString();
+                    supervisor.monitor(identifier, "dummySP", "dummyTenant", 0L, 0L);
+                    HashMap<Object, Object> objectHashMap = new HashMap<>();
+                    for (int i = 0; i < 200; i++) {
+                        Thread.sleep(1);
+                        objectHashMap.put(new Object(), new Object());
+                    }
+                } catch (Exception ignored) {
+                    // We are expecting that a exception will be thrown as the monitor will kill the thread.
+                }
+            });
+            testExecutionThread.start();
+            // Sleeping until the test completes.
+            Thread.sleep(300L);
+            Assert.assertFalse("The monitor should have killed the testExecutionThread but it didn't happen.",
+                    testExecutionThread.isAlive());
+        } finally {
+            if (testExecutionThread != null && testExecutionThread.isAlive()) {
+                testExecutionThread.interrupt();
+                testExecutionThread.stop();
+            }
+            supervisor.shutdown();
+        }
+    }
+
+    @Test
+    public void testMemoryBasedMonitorWithAlreadyConsumedMemory() {
+
+        long memoryLimit = 60000000L; // 60mb;
+        JSExecutionSupervisor supervisor = new JSExecutionSupervisor(1, 2000L, memoryLimit);
+        try {
+            String identifier = UUID.randomUUID().toString();
+            long consumedMemory = 50000000L; // 50mb
+            supervisor.monitor(identifier, "dummySP", "dummyTenant", 0L, consumedMemory);
+            JSExecutionMonitorData result = supervisor.completed(identifier);
+            long totalConsumedMemory = result.getConsumedMemory();
+            Assert.assertTrue("Consumed memory should be greater than " + consumedMemory + " but the recorded " +
+                    "consumed memory is: " + totalConsumedMemory, totalConsumedMemory >= consumedMemory);
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);
             Assert.fail("This is within the valid execution period but the monitor has killed the thread. " +

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2580,11 +2580,14 @@
         <LongWaitTimeout>{{authentication.adaptive.long_wait.timout}}</LongWaitTimeout>
 
         {% if authentication.adaptive.allow_loops is defined %}
-            <AllowLoops>{{authentication.adaptive.allow_loops}}</AllowLoops>
+        <AllowLoops>{{authentication.adaptive.allow_loops}}</AllowLoops>
         {% endif %}
         <ExecutionSupervisor>
             <ThreadCount>{{authentication.adaptive.execution_supervisor.thread_count}}</ThreadCount>
             <Timeout>{{authentication.adaptive.execution_supervisor.timeout}}</Timeout>
+            {% if authentication.adaptive.execution_supervisor.memory_limit is defined %}
+            <MemoryLimit>{{authentication.adaptive.execution_supervisor.memory_limit}}</MemoryLimit>
+            {% endif %}
         </ExecutionSupervisor>
     </AdaptiveAuth>
 


### PR DESCRIPTION
This PR provides the capability to limit the amount of memory that can be consumed by an adaptive auth script when it is being executed.

By default, no memory limits are imposed. If a memory limit needs to be set add the following config to the deployment.toml file

memory_limit is set in bytes.
```
[authentication.adaptive.execution_supervisor]
memory_limit = "500000"
```