### PR TITLE
Improve jit provisioning feature

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -117,6 +117,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
             int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
             UserRealm realm = AnonymousSessionUtil.getRealmByTenantDomain(registryService,
                     realmService, tenantDomain);
+            String username = MultitenantUtils.getTenantAwareUsername(subject);
 
             String userStoreDomain;
             UserStoreManager userStoreManager;
@@ -137,7 +138,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                 userStoreDomain = getUserStoreDomain(provisioningUserStoreId, realm);
                 userStoreManager = getUserStoreManager(realm, userStoreDomain);
             }
-            String username = UserCoreUtil.removeDomainFromName(subject);
+            username = UserCoreUtil.removeDomainFromName(username);
 
             if (log.isDebugEnabled()) {
                 log.debug("User: " + username + " with roles : " + roles + " is going to be provisioned");

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -117,7 +117,6 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
             int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
             UserRealm realm = AnonymousSessionUtil.getRealmByTenantDomain(registryService,
                     realmService, tenantDomain);
-            String username = MultitenantUtils.getTenantAwareUsername(subject);
 
             String userStoreDomain;
             UserStoreManager userStoreManager;
@@ -138,7 +137,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                 userStoreDomain = getUserStoreDomain(provisioningUserStoreId, realm);
                 userStoreManager = getUserStoreManager(realm, userStoreDomain);
             }
-            username = UserCoreUtil.removeDomainFromName(username);
+            String username = UserCoreUtil.removeDomainFromName(subject);
 
             if (log.isDebugEnabled()) {
                 log.debug("User: " + username + " with roles : " + roles + " is going to be provisioned");

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -117,7 +117,6 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
             int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
             UserRealm realm = AnonymousSessionUtil.getRealmByTenantDomain(registryService,
                     realmService, tenantDomain);
-            String username = MultitenantUtils.getTenantAwareUsername(subject);
 
             String userStoreDomain;
             UserStoreManager userStoreManager;
@@ -138,7 +137,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                 userStoreDomain = getUserStoreDomain(provisioningUserStoreId, realm);
                 userStoreManager = getUserStoreManager(realm, userStoreDomain);
             }
-            username = UserCoreUtil.removeDomainFromName(username);
+            String username = UserCoreUtil.removeDomainFromName(subject);
 
             if (log.isDebugEnabled()) {
                 log.debug("User: " + username + " with roles : " + roles + " is going to be provisioned");
@@ -183,6 +182,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
 
                     userClaims.remove(FrameworkConstants.PASSWORD);
                     userClaims.remove(USERNAME_CLAIM);
+                    userClaims.remove(FrameworkConstants.USERID_CLAIM);
                     userStoreManager.setUserClaimValues(UserCoreUtil.removeDomainFromName(username), userClaims, null);
                     /*
                     Since the user is exist following code is get all active claims of user and crosschecking against

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -203,8 +203,7 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                     if (context.getProperty(FrameworkConstants.CHANGING_USERNAME_ALLOWED) != null) {
                         username = request.getParameter(FrameworkConstants.USERNAME);
                     }
-                    String sanitizedUserName = removeEmailDomainFromName(UserCoreUtil.removeDomainFromName(
-                            MultitenantUtils.getTenantAwareUsername(username)));
+                    String sanitizedUserName = removeEmailDomainFromName(username);
                     callDefaultProvisioningHandler(sanitizedUserName, context, externalIdPConfig, combinedLocalClaims,
                             stepConfig);
                    handleConsents(request, stepConfig, context.getTenantDomain());

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -73,7 +73,6 @@ import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.user.core.service.RealmService;
-import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
@@ -203,7 +202,8 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                     if (context.getProperty(FrameworkConstants.CHANGING_USERNAME_ALLOWED) != null) {
                         username = request.getParameter(FrameworkConstants.USERNAME);
                     }
-                    String sanitizedUserName = removeEmailDomainFromName(username);
+                    String sanitizedUserName = removeEmailDomainFromName(
+                            MultitenantUtils.getTenantAwareUsername(username));
                     callDefaultProvisioningHandler(sanitizedUserName, context, externalIdPConfig, combinedLocalClaims,
                             stepConfig);
                    handleConsents(request, stepConfig, context.getTenantDomain());

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -203,8 +203,8 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                     if (context.getProperty(FrameworkConstants.CHANGING_USERNAME_ALLOWED) != null) {
                         username = request.getParameter(FrameworkConstants.USERNAME);
                     }
-                    String sanitizedUserName = UserCoreUtil.removeDomainFromName(
-                            MultitenantUtils.getTenantAwareUsername(username));
+                    String sanitizedUserName = removeEmailDomainFromName(UserCoreUtil.removeDomainFromName(
+                            MultitenantUtils.getTenantAwareUsername(username)));
                     callDefaultProvisioningHandler(sanitizedUserName, context, externalIdPConfig, combinedLocalClaims,
                             stepConfig);
                    handleConsents(request, stepConfig, context.getTenantDomain());
@@ -366,7 +366,8 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                                 + " coming from " + externalIdPConfig.getIdPName()
                                 + " do have a local account, with the username " + username);
                     }
-                    callDefaultProvisioningHandler(username, context, externalIdPConfig, localClaimValues,
+                    String sanitizedUserName = removeEmailDomainFromName(username);
+                    callDefaultProvisioningHandler(sanitizedUserName, context, externalIdPConfig, localClaimValues,
                             stepConfig);
                 }
             }
@@ -1000,4 +1001,17 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
         return localClaimValues;
     }
 
+    /**
+     * Remove email domain from the username.
+     *
+     * @param username        Tenant domain.
+     * @return email domain removed username.
+     */
+    private String removeEmailDomainFromName(String username) {
+
+        if (username.contains("@") && !(MultitenantUtils.isEmailUserName())) {
+            username = username.substring(0, username.indexOf("@"));
+        }
+        return username;
+    }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -73,7 +73,9 @@ import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -201,7 +203,9 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                     if (context.getProperty(FrameworkConstants.CHANGING_USERNAME_ALLOWED) != null) {
                         username = request.getParameter(FrameworkConstants.USERNAME);
                     }
-                    callDefaultProvisioningHandler(username, context, externalIdPConfig, combinedLocalClaims,
+                    String sanitizedUserName = UserCoreUtil.removeDomainFromName(
+                            MultitenantUtils.getTenantAwareUsername(username));
+                    callDefaultProvisioningHandler(sanitizedUserName, context, externalIdPConfig, combinedLocalClaims,
                             stepConfig);
                    handleConsents(request, stepConfig, context.getTenantDomain());
                 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -38,6 +38,7 @@ public abstract class FrameworkConstants {
     public static final String ACCOUNT_DISABLED_CLAIM_URI = "http://wso2.org/claims/identity/accountDisabled";
     public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
     public static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
+    public static final String USERID_CLAIM = "http://wso2.org/claims/userid";
     public static final String PROVISIONED_SOURCE_ID_CLAIM = "http://wso2.org/claims/identity/userSourceId";
     public static final String UNFILTERED_LOCAL_CLAIM_VALUES = "UNFILTERED_LOCAL_CLAIM_VALUES";
     public static final String UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES = "UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES";


### PR DESCRIPTION
This fix introduce following changes:
- Prevent username claim update for jit provisioned user in federated IDP claims and local claim syncing process.
- Maintain the consistancancy for the format of username claim variable in DefaultProvisioningHandler.class and JITProvisioningPostAuthenticationHandler.class. 