### PR TITLE
Add config to enable/disable Stored Procedure supported DAO

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2853,5 +2853,13 @@
     <!-- Configuration for allowing users to introspect tokens from other tenants. -->
     <AllowCrossTenantTokenIntrospection>{{oauth.allow_cross_tenant_token_introspection}}</AllowCrossTenantTokenIntrospection>
 
-
+    {% if stored_procedure_dao is defined %}
+    <!-- Stored Procedure supported DAO Implementation of Identity components.
+    To enable this, the corresponding Stored Procedure supported DAO extension has to be added to product.   -->
+    <StoredProcedureDAO>
+        {% for key,value in stored_procedure_dao.items() %}
+        <DAO name="{{key}}" enabled="{{value}}"/>
+        {% endfor %}
+    </StoredProcedureDAO>
+    {% endif %}
 </Server>


### PR DESCRIPTION
### Proposed changes in this pull request

- Add config to enable/disable Stored Procedure supported DAO

For example, We can enable/disable by adding the following in deployment.toml,
```
[stored_procedure_dao]
oidc_scope_mapping = false
claim_mgt = true
```

