### PR TITLE
Handle the error when SCIM request fails in Outbound provisioning

### DIFF
--- a/components/provisioning/org.wso2.carbon.identity.provisioning/pom.xml
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/pom.xml
@@ -165,6 +165,8 @@
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt.*;
                             version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.user.mgt.*;
+                            version="${carbon.identity.package.import.version.range}",
                             org.json;version="${json.wso2.version.range}",
                         </Import-Package>
                         <Export-Package>

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
@@ -31,15 +31,18 @@ import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
 import org.wso2.carbon.identity.entitlement.EntitlementService;
 import org.wso2.carbon.identity.provisioning.AbstractProvisioningConnectorFactory;
 import org.wso2.carbon.identity.provisioning.listener.DefaultInboundUserProvisioningListener;
+import org.wso2.carbon.identity.provisioning.listener.OutboundProvisioningErrorListener;
 import org.wso2.carbon.identity.provisioning.listener.ProvisioningApplicationMgtListener;
 import org.wso2.carbon.identity.provisioning.listener.ProvisioningIdentityProviderMgtListener;
 import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
 import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.user.core.listener.UserManagementErrorEventListener;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.user.core.service.RealmService;
 import java.util.Map;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Deactivate;
+import org.wso2.carbon.user.mgt.RolePermissionManagementService;
 
 @Component(
          name = "org.wso2.carbon.identity.provision.internal.IdentityProvisionServiceComponent",
@@ -119,6 +122,10 @@ public class IdentityProvisionServiceComponent {
             ProvisioningServiceDataHolder.getInstance().getBundleContext().registerService(IdentityProviderMgtListener.class.getName(), new ProvisioningIdentityProviderMgtListener(), null);
             if (log.isDebugEnabled()) {
                 log.debug("Identity Provider Management Event listener registered successfully");
+            }
+            ProvisioningServiceDataHolder.getInstance().getBundleContext().registerService(UserManagementErrorEventListener.class.getName(), new OutboundProvisioningErrorListener(), null);
+            if (log.isDebugEnabled()) {
+                log.debug("Identity Provision Event listener registered successfully");
             }
             if (log.isDebugEnabled()) {
                 log.debug("Identity Provisioning framework bundle is activated");
@@ -209,6 +216,34 @@ public class IdentityProvisionServiceComponent {
             log.debug("EntitlementService is unset in the Application Authentication Framework bundle");
         }
         ProvisioningServiceDataHolder.getInstance().setEntitlementService(null);
+    }
+
+    /**
+     * @param rolePermissionManagementService
+     */
+    @Reference(
+            name = "user.mgt.role.permission",
+            service = org.wso2.carbon.user.mgt.RolePermissionManagementService.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRolePermissionManagementService"
+    )
+    protected void setRolePermissionManagementService(RolePermissionManagementService rolePermissionManagementService) {
+        if (log.isDebugEnabled()) {
+            log.info("Role Permission Management Service is set to Identity Provisioning bundle.");
+        }
+        ProvisioningServiceDataHolder.getInstance().setRolePermissionManagementService(rolePermissionManagementService);
+    }
+
+    protected void unsetRolePermissionManagementService(RolePermissionManagementService rolePermissionManagementService){
+        if (log.isDebugEnabled()) {
+            log.info("Role Permission Management Service is unset to Identity Provisioning bundle.");
+        }
+        ProvisioningServiceDataHolder.getInstance().setRolePermissionManagementService(null);
+    }
+
+    public static RolePermissionManagementService getRolePermissionManagementService() {
+        return ProvisioningServiceDataHolder.getInstance().getRolePermissionManagementService();
     }
 }
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
@@ -218,9 +218,6 @@ public class IdentityProvisionServiceComponent {
         ProvisioningServiceDataHolder.getInstance().setEntitlementService(null);
     }
 
-    /**
-     * @param rolePermissionManagementService
-     */
     @Reference(
             name = "user.mgt.role.permission",
             service = org.wso2.carbon.user.mgt.RolePermissionManagementService.class,

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
@@ -127,10 +127,7 @@ public class IdentityProvisionServiceComponent {
                     .registerService(UserManagementErrorEventListener.class.getName(), new ProvisioningErrorListener(),
                             null);
             if (log.isDebugEnabled()) {
-                log.debug("Identity Provision Error Event listener registered successfully");
-            }
-            if (log.isDebugEnabled()) {
-                log.debug("Identity Provisioning framework bundle is activated");
+                log.debug("Identity provisioning error event listener registered successfully");
             }
         } catch (Throwable e) {
             log.error("Error while initiating identity provisioning connector framework", e);
@@ -234,7 +231,7 @@ public class IdentityProvisionServiceComponent {
     protected void setRolePermissionManagementService(RolePermissionManagementService rolePermissionManagementService) {
 
         if (log.isDebugEnabled()) {
-            log.info("Role Permission Management Service is set to Identity Provisioning bundle.");
+            log.debug("Role Permission Management Service is set to Identity Provisioning bundle.");
         }
         ProvisioningServiceDataHolder.getInstance().setRolePermissionManagementService(rolePermissionManagementService);
     }
@@ -242,7 +239,7 @@ public class IdentityProvisionServiceComponent {
     protected void unsetRolePermissionManagementService(RolePermissionManagementService rolePermissionManagementService){
 
         if (log.isDebugEnabled()) {
-            log.info("Role Permission Management Service is unset to Identity Provisioning bundle.");
+            log.debug("Role Permission Management Service is unset to Identity Provisioning bundle.");
         }
         ProvisioningServiceDataHolder.getInstance().setRolePermissionManagementService(null);
     }

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
@@ -31,8 +31,8 @@ import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
 import org.wso2.carbon.identity.entitlement.EntitlementService;
 import org.wso2.carbon.identity.provisioning.AbstractProvisioningConnectorFactory;
 import org.wso2.carbon.identity.provisioning.listener.DefaultInboundUserProvisioningListener;
-import org.wso2.carbon.identity.provisioning.listener.OutboundProvisioningErrorListener;
 import org.wso2.carbon.identity.provisioning.listener.ProvisioningApplicationMgtListener;
+import org.wso2.carbon.identity.provisioning.listener.ProvisioningErrorListener;
 import org.wso2.carbon.identity.provisioning.listener.ProvisioningIdentityProviderMgtListener;
 import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
 import org.wso2.carbon.registry.core.service.RegistryService;
@@ -123,9 +123,9 @@ public class IdentityProvisionServiceComponent {
             if (log.isDebugEnabled()) {
                 log.debug("Identity Provider Management Event listener registered successfully");
             }
-            ProvisioningServiceDataHolder.getInstance().getBundleContext().registerService(UserManagementErrorEventListener.class.getName(), new OutboundProvisioningErrorListener(), null);
+            ProvisioningServiceDataHolder.getInstance().getBundleContext().registerService(UserManagementErrorEventListener.class.getName(), new ProvisioningErrorListener(), null);
             if (log.isDebugEnabled()) {
-                log.debug("Identity Provision Event listener registered successfully");
+                log.debug("Identity Provision Error Event listener registered successfully");
             }
             if (log.isDebugEnabled()) {
                 log.debug("Identity Provisioning framework bundle is activated");

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
@@ -123,7 +123,9 @@ public class IdentityProvisionServiceComponent {
             if (log.isDebugEnabled()) {
                 log.debug("Identity Provider Management Event listener registered successfully");
             }
-            ProvisioningServiceDataHolder.getInstance().getBundleContext().registerService(UserManagementErrorEventListener.class.getName(), new ProvisioningErrorListener(), null);
+            ProvisioningServiceDataHolder.getInstance().getBundleContext()
+                    .registerService(UserManagementErrorEventListener.class.getName(), new ProvisioningErrorListener(),
+                            null);
             if (log.isDebugEnabled()) {
                 log.debug("Identity Provision Error Event listener registered successfully");
             }
@@ -212,6 +214,7 @@ public class IdentityProvisionServiceComponent {
      * @param entitlementService
      */
     protected void unsetEntitlementService(EntitlementService entitlementService) {
+
         if (log.isDebugEnabled()) {
             log.debug("EntitlementService is unset in the Application Authentication Framework bundle");
         }
@@ -229,6 +232,7 @@ public class IdentityProvisionServiceComponent {
             unbind = "unsetRolePermissionManagementService"
     )
     protected void setRolePermissionManagementService(RolePermissionManagementService rolePermissionManagementService) {
+
         if (log.isDebugEnabled()) {
             log.info("Role Permission Management Service is set to Identity Provisioning bundle.");
         }
@@ -236,14 +240,11 @@ public class IdentityProvisionServiceComponent {
     }
 
     protected void unsetRolePermissionManagementService(RolePermissionManagementService rolePermissionManagementService){
+
         if (log.isDebugEnabled()) {
             log.info("Role Permission Management Service is unset to Identity Provisioning bundle.");
         }
         ProvisioningServiceDataHolder.getInstance().setRolePermissionManagementService(null);
-    }
-
-    public static RolePermissionManagementService getRolePermissionManagementService() {
-        return ProvisioningServiceDataHolder.getInstance().getRolePermissionManagementService();
     }
 }
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/ProvisioningServiceDataHolder.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/ProvisioningServiceDataHolder.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.entitlement.EntitlementService;
 import org.wso2.carbon.identity.provisioning.AbstractProvisioningConnectorFactory;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.mgt.RolePermissionManagementService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,6 +35,7 @@ public class ProvisioningServiceDataHolder {
     private RegistryService registryService;
     private BundleContext bundleContext;
     private EntitlementService entitlementService;
+    private RolePermissionManagementService rolePermissionManagementService;
     private Map<String, AbstractProvisioningConnectorFactory> connectorFactories = new HashMap<String, AbstractProvisioningConnectorFactory>();
 
     private ProvisioningServiceDataHolder() {
@@ -83,6 +85,16 @@ public class ProvisioningServiceDataHolder {
     public void setEntitlementService(EntitlementService entitlementService) {
 
         this.entitlementService = entitlementService;
+    }
+
+    public void setRolePermissionManagementService(RolePermissionManagementService rolePermissionManagementService) {
+
+        this.rolePermissionManagementService = rolePermissionManagementService;
+    }
+
+    public RolePermissionManagementService getRolePermissionManagementService() {
+
+        return rolePermissionManagementService;
     }
 }
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/ProvisioningServiceDataHolder.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/ProvisioningServiceDataHolder.java
@@ -92,8 +92,16 @@ public class ProvisioningServiceDataHolder {
         this.rolePermissionManagementService = rolePermissionManagementService;
     }
 
+    /**
+     * Method to get rolePermissionManagementService.
+     *
+     * @return {RolePermissionManagementService}
+     */
     public RolePermissionManagementService getRolePermissionManagementService() {
 
+        if (rolePermissionManagementService == null) {
+            throw new RuntimeException("Role permission management service cannot be found.");
+        }
         return rolePermissionManagementService;
     }
 }

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/OutboundProvisioningErrorListener.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/OutboundProvisioningErrorListener.java
@@ -1,0 +1,463 @@
+*
+        * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+        *
+        * WSO2 Inc. licenses this file to you under the Apache License,
+        * Version 2.0 (the "License"); you may not use this file except
+        * in compliance with the License.
+        * You may obtain a copy of the License at
+        *
+        *      http://www.apache.org/licenses/LICENSE-2.0
+        *
+        * Unless required by applicable law or agreed to in writing,
+        * software distributed under the License is distributed on an
+        * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+        * KIND, either express or implied.  See the License for the
+        * specific language governing permissions and limitations
+        * under the License.
+        */
+
+        package org.wso2.carbon.identity.provisioning.listener;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.application.common.model.ProvisioningServiceProviderType;
+import org.wso2.carbon.identity.application.common.model.ThreadLocalProvisioningServiceProvider;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
+import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.core.AbstractIdentityUserMgtFailureEventListener;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants;
+import org.wso2.carbon.identity.provisioning.IdentityProvisioningException;
+import org.wso2.carbon.identity.provisioning.OutboundProvisioningManager;
+import org.wso2.carbon.identity.provisioning.ProvisioningEntity;
+import org.wso2.carbon.identity.provisioning.ProvisioningEntityType;
+import org.wso2.carbon.identity.provisioning.ProvisioningOperation;
+import org.wso2.carbon.identity.provisioning.internal.ProvisioningServiceDataHolder;
+import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.user.mgt.UserMgtConstants;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class OutboundProvisioningErrorListener extends AbstractIdentityUserMgtFailureEventListener {
+
+    private static final Log log = LogFactory.getLog(OutboundProvisioningErrorListener.class);
+
+    // Add user related error codes.
+    private String ERROR_CODE_INVALID_USER_NAME = "31301";
+    private String ERROR_CODE_INVALID_PASSWORD = "30003";
+    private String ERROR_CODE_USER_ALREADY_EXISTS = "30004";
+    private String ERROR_CODE_INTERNAL_ROLE_NOT_EXISTS = "31303";
+    private String ERROR_CODE_EXTERNAL_ROLE_NOT_EXISTS = "31304";
+    private String ERROR_CODE_UNABLE_TO_FETCH_CLAIM_MAPPING = "31305";
+    private String ERROR_CODE_INVALID_CLAIM_URI = "30005";
+    private String ERROR_CODE_ERROR_WHILE_ADDING_USER = "31306";
+
+    // Add roles related error codes.
+    private String ERROR_CODE_READONLY_USER_STORE = "30002";
+    private String ERROR_CODE_INVALID_ROLE_NAME = "30011";
+    private String ERROR_CODE_ERROR_WHILE_ADDING_ROLE = "31702";
+    private String ERROR_CODE_WRITE_GROUPS_NOT_ENABLED = "30014";
+    private String ERROR_CODE_ROLE_ALREADY_EXISTS = "30012";
+
+    // Set claims related error codes.
+    private String ERROR_CODE_ERROR_WHILE_SETTING_USER_CLAIM_VALUES = "39002";
+
+    // Delete Claim values related codes.
+    private String ERROR_CODE_ERROR_WHILE_DELETING_USER_CLAIM_VALUES = "31103";
+    private String ERROR_CODE_ERROR_WHILE_DELETING_USER_CLAIM_VALUE = "31203";
+
+    // Delete role related codes.
+    private String ERROR_CODE_ERROR_WHILE_DELETE_ROLE = "31802";
+
+    @Override
+    public boolean onAddUserFailureWithID(String errorCode, String errorMessage, String userName, Object credential,
+                                          String[] roleList, Map<String, String> claims, String profile, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        if (errorCode.equalsIgnoreCase(ERROR_CODE_INVALID_USER_NAME) ||
+                errorCode.equalsIgnoreCase(ERROR_CODE_INVALID_PASSWORD) ||
+                errorCode.equalsIgnoreCase(ERROR_CODE_USER_ALREADY_EXISTS) ||
+                errorCode.equalsIgnoreCase(ERROR_CODE_INTERNAL_ROLE_NOT_EXISTS) ||
+                errorCode.equalsIgnoreCase(ERROR_CODE_EXTERNAL_ROLE_NOT_EXISTS) ||
+                errorCode.equalsIgnoreCase(ERROR_CODE_UNABLE_TO_FETCH_CLAIM_MAPPING) ||
+                errorCode.equalsIgnoreCase(ERROR_CODE_INVALID_CLAIM_URI) ||
+                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_WHILE_ADDING_USER)
+        ) {
+            return deleteUser(userName, userStoreManager);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean onAddRoleFailure(String errorCode, String errorMessage, String roleName, String[] userList,
+                                    org.wso2.carbon.user.api.Permission[] permissions, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        if (errorCode.equalsIgnoreCase(ERROR_CODE_READONLY_USER_STORE) ||
+                errorCode.equalsIgnoreCase(ERROR_CODE_INVALID_ROLE_NAME) ||
+                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_WHILE_ADDING_ROLE) ||
+                errorCode.equalsIgnoreCase(ERROR_CODE_WRITE_GROUPS_NOT_ENABLED) ||
+                errorCode.equalsIgnoreCase(ERROR_CODE_ROLE_ALREADY_EXISTS)
+        ) {
+            deleteRole(roleName, permission, userStoreManager);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean onSetUserClaimValuesFailure(String errorCode, String errorMessage, String userName,
+                                               Map<String, String> claims, String profileName, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        if (errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_WHILE_SETTING_USER_CLAIM_VALUES) ||
+                errorCode.equalsIgnoreCase(ERROR_CODE_READONLY_USER_STORE)
+        ) {
+            Set<String> keys = claims.keySet();
+            String[] claimURIs = keys.toArray(new String[keys.size()]);
+
+            if (claimURIs.length > 0) {
+                Map<String, String> inboundAttributes = userStoreManager.getUserClaimValues(userName, claimURIs,
+                        UserCoreConstants.DEFAULT_PROFILE);
+                setUserClaimValues(userName, inboundAttributes, userStoreManager);
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean onDeleteUserClaimValuesFailure(String errorCode, String errorMessage, String userName, String[] claims,
+                                                  String profileName, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        if (errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_WHILE_DELETING_USER_CLAIM_VALUES)) {
+            if (claims.length > 0) {
+                Map<String, String> inboundAttributes = userStoreManager.getUserClaimValues(userName, claims,
+                        UserCoreConstants.DEFAULT_PROFILE);
+                setUserClaimValues(userName, inboundAttributes, userStoreManager);
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean onDeleteUserClaimValueFailure(String errorCode, String errorMessage, String userName, String claimURI,
+                                                 String profileName, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        if (errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_WHILE_DELETING_USER_CLAIM_VALUE)) {
+            if (!claimURI.isEmpty()) {
+                Map<String, String> inboundAttributes = userStoreManager.getUserClaimValues(userName, new String[] {
+                        claimURI}, UserCoreConstants.DEFAULT_PROFILE);
+                setUserClaimValues(userName, inboundAttributes, userStoreManager);
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean onDeleteRoleFailure(String errorCode, String errorMessage, String roleName,
+                                       UserStoreManager userStoreManager) throws UserStoreException {
+
+        if (errorCode.equalsIgnoreCase(ERROR_CODE_READONLY_USER_STORE) ||
+                errorCode.equalsIgnoreCase(ERROR_CODE_WRITE_GROUPS_NOT_ENABLED) ||
+                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_WHILE_DELETE_ROLE)
+        ) {
+            org.wso2.carbon.user.api.Permission[] permissions = null;
+            String[] users = userStoreManager.getUserListOfRole(roleName);
+            String tenantDomainName = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomainName);
+            try {
+                String[] permissionList = ProvisioningServiceDataHolder.getInstance().getRolePermissionManagementService()
+                        .getRolePermissions(roleName, tenantId);
+                if (permissionList.length > 0) {
+                    for (int index=0; index<permissionList.length; index++) {
+                        permissions[index] = new org.wso2.carbon.user.api.Permission(permissionList[index],
+                                UserMgtConstants.EXECUTE_ACTION);
+                    }
+                }
+            } catch (Exception e) {
+                // Do nothing
+            }
+            if (permissions == null) {
+                permissions = new org.wso2.carbon.user.api.Permission[0];
+            }
+            addRole(roleName, users, userStoreManager);
+        }
+        return true;
+    }
+
+    /**
+     * Method to add role.
+     * @param roleName - Name of the role
+     * @param userList - Users assigned to the role
+     * @param userStoreManager - User store
+     * @return boolean
+     * @throws UserStoreException
+     */
+    private boolean addRole(String roleName, String[] userList, UserStoreManager userStoreManager)
+            throws  UserStoreException {
+
+        Map<ClaimMapping, List<String>> outboundAttributes = new HashMap<>();
+
+        if (roleName != null) {
+            outboundAttributes.put(ClaimMapping.build(
+                    IdentityProvisioningConstants.GROUP_CLAIM_URI, null, null, false), Arrays
+                    .asList(new String[]{roleName}));
+        }
+
+        if (userList != null && userList.length > 0) {
+            outboundAttributes.put(ClaimMapping.build(
+                    IdentityProvisioningConstants.USERNAME_CLAIM_URI, null, null, false), Arrays
+                    .asList(userList));
+        }
+
+        String domainName = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
+        if (log.isDebugEnabled()) {
+            log.debug("Adding domain name : " + domainName + " to user : " + roleName);
+        }
+        String domainAwareName = UserCoreUtil.addDomainToName(roleName, domainName);
+
+        ProvisioningEntity provisioningEntity = new ProvisioningEntity(
+                ProvisioningEntityType.GROUP, domainAwareName, ProvisioningOperation.POST,
+                outboundAttributes);
+
+        String tenantDomainName = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+
+        ThreadLocalProvisioningServiceProvider threadLocalServiceProvider;
+        threadLocalServiceProvider = IdentityApplicationManagementUtil
+                .getThreadLocalProvisioningServiceProvider();
+
+        if (threadLocalServiceProvider != null) {
+            String serviceProvider = threadLocalServiceProvider.getServiceProviderName();
+            tenantDomainName = threadLocalServiceProvider.getTenantDomain();
+            if (threadLocalServiceProvider.getServiceProviderType() == ProvisioningServiceProviderType.OAUTH) {
+                try {
+                    serviceProvider = ApplicationManagementService.getInstance()
+                            .getServiceProviderNameByClientId(
+                                    threadLocalServiceProvider.getServiceProviderName(),
+                                    IdentityApplicationConstants.OAuth2.NAME, tenantDomainName);
+                } catch (IdentityApplicationManagementException e) {
+                    log.error("Error while provisioning", e);
+                    return true;
+                }
+            }
+
+            // call framework method to provision the user.
+            OutboundProvisioningManager.getInstance().provision(provisioningEntity,
+                    serviceProvider, threadLocalServiceProvider.getClaimDialect(),
+                    tenantDomainName, threadLocalServiceProvider.isJustInTimeProvisioning());
+        } else {
+            // call framework method to provision the group.
+            OutboundProvisioningManager.getInstance()
+                    .provision(provisioningEntity, ApplicationConstants.LOCAL_SP,
+                            IdentityProvisioningConstants.WSO2_CARBON_DIALECT, tenantDomainName, false);
+        }
+
+        return true;
+    }
+
+    /**
+     * Method to set values for user claims.
+     * @param userName - UserName
+     * @param inboundAttributes - Claims
+     * @param userStoreManager - User Store
+     * @return boolean
+     * @throws IdentityProvisioningException
+     */
+    private boolean setUserClaimValues(String userName, Map<String, String> inboundAttributes,
+                                       UserStoreManager userStoreManager) throws IdentityProvisioningException {
+
+        Map<ClaimMapping, List<String>> outboundAttributes = new HashMap<>();
+
+        if (userName != null) {
+            outboundAttributes.put(ClaimMapping.build(
+                            IdentityProvisioningConstants.USERNAME_CLAIM_URI, null, null, false),
+                    Arrays.asList(new String[]{userName}));
+        }
+
+        String domainName = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
+        if (log.isDebugEnabled()) {
+            log.debug("Adding domain name : " + domainName + " to user : " + userName);
+        }
+        String domainAwareName = UserCoreUtil.addDomainToName(userName, domainName);
+
+        ProvisioningEntity provisioningEntity = new ProvisioningEntity(
+                ProvisioningEntityType.USER, domainAwareName, ProvisioningOperation.PUT,
+                outboundAttributes);
+
+        // set the in-bound attribute list.
+        provisioningEntity.setInboundAttributes(inboundAttributes);
+
+        String tenantDomainName = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+
+        ThreadLocalProvisioningServiceProvider threadLocalServiceProvider;
+        threadLocalServiceProvider = IdentityApplicationManagementUtil
+                .getThreadLocalProvisioningServiceProvider();
+
+        if (threadLocalServiceProvider != null) {
+
+            String serviceProvider = threadLocalServiceProvider.getServiceProviderName();
+            tenantDomainName = threadLocalServiceProvider.getTenantDomain();
+            if (threadLocalServiceProvider.getServiceProviderType() == ProvisioningServiceProviderType.OAUTH) {
+                try {
+                    serviceProvider = ApplicationManagementService.getInstance()
+                            .getServiceProviderNameByClientId(
+                                    threadLocalServiceProvider.getServiceProviderName(),
+                                    IdentityApplicationConstants.OAuth2.NAME, tenantDomainName);
+                } catch (IdentityApplicationManagementException e) {
+                    log.error("Error while provisioning", e);
+                    return true;
+                }
+            }
+
+            // call framework method to provision the user.
+            OutboundProvisioningManager.getInstance().provision(provisioningEntity,
+                    serviceProvider, threadLocalServiceProvider.getClaimDialect(),
+                    tenantDomainName, threadLocalServiceProvider.isJustInTimeProvisioning());
+        } else {
+            // call framework method to provision the user.
+            OutboundProvisioningManager.getInstance()
+                    .provision(provisioningEntity, ApplicationConstants.LOCAL_SP,
+                            IdentityProvisioningConstants.WSO2_CARBON_DIALECT, tenantDomainName, false);
+        }
+        return true;
+    }
+
+    /**
+     * Method to delete a role.
+     * @param roleName - Name of the role
+     * @param userStoreManager - User Store
+     * @return boolean
+     * @throws UserStoreException
+     */
+    private boolean deleteRole(String roleName, org.wso2.carbon.user.api.Permission[] permissions,
+                               UserStoreManager userStoreManager) throws UserStoreException {
+
+        Map<ClaimMapping, List<String>> outboundAttributes = new HashMap<>();
+
+        if (roleName != null) {
+            outboundAttributes.put(ClaimMapping.build(
+                    IdentityProvisioningConstants.GROUP_CLAIM_URI, null, null, false), Arrays
+                    .asList(new String[]{roleName}));
+        }
+
+        String domainName = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
+        if (log.isDebugEnabled()) {
+            log.debug("Adding domain name : " + domainName + " to user : " + roleName);
+        }
+        String domainAwareName = UserCoreUtil.addDomainToName(roleName, domainName);
+
+        ProvisioningEntity provisioningEntity = new ProvisioningEntity(
+                ProvisioningEntityType.GROUP, domainAwareName, ProvisioningOperation.DELETE,
+                outboundAttributes);
+
+        String tenantDomainName = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+
+        ThreadLocalProvisioningServiceProvider threadLocalServiceProvider;
+        threadLocalServiceProvider = IdentityApplicationManagementUtil
+                .getThreadLocalProvisioningServiceProvider();
+
+        if (threadLocalServiceProvider != null) {
+            String serviceProvider = threadLocalServiceProvider.getServiceProviderName();
+            tenantDomainName = threadLocalServiceProvider.getTenantDomain();
+            if (threadLocalServiceProvider.getServiceProviderType() == ProvisioningServiceProviderType.OAUTH) {
+                try {
+                    serviceProvider = ApplicationManagementService.getInstance()
+                            .getServiceProviderNameByClientId(
+                                    threadLocalServiceProvider.getServiceProviderName(),
+                                    IdentityApplicationConstants.OAuth2.NAME, tenantDomainName);
+                } catch (IdentityApplicationManagementException e) {
+                    log.error("Error while provisioning", e);
+                    return true;
+                }
+            }
+
+            // call framework method to provision the user.
+            OutboundProvisioningManager.getInstance().provision(provisioningEntity,
+                    serviceProvider, threadLocalServiceProvider.getClaimDialect(),
+                    tenantDomainName, threadLocalServiceProvider.isJustInTimeProvisioning());
+        } else {
+            // call framework method to provision the group.
+            OutboundProvisioningManager.getInstance()
+                    .provision(provisioningEntity, ApplicationConstants.LOCAL_SP,
+                            IdentityProvisioningConstants.WSO2_CARBON_DIALECT, tenantDomainName, false);
+        }
+        return true;
+    }
+
+    /**
+     * Method to delete a user.
+     * @param userName - UserName
+     * @param userStoreManager - User Store
+     * @return boolean
+     * @throws UserStoreException
+     */
+    private boolean deleteUser(String userName, UserStoreManager userStoreManager) throws UserStoreException {
+        Map<ClaimMapping, List<String>> outboundAttributes = new HashMap<>();
+
+        outboundAttributes.put(ClaimMapping.build(
+                IdentityProvisioningConstants.USERNAME_CLAIM_URI, null, null, false), Arrays
+                .asList(new String[]{userName}));
+
+        String domainName = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
+        if (log.isDebugEnabled()) {
+            log.debug("Adding domain name : " + domainName + " to user : " + userName);
+        }
+        String domainAwareName = UserCoreUtil.addDomainToName(userName, domainName);
+
+        ProvisioningEntity provisioningEntity = new ProvisioningEntity(
+                ProvisioningEntityType.USER, domainAwareName, ProvisioningOperation.DELETE,
+                outboundAttributes);
+        String tenantDomainName = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+
+        ThreadLocalProvisioningServiceProvider threadLocalServiceProvider;
+        threadLocalServiceProvider = IdentityApplicationManagementUtil
+                .getThreadLocalProvisioningServiceProvider();
+
+        if (threadLocalServiceProvider != null) {
+            String serviceProvider = threadLocalServiceProvider.getServiceProviderName();
+            tenantDomainName = threadLocalServiceProvider.getTenantDomain();
+            if (threadLocalServiceProvider.getServiceProviderType() == ProvisioningServiceProviderType.OAUTH) {
+                try {
+                    serviceProvider = ApplicationManagementService.getInstance()
+                            .getServiceProviderNameByClientId(
+                                    threadLocalServiceProvider.getServiceProviderName(),
+                                    IdentityApplicationConstants.OAuth2.NAME, tenantDomainName);
+                } catch (IdentityApplicationManagementException e) {
+                    log.error("Error while provisioning", e);
+                    return true;
+                }
+            }
+
+            // call framework method to provision the user.
+            OutboundProvisioningManager.getInstance().provision(provisioningEntity,
+                    serviceProvider, threadLocalServiceProvider.getClaimDialect(),
+                    tenantDomainName, threadLocalServiceProvider.isJustInTimeProvisioning());
+        } else {
+            OutboundProvisioningManager.getInstance()
+                    .provision(provisioningEntity, ApplicationConstants.LOCAL_SP,
+                            IdentityProvisioningConstants.WSO2_CARBON_DIALECT, tenantDomainName, false);
+        }
+        return true;
+    }
+
+    /**
+     * Method to get the priority of the listener.
+     * @return {int} priority
+     */
+    public int getExecutionOrderId() {
+        return 9;
+    }
+}

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/ProvisioningErrorListener.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/ProvisioningErrorListener.java
@@ -200,7 +200,7 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
                 ProvisioningEntityType.GROUP, domainAwareName, ProvisioningOperation.POST,
                 outboundAttributes);
 
-        return outBoundProvisionEntity(provisioningEntity);
+        return outboundProvisionEntity(provisioningEntity);
     }
 
     /**
@@ -236,7 +236,7 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
         // Set the in-bound attribute list.
         provisioningEntity.setInboundAttributes(inboundAttributes);
 
-        return outBoundProvisionEntity(provisioningEntity);
+        return outboundProvisionEntity(provisioningEntity);
     }
 
     /**
@@ -268,7 +268,7 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
                 ProvisioningEntityType.GROUP, domainAwareName, ProvisioningOperation.DELETE,
                 outboundAttributes);
 
-        return outBoundProvisionEntity(provisioningEntity);
+        return outboundProvisionEntity(provisioningEntity);
     }
 
     /**
@@ -296,11 +296,12 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
                 ProvisioningEntityType.USER, domainAwareName, ProvisioningOperation.DELETE,
                 outboundAttributes);
 
-        return outBoundProvisionEntity(provisioningEntity);
+        return outboundProvisionEntity(provisioningEntity);
     }
 
     /**
      * Method to get the priority of the listener.
+     *
      * @return {int} priority.
      */
     public int getExecutionOrderId() {
@@ -320,7 +321,7 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
      * @return {boolean} Status shows that the entity is provisioned.
      * @throws IdentityProvisioningException if error occurred while out provisioning an entity.
      */
-    private boolean outBoundProvisionEntity(ProvisioningEntity provisioningEntity) throws IdentityProvisioningException {
+    private boolean outboundProvisionEntity(ProvisioningEntity provisioningEntity) throws IdentityProvisioningException {
 
         String tenantDomainName = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/ProvisioningErrorListener.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/ProvisioningErrorListener.java
@@ -57,6 +57,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Used for handle provisioning errors.
+ */
 public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEventListener {
 
     private static final Log log = LogFactory.getLog(ProvisioningErrorListener.class);
@@ -177,19 +180,16 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
             throws  UserStoreException {
 
         Map<ClaimMapping, List<String>> outboundAttributes = new HashMap<>();
-
         if (StringUtils.isNotEmpty(roleName)) {
             outboundAttributes.put(ClaimMapping.build(
                     IdentityProvisioningConstants.GROUP_CLAIM_URI, null, null, false), Arrays
                     .asList(new String[]{roleName}));
         }
-
         if (userList != null && userList.length > 0) {
             outboundAttributes.put(ClaimMapping.build(
                     IdentityProvisioningConstants.USERNAME_CLAIM_URI, null, null, false), Arrays
                     .asList(userList));
         }
-
         String domainName = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
         if (log.isDebugEnabled()) {
             log.debug("Adding domain name : " + domainName + " to role : " + roleName);
@@ -199,7 +199,6 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
         ProvisioningEntity provisioningEntity = new ProvisioningEntity(
                 ProvisioningEntityType.GROUP, domainAwareName, ProvisioningOperation.POST,
                 outboundAttributes);
-
         return outboundProvisionEntity(provisioningEntity);
     }
 
@@ -216,26 +215,21 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
                                                           UserStoreManager userStoreManager) throws IdentityProvisioningException {
 
         Map<ClaimMapping, List<String>> outboundAttributes = new HashMap<>();
-
         if (StringUtils.isNotEmpty(userName)) {
             outboundAttributes.put(ClaimMapping.build(
                             IdentityProvisioningConstants.USERNAME_CLAIM_URI, null, null, false),
                     Arrays.asList(new String[]{userName}));
         }
-
         String domainName = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
         if (log.isDebugEnabled()) {
             log.debug("Adding domain name : " + domainName + " to user : " + userName);
         }
         String domainAwareName = UserCoreUtil.addDomainToName(userName, domainName);
-
         ProvisioningEntity provisioningEntity = new ProvisioningEntity(
                 ProvisioningEntityType.USER, domainAwareName, ProvisioningOperation.PUT,
                 outboundAttributes);
-
         // Set the in-bound attribute list.
         provisioningEntity.setInboundAttributes(inboundAttributes);
-
         return outboundProvisionEntity(provisioningEntity);
     }
 
@@ -251,13 +245,11 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
                                                   UserStoreManager userStoreManager) throws UserStoreException {
 
         Map<ClaimMapping, List<String>> outboundAttributes = new HashMap<>();
-
         if (StringUtils.isNotEmpty(roleName)) {
             outboundAttributes.put(ClaimMapping.build(
                     IdentityProvisioningConstants.GROUP_CLAIM_URI, null, null, false), Arrays
                     .asList(new String[]{roleName}));
         }
-
         String domainName = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
         if (log.isDebugEnabled()) {
             log.debug("Adding domain name : " + domainName + " to user : " + roleName);
@@ -267,7 +259,6 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
         ProvisioningEntity provisioningEntity = new ProvisioningEntity(
                 ProvisioningEntityType.GROUP, domainAwareName, ProvisioningOperation.DELETE,
                 outboundAttributes);
-
         return outboundProvisionEntity(provisioningEntity);
     }
 
@@ -285,17 +276,14 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
         outboundAttributes.put(ClaimMapping.build(
                 IdentityProvisioningConstants.USERNAME_CLAIM_URI, null, null, false), Arrays
                 .asList(new String[]{userName}));
-
         String domainName = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
         if (log.isDebugEnabled()) {
             log.debug("Adding domain name : " + domainName + " to user : " + userName);
         }
         String domainAwareName = UserCoreUtil.addDomainToName(userName, domainName);
-
         ProvisioningEntity provisioningEntity = new ProvisioningEntity(
                 ProvisioningEntityType.USER, domainAwareName, ProvisioningOperation.DELETE,
                 outboundAttributes);
-
         return outboundProvisionEntity(provisioningEntity);
     }
 
@@ -324,7 +312,6 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
     private boolean outboundProvisionEntity(ProvisioningEntity provisioningEntity) throws IdentityProvisioningException {
 
         String tenantDomainName = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-
         ThreadLocalProvisioningServiceProvider threadLocalServiceProvider;
         threadLocalServiceProvider = IdentityApplicationManagementUtil
                 .getThreadLocalProvisioningServiceProvider();
@@ -343,7 +330,6 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
                     return true;
                 }
             }
-
             // Call framework method to provision the user.
             OutboundProvisioningManager.getInstance().provision(provisioningEntity,
                     serviceProvider, threadLocalServiceProvider.getClaimDialect(),

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/ProvisioningErrorListener.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/ProvisioningErrorListener.java
@@ -338,7 +338,7 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
 
         Map<ClaimMapping, List<String>> outboundAttributes = new HashMap<>();
 
-        if (roleName != null) {
+        if (StringUtils.isNotEmpty(roleName)) {
             outboundAttributes.put(ClaimMapping.build(
                     IdentityProvisioningConstants.GROUP_CLAIM_URI, null, null, false), Arrays
                     .asList(new String[]{roleName}));

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/ProvisioningErrorListener.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/ProvisioningErrorListener.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.provisioning.listener;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.CarbonContext;
@@ -59,28 +60,28 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
     private static final Log log = LogFactory.getLog(ProvisioningErrorListener.class);
 
     // Error codes related to add user failure.
-    private String ERROR_CODE_ERROR_DURING_PRE_ADD_USER = "31302";
-    private String ERROR_CODE_ERROR_DURING_POST_ADD_USER = "31307";
+    private final String ERROR_CODE_ERROR_DURING_PRE_ADD_USER = "31302";
+    private final String ERROR_CODE_ERROR_DURING_POST_ADD_USER = "31307";
 
     // Error codes related to add role failure.
-    private String ERROR_CODE_ERROR_DURING_PRE_ADD_ROLE = "31701";
-    private String ERROR_CODE_ERROR_DURING_POST_ADD_ROLE = "31703";
+    private final String ERROR_CODE_ERROR_DURING_PRE_ADD_ROLE = "31701";
+    private final String ERROR_CODE_ERROR_DURING_POST_ADD_ROLE = "31703";
 
     // Error codes related to delete role failure.
-    private String ERROR_CODE_ERROR_DURING_PRE_DELETE_ROLE = "31801";
-    private String ERROR_CODE_ERROR_DURING_POST_DELETE_ROLE = "31803";
+    private final String ERROR_CODE_ERROR_DURING_PRE_DELETE_ROLE = "31801";
+    private final String ERROR_CODE_ERROR_DURING_POST_DELETE_ROLE = "31803";
 
     // Error codes related to set claim values failure.
-    private String ERROR_CODE_ERROR_DURING_PRE_SET_USER_CLAIM_VALUES = "39001";
-    private String ERROR_CODE_ERROR_DURING_POST_SET_USER_CLAIM_VALUES = "39003";
+    private final String ERROR_CODE_ERROR_DURING_PRE_SET_USER_CLAIM_VALUES = "39001";
+    private final String ERROR_CODE_ERROR_DURING_POST_SET_USER_CLAIM_VALUES = "39003";
 
     // Error codes related to delete claims failure.
-    private String ERROR_CODE_ERROR_DURING_PRE_DELETE_USER_CLAIM_VALUES = "31101";
-    private String ERROR_CODE_ERROR_DURING_POST_DELETE_USER_CLAIM_VALUES = "31102";
+    private final String ERROR_CODE_ERROR_DURING_PRE_DELETE_USER_CLAIM_VALUES = "31101";
+    private final String ERROR_CODE_ERROR_DURING_POST_DELETE_USER_CLAIM_VALUES = "31102";
 
     // Error codes related to delete claim failure.
-    private String ERROR_CODE_ERROR_DURING_PRE_DELETE_USER_CLAIM_VALUE = "31201";
-    private String ERROR_CODE_ERROR_DURING_POST_DELETE_USER_CLAIM_VALUE = "31202";
+    private final String ERROR_CODE_ERROR_DURING_PRE_DELETE_USER_CLAIM_VALUE = "31201";
+    private final String ERROR_CODE_ERROR_DURING_POST_DELETE_USER_CLAIM_VALUE = "31202";
 
     @Override
     public boolean onAddUserFailureWithID(String errorCode, String errorMessage, String userName, Object credential,
@@ -88,8 +89,7 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
             throws UserStoreException {
 
         if (!(errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_PRE_ADD_USER) ||
-                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_POST_ADD_USER))
-        ) {
+                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_POST_ADD_USER))) {
             return deleteOutboundProvisionedUser(userName, userStoreManager);
         }
         return true;
@@ -101,8 +101,7 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
             throws UserStoreException {
 
         if (!(errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_PRE_ADD_ROLE) ||
-                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_POST_ADD_ROLE))
-        ) {
+                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_POST_ADD_ROLE))) {
             deleteOutboundProvisionedRole(roleName, permissions, userStoreManager);
         }
         return true;
@@ -114,8 +113,7 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
             throws UserStoreException {
 
         if (!(errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_PRE_SET_USER_CLAIM_VALUES) ||
-                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_POST_SET_USER_CLAIM_VALUES))
-        ) {
+                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_POST_SET_USER_CLAIM_VALUES))) {
             Set<String> keys = claims.keySet();
             String[] claimURIs = keys.toArray(new String[keys.size()]);
 
@@ -134,8 +132,7 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
             throws UserStoreException {
 
         if (!(errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_PRE_DELETE_USER_CLAIM_VALUES) ||
-                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_POST_DELETE_USER_CLAIM_VALUES))
-        ) {
+                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_POST_DELETE_USER_CLAIM_VALUES))) {
             if (claims.length > 0) {
                 Map<String, String> inboundAttributes = userStoreManager.getUserClaimValues(userName, claims,
                         UserCoreConstants.DEFAULT_PROFILE);
@@ -151,8 +148,7 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
             throws UserStoreException {
 
         if (!(errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_PRE_DELETE_USER_CLAIM_VALUE) ||
-                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_POST_DELETE_USER_CLAIM_VALUE))
-        ) {
+                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_POST_DELETE_USER_CLAIM_VALUE))) {
             if (!claimURI.isEmpty()) {
                 Map<String, String> inboundAttributes = userStoreManager.getUserClaimValues(userName, new String[] {
                         claimURI}, UserCoreConstants.DEFAULT_PROFILE);
@@ -167,8 +163,7 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
                                        UserStoreManager userStoreManager) throws UserStoreException {
 
         if (!(errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_PRE_DELETE_ROLE) ||
-                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_POST_DELETE_ROLE))
-        ) {
+                errorCode.equalsIgnoreCase(ERROR_CODE_ERROR_DURING_POST_DELETE_ROLE))) {
             org.wso2.carbon.user.api.Permission[] permissions = null;
             String[] users = userStoreManager.getUserListOfRole(roleName);
             String tenantDomainName = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
@@ -177,13 +172,14 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
                 String[] permissionList = ProvisioningServiceDataHolder.getInstance().getRolePermissionManagementService()
                         .getRolePermissions(roleName, tenantId);
                 if (permissionList.length > 0) {
+                    permissions = new org.wso2.carbon.user.api.Permission[permissionList.length];
                     for (int index=0; index<permissionList.length; index++) {
                         permissions[index] = new org.wso2.carbon.user.api.Permission(permissionList[index],
                                 UserMgtConstants.EXECUTE_ACTION);
                     }
                 }
             } catch (Exception e) {
-                // Do nothing
+                // Do nothing.
             }
             if (permissions == null) {
                 permissions = new org.wso2.carbon.user.api.Permission[0];
@@ -198,15 +194,15 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
      * @param roleName - Name of the role
      * @param userList - Users assigned to the role
      * @param userStoreManager - User store
-     * @return boolean
-     * @throws UserStoreException
+     * @return {boolean} - Status shows that the error is handled.
+     * @throws UserStoreException if error occurred while adding an outbound provisioning role.
      */
     private boolean addOutboundProvisioningRole(String roleName, String[] userList, UserStoreManager userStoreManager)
             throws  UserStoreException {
 
         Map<ClaimMapping, List<String>> outboundAttributes = new HashMap<>();
 
-        if (roleName != null) {
+        if (StringUtils.isNotEmpty(roleName)) {
             outboundAttributes.put(ClaimMapping.build(
                     IdentityProvisioningConstants.GROUP_CLAIM_URI, null, null, false), Arrays
                     .asList(new String[]{roleName}));
@@ -220,7 +216,7 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
 
         String domainName = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
         if (log.isDebugEnabled()) {
-            log.debug("Adding domain name : " + domainName + " to user : " + roleName);
+            log.debug("Adding domain name : " + domainName + " to role : " + roleName);
         }
         String domainAwareName = UserCoreUtil.addDomainToName(roleName, domainName);
 
@@ -249,12 +245,12 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
                 }
             }
 
-            // call framework method to provision the user.
+            // Call framework method to provision the user.
             OutboundProvisioningManager.getInstance().provision(provisioningEntity,
                     serviceProvider, threadLocalServiceProvider.getClaimDialect(),
                     tenantDomainName, threadLocalServiceProvider.isJustInTimeProvisioning());
         } else {
-            // call framework method to provision the group.
+            // Call framework method to provision the group.
             OutboundProvisioningManager.getInstance()
                     .provision(provisioningEntity, ApplicationConstants.LOCAL_SP,
                             IdentityProvisioningConstants.WSO2_CARBON_DIALECT, tenantDomainName, false);
@@ -268,15 +264,15 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
      * @param userName - UserName
      * @param inboundAttributes - Claims
      * @param userStoreManager - User Store
-     * @return boolean
-     * @throws IdentityProvisioningException
+     * @return {boolean} - Status shows that the error is handled.
+     * @throws IdentityProvisioningException if error occurred while setting outbound provisioned user claims.
      */
     private boolean setOutboundProvisionedUserClaimValues(String userName, Map<String, String> inboundAttributes,
                                                           UserStoreManager userStoreManager) throws IdentityProvisioningException {
 
         Map<ClaimMapping, List<String>> outboundAttributes = new HashMap<>();
 
-        if (userName != null) {
+        if (StringUtils.isNotEmpty(userName)) {
             outboundAttributes.put(ClaimMapping.build(
                             IdentityProvisioningConstants.USERNAME_CLAIM_URI, null, null, false),
                     Arrays.asList(new String[]{userName}));
@@ -292,7 +288,7 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
                 ProvisioningEntityType.USER, domainAwareName, ProvisioningOperation.PUT,
                 outboundAttributes);
 
-        // set the in-bound attribute list.
+        // Set the in-bound attribute list.
         provisioningEntity.setInboundAttributes(inboundAttributes);
 
         String tenantDomainName = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
@@ -317,12 +313,12 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
                 }
             }
 
-            // call framework method to provision the user.
+            // Call framework method to provision the user.
             OutboundProvisioningManager.getInstance().provision(provisioningEntity,
                     serviceProvider, threadLocalServiceProvider.getClaimDialect(),
                     tenantDomainName, threadLocalServiceProvider.isJustInTimeProvisioning());
         } else {
-            // call framework method to provision the user.
+            // Call framework method to provision the user.
             OutboundProvisioningManager.getInstance()
                     .provision(provisioningEntity, ApplicationConstants.LOCAL_SP,
                             IdentityProvisioningConstants.WSO2_CARBON_DIALECT, tenantDomainName, false);
@@ -334,8 +330,8 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
      * Method to delete a role.
      * @param roleName - Name of the role
      * @param userStoreManager - User Store
-     * @return boolean
-     * @throws UserStoreException
+     * @return {boolean} - Status shows that the error is handled.
+     * @throws UserStoreException if error occurred while deleting an outbound provisioned role.
      */
     private boolean deleteOutboundProvisionedRole(String roleName, org.wso2.carbon.user.api.Permission[] permissions,
                                                   UserStoreManager userStoreManager) throws UserStoreException {
@@ -379,12 +375,12 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
                 }
             }
 
-            // call framework method to provision the user.
+            // Call framework method to provision the user.
             OutboundProvisioningManager.getInstance().provision(provisioningEntity,
                     serviceProvider, threadLocalServiceProvider.getClaimDialect(),
                     tenantDomainName, threadLocalServiceProvider.isJustInTimeProvisioning());
         } else {
-            // call framework method to provision the group.
+            // Call framework method to provision the group.
             OutboundProvisioningManager.getInstance()
                     .provision(provisioningEntity, ApplicationConstants.LOCAL_SP,
                             IdentityProvisioningConstants.WSO2_CARBON_DIALECT, tenantDomainName, false);
@@ -396,8 +392,8 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
      * Method to delete a user.
      * @param userName - UserName
      * @param userStoreManager - User Store
-     * @return boolean
-     * @throws UserStoreException
+     * @return {boolean} - Status shows that the error is handled.
+     * @throws UserStoreException if error occurred while deleting an outbound provisioned role.
      */
     private boolean deleteOutboundProvisionedUser(String userName, UserStoreManager userStoreManager) throws UserStoreException {
         Map<ClaimMapping, List<String>> outboundAttributes = new HashMap<>();
@@ -436,7 +432,7 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
                 }
             }
 
-            // call framework method to provision the user.
+            // Call framework method to provision the user.
             OutboundProvisioningManager.getInstance().provision(provisioningEntity,
                     serviceProvider, threadLocalServiceProvider.getClaimDialect(),
                     tenantDomainName, threadLocalServiceProvider.isJustInTimeProvisioning());

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/ProvisioningErrorListener.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/ProvisioningErrorListener.java
@@ -106,36 +106,6 @@ public class ProvisioningErrorListener extends AbstractIdentityUserMgtFailureEve
     }
 
     @Override
-    public boolean onDeleteUserClaimValuesFailure(String errorCode, String errorMessage, String userName, String[] claims,
-                                                  String profileName, UserStoreManager userStoreManager)
-            throws UserStoreException {
-
-        // Outbound provisioning calls should not to be reverted if inbound provisioning is success.
-        if (errorCode.equalsIgnoreCase(ErrorMessages.ERROR_CODE_ERROR_DURING_POST_DELETE_USER_CLAIM_VALUES.getCode()) ||
-                claims.length == 0) {
-            return true;
-        }
-        Map<String, String> inboundAttributes = userStoreManager.getUserClaimValues(userName, claims,
-                UserCoreConstants.DEFAULT_PROFILE);
-        return setOutboundProvisionedUserClaimValues(userName, inboundAttributes, userStoreManager);
-    }
-
-    @Override
-    public boolean onDeleteUserClaimValueFailure(String errorCode, String errorMessage, String userName, String claimURI,
-                                                 String profileName, UserStoreManager userStoreManager)
-            throws UserStoreException {
-
-        // Outbound provisioning calls should not to be reverted if inbound provisioning is success.
-        if (errorCode.equalsIgnoreCase(ErrorMessages.ERROR_CODE_ERROR_DURING_POST_DELETE_USER_CLAIM_VALUE.getCode()) ||
-                claimURI.isEmpty()) {
-            return true;
-        }
-        Map<String, String> inboundAttributes = userStoreManager.getUserClaimValues(userName, new String[] {
-                claimURI}, UserCoreConstants.DEFAULT_PROFILE);
-        return setOutboundProvisionedUserClaimValues(userName, inboundAttributes, userStoreManager);
-    }
-
-    @Override
     public boolean onDeleteRoleFailure(String errorCode, String errorMessage, String roleName,
                                        UserStoreManager userStoreManager) throws UserStoreException {
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1127,8 +1127,8 @@
                        name="org.wso2.carbon.user.mgt.listeners.UserClaimsAuditLogger"
                        orderId="9" enable="false"/>
         <EventListener type="org.wso2.carbon.user.core.listener.UserManagementErrorEventListener"
-                       name="org.wso2.carbon.identity.provisioning.listener.OutboundProvisioningErrorListener"
-                       orderId="9" enable="true"/>
+                       name="org.wso2.carbon.identity.provisioning.listener.ProvisioningErrorListener"
+                       orderId="1" enable="false"/>
     </EventListeners>
 
     <!-- These recorders are used to write user delete information to specific sources. Default event recorder is CSV

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1126,6 +1126,9 @@
         <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
                        name="org.wso2.carbon.user.mgt.listeners.UserClaimsAuditLogger"
                        orderId="9" enable="false"/>
+        <EventListener type="org.wso2.carbon.user.core.listener.UserManagementErrorEventListener"
+                       name="org.wso2.carbon.identity.provisioning.listener.OutboundProvisioningErrorListener"
+                       orderId="9" enable="true"/>
     </EventListeners>
 
     <!-- These recorders are used to write user delete information to specific sources. Default event recorder is CSV

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1592,6 +1592,12 @@
             {% endfor %}
         </EventListener>
         {% endfor %}
+        <EventListener id="custom_error_resolver"
+                type="org.wso2.carbon.user.core.listener.UserManagementErrorEventListener"
+                name="org.wso2.carbon.identity.provisioning.listener.OutboundProvisioningErrorListener"
+                orderId="{{event.default_listener.outbound_provisioning_error_handler.priority}}"
+                enable="{{event.default_listener.outbound_provisioning_error_handler.enable}}">
+        </EventListener>
     </EventListeners>
 
     {% if analytics.publish_active_session_count is defined %}

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1592,9 +1592,9 @@
             {% endfor %}
         </EventListener>
         {% endfor %}
-        <EventListener id="custom_error_resolver"
+        <EventListener id="provision_error_listener"
                 type="org.wso2.carbon.user.core.listener.UserManagementErrorEventListener"
-                name="org.wso2.carbon.identity.provisioning.listener.OutboundProvisioningErrorListener"
+                name="org.wso2.carbon.identity.provisioning.listener.ProvisioningErrorListener"
                 orderId="{{event.default_listener.outbound_provisioning_error_handler.priority}}"
                 enable="{{event.default_listener.outbound_provisioning_error_handler.enable}}">
         </EventListener>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -440,8 +440,8 @@
   "event.default_listener.uma_introspection_data_provider.enable": false,
   "event.default_listener.is_introspection_data_provider.priority": "162",
   "event.default_listener.is_introspection_data_provider.enable": false,
-  "event.default_listener.outbound_provisioning_error_handler.priority": "9",
-  "event.default_listener.outbound_provisioning_error_handler.enable": true,
+  "event.default_listener.outbound_provisioning_error_handler.priority": "1",
+  "event.default_listener.outbound_provisioning_error_handler.enable": false,
 
   "event.default_listener.unique_claim_user_operation_event_listener.priority": "101",
   "event.default_listener.unique_claim_user_operation_event_listener.enable": false,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -440,6 +440,8 @@
   "event.default_listener.uma_introspection_data_provider.enable": false,
   "event.default_listener.is_introspection_data_provider.priority": "162",
   "event.default_listener.is_introspection_data_provider.enable": false,
+  "event.default_listener.outbound_provisioning_error_handler.priority": "9",
+  "event.default_listener.outbound_provisioning_error_handler.enable": true,
 
   "event.default_listener.unique_claim_user_operation_event_listener.priority": "101",
   "event.default_listener.unique_claim_user_operation_event_listener.enable": false,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -441,7 +441,7 @@
   "event.default_listener.is_introspection_data_provider.priority": "162",
   "event.default_listener.is_introspection_data_provider.enable": false,
   "event.default_listener.outbound_provisioning_error_handler.priority": "1",
-  "event.default_listener.outbound_provisioning_error_handler.enable": false,
+  "event.default_listener.outbound_provisioning_error_handler.enable": true,
 
   "event.default_listener.unique_claim_user_operation_event_listener.priority": "101",
   "event.default_listener.unique_claim_user_operation_event_listener.enable": false,


### PR DESCRIPTION
Purpose
Fixes the issue:
If the SCIM request fails by any other listener or even from the userstore level, the user will be outbound provisioned.

Solution:
Introduce a error listener to revert the provisioning if SCIM request fails.

Related issue: https://github.com/wso2/product-is/issues/12074