### PR TITLE
Move isTableExists util method to IdentityDatabaseUtil class.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2557,42 +2557,13 @@ public class FrameworkUtils {
      *
      * @param tableName name of the table.
      * @return true if table exists.
+     *
+     * @deprecated Please use IdentityDatabaseUtil.isTableExists(String tableName) instead.
      */
+    @Deprecated
     public static boolean isTableExists(String tableName) {
 
-        try (Connection connection = IdentityDatabaseUtil.getDBConnection()) {
-
-            DatabaseMetaData metaData = connection.getMetaData();
-            if (metaData.storesLowerCaseIdentifiers()) {
-                tableName = tableName.toLowerCase();
-            }
-
-            try (ResultSet resultSet = metaData.getTables(null, null, tableName, new String[] { "TABLE" })) {
-                if (resultSet.next()) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Table - " + tableName + " available in the Identity database.");
-                    }
-                    IdentityDatabaseUtil.commitTransaction(connection);
-                    return true;
-                }
-                IdentityDatabaseUtil.commitTransaction(connection);
-            } catch (SQLException e) {
-                IdentityDatabaseUtil.rollbackTransaction(connection);
-                if (log.isDebugEnabled()) {
-                    log.debug("Table - " + tableName + " not available in the Identity database.");
-                }
-                return false;
-            }
-        } catch (SQLException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Table - " + tableName + " not available in the Identity database.");
-            }
-            return false;
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("Table - " + tableName + " not available in the Identity database.");
-        }
-        return false;
+        return IdentityDatabaseUtil.isTableExists(tableName);
     }
 
     /**

--- a/components/secret-mgt/org.wso2.carbon.identity.secret.mgt.core/pom.xml
+++ b/components/secret-mgt/org.wso2.carbon.identity.secret.mgt.core/pom.xml
@@ -81,10 +81,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -139,7 +135,6 @@
                             org.wso2.carbon.core.util; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.core.cache; version="${carbon.identity.package.import.version.range}",
 
-                            org.wso2.carbon.identity.application.authentication.framework.util; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.*; version="${carbon.identity.package.import.version.range}",
                         </Import-Package>
                         <Export-Package>

--- a/components/secret-mgt/org.wso2.carbon.identity.secret.mgt.core/src/main/java/org/wso2/carbon/identity/secret/mgt/core/internal/SecretManagerComponent.java
+++ b/components/secret-mgt/org.wso2.carbon.identity.secret.mgt.core/src/main/java/org/wso2/carbon/identity/secret/mgt/core/internal/SecretManagerComponent.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.secret.mgt.core.SecretManager;
 import org.wso2.carbon.identity.secret.mgt.core.SecretManagerImpl;
 import org.wso2.carbon.identity.secret.mgt.core.SecretResolveManager;
@@ -102,6 +102,7 @@ public class SecretManagerComponent {
 
     private boolean isSecretManagementEnabled() {
 
-        return FrameworkUtils.isTableExists(DB_TABLE_SECRET) && FrameworkUtils.isTableExists(DB_TABLE_SECRET_TYPE);
+        return IdentityDatabaseUtil.isTableExists(DB_TABLE_SECRET) &&
+                IdentityDatabaseUtil.isTableExists(DB_TABLE_SECRET_TYPE);
     }
 }


### PR DESCRIPTION
$subject is performed to prevent possible cyclic reference issues that can occur when the secret mgt component is referred from other components such as the IdP mgt component. 