### PR TITLE
Fix default profile

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -152,6 +152,17 @@
             "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.pager",
             "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.fax"
           ]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User",
+          "attributes": [
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses.home",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses.work",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses.other",
+            "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers",
+            "urn:ietf:params:scim:schemas:core:2.0:User:photos"
+          ]
         }
       ],
       "schemas.add_to_default_schema": [
@@ -159,7 +170,21 @@
           "id": "urn:ietf:params:scim:schemas:core:2.0:User",
           "attributes": [
             "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.pager",
-            "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.fax"
+            "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.fax",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses#home.country",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses#home.formatted",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses#work.country",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses#work.formatted",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses#work.locality",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses#work.postalCode",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses#work.region",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses#work.streetAddress",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses#other.country",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses#other.formatted",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses#other.locality",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses#other.postalCode",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses#other.region",
+            "urn:ietf:params:scim:schemas:core:2.0:User:addresses#other.streetAddress"
           ]
         }
       ]


### PR DESCRIPTION
### Proposed changes in this pull request
Fix default profile of SCIM user schema

- Remove multi valued complex attributes such as `addresses`, `phoneNumbers` and `photos`
- Add all forms of subattributes of home address, work address and other address