### PR TITLE
[Config Mgt] Add CorrelationId for Config EndPoint

### DIFF
--- a/components/configuration-mgt/org.wso2.carbon.identity.api.server.configuration.mgt/src/gen/java/org/wso2/carbon/identity/configuration/mgt/endpoint/dto/ErrorDTO.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.api.server.configuration.mgt/src/gen/java/org/wso2/carbon/identity/configuration/mgt/endpoint/dto/ErrorDTO.java
@@ -23,7 +23,8 @@ public class ErrorDTO  {
   
   private String description = null;
 
-  
+  private String ref = null;
+
   /**
    **/
   @ApiModelProperty(value = "")
@@ -59,7 +60,13 @@ public class ErrorDTO  {
     this.description = description;
   }
 
-  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("traceId")
+  public String getRef() {return ref;}
+  public void setRef(String ref) {this.ref = ref;}
+
 
   @Override
   public String toString()  {
@@ -69,6 +76,9 @@ public class ErrorDTO  {
     sb.append("  code: ").append(code).append("\n");
     sb.append("  message: ").append(message).append("\n");
     sb.append("  description: ").append(description).append("\n");
+    if (!ref.isEmpty()) {
+      sb.append("  traceId: ").append(ref).append("\n");
+    }
     sb.append("}\n");
     return sb.toString();
   }

--- a/components/configuration-mgt/org.wso2.carbon.identity.api.server.configuration.mgt/src/main/java/org/wso2/carbon/identity/configuration/mgt/endpoint/util/ConfigurationEndpointUtils.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.api.server.configuration.mgt/src/main/java/org/wso2/carbon/identity/configuration/mgt/endpoint/util/ConfigurationEndpointUtils.java
@@ -215,7 +215,7 @@ public class ConfigurationEndpointUtils {
             ref = MDC.get(ConfigurationConstants.CORRELATION_ID_MDC).toString();
         } else {
             ref = UUID.randomUUID().toString();
-
+            MDC.put(ConfigurationConstants.CORRELATION_ID_MDC, ref);
         }
         return ref;
     }

--- a/components/configuration-mgt/org.wso2.carbon.identity.api.server.configuration.mgt/src/main/java/org/wso2/carbon/identity/configuration/mgt/endpoint/util/ConfigurationEndpointUtils.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.api.server.configuration.mgt/src/main/java/org/wso2/carbon/identity/configuration/mgt/endpoint/util/ConfigurationEndpointUtils.java
@@ -24,6 +24,7 @@ import org.apache.cxf.jaxrs.ext.search.SearchCondition;
 import org.apache.cxf.jaxrs.impl.UriInfoImpl;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.PhaseInterceptorChain;
+import org.apache.log4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants;
@@ -64,6 +65,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -193,12 +195,38 @@ public class ConfigurationEndpointUtils {
         return attributeDTO;
     }
 
+    /**
+     * Check whether correlation id present in the log MDC
+     *
+     * @return whether the correlation id is present
+     */
+    public static boolean isCorrelationIDPresent() {
+        return MDC.get(ConfigurationConstants.CORRELATION_ID_MDC) != null;
+    }
+
+    /**
+     * Get correlation id of current thread
+     *
+     * @return correlation-id
+     */
+    public static String getCorrelation() {
+        String ref;
+        if (isCorrelationIDPresent()) {
+            ref = MDC.get(ConfigurationConstants.CORRELATION_ID_MDC).toString();
+        } else {
+            ref = UUID.randomUUID().toString();
+
+        }
+        return ref;
+    }
+
     private static ErrorDTO getErrorDTO(String message, String description, String code) {
 
         ErrorDTO errorDTO = new ErrorDTO();
         errorDTO.setCode(code);
         errorDTO.setMessage(message);
         errorDTO.setDescription(description);
+        errorDTO.setRef(getCorrelation());
         return errorDTO;
     }
 

--- a/components/configuration-mgt/org.wso2.carbon.identity.api.server.configuration.mgt/src/main/java/org/wso2/carbon/identity/configuration/mgt/endpoint/util/ConfigurationEndpointUtils.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.api.server.configuration.mgt/src/main/java/org/wso2/carbon/identity/configuration/mgt/endpoint/util/ConfigurationEndpointUtils.java
@@ -210,12 +210,9 @@ public class ConfigurationEndpointUtils {
      * @return correlation-id
      */
     public static String getCorrelation() {
-        String ref;
+        String ref = null;
         if (isCorrelationIDPresent()) {
             ref = MDC.get(ConfigurationConstants.CORRELATION_ID_MDC).toString();
-        } else {
-            ref = UUID.randomUUID().toString();
-            MDC.put(ConfigurationConstants.CORRELATION_ID_MDC, ref);
         }
         return ref;
     }

--- a/components/configuration-mgt/org.wso2.carbon.identity.api.server.configuration.mgt/src/main/resources/org.wso2.carbon.identity.configuration.management.yaml
+++ b/components/configuration-mgt/org.wso2.carbon.identity.api.server.configuration.mgt/src/main/resources/org.wso2.carbon.identity.configuration.management.yaml
@@ -890,6 +890,9 @@ definitions:
       description:
         type: string
         example: "Some error description"
+      traceId:
+        type: string
+        example: e0fbcfeb-3617-43c4-8dd0-7b7d38e13047
 
   #-----------------------------------------------------
   # Resources object

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/constant/ConfigurationConstants.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/constant/ConfigurationConstants.java
@@ -69,6 +69,7 @@ public class ConfigurationConstants {
     public static final String TENANT_CONTEXT_PATH_COMPONENT = "/t/%s";
     public static final String TENANT_NAME_FROM_CONTEXT = "TenantNameFromContext";
     public static final String PATH_SEPARATOR = "/";
+    public static final String CORRELATION_ID_MDC = "Correlation-ID";
 
 
     public enum ErrorMessages {
@@ -129,6 +130,7 @@ public class ConfigurationConstants {
         ERROR_CODE_INVALID_RESOURCE_ID("CONFIGM_00047", "Invalid resource id: %s."),
         ERROR_CODE_DELETE_RESOURCE("CONFIGM_00048", "Error while deleting the resource: %s."),
         ERROR_CODE_CHECK_DB_METADATA("CONFIGM_00049", "Error occurred while checking the DB metadata.");
+
 
         private final String code;
         private final String message;


### PR DESCRIPTION
### Purpose
> This PR add correlationID support for config managment REST APIs. 

### Goals
> This correlationID (returned as `traceId`) will help in tracking issues and to follow up on the errors. 

### Approach
> Since the correlationID is set in MDC, first we check for any available ID and if not send a random UUID for tracking purposes.

