### PR TITLE
Add Configurations to perform AMR value mapping

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/AuthenticationMethodNameTranslatorImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/AuthenticationMethodNameTranslatorImpl.java
@@ -92,13 +92,11 @@ public class AuthenticationMethodNameTranslatorImpl implements AuthenticationMet
 
         String uri = amrEntryElement.getAttributeValue(URI_ATTR_QNAME);
         String method = amrEntryElement.getAttributeValue(METHOD_ATTR_QNAME);
+        Set<String> externalMappings = amrInternalToExternalMap.computeIfAbsent(method, k -> new HashSet<>());
         if (amrEntryElement.getAttribute(NIL_QNAME) == null) {
-            Set<String> externalMappings = amrInternalToExternalMap.get(method);
-            if (externalMappings == null) {
-                externalMappings = new HashSet<>();
-                amrInternalToExternalMap.put(method, externalMappings);
-            }
             externalMappings.add(uri);
+        } else {
+            externalMappings.add(String.valueOf(Character.MIN_VALUE));
         }
         amrExternalToInternalMap.put(uri, method);
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/AuthenticationMethodNameTranslatorImplTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/AuthenticationMethodNameTranslatorImplTest.java
@@ -62,6 +62,8 @@ public class AuthenticationMethodNameTranslatorImplTest {
         assertTrue(translator.translateToExternalAmr("SampleHardwareKeyAuthenticator", "openid").contains("hwk"));
         assertTrue(translator.translateToExternalAmr("SomeOtherHwkAuthenticator", "openid").contains("hwk1"));
         assertTrue(translator.translateToExternalAmr("SomeOtherHwkAuthenticator", "openid").contains("hwk2"));
+        assertTrue(translator.translateToExternalAmr("AuthenticatorNoNeedToProvideInformation",
+                "openid").contains(String.valueOf(Character.MIN_VALUE)));
     }
 
     private AuthenticationMethodNameTranslatorImpl getTranslator(String fileName) throws XMLStreamException {

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2997,4 +2997,21 @@
         {% endfor %}
     </StoredProcedureDAO>
     {% endif %}
+
+    {% if authentication_context.method_refs is defined %}
+        <AuthenticationContext>
+            <MethodRefs>
+                {% for method_ref in authentication_context.method_refs %}
+                    {% if method_ref.amr_value is defined %}
+                    <MethodRef method="{{method_ref.method}}" uri="{{method_ref.amr_value}}" />
+                    {% elif method_ref.excluded_methods is defined %}
+                    {% for excluded_method in method_ref.excluded_methods %}
+                    <MethodRef method="{{excluded_method}}" xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
+                    {% endfor %}
+                    {% endif %}
+                {% endfor %}
+            </MethodRefs>
+        </AuthenticationContext>
+    {% endif %}
+
 </Server>


### PR DESCRIPTION
## Purpose

* $subject
* Fix https://github.com/wso2/product-is/issues/13225

## Approach
* Update `identity.xml.j2` with missing AMR value mapping configs
* Add authentication methods that are configured to prevent being available on the ID Token into the amrExternalToInternalMap. Hence, it will not return empty collections when calling the `translateToExternalAmr` method

## Notes
Users can add custom values to this config by adding the following configs in the `deployment.toml`
```
[[authentication_context.method_refs]]
method = "SMSOTP"
amr_value = "sms"
[[authentication_context.method_refs]]
method = "EmailOTP"
amr_value = "otp"
[[authentication_context.method_refs]]
excluded_methods = ["BasicAuthenticator", "AuthenticationMethodToBeIgnored"]
```

identity.xml preview
```
<AuthenticationContext>
        <MethodRefs>
                <MethodRef method="SMSOTP" uri="sms" />
                <MethodRef method="EmailOTP" uri="otp" />
                <MethodRef method="BasicAuthenticator" xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
                <MethodRef method="AuthenticationMethodToBeIgnored" xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
        </MethodRefs>
 </AuthenticationContext>
```

## Related PRs
* https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1814