### PR TITLE
Move resolveUserIdFromUsername(int tenantId, String userStoreDomain, String username) to indentityUtils

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -97,6 +97,7 @@ import org.wso2.carbon.identity.application.common.model.IdentityProviderPropert
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
+import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
@@ -2747,36 +2748,8 @@ public class FrameworkUtils {
             UserSessionException {
 
         try {
-            if (userStoreDomain == null) {
-                userStoreDomain = UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
-            }
-            UserStoreManager userStoreManager = getUserStoreManager(tenantId, userStoreDomain);
-            try {
-                if (userStoreManager instanceof AbstractUserStoreManager) {
-                    String userId = ((AbstractUserStoreManager) userStoreManager).getUserIDFromUserName(username);
-
-                    // If the user id is could not be resolved, probably user does not exist in the user store.
-                    if (StringUtils.isBlank(userId)) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("User id could not be resolved for username: " + username + " in user store " +
-                                    "domain: " + userStoreDomain + " and tenant with id: " + tenantId + ". Probably " +
-                                    "user does not exist in the user store.");
-                        }
-                    }
-                    return userId;
-                }
-                if (log.isDebugEnabled()) {
-                    log.debug("Provided user store manager for the user: " + username + ", is not an instance of the " +
-                            "AbstractUserStore manager");
-                }
-                throw new UserSessionException("Unable to get the unique id of the user: " + username + ".");
-            } catch (org.wso2.carbon.user.core.UserStoreException e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Error occurred while resolving Id for the user: " + username, e);
-                }
-                throw new UserSessionException("Error occurred while resolving Id for the user: " + username, e);
-            }
-        } catch (UserStoreException e) {
+            return IdentityUtil.resolveUserIdFromUsername(tenantId, userStoreDomain, username);
+        } catch (IdentityException e) {
             throw new UserSessionException("Error occurred while retrieving the userstore manager to resolve Id for " +
                     "the user: " + username, e);
         }
@@ -2939,24 +2912,6 @@ public class FrameworkUtils {
             }
         }
         return userId;
-    }
-
-    private static UserStoreManager getUserStoreManager(int tenantId, String userStoreDomain)
-            throws UserStoreException {
-
-        UserStoreManager userStoreManager = FrameworkServiceComponent.getRealmService().getTenantUserRealm(tenantId)
-                .getUserStoreManager();
-        if (userStoreManager instanceof org.wso2.carbon.user.core.UserStoreManager) {
-            return ((org.wso2.carbon.user.core.UserStoreManager) userStoreManager).getSecondaryUserStoreManager(
-                    userStoreDomain);
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("Unable to resolve the corresponding user store manager for the domain: " + userStoreDomain
-                    + ", as the provided user store manager: " + userStoreManager.getClass() + ", is not an instance " +
-                    "of org.wso2.carbon.user.core.UserStoreManager. Therefore returning the user store " +
-                    "manager: " + userStoreManager.getClass() + ", from the realm.");
-        }
-        return userStoreManager;
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2750,8 +2750,7 @@ public class FrameworkUtils {
         try {
             return IdentityUtil.resolveUserIdFromUsername(tenantId, userStoreDomain, username);
         } catch (IdentityException e) {
-            throw new UserSessionException("Error occurred while retrieving the userstore manager to resolve Id for " +
-                    "the user: " + username, e);
+            throw new UserSessionException("Error occurred while resolving Id for the user: " + username, e);
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerAbstractTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerAbstractTest.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.application.authentication.framework.handler.Sub
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.core.internal.IdentityCoreServiceDataHolder;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
@@ -106,6 +107,7 @@ public class GraphBasedSequenceHandlerAbstractTest extends AbstractFrameworkTest
 
         RealmService mockRealmService = mock(RealmService.class);
         FrameworkServiceDataHolder.getInstance().setRealmService(mockRealmService);
+        IdentityCoreServiceDataHolder.getInstance().setRealmService(mockRealmService);
 
         CacheBackedIdPMgtDAO cacheBackedIdPMgtDAO = mock(CacheBackedIdPMgtDAO.class);
         Field daoField = IdentityProviderManager.class.getDeclaredField("dao");

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/IdentityCoreServiceComponent.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/IdentityCoreServiceComponent.java
@@ -225,6 +225,7 @@ public class IdentityCoreServiceComponent {
     protected void setRealmService(RealmService realmService) {
         IdentityTenantUtil.setRealmService(realmService);
         defaultKeystoreManagerExtension.setRealmService(realmService);
+        IdentityCoreServiceDataHolder.getInstance().setRealmService(realmService);
     }
 
     /**
@@ -233,6 +234,7 @@ public class IdentityCoreServiceComponent {
     protected void unsetRealmService(RealmService realmService) {
         defaultKeystoreManagerExtension.setRealmService(null);
         IdentityTenantUtil.setRealmService(null);
+        IdentityCoreServiceDataHolder.getInstance().setRealmService(null);
     }
 
     @Reference(

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/IdentityCoreServiceDataHolder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/IdentityCoreServiceDataHolder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.core.internal;
+
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * Identity core service data holder.
+ */
+public class IdentityCoreServiceDataHolder {
+
+    private static IdentityCoreServiceDataHolder instance = new IdentityCoreServiceDataHolder();
+    private RealmService realmService = null;
+
+    private IdentityCoreServiceDataHolder() {
+
+    }
+    public static IdentityCoreServiceDataHolder getInstance() {
+
+        return instance;
+    }
+
+    /**
+     * Get realm service.
+     * @return realm service.
+     */
+    public RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    /**
+     * Set realm service.
+     * @param realmService Realm service.
+     */
+    public void setRealmService(RealmService realmService) {
+
+        this.realmService = realmService;
+    }
+}

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/IdentityCoreServiceDataHolder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/IdentityCoreServiceDataHolder.java
@@ -31,6 +31,7 @@ public class IdentityCoreServiceDataHolder {
     private IdentityCoreServiceDataHolder() {
 
     }
+
     public static IdentityCoreServiceDataHolder getInstance() {
 
         return instance;
@@ -38,6 +39,7 @@ public class IdentityCoreServiceDataHolder {
 
     /**
      * Get realm service.
+     *
      * @return realm service.
      */
     public RealmService getRealmService() {
@@ -47,6 +49,7 @@ public class IdentityCoreServiceDataHolder {
 
     /**
      * Set realm service.
+     *
      * @param realmService Realm service.
      */
     public void setRealmService(RealmService realmService) {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -1569,6 +1569,7 @@ public class IdentityUtil {
      * @return Unique user id of the user.
      * @throws IdentityException When error occurred while retrieving the user id.
      */
+    @Deprecated
     public static String resolveUserIdFromUsername(int tenantId, String userStoreDomain, String username) throws
             IdentityException {
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.internal.IdentityCoreServiceComponent;
+import org.wso2.carbon.identity.core.internal.IdentityCoreServiceDataHolder;
 import org.wso2.carbon.identity.core.model.IdentityCacheConfig;
 import org.wso2.carbon.identity.core.model.IdentityCacheConfigKey;
 import org.wso2.carbon.identity.core.model.IdentityCookieConfig;
@@ -54,6 +55,7 @@ import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.NetworkUtils;
@@ -1557,4 +1559,74 @@ public class IdentityUtil {
         }
     }
 
+    /**
+     * Retrieves the unique user id of the given username. If the unique user id is not available, generate an id and
+     * update the userid claim in read/write userstores.
+     *
+     * @param tenantId        Id of the tenant domain of the user.
+     * @param userStoreDomain Userstore of the user.
+     * @param username        Username.
+     * @return Unique user id of the user.
+     * @throws IdentityException When error occurred while retrieving the user id.
+     */
+    public static String resolveUserIdFromUsername(int tenantId, String userStoreDomain, String username) throws
+            IdentityException {
+
+        try {
+            if (userStoreDomain == null) {
+                userStoreDomain = UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
+            }
+            org.wso2.carbon.user.api.UserStoreManager userStoreManager = getUserStoreManager(tenantId, userStoreDomain);
+            try {
+                if (userStoreManager instanceof AbstractUserStoreManager) {
+                    String userId = ((AbstractUserStoreManager) userStoreManager).getUserIDFromUserName(username);
+
+                    // If the user id could not be resolved, probably user does not exist in the user store.
+                    if (StringUtils.isBlank(userId)) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("User id could not be resolved for username: " + username + " in user store " +
+                                    "domain: " + userStoreDomain + " and tenant with id: " + tenantId + ". Probably " +
+                                    "user does not exist in the user store.");
+                        }
+                    }
+                    return userId;
+                }
+                if (log.isDebugEnabled()) {
+                    log.debug("Provided user store manager for the user: " + username + ", is not an instance of the " +
+                            "AbstractUserStore manager");
+                }
+                throw new IdentityException("Unable to get the unique id of the user: " + username + ".");
+            } catch (org.wso2.carbon.user.core.UserStoreException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Error occurred while resolving Id for the user: " + username, e);
+                }
+                throw new IdentityException("Error occurred while resolving Id for the user: " + username, e);
+            }
+        } catch (UserStoreException e) {
+            throw new IdentityException("Error occurred while retrieving the userstore manager to resolve Id for " +
+                    "the user: " + username, e);
+        }
+    }
+
+    private static org.wso2.carbon.user.api.UserStoreManager getUserStoreManager(int tenantId, String userStoreDomain)
+            throws UserStoreException {
+
+        org.wso2.carbon.user.api.UserStoreManager userStoreManager =
+                IdentityCoreServiceDataHolder.getInstance().getRealmService().getTenantUserRealm(tenantId)
+                        .getUserStoreManager();
+        if (userStoreManager instanceof org.wso2.carbon.user.core.UserStoreManager) {
+            return ((org.wso2.carbon.user.core.UserStoreManager) userStoreManager).getSecondaryUserStoreManager(
+                    userStoreDomain);
+        }
+        if (log.isDebugEnabled()) {
+            String debugLog = String.format(
+                    "Unable to resolve the corresponding user store manager for the domain: %s, " +
+                            "as the provided user store manager: %s, is not an instance of " +
+                            "org.wso2.carbon.user.core.UserStoreManager. Therefore returning the user store manager: %s," +
+                            " from the realm.", userStoreDomain, userStoreManager.getClass(),
+                    userStoreManager.getClass());
+            log.debug(debugLog);
+        }
+        return userStoreManager;
+    }
 }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -1574,7 +1574,7 @@ public class IdentityUtil {
             IdentityException {
 
         try {
-            if (userStoreDomain == null) {
+            if (StringUtils.isEmpty(userStoreDomain)) {
                 userStoreDomain = UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
             }
             org.wso2.carbon.user.api.UserStoreManager userStoreManager = getUserStoreManager(tenantId, userStoreDomain);


### PR DESCRIPTION
### Proposed changes in this pull request
Note $subject

### Problem trying to solve:
Resolving initiator id for the audit logs in **application.mgt, idp.mgt, claim.metadata.mgt, functions.library.mgt, identity.multi.attribute.login.mgt** and **identity.handler.event.account.lock** modules

```java
    /**
     * Get the initiator id.
     *
     * @param userName     Username of the initiator.
     * @param tenantDomain Tenant domain of the initiator.
     * @return User id of the initiator.
     */
    public static String getInitiatorId(String userName, String tenantDomain) {

        String userId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
        if (userId == null) {
            AuthenticatedUser user = new AuthenticatedUser();
            user.setUserName(UserCoreUtil.removeDomainFromName(userName));
            user.setUserStoreDomain(UserCoreUtil.extractDomainFromName(userName));
            user.setTenantDomain(tenantDomain);
            userId = user.getUserId();
        }
        return userId;
    }
```
This code causes cyclic dependency if we use AuthenticatedUser in authentication-framework
