### PR TITLE
Revert "Deprecate old identity management feature"

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/IdentityMgtEventListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/IdentityMgtEventListener.java
@@ -71,10 +71,7 @@ import java.util.Map.Entry;
  * This is an implementation of UserOperationEventListener. This defines
  * additional operations
  * for some of the core user management operations
- *
- * @deprecated use {@link org.wso2.carbon.identity.governance.listener.IdentityMgtEventListener} instead.
  */
-@Deprecated
 public class IdentityMgtEventListener extends AbstractIdentityUserOperationEventListener {
 
     /*
@@ -530,7 +527,7 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
         //Removing existing thread local before setting
         IdentityUtil.threadLocalProperties.get().remove(EMPTY_PASSWORD_USED);
         IdentityUtil.threadLocalProperties.get().remove(USER_IDENTITY_DO);
-
+        
         IdentityMgtConfig config = IdentityMgtConfig.getInstance();
         try {
             // Enforcing the password policies.

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/TenantManagementListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/TenantManagementListener.java
@@ -35,10 +35,6 @@ import org.wso2.carbon.stratos.common.exception.StratosException;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 
-/**
- * @deprecated use org.wso2.carbon.identity.recovery.listener.TenantManagementListener instead.
- */
-@Deprecated
 public class TenantManagementListener implements TenantMgtListener {
     private static final int EXEC_ORDER = 40;
     private static final Log log = LogFactory.getLog(TenantManagementListener.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/password/DefaultPasswordGenerator.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/password/DefaultPasswordGenerator.java
@@ -23,9 +23,7 @@ import java.util.Random;
 
 /**
  * default password generator with 8 letter password
- * @deprecated use {@link org.wso2.carbon.user.mgt.common.DefaultPasswordGenerator} instead.
  */
-@Deprecated
 public class DefaultPasswordGenerator implements RandomPasswordGenerator {
 
     //TODO : read the lenth from the user-mgt.xml

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/password/RandomPasswordGenerator.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/password/RandomPasswordGenerator.java
@@ -20,9 +20,7 @@ package org.wso2.carbon.identity.mgt.password;
 
 /**
  * This can be implemented to generate random password
- * @deprecated use {@link org.wso2.carbon.user.mgt.common.RandomPasswordGenerator} instead.
  */
-@Deprecated
 public interface RandomPasswordGenerator {
 
     /**

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/AccountCredentialMgtConfigService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/AccountCredentialMgtConfigService.java
@@ -35,10 +35,7 @@ import java.util.Properties;
 /**
  * This service is to configure the Account and Credential Management
  * functionality.
- * @deprecated use the rest API implementation available in
- * org.wso2.carbon.identity.rest.api.server.email.template.v1.core.ServerEmailTemplatesService instead.
  */
-@Deprecated
 public class AccountCredentialMgtConfigService {
 
     private static final Log log = LogFactory.getLog(AccountCredentialMgtConfigService.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementAdminService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementAdminService.java
@@ -59,10 +59,7 @@ import java.util.Set;
  * allowed to all logged in users.
  *
  * @author sga
- * @deprecated use REST API implementation available in org.wso2.carbon.identity.scim2.provider.resources.UserResource
- * and org.wso2.carbon.identity.rest.api.user.challenge.v1.core.UserChallengeService instead.
  */
-@Deprecated
 public class UserIdentityManagementAdminService {
 
     private static final Log log = LogFactory.getLog(UserIdentityManagementAdminService.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementService.java
@@ -46,13 +46,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.UUID;
 
-// TODO: User Account Recovery Service
-/**
- * @deprecated use REST API implementation available in org.wso2.carbon.identity.user.endpoint,
- * org.wso2.carbon.identity.rest.api.user.challenge.v1.core.UserChallengeService,
- * org.wso2.carbon.identity.rest.api.user.recovery.v1.impl.core.PasswordRecoveryService instead.
- */
-@Deprecated
+// TODO: User Account Recovery Service 
 public class UserIdentityManagementService {
 
     private static final Log log = LogFactory.getLog(UserIdentityManagementService.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserInformationRecoveryService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserInformationRecoveryService.java
@@ -70,12 +70,7 @@ import java.util.Map;
 /**
  * This service provides the services needed to recover user password and user
  * account information.
- * @deprecated use identity management REST API implementation available in
- * org.wso2.carbon.identity.rest.api.user.recovery.v1.impl.core.UsernameRecoveryService,
- * org.wso2.carbon.identity.rest.api.user.recovery.v1.impl.core.PasswordRecoveryService,
- * org.wso2.carbon.identity.user.endpoint.impl.MeApiServiceImpl instead.
  */
-@Deprecated
 public class UserInformationRecoveryService {
 
     private static final Log log = LogFactory.getLog(UserInformationRecoveryService.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/JDBCIdentityDataStore.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/JDBCIdentityDataStore.java
@@ -39,9 +39,7 @@ import java.util.Map;
 
 /**
  * //TODO remove method when user is deleted
- * @deprecated use {@link org.wso2.carbon.identity.governance.store.JDBCIdentityDataStore} instead.
  */
-@Deprecated
 public class JDBCIdentityDataStore extends InMemoryIdentityDataStore {
 
     private static Log log = LogFactory.getLog(JDBCIdentityDataStore.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserIdentityDataStore.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserIdentityDataStore.java
@@ -25,9 +25,7 @@ import org.wso2.carbon.user.core.UserCoreConstants;
 
 /**
  * This interface provides to plug module for preferred persistence store.
- * @deprecated use {@link org.wso2.carbon.identity.governance.store.UserIdentityDataStore} instead.
  */
-@Deprecated
 public abstract class UserIdentityDataStore {
 
     public static final String ONE_TIME_PASSWORD = "http://wso2.org/claims/identity/otp";

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserRecoveryDataStore.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserRecoveryDataStore.java
@@ -23,9 +23,7 @@ import org.wso2.carbon.identity.mgt.dto.UserRecoveryDataDO;
 
 /**
  * TODO add java comments
- * @deprecated use org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore instead.
  */
-@Deprecated
 public interface UserRecoveryDataStore {
 
     public static final String EXPIRE_TIME = "expireTime";

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserStoreBasedIdentityDataStore.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserStoreBasedIdentityDataStore.java
@@ -40,9 +40,7 @@ import java.util.Map;
 /**
  * This module persists data in to user store as user's attribute
  * //TODO remove method when user is deleted
- * @deprecated use {@link org.wso2.carbon.identity.governance.store.UserStoreBasedIdentityDataStore} instead.
  */
-@Deprecated
 public class UserStoreBasedIdentityDataStore extends InMemoryIdentityDataStore {
 
     private static Log log = LogFactory.getLog(UserStoreBasedIdentityDataStore.class);


### PR DESCRIPTION
Reverts wso2/carbon-identity-framework#3990 since it causes a test failure with below error
`[ERROR] testVerifyUserAccount(org.wso2.identity.integration.test.identity.mgt.UserInformationRecoveryServiceTenantEmailUserTestCase)  Time elapsed: 0.573 s  <<< FAILURE!
org.apache.axis2.AxisFault: The service cannot be found for the endpoint reference (EPR) https://localhost:9853/services/UserInformationRecoveryService
        at org.wso2.identity.integration.test.identity.mgt.UserInformationRecoveryServiceTenantEmailUserTestCase.testVerifyUserAccount(UserInformationRecoveryServiceTenantEmailUserTestCase.java:117)
`
Fix the test failure and will resend the fix