### PR TITLE
Fix consent filtering issue for openid scope

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/constant/SSOConsentConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/constant/SSOConsentConstants.java
@@ -29,6 +29,7 @@ public class SSOConsentConstants {
     public static final String CONFIG_ELEM_ENABLE_SSO_CONSENT_MANAGEMENT = "EnableSSOConsentManagement";
     public static final String CONFIG_PROMPT_SUBJECT_CLAIM_REQUESTED_CONSENT =
             "Consent.PromptSubjectClaimRequestedConsent";
+    public static final String CONFIG_ENABLE_CONSENT_SCOPE_FILTERING = "Consent.EnableConsentScopeFiltering";
     public static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
     public static final String FEDERATED_USER_DOMAIN_PREFIX = "FEDERATED";
     public static final String FEDERATED_USER_DOMAIN_SEPARATOR = ":";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/constant/SSOConsentConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/constant/SSOConsentConstants.java
@@ -29,7 +29,6 @@ public class SSOConsentConstants {
     public static final String CONFIG_ELEM_ENABLE_SSO_CONSENT_MANAGEMENT = "EnableSSOConsentManagement";
     public static final String CONFIG_PROMPT_SUBJECT_CLAIM_REQUESTED_CONSENT =
             "Consent.PromptSubjectClaimRequestedConsent";
-    public static final String CONFIG_ENABLE_CONSENT_SCOPE_FILTERING = "Consent.EnableConsentScopeFiltering";
     public static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
     public static final String FEDERATED_USER_DOMAIN_PREFIX = "FEDERATED";
     public static final String FEDERATED_USER_DOMAIN_SEPARATOR = ":";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -128,6 +128,7 @@ public abstract class FrameworkConstants {
     public static final String SESSION_AUTH_HISTORY = "SESSION_AUTH_HISTORY";
 
     public static final String SERVICE_PROVIDER_SUBJECT_CLAIM_VALUE = "ServiceProviderSubjectClaimValue";
+    public static final String CONFIG_ENABLE_SCOPE_BASED_CLAIM_FILTERING = "EnableScopeBasedClaimFiltering";
 
     public static final String REMEMBER_ME_OPT_ON = "on";
     public static final String LAST_FAILED_AUTHENTICATOR = "LastFailedAuthenticator";

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -699,8 +699,6 @@
         <EnableSSOConsentManagement>true</EnableSSOConsentManagement>
         <!--Specify whether consent should be prompted for subject claim uri if configured as a requested claim.-->
         <PromptSubjectClaimRequestedConsent>true</PromptSubjectClaimRequestedConsent>
-        <!--Specify whether consent should be filtered according to the scope.-->
-        <EnableConsentScopeFiltering>true</EnableConsentScopeFiltering>
     </Consent>
 
     <SecurityTokenService>
@@ -2099,4 +2097,6 @@
     <!--    By setting false localization code will be stored inside the http://wso2.org/claims/local-->
     <UseLegacyLocalizationClaim>false</UseLegacyLocalizationClaim>
 
+    <!-- Configuration to enable or disable claim filtering based on scope. -->
+    <EnableScopeBasedClaimFiltering>true</EnableScopeBasedClaimFiltering>
 </Server>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -699,6 +699,8 @@
         <EnableSSOConsentManagement>true</EnableSSOConsentManagement>
         <!--Specify whether consent should be prompted for subject claim uri if configured as a requested claim.-->
         <PromptSubjectClaimRequestedConsent>true</PromptSubjectClaimRequestedConsent>
+        <!--Specify whether consent should be filtered according to the scope.-->
+        <EnableConsentScopeFiltering>true</EnableConsentScopeFiltering>
     </Consent>
 
     <SecurityTokenService>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -945,8 +945,6 @@
         <EnableSSOConsentManagement>{{authentication.consent.prompt}}</EnableSSOConsentManagement>
         <!--Specify whether consent should be prompted for subject claim uri if configured as a requested claim.-->
         <PromptSubjectClaimRequestedConsent>{{authentication.consent.subject.prompt}}</PromptSubjectClaimRequestedConsent>
-        <!--Specify whether consent should be filtered according to the scope.-->
-        <EnableConsentScopeFiltering>{{authentication.consent.scope.filtering}}</EnableConsentScopeFiltering>
     </Consent>
 
     <SecurityTokenService>
@@ -2994,6 +2992,9 @@
 
     <!-- Configuration for allowing users to introspect tokens from other tenants. -->
     <AllowCrossTenantTokenIntrospection>{{oauth.allow_cross_tenant_token_introspection}}</AllowCrossTenantTokenIntrospection>
+
+    <!-- Configuration to enable or disable claim filtering based on scope. -->
+    <EnableScopeBasedClaimFiltering>{{authentication.enable_scope_based_claim_filtering}}</EnableScopeBasedClaimFiltering>
 
     {% if stored_procedure_dao is defined %}
     <!-- Stored Procedure supported DAO Implementation of Identity components.

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -945,6 +945,8 @@
         <EnableSSOConsentManagement>{{authentication.consent.prompt}}</EnableSSOConsentManagement>
         <!--Specify whether consent should be prompted for subject claim uri if configured as a requested claim.-->
         <PromptSubjectClaimRequestedConsent>{{authentication.consent.subject.prompt}}</PromptSubjectClaimRequestedConsent>
+        <!--Specify whether consent should be filtered according to the scope.-->
+        <EnableConsentScopeFiltering>{{authentication.consent.scope.filtering}}</EnableConsentScopeFiltering>
     </Consent>
 
     <SecurityTokenService>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1,6 +1,7 @@
 {
   "authentication.consent.prompt": true,
   "authentication.consent.subject.prompt": true,
+  "authentication.consent.scope.filtering": true,
   "authentication.map_federated_users_to_local": false,
 
   "identity.data_source": "jdbc/WSO2IdentityDB",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1,8 +1,8 @@
 {
   "authentication.consent.prompt": true,
   "authentication.consent.subject.prompt": true,
-  "authentication.consent.scope.filtering": true,
   "authentication.map_federated_users_to_local": false,
+  "authentication.enable_scope_based_claim_filtering": true,
 
   "identity.data_source": "jdbc/WSO2IdentityDB",
   "identity_data_source.skip_db_schema_creation": false,


### PR DESCRIPTION
Fixes: https://github.com/wso2-enterprise/asgardeo-product/issues/5011

This PR adds a new flag to enable consent filtering based on the scope to support backward compatibility, and fixes the consent filtering issue when the scope was set to openid. This flag is set to true by default and will not send mandatory claims if they are not included in the requested scope. If a user needs to get mandatory claims regardless of the scope, this flag should be set to false.