### PR TITLE
Fix for renaming a PRIMARY role name resets the role permissions

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserAdmin.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserAdmin.java
@@ -397,8 +397,7 @@ public class UserAdmin {
             }
         }
     }
-
-
+    
     /**
      * @return
      * @throws UserAdminException

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserAdmin.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserAdmin.java
@@ -372,11 +372,32 @@ public class UserAdmin {
      */
     public void updateRoleName(String roleName, String newRoleName) throws UserAdminException {
         try {
+            if (getUserAdminProxy().isRoleAndGroupSeparationEnabled()) {
+                UIPermissionNode uiPermissionNode = getRolePermissions(roleName);
+                List<String> permissions = new ArrayList<>();
+                extractPermissionsFromUIPermissionNode(uiPermissionNode, permissions);
+                if (!permissions.isEmpty()) {
+                    addInternalSystemRole(newRoleName, permissions.toArray(new String[0]));
+                }
+            }
             getUserAdminProxy().updateRoleName(roleName, newRoleName);
         } catch (UserAdminException e) {
             throw e;
         }
     }
+
+    private void extractPermissionsFromUIPermissionNode(UIPermissionNode uiPermissionNode, List<String> permissionList) {
+        if (uiPermissionNode.isSelected()) {
+            permissionList.add(uiPermissionNode.getResourcePath());
+        }
+        if (uiPermissionNode.getNodeList().length > 0) {
+            for (UIPermissionNode childUIPermissionNode : uiPermissionNode.getNodeList()) {
+                /* Extract resource path from UI permission node recursively. */
+                extractPermissionsFromUIPermissionNode(childUIPermissionNode, permissionList);
+            }
+        }
+    }
+
 
     /**
      * @return


### PR DESCRIPTION
Issue - Renaming a PRIMARY Role Name resets the Role Permissions.
https://github.com/wso2/product-is/issues/13198 

Fix - Added addInternalSystemRole[1] method call to the updateRoleName[2] flow based on the isRoleAndGroupSeparationEnabled() configuration option.

[1]https://github.com/wso2/carbon-identity-framework/blob/ba593088a6c9f9db1fc18a9ccd7f3dd4936ac093/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserAdmin.java#L515
[2]https://github.com/wso2/carbon-identity-framework/blob/ba593088a6c9f9db1fc18a9ccd7f3dd4936ac093/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserAdmin.java#L373

