### PR TITLE
Fix tenant resolving when retrieving attribute mappings

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
@@ -209,7 +209,6 @@ public class SSOConsentServiceImpl implements SSOConsentService {
         String spName = serviceProvider.getApplicationName();
         String spTenantDomain = getSPTenantDomain(serviceProvider);
         String subject = buildSubjectWithUserStoreDomain(authenticatedUser);
-        String tenantDomain = authenticatedUser.getTenantDomain();
 
         ClaimMapping[] claimMappings = getSpClaimMappings(serviceProvider);
 
@@ -222,7 +221,7 @@ public class SSOConsentServiceImpl implements SSOConsentService {
         if (claimsListOfScopes != null) {
             try {
                 claimMappings = FrameworkUtils.getFilteredScopeClaims(claimsListOfScopes,
-                        Arrays.asList(claimMappings), tenantDomain).toArray(new ClaimMapping[0]);
+                        Arrays.asList(claimMappings), authenticatedUser.getTenantDomain()).toArray(new ClaimMapping[0]);
             } catch (ClaimManagementException e) {
                 throw new SSOConsentServiceException("Error occurred while filtering claims of requested scopes");
             }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
@@ -21,6 +21,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.CarbonException;
 import org.wso2.carbon.claim.mgt.ClaimManagementException;
 import org.wso2.carbon.consent.mgt.core.ConsentManager;
 import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementClientException;
@@ -55,6 +56,7 @@ import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
@@ -222,7 +224,7 @@ public class SSOConsentServiceImpl implements SSOConsentService {
             try {
                 claimMappings = FrameworkUtils.getFilteredScopeClaims(claimsListOfScopes,
                         Arrays.asList(claimMappings), authenticatedUser.getTenantDomain()).toArray(new ClaimMapping[0]);
-            } catch (ClaimManagementException e) {
+            } catch (ClaimManagementException | CarbonException | UserStoreException e) {
                 throw new SSOConsentServiceException("Error occurred while filtering claims of requested scopes");
             }
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
@@ -223,7 +223,8 @@ public class SSOConsentServiceImpl implements SSOConsentService {
         if (claimsListOfScopes != null) {
             try {
                 claimMappings = FrameworkUtils.getFilteredScopeClaims(claimsListOfScopes,
-                        Arrays.asList(claimMappings), authenticatedUser.getTenantDomain()).toArray(new ClaimMapping[0]);
+                        Arrays.asList(claimMappings), serviceProvider.getOwner().getTenantDomain())
+                        .toArray(new ClaimMapping[0]);
             } catch (ClaimManagementException | CarbonException | UserStoreException e) {
                 throw new SSOConsentServiceException("Error occurred while filtering claims of requested scopes");
             }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
@@ -209,6 +209,7 @@ public class SSOConsentServiceImpl implements SSOConsentService {
         String spName = serviceProvider.getApplicationName();
         String spTenantDomain = getSPTenantDomain(serviceProvider);
         String subject = buildSubjectWithUserStoreDomain(authenticatedUser);
+        String tenantDomain = authenticatedUser.getTenantDomain();
 
         ClaimMapping[] claimMappings = getSpClaimMappings(serviceProvider);
 
@@ -221,7 +222,7 @@ public class SSOConsentServiceImpl implements SSOConsentService {
         if (claimsListOfScopes != null) {
             try {
                 claimMappings = FrameworkUtils.getFilteredScopeClaims(claimsListOfScopes,
-                        Arrays.asList(claimMappings)).toArray(new ClaimMapping[0]);
+                        Arrays.asList(claimMappings), tenantDomain).toArray(new ClaimMapping[0]);
             } catch (ClaimManagementException e) {
                 throw new SSOConsentServiceException("Error occurred while filtering claims of requested scopes");
             }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
@@ -21,7 +21,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.CarbonException;
 import org.wso2.carbon.claim.mgt.ClaimManagementException;
 import org.wso2.carbon.consent.mgt.core.ConsentManager;
 import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementClientException;
@@ -56,7 +55,6 @@ import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
-import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
@@ -225,7 +223,7 @@ public class SSOConsentServiceImpl implements SSOConsentService {
                 claimMappings = FrameworkUtils.getFilteredScopeClaims(claimsListOfScopes,
                         Arrays.asList(claimMappings), serviceProvider.getOwner().getTenantDomain())
                         .toArray(new ClaimMapping[0]);
-            } catch (ClaimManagementException | CarbonException | UserStoreException e) {
+            } catch (ClaimManagementException e) {
                 throw new SSOConsentServiceException("Error occurred while filtering claims of requested scopes");
             }
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -3164,9 +3164,10 @@ public class FrameworkUtils {
      * @throws ClaimManagementException
      */
     public static List<ClaimMapping> getFilteredScopeClaims(List<String> claimListOfScopes,
-                                                            List<ClaimMapping> claimMappings)
+                                                            List<ClaimMapping> claimMappings, String tenantDomain)
             throws ClaimManagementException {
 
+        startTenantFlow(tenantDomain);
         ClaimManagerHandler handler = ClaimManagerHandler.getInstance();
         List<String> claimMappingListOfScopes = new ArrayList<>();
         for (String claim : claimListOfScopes) {
@@ -3179,6 +3180,7 @@ public class FrameworkUtils {
                 requestedScopeClaims.add(claim);
             }
         }
+        PrivilegedCarbonContext.endTenantFlow();
         return requestedScopeClaims;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -3180,10 +3180,12 @@ public class FrameworkUtils {
             if (claimManager != null) {
                 for (String claim : claimListOfScopes) {
                     org.wso2.carbon.user.api.ClaimMapping currentMapping = claimManager.getClaimMapping(claim);
-                    if (currentMapping.getClaim().getClaimUri() != null) {
+                    if (currentMapping != null && currentMapping.getClaim() != null &&
+                            currentMapping.getClaim().getClaimUri() != null) {
                         claimMappingListOfScopes.add(currentMapping.getClaim().getClaimUri());
                     } else {
-                        throw new ClaimManagementException("No claim mapping are found for claim in ");
+                        throw new ClaimManagementException("No claim mapping are found for claim :" +
+                                claim + " in :" + tenantDomain);
                     }
                 }
             }


### PR DESCRIPTION
Related to 
- https://github.com/wso2-enterprise/asgardeo-product/issues/9080

As at the begin of this flow, the super tenant flow initiated, when trying to resolve the tenant domain, it picks carbon super tenant instead of sp tenant domain. To address that, introduce these changes. [We cannot initiate the authenticated user's tenant flow instead of carbon super, due to unavailability of the tenant domain at that point for some other flows ]

Note: It is decided to modify the public method (getFilteredScopeClaims) signature as no product version has released containing this method or back-port it.