### PR TITLE
OAuthAuthzRequest extension configuration change

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -739,6 +739,7 @@
                 Supported versions: IS 5.4.0 onwards
             -->
             <RequestObjectValidator>{{oauth.oidc.extensions.request_object_validator}}</RequestObjectValidator>
+            <OAuthAuthzRequest>{{oauth.oidc.extensions.oauth_authz_request}}</OAuthAuthzRequest>
             {% if oauth.oidc.extensions.ciba_request_object_validator is defined %}
                 <CIBARequestObjectValidator>{{oauth.oidc.extensions.ciba_request_object_validator}}</CIBARequestObjectValidator>
             {% endif %}

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -739,7 +739,9 @@
                 Supported versions: IS 5.4.0 onwards
             -->
             <RequestObjectValidator>{{oauth.oidc.extensions.request_object_validator}}</RequestObjectValidator>
+            {% if oauth.oidc.extensions.oauth_authz_request is defined %}
             <OAuthAuthzRequest>{{oauth.oidc.extensions.oauth_authz_request}}</OAuthAuthzRequest>
+            {% endif %}
             {% if oauth.oidc.extensions.ciba_request_object_validator is defined %}
                 <CIBARequestObjectValidator>{{oauth.oidc.extensions.ciba_request_object_validator}}</CIBARequestObjectValidator>
             {% endif %}

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -739,8 +739,8 @@
                 Supported versions: IS 5.4.0 onwards
             -->
             <RequestObjectValidator>{{oauth.oidc.extensions.request_object_validator}}</RequestObjectValidator>
-            {% if oauth.oidc.extensions.oauth_authz_request is defined %}
-            <OAuthAuthzRequest>{{oauth.oidc.extensions.oauth_authz_request}}</OAuthAuthzRequest>
+            {% if oauth.oidc.extensions.oauth_authz_request_class is defined %}
+            <OAuthAuthzRequestClass>{{oauth.oidc.extensions.oauth_authz_request_class}}</OAuthAuthzRequestClass>
             {% endif %}
             {% if oauth.oidc.extensions.ciba_request_object_validator is defined %}
                 <CIBARequestObjectValidator>{{oauth.oidc.extensions.ciba_request_object_validator}}</CIBARequestObjectValidator>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -193,7 +193,6 @@
   ],
   "oauth.oidc.token_validation.logout_token_validity": "2m",
   "oauth.oidc.extensions.request_object_validator": "org.wso2.carbon.identity.openidconnect.RequestObjectValidatorImpl",
-  "oauth.oidc.extensions.oauth_authz_request": "org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest",
   "oauth.oidc.user_info.jwt_signature_algorithm": "$ref{oauth.oidc.id_token.signature_algorithm}",
   "oauth.oidc.extensions.user_info_claim_retriever": "org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoUserStoreClaimRetriever",
   "oauth.oidc.extensions.user_info_request_validator": "org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInforRequestDefaultValidator",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -193,6 +193,7 @@
   ],
   "oauth.oidc.token_validation.logout_token_validity": "2m",
   "oauth.oidc.extensions.request_object_validator": "org.wso2.carbon.identity.openidconnect.RequestObjectValidatorImpl",
+  "oauth.oidc.extensions.oauth_authz_request": "org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest",
   "oauth.oidc.user_info.jwt_signature_algorithm": "$ref{oauth.oidc.id_token.signature_algorithm}",
   "oauth.oidc.extensions.user_info_claim_retriever": "org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoUserStoreClaimRetriever",
   "oauth.oidc.extensions.user_info_request_validator": "org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInforRequestDefaultValidator",


### PR DESCRIPTION
Configuration to define extension point to OAuthAuthzRequest for the OAuth2AuthzEndpoint.
The default value is set to the org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest

issue: https://github.com/wso2/product-is/issues/13416