### PR TITLE
Remove ant dependancies and re-implement the usages

### DIFF
--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration.deployer/pom.xml
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration.deployer/pom.xml
@@ -91,7 +91,6 @@
                             org.apache.axis2.*; version="${axis2.osgi.version.range}",
                             org.apache.commons.io; version="${commons.io.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${import.package.version.commons.logging}",
-                            org.apache.tools.ant.util,
 
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
 

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration.deployer/src/main/java/org/wso2/carbon/identity/user/store/configuration/deployer/UserStoreConfigurationDeployer.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration.deployer/src/main/java/org/wso2/carbon/identity/user/store/configuration/deployer/UserStoreConfigurationDeployer.java
@@ -29,7 +29,6 @@ import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.tools.ant.util.FileUtils;
 import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.core.util.CryptoException;
 import org.wso2.carbon.identity.core.util.IdentityIOStreamUtils;
@@ -146,7 +145,7 @@ public class UserStoreConfigurationDeployer extends AbstractDeployer {
 
                         File file = new File(absolutePath);
                         if (file.exists()) {
-                            FileUtils.delete(file);
+                            file.delete();
                         }
                     }
                     return;


### PR DESCRIPTION
Safely remove the ant dependency due to vulnerability concerns.
Relates Issue: wso2/product-is#12595