### PR TITLE
Fixing default userstore for JIT provisioning

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -2628,12 +2628,16 @@ public class IdPManagementDAO {
 
             prepStmt.setString(6, identityProvider.getAlias());
 
-            if (identityProvider.getJustInTimeProvisioningConfig() != null
-                    && identityProvider.getJustInTimeProvisioningConfig().isProvisioningEnabled()) {
+
+            if (identityProvider.getJustInTimeProvisioningConfig() != null) {
                 // just in time provisioning enabled for this identity provider.
                 // based on the authentication response from the identity provider - user will be
                 // provisioned locally.
-                prepStmt.setString(7, IdPManagementConstants.IS_TRUE_VALUE);
+                if (identityProvider.getJustInTimeProvisioningConfig().isProvisioningEnabled()) {
+                    prepStmt.setString(7, IdPManagementConstants.IS_TRUE_VALUE);
+                } else {
+                    prepStmt.setString(7, IdPManagementConstants.IS_FALSE_VALUE);
+                }
                 // user will be provisioned to the configured user store.
                 prepStmt.setString(8, identityProvider.getJustInTimeProvisioningConfig().getProvisioningUserStore());
             } else {


### PR DESCRIPTION
### Purpose

Fixing the issue in saving `PRIMARY` as the user store when we creating an IDP(any kind of template) with a different user store.

Related Issue : [https://github.com/wso2/product-is#12996](https://github.com/wso2/product-is/issues/12996)
