### PR TITLE
Introducing new event property `SEND_EMPTY_RECOVERY_NOTIFICATION_SCENARIO`.

### DIFF
--- a/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
@@ -287,6 +287,8 @@ public class IdentityEventConstants {
                 "GET_USER_RECOVERY_DATA_SCENARIO_WITH_CODE_EXPIRY_VALIDATION";
         public static final String GET_USER_RECOVERY_DATA_SCENARIO_WITHOUT_CODE_EXPIRY_VALIDATION =
                 "GET_USER_RECOVERY_DATA_SCENARIO_WITHOUT_CODE_EXPIRY_VALIDATION";
+        public static final String SEND_EMPTY_RECOVERY_NOTIFICATION_SCENARIO =
+                "SEND_EMPTY_RECOVERY_NOTIFICATION_SCENARIO";
 
         public static final String REQUEST = "request";
         public static final String USER_ID = "USER_ID";


### PR DESCRIPTION
### Proposed changes in this pull request

Introducing new event property `SEND_EMPTY_RECOVERY_NOTIFICATION_SCENARIO`. This property will be used to decide to skip recovery flow and send empty notification response scenario.

#### Related PRs

- https://github.com/wso2-extensions/identity-governance/pull/575
