### PR TITLE
Fix CORS Requests with origin header value "null" are not accepted by the CORS valve

### DIFF
--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/pom.xml
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/pom.xml
@@ -109,7 +109,7 @@
                         <Import-Package>
                             org.wso2.carbon.identity.core.util;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.database.utils.*;version="${org.wso2.carbon.database.utils.version.range}",
-                            org.wso2.carbon.identity.configuration.mgt.core.*; version="${project.version}",
+                            org.wso2.carbon.identity.configuration.mgt.core.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.*;version="${carbon.identity.package.import.version.range}",
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/model/Origin.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/model/Origin.java
@@ -74,40 +74,42 @@ public class Origin {
                     ERROR_CODE_NULL_ORIGIN.getCode());
         }
 
-        // Parse URI value.
-        URI uri;
-        try {
-            uri = new URI(origin);
-        } catch (URISyntaxException e) {
-            throw new CORSManagementServiceClientException(
-                    String.format(ERROR_CODE_INVALID_URI.getMessage(), origin),
-                    ERROR_CODE_INVALID_URI.getCode());
+        if (!StringUtils.equals(origin, "null")) {
+            // Parse URI value.
+            URI uri;
+            try {
+                uri = new URI(origin);
+            } catch (URISyntaxException e) {
+                throw new CORSManagementServiceClientException(
+                        String.format(ERROR_CODE_INVALID_URI.getMessage(), origin),
+                        ERROR_CODE_INVALID_URI.getCode());
+            }
+
+            scheme = uri.getScheme();
+            host = uri.getHost();
+            port = uri.getPort();
+
+            if (scheme == null) {
+                throw new CORSManagementServiceClientException(
+                        String.format(ERROR_CODE_MISSING_SCHEME.getMessage(), origin),
+                        ERROR_CODE_MISSING_SCHEME.getCode());
+            }
+
+            // Canonicalise scheme and host.
+            scheme = scheme.toLowerCase(Locale.ENGLISH);
+
+            if (host == null) {
+                throw new CORSManagementServiceClientException(
+                        String.format(ERROR_CODE_MISSING_HOST.getMessage(), origin),
+                        ERROR_CODE_MISSING_HOST.getCode());
+            }
+
+            // Apply the IDNA to ASCII algorithm [RFC3490] to /host/.
+            host = IDN.toASCII(host, IDN.ALLOW_UNASSIGNED | IDN.USE_STD3_ASCII_RULES);
+
+            // Convert to lower case.
+            host = host.toLowerCase(Locale.ENGLISH);
         }
-
-        scheme = uri.getScheme();
-        host = uri.getHost();
-        port = uri.getPort();
-
-        if (scheme == null) {
-            throw new CORSManagementServiceClientException(
-                    String.format(ERROR_CODE_MISSING_SCHEME.getMessage(), origin),
-                    ERROR_CODE_MISSING_SCHEME.getCode());
-        }
-
-        // Canonicalise scheme and host.
-        scheme = scheme.toLowerCase(Locale.ENGLISH);
-
-        if (host == null) {
-            throw new CORSManagementServiceClientException(
-                    String.format(ERROR_CODE_MISSING_HOST.getMessage(), origin),
-                    ERROR_CODE_MISSING_HOST.getCode());
-        }
-
-        // Apply the IDNA to ASCII algorithm [RFC3490] to /host/.
-        host = IDN.toASCII(host, IDN.ALLOW_UNASSIGNED | IDN.USE_STD3_ASCII_RULES);
-
-        // Convert to lower case.
-        host = host.toLowerCase(Locale.ENGLISH);
     }
 
     /**


### PR DESCRIPTION
## Purpose
The spec mentions that the Origin header can have the value "null" when request from a "privacy-sensitive" context. Therefore avoid origin URI validation when origin value = "null". https://datatracker.ietf.org/doc/html/rfc6454#section-7.3

Fixes wso2/product-is#12592