### PR TITLE
[5.18.x] Update pax versions and remove redundant dependencies

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>org.wso2.carbon.ui</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>commons-collections</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
@@ -95,7 +95,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>
@@ -272,7 +272,7 @@
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
                     <classpathDependencyExcludes>
-                        <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>

--- a/components/carbon-authenticators/thrift-authenticator/org.wso2.carbon.identity.authenticator.thrift/pom.xml
+++ b/components/carbon-authenticators/thrift-authenticator/org.wso2.carbon.identity.authenticator.thrift/pom.xml
@@ -62,7 +62,7 @@
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/components/claim-mgt/org.wso2.carbon.claim.mgt.ui/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.claim.mgt.ui/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>org.wso2.carbon.ui</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/claim-mgt/org.wso2.carbon.claim.mgt/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.claim.mgt/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt.ui/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt.ui/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>org.wso2.carbon.ui</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/pom.xml
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>org.eclipse.osgi.services</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/pom.xml
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/pom.xml
@@ -68,7 +68,7 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/directory-server-manager/org.wso2.carbon.directory.server.manager.ui/pom.xml
+++ b/components/directory-server-manager/org.wso2.carbon.directory.server.manager.ui/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>org.wso2.carbon.directory.server.manager.common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.common/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.common/pom.xml
@@ -64,7 +64,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.endpoint/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.endpoint/pom.xml
@@ -187,7 +187,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <classpathDependencyExcludes>
-                        <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.ui/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.ui/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/pom.xml
@@ -89,7 +89,7 @@
             <artifactId>javax.cache.wso2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/pom.xml
+++ b/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>org.wso2.carbon.user.mgt.stub</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt/pom.xml
+++ b/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt/pom.xml
@@ -80,7 +80,7 @@
                     </systemPropertyVariables>
                     <reuseForks>true</reuseForks>
                     <classpathDependencyExcludes>
-                        <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>
@@ -161,7 +161,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/identity-core/org.wso2.carbon.identity.base/pom.xml
+++ b/components/identity-core/org.wso2.carbon.identity.base/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/identity-core/org.wso2.carbon.identity.core/pom.xml
+++ b/components/identity-core/org.wso2.carbon.identity.core/pom.xml
@@ -87,7 +87,7 @@
             <artifactId>commons-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/identity-event/org.wso2.carbon.identity.event/pom.xml
+++ b/components/identity-event/org.wso2.carbon.identity.event/pom.xml
@@ -83,7 +83,7 @@
             <artifactId>javax.cache.wso2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.ui/pom.xml
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.ui/pom.xml
@@ -53,7 +53,7 @@
             <artifactId>axiom</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/pom.xml
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/pom.xml
@@ -58,7 +58,7 @@
             <artifactId>axiom</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/notification-mgt/org.wso2.carbon.identity.notification.mgt/pom.xml
+++ b/components/notification-mgt/org.wso2.carbon.identity.notification.mgt/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/pom.xml
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/pom.xml
@@ -57,7 +57,7 @@
             <artifactId>axiom</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/security-mgt/org.wso2.carbon.security.mgt/pom.xml
+++ b/components/security-mgt/org.wso2.carbon.security.mgt/pom.xml
@@ -175,7 +175,7 @@
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
                     <classpathDependencyExcludes>
-                        <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>

--- a/components/template-mgt/org.wso2.carbon.identity.template.mgt.endpoint/pom.xml
+++ b/components/template-mgt/org.wso2.carbon.identity.template.mgt.endpoint/pom.xml
@@ -162,7 +162,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/components/template-mgt/org.wso2.carbon.identity.template.mgt/pom.xml
+++ b/components/template-mgt/org.wso2.carbon.identity.template.mgt/pom.xml
@@ -155,7 +155,7 @@
             <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/user-functionality-mgt/org.wso2.carbon.identity.user.functionality.mgt/pom.xml
+++ b/components/user-functionality-mgt/org.wso2.carbon.identity.user.functionality.mgt/pom.xml
@@ -212,7 +212,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/components/user-mgt/org.wso2.carbon.identity.user.profile.ui/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.identity.user.profile.ui/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>org.wso2.carbon.ui</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/user-mgt/org.wso2.carbon.identity.user.profile/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.identity.user.profile/pom.xml
@@ -55,7 +55,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/user-mgt/org.wso2.carbon.identity.user.registration/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.identity.user.registration/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>org.wso2.carbon.identity.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/components/user-mgt/org.wso2.carbon.user.mgt.common/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.common/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>org.wso2.carbon.user.mgt.common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/user-mgt/org.wso2.carbon.user.mgt/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/pom.xml
@@ -89,11 +89,11 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-log4j2</artifactId>
         </dependency>
         <dependency>
@@ -210,7 +210,7 @@
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
                     <classpathDependencyExcludes>
-                        <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration.ui/pom.xml
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration.ui/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>org.wso2.carbon.user.mgt.ui</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/pom.xml
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/user-store/org.wso2.carbon.identity.user.store.count/pom.xml
+++ b/components/user-store/org.wso2.carbon.identity.user.store.count/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>org.wso2.carbon.user.api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/pom.xml
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/pom.xml
@@ -36,7 +36,7 @@
             <artifactId>org.wso2.carbon.ui</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,12 @@
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.user.core</artifactId>
                 <version>${carbon.kernel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -219,6 +225,12 @@
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.core</artifactId>
                 <version>${carbon.kernel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -239,6 +251,12 @@
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.ui</artifactId>
                 <version>${carbon.kernel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -295,6 +313,12 @@
                 <groupId>org.apache.axis2.wso2</groupId>
                 <artifactId>axis2-client</artifactId>
                 <version>${axis2.wso2.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.axis2.transport</groupId>
@@ -317,6 +341,12 @@
                 <groupId>org.wso2.balana</groupId>
                 <artifactId>org.wso2.balana</artifactId>
                 <version>${balana.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.google.gdata.wso2</groupId>
@@ -462,6 +492,12 @@
                 <groupId>org.wso2.securevault</groupId>
                 <artifactId>org.wso2.securevault</artifactId>
                 <version>${org.wso2.securevault.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -539,12 +575,12 @@
                 <version>${wsdl4j.wso2.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.ops4j.pax.logging</groupId>
+                <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-api</artifactId>
                 <version>${pax.logging.api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.ops4j.pax.logging</groupId>
+                <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-log4j2</artifactId>
                 <version>${pax.logging.log4j2.version}</version>
             </dependency>
@@ -1404,6 +1440,12 @@
                 <groupId>org.wso2.balana</groupId>
                 <artifactId>org.wso2.balana.utils</artifactId>
                 <version>${balana.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
@@ -1612,11 +1654,23 @@
                 <groupId>org.wso2.carbon.registry</groupId>
                 <artifactId>org.wso2.carbon.registry.common</artifactId>
                 <version>${org.wso2.carbon.registry.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.registry</groupId>
                 <artifactId>org.wso2.carbon.registry.indexing</artifactId>
                 <version>${org.wso2.carbon.registry.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- Testing related dependencies -->
@@ -1667,6 +1721,12 @@
                 <groupId>org.wso2.carbon.consent.mgt</groupId>
                 <artifactId>org.wso2.carbon.consent.mgt.core</artifactId>
                 <version>${carbon.consent.mgt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
@@ -2008,8 +2068,8 @@
         <jersey-version>1.19.1</jersey-version>
 
         <!-- Pax Logging Version -->
-        <pax.logging.api.version>1.10.1</pax.logging.api.version>
-        <pax.logging.log4j2.version>1.10.1</pax.logging.log4j2.version>
+        <pax.logging.api.version>2.1.0-wso2v4</pax.logging.api.version>
+        <pax.logging.log4j2.version>2.1.0-wso2v4</pax.logging.log4j2.version>
 
         <!-- Log4j -->
         <log4j.api.version>2.12.0</log4j.api.version>

--- a/service-stubs/identity/org.wso2.carbon.security.mgt.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.security.mgt.stub/pom.xml
@@ -127,7 +127,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Proposed changes in this pull request
This PR updates the pax-logging to use `org.wso2.org.ops4j.pax.logging`