### PR TITLE
Fix overriding federated auth sessions

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
@@ -155,6 +155,10 @@ public class SQLQueries {
     public static final String SQL_STORE_FEDERATED_AUTH_SESSION_INFO = "INSERT INTO IDN_FED_AUTH_SESSION_MAPPING "
             + "(IDP_SESSION_ID, SESSION_ID, IDP_NAME,  AUTHENTICATOR_ID, PROTOCOL_TYPE) VALUES (?, ?, ?, ?, ?)";
 
+    // Get federated authentication session id using the idp session id.
+    public static final String SQL_GET_FEDERATED_AUTH_SESSION_ID_BY_SESSION_ID = "SELECT SESSION_ID FROM " +
+            "IDN_FED_AUTH_SESSION_MAPPING WHERE IDP_SESSION_ID = ?";
+
     // Get federated authentication session details using the IDP session id.
     public static final String SQL_GET_FEDERATED_AUTH_SESSION_INFO_BY_SESSION_ID =
             "SELECT IDP_SESSION_ID, SESSION_ID, IDP_NAME, AUTHENTICATOR_ID, PROTOCOL_TYPE FROM " +

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -851,6 +851,32 @@ public class UserSessionStore {
     }
 
     /**
+     * Check whether there is already existing federated auth session with the given session index.
+     *
+     * @param idpSessionIndex IDP session index.
+     * @return True if a federated auth session found with the given session index.
+     * @throws UserSessionException If an error occurred while checking for an federated auth session.
+     */
+    public boolean hasExistingFederatedAuthSession(String idpSessionIndex) throws UserSessionException {
+
+        boolean isExisting = false;
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false);
+             PreparedStatement prepStmt
+                     = connection.prepareStatement(SQLQueries.SQL_GET_FEDERATED_AUTH_SESSION_ID_BY_SESSION_ID)) {
+            prepStmt.setString(1, idpSessionIndex);
+            try (ResultSet resultSet = prepStmt.executeQuery()) {
+                if (resultSet.next()) {
+                    isExisting = true;
+                }
+            }
+        } catch (SQLException e) {
+            throw new UserSessionException("Error occurred while checking for an federated auth session " +
+                    "with session index: " + idpSessionIndex, e);
+        }
+        return isExisting;
+    }
+
+    /**
      * Remove federated authentication session details of a given session context key.
      *
      * @param sessionContextKey Session Context Key.


### PR DESCRIPTION
### Proposed changes in this pull request
Fix overriding federated auth session mapping when the logout URL is not configured in the IDP. 