### PR TITLE
Fix hostname verify issue in mutual SSL authentication requests

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/MutualSSLManager.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/MutualSSLManager.java
@@ -356,7 +356,7 @@ public class MutualSSLManager {
             SSLContext sslContext = SSLContext.getInstance(protocol);
 
             if (hostNameVerificationEnabled) {
-                if (System.getProperty(HOST_NAME_VERIFIER).equals(DEFAULT_AND_LOCALHOST)) {
+                if (DEFAULT_AND_LOCALHOST.equals(System.getProperty(HOST_NAME_VERIFIER))) {
                     HostnameVerifier hv = new HostnameVerifier() {
                         @Override
                         public boolean verify(String urlHostName, SSLSession session) {


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/12577

The hostname verification is ignored for localhost when `DefaultAndLocalhost` is set as -D property.
```
-Dhttpclient.hostnameVerifier="DefaultAndLocalhost" \
```