### PR TITLE
Fix mandatory claim update for the users from read-only user store

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthnMissingClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthnMissingClaimHandler.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.io.IOException;
@@ -321,6 +322,12 @@ public class PostAuthnMissingClaimHandler extends AbstractPostAuthnHandler {
                                 setUserAttributes(authenticatedUserAttributes);
                         return;
                     }
+                }
+                if (ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getCode().
+                        equals(e.getErrorCode())) {
+                    context.getSequenceConfig().getAuthenticatedUser().
+                            setUserAttributes(authenticatedUserAttributes);
+                    return;
                 }
                 throw new PostAuthenticationFailedException(
                         "Error while handling missing mandatory claims",

--- a/pom.xml
+++ b/pom.xml
@@ -1726,7 +1726,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.7.0-m3</carbon.kernel.version>
+        <carbon.kernel.version>4.7.0-m4</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>


### PR DESCRIPTION
### Proposed changes in this pull request

With this fix, the users who are in read-only userstores, will prompt for the missing mandatory claims on each login attempt for those service providers and missing mandatory claims will not be persisted into user profiles of those users in read-only user stores.
Resolves: wso2/product-is#12382

### When should this PR be merged
This PR should merge after merging https://github.com/wso2/carbon-kernel/pull/3060 and upgrading the released kernel version.