### PR TITLE
Update service context url to build honoring internal hostname config

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementServiceUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementServiceUtil.java
@@ -25,6 +25,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.jaxrs.provider.json.JSONProvider;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.mgt.endpoint.util.client.model.User;
 import org.wso2.carbon.user.core.UserCoreConstants;
@@ -126,11 +128,13 @@ public class IdentityManagementServiceUtil {
             String serviceContextURL = properties
                     .getProperty(IdentityManagementEndpointConstants.ServiceConfigConstants.SERVICE_CONTEXT_URL);
             contextURL = serviceContextURL;
-            this.serviceContextURL = StringUtils.isBlank(serviceContextURL) ? IdentityUtil.getServerURL(
-                    IdentityUtil.getServicePath(), true, true) : serviceContextURL;
+            this.serviceContextURL = StringUtils.isBlank(serviceContextURL) ? ServiceURLBuilder.create().
+                    addPath(IdentityUtil.getServicePath()).build().getAbsoluteInternalURL() : serviceContextURL;
 
         } catch (IOException e) {
             log.error("Failed to load service configurations.", e);
+        } catch (URLBuilderException e) {
+            log.error("Error occurred while building service URL.", e);
         } finally {
             if (inputStream != null) {
                 try {


### PR DESCRIPTION
## Purpose
> Fix https://github.com/wso2/product-is/issues/12908
> In the username recovery flow, the internal API calls doesn't honor the internal_hostname config.

## Goals
> To honor internal_hostname in internal API call to obtain resident idp details in username recovery flow. 

## Approach
> Updated the util method in building service context url to honor the internal hostname when available. 