### PR TITLE
Adding user claim regex validation configuration

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -962,6 +962,9 @@
         temporary claim ('verifyEmail'/'verifyMobile') along with the update request. To enable this option,
         'UseVerifyClaim' should be set to true. -->
         <UseVerifyClaim>false</UseVerifyClaim>
+        <!-- When updating the claim value, it can be validated against the provided regex pattern.
+        To enable this option,'EnableUserClaimInputRegexValidation' should be set to true. -->
+        <!--<EnableUserClaimInputRegexValidation>false</EnableUserClaimInputRegexValidation>-->
     </UserClaimUpdate>
 
     <AccountSuspension>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1278,6 +1278,9 @@
         temporary claim ('verifyEmail'/'verifyMobile') along with the update request. To enable this option,
         'UseVerifyClaim' should be set to true. -->
         <UseVerifyClaim>{{identity_mgt.user_claim_update.use_verify_claim}}</UseVerifyClaim>
+          <!-- When updating the claim value, it can be validated against the provided regex pattern.
+          To enable this option,'EnableUserClaimInputRegexValidation' should be set to true. -->
+          <EnableUserClaimInputRegexValidation>{{identity_mgt.enable_user_claim_input_regex_validation}}</EnableUserClaimInputRegexValidation>
     </UserClaimUpdate>
 
      <AccountSuspension>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -366,6 +366,8 @@
 
   "identity_mgt_account_suspension.use_identity_claims": true,
 
+  "identity_mgt.enable_user_claim_input_regex_validation": true,
+
   "scim2_multi_attribute_filtering.use_pagination" : false,
 
   "sso_login.recaptcha.enabled": false,


### PR DESCRIPTION
Related to : [wso2/product-is#13174](https://github.com/wso2/product-is/issues/13174)

The following configuration should be added to `deployment.toml` file to enable/disable regex validation for user claims inputs.
(To enable regex validation variable should be set to true)

`[identity_mgt]`
`enable_user_claim_input_regex_validation = false`
