### PR TITLE
Exclude new pax logging from surefire plugin

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
@@ -285,6 +285,7 @@
                     </suiteXmlFiles>
                     <classpathDependencyExcludes>
                         <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>

--- a/components/entitlement/org.wso2.carbon.identity.api.server.entitlement/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.api.server.entitlement/pom.xml
@@ -171,6 +171,7 @@
                 <configuration>
                     <classpathDependencyExcludes>
                         <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>

--- a/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt/pom.xml
+++ b/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt/pom.xml
@@ -82,6 +82,7 @@
                     <reuseForks>true</reuseForks>
                     <classpathDependencyExcludes>
                         <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>

--- a/components/security-mgt/org.wso2.carbon.security.mgt/pom.xml
+++ b/components/security-mgt/org.wso2.carbon.security.mgt/pom.xml
@@ -176,6 +176,7 @@
                     </suiteXmlFiles>
                     <classpathDependencyExcludes>
                         <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>

--- a/components/user-mgt/org.wso2.carbon.user.mgt/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/pom.xml
@@ -211,6 +211,7 @@
                     </suiteXmlFiles>
                     <classpathDependencyExcludes>
                         <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1726,7 +1726,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.7.0-m11</carbon.kernel.version>
+        <carbon.kernel.version>4.7.0-beta</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>


### PR DESCRIPTION
### Proposed changes in this pull request
Log4j1 removed pax logging framework is introduced from the new carbon kernel 4.7.0-beta and it was needed to exclude the new pax logging library from the maven surefire plugin in order to fix the test failures.