### PR TITLE
Fix CORS error in workflow creation

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -25,6 +25,7 @@ public class IdentityCoreConstants {
     public static final String IDENTITY_CONFIG = "identity.xml";
     public static final String IDENTITY_DEFAULT_NAMESPACE = "http://wso2.org/projects/carbon/carbon.xml";
     public static final String HOST_NAME = "HostName";
+    public static final String MGT_CONSOLE_HOST_NAME = "MgtHostName";
     public static final String SERVER_HOST_NAME = "ServerHostName";
     public static final String AUTHENTICATION_ENDPOINT_HOST_NAME = "AuthenticationEndpoint.HostName";
     public static final String AUTHENTICATION_ENDPOINT_PATH = "AuthenticationEndpoint.Path";

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -479,6 +479,39 @@ public class IdentityUtil {
             throw IdentityRuntimeException.error("Error while trying to read hostname.", e);
         }
 
+        StringBuilder serverUrl = getServerUrlWithPort(hostName);
+
+        appendContextToUri(endpoint, addProxyContextPath, addWebContextRoot, serverUrl);
+        return serverUrl.toString();
+    }
+
+    /**
+     * Returns the Management console URL for the endpoint with the proxy context and the web context root.
+     *
+     * @param endpoint            Endpoint that needs to be called.
+     * @param addProxyContextPath Flag that defines to add the proxy context path.
+     * @param addWebContextRoot   Flag that defines to add the web context root.
+     * @return Full path for the endpoint.
+     * @throws IdentityRuntimeException When an exception is occurred.
+     */
+    public static String getMgtConsoleURL(String endpoint, boolean addProxyContextPath, boolean addWebContextRoot)
+            throws IdentityRuntimeException {
+
+        String hostName = ServerConfiguration.getInstance().getFirstProperty(
+                IdentityCoreConstants.MGT_CONSOLE_HOST_NAME);
+
+        if (StringUtils.isBlank(hostName)) {
+            hostName = NetworkUtils.getMgtHostName();
+        }
+
+        StringBuilder serverUrl = getServerUrlWithPort(hostName);
+
+        appendContextToUri(endpoint, addProxyContextPath, addWebContextRoot, serverUrl);
+        return serverUrl.toString();
+    }
+
+    private static StringBuilder getServerUrlWithPort(String hostName) {
+
         String mgtTransport = CarbonUtils.getManagementTransport();
         AxisConfiguration axisConfiguration = IdentityCoreServiceComponent.getConfigurationContextService().
                 getServerConfigContext().getAxisConfiguration();
@@ -494,9 +527,7 @@ public class IdentityUtil {
         if (mgtTransportPort != IdentityCoreConstants.DEFAULT_HTTPS_PORT) {
             serverUrl.append(":").append(mgtTransportPort);
         }
-
-        appendContextToUri(endpoint, addProxyContextPath, addWebContextRoot, serverUrl);
-        return serverUrl.toString();
+        return serverUrl;
     }
 
     private static void appendContextToUri(String endpoint, boolean addProxyContextPath, boolean addWebContextRoot,

--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/userstore/user-role-search.jsp
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/userstore/user-role-search.jsp
@@ -287,7 +287,7 @@
             if (doValidateForm($("#id_search")[0], '<fmt:message key="error.input.validation.msg"/>')) {
                 var category = $("input[name=radio_user_role]:checked").val();
                 $.ajax({
-                    url: "<%=IdentityUtil.getServerURL("/userandrolemgtservice", true, true)%>?category=" + category
+                    url: "<%=IdentityUtil.getMgtConsoleURL("/userandrolemgtservice", true, true)%>?category=" + category
                     + "&pageNumber=" + pageNumber,
                     type: "POST",
                     data: $("#id_search").serialize(),


### PR DESCRIPTION
### Proposed changes in this pull request
Fixes https://github.com/wso2/product-is/issues/12671

> When configure the management console hostname to a different hostname than the server, a CORS error is occurred when adding a workflow definition. Configuring CORS filter is also not an option because the returning result also occurring a CORS error. 

> In the other places there are JSP files called *ajaxprocessors to call the corresponding admin services, but for this there is no any admin service. It directly calling to the servlet. 

> In this implementation the mgtconsole hostname will be picked from the configurations and complete the other tenant context rewriting part as well. From the configuration level when the mgtconsole hostname is not specifically defined, the server name will be added as the mgtconsole hostname[1].

[1] https://github.com/wso2/carbon-kernel/blob/a3ba32b495c2dd4eab19264cd015d1a2f02dffa9/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2#L53