### PR TITLE
Use reference for authentication endpoint credentials.

### DIFF
--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -13,8 +13,8 @@
   "identity.auth_framework.endpoint.tls_protocol" : "TLSv1.2",
   "identity.auth_framework.endpoint.app_name": "dashboard",
   "identity.auth_framework.endpoint.app_password": "dashboard",
-  "identity.auth_framework.endpoint.username": "admin",
-  "identity.auth_framework.endpoint.password": "admin",
+  "identity.auth_framework.endpoint.username": "$ref{super_admin.username}",
+  "identity.auth_framework.endpoint.password": "$ref{super_admin.password}",
   "identity.auth_framework.identity_server_origin": "${carbon.protocol}://${carbon.host}:${carbon.management.port}",
   "identity.auth_framework.endpoint.securevault_secret_handler": "org.wso2.securevault.secret.handler.SecretManagerSecretCallbackHandler",
 


### PR DESCRIPTION
### Purpose
Improvement for https://github.com/wso2/product-is/issues/13124

By default, server uses admin credentials to invoke authentication framework endpoints. If user updates the admin credentials, configurations has to be updated in deployment.toml to reflect the credentials used for authentication framework endpoints.

This PR updates the default values for credentials used for authentication framework endpoints by providing reference of admin credentials. 
