### PR TITLE
Throw userstore client exception for claim uniqueness violation

### DIFF
--- a/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/src/main/java/org/wso2/carbon/identity/unique/claim/mgt/listener/UniqueClaimUserOperationEventListener.java
+++ b/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/src/main/java/org/wso2/carbon/identity/unique/claim/mgt/listener/UniqueClaimUserOperationEventListener.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.unique.claim.mgt.internal.UniqueClaimUserOperati
 import org.wso2.carbon.user.api.Claim;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
@@ -170,7 +171,7 @@ public class UniqueClaimUserOperationEventListener extends AbstractIdentityUserO
             String claimList = String.join(", ", duplicateClaim);
             errorMessage = "The values defined for " + claimList + " are already in use by a different users!";
         }
-        throw new UserStoreException(errorMessage, new PolicyViolationException(errorMessage));
+        throw new UserStoreClientException(errorMessage, new PolicyViolationException(errorMessage));
     }
 
     private boolean isClaimDuplicated(String username, String claimUri, String claimValue, String profile,


### PR DESCRIPTION
### Proposed changes in this pull request
Fix https://github.com/wso2/product-is/issues/13280#issuecomment-1074933477

claim uniqueness violation is a client exception. So need to throw UserStoreClientException and error stack trace should not be printed in the terminal.
Client error will be logged as a debug long in the service layer.