### PR TITLE
Fix consent filtering issue for openid scope

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
@@ -243,7 +243,7 @@ public class SSOConsentServiceImpl implements SSOConsentService {
                     Boolean.parseBoolean(IdentityUtil.getProperty(CONFIG_PROMPT_SUBJECT_CLAIM_REQUESTED_CONSENT));
         }
 
-        if (isPassThroughScenario(claimMappings, userAttributes)) {
+        if (isPassThroughScenario(claimsListOfScopes, claimMappings, userAttributes)) {
             for (Map.Entry<ClaimMapping, String> userAttribute : userAttributes.entrySet()) {
                 String remoteClaimUri = userAttribute.getKey().getRemoteClaim().getClaimUri();
                 if (subjectClaimUri.equals(remoteClaimUri) ||
@@ -319,9 +319,10 @@ public class SSOConsentServiceImpl implements SSOConsentService {
         return !serviceProvider.getClaimConfig().isLocalClaimDialect();
     }
 
-    private boolean isPassThroughScenario(ClaimMapping[] claimMappings, Map<ClaimMapping, String> userAttributes) {
+    private boolean isPassThroughScenario(List<String> claimsListOfScopes, ClaimMapping[] claimMappings,
+                                          Map<ClaimMapping, String> userAttributes) {
 
-        return isEmpty(claimMappings) && isNotEmpty(userAttributes);
+        return isNotEmpty(claimsListOfScopes) && isEmpty(claimMappings) && isNotEmpty(userAttributes);
     }
 
     private String getSubjectClaimUri(ServiceProvider serviceProvider) {


### PR DESCRIPTION
Fixes: https://github.com/wso2-enterprise/asgardeo-product/issues/5011

This PR handles the consent filtering flowed based on OIDC scopes for `scope=openid` where there are no requested claims. 

When there are no requested claims from the scope, `claimsListOfScopes` is empty. In such a case, with the current implementation the `isPassThroughScenario` method will add mandatory claims of the SP as mandatory claims without considering the scope. 