### PR TITLE
Remove groups from provisioning as user attributes

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -798,7 +798,7 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
 
         // Remove role claim from local claims as roles are specifically handled.
         localClaimValues.remove(FrameworkUtils.getLocalClaimUriMappedForIdPRoleClaim(externalIdPConfig));
-
+        localClaimValues.remove(UserCoreConstants.USER_STORE_GROUPS_CLAIM);
         try {
             FrameworkUtils.getStepBasedSequenceHandler()
                     .callJitProvisioning(username, context, identityProviderMappedUserRolesUnmappedExclusive,


### PR DESCRIPTION
### Proposed changes in this pull request
Remove `http://wso2.org/claims/groups` claim from the user claims map when the role mapping is not enabled for JIT provisioning IDP. As a result, no group mapping will be added.