### PR TITLE
Client exceptions returned when operations fail due to user input

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -2447,7 +2447,7 @@ public class IdentityProviderManager implements IdpManager {
                                             "An Identity Provider Entity ID has already been registered with the " +
                                                     "name '" + property.getValue() + "' for tenant '" + tenantDomain +
                                                     "'";
-                                    throw new IdentityProviderManagementException(msg);
+                                    throw new IdentityProviderManagementClientException(msg);
                                 }
                                 return true;
                             }
@@ -2505,7 +2505,7 @@ public class IdentityProviderManager implements IdpManager {
                                         String msg = "An Identity Provider Entity ID has already been registered " +
                                                 "with the name '" +
                                                 property.getValue() + "' for tenant '" + tenantDomain + "'";
-                                        throw new IdentityProviderManagementException(msg);
+                                        throw new IdentityProviderManagementClientException(msg);
                                     }
                                     return true;
                                 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -2618,8 +2618,8 @@ public class IdPManagementDAO {
                     // Check whether certificate decoding and certificate generation fails or not.
                     IdentityApplicationManagementUtil.getCertDataArray(identityProvider.getCertificateInfoArray());
                 } catch (CertificateException ex) {
-                    throw new IdentityProviderManagementException("Malformed Public Certificate file has been provided."
-                            , ex);
+                    throw new IdentityProviderManagementClientException("Malformed Public Certificate file has been " +
+                            "provided.", ex);
                 }
             }
             JSONArray certificateInfoJsonArray = new JSONArray(identityProvider.getCertificateInfoArray());
@@ -2884,7 +2884,7 @@ public class IdPManagementDAO {
                 try {
                     IdentityApplicationManagementUtil.getCertDataArray(newIdentityProvider.getCertificateInfoArray());
                 } catch (CertificateException ex) {
-                    throw new IdentityProviderManagementException("Malformed Public Certificate file has been " +
+                    throw new IdentityProviderManagementClientException("Malformed Public Certificate file has been " +
                             "provided.", ex);
                 }
             }


### PR DESCRIPTION
### Proposed changes in this pull request

Fix client exceptions returned when operations fail due 
1. provided malformed certificate
2. provided saml authenticator entityId not unique

Fixes https://github.com/wso2/product-is/issues/12408
Fixes https://github.com/wso2/product-is/issues/12400
