### PR TITLE
Honour internal-hostname in self-registration endpoint

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/api/SelfRegisterApi.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/api/SelfRegisterApi.java
@@ -47,8 +47,7 @@ import java.util.Map;
 
 public class SelfRegisterApi {
 
-    String basePath = IdentityManagementEndpointUtil.buildEndpointUrl(IdentityManagementEndpointConstants
-            .UserInfoRecovery.USER_API_RELATIVE_PATH);
+    String basePath;
     private ApiClient apiClient;
 
     public SelfRegisterApi() {
@@ -57,6 +56,12 @@ public class SelfRegisterApi {
 
     public SelfRegisterApi(ApiClient apiClient) {
         this.apiClient = apiClient;
+        try {
+            basePath = IdentityManagementEndpointUtil.getBasePath(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME,
+                    IdentityManagementEndpointConstants.UserInfoRecovery.USER_API_RELATIVE_PATH, false);
+        } catch (ApiException e) {
+            throw new RuntimeException("Error occurred while building URL in tenant qualified mode.", e);
+        }
     }
 
     public ApiClient getApiClient() {
@@ -257,7 +262,7 @@ public class SelfRegisterApi {
         }
 
         if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
-            basePath = IdentityManagementEndpointUtil.buildEndpointUrl("t/" + tenantDomain +
+            basePath = IdentityManagementEndpointUtil.getBasePath(tenantDomain,
                     IdentityManagementEndpointConstants.UserInfoRecovery.USER_API_RELATIVE_PATH);
         }
 


### PR DESCRIPTION
### Proposed changes in this pull request

Internal API invocation should use the `Internal_hostname` configuration. However, in the self-registration account confirmation flow (when the user clicks the confirmation email link to confirm the user account), the validate-code API invocation should use the `Internal_hostname`.

Related issue: wso2/product-is#12909