### PR TITLE
Modify the handleStepOption method

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
@@ -380,6 +380,14 @@ public class JsGraphBuilder {
     private void handleStepOptions(StepConfig stepConfig, Map<String, String> stepOptions) {
 
         stepConfig.setForced(Boolean.parseBoolean(stepOptions.get(FrameworkConstants.JSAttributes.FORCE_AUTH_PARAM)));
+        if (Boolean.parseBoolean(stepOptions.get(FrameworkConstants.JSAttributes.SUBJECT_IDENTIFIER))) {
+            setCurrentSubjectIdentifierToFalse();
+            stepConfig.setSubjectIdentifierStep(true);
+        }
+        if (Boolean.parseBoolean(stepOptions.get(FrameworkConstants.JSAttributes.SUBJECT_ATTRIBUTE_STEP))) {
+            setCurrentSubjectAttributeStepToFalse();
+            stepConfig.setSubjectAttributeStep(true);
+        }
     }
 
     /**
@@ -1010,6 +1018,24 @@ public class JsGraphBuilder {
             return new JSExecutionMonitorData(0, 0);
         }
         return getJSExecutionSupervisor().completed(identifier);
+    }
+
+    private void setCurrentSubjectIdentifierToFalse() {
+
+        stepNamedMap.forEach((integer, stepConfig) -> {
+            if (stepConfig.isSubjectIdentifierStep()) {
+                stepConfig.setSubjectIdentifierStep(false);
+            }
+        });
+    }
+
+    private void setCurrentSubjectAttributeStepToFalse() {
+
+        stepNamedMap.forEach((integer, stepConfig) -> {
+            if (stepConfig.isSubjectIdentifierStep()) {
+                stepConfig.setSubjectAttributeStep(false);
+            }
+        });
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
@@ -381,12 +381,10 @@ public class JsGraphBuilder {
 
         stepConfig.setForced(Boolean.parseBoolean(stepOptions.get(FrameworkConstants.JSAttributes.FORCE_AUTH_PARAM)));
         if (Boolean.parseBoolean(stepOptions.get(FrameworkConstants.JSAttributes.SUBJECT_IDENTIFIER_PARAM))) {
-            setCurrentSubjectIdentifierToFalse();
-            stepConfig.setSubjectIdentifierStep(true);
+            setCurrentStepAsSubjectIdentifier(stepConfig);
         }
         if (Boolean.parseBoolean(stepOptions.get(FrameworkConstants.JSAttributes.SUBJECT_ATTRIBUTE_PARAM))) {
-            setCurrentSubjectAttributeStepToFalse();
-            stepConfig.setSubjectAttributeStep(true);
+            setCurrentStepAsSubjectAttribute(stepConfig);
         }
     }
 
@@ -1020,22 +1018,22 @@ public class JsGraphBuilder {
         return getJSExecutionSupervisor().completed(identifier);
     }
 
-    private void setCurrentSubjectIdentifierToFalse() {
-
-        stepNamedMap.forEach((integer, stepConfig) -> {
-            if (stepConfig.isSubjectIdentifierStep()) {
-                stepConfig.setSubjectIdentifierStep(false);
+    private void setCurrentStepAsSubjectIdentifier(StepConfig stepConfig) {
+        stepNamedMap.forEach((integer, config) -> { // remove existing subject identifier step
+            if (config.isSubjectIdentifierStep()) {
+                config.setSubjectIdentifierStep(false);
             }
         });
+        stepConfig.setSubjectIdentifierStep(true);
     }
 
-    private void setCurrentSubjectAttributeStepToFalse() {
-
-        stepNamedMap.forEach((integer, stepConfig) -> {
-            if (stepConfig.isSubjectIdentifierStep()) {
-                stepConfig.setSubjectAttributeStep(false);
+    private void setCurrentStepAsSubjectAttribute(StepConfig stepConfig) {
+        stepNamedMap.forEach((integer, config) -> { // remove existing subject attribute step
+            if (config.isSubjectIdentifierStep()) {
+                config.setSubjectAttributeStep(false);
             }
         });
+        stepConfig.setSubjectAttributeStep(true);
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
@@ -380,11 +380,11 @@ public class JsGraphBuilder {
     private void handleStepOptions(StepConfig stepConfig, Map<String, String> stepOptions) {
 
         stepConfig.setForced(Boolean.parseBoolean(stepOptions.get(FrameworkConstants.JSAttributes.FORCE_AUTH_PARAM)));
-        if (Boolean.parseBoolean(stepOptions.get(FrameworkConstants.JSAttributes.SUBJECT_IDENTIFIER))) {
+        if (Boolean.parseBoolean(stepOptions.get(FrameworkConstants.JSAttributes.SUBJECT_IDENTIFIER_PARAM))) {
             setCurrentSubjectIdentifierToFalse();
             stepConfig.setSubjectIdentifierStep(true);
         }
-        if (Boolean.parseBoolean(stepOptions.get(FrameworkConstants.JSAttributes.SUBJECT_ATTRIBUTE_STEP))) {
+        if (Boolean.parseBoolean(stepOptions.get(FrameworkConstants.JSAttributes.SUBJECT_ATTRIBUTE_PARAM))) {
             setCurrentSubjectAttributeStepToFalse();
             stepConfig.setSubjectAttributeStep(true);
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -500,8 +500,8 @@ public abstract class FrameworkConstants {
         public static final String STEP_OPTIONS = "stepOptions";
         public static final String AUTHENTICATOR_PARAMS = "authenticatorParams";
         public static final String FORCE_AUTH_PARAM = "forceAuth";
-        public static final String SUBJECT_IDENTIFIER_PARAM = "subjectIdentifier";
-        public static final String SUBJECT_ATTRIBUTE_PARAM = "subjectAttribute";
+        public static final String SUBJECT_IDENTIFIER_PARAM = "markAsSubjectIdentifierStep";
+        public static final String SUBJECT_ATTRIBUTE_PARAM = "markAsSubjectAttributeStep";
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -500,6 +500,8 @@ public abstract class FrameworkConstants {
         public static final String STEP_OPTIONS = "stepOptions";
         public static final String AUTHENTICATOR_PARAMS = "authenticatorParams";
         public static final String FORCE_AUTH_PARAM = "forceAuth";
+        public static final String SUBJECT_IDENTIFIER = "subjectIdentifier";
+        public static final String SUBJECT_ATTRIBUTE_STEP = "subjectAttributeStep";
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -500,8 +500,8 @@ public abstract class FrameworkConstants {
         public static final String STEP_OPTIONS = "stepOptions";
         public static final String AUTHENTICATOR_PARAMS = "authenticatorParams";
         public static final String FORCE_AUTH_PARAM = "forceAuth";
-        public static final String SUBJECT_IDENTIFIER = "subjectIdentifier";
-        public static final String SUBJECT_ATTRIBUTE_STEP = "subjectAttributeStep";
+        public static final String SUBJECT_IDENTIFIER_PARAM = "subjectIdentifier";
+        public static final String SUBJECT_ATTRIBUTE_PARAM = "subjectAttribute";
     }
 
     /**


### PR DESCRIPTION
## Purpose
* Modify the `handleStepOptions` method to work with `markAsSubjectIdentifierStep` and `markAsSubjectAttributeStep` attributes.
* Fixed https://github.com/wso2/product-is/issues/12896

With this implementation, we can set the **Subject Identifier Step** and **Subject Attribute Step** with the adaptive authentication script as shown below,


![Screenshot 2022-01-04 at 12 41 01 PM](https://user-images.githubusercontent.com/32576163/148022957-e9308a36-bb3c-41e9-a69a-a1aa97f8895d.jpg)

