### PR TITLE
Validate configuring MFA when proxy mode is enabled for a federated IDP

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/validator/DefaultApplicationValidator.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/validator/DefaultApplicationValidator.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.identity.application.common.ApplicationAuthenticatorService;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementClientException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.AuthenticationStep;
@@ -83,6 +84,8 @@ public class DefaultApplicationValidator implements ApplicationValidator {
     private static final String PROVISIONING_CONNECTOR_NOT_CONFIGURED = "No Provisioning connector configured for %s.";
     private static final String FEDERATED_IDP_NOT_AVAILABLE =
             "Federated Identity Provider %s is not available in the server.";
+    private static final String PROXY_MODE_ENABLED = "Configuring MFA is not allowed as proxy mode is enabled " +
+            "for the federated IDP: %s";
     private static final String CLAIM_DIALECT_NOT_AVAILABLE = "Claim Dialect %s is not available in the server " +
             "for tenantDomain:%s.";
     private static final String CLAIM_NOT_AVAILABLE = "Local claim %s is not available in the server " +
@@ -249,6 +252,7 @@ public class DefaultApplicationValidator implements ApplicationValidator {
 
         AtomicBoolean isAuthenticatorIncluded = new AtomicBoolean(false);
 
+        validateConfiguring2FA(validationMsg, tenantDomain, authenticationSteps);
         for (AuthenticationStep authenticationStep : authenticationSteps) {
             for (IdentityProvider idp : authenticationStep.getFederatedIdentityProviders()) {
                 validateFederatedIdp(idp, isAuthenticatorIncluded, validationMsg, tenantDomain);
@@ -302,6 +306,176 @@ public class DefaultApplicationValidator implements ApplicationValidator {
                 }
             }
         }
+    }
+
+    /**
+     * Validate configuring a second-factor authenticator with a federated IdP when proxy mode is enabled for that
+     * federated IDP.
+     *
+     * @param validationMsg       Validation error messages.
+     * @param tenantDomain        Tenant domain.
+     * @param authenticationSteps Authentication Steps.
+     */
+    private void validateConfiguring2FA(List<String> validationMsg, String tenantDomain,
+                                        AuthenticationStep[] authenticationSteps) {
+
+        int proxyModeEnabledFIDPStepOrder = 0;
+        StringBuilder proxyModeEnabledFIDP = new StringBuilder();
+        if (ArrayUtils.isNotEmpty(authenticationSteps) && authenticationSteps.length < 2) {
+            if (log.isDebugEnabled()) {
+                log.debug("Since multi-steps were not configured, validating second factor " +
+                        "authenticators will not be required.");
+            }
+            return;
+        }
+        for (AuthenticationStep authenticationStep : authenticationSteps) {
+            if (validationMsg.contains(String.format(PROXY_MODE_ENABLED, proxyModeEnabledFIDP))) {
+                return;
+            }
+            proxyModeEnabledFIDPStepOrder = getProxyModeEnabledFIDPStepOrder(authenticationStep, proxyModeEnabledFIDP,
+                    tenantDomain, validationMsg, proxyModeEnabledFIDPStepOrder);
+            if (isValidMFAWithLocalAuthenticators(authenticationStep, proxyModeEnabledFIDPStepOrder,
+                    validationMsg, proxyModeEnabledFIDP)) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * Check whether the proxy mode enabled federated idp has been added as a step in configured MFA.
+     *
+     * @param federatedAuth Federated authenticator config.
+     * @param fedIdp        Federated identity provider.
+     * @param tenantDomain  Tenant domain.
+     * @param validationMsg Validation error message.
+     * @return Whether the proxy mode enabled federated idp has been added as a step in configured MFA.
+     */
+    private boolean isProxyModeEnabledFIdpStepConfigured(FederatedAuthenticatorConfig federatedAuth,
+                                                         IdentityProvider fedIdp, String tenantDomain,
+                                                         List<String> validationMsg) {
+
+        boolean isProxyModeEnabledFIdpStepConfigured = false;
+        boolean isJITProvisioningEnabled = isJitProvisioningEnabled(fedIdp, tenantDomain, validationMsg);
+        FederatedAuthenticatorConfig federatedAuthenticatorConfig =
+                ApplicationAuthenticatorService.getInstance().getFederatedAuthenticatorByName(
+                        federatedAuth.getName());
+        List<String> federatedAuthTagList = Arrays.asList(federatedAuthenticatorConfig.getTags());
+        if (!isJITProvisioningEnabled && (federatedAuthTagList.contains("Social-Login") ||
+                federatedAuthTagList.contains("SAML") || federatedAuthTagList.contains("OIDC"))) {
+            isProxyModeEnabledFIdpStepConfigured = true;
+        }
+        return isProxyModeEnabledFIdpStepConfigured;
+    }
+
+    /**
+     * Get the step order number of the configured federated authenticator that has been already enabled proxy mode.
+     *
+     * @param authenticationStep            Authentication step.
+     * @param proxyModeEnabledFIDP          Proxy mode enabled federated IDP name.
+     * @param tenantDomain                  Tenant domain.
+     * @param validationMsg                 Validation error messages.
+     * @param proxyModeEnabledFIDPStepOrder Proxy mode enabled federated IDP's step order number.
+     * @return Step order number of the configured federated authenticator that has been already enabled proxy mode.
+     */
+    private int getProxyModeEnabledFIDPStepOrder(AuthenticationStep authenticationStep,
+                                                 StringBuilder proxyModeEnabledFIDP, String tenantDomain,
+                                                 List<String> validationMsg, int proxyModeEnabledFIDPStepOrder) {
+
+        boolean isProxyModeEnabledFIdpStepConfigured = false;
+        for (IdentityProvider fedIdp : authenticationStep.getFederatedIdentityProviders()) {
+            for (FederatedAuthenticatorConfig federatedAuth : fedIdp.getFederatedAuthenticatorConfigs()) {
+                FederatedAuthenticatorConfig federatedAuthenticatorConfig =
+                        ApplicationAuthenticatorService.getInstance().getFederatedAuthenticatorByName(
+                                federatedAuth.getName());
+                if (federatedAuthenticatorConfig == null) {
+                    return proxyModeEnabledFIDPStepOrder;
+                }
+                List<String> federatedAuthTagList = Arrays.asList(federatedAuthenticatorConfig.getTags());
+                isProxyModeEnabledFIdpStepConfigured =
+                        isProxyModeEnabledFIdpStepConfigured(federatedAuth, fedIdp, tenantDomain, validationMsg);
+                if (isProxyModeEnabledFIdpStepConfigured) {
+                    proxyModeEnabledFIDP.append(fedIdp.getIdentityProviderName());
+                    proxyModeEnabledFIDPStepOrder = authenticationStep.getStepOrder();
+                    break;
+                }
+                if (isMFAWithProxyModeEnabledFIDP(proxyModeEnabledFIDPStepOrder, authenticationStep,
+                        federatedAuthTagList, validationMsg, proxyModeEnabledFIDP)) {
+                    break;
+                }
+            }
+            if (isProxyModeEnabledFIdpStepConfigured) {
+                break;
+            }
+        }
+        return proxyModeEnabledFIDPStepOrder;
+    }
+
+    /**
+     * Check the validity of configuring MFA step(ex:TOTP which is a local authenticator) when proxy mode
+     * enabled federated IDP has been already added toa prior step.
+     *
+     * @param authenticationStep            Authentication step.
+     * @param proxyModeEnabledFIDPStepOrder Proxy mode enabled federated IDP's step order number.
+     * @return Validity of configuring MFA step when proxy mode enabled federated IDP
+     * has been already added toa prior step.
+     */
+    private boolean isValidMFAWithLocalAuthenticators(AuthenticationStep authenticationStep,
+                                                      int proxyModeEnabledFIDPStepOrder, List<String> validationMsg,
+                                                      StringBuilder proxyModeEnabledFIDP) {
+
+        boolean isValidToConfigureMFAWithLocalAuthenticators = false;
+        for (LocalAuthenticatorConfig localAuth : authenticationStep.getLocalAuthenticatorConfigs()) {
+            LocalAuthenticatorConfig localAuthenticatorConfig = ApplicationAuthenticatorService.
+                    getInstance().getLocalAuthenticatorByName(localAuth.getName());
+            List<String> localAuthTagList = Arrays.asList(localAuthenticatorConfig.getTags());
+            if (isMFAWithProxyModeEnabledFIDP(proxyModeEnabledFIDPStepOrder, authenticationStep,
+                    localAuthTagList, validationMsg, proxyModeEnabledFIDP)) {
+                isValidToConfigureMFAWithLocalAuthenticators = true;
+            }
+        }
+        return isValidToConfigureMFAWithLocalAuthenticators;
+    }
+
+    /**
+     * Check whether configuring MFA with federated IDP and 2FA is valid and if it is not
+     * set a validation error message.
+     *
+     * @param proxyModeEnabledFIDPStepOrder Proxy mode enabled federated IDP step order Id.
+     * @param authenticationStep            Authentication step.
+     * @param authTagList                   Auth tag list for the configured auth steps.
+     * @param validationMsg                 Validation error message.
+     * @param proxyModeEnabledFIDP          Proxy mode enabled federated IDP name.
+     * @return Whether configuring MFA with federated IDP and 2FA is valid.
+     */
+    private boolean isMFAWithProxyModeEnabledFIDP(int proxyModeEnabledFIDPStepOrder,
+                                                  AuthenticationStep authenticationStep,
+                                                  List<String> authTagList, List<String> validationMsg,
+                                                  StringBuilder proxyModeEnabledFIDP) {
+
+        boolean isMFAWithProxyModeEnabledFIDP = false;
+        if (proxyModeEnabledFIDPStepOrder != 0 &&
+                authenticationStep.getStepOrder() > proxyModeEnabledFIDPStepOrder &&
+                authTagList.contains("MFA")) {
+            validationMsg.add(String.format(PROXY_MODE_ENABLED, proxyModeEnabledFIDP));
+            isMFAWithProxyModeEnabledFIDP = true;
+        }
+        return isMFAWithProxyModeEnabledFIDP;
+    }
+
+    private boolean isJitProvisioningEnabled(IdentityProvider fedIdp, String tenantDomain,
+                                             List<String> validationMsg) {
+
+        boolean isJITProvisioningEnabled = false;
+        try {
+            isJITProvisioningEnabled = IdentityProviderManager.getInstance().
+                    getIdPByName(fedIdp.getIdentityProviderName(), tenantDomain, false)
+                    .getJustInTimeProvisioningConfig().isProvisioningEnabled();
+        } catch (IdentityProviderManagementException e) {
+            String errorMsg = String.format(FEDERATED_IDP_NOT_AVAILABLE,
+                    fedIdp.getIdentityProviderName());
+            validationMsg.add(errorMsg);
+        }
+        return isJITProvisioningEnabled;
     }
 
     private void validateFederatedIdp(IdentityProvider idp, AtomicBoolean isAuthenticatorIncluded, List<String>

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/DefaultApplicationValidatorTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/DefaultApplicationValidatorTest.java
@@ -17,12 +17,27 @@
 package org.wso2.carbon.identity.application.mgt;
 
 import org.apache.commons.lang.StringUtils;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.ApplicationAuthenticatorService;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.AuthenticationStep;
+import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.JustInTimeProvisioningConfig;
+import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
+import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.script.AuthenticationScriptConfig;
+import org.wso2.carbon.identity.application.mgt.validator.ApplicationValidator;
 import org.wso2.carbon.identity.application.mgt.validator.DefaultApplicationValidator;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -32,10 +47,25 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
 /**
  * Test class for DefaultApplicationValidator.
  */
+@PrepareForTest({ApplicationManagementService.class, ApplicationAuthenticatorService.class,
+        IdentityProviderManager.class, IdentityProvider.class})
 public class DefaultApplicationValidatorTest {
+
+    @Mock
+    LocalAndOutboundAuthenticationConfig localAndOutBoundAuthenticationConfig;
+
+    @Mock
+    private IdentityProviderManager mockedIdentityProviderManager;
 
     @DataProvider(name = "validateAdaptiveAuthScriptDataProvider")
     public Object[][] validateAdaptiveAuthScriptDataProvider() {
@@ -171,5 +201,83 @@ public class DefaultApplicationValidatorTest {
                     "there should not be any validation messages. Validation messages: " +
                     String.join("|", validationErrors));
         }
+    }
+
+    @Test
+    public void testValidateApplication() throws IdentityApplicationManagementException,
+            IdentityProviderManagementException {
+
+        ServiceProvider serviceProvider = new ServiceProvider();
+        serviceProvider.setDiscoverable(false);
+        serviceProvider.setInboundAuthenticationConfig(null);
+        serviceProvider.setRequestPathAuthenticatorConfigs(null);
+        serviceProvider.setOutboundProvisioningConfig(null);
+        serviceProvider.setClaimConfig(null);
+        serviceProvider.setPermissionAndRoleConfig(null);
+
+        mockStatic(ApplicationManagementService.class);
+        ApplicationManagementService applicationManagementService =
+                mock(ApplicationManagementService.class);
+        when(ApplicationManagementService.getInstance()).thenReturn(applicationManagementService);
+        when(applicationManagementService.getAllLocalAuthenticators(anyString())).thenReturn(null);
+
+        RequestPathAuthenticatorConfig[] requestPathAuthenticatorConfigs = new RequestPathAuthenticatorConfig[0];
+        when(applicationManagementService.getAllRequestPathAuthenticators(anyString())).
+                thenReturn(requestPathAuthenticatorConfigs);
+
+        AuthenticationStep authenticationStep1 = new AuthenticationStep();
+        authenticationStep1.setStepOrder(1);
+        IdentityProvider federatedIdentityProvider = new IdentityProvider();
+        federatedIdentityProvider.setIdentityProviderName("OIDC_IDP");
+        IdentityProvider[] federatedIdentityProviders = new IdentityProvider[]{federatedIdentityProvider};
+        FederatedAuthenticatorConfig federatedAuthenticatorConfig =
+                new FederatedAuthenticatorConfig();
+        federatedAuthenticatorConfig.setName("FederatedIDP");
+        federatedAuthenticatorConfig.setTags(new String[]{"OIDC"});
+
+        FederatedAuthenticatorConfig[] federatedAuthenticatorConfigs =
+                new FederatedAuthenticatorConfig[]{federatedAuthenticatorConfig};
+        federatedIdentityProvider.setFederatedAuthenticatorConfigs(federatedAuthenticatorConfigs);
+        authenticationStep1.setFederatedIdentityProviders(federatedIdentityProviders);
+
+        mockStatic(ApplicationAuthenticatorService.class);
+        ApplicationAuthenticatorService applicationAuthenticatorService =
+                mock(ApplicationAuthenticatorService.class);
+        when(ApplicationAuthenticatorService.getInstance()).thenReturn(applicationAuthenticatorService);
+
+        mockStatic(IdentityProviderManager.class);
+        when(IdentityProviderManager.getInstance()).thenReturn(mockedIdentityProviderManager);
+
+        IdentityProvider identityProvider = new IdentityProvider();
+        doReturn(identityProvider).when(mockedIdentityProviderManager).
+                getIdPByName(anyString(), anyString(), anyBoolean());
+        JustInTimeProvisioningConfig justInTimeProvisioningConfig = new JustInTimeProvisioningConfig();
+        justInTimeProvisioningConfig.setProvisioningEnabled(false);
+        identityProvider.setJustInTimeProvisioningConfig(justInTimeProvisioningConfig);
+
+       doReturn(federatedAuthenticatorConfig).when(applicationAuthenticatorService).
+               getFederatedAuthenticatorByName(anyString());
+
+        AuthenticationStep authenticationStep2 = new AuthenticationStep();
+        authenticationStep2.setStepOrder(2);
+        LocalAuthenticatorConfig localAuthenticatorConfig = new LocalAuthenticatorConfig();
+        localAuthenticatorConfig.setName("TOTP");
+        localAuthenticatorConfig.setTags(new String[]{"MFA"});
+        LocalAuthenticatorConfig[] localAuthenticatorConfigs =
+                new LocalAuthenticatorConfig[]{localAuthenticatorConfig};
+        authenticationStep2.setLocalAuthenticatorConfigs(localAuthenticatorConfigs);
+
+        doReturn(localAuthenticatorConfig).when(applicationAuthenticatorService).
+                getLocalAuthenticatorByName(anyString());
+        when(applicationManagementService.getAllLocalAuthenticators(anyString())).
+                thenReturn(localAuthenticatorConfigs);
+
+        AuthenticationStep[] authenticationSteps = new AuthenticationStep[]{authenticationStep1, authenticationStep2};
+        when(localAndOutBoundAuthenticationConfig.getAuthenticationSteps()).thenReturn(authenticationSteps);
+        serviceProvider.setLocalAndOutBoundAuthenticationConfig(localAndOutBoundAuthenticationConfig);
+
+        ApplicationValidator validator = new DefaultApplicationValidator();
+        Assert.assertTrue(validator.validateApplication(serviceProvider, "carbon.super", "admin").
+                contains("Configuring MFA is not allowed as proxy mode is enabled for the federated IDP: OIDC_IDP"));
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/DefaultApplicationValidatorTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/DefaultApplicationValidatorTest.java
@@ -23,6 +23,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.common.ApplicationAuthenticatorService;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementClientException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.AuthenticationStep;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
@@ -277,7 +278,7 @@ public class DefaultApplicationValidatorTest {
         serviceProvider.setLocalAndOutBoundAuthenticationConfig(localAndOutBoundAuthenticationConfig);
 
         ApplicationValidator validator = new DefaultApplicationValidator();
-        Assert.assertTrue(validator.validateApplication(serviceProvider, "carbon.super", "admin").
-                contains("Configuring MFA is not allowed as proxy mode is enabled for the federated IDP: OIDC_IDP"));
+        Assert.assertThrows(IdentityApplicationManagementClientException.class, () ->
+                validator.validateApplication(serviceProvider, "carbon.super", "admin"));
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

This PR is to validate configuring a second-factor authenticator with a federated IdP when proxy mode is enabled for that federated IDP.