### PR TITLE
add default configurations

### DIFF
--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -217,5 +217,9 @@
   "identity_mgt.events.schemes.CentralLogger.subscriptions": [
     "PUBLISH_AUDIT_LOG",
     "PUBLISH_DIAGNOSTIC_LOG"
+  ],
+  "identity_mgt.events.schemes.OIDCClaimMetaDataOperationHandler.module_index": "34",
+  "identity_mgt.events.schemes.OIDCClaimMetaDataOperationHandler.subscriptions": [
+    "POST_DELETE_EXTERNAL_CLAIM"
   ]
 }


### PR DESCRIPTION
### Proposed changes in this pull request
Add default subscribed event configs to `OIDCClaimMetaDataOperationHandler`.

Related handler impl: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1693