### PR TITLE
Fix the issue with data types in postgresql

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/dao/impl/UserSessionDAOImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/dao/impl/UserSessionDAOImpl.java
@@ -108,7 +108,7 @@ public class UserSessionDAOImpl implements UserSessionDAO {
              PreparedStatement ps = connection.prepareStatement(sql)) {
             int index = 1;
             for (String appId : appIdMap.keySet()) {
-                ps.setString(index, appId);
+                ps.setInt(index, Integer.parseInt(appId));
                 index++;
             }
             try (ResultSet rs = ps.executeQuery()) {


### PR DESCRIPTION
### Proposed changes in this pull request
Resolves https://github.com/wso2/product-is/issues/12955

The issue was we are trying to use string instead of int while getting the application. The root cause of the issues was we are setting string for application id column which is having integer as the data type.
```
org.wso2.carbon.identity.application.mgt.dao.impl.ApplicationDAOImpl.getDiscoverableApplicationBasicInfo(ApplicationDAOImpl.java:5073)
... 61 more
Caused by: org.postgresql.util.PSQLException: ERROR: operator does not exist: integer = character varying

```
This fix add the integer value to the integer column.


-
