### PR TITLE
IdPEntityId uniqueness validation for SAML metadata

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -3013,11 +3013,12 @@ public class IdentityProviderManager implements IdpManager {
     }
 
     /**
-     * Extracts IdpEntityId property from metadata
-     * and adds it to the existing properties of the federatedAuthenticatorConfigs.
+     * Extracts IdpEntityId property from metadata and adds it to the existing properties of the
+     * federatedAuthenticatorConfigs.
      *
      * @param identityProvider IdentityProvider.
-     * @return federatedAuthenticatorConfigs FederatedAuthenticatorConfig[].
+     * @return federatedAuthenticatorConfigs - FederatedAuthenticatorConfig[] of the given identityProvider with the
+     * IdPEntityId property added by extracting from metadata.
      * @throws IdentityProviderManagementException If the IdpMgtServiceComponentHolder does not contain any
      *                                             metadataConverters.
      */

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -3072,10 +3072,10 @@ public class IdentityProviderManager implements IdpManager {
      * Extracts and returns the property from metadata with the given property name.
      * If the property with the given name is not included in metadata, returns null.
      *
-     * @param metadataConverter MetadataConverter.
-     * @param properties        Property[].
-     * @param propertyName      String.
-     * @return propertyWithName Property.
+     * @param metadataConverter MetadataConverter to convert the metadata.
+     * @param properties        Property[] from which the property should be extracted.
+     * @param propertyName      String which is the property name.
+     * @return propertyWithName Property with the propertyName is equal to the given property name.
      * @throws IdentityProviderManagementException If an error occurs when converting or configuring metadata.
      */
     private Property extractPropertyFromMetadata(MetadataConverter metadataConverter, Property[] properties,

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -2061,7 +2061,7 @@ public class IdentityProviderManager implements IdpManager {
             verifyAndUpdateRoleConfiguration(tenantDomain, tenantId, identityProvider.getPermissionAndRoleConfig());
         }
 
-        validateIdPEntityId(identityProvider.getFederatedAuthenticatorConfigs(), tenantId, tenantDomain);
+        validateIdPEntityId(extractIdpEntityIdFromMetadata(identityProvider), tenantId, tenantDomain);
         validateIdPIssuerName(identityProvider, tenantId, tenantDomain);
 
         handleMetadata(tenantId, identityProvider);
@@ -3010,5 +3010,94 @@ public class IdentityProviderManager implements IdpManager {
             return MultitenantConstants.TENANT_AWARE_URL_PREFIX + "/" + tenantDomain + "/";
         }
         return "";
+    }
+
+    /**
+     * Extracts IdpEntityId property from metadata
+     * and adds it to the existing properties of the federatedAuthenticatorConfigs.
+     *
+     * @param identityProvider IdentityProvider.
+     * @return federatedAuthenticatorConfigs FederatedAuthenticatorConfig[].
+     * @throws IdentityProviderManagementException If the IdpMgtServiceComponentHolder does not contain any
+     *                                             metadataConverters.
+     */
+    private FederatedAuthenticatorConfig[] extractIdpEntityIdFromMetadata(IdentityProvider identityProvider)
+            throws IdentityProviderManagementException {
+
+        List<MetadataConverter> metadataConverters = IdpMgtServiceComponentHolder.getInstance().getMetadataConverters();
+        if (metadataConverters.isEmpty()) {
+            throw new IdentityProviderManagementException("Metadata Converter is not set");
+        }
+
+        FederatedAuthenticatorConfig[] federatedAuthenticatorConfigs =
+                identityProvider.getFederatedAuthenticatorConfigs();
+
+        for (FederatedAuthenticatorConfig federatedAuthenticatorConfig : federatedAuthenticatorConfigs) {
+            Property[] properties = federatedAuthenticatorConfig.getProperties();
+            if (ArrayUtils.isEmpty(properties)) {
+                return federatedAuthenticatorConfigs;
+            }
+            for (Property property : properties) {
+                if (property == null) {
+                    continue;
+                }
+                // Searching for the metadata property to extract data.
+                // Ignoring the properties with blank names and names not equal to meta_data.
+                if (StringUtils.isBlank(property.getName()) ||
+                        !property.getName().contains((IdPManagementConstants.META_DATA))) {
+                    continue;
+                }
+                for (MetadataConverter metadataConverter : metadataConverters) {
+                    if (!metadataConverter.canHandle(property)) {
+                        continue;
+                    }
+                    // Extracting IdpEntityId property and adding to properties of federatedAuthenticatorConfig.
+                    Property idpEntityIdFromMetadata = extractPropertyFromMetadata(metadataConverter, properties,
+                            IdentityApplicationConstants.Authenticator.SAML2SSO.IDP_ENTITY_ID);
+                    if (idpEntityIdFromMetadata != null) {
+                        ArrayList<Property> propertiesList = new ArrayList<>(Arrays.asList(properties));
+                        propertiesList.add(idpEntityIdFromMetadata);
+                        properties = propertiesList.toArray(properties);
+                        federatedAuthenticatorConfig.setProperties(properties);
+                        break;
+                    }
+                }
+            }
+        }
+        return federatedAuthenticatorConfigs;
+    }
+
+    /**
+     * Extracts and returns the property from metadata with the given property name.
+     * If the property with the given name is not included in metadata, returns null.
+     *
+     * @param metadataConverter MetadataConverter.
+     * @param properties        Property[].
+     * @param propertyName      String.
+     * @return propertyWithName Property.
+     * @throws IdentityProviderManagementException If an error occurs when converting or configuring metadata.
+     */
+    private Property extractPropertyFromMetadata(MetadataConverter metadataConverter, Property[] properties,
+                                                 String propertyName) throws IdentityProviderManagementException {
+
+        Property propertyWithName = null;
+        StringBuilder certificate = new StringBuilder();
+        try {
+            FederatedAuthenticatorConfig metaFederated =
+                    metadataConverter.getFederatedAuthenticatorConfig(properties, certificate);
+            Property[] metadataProperties = metaFederated.getProperties();
+            for (Property metadataProperty : metadataProperties) {
+                // Searching for the property.
+                if (propertyName.equals(metadataProperty.getName())) {
+                    propertyWithName = metadataProperty;
+                    break;
+                }
+            }
+        } catch (IdentityProviderManagementException ex) {
+            throw new IdentityProviderManagementException("Error converting metadata", ex);
+        } catch (XMLStreamException e) {
+            throw new IdentityProviderManagementException("Error while configuring metadata", e);
+        }
+        return propertyWithName;
     }
 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
@@ -1074,8 +1074,8 @@ public class IdentityProviderManagementServiceTest extends PowerMockTestCase {
         identityProviderManagementService.deleteIdP("SHARED_IDP");
     }
 
-    @Test(expectedExceptions = {
-            IdentityProviderManagementException.class}, expectedExceptionsMessageRegExp = "An Identity Provider Entity ID has already been registered with the name 'localhost' for tenant .*")
+    @Test(expectedExceptions = {IdentityProviderManagementException.class}, expectedExceptionsMessageRegExp =
+            "An Identity Provider Entity ID has already been registered with the name 'localhost' for tenant .*")
     public void testAddIdPWithResourceId() throws IdentityProviderManagementException, XMLStreamException {
 
         when(mockMetadataConverter.canHandle((Property) anyObject())).thenReturn(TRUE);

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
@@ -61,6 +61,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.xml.stream.XMLStreamException;
+
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -1070,6 +1072,54 @@ public class IdentityProviderManagementServiceTest extends PowerMockTestCase {
         identityProviderManagementService.deleteIdP("LOCAL");
         // Remove shared idp.
         identityProviderManagementService.deleteIdP("SHARED_IDP");
+    }
+
+    @Test(expectedExceptions = {
+            IdentityProviderManagementException.class}, expectedExceptionsMessageRegExp = "An Identity Provider Entity ID has already been registered with the name 'localhost' for tenant .*")
+    public void testAddIdPWithResourceId() throws IdentityProviderManagementException, XMLStreamException {
+
+        when(mockMetadataConverter.canHandle((Property) anyObject())).thenReturn(TRUE);
+        when(mockMetadataConverter.getFederatedAuthenticatorConfig(anyObject(), anyObject())).thenReturn(
+                federatedAuthenticatorConfigWithIdpEntityIdPropertySet());
+        identityProviderManagementService.addIdP(addIdPDataWithSameIdpEntityId("idp1"));
+        identityProviderManagementService.addIdP(addIdPDataWithSameIdpEntityId("idp2"));
+    }
+
+    private IdentityProvider addIdPDataWithSameIdpEntityId(String idpName) {
+
+        // Initialize Test Identity Provider.
+        IdentityProvider idp = new IdentityProvider();
+        idp.setIdentityProviderName(idpName);
+
+        FederatedAuthenticatorConfig federatedAuthenticatorConfig = new FederatedAuthenticatorConfig();
+        federatedAuthenticatorConfig.setDisplayName("DisplayName");
+        federatedAuthenticatorConfig.setName("SAMLSSOAuthenticator");
+        federatedAuthenticatorConfig.setEnabled(true);
+        Property property1 = new Property();
+        property1.setName("SPEntityId");
+        property1.setValue("wso2-is");
+        Property property2 = new Property();
+        property2.setName("meta_data_saml");
+        property2.setValue("dummyMetadataValue");
+
+        federatedAuthenticatorConfig.setProperties(new Property[]{property1, property2});
+
+        idp.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{federatedAuthenticatorConfig});
+
+        return idp;
+    }
+
+    private FederatedAuthenticatorConfig federatedAuthenticatorConfigWithIdpEntityIdPropertySet() {
+
+        // Initialize IdPEntityId Property.
+        Property property = new Property();
+        property.setName("IdPEntityId");
+        property.setValue("localhost");
+
+        // Add to and return federatedAuthenticatorConfig.
+        FederatedAuthenticatorConfig federatedAuthenticatorConfig = new FederatedAuthenticatorConfig();
+        federatedAuthenticatorConfig.setProperties(new Property[]{property});
+        return federatedAuthenticatorConfig;
     }
 
 }


### PR DESCRIPTION
## Purpose
> This PR will add the validation for uniqueness of the IdpEntityId when IdP is created using a metadata file.

## Related Issues
> https://github.com/wso2/product-is/issues/13347

## Approach
> This issue was addressed by checking the properties of the identity provider's federatedAuthenticatorConfigs, if it contains metadata extracting the IdpEntityId from metadata, and adding it back to properties of the identity provider's federated authenticator config.