### PR TITLE
Load tenant registry at the resource management service level

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/persistence/registry/RegistryResourceMgtServiceImpl.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/persistence/registry/RegistryResourceMgtServiceImpl.java
@@ -196,6 +196,7 @@ public class RegistryResourceMgtServiceImpl implements RegistryResourceMgtServic
 
     private Registry getRegistryForTenant(String tenantDomain) throws RegistryException {
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        IdentityTenantUtil.getTenantRegistryLoader().loadTenantRegistry(tenantId);
         return registryService.getConfigSystemRegistry(tenantId);
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

Fix https://github.com/wso2-enterprise/asgardeo-product/issues/8213

Forcefully load the SHARED_DB to prevent the Resource Management service from intermittently accessing the WSO2CARBON registry instead of configured SHARED_DB. 

### When should this PR be merged
ASAP
