### PR TITLE
Add new permission to allow deleting workflow requests created by any user

### DIFF
--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/java/org/wso2/carbon/identity/workflow/mgt/ui/WorkflowAdminServiceClient.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/java/org/wso2/carbon/identity/workflow/mgt/ui/WorkflowAdminServiceClient.java
@@ -350,6 +350,19 @@ public class WorkflowAdminServiceClient {
     }
 
     /**
+     * Move workflow request created by any user to DELETED state.
+     *
+     * @param requestId Request ID to delete requests of.
+     * @throws WorkflowAdminServiceWorkflowException
+     * @throws RemoteException
+     */
+    public void deleteRequestCreatedByAnyUser(String requestId) throws WorkflowAdminServiceWorkflowException,
+            RemoteException {
+
+        stub.deleteWorkflowRequestCreatedByAnyUser(requestId);
+    }
+
+    /**
      * Get workflows of a request.
      *
      * @param requestId Request ID to get workflows of.

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/wf-request-delete-finish-ajaxprocessor.jsp
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/wf-request-delete-finish-ajaxprocessor.jsp
@@ -49,7 +49,11 @@ Work<%--
     ResourceBundle resourceBundle = ResourceBundle.getBundle(bundle, request.getLocale());
     String forwardTo = "wf-request-list.jsp";
     try {
-        client.deleteRequest(requestId);
+        if (CarbonUIUtil.isUserAuthorized(request, "/permission/admin/manage/identity/workflow/monitor/anydelete")) {
+            client.deleteRequestCreatedByAnyUser(requestId);
+        } else {
+            client.deleteRequest(requestId);
+        }
     } catch (Exception e) {
         String message = resourceBundle.getString("workflow.error.request.delete");
         CarbonUIMessage.sendCarbonUIMessage(message, CarbonUIMessage.ERROR, request);

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/wf-request-list.jsp
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/wf-request-list.jsp
@@ -469,8 +469,20 @@
                            onclick="listWorkflows('<%=workflowReq.getRequestId()%>');return false;"
                            href="#" style="background-image: url(images/list.png);"
                            class="icon-link"><fmt:message key='workflows'/></a>
-                        <% if (PENDING_STATUS.equals(workflowReq.getStatus()) && CarbonUIUtil.isUserAuthorized(request,
-                                "/permission/admin/manage/identity/workflow/monitor/delete")) { %>
+                        <%
+                            Boolean authorizedToDelete = false;
+                            if (PENDING_STATUS.equals(workflowReq.getStatus())) {
+                                if (CarbonUIUtil.isUserAuthorized(request,
+                                        "/permission/admin/manage/identity/workflow/monitor/anydelete")) {
+                                    authorizedToDelete = true;
+                                }
+                                else if (workflowReq.getCreatedBy() != null && CarbonUIUtil.isUserAuthorized(request,
+                                        "/permission/admin/manage/identity/workflow/monitor/delete") &&
+                                        workflowReq.getCreatedBy().equals(loggedUser)) {
+                                    authorizedToDelete = true;
+                                }
+                            }
+                            if (authorizedToDelete) { %>
                         <a title="<fmt:message key='workflow.request.delete.title'/>"
                            onclick="removeRequest('<%=workflowReq.getRequestId()%>');return false;"
                            href="#" style="background-image: url(images/delete.gif);"

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementAdminService.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementAdminService.java
@@ -455,7 +455,7 @@ public class WorkflowManagementAdminService {
     }
 
     /**
-     * Move Workflow request to DELETED state.
+     * Move workflow requests created by the logged in user to DELETED state.
      *
      * @param requestId Request ID to delete requests of.
      * @throws WorkflowException
@@ -464,6 +464,18 @@ public class WorkflowManagementAdminService {
 
         WorkflowServiceDataHolder.getInstance().getWorkflowService()
                 .deleteWorkflowRequest(requestId);
+    }
+
+    /**
+     * Move workflow requests created by any user to DELETED state.
+     *
+     * @param requestId Request ID to delete requests of.
+     * @throws WorkflowException
+     */
+    public void deleteWorkflowRequestCreatedByAnyUser(String requestId) throws WorkflowException {
+
+        WorkflowServiceDataHolder.getInstance().getWorkflowService()
+                .deleteWorkflowRequestCreatedByAnyUser(requestId);
     }
 
     /**

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementService.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementService.java
@@ -249,12 +249,20 @@ public interface WorkflowManagementService {
     WorkflowRequestAssociation[] getWorkflowsOfRequest(String requestId) throws WorkflowException;
 
     /**
-     * Update state of a existing workflow request
+     * Move workflow requests created by the logged in user to DELETED state.
      *
-     * @param requestId
+     * @param requestId Request ID
      * @throws WorkflowException
      */
     void deleteWorkflowRequest(String requestId) throws WorkflowException;
+
+    /**
+     * Move workflow requests created by any user to DELETED state.
+     *
+     * @param requestId Request ID
+     * @throws WorkflowException
+     */
+    default void deleteWorkflowRequestCreatedByAnyUser(String requestId) throws WorkflowException { }
 
     WorkflowRequest[] getRequestsFromFilter(String user, String beginDate, String endDate, String
             dateCategory, int tenantId, String status) throws WorkflowException;

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/resources/META-INF/component.xml
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/resources/META-INF/component.xml
@@ -77,6 +77,10 @@
             <DisplayName>Delete</DisplayName>
             <ResourceId>/permission/admin/manage/identity/workflow/monitor/delete</ResourceId>
         </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Delete Any</DisplayName>
+            <ResourceId>/permission/admin/manage/identity/workflow/monitor/anydelete</ResourceId>
+        </ManagementPermission>
     </ManagementPermissions>
 
 </component>

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/resources/META-INF/services.xml
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/resources/META-INF/services.xml
@@ -121,6 +121,11 @@
                        locked="true">/permission/admin/manage/identity/workflow/monitor/delete
             </parameter>
         </operation>
+        <operation name="deleteWorkflowRequestCreatedByAnyUser">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/workflow/monitor/anydelete
+            </parameter>
+        </operation>
         <operation name="getWorkflowsOfRequest">
             <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/identity/workflow/monitor/view
             </parameter>

--- a/service-stubs/identity/org.wso2.carbon.identity.workflow.mgt.stub/src/main/resources/WorkflowAdminService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.workflow.mgt.stub/src/main/resources/WorkflowAdminService.wsdl
@@ -307,6 +307,13 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="deleteWorkflowRequestCreatedByAnyUser">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="requestId" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="getWorkflowsOfRequest">
                 <xs:complexType>
                     <xs:sequence>
@@ -387,6 +394,13 @@
         <wsdl:part name="parameters" element="ns:deleteWorkflowRequest"/>
     </wsdl:message>
     <wsdl:message name="deleteWorkflowRequestResponse"/>
+    <wsdl:message name="WorkflowAdminServiceWorkflowException">
+        <wsdl:part name="parameters" element="ns:WorkflowAdminServiceWorkflowException"/>
+    </wsdl:message>
+    <wsdl:message name="deleteWorkflowRequestCreatedByAnyUserRequest">
+        <wsdl:part name="parameters" element="ns:deleteWorkflowRequestCreatedByAnyUser"/>
+    </wsdl:message>
+    <wsdl:message name="deleteWorkflowRequestCreatedByAnyUserResponse"/>
     <wsdl:message name="WorkflowAdminServiceWorkflowException">
         <wsdl:part name="parameters" element="ns:WorkflowAdminServiceWorkflowException"/>
     </wsdl:message>
@@ -494,6 +508,11 @@
             <wsdl:output message="tns:deleteWorkflowRequestResponse" wsaw:Action="urn:deleteWorkflowRequestResponse"/>
             <wsdl:fault message="tns:WorkflowAdminServiceWorkflowException" name="WorkflowAdminServiceWorkflowException" wsaw:Action="urn:deleteWorkflowRequestWorkflowAdminServiceWorkflowException"/>
         </wsdl:operation>
+        <wsdl:operation name="deleteWorkflowRequestCreatedByAnyUser">
+            <wsdl:input message="tns:deleteWorkflowRequestCreatedByAnyUserRequest" wsaw:Action="urn:deleteWorkflowRequestCreatedByAnyUser"/>
+            <wsdl:output message="tns:deleteWorkflowRequestCreatedByAnyUserResponse" wsaw:Action="urn:deleteWorkflowRequestCreatedByAnyUserResponse"/>
+            <wsdl:fault message="tns:WorkflowAdminServiceWorkflowException" name="WorkflowAdminServiceWorkflowException" wsaw:Action="urn:deleteWorkflowRequestCreatedByAnyUserWorkflowAdminServiceWorkflowException"/>
+        </wsdl:operation>
         <wsdl:operation name="listAssociations">
             <wsdl:input message="tns:listAssociationsRequest" wsaw:Action="urn:listAssociations"/>
             <wsdl:output message="tns:listAssociationsResponse" wsaw:Action="urn:listAssociationsResponse"/>
@@ -587,6 +606,18 @@
         <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
         <wsdl:operation name="deleteWorkflowRequest">
             <soap:operation soapAction="urn:deleteWorkflowRequest" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="WorkflowAdminServiceWorkflowException">
+                <soap:fault use="literal" name="WorkflowAdminServiceWorkflowException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="deleteWorkflowRequestCreatedByAnyUser">
+            <soap:operation soapAction="urn:deleteWorkflowRequestCreatedByAnyUser" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -822,6 +853,18 @@
                 <soap12:fault use="literal" name="WorkflowAdminServiceWorkflowException"/>
             </wsdl:fault>
         </wsdl:operation>
+        <wsdl:operation name="deleteWorkflowRequestCreatedByAnyUser">
+            <soap12:operation soapAction="urn:deleteWorkflowRequestCreatedByAnyUser" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="WorkflowAdminServiceWorkflowException">
+                <soap12:fault use="literal" name="WorkflowAdminServiceWorkflowException"/>
+            </wsdl:fault>
+        </wsdl:operation>
         <wsdl:operation name="listAssociations">
             <soap12:operation soapAction="urn:listAssociations" style="document"/>
             <wsdl:input>
@@ -1037,6 +1080,15 @@
         <http:binding verb="POST"/>
         <wsdl:operation name="deleteWorkflowRequest">
             <http:operation location="deleteWorkflowRequest"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="deleteWorkflowRequestCreatedByAnyUser">
+            <http:operation location="deleteWorkflowRequestCreatedByAnyUser"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>


### PR DESCRIPTION
Resolves [wso2/product-is #12559](https://github.com/wso2/product-is/issues/12559)

This PR introduces a new permission 
`Admin permissions -> Manage -> Identity -> Workflow Management -> Monitor -> Delete Any`
Users with the existing permission 
`Admin permissions -> Manage -> Identity -> Workflow Management -> Monitor -> Delete` 
are allowed to delete workflow requests created by them selves only. It results in no user being able to delete pending workflow requests created during self registration as the created user is set to null. 

Users having the new permission are allowed to delete all the workflow requests regardless of who created it.