### PR TITLE
Switch for logging facades

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -28,8 +28,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.logging.log4j.ThreadContext;
 import org.json.JSONObject;
+import org.slf4j.MDC;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.CarbonException;
 import org.wso2.carbon.claim.mgt.ClaimManagementException;
@@ -3117,7 +3117,7 @@ public class FrameworkUtils {
 
         String ref;
         if (isCorrelationIDPresent()) {
-            ref = ThreadContext.get(CORRELATION_ID_MDC);
+            ref = MDC.get(CORRELATION_ID_MDC);
         } else {
             ref = UUID.randomUUID().toString();
         }
@@ -3131,7 +3131,7 @@ public class FrameworkUtils {
      */
     public static boolean isCorrelationIDPresent() {
 
-        return ThreadContext.get(CORRELATION_ID_MDC) != null;
+        return MDC.get(CORRELATION_ID_MDC) != null;
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/session/extender/request/SessionExtenderRequestFactoryTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/session/extender/request/SessionExtenderRequestFactoryTest.java
@@ -18,8 +18,8 @@
 
 package org.wso2.carbon.identity.application.authentication.framework.session.extender.request;
 
-import org.apache.logging.log4j.ThreadContext;
 import org.mockito.Mock;
+import org.slf4j.MDC;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -144,7 +144,7 @@ public class SessionExtenderRequestFactoryTest {
         when(exception.getErrorCode()).thenReturn(EXCEPTION_ERROR_CODE);
         when(exception.getErrorMessage()).thenReturn(EXCEPTION_MESSAGE);
         when(exception.getDescription()).thenReturn(EXCEPTION_DESCRIPTION);
-        ThreadContext.put("Correlation-ID", TRACE_ID);
+        MDC.put("Correlation-ID", TRACE_ID);
 
         HttpIdentityResponse.HttpIdentityResponseBuilder responseBuilder =
                 sessionExtenderRequestFactory.handleException(exception, mockedHttpRequest, mockedHttpResponse);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/session/extender/response/SessionExtenderResponseFactoryTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/session/extender/response/SessionExtenderResponseFactoryTest.java
@@ -18,8 +18,8 @@
 
 package org.wso2.carbon.identity.application.authentication.framework.session.extender.response;
 
-import org.apache.logging.log4j.ThreadContext;
 import org.powermock.modules.testng.PowerMockTestCase;
+import org.slf4j.MDC;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -99,7 +99,7 @@ public class SessionExtenderResponseFactoryTest extends PowerMockTestCase {
     @Test(dataProvider = "handleExceptionProvider")
     public void testHandleExceptions(FrameworkException exception, int expectedStatusCode) {
 
-        ThreadContext.put("Correlation-ID", TRACE_ID);
+        MDC.put("Correlation-ID", TRACE_ID);
         HttpIdentityResponse.HttpIdentityResponseBuilder responseBuilder =
                 sessionExtenderResponseFactory.handleException(exception);
         HttpIdentityResponse response = responseBuilder.build();

--- a/components/configuration-mgt/org.wso2.carbon.identity.api.server.configuration.mgt/src/main/java/org/wso2/carbon/identity/configuration/mgt/endpoint/util/ConfigurationEndpointUtils.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.api.server.configuration.mgt/src/main/java/org/wso2/carbon/identity/configuration/mgt/endpoint/util/ConfigurationEndpointUtils.java
@@ -24,7 +24,7 @@ import org.apache.cxf.jaxrs.ext.search.SearchCondition;
 import org.apache.cxf.jaxrs.impl.UriInfoImpl;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.PhaseInterceptorChain;
-import org.apache.logging.log4j.ThreadContext;
+import org.slf4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants;
@@ -201,7 +201,7 @@ public class ConfigurationEndpointUtils {
      * @return whether the correlation id is present
      */
     public static boolean isCorrelationIDPresent() {
-        return ThreadContext.get(ConfigurationConstants.CORRELATION_ID_MDC) != null;
+        return MDC.get(ConfigurationConstants.CORRELATION_ID_MDC) != null;
     }
 
     /**
@@ -212,7 +212,7 @@ public class ConfigurationEndpointUtils {
     public static String getCorrelation() {
         String ref = null;
         if (isCorrelationIDPresent()) {
-            ref = ThreadContext.get(ConfigurationConstants.CORRELATION_ID_MDC);
+            ref = MDC.get(ConfigurationConstants.CORRELATION_ID_MDC);
         }
         return ref;
     }


### PR DESCRIPTION
### Proposed changes in this pull request
Switch for logging facade instead of concrete implementations like log4j2. Then it would be easy to switch between logging frameworks based on necessity without any code changes.
