### PR TITLE
Fix federated authenticator's post authentication

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
@@ -165,7 +165,11 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
             eventProperties.put(IdentityEventConstants.EventProperty.USER_STORE_MANAGER, userRealm
                     .getUserStoreManager());
             eventProperties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
-            eventProperties.put(IdentityEventConstants.EventProperty.OPERATION_STATUS, false);
+            if (context.isRequestAuthenticated()) {
+                eventProperties.put(IdentityEventConstants.EventProperty.OPERATION_STATUS, true);
+            } else {
+                eventProperties.put(IdentityEventConstants.EventProperty.OPERATION_STATUS, false);
+            }
             Event event = new Event(IdentityEventConstants.Event.POST_AUTHENTICATION, eventProperties);
             identityEventService.handleEvent(event);
         } catch (UserStoreException e) {


### PR DESCRIPTION
### Proposed changes in this pull request

Resolve https://github.com/wso2/product-is/issues/12276

Currently we have hard coded the value for IdentityEventConstants.EventProperty.OPERATION_STATUS as false. Therefore even for successful authentication this value is false. Because of that in the account lock handler we are considering a successful authentication as a failure one[1]. 

As a solution I have put the value for IdentityEventConstants.EventProperty.OPERATION_STATUS according to the authentication context isRequestAuthenticated value.

[1] https://github.com/wso2-extensions/identity-event-handler-account-lock/blob/v1.4.11/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java#L331