### PR TITLE
Remove packed slf4j-api

### DIFF
--- a/features/xacml/org.wso2.carbon.identity.xacml.server.feature/pom.xml
+++ b/features/xacml/org.wso2.carbon.identity.xacml.server.feature/pom.xml
@@ -151,7 +151,6 @@
                             </adviceFile>
                             <bundles>
                                 <bundleDef>libthrift.wso2:libthrift</bundleDef>
-                                <bundleDef>org.slf4j:slf4j-api</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.authenticator.thrift
                                 </bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.entitlement


### PR DESCRIPTION
### Proposed changes in this pull request

The slf4j-api bundle is packed via the identity-framework and that bundle expect slf4j implementation of 1.6 version but the updated pax-logging does not provide it. Therefore the slf4j-api bundle is removed and required slf4j-api will be provided by the Identity server runtime. 

ref : https://github.com/wso2/carbon-metrics/pull/104