### PR TITLE
Add Console application name to IdentityManagementEndpointConstants

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointConstants.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointConstants.java
@@ -100,6 +100,7 @@ public class IdentityManagementEndpointConstants {
     public static final String DEFAULT_USER_PORTAL_URL = "../myaccount";
     public static final String USER_PORTAL_URL = "/myaccount";
     public static final String My_ACCOUNT_APPLICATION_NAME = "My Account";
+    public static final String CONSOLE_APPLICATION_NAME = "Console";
     public static final String USER_TENANT_HINT_PLACE_HOLDER = "${UserTenantHint}";
 
     public static final String RELATIVE_PATH_START_CHAR = ".";


### PR DESCRIPTION
### Proposed changes in this pull request

Added Console application name to IdentityManagementEndpointConstants for use at the recovery endpoint.