### PR TITLE
Improve UserSessionException logs for both local user and federated user.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -177,11 +177,11 @@ public class AuthenticatedUser extends User {
                 userId = FrameworkUtils.resolveUserIdFromUsername(tenantId,
                         this.getUserStoreDomain(), this.getUserName());
             } catch (UserSessionException e) {
-                log.error("Error while resolving the user id from username");
+                log.error("Error while resolving the user id from username for local user.");
             }
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("User id could not be resolved for user: " + toFullQualifiedUsername());
+                log.debug("User id could not be resolved for local user: " + toFullQualifiedUsername());
             }
         }
         return userId;
@@ -217,11 +217,11 @@ public class AuthenticatedUser extends User {
                             .getFederatedUserId(this.getAuthenticatedSubjectIdentifier(), tenantId, idpId);
                 }
             } catch (UserSessionException e) {
-                log.error("Error while resolving the user id from username.");
+                log.error("Error while resolving the user id from username for federated user.");
             }
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("User id could not be resolved for user: " + toFullQualifiedUsername());
+                log.debug("User id could not be resolved for federated user: " + toFullQualifiedUsername());
             }
         }
         return userId;


### PR DESCRIPTION
### Proposed changes in this pull request
$sub

### Description
Earlier Both getFederatedUserIdInternal method and getLocalUserIdInternal method has same error log and debug log. So its hard to Isolate the user from the error log and debug log.

