### PR TITLE
Add missing templates for application-authentication.xml

### DIFF
--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml.j2
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml.j2
@@ -36,6 +36,15 @@
     <AuthenticationEndpointURL>{{authentication.endpoints.login_url}}</AuthenticationEndpointURL>
     <AuthenticationEndpointRetryURL>{{authentication.endpoints.retry_url}}</AuthenticationEndpointRetryURL>
     <AuthenticationEndpointMissingClaimsURL>{{authentication.endpoints.request_missing_claims_url}}</AuthenticationEndpointMissingClaimsURL>
+    {% if authentication.endpoints.wait_url is defined %}
+    <AuthenticationEndpointWaitURL>{{authentication.endpoints.wait_url}}</AuthenticationEndpointWaitURL>
+    {% endif %}
+    {% if authentication.endpoints.prompt_url is defined %}
+    <AuthenticationEndpointPromptURL>{{authentication.endpoints.prompt_url}}</AuthenticationEndpointPromptURL>
+    {% endif %}
+    {% if authentication.identifier.first.endpoint.confirmation_url is defined %}
+    <IdentifierFirstConfirmationURL>{{authentication.identifier.first.endpoint.confirmation_url}}</IdentifierFirstConfirmationURL>
+    {% endif %}
 
     <!--
         Extensions allow extending the default behaviour of the authentication


### PR DESCRIPTION
### Proposed changes in this pull request

> Adding following missing templates to application-authentication.xml
> - AuthenticationEndpointWaitURL
> - AuthenticationEndpointPromptURL
> - IdentifierFirstConfirmationURL

### Related Issues
> https://github.com/wso2/product-is/issues/13207