### PR TITLE
Add event handler to validate when non-approved users are trying to login

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -67,6 +67,7 @@ public class IdentityCoreConstants {
     public static final String ADMIN_FORCED_USER_PASSWORD_RESET_VIA_EMAIL_LINK_ERROR_CODE = "17006";
     public static final String ADMIN_FORCED_USER_PASSWORD_RESET_VIA_OTP_ERROR_CODE = "17007";
     public static final String ADMIN_FORCED_USER_PASSWORD_RESET_VIA_OTP_MISMATCHED_ERROR_CODE = "17008";
+    public static final String USER_ACCOUNT_PENDING_APPROVAL_ERROR_CODE = "17009";
 
     public static final String USER_ACCOUNT_STATE = "UserAccountState";
 

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/pom.xml
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/pom.xml
@@ -51,6 +51,10 @@
             <groupId>org.wso2.orbit.javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.event</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -90,6 +94,12 @@
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.wso2.carbon.base; version="${carbon.base.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.event; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.event.event; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.event.handler; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.bean.context; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.handler; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.model; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.base; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core; version="${carbon.identity.package.import.version.range}",
@@ -100,6 +110,7 @@
                             org.wso2.carbon.user.core.tenant; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.util; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.utils; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.utils.multitenancy; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.core.util; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.stratos.common.*; version="${carbon.commons.imp.pkg.version}",
                             org.wso2.carbon; version="${carbon.kernel.package.import.version.range}"

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/handler/WorkflowPendingUserAuthnHandler.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/handler/WorkflowPendingUserAuthnHandler.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.workflow.mgt.handler;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.core.bean.context.MessageContext;
+import org.wso2.carbon.identity.core.handler.InitConfig;
+import org.wso2.carbon.identity.core.model.IdentityErrorMsgContext;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.workflow.mgt.WorkflowManagementService;
+import org.wso2.carbon.identity.workflow.mgt.WorkflowManagementServiceImpl;
+import org.wso2.carbon.identity.workflow.mgt.bean.Entity;
+import org.wso2.carbon.identity.workflow.mgt.exception.WorkflowException;
+import org.wso2.carbon.identity.workflow.mgt.util.WFConstant;
+import org.wso2.carbon.identity.workflow.mgt.util.WorkflowErrorConstants;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
+import java.util.Map;
+
+/**
+ * The WorkflowPendingUserAuthnHandler is to handle authentication when the ADD USER workflow is engaged.
+ */
+public class WorkflowPendingUserAuthnHandler extends AbstractEventHandler {
+
+    private static final Log log = LogFactory.getLog(WorkflowPendingUserAuthnHandler.class);
+
+    @Override
+    public void handleEvent(Event event) throws IdentityEventException {
+
+        Map<String, Object> eventProperties = event.getEventProperties();
+
+        if (log.isDebugEnabled()) {
+            log.debug("Handling the event : " + event.getEventName());
+        }
+        String userName = (String) eventProperties.get(IdentityEventConstants.EventProperty.USER_NAME);
+        int tenantId = (Integer) eventProperties.get(IdentityEventConstants.EventProperty.TENANT_ID);
+        validatePendingApproval(userName, tenantId);
+    }
+
+    public String getName() {
+
+        return "WorkflowPendingUserAuthnHandler";
+    }
+
+    public String getFriendlyName() {
+
+        return "Workflow Pending User Authentication Handler";
+    }
+
+    @Override
+    public void init(InitConfig configuration) throws IdentityRuntimeException {
+
+        super.init(configuration);
+    }
+
+    @Override
+    public int getPriority(MessageContext messageContext) {
+
+        return 113;
+    }
+
+    /**
+     * Validate whether the user account approval is pending.
+     *
+     * @param username Username.
+     * @throws IdentityEventException If an error occurred while validating pending approval.
+     */
+    private void validatePendingApproval(String username, int tenantId) throws IdentityEventException {
+
+        boolean isPendingApproval;
+        try {
+            Entity entity = new Entity(MultitenantUtils.getTenantAwareUsername(username),
+                    WFConstant.WORKFLOW_ENTITY_TYPE, tenantId);
+            WorkflowManagementService workflowManagementService = new WorkflowManagementServiceImpl();
+            isPendingApproval = workflowManagementService.entityHasPendingWorkflowsOfType(entity,
+                    WFConstant.WORKFLOW_REQUEST_TYPE);
+        } catch (WorkflowException e) {
+            throw new IdentityEventException("Error occurred while checking the pending approvals for " +
+                    "the account of the user: " + username, e);
+        } catch (IdentityRuntimeException e) {
+            throw new IdentityEventException("Can't find the tenant domain for the user: " + username, e);
+        }
+
+        if (isPendingApproval) {
+            IdentityErrorMsgContext customErrorMessageContext =
+                    new IdentityErrorMsgContext(IdentityCoreConstants.USER_ACCOUNT_PENDING_APPROVAL_ERROR_CODE);
+            IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
+            throw new IdentityEventException(
+                    WorkflowErrorConstants.ErrorMessages.ERROR_CODE_USER_ACCOUNT_PENDING_APPROVAL.getCode(),
+                    WorkflowErrorConstants.ErrorMessages.ERROR_CODE_USER_ACCOUNT_PENDING_APPROVAL.getMessage());
+        }
+    }
+}

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/internal/WorkflowMgtServiceComponent.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/internal/WorkflowMgtServiceComponent.java
@@ -29,6 +29,8 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
+import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.workflow.mgt.handler.WorkflowPendingUserAuthnHandler;
 import org.wso2.carbon.identity.workflow.mgt.WorkflowManagementService;
 import org.wso2.carbon.identity.workflow.mgt.WorkflowManagementServiceImpl;
 import org.wso2.carbon.identity.workflow.mgt.extension.WorkflowRequestHandler;
@@ -56,6 +58,8 @@ public class WorkflowMgtServiceComponent {
             BundleContext bundleContext = context.getBundleContext();
             WorkflowManagementService workflowService = new WorkflowManagementServiceImpl();
             bundleContext.registerService(WorkflowManagementService.class, workflowService, null);
+            AbstractEventHandler workflowPendingUserAuthnHandler = new WorkflowPendingUserAuthnHandler();
+            bundleContext.registerService(AbstractEventHandler.class, workflowPendingUserAuthnHandler, null);
             WorkflowServiceDataHolder.getInstance().setWorkflowService(workflowService);
             WorkflowServiceDataHolder.getInstance().setBundleContext(bundleContext);
             ServiceRegistration serviceRegistration = context.getBundleContext()

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/util/WFConstant.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/util/WFConstant.java
@@ -33,6 +33,8 @@ public class WFConstant {
     public static final String KEYSTORE_CARBON_CONFIG_PATH = "Security.KeyStore.Location";
     public static final String KEYSTORE_PASSWORD_CARBON_CONFIG_PATH = "Security.KeyStore.Password";
 
+    public static final String WORKFLOW_ENTITY_TYPE = "USER";
+    public static final String WORKFLOW_REQUEST_TYPE = "ADD_USER";
 
     public static final Set<Class> NUMERIC_CLASSES;
 

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/util/WorkflowErrorConstants.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/util/WorkflowErrorConstants.java
@@ -29,7 +29,10 @@ public class WorkflowErrorConstants {
     public enum ErrorMessages {
 
         // Generic error messages.
-        ERROR_CODE_USER_WF_ALREADY_EXISTS("WFM-10001", "There is a pending workflow already defined for the user.");
+        ERROR_CODE_USER_WF_ALREADY_EXISTS("WFM-10001",
+                "There is a pending workflow already defined for the user."),
+        ERROR_CODE_USER_ACCOUNT_PENDING_APPROVAL("WFM-10002",
+                "The user authentication failed due to pending approval of the user: %s");
         private final String code;
         private final String message;
 

--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -221,5 +221,9 @@
   "identity_mgt.events.schemes.OIDCClaimMetaDataOperationHandler.module_index": "34",
   "identity_mgt.events.schemes.OIDCClaimMetaDataOperationHandler.subscriptions": [
     "POST_DELETE_EXTERNAL_CLAIM"
+  ],
+  "identity_mgt.events.schemes.WorkflowPendingUserAuthnHandler.module_index": "35",
+  "identity_mgt.events.schemes.WorkflowPendingUserAuthnHandler.subscriptions": [
+    "PRE_AUTHENTICATION"
   ]
 }


### PR DESCRIPTION
### Proposed changes in this pull request
This PR change, will fix the issue of not showing proper error messages in the UI when not approved users are trying to log in when the 'Add User' workflow operation is engaged. An event handler has been added to handle authentication when there is pending user account approval.
Resolves: wso2/product-is#12462

### When should this PR be merged
Before merging https://github.com/wso2-extensions/identity-local-auth-basicauth/pull/119
