### PR TITLE
Fix throwing server errors for client error scenarios

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
@@ -209,6 +209,7 @@
                             org.wso2.carbon.identity.application.common.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.idp.mgt.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.claim.metadata.mgt.util; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt.model; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt.exception; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt.listener; version="${carbon.identity.package.import.version.range}",

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/ApplicationClaimMgtListener.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/ApplicationClaimMgtListener.java
@@ -20,9 +20,12 @@ package org.wso2.carbon.identity.application.mgt.listener;
 
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.mgt.dao.impl.ApplicationDAOImpl;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataClientException;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.listener.AbstractClaimMetadataMgtListener;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+
+import static org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants.ErrorMessage.ERROR_CODE_LOCAL_CLAIM_REFERRED_BY_APPLICATION;
 
 /**
  * Internal implementation of {@link AbstractClaimMetadataMgtListener} to listen to claim CRUD events.
@@ -44,7 +47,8 @@ public class ApplicationClaimMgtListener extends AbstractClaimMetadataMgtListene
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
         try {
             if (applicationDAO.isClaimReferredByAnySp(null, claimUri, tenantId)) {
-                throw new ClaimMetadataException("Unable to delete claim as it is referred by an application.");
+                throw new ClaimMetadataClientException(ERROR_CODE_LOCAL_CLAIM_REFERRED_BY_APPLICATION.getCode(),
+                        ERROR_CODE_LOCAL_CLAIM_REFERRED_BY_APPLICATION.getMessage());
             }
         } catch (IdentityApplicationManagementException e) {
             throw new ClaimMetadataException("Error when deleting claim.", e);

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
@@ -69,6 +69,10 @@ public class ClaimConstants {
                 "Local claim URI : %s already exists."),
         ERROR_CODE_NON_EXISTING_LOCAL_CLAIM_URI("100012",
                 "Local claim URI : %s does not exist."),
+        ERROR_CODE_LOCAL_CLAIM_REFERRED_BY_APPLICATION("10013",
+                "Unable to delete claim as it is referred by an application"),
+        ERROR_CODE_LOCAL_CLAIM_REFERRED_BY_AN_IDP("10014",
+                "Unable to delete claim as it is referred by an IDP"),
 
         // Client errors.
         ERROR_CODE_EMPTY_TENANT_DOMAIN("60000", "Empty tenant domain in the request"),

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/listener/IdentityProviderClaimMgtListener.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/listener/IdentityProviderClaimMgtListener.java
@@ -18,11 +18,14 @@
 
 package org.wso2.carbon.idp.mgt.listener;
 
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataClientException;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.listener.AbstractClaimMetadataMgtListener;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.dao.IdPManagementDAO;
+
+import static org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants.ErrorMessage.ERROR_CODE_LOCAL_CLAIM_REFERRED_BY_AN_IDP;
 
 /**
  * Internal implementation of {@link AbstractClaimMetadataMgtListener} to listen to claim CRUD events.
@@ -43,7 +46,8 @@ public class IdentityProviderClaimMgtListener extends AbstractClaimMetadataMgtLi
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
         try {
             if (idPManagementDAO.isClaimReferredByAnyIdp(null, claimUri, tenantId)) {
-                throw new ClaimMetadataException("Unable to delete claim as it is referred by an IDP.");
+                throw new ClaimMetadataClientException(ERROR_CODE_LOCAL_CLAIM_REFERRED_BY_AN_IDP.getCode(),
+                        ERROR_CODE_LOCAL_CLAIM_REFERRED_BY_AN_IDP.getMessage());
             }
         } catch (IdentityProviderManagementException e) {
             throw new ClaimMetadataException("Error when deleting claim.", e);


### PR DESCRIPTION
### Proposed changes in this pull request
Fix throwing server errors for the client error scenarios when deleting a local claim

**Related PR:**
https://github.com/wso2/identity-api-server/pull/325