### PR TITLE
Revert "Move phoneNumbers.fax and phoneNumbers.pager from core schema to user schema"

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/schemas.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/schemas.xml.j2
@@ -38,6 +38,8 @@
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:meta.resourceType</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:meta.version</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:externalId</Attribute>
+                <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.fax</Attribute>
+                <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.pager</Attribute>
             </Schema>
             <Schema id="urn:ietf:params:scim:schemas:core:2.0:User">
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:userName</Attribute>
@@ -61,8 +63,6 @@
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.home</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.work</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.mobile</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.fax</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.pager</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.other</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:ims.aim</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:ims.gtalk</Attribute>


### PR DESCRIPTION
Reverts wso2/carbon-identity-framework#3790

Revert this PR because we can do this by enabling 

```
[schemas]
profile = "default"
```
