### PR TITLE
Introduce configuration to check claim uniqueness

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1469,6 +1469,15 @@
                 enable="{{event.default_listener.is_introspection_data_provider.enable}}">
         </EventListener>
 
+        {% if identity_mgt.user_claim_update.uniqueness.enable is defined %}
+            <EventListener id="unique_claim_user_operation_event_listener" type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
+                    name="org.wso2.carbon.identity.unique.claim.mgt.listener.UniqueClaimUserOperationEventListener"
+                    orderId="{{identity_mgt.user_claim_update.uniqueness.listener_priority}}"
+                    enable="{{identity_mgt.user_claim_update.uniqueness.enable}}">
+                    <Property name="ScopeWithinUserstore">{{identity_mgt.user_claim_update.uniqueness.scope_within_userstore}}</Property>
+            </EventListener>
+        {% endif %}
+
         <!-- Custom Audit Loggers-->
         {% for listener in event_listener %}
         <EventListener id="{{listener.id}}"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -354,6 +354,9 @@
   "identity_mgt.user_claim_update.mobile.enable_verification": false,
   "identity_mgt.user_claim_update.mobile.verification_sms_otp_validity": "5",
   "identity_mgt.user_claim_update.use_verify_claim": true,
+  "identity_mgt.user_claim_update.uniqueness.enable": false,
+  "identity_mgt.user_claim_update.uniqueness.listener_priority": "2",
+  "identity_mgt.user_claim_update.uniqueness.scope_within_userstore": false,
 
   "identity_mgt_account_suspension.use_identity_claims": true,
 


### PR DESCRIPTION
### Proposed changes in this pull request
With this changes, the uniqueness of the claims can be enabled with following configuration in the `deployment.toml` file.
```
[identity_mgt.user_claim_update.uniqueness]
enable = true
scope_within_userstore = true #optional
```

Fixes: wso2/product-is#12360