### PR TITLE
Upgrade ua-parser orbit version to 1.5.2.wso2v1

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/pom.xml
+++ b/components/identity-core/org.wso2.carbon.identity.core/pom.xml
@@ -200,6 +200,7 @@
 
                             org.xml.sax,
                             org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
+                            org.apache.commons.collections4; version = "${commons-collections4.wso2.osgi.version.range}",
                             ua_parser; version="${ua_parser.version.range}",
                         </Import-Package>
                         <Export-Package>

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/model/UserAgent.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/model/UserAgent.java
@@ -47,11 +47,7 @@ public class UserAgent {
     public static synchronized Parser getParser() {
 
         if (parser == null) {
-            try {
-                parser = new Parser();
-            } catch (IOException e) {
-                LOG.error("Unable to initialize the user agent parser: ", e);
-            }
+            parser = new Parser();
         }
         return parser;
     }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/pom.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/pom.xml
@@ -58,6 +58,10 @@
             <groupId>commons-collections.wso2</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -120,6 +124,7 @@
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.core</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.application.common</bundleDef>
                                 <bundleDef>ua.parser.wso2:ua-parser:${ua_parser.version}</bundleDef>
+                                <bundleDef>org.wso2.orbit.org.apache.commons:commons-collections4:${apache.common.collections4.version}</bundleDef>
                             </bundles>
                             <importFeatures>
                                 <importFeatureDef>org.wso2.carbon.core:compatible:${carbon.kernel.feature.version}</importFeatureDef>
@@ -152,5 +157,5 @@
             </plugin>
         </plugins>
     </build>
-    
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1530,6 +1530,11 @@
                 <artifactId>commons-collections</artifactId>
                 <version>${apache.common.collection.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>${apache.common.collections4.version}</version>
+            </dependency>
 
             <!--Dependencies requires for rest client-->
 
@@ -1818,9 +1823,10 @@
         <orbit.version.h2.engine>1.4.199.wso2v1</orbit.version.h2.engine>
         <version.org.wso2.orbit.javax.xml.bind>2.3.1.wso2v1</version.org.wso2.orbit.javax.xml.bind>
         <version.org.wso2.orbit.javax.activation>1.1.1.wso2v1</version.org.wso2.orbit.javax.activation>
-        <ua_parser.version>1.3.0.wso2v2</ua_parser.version>
+        <ua_parser.version>1.5.2.wso2v1</ua_parser.version>
         <ua_parser.version.range>[1.3.0, 2.0.0)</ua_parser.version.range>
         <apache.common.collection.version>3.2.0.wso2v1</apache.common.collection.version>
+        <apache.common.collections4.version>4.4.wso2v1</apache.common.collections4.version>
 
         <!-- Abdera -->
         <version.abdera>1.0-wso2v2</version.abdera>
@@ -1870,6 +1876,7 @@
         <commons-pool.wso2.osgi.version.range>[1.5.6,2.0.0)</commons-pool.wso2.osgi.version.range>
         <commons-codec.wso2.osgi.version.range>[1.4.0,2.0.0)</commons-codec.wso2.osgi.version.range>
         <commons-collections.wso2.osgi.version.range>[3.2.0,4.0.0)</commons-collections.wso2.osgi.version.range>
+        <commons-collections4.wso2.osgi.version.range>[4.1.0,5.0.0)</commons-collections4.wso2.osgi.version.range>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
 
         <neethi.osgi.version>2.0.4.wso2v5</neethi.osgi.version>


### PR DESCRIPTION
### Proposed changes in this pull request
Resolves - https://github.com/wso2/product-is/issues/12780

> In the limiting active user session feature, it displays the current active sessions with browser family in the browser column. When we have a logged in session with Microsoft edge, it shows the browser as chrome.
> In this feature, we used the ua-parser library to extract these user-agent details. But the mentioned issue is already identified in the ua-parser 1.3.0 and it has been fixed and released as a new version. So issue is fixed by upgrading to ua-parser 1.5.2.