### PR TITLE
update readme to include 5.5.0 version

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/oracle/README.MD
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/oracle/README.MD
@@ -20,7 +20,7 @@ Then execute the compiled store procedure by using the exec function in the Orac
 sqlplus> exec WSO2_TOKEN_CLEANUP_SP();
 ```
 
-! Starting from IS 5.7.0 following indexes should be inplace to avoid deadlock situation cause by the foreign keys
+! Starting from IS 5.5.0 following indexes should be inplace to avoid deadlock situation cause by the foreign keys. Make sure to add these indexes if they are not already present
 ```
 CREATE INDEX IDX_OROR_TID ON IDN_OIDC_REQ_OBJECT_REFERENCE(TOKEN_ID);
 CREATE INDEX IDX_OROR_CID ON IDN_OIDC_REQ_OBJECT_REFERENCE(CODE_ID);


### PR DESCRIPTION
PR [1] introduced the same foreign keys. before the 5.5.0 release (5.5.0 release date: Apr 05, 2018). Therefore, the indexes are required from 5.5.0.

[1] https://github.com/wso2/carbon-identity-framework/pull/1273