### PR TITLE
Fix possible IdentityProviderManagementServerException when getting IDP List

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -553,7 +553,7 @@ public class IdPManagementDAO {
             try {
                 populateRequiredAttributesForIdentityProviderList(resultSet, dbConnection, requiredAttributes, tenantId,
                         identityProvider);
-            } catch (IdentityProviderManagementServerException e) {
+            } catch (IdentityProviderManagementClientException e) {
                 continue;
             }
 
@@ -580,7 +580,7 @@ public class IdPManagementDAO {
     private void populateRequiredAttributesForIdentityProviderList(ResultSet resultSet, Connection dbConnection,
                                                                    List<String> requiredAttributes, int tenantId,
                                                                    IdentityProvider identityProvider)
-            throws SQLException, IdentityProviderManagementServerException {
+            throws SQLException, IdentityProviderManagementServerException, IdentityProviderManagementClientException {
 
         int idpId = Integer.parseInt(identityProvider.getId());
         String idPName = identityProvider.getIdentityProviderName();
@@ -684,6 +684,8 @@ public class IdPManagementDAO {
                     }
                 }
             }
+        } catch (IdentityProviderManagementClientException e) {
+            throw e;
         } catch (IdentityProviderManagementException e) {
             throw new IdentityProviderManagementServerException("Error occurred while performing required " +
                     "attribute filter", e);
@@ -910,7 +912,7 @@ public class IdPManagementDAO {
      */
     private FederatedAuthenticatorConfig[] getFederatedAuthenticatorConfigs(
             Connection dbConnection, String idPName, IdentityProvider federatedIdp, int tenantId)
-            throws IdentityProviderManagementException, SQLException {
+            throws IdentityProviderManagementClientException, SQLException {
 
         int idPId = getIdentityProviderIdentifier(dbConnection, idPName, tenantId);
 
@@ -4036,7 +4038,7 @@ public class IdPManagementDAO {
      * @throws IdentityProviderManagementException
      */
     private int getIdentityProviderIdentifier(Connection dbConnection, String idPName, int tenantId)
-            throws SQLException, IdentityProviderManagementException {
+            throws SQLException, IdentityProviderManagementClientException {
 
         String sqlStmt = null;
         PreparedStatement prepStmt = null;
@@ -4051,7 +4053,7 @@ public class IdPManagementDAO {
             if (rs.next()) {
                 return rs.getInt("ID");
             } else {
-                throw new IdentityProviderManagementException("Invalid Identity Provider Name "
+                throw new IdentityProviderManagementClientException("Invalid Identity Provider Name "
                         + idPName);
             }
         } finally {

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -550,8 +550,12 @@ public class IdPManagementDAO {
             identityProvider.setImageUrl(resultSet.getString("IMAGE_URL"));
             identityProvider.setResourceId(resultSet.getString("UUID"));
 
-            populateRequiredAttributesForIdentityProviderList(resultSet, dbConnection, requiredAttributes, tenantId,
-                    identityProvider);
+            try {
+                populateRequiredAttributesForIdentityProviderList(resultSet, dbConnection, requiredAttributes, tenantId,
+                        identityProvider);
+            } catch (IdentityProviderManagementServerException e) {
+                continue;
+            }
 
             if (!IdentityApplicationConstants.RESIDENT_IDP_RESERVED_NAME
                     .equals(identityProvider.getIdentityProviderName())) {


### PR DESCRIPTION
### Proposed changes in this pull request

This PR fixes the IdentityProviderManagementException that can occur when invoking GET idp list concurrently with another request deleting a IdP. When getting idps, the populateIdentityProviderList method iterates through existing IdPs to populate result set. If some other process is deleting an existing IDP during this process, there is a possibility of IdentityProviderManagementException.

Fixes - https://github.com/wso2-enterprise/asgardeo-product/issues/9673
