### PR TITLE
Avoid the error log when Session nonce cookie value is not matching for session

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -323,7 +323,6 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     .sendToRetryPage(request, responseWrapper, context, "Authentication attempt failed.",
                             e.getErrorCode());
         } catch (Throwable e) {
-            log.error("Exception in Authentication Framework", e);
             if ((e instanceof FrameworkException)
                     && (NONCE_ERROR_CODE.equals(((FrameworkException) e).getErrorCode()))) {
                 if (log.isDebugEnabled()) {
@@ -332,6 +331,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                 FrameworkUtils.sendToRetryPage(request, response, context, "suspicious.authentication.attempts",
                         "suspicious.authentication.attempts.description");
             } else {
+                log.error("Exception in Authentication Framework", e);
                 FrameworkUtils.sendToRetryPage(request, responseWrapper, context);
             }
         } finally {


### PR DESCRIPTION
### Proposed changes in this pull request

An error log is printed when Session nonce cookie value is not matching for the session. Since it's expected behaviour from the server side, there shouldn't be an error log. Therefore with this PR the error log for the above-mentioned scenario will be removed and keep the debug log only. 
