### PR TITLE
Fix updating tenant domains in dropdown

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/TenantDataManager.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/TenantDataManager.java
@@ -226,7 +226,7 @@ public class TenantDataManager {
      */
     public static List<String> getAllActiveTenantDomains() {
 
-        if (initialized && tenantDomainList.isEmpty()) {
+        if (initialized) {
             refreshActiveTenantDomainsList();
         }
         return tenantDomainList;


### PR DESCRIPTION
**Purpose**
Fix newly added tenants will not be shown in the tenant list when loading tenants into the dropdown in the login page. Server doesn't need to restart with new changes. 

Fixes https://github.com/wso2/product-is/issues/12335