### PR TITLE
Enable 'Password can't be equal to login attributes' for password recovery flow

### DIFF
--- a/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/src/main/java/org/wso2/carbon/identity/unique/claim/mgt/listener/UniqueClaimUserOperationEventListener.java
+++ b/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/src/main/java/org/wso2/carbon/identity/unique/claim/mgt/listener/UniqueClaimUserOperationEventListener.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -220,5 +221,21 @@ public class UniqueClaimUserOperationEventListener extends AbstractIdentityUserO
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean doPreUpdateCredentialByAdmin(String userName, Object newCredential,
+                                                UserStoreManager userStoreManager) throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+        Claim[] claims = userStoreManager.getUserClaimValues(userName, null);
+        Map<String, String> claimMap = new HashMap<>();
+        for (Claim claim : claims) {
+            claimMap.put(claim.getClaimUri(), claim.getValue());
+        }
+        checkClaimUniqueness(userName, claimMap, null, userStoreManager, newCredential);
+        return true;
     }
 }


### PR DESCRIPTION
Releated Issues: wso2/product-is#12699

**Purpose**
Implement doPreUpdateCredentialByAdmin method on UniqueClaimUserOperationEventListener to enable "Password can't be equal to login attributes" condition in password recovery flow.