### PR TITLE
Fix SAML Federated SSO failure due to integrity constraint violation

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -567,14 +567,15 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                     if (StringUtils.isNotBlank(authHistory.getIdpSessionIndex()) &&
                             StringUtils.isNotBlank(authHistory.getIdpName())) {
                         try {
-                            if (userSessionStore.hasExistingFederatedAuthSession(authHistory.getIdpSessionIndex())) {
+                            if (!userSessionStore.hasExistingFederatedAuthSession(authHistory.getIdpSessionIndex())) {
+                                userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory);
+                            } else {
                                 if (log.isDebugEnabled()) {
                                     log.debug(String.format("Federated auth session with the id: %s already exists",
                                             authHistory.getIdpSessionIndex()));
                                 }
-                                continue;
+                                userSessionStore.updateFederatedAuthSessionInfo(sessionContextKey, authHistory);
                             }
-                            userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory);
                         } catch (UserSessionException e) {
                             throw new FrameworkException("Error while storing federated authentication session details "
                                     + "of the authenticated user to the database", e);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
@@ -159,7 +159,11 @@ public class SQLQueries {
     public static final String SQL_GET_FEDERATED_AUTH_SESSION_ID_BY_SESSION_ID = "SELECT SESSION_ID FROM " +
             "IDN_FED_AUTH_SESSION_MAPPING WHERE IDP_SESSION_ID = ?";
 
-    // Get federated authentication session details using the IDP session id.
+    // Update federated authentication session id using the idp session id.
+    public static final String SQL_UPDATE_FEDERATED_AUTH_SESSION_INFO = "UPDATE IDN_FED_AUTH_SESSION_MAPPING SET " +
+            "SESSION_ID=? WHERE IDP_SESSION_ID=?";
+
+    // Get federated authentication session details if there is an already existing session.
     public static final String SQL_GET_FEDERATED_AUTH_SESSION_INFO_BY_SESSION_ID =
             "SELECT IDP_SESSION_ID, SESSION_ID, IDP_NAME, AUTHENTICATOR_ID, PROTOCOL_TYPE FROM " +
                     "IDN_FED_AUTH_SESSION_MAPPING WHERE IDP_SESSION_ID = ?";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -851,6 +851,29 @@ public class UserSessionStore {
     }
 
     /**
+     * Update session details of a given session context key to map the current session context key with
+     * the federated IdP's session ID.
+     *
+     * @param sessionContextKey Session Context Key.
+     * @param authHistory       History of the authentication flow.
+     * @throws UserSessionException Error while storing session details.
+     */
+    public void updateFederatedAuthSessionInfo(String sessionContextKey, AuthHistory authHistory) throws
+            UserSessionException {
+
+        JdbcTemplate jdbcTemplate = JdbcUtils.getNewTemplate();
+        try {
+            jdbcTemplate.executeUpdate(SQLQueries.SQL_UPDATE_FEDERATED_AUTH_SESSION_INFO, preparedStatement -> {
+                preparedStatement.setString(1, sessionContextKey);
+                preparedStatement.setString(2, authHistory.getIdpSessionIndex());
+            });
+        } catch (DataAccessException e) {
+            throw new UserSessionException("Error while updating " + sessionContextKey + " of session:" +
+                    authHistory.getIdpSessionIndex() + " in table " + IDN_AUTH_SESSION_META_DATA_TABLE + ".", e);
+        }
+    }
+
+    /**
      * Check whether there is already existing federated auth session with the given session index.
      *
      * @param idpSessionIndex IDP session index.


### PR DESCRIPTION
### Purpose

When a user login with federated SAML IDP and clear only the WSO2 IS session, and try to login again a primary key violation occurs, since the SessionIndex returned by the IDP is both logins, when persisting the federated SSO session info using authHistory.getIdpSessionIndex(), it fails with integrity constraint violation since the primary key of the table: IDN_FED_AUTH_SESSION_MAPPING is IDP_SESSION_ID.

Therefore, first check whether there is a record in IDN_FED_AUTH_SESSION_MAPPING, for the particular session-id, if it exists, update that session with the current session context key and if it does not exist store the session information.

Resolves: https://github.com/wso2/product-is/issues/12599