### PR TITLE
Minor UI Fix in SP Claim Configuration UI

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider.jsp
@@ -1141,8 +1141,8 @@
         }).remove();
         $.each($('.spClaimVal'), function () {
             if ($(this).val().length > 0) {
-                $("#roleClaim").append('<option value="' + $(this).val() + '">' + $(this).val() + '</option>');
-                $('#subject_claim_uri').append('<option value="' + $(this).val() + '">' + $(this).val() + '</option>');
+                $("#roleClaim").append('<option value="' + encodeForHTML($(this).val()) + '">' + encodeForHTML($(this).val()) + '</option>');
+                $('#subject_claim_uri').append('<option value="' + encodeForHTML($(this).val()) + '">' + encodeForHTML($(this).val()) + '</option>');
             }
         });
     }


### PR DESCRIPTION
## Purpose
This PR will fix a minor UI issue in SP Claim Configuration UI

## Approach
Encoded the `roleClaim` and `subject_claim_uri` content using the existing `encodeForHTML` function [1]

[1] https://github.com/wso2/carbon-identity-framework/blob/5.18.x/components/identity-core/org.wso2.carbon.identity.core.ui/src/main/resources/web/identity/encode/js/identity-encode.js#L19