### PR TITLE
Add new configuration to enable ELK analytics

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1601,18 +1601,28 @@
                 orderId="{{event.default_listener.outbound_provisioning_error_handler.priority}}"
                 enable="{{event.default_listener.outbound_provisioning_error_handler.enable}}">
         </EventListener>
+        {% if analytics.elk.enable is defined && analytics.elk.enable is sameas true %}
+        <EventListener id="authn_data_publisher_proxy"
+               type="org.wso2.carbon.identity.core.handler.AbstractIdentityMessageHandler"
+               name = "org.wso2.carbon.identity.data.publisher.application.authentication.AuthnDataPublisherProxy"
+               orderId="11"
+               enable="true"/>
+        {% endif %}
     </EventListeners>
 
-    {% if analytics.publish_active_session_count is defined %}
     <Analytics>
         <!-- By default value of analytics.publish_active_session_count is set to false so that the identity server
         publishes session data to the stream org.wso2.is.analytics.stream.OverallSession:1.0.0.
         When this configuration is enabled, the stream definition org.wso2.is.analytics.stream.OverallSession:1.0.1
         is used and the current active session count of the identity server will be added as an attribute. Enable it
         by setting analytics.publish_active_session_count = true -->
+        {% if analytics.publish_active_session_count is defined %}
         <PublishActiveSessionCount>{{analytics.publish_active_session_count}}</PublishActiveSessionCount>
+        {% endif %}
+        {% if analytics.elk.enable is defined && analytics.elk.enable is sameas true %}
+        <PublishActiveSessionCount>true</PublishActiveSessionCount>
+        {% endif %}
     </Analytics>
-    {% endif %}
 
     <!-- These recorders are used to write user delete information to specific sources. Default event recorder is CSV
      file recorder. This recorder is disabled by default. Enable it by setting enable="true". To run these recorders,

--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/identity-event.properties.j2
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/identity-event.properties.j2
@@ -31,7 +31,13 @@ module.name.{{event_value.module_index}}={{event_name}}
 {{event_name}}.subscription.{{loop.index}}={{subscription}}
 {% endfor %}
 {% for property_name,property_value in event_value.properties.items()%}
+{% if analytics.elk.enable is defined && analytics.elk.enable is sameas true &&
+event_name == "analyticsSessionDataPublisher" || event_name == "analyticsLoginDataPublisher"
+&& property_name == "enable" %}
+{{event_name}}.{{property_name}}=true
+{% else %}
 {{event_name}}.{{property_name}}={{property_value}}
+{% endif %}
 {% endfor %}
 {% if count.append(1) %}{% endif %}
 {% endfor %}


### PR DESCRIPTION
### Proposed changes in this pull request

To enable ELK analytics, following configurations should be added to the deployment.toml. Instead of adding following 4 configurations, decided to add one configuration considering the user experience. 

```
[[event_listener]]
id = "authn_data_publisher_proxy"
type = "org.wso2.carbon.identity.core.handler.AbstractIdentityMessageHandler"
name = "org.wso2.carbon.identity.data.publisher.application.authentication.AuthnDataPublisherProxy" 
order = 11 

[analytics]
publish_active_session_count=true

[identity_mgt.analytics_login_data_publisher]
enable=true

[identity_mgt.analytics_session_data_publisher]
enable=true
```
Following new configuration enables the above all configurations.

```
[analytics.elk]
enable=true
```
