### PR TITLE
Remove "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingEmails.value" from default profile of enterprise schema

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -142,7 +142,8 @@
             "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:unlockTime",
             "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:userSourceId",
             "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyEmail",
-            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyMobile"
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyMobile",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingEmails.value"
           ]
         },
         {


### PR DESCRIPTION
### Proposed changes in this pull request
Note $Subject