### PR TITLE
Remove openid4java dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -718,16 +718,6 @@
                 <type>zip</type>
             </dependency>
             <dependency>
-                <groupId>org.openid4java</groupId>
-                <artifactId>openid4java</artifactId>
-                <version>${openid4java.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.orbit.org.openid4java</groupId>
-                <artifactId>openid4java</artifactId>
-                <version>${openid4java.wso2.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.step2.wso2</groupId>
                 <artifactId>step2</artifactId>
                 <version>${google.step2.wso2.version}</version>
@@ -1913,9 +1903,6 @@
         <google.step2.wso2.version>1.0.wso2v2</google.step2.wso2.version>
         <google.guice.wso2.version>3.0.wso2v1</google.guice.wso2.version>
         <google.guice.imp.pkg.version.range>[1.3.0,2.0.0)</google.guice.imp.pkg.version.range>
-        <openid4java.version>1.0.0</openid4java.version>
-        <openid4java.wso2.version>1.0.0.wso2v4</openid4java.wso2.version>
-        <openid4java.wso2.osgi.version.range>[1.0.0,2.0.0)</openid4java.wso2.osgi.version.range>
         <gdata-core.wso2.version>1.47.0.wso2v1</gdata-core.wso2.version>
         <gdata-core.imp.pkg.version.range>[1.47.0.wso2v1,2.0.0)</gdata-core.imp.pkg.version.range>
         <httpcomponents-httpclient.wso2.version>4.3.6.wso2v2</httpcomponents-httpclient.wso2.version>


### PR DESCRIPTION
### Proposed changes in this pull request
This PR removes the `openid4java` dependency. This has no usage and needs to be removed in order to remove apache httpclient `4.3.6.wso2v3`.
