### PR TITLE
Add default value to min required answers property related to forced challenge questions

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -877,11 +877,11 @@
             <!--
                 The purpose of this property is to configure minimum number of challenge questions to be answered
                 by the user.
-                Default value : 2
+                Default value : 1
                 If this property is configured to a positive integer, user must answer more or equal to that number of
                 questions.
             -->
-            <!--<MinQuestionsToAnswer></MinQuestionsToAnswer>
+            <!--<MinQuestionsToAnswer>1</MinQuestionsToAnswer>
         </Question>
         <ExpiryTime>1440</ExpiryTime>
         <NotifySuccess>false</NotifySuccess>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -877,7 +877,7 @@
             <!--
                 The purpose of this property is to configure minimum number of challenge questions to be answered
                 by the user.
-                If this property is Empty, there is no minimum number of mandatory questions to be answered.
+                Default value : 2
                 If this property is configured to a positive integer, user must answer more or equal to that number of
                 questions.
             -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1154,7 +1154,7 @@
              <!--
                 The purpose of this property is to configure minimum number of challenge questions to be answered
                 by the user.
-                If this property is Empty, there is no minimum number of mandatory questions to be answered.
+                Default value : 2
                 If this property is configured to a positive integer, user must answer more or equal to that number of
                 questions.
              -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1154,7 +1154,7 @@
              <!--
                 The purpose of this property is to configure minimum number of challenge questions to be answered
                 by the user.
-                Default value : 2
+                Default value : 1
                 If this property is configured to a positive integer, user must answer more or equal to that number of
                 questions.
              -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -308,7 +308,7 @@
   "identity_mgt.password_reset_challenge_questions.skip_on_insufficient_answers": true,
 
   "identity_mgt.forced_challenge_questions.enable_forced_challenge_questions": false,
-  "identity_mgt.challenge_questions.min_required_answers": "",
+  "identity_mgt.challenge_questions.min_required_answers": "1",
 
   "identity_mgt.password_reset_challenge_questions.answer_regex": ".*",
   "identity_mgt.password_reset_challenge_questions.enforce_answer_uniqueness": false,


### PR DESCRIPTION
### Proposed changes in this pull request
 
add default value to min_required_answers property related to  forced challenge questions

### Related PRs
https://github.com/wso2-extensions/identity-governance/pull/583
