### PR TITLE
Deprecate old identity management feature

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/IdentityMgtEventListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/IdentityMgtEventListener.java
@@ -71,7 +71,10 @@ import java.util.Map.Entry;
  * This is an implementation of UserOperationEventListener. This defines
  * additional operations
  * for some of the core user management operations
+ *
+ * @deprecated use {@link org.wso2.carbon.identity.governance.listener.IdentityMgtEventListener} instead.
  */
+@Deprecated
 public class IdentityMgtEventListener extends AbstractIdentityUserOperationEventListener {
 
     /*
@@ -527,7 +530,7 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
         //Removing existing thread local before setting
         IdentityUtil.threadLocalProperties.get().remove(EMPTY_PASSWORD_USED);
         IdentityUtil.threadLocalProperties.get().remove(USER_IDENTITY_DO);
-        
+
         IdentityMgtConfig config = IdentityMgtConfig.getInstance();
         try {
             // Enforcing the password policies.

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/TenantManagementListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/TenantManagementListener.java
@@ -35,6 +35,10 @@ import org.wso2.carbon.stratos.common.exception.StratosException;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 
+/**
+ * @deprecated use org.wso2.carbon.identity.recovery.listener.TenantManagementListener instead.
+ */
+@Deprecated
 public class TenantManagementListener implements TenantMgtListener {
     private static final int EXEC_ORDER = 40;
     private static final Log log = LogFactory.getLog(TenantManagementListener.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/password/DefaultPasswordGenerator.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/password/DefaultPasswordGenerator.java
@@ -23,7 +23,9 @@ import java.util.Random;
 
 /**
  * default password generator with 8 letter password
+ * @deprecated use {@link org.wso2.carbon.user.mgt.common.DefaultPasswordGenerator} instead.
  */
+@Deprecated
 public class DefaultPasswordGenerator implements RandomPasswordGenerator {
 
     //TODO : read the lenth from the user-mgt.xml

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/password/RandomPasswordGenerator.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/password/RandomPasswordGenerator.java
@@ -20,7 +20,9 @@ package org.wso2.carbon.identity.mgt.password;
 
 /**
  * This can be implemented to generate random password
+ * @deprecated use {@link org.wso2.carbon.user.mgt.common.RandomPasswordGenerator} instead.
  */
+@Deprecated
 public interface RandomPasswordGenerator {
 
     /**

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/AccountCredentialMgtConfigService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/AccountCredentialMgtConfigService.java
@@ -38,7 +38,6 @@ import java.util.Properties;
  * @deprecated use the rest API implementation available in
  * org.wso2.carbon.identity.rest.api.server.email.template.v1.core.ServerEmailTemplatesService instead.
  */
-@Deprecated
 public class AccountCredentialMgtConfigService {
 
     private static final Log log = LogFactory.getLog(AccountCredentialMgtConfigService.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/AccountCredentialMgtConfigService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/AccountCredentialMgtConfigService.java
@@ -35,7 +35,10 @@ import java.util.Properties;
 /**
  * This service is to configure the Account and Credential Management
  * functionality.
+ * @deprecated use the rest API implementation available in
+ * org.wso2.carbon.identity.rest.api.server.email.template.v1.core.ServerEmailTemplatesService instead.
  */
+@Deprecated
 public class AccountCredentialMgtConfigService {
 
     private static final Log log = LogFactory.getLog(AccountCredentialMgtConfigService.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementAdminService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementAdminService.java
@@ -62,7 +62,6 @@ import java.util.Set;
  * @deprecated use REST API implementation available in org.wso2.carbon.identity.scim2.provider.resources.UserResource
  * and org.wso2.carbon.identity.rest.api.user.challenge.v1.core.UserChallengeService instead.
  */
-@Deprecated
 public class UserIdentityManagementAdminService {
 
     private static final Log log = LogFactory.getLog(UserIdentityManagementAdminService.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementAdminService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementAdminService.java
@@ -59,7 +59,10 @@ import java.util.Set;
  * allowed to all logged in users.
  *
  * @author sga
+ * @deprecated use REST API implementation available in org.wso2.carbon.identity.scim2.provider.resources.UserResource
+ * and org.wso2.carbon.identity.rest.api.user.challenge.v1.core.UserChallengeService instead.
  */
+@Deprecated
 public class UserIdentityManagementAdminService {
 
     private static final Log log = LogFactory.getLog(UserIdentityManagementAdminService.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementService.java
@@ -52,7 +52,6 @@ import java.util.UUID;
  * org.wso2.carbon.identity.rest.api.user.challenge.v1.core.UserChallengeService,
  * org.wso2.carbon.identity.rest.api.user.recovery.v1.impl.core.PasswordRecoveryService instead.
  */
-@Deprecated
 public class UserIdentityManagementService {
 
     private static final Log log = LogFactory.getLog(UserIdentityManagementService.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementService.java
@@ -46,7 +46,13 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.UUID;
 
-// TODO: User Account Recovery Service 
+// TODO: User Account Recovery Service
+/**
+ * @deprecated use REST API implementation available in org.wso2.carbon.identity.user.endpoint,
+ * org.wso2.carbon.identity.rest.api.user.challenge.v1.core.UserChallengeService,
+ * org.wso2.carbon.identity.rest.api.user.recovery.v1.impl.core.PasswordRecoveryService instead.
+ */
+@Deprecated
 public class UserIdentityManagementService {
 
     private static final Log log = LogFactory.getLog(UserIdentityManagementService.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserInformationRecoveryService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserInformationRecoveryService.java
@@ -75,7 +75,6 @@ import java.util.Map;
  * org.wso2.carbon.identity.rest.api.user.recovery.v1.impl.core.PasswordRecoveryService,
  * org.wso2.carbon.identity.user.endpoint.impl.MeApiServiceImpl instead.
  */
-@Deprecated
 public class UserInformationRecoveryService {
 
     private static final Log log = LogFactory.getLog(UserInformationRecoveryService.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserInformationRecoveryService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserInformationRecoveryService.java
@@ -70,7 +70,12 @@ import java.util.Map;
 /**
  * This service provides the services needed to recover user password and user
  * account information.
+ * @deprecated use identity management REST API implementation available in
+ * org.wso2.carbon.identity.rest.api.user.recovery.v1.impl.core.UsernameRecoveryService,
+ * org.wso2.carbon.identity.rest.api.user.recovery.v1.impl.core.PasswordRecoveryService,
+ * org.wso2.carbon.identity.user.endpoint.impl.MeApiServiceImpl instead.
  */
+@Deprecated
 public class UserInformationRecoveryService {
 
     private static final Log log = LogFactory.getLog(UserInformationRecoveryService.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/JDBCIdentityDataStore.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/JDBCIdentityDataStore.java
@@ -39,7 +39,9 @@ import java.util.Map;
 
 /**
  * //TODO remove method when user is deleted
+ * @deprecated use {@link org.wso2.carbon.identity.governance.store.JDBCIdentityDataStore} instead.
  */
+@Deprecated
 public class JDBCIdentityDataStore extends InMemoryIdentityDataStore {
 
     private static Log log = LogFactory.getLog(JDBCIdentityDataStore.class);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserIdentityDataStore.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserIdentityDataStore.java
@@ -25,7 +25,9 @@ import org.wso2.carbon.user.core.UserCoreConstants;
 
 /**
  * This interface provides to plug module for preferred persistence store.
+ * @deprecated use {@link org.wso2.carbon.identity.governance.store.UserIdentityDataStore} instead.
  */
+@Deprecated
 public abstract class UserIdentityDataStore {
 
     public static final String ONE_TIME_PASSWORD = "http://wso2.org/claims/identity/otp";

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserRecoveryDataStore.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserRecoveryDataStore.java
@@ -23,7 +23,9 @@ import org.wso2.carbon.identity.mgt.dto.UserRecoveryDataDO;
 
 /**
  * TODO add java comments
+ * @deprecated use org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore instead.
  */
+@Deprecated
 public interface UserRecoveryDataStore {
 
     public static final String EXPIRE_TIME = "expireTime";

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserStoreBasedIdentityDataStore.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserStoreBasedIdentityDataStore.java
@@ -40,7 +40,9 @@ import java.util.Map;
 /**
  * This module persists data in to user store as user's attribute
  * //TODO remove method when user is deleted
+ * @deprecated use {@link org.wso2.carbon.identity.governance.store.UserStoreBasedIdentityDataStore} instead.
  */
+@Deprecated
 public class UserStoreBasedIdentityDataStore extends InMemoryIdentityDataStore {
 
     private static Log log = LogFactory.getLog(UserStoreBasedIdentityDataStore.class);


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/11864
Deprecating old identity management publicly available services/interfaces/listeners/extension points.

Reading the changes added by https://github.com/wso2/carbon-identity-framework/pull/3990 by fixing the test failures mentioned in https://github.com/wso2/carbon-identity-framework/pull/3991

Following interfaces/classes have been deprecated with this PR
[IdentityMgtEventListener.java]
[TenantManagementListener.java]
[DefaultPasswordGenerator.java]
[RandomPasswordGenerator.java]
[AccountCredentialMgtConfigService.java]
[UserIdentityManagementAdminService.java]
[UserIdentityManagementService.java]
[UserInformationRecoveryService.java]
[JDBCIdentityDataStore.java]
[UserIdentityDataStore.java]
[UserRecoveryDataStore.java]
[UserStoreBasedIdentityDataStore.java]