### PR TITLE
[Public]Support to use tenant usage for outbound provisioning when saas apps are used

### DIFF
--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/IdentityProvisioningConstants.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/IdentityProvisioningConstants.java
@@ -44,6 +44,9 @@ public class IdentityProvisioningConstants {
     public static final String IS_TRUE_VALUE = "1";
     public static final String IS_FALSE_VALUE = "0";
 
+    // Outbound provisioning constants.
+    public static final String USE_USER_TENANT_DOMAIN_FOR_OUTBOUND_PROVISIONING_IN_SAAS_APPS = "OutboundProvisioning.useUserTenantDomainInSaasApps";
+
     public static class SQLQueries {
 
         public static final String ADD_PROVISIONING_ENTITY_SQL = "INSERT INTO IDP_PROVISIONING_ENTITY " +

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/OutboundProvisioningManager.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/OutboundProvisioningManager.java
@@ -539,22 +539,23 @@ public class OutboundProvisioningManager {
                         outboundProEntity = new ProvisioningEntity(provisioningEntity.getEntityType(),
                                 provisioningEntity.getEntityName(), provisioningOp, mapppedClaims);
 
-                    Callable<Boolean> proThread = new ProvisioningThread(outboundProEntity, spTenantDomainName,
-                            provisioningEntityTenantDomainName, connector, connectorType, idPName, dao);
-                    outboundProEntity.setIdentifier(provisionedIdentifier);
-                    outboundProEntity.setJitProvisioning(jitProvisioning);
-                    boolean isAllowed = true;
-                    boolean isBlocking = entry.getValue().isBlocking();
-                    boolean isPolicyEnabled = entry.getValue().isPolicyEnabled();
-                    if (isPolicyEnabled) {
-                        isAllowed = XACMLBasedRuleHandler.getInstance().isAllowedToProvision(spTenantDomainName,
-                                provisioningEntity,
-                                serviceProvider,
-                                idPName,
-                                connectorType);
-                    }
-                    if (isAllowed) {
-                        executeOutboundProvisioning(provisioningEntity, executors, connectorType, idPName, proThread, isBlocking);
+                        Callable<Boolean> proThread = new ProvisioningThread(outboundProEntity, spTenantDomainName,
+                                provisioningEntityTenantDomainName, connector, connectorType, idPName, dao);
+                        outboundProEntity.setIdentifier(provisionedIdentifier);
+                        outboundProEntity.setJitProvisioning(jitProvisioning);
+                        boolean isAllowed = true;
+                        boolean isBlocking = entry.getValue().isBlocking();
+                        boolean isPolicyEnabled = entry.getValue().isPolicyEnabled();
+                        if (isPolicyEnabled) {
+                            isAllowed = XACMLBasedRuleHandler.getInstance().isAllowedToProvision(spTenantDomainName,
+                                    provisioningEntity,
+                                    serviceProvider,
+                                    idPName,
+                                    connectorType);
+                        }
+                        if (isAllowed) {
+                            executeOutboundProvisioning(provisioningEntity, executors, connectorType, idPName, proThread, isBlocking);
+                        }
                     }
                 }
             }

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/OutboundProvisioningManager.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/OutboundProvisioningManager.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonException;
+import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.core.util.AnonymousSessionUtil;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
@@ -66,6 +67,8 @@ import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import static org.wso2.carbon.identity.provisioning.ProvisioningUtil.isUserTenantBasedOutboundProvisioningEnabled;
 
 /**
  *
@@ -322,15 +325,17 @@ public class OutboundProvisioningManager {
     }
 
     /**
-     * @param provisioningEntity
-     * @param serviceProviderIdentifier
-     * @param inboundClaimDialect
-     * @param tenantDomainName
-     * @param jitProvisioning
-     * @throws IdentityProvisioningException
+     * Outbound provisioning method.
+     *
+     * @param provisioningEntity        Provisioning entity.
+     * @param serviceProviderIdentifier Identifier of the service provider.
+     * @param inboundClaimDialect       Inbound claim dialect.
+     * @param spTenantDomainName        Tenant domain of the service provider.
+     * @param jitProvisioning           Is JIT provisioning enabled.
+     * @throws IdentityProvisioningException if error occurred while user provisioning.
      */
     public void provision(ProvisioningEntity provisioningEntity, String serviceProviderIdentifier,
-                          String inboundClaimDialect, String tenantDomainName, boolean jitProvisioning)
+                          String inboundClaimDialect, String spTenantDomainName, boolean jitProvisioning)
             throws IdentityProvisioningException {
 
         try {
@@ -341,11 +346,16 @@ public class OutboundProvisioningManager {
             // the SOAP based API (or the management console) - or SCIM API with HTTP Basic
             // Authentication is considered as coming from the local service provider.
             ServiceProvider serviceProvider = ApplicationManagementService.getInstance()
-                    .getServiceProvider(serviceProviderIdentifier, tenantDomainName);
+                    .getServiceProvider(serviceProviderIdentifier, spTenantDomainName);
 
             if (serviceProvider == null) {
                 throw new IdentityProvisioningException("Invalid service provider name : "
-                                                        + serviceProviderIdentifier);
+                        + serviceProviderIdentifier);
+            }
+
+            String provisioningEntityTenantDomainName = spTenantDomainName;
+            if (serviceProvider.isSaasApp() && isUserTenantBasedOutboundProvisioningEnabled()) {
+                provisioningEntityTenantDomainName = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
             }
 
             ClaimMapping[] spClaimMappings = null;
@@ -358,8 +368,8 @@ public class OutboundProvisioningManager {
             // get all the provisioning connectors associated with local service provider for
             // out-bound provisioning.
             // TODO: stop loading connectors all the time.
-            Map<String, RuntimeProvisioningConfig> connectors = getOutboundProvisioningConnectors(
-                    serviceProvider, tenantDomainName);
+            Map<String, RuntimeProvisioningConfig> connectors =
+                    getOutboundProvisioningConnectors(serviceProvider, spTenantDomainName);
 
             ProvisioningEntity outboundProEntity;
 
@@ -381,8 +391,8 @@ public class OutboundProvisioningManager {
                 String connectorType = connectorEntry.getKey();
                 String idPName = entry.getKey();
 
-                IdentityProvider provisioningIdp = IdentityProviderManager.getInstance()
-                        .getIdPByName(idPName, tenantDomainName);
+                IdentityProvider provisioningIdp =
+                        IdentityProviderManager.getInstance().getIdPByName(idPName, spTenantDomainName);
 
                 if (provisioningIdp == null) {
                     // this is an exception if we cannot find the provisioning identity provider
@@ -412,8 +422,9 @@ public class OutboundProvisioningManager {
                 Map<ClaimMapping, List<String>> mapppedClaims;
 
                 // get mapped claims.
-                mapppedClaims = getMappedClaims(inboundClaimDialect, outboundClaimDialect,
-                                                provisioningEntity, spClaimMappings, idpClaimMappings, tenantDomainName);
+                mapppedClaims =
+                        getMappedClaims(inboundClaimDialect, outboundClaimDialect, provisioningEntity, spClaimMappings,
+                                idpClaimMappings, spTenantDomainName);
 
                 if (provisioningIdp.getPermissionAndRoleConfig() != null) {
                     // update with mapped user groups.
@@ -425,8 +436,8 @@ public class OutboundProvisioningManager {
                 // so set it.
                 ProvisionedIdentifier provisionedIdentifier;
 
-                provisionedIdentifier = getProvisionedEntityIdentifier(idPName, connectorType,
-                                                                       provisioningEntity, tenantDomainName);
+                provisionedIdentifier =
+                        getProvisionedEntityIdentifier(idPName, connectorType, provisioningEntity, spTenantDomainName);
 
                 ProvisioningOperation provisioningOp = provisioningEntity.getOperation();
 
@@ -459,23 +470,26 @@ public class OutboundProvisioningManager {
                     ProvisionedIdentifier provisionedUserIdentifier;
 
                     for (String user : newUsersList) {
-                        ProvisioningEntity inboundProvisioningEntity = getInboundProvisioningEntity(provisioningEntity,
-                                                                                                    tenantDomainName, ProvisioningOperation.POST, user);
+                        ProvisioningEntity inboundProvisioningEntity =
+                                getInboundProvisioningEntity(provisioningEntity, provisioningEntityTenantDomainName,
+                                        ProvisioningOperation.POST, user);
 
-                        provisionedUserIdentifier = getProvisionedEntityIdentifier(idPName, connectorType,
-                                                                                   inboundProvisioningEntity, tenantDomainName);
+                        provisionedUserIdentifier =
+                                getProvisionedEntityIdentifier(idPName, connectorType, inboundProvisioningEntity,
+                                        spTenantDomainName);
 
                         if (provisionedUserIdentifier != null && provisionedUserIdentifier.getIdentifier() != null) {
                             continue;
                         }
 
-                        mappedUserClaims = getMappedClaims(inboundClaimDialect, outboundClaimDialect,
-                                                           inboundProvisioningEntity, spClaimMappings, idpClaimMappings, tenantDomainName);
+                        mappedUserClaims =
+                                getMappedClaims(inboundClaimDialect, outboundClaimDialect, inboundProvisioningEntity,
+                                        spClaimMappings, idpClaimMappings, spTenantDomainName);
 
                         outboundProEntity = new ProvisioningEntity(ProvisioningEntityType.USER,
                                                                    user, ProvisioningOperation.POST, mappedUserClaims);
-                        Callable<Boolean> proThread = new ProvisioningThread(outboundProEntity,
-                                                                             tenantDomainName, connector, connectorType, idPName, dao);
+                        Callable<Boolean> proThread = new ProvisioningThread(outboundProEntity, spTenantDomainName,
+                                provisioningEntityTenantDomainName, connector, connectorType, idPName, dao);
                         outboundProEntity.setIdentifier(provisionedIdentifier);
                         outboundProEntity.setJitProvisioning(jitProvisioning);
                         boolean isBlocking = entry.getValue().isBlocking();
@@ -485,20 +499,22 @@ public class OutboundProvisioningManager {
 
                     for (String user : deletedUsersList) {
 
-                        ProvisioningEntity inboundProvisioningEntity = getInboundProvisioningEntity(provisioningEntity,
-                                                                                                    tenantDomainName, ProvisioningOperation.DELETE, user);
+                        ProvisioningEntity inboundProvisioningEntity =
+                                getInboundProvisioningEntity(provisioningEntity, provisioningEntityTenantDomainName,
+                                        ProvisioningOperation.DELETE, user);
 
-                        provisionedUserIdentifier = getProvisionedEntityIdentifier(idPName, connectorType,
-                                                                                   inboundProvisioningEntity, tenantDomainName);
+                        provisionedUserIdentifier =
+                                getProvisionedEntityIdentifier(idPName, connectorType, inboundProvisioningEntity,
+                                        spTenantDomainName);
 
                         if (provisionedUserIdentifier != null && provisionedUserIdentifier.getIdentifier() != null) {
                             mappedUserClaims = getMappedClaims(inboundClaimDialect, outboundClaimDialect,
-                                                               inboundProvisioningEntity, spClaimMappings, idpClaimMappings, tenantDomainName);
+                                    inboundProvisioningEntity, spClaimMappings, idpClaimMappings, spTenantDomainName);
 
                             outboundProEntity = new ProvisioningEntity(ProvisioningEntityType.USER,
                                                                        user, ProvisioningOperation.DELETE, mappedUserClaims);
-                            Callable<Boolean> proThread = new ProvisioningThread(outboundProEntity,
-                                                                                 tenantDomainName, connector, connectorType, idPName, dao);
+                            Callable<Boolean> proThread = new ProvisioningThread(outboundProEntity, spTenantDomainName,
+                                    provisioningEntityTenantDomainName, connector, connectorType, idPName, dao);
                             outboundProEntity.setIdentifier(provisionedUserIdentifier);
                             outboundProEntity.setJitProvisioning(jitProvisioning);
                             boolean isBlocking = entry.getValue().isBlocking();
@@ -510,7 +526,8 @@ public class OutboundProvisioningManager {
                     // see whether the given provisioning entity satisfies the conditions to be
                     // provisioned.
 
-                    if (!canUserBeProvisioned(provisioningEntity, provisionByRoleList, tenantDomainName)) {
+                    if (!canUserBeProvisioned(provisioningEntity, provisionByRoleList,
+                            provisioningEntityTenantDomainName)) {
                         if (!canUserBeDeProvisioned(provisionedIdentifier)) {
                             continue;
                         } else {
@@ -522,25 +539,22 @@ public class OutboundProvisioningManager {
                         outboundProEntity = new ProvisioningEntity(provisioningEntity.getEntityType(),
                                 provisioningEntity.getEntityName(), provisioningOp, mapppedClaims);
 
-                        Callable<Boolean> proThread = new ProvisioningThread(outboundProEntity,
-                                tenantDomainName, connector, connectorType,
-                                idPName, dao);
-                        outboundProEntity.setIdentifier(provisionedIdentifier);
-                        outboundProEntity.setJitProvisioning(jitProvisioning);
-                        boolean isAllowed = true;
-                        boolean isBlocking = entry.getValue().isBlocking();
-                        boolean isPolicyEnabled = entry.getValue().isPolicyEnabled();
-                        if (isPolicyEnabled) {
-                            isAllowed = XACMLBasedRuleHandler.getInstance().isAllowedToProvision(tenantDomainName,
-                                    provisioningEntity,
-                                    serviceProvider,
-                                    idPName,
-                                    connectorType);
-                        }
-                        if (isAllowed) {
-                            executeOutboundProvisioning(provisioningEntity, executors, connectorType, idPName,
-                                    proThread, isBlocking);
-                        }
+                    Callable<Boolean> proThread = new ProvisioningThread(outboundProEntity, spTenantDomainName,
+                            provisioningEntityTenantDomainName, connector, connectorType, idPName, dao);
+                    outboundProEntity.setIdentifier(provisionedIdentifier);
+                    outboundProEntity.setJitProvisioning(jitProvisioning);
+                    boolean isAllowed = true;
+                    boolean isBlocking = entry.getValue().isBlocking();
+                    boolean isPolicyEnabled = entry.getValue().isPolicyEnabled();
+                    if (isPolicyEnabled) {
+                        isAllowed = XACMLBasedRuleHandler.getInstance().isAllowedToProvision(spTenantDomainName,
+                                provisioningEntity,
+                                serviceProvider,
+                                idPName,
+                                connectorType);
+                    }
+                    if (isAllowed) {
+                        executeOutboundProvisioning(provisioningEntity, executors, connectorType, idPName, proThread, isBlocking);
                     }
                 }
             }

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisioningUtil.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisioningUtil.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +34,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import static org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants.USE_USER_TENANT_DOMAIN_FOR_OUTBOUND_PROVISIONING_IN_SAAS_APPS;
 
 public class ProvisioningUtil {
 
@@ -523,5 +526,22 @@ public class ProvisioningUtil {
         }
 
         return outboundClaimValueMappings;
+    }
+
+    /**
+     * Is user tenant used for outbound provisioning thread if user provisioning is happens through a saas app.
+     *
+     * @return true if useUserTenantDomainInSaasApps config is enabled.
+     */
+    public static boolean isUserTenantBasedOutboundProvisioningEnabled() {
+
+        boolean userTenantBasedProvisioningThreadEnabled = false;
+
+        if (StringUtils.isNotEmpty(
+                IdentityUtil.getProperty(USE_USER_TENANT_DOMAIN_FOR_OUTBOUND_PROVISIONING_IN_SAAS_APPS))) {
+            userTenantBasedProvisioningThreadEnabled = Boolean
+                    .parseBoolean(IdentityUtil.getProperty(USE_USER_TENANT_DOMAIN_FOR_OUTBOUND_PROVISIONING_IN_SAAS_APPS));
+        }
+        return userTenantBasedProvisioningThreadEnabled;
     }
 }

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/test/java/org/wso2/carbon/identity/provisioning/ProvisioningThreadTest.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/test/java/org/wso2/carbon/identity/provisioning/ProvisioningThreadTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.provisioning.dao.CacheBackedProvisioningMgtDAO;
 import org.wso2.carbon.idp.mgt.util.IdPManagementUtil;
@@ -93,8 +94,8 @@ public class ProvisioningThreadTest extends PowerMockTestCase {
         Assert.assertTrue(result);
     }
 
-    @Test(expectedExceptions = IdentityProvisioningException.class)
-    public void testCallForExceptions()
+    @Test
+    public void testCallForInvalidTenant()
             throws Exception {
 
         provisioningEntity = new ProvisioningEntity(USER, DELETE, null);
@@ -104,6 +105,7 @@ public class ProvisioningThreadTest extends PowerMockTestCase {
                         idPName, mockCacheBackedProvisioningMgDAO);
 
         provisioningThread.call();
+        Assert.assertEquals(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId(), -1);
     }
 
     @DataProvider(name = "provisioningData")

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1378,17 +1378,25 @@
         <EnableRoleValidation>{{application_mgt.enable_role_validation}}</EnableRoleValidation>
     </ApplicationMgt>
 
-    {% if outbound_provisioning_management.reset_provisioning_entities_on_config_update is defined %}
-        <!--
-        Disabling this configuration will allow to keep the provisioned entities as it is and  will update the outbound
-        provisioning config rather than deleting the existing entries and add them as the new entries whenever updating
-        the provisioning connector configurations.
-        The default value of the configuration is true.
-        -->
-         <OutboundProvisioning>
+    <OutboundProvisioning>
+        {% if outbound_provisioning_management.reset_provisioning_entities_on_config_update is defined %}
+            <!--
+            Disabling this configuration will allow to keep the provisioned entities as it is and  will update the outbound
+            provisioning config rather than deleting the existing entries and add them as the new entries whenever updating
+            the provisioning connector configurations.
+            The default value of the configuration is true.
+            -->
             <ResetProvisioningEntitiesOnConfigUpdate>{{outbound_provisioning_management.reset_provisioning_entities_on_config_update}}</ResetProvisioningEntitiesOnConfigUpdate>
-         </OutboundProvisioning>
-    {% endif %}
+        {% endif %}
+        {% if outbound_provisioning_management.use_user_tenant_domain_in_saas_apps is defined %}
+            <!--
+                Enabling this configuration will use the user's tenant domain for outbound provisioning flow
+                if the user provisioning is happened through a SaaS application.
+            -->
+            <useUserTenantDomainInSaasApps>{{outbound_provisioning_management.use_user_tenant_domain_in_saas_apps}}</useUserTenantDomainInSaasApps>
+        {% endif %}
+    </OutboundProvisioning>
+
 
     <EventListeners>
         <EventListener id="workflow"


### PR DESCRIPTION
### Proposed changes in this pull request
Fix wso2/product-is#12993

Add the following config is deployment.toml to set true for useUserTenantDomainInSaasApps
```
[outbound_provisioning_management]
use_user_tenant_domain_in_saas_apps=true
```
if useUserTenantDomainInSaasApps = true, the user's tenant domain is used for outbound provisioning thread instead of the sp tenant domain when provisioning is happened through a SaaS app