### PR TITLE
Add default configurations of axis2 transport senders to default.json

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -844,5 +844,19 @@
   "cors.max_age": -1,
   "cors.tag_requests": false,
   "audit.log.contextual_param.params": [],
-  "common_auth_caller_path.enable_common_auth_caller_path_validation": true
+  "common_auth_caller_path.enable_common_auth_caller_path_validation": true,
+  "axis2.transport_sender.local.name": "local",
+  "axis2.transport_sender.local.class": "org.apache.axis2.transport.local.LocalTransportSender",
+  "axis2.transport_sender.http.name": "http",
+  "axis2.transport_sender.http.class": "org.apache.axis2.transport.http.CommonsHTTPTransportSender",
+  "axis2.transport_sender.http.parameters.PROTOCOL": "HTTP/1.1",
+  "axis2.transport_sender.http.parameters.Transfer-Encoding": "chunked",
+  "axis2.transport_sender.http.parameters.SO_TIMEOUT": "60000",
+  "axis2.transport_sender.http.parameters.CONNECTION_TIMEOUT": "60000",
+  "axis2.transport_sender.https.name": "https",
+  "axis2.transport_sender.https.class": "org.apache.axis2.transport.http.CommonsHTTPTransportSender",
+  "axis2.transport_sender.https.parameters.PROTOCOL": "HTTP/1.1",
+  "axis2.transport_sender.https.parameters.Transfer-Encoding": "chunked",
+  "axis2.transport_sender.https.parameters.SO_TIMEOUT": "60000",
+  "axis2.transport_sender.https.parameters.CONNECTION_TIMEOUT": "60000"
 }


### PR DESCRIPTION
### Proposed changes in this pull request
Add default configurations of axis2 transport senders to default.json
Resolves [product-is #12886](https://github.com/wso2/product-is/issues/12886)

### Related PRs
wso2/carbon-kernel [#3158](https://github.com/wso2/carbon-kernel/pull/3158)