### PR TITLE
[Public][IS-5.11.0] Adding the configuration for enabling/disabling payload encoding of SMS OTP

### DIFF
--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -171,7 +171,7 @@
   "authentication.authenticator.sms_otp.parameters.SendOTPDirectlyToMobile": false,
   "authentication.authenticator.sms_otp.parameters.redirectToMultiOptionPageOnFailure": false,
   "authentication.authenticator.sms_otp.parameters.Tags": "MFA",
-  "authentication.authenticator.sms_otp.parameters.enable_payload_encoding_for_sms_otp": false,
+  "authentication.authenticator.sms_otp.parameters.enable_payload_encoding_for_sms_otp": true,
 
   "authentication.authenticator.totp.name": "totp",
   "authentication.authenticator.totp.enable": true,

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -171,6 +171,7 @@
   "authentication.authenticator.sms_otp.parameters.SendOTPDirectlyToMobile": false,
   "authentication.authenticator.sms_otp.parameters.redirectToMultiOptionPageOnFailure": false,
   "authentication.authenticator.sms_otp.parameters.Tags": "MFA",
+  "authentication.authenticator.sms_otp.parameters.enable_payload_encoding_for_sms_otp": false,
 
   "authentication.authenticator.totp.name": "totp",
   "authentication.authenticator.totp.enable": true,


### PR DESCRIPTION
**Description**

This configuration will enable/disable payload encoding of SMS OTP based on the content type. The default value has been set to true, therefore by default content-based encoding will be applied to the payload.

Related Git Issue : [wso2/product-is#13226](https://github.com/wso2/product-is/issues/13226)

