### PR TITLE
Fix response issues when overlapping IDP API calls.

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -2372,7 +2372,7 @@ public class IdentityProviderManager implements IdpManager {
                 return null;
             }
         }
-        return dao.getIdPByResourceId(resourceId, tenantId, tenantDomain);
+        return dao.getUpdatedIdPByResourceId(resourceId, tenantId, tenantDomain);
     }
 
     private void updateIDP(IdentityProvider currentIdentityProvider, IdentityProvider newIdentityProvider, int tenantId,

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAO.java
@@ -285,7 +285,7 @@ public class CacheBackedIdPMgtDAO {
      * @param tenantId     Tenant ID of the identity provider.
      * @param tenantDomain Tenant domain of the identity provider.
      * @return Updated identity provider with given resource ID.
-     * @throws IdentityProviderManagementException Error when getting the iIdentity Provider.
+     * @throws IdentityProviderManagementException Error when getting the identity provider.
      */
     public IdentityProvider getUpdatedIdPByResourceId(String resourceId, int tenantId, String tenantDomain) throws
             IdentityProviderManagementException {

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAO.java
@@ -285,7 +285,7 @@ public class CacheBackedIdPMgtDAO {
      * @param tenantId     Tenant ID of the identity provider.
      * @param tenantDomain Tenant domain of the identity provider.
      * @return Updated identity provider with given resource ID.
-     * @throws IdentityProviderManagementException Error when getting Resident Identity Provider.
+     * @throws IdentityProviderManagementException Error when getting the iIdentity Provider.
      */
     public IdentityProvider getUpdatedIdPByResourceId(String resourceId, int tenantId, String tenantDomain) throws
             IdentityProviderManagementException {

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAO.java
@@ -281,11 +281,11 @@ public class CacheBackedIdPMgtDAO {
     /**
      * Get the updated IDP details using the resource ID.
      *
-     * @param resourceId   resource ID of the identity provider.
+     * @param resourceId   Resource ID of the identity provider.
      * @param tenantId     Tenant ID of the identity provider.
      * @param tenantDomain Tenant domain of the identity provider.
      * @return Updated identity provider with given resource ID.
-     * @throws IdentityProviderManagementException
+     * @throws IdentityProviderManagementException Error when getting Resident Identity Provider.
      */
     public IdentityProvider getUpdatedIdPByResourceId(String resourceId, int tenantId, String tenantDomain) throws
             IdentityProviderManagementException {
@@ -296,9 +296,9 @@ public class CacheBackedIdPMgtDAO {
 
         if (entry != null) {
             /*
-            Before updating an IDP we clear the cache. Therefore, if we get a cache hit again at this point, it should
-            be a reason of some other process done on the same IDP. Hence, we need to clear the cache before proceed
-            in order to generate a correct response.
+             * Before updating an IDP we clear the cache. Therefore, if we get a cache hit again at this point, it
+             * should be a reason of some other process done on the same IDP. Hence, we need to clear the cache before
+             * proceed in order to generate a correct response.
              */
             if (log.isDebugEnabled()) {
                 log.debug("Cache entry found for Identity Provider with resource ID: " + resourceId
@@ -311,14 +311,13 @@ public class CacheBackedIdPMgtDAO {
 
         identityProvider = idPMgtDAO.getIDPbyResourceId(null, resourceId, tenantId, tenantDomain);
 
-        if (identityProvider != null) {
-            addIdPCache(identityProvider, tenantDomain);
-        } else {
+        if (identityProvider == null) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("No IDP found with resource ID: %s in DB", resourceId));
             }
+            return null;
         }
-
+        addIdPCache(identityProvider, tenantDomain);
         return identityProvider;
     }
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
@@ -610,6 +610,19 @@ public class IdentityProviderManagementServiceTest extends PowerMockTestCase {
         Assert.assertNotNull(identityProviderManagementService.getIdPByName(newIdpName));
     }
 
+    @Test(dataProvider = "updateIdPData")
+    public void testUpdateIdPByResourceId(String oldIdpName, Object newIdp) throws Exception {
+
+        addTestIdps();
+        IdentityProvider oldIdp = identityProviderManagementService.getIdPByName(oldIdpName);
+        IdentityProviderManager.getInstance()
+                .updateIdPByResourceId(oldIdp.getResourceId(), (IdentityProvider) newIdp, "carbon.super");
+        String newIdpName = ((IdentityProvider) newIdp).getIdentityProviderName();
+
+        Assert.assertNull(identityProviderManagementService.getIdPByName(oldIdpName));
+        Assert.assertNotNull(identityProviderManagementService.getIdPByName(newIdpName));
+    }
+
     @DataProvider
     public Object[][] updateIdPExceptionData() {
 


### PR DESCRIPTION
### Proposed changes in this pull request

When overlapping update calls on the same IDP,  responses from REST API had issues because of invalid cache hits. This PR is to fix that issue.