### PR TITLE
Update error message when the mandatory claims are duplicated

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthnMissingClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthnMissingClaimHandler.java
@@ -408,8 +408,7 @@ public class PostAuthnMissingClaimHandler extends AbstractPostAuthnHandler {
                     return;
                 }
                 throw new PostAuthenticationFailedException(
-                        "Error while handling missing mandatory claims",
-                        "Error while updating claims for local user. Could not update profile", e);
+                        e.getMessage(), "Error while updating claims for local user. Could not update profile", e);
             } catch (UserIdNotFoundException e) {
                 throw new PostAuthenticationFailedException(
                         "User id not found",


### PR DESCRIPTION
When entering a duplicate value for a mandatory claim, it prompts the error message "Error while handling missing mandatory claims", which doesn't give an idea for the failure.

This error message was updated to "The value defined for _claim_ is already in use by different user!".

Fix https://github.com/wso2/product-is/issues/12809