### PR TITLE
Sanitize the storing attributes via Attribute mgt API

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -1067,7 +1067,7 @@
 			</Claim>
 		</Dialect>
         <Dialect dialectURI="urn:scim:schemas:core:1.0"
-				 claimURIRegex="urn:scim:schemas:core:1.0:[a-z 0-9$\-_]*$">
+				 claimURIRegex="urn:scim:schemas:core:1.0:[a-zA-Z0-9$\-_]*$">
 			<Claim>
 				<ClaimURI>urn:scim:schemas:core:1.0:id</ClaimURI>
 				<DisplayName>Id</DisplayName>
@@ -1772,7 +1772,7 @@
 		    </Claim>
 		</Dialect>
 		<Dialect dialectURI="urn:ietf:params:scim:schemas:core:2.0"
-				 claimURIRegex="urn:ietf:params:scim:schemas:core:2.0:[a-z 0-9$\-_]*$">
+				 claimURIRegex="urn:ietf:params:scim:schemas:core:2.0:[a-zA-Z0-9$\-_]*$">
 			<Claim>
 				<ClaimURI>urn:ietf:params:scim:schemas:core:2.0:id</ClaimURI>
 				<DisplayName>Id</DisplayName>
@@ -1865,7 +1865,7 @@
 			</Claim>
 		</Dialect>
 		<Dialect dialectURI="urn:ietf:params:scim:schemas:core:2.0:User"
-				 claimURIRegex="urn:ietf:params:scim:schemas:core:2.0:User:[a-z 0-9$\-_]*$">
+				 claimURIRegex="urn:ietf:params:scim:schemas:core:2.0:User:[a-zA-Z0-9$\-_]*$">
 			<Claim>
 				<ClaimURI>urn:ietf:params:scim:schemas:core:2.0:User:userName</ClaimURI>
 				<DisplayName>User Name</DisplayName>
@@ -2226,7 +2226,7 @@
 			</Claim>
 		</Dialect>
 		<Dialect dialectURI="urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
-				 claimURIRegex="urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:[a-z 0-9$\-_]*$">
+				 claimURIRegex="urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:[a-zA-Z0-9$\-_]*$">
 			<Claim>
 				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber</ClaimURI>
 				<DisplayName>Employee Number</DisplayName>


### PR DESCRIPTION
### Proposed changes in this pull request

This adds the missing functionality of allowing CAPS to the previous PR[1] related to the $subject
Validation is done according to SCIM specification [2]

[1] https://github.com/wso2/carbon-identity-framework/pull/3889
[2] [SCIM - allowed chars](https://datatracker.ietf.org/doc/html/rfc7643#section-2.1)

### Related PRs

[carbon-identity-framework/pull/3889](https://github.com/wso2/carbon-identity-framework/pull/3889)
[carbon-kernel/pull/3165](https://github.com/wso2/carbon-kernel/pull/3165)