### PR TITLE
SP and IDP listeners added to monitor claim deletions.

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
@@ -211,6 +211,7 @@
                             org.wso2.carbon.identity.claim.metadata.mgt; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt.model; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt.exception; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.claim.metadata.mgt.listener; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.consent.mgt.core.*; version="${carbon.consent.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.database.utils.*;version="${org.wso2.carbon.database.utils.version.range}",

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtDBQueries.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtDBQueries.java
@@ -419,6 +419,8 @@ public class ApplicationMgtDBQueries {
     public static final String IS_APP_BY_TENANT_AND_UUID_DISCOVERABLE = "SELECT COUNT(UUID) FROM SP_APP WHERE " +
             "TENANT_ID = :TENANT_ID; AND UUID = :UUID; AND IS_DISCOVERABLE = '1'";
 
+    public static final String GET_TOTAL_SP_CLAIM_USAGES = "SELECT COUNT(*) FROM SP_CLAIM_MAPPING WHERE TENANT_ID = ?" +
+            " AND IDP_CLAIM = ?";
 }
 
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 
+import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
 
@@ -263,5 +264,20 @@ public interface ApplicationDAO {
     default void clearApplicationFromCache(ServiceProvider serviceProvider, String tenantDomain)
             throws IdentityApplicationManagementException {
 
+    }
+
+    /**
+     * Method that checks whether a claim is associated with any service provider.
+     *
+     * @param dbConnection  Optional DB connection.
+     * @param claimUri      Claim URI.
+     * @param tenantId      ID of the tenant.
+     * @return  True if claim is referred by a service provider.
+     * @throws IdentityApplicationManagementException   Error when obtaining claim references.
+     */
+    default boolean isClaimReferredByAnySp(Connection dbConnection, String claimUri, int tenantId)
+            throws IdentityApplicationManagementException {
+
+        return false;
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponent.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponent.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.identity.application.mgt.DiscoverableApplicationManager;
 import org.wso2.carbon.identity.application.mgt.defaultsequence.DefaultAuthSeqMgtService;
 import org.wso2.carbon.identity.application.mgt.defaultsequence.DefaultAuthSeqMgtServiceImpl;
 import org.wso2.carbon.identity.application.mgt.internal.impl.DiscoverableApplicationManagerImpl;
+import org.wso2.carbon.identity.application.mgt.listener.ApplicationClaimMgtListener;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationIdentityProviderMgtListener;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtAuditLogger;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
@@ -54,6 +55,7 @@ import org.wso2.carbon.identity.application.mgt.listener.DefaultApplicationResou
 import org.wso2.carbon.identity.application.mgt.validator.ApplicationValidator;
 import org.wso2.carbon.identity.application.mgt.validator.DefaultApplicationValidator;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.listener.ClaimMetadataMgtListener;
 import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -114,6 +116,9 @@ public class ApplicationManagementServiceComponent {
 
             bundleContext.registerService(DiscoverableApplicationManager.class.getName(),
                     new DiscoverableApplicationManagerImpl(), null);
+
+            bundleContext.registerService(ClaimMetadataMgtListener.class.getName(), new ApplicationClaimMgtListener(),
+                    null);
 
             // Register the ApplicationValidator.
             context.getBundleContext().registerService(ApplicationValidator.class,

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/ApplicationClaimMgtListener.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/ApplicationClaimMgtListener.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.mgt.listener;
+
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.mgt.dao.impl.ApplicationDAOImpl;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.claim.metadata.mgt.listener.AbstractClaimMetadataMgtListener;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+
+/**
+ * Internal implementation of {@link AbstractClaimMetadataMgtListener} to listen to claim CRUD events.
+ * Changes the Application/Service Provider data according to claim changes.
+ */
+public class ApplicationClaimMgtListener extends AbstractClaimMetadataMgtListener {
+
+    private static ApplicationDAOImpl applicationDAO = new ApplicationDAOImpl();
+
+    @Override
+    public int getDefaultOrderId() {
+
+        return 21;
+    }
+
+    @Override
+    public boolean doPreDeleteClaim(String claimUri, String tenantDomain) throws ClaimMetadataException {
+
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        try {
+            if (applicationDAO.isClaimReferredByAnySp(null, claimUri, tenantId)) {
+                throw new ClaimMetadataException("Unable to delete claim as it is referred by an application.");
+            }
+        } catch (IdentityApplicationManagementException e) {
+            throw new ClaimMetadataException("Error when deleting claim.", e);
+        }
+        return true;
+    }
+}

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementServiceImpl.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementServiceImpl.java
@@ -30,6 +30,8 @@ import org.wso2.carbon.identity.claim.metadata.mgt.dao.LocalClaimDAO;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataClientException;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataServerException;
+import org.wso2.carbon.identity.claim.metadata.mgt.internal.IdentityClaimManagementServiceComponent;
+import org.wso2.carbon.identity.claim.metadata.mgt.listener.ClaimMetadataMgtListener;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ClaimDialect;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
@@ -41,6 +43,7 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -274,10 +277,22 @@ public class ClaimMetadataManagementServiceImpl implements ClaimMetadataManageme
         }
 
         ClaimMetadataEventPublisherProxy.getInstance().publishPreDeleteLocalClaim(tenantId, localClaimURI);
+        Collection<ClaimMetadataMgtListener> listeners =
+                IdentityClaimManagementServiceComponent.getClaimMetadataMgtListeners();
+        for (ClaimMetadataMgtListener listener : listeners) {
+            if (listener.isEnable() && !listener.doPreDeleteClaim(localClaimURI, tenantDomain)) {
+                return;
+            }
+        }
 
         this.localClaimDAO.removeLocalClaim(localClaimURI, tenantId);
 
         ClaimMetadataEventPublisherProxy.getInstance().publishPostDeleteLocalClaim(tenantId, localClaimURI);
+        for (ClaimMetadataMgtListener listener : listeners) {
+            if (listener.isEnable() && !listener.doPostDeleteClaim(localClaimURI, tenantDomain)) {
+                return;
+            }
+        }
     }
 
     @Override

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/internal/IdentityClaimManagementServiceComponent.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/internal/IdentityClaimManagementServiceComponent.java
@@ -240,7 +240,6 @@ public class IdentityClaimManagementServiceComponent {
 
         return IdentityClaimManagementServiceDataHolder.getClaimMetadataMgtListeners();
     }
-}
 
     @Reference(
             name = "claim.config.init.dao",

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/internal/IdentityClaimManagementServiceComponent.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/internal/IdentityClaimManagementServiceComponent.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.identity.claim.metadata.mgt.dao.ClaimConfigInitDAO;
 import org.wso2.carbon.identity.claim.metadata.mgt.internal.impl.DefaultClaimConfigInitDAO;
 import org.wso2.carbon.identity.claim.metadata.mgt.listener.ClaimConfigListener;
 import org.wso2.carbon.identity.claim.metadata.mgt.listener.ClaimMetadataManagementAuditLogger;
+import org.wso2.carbon.identity.claim.metadata.mgt.listener.ClaimMetadataMgtListener;
 import org.wso2.carbon.identity.claim.metadata.mgt.listener.ClaimMetadataTenantMgtListener;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
@@ -43,6 +44,8 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+
+import java.util.Collection;
 
 @SuppressWarnings("unused")
 @Component(
@@ -214,6 +217,30 @@ public class IdentityClaimManagementServiceComponent {
             log.debug("IdentityEventService set in Identity Claim Management bundle");
         }
     }
+
+    @Reference(
+            name = "claim.metadata.mgt.event.listener.service",
+            service = ClaimMetadataMgtListener.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "removeClaimMetadataMgtListenerService"
+    )
+    protected void addClaimMetadataMgtListenerService(ClaimMetadataMgtListener claimMetadataMgtListenerService) {
+
+        IdentityClaimManagementServiceDataHolder.getInstance().addClaimMetadataMgtListener(
+                claimMetadataMgtListenerService);
+    }
+
+    protected void removeClaimMetadataMgtListenerService(ClaimMetadataMgtListener claimMetadataMgtListener) {
+
+        IdentityClaimManagementServiceDataHolder.getInstance().removeClaimMetadataMgtListener(claimMetadataMgtListener);
+    }
+
+    public static Collection<ClaimMetadataMgtListener> getClaimMetadataMgtListeners() {
+
+        return IdentityClaimManagementServiceDataHolder.getClaimMetadataMgtListeners();
+    }
+}
 
     @Reference(
             name = "claim.config.init.dao",

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/internal/IdentityClaimManagementServiceDataHolder.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/internal/IdentityClaimManagementServiceDataHolder.java
@@ -19,12 +19,16 @@ package org.wso2.carbon.identity.claim.metadata.mgt.internal;
 import org.osgi.framework.BundleContext;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.dao.ClaimConfigInitDAO;
+import org.wso2.carbon.identity.claim.metadata.mgt.listener.ClaimMetadataMgtListener;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.listener.ClaimManagerListener;
 import org.wso2.carbon.user.core.service.RealmService;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -42,6 +46,7 @@ public class IdentityClaimManagementServiceDataHolder {
     private IdentityEventService identityEventService;
     private static Map<Integer, ClaimManagerListener> claimManagerListeners = new TreeMap<Integer,
             ClaimManagerListener>();
+    private static List<ClaimMetadataMgtListener> claimMetadataMgtListeners = new ArrayList<>();
     private ClaimConfigInitDAO claimConfigInitDAO;
 
     private IdentityClaimManagementServiceDataHolder() {
@@ -120,6 +125,27 @@ public class IdentityClaimManagementServiceDataHolder {
 
         this.identityEventService = identityEventService;
     }
+
+    public static synchronized List<ClaimMetadataMgtListener> getClaimMetadataMgtListeners() {
+
+        return claimMetadataMgtListeners;
+    }
+
+    public synchronized void addClaimMetadataMgtListener(ClaimMetadataMgtListener claimMetadataMgtListener) {
+
+        claimMetadataMgtListeners.add(claimMetadataMgtListener);
+        claimMetadataMgtListeners.sort(claimMetadataMgtListenerComparator);
+    }
+
+    public synchronized void removeClaimMetadataMgtListener(ClaimMetadataMgtListener claimMetadataMgtListener) {
+
+        if (claimMetadataMgtListener != null) {
+            claimMetadataMgtListeners.remove(claimMetadataMgtListener);
+        }
+    }
+
+    private static Comparator<ClaimMetadataMgtListener> claimMetadataMgtListenerComparator =
+            Comparator.comparingInt(ClaimMetadataMgtListener::getExecutionOrderId);
 
     public void setClaimConfigInitDAO(ClaimConfigInitDAO claimConfigInitDAO) {
 

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/listener/AbstractClaimMetadataMgtListener.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/listener/AbstractClaimMetadataMgtListener.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.claim.metadata.mgt.listener;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+/**
+ * Abstract implementation for the {@link ClaimMetadataMgtListener}.
+ */
+public abstract class AbstractClaimMetadataMgtListener  implements ClaimMetadataMgtListener {
+
+    public boolean isEnable() {
+
+        IdentityEventListenerConfig identityEventListenerConfig = IdentityUtil.readEventListenerProperty
+                (ClaimMetadataMgtListener.class.getName(), this.getClass().getName());
+        if (identityEventListenerConfig == null) {
+            return true;
+        }
+        if (StringUtils.isNotBlank(identityEventListenerConfig.getEnable())) {
+            return Boolean.parseBoolean(identityEventListenerConfig.getEnable());
+        } else {
+            return true;
+        }
+    }
+
+    public int getExecutionOrderId() {
+
+        IdentityEventListenerConfig identityEventListenerConfig = IdentityUtil.readEventListenerProperty
+                (ClaimMetadataMgtListener.class.getName(), this.getClass().getName());
+        int orderId = IdentityCoreConstants.EVENT_LISTENER_ORDER_ID;
+        if (identityEventListenerConfig != null) {
+            orderId = identityEventListenerConfig.getOrder();
+        }
+        if (orderId != IdentityCoreConstants.EVENT_LISTENER_ORDER_ID) {
+            return orderId;
+        }
+        return getDefaultOrderId();
+    }
+
+    @Override
+    public boolean doPreDeleteClaim(String claimUri, String tenantDomain) throws ClaimMetadataException {
+
+        return true;
+    }
+
+    @Override
+    public boolean doPostDeleteClaim(String claimUri, String tenantDomain) throws ClaimMetadataException {
+
+        return true;
+    }
+}

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/listener/ClaimMetadataMgtListener.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/listener/ClaimMetadataMgtListener.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.claim.metadata.mgt.listener;
+
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+
+/**
+ * Definition for the listeners which listens to Claim CRUD events.
+ */
+public interface ClaimMetadataMgtListener {
+
+    /**
+     * Get the execution order identifier for this listener.
+     *
+     * @return The execution order identifier integer value.
+     */
+    int getExecutionOrderId();
+
+    /**
+     * Get the default order identifier for this listener.
+     *
+     * @return Default order id.
+     */
+    int getDefaultOrderId();
+
+    /**
+     * Check whether the listener is enabled or not.
+     *
+     * @return True if enabled.
+     */
+    boolean isEnable();
+
+    /**
+     * Method which carries out tasks which should run before deleting a claim.
+     *
+     * @param claimUri      Claim URI.
+     * @param tenantDomain  Tenant domain.
+     * @return  True if method executes successfully.
+     * @throws ClaimMetadataException   ClaimMetadataException error.
+     */
+    boolean doPreDeleteClaim(String claimUri, String tenantDomain) throws ClaimMetadataException;
+
+    /**
+     * Method which carries out tasks which should run after deleting a claim.
+     *
+     * @param claimUri      Claim URI.
+     * @param tenantDomain  Tenant domain.
+     * @return  True if method executes successfully.
+     * @throws ClaimMetadataException   ClaimMetadataException error.
+     */
+    boolean doPostDeleteClaim(String claimUri, String tenantDomain) throws ClaimMetadataException;
+}

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/internal/IdPManagementServiceComponent.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/internal/IdPManagementServiceComponent.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.listener.ClaimMetadataMgtListener;
 import org.wso2.carbon.identity.core.ConnectorConfig;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -46,6 +47,7 @@ import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.idp.mgt.dao.CacheBackedIdPMgtDAO;
 import org.wso2.carbon.idp.mgt.dao.IdPManagementDAO;
+import org.wso2.carbon.idp.mgt.listener.IdentityProviderClaimMgtListener;
 import org.wso2.carbon.idp.mgt.listener.IdentityProviderNameResolverListener;
 import org.wso2.carbon.idp.mgt.listener.IDPMgtAuditLogger;
 import org.wso2.carbon.idp.mgt.listener.IdPMgtValidationListener;
@@ -236,6 +238,18 @@ public class IdPManagementServiceComponent {
                 addSuperTenantIdp();
             }
             bundleCtx.registerService(IdpManager.class, IdentityProviderManager.getInstance(), null);
+
+            ServiceRegistration idpClaimMetadataMgtListener =
+                    bundleCtx.registerService(ClaimMetadataMgtListener.class.getName(),
+                            new IdentityProviderClaimMgtListener(), null);
+            if (idpClaimMetadataMgtListener != null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Identity Provider Claim Metadata Management Listener registered.");
+                }
+            } else {
+                log.error("Identity Provider Management - Error while registering Identity Provider Claim Metadata " +
+                        "Management Listener.");
+            }
 
             buildFileBasedIdPList();
             cleanUpRemovedIdps();

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/listener/IdentityProviderClaimMgtListener.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/listener/IdentityProviderClaimMgtListener.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.idp.mgt.listener;
+
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.claim.metadata.mgt.listener.AbstractClaimMetadataMgtListener;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.dao.IdPManagementDAO;
+
+/**
+ * Internal implementation of {@link AbstractClaimMetadataMgtListener} to listen to claim CRUD events.
+ * Changes the Identity Provider data according to claim changes.
+ */
+public class IdentityProviderClaimMgtListener extends AbstractClaimMetadataMgtListener {
+
+    private static IdPManagementDAO idPManagementDAO = new IdPManagementDAO();
+
+    public int getDefaultOrderId() {
+
+        return 22;
+    }
+
+    @Override
+    public boolean doPreDeleteClaim(String claimUri, String tenantDomain) throws ClaimMetadataException {
+
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        try {
+            if (idPManagementDAO.isClaimReferredByAnyIdp(null, claimUri, tenantId)) {
+                throw new ClaimMetadataException("Unable to delete claim as it is referred by an IDP.");
+            }
+        } catch (IdentityProviderManagementException e) {
+            throw new ClaimMetadataException("Error when deleting claim.", e);
+        }
+        return true;
+    }
+}

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
@@ -438,6 +438,8 @@ public class IdPManagementConstants {
         public static final String GET_IDP_NAME_BY_METADATA = "SELECT IDP.NAME FROM IDP INNER JOIN IDP_METADATA ON " +
                 "IDP.ID = IDP_METADATA.IDP_ID WHERE IDP_METADATA.NAME = ? AND IDP_METADATA.VALUE = ? AND " +
                 "IDP_METADATA.TENANT_ID = ?";
+        public static final String GET_TOTAL_IDP_CLAIM_USAGES = "SELECT COUNT(*) FROM IDP_CLAIM_MAPPING WHERE " +
+                "TENANT_ID = ? AND LOCAL_CLAIM = ?";
     }
 
     public enum ErrorMessage {


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/12290
> Claim deletion was successful even if a claim had been referred by an IDP or SP. This should not be the case as it would leave the IDP and SPs in a stale and broken state. This PR adds listeners for SPs and IDPs to monitor when claims are being deleted and prevent deletion if those claims are being referred. 