### PR TITLE
set IdPEntityId to be tenant qualified

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -360,7 +360,7 @@ public class IdentityProviderManager implements IdpManager {
         }
         propertiesList = new ArrayList<Property>();
 
-        Property idPEntityIdProp = resolveFedAuthnProperty(getOIDCResidentIdPEntityId(), oidcFedAuthn,
+        Property idPEntityIdProp = resolveFedAuthnProperty(oauth2TokenEPUrl, oidcFedAuthn,
                 OPENID_IDP_ENTITY_ID);
         propertiesList.add(idPEntityIdProp);
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -360,8 +360,15 @@ public class IdentityProviderManager implements IdpManager {
         }
         propertiesList = new ArrayList<Property>();
 
-        Property idPEntityIdProp = resolveFedAuthnProperty(oauth2TokenEPUrl, oidcFedAuthn,
-                OPENID_IDP_ENTITY_ID);
+        Property idPEntityIdProp;
+        // When the tenant qualified urls are enabled, we need to see the oauth2 token endpoint.
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            idPEntityIdProp = resolveFedAuthnProperty(oauth2TokenEPUrl, oidcFedAuthn,
+                    OPENID_IDP_ENTITY_ID);
+        } else {
+            idPEntityIdProp = resolveFedAuthnProperty(getOIDCResidentIdPEntityId(), oidcFedAuthn,
+                    OPENID_IDP_ENTITY_ID);
+        }
         propertiesList.add(idPEntityIdProp);
 
         Property authzUrlProp = resolveFedAuthnProperty(oauth2AuthzEPUrl, oidcFedAuthn,


### PR DESCRIPTION
### Proposed changes in this pull request
In the current implementation, even though `tenant-qualified URLs` is enabled, IdPEntityId did not reflect that. This PR changes that by overwriting with tenant.

Related to the improvements in https://github.com/wso2/carbon-identity-framework/pull/3240