### PR TITLE
Skip username validation for jit provisioning

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -228,11 +228,12 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                 boolean userWorkflowEngaged = false;
                 try {
                     /*
-                    This thread local is set to skip the password pattern validation even if the password
+                    This thread local is set to skip the password and username pattern validation even if the password
                     is generated, or user entered one. If it is required to check password pattern validation,
                     need to write a provisioning handler extending the "DefaultProvisioningHandler".
                      */
                     UserCoreUtil.setSkipPasswordPatternValidationThreadLocal(true);
+                    UserCoreUtil.setSkipUsernamePatternValidationThreadLocal(true);
                     if (FrameworkUtils.isJITProvisionEnhancedFeatureEnabled()) {
                         setJitProvisionedSource(tenantDomain, idp, userClaims);
                     }
@@ -250,6 +251,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                     }
                 } finally {
                     UserCoreUtil.removeSkipPasswordPatternValidationThreadLocal();
+                    UserCoreUtil.removeSkipUsernamePatternValidationThreadLocal();
                 }
 
                 if (userWorkflowEngaged ||

--- a/pom.xml
+++ b/pom.xml
@@ -1726,7 +1726,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.7.0-m11</carbon.kernel.version>
+        <carbon.kernel.version>4.7.0-beta</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1726,7 +1726,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.7.0-beta</carbon.kernel.version>
+        <carbon.kernel.version>4.7.0-m11</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>


### PR DESCRIPTION
### Proposed changes in this pull request

Unique identifier is returned as subject identifier for a federated user during JIT provisioning. Therefore this PR skip the username regex validation during JIT provisioning flow.


### When should this PR be merged
Need to merge after merging the relevant kernal PR https://github.com/wso2/carbon-kernel/pull/3263
