### PR TITLE
Add backup code configurations to default.json

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-authentication-flow.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-authentication-flow.jsp
@@ -81,6 +81,7 @@
 <%@ page import="java.util.ResourceBundle" %>
 
 <%!public static final String IS_HANDLER = "IS_HANDLER";%>
+<%!public static final String BACKUP_CODE_AUTHENTICATOR = "backup-code-authenticator";%>
 <carbon:breadcrumb label="breadcrumb.advanced.auth.step.config"
                    resourceBundle="org.wso2.carbon.identity.application.mgt.ui.i18n.Resources"
                    topPage="true" request="<%=request%>"/>
@@ -92,6 +93,7 @@
     ApplicationBean appBean = ApplicationMgtUIUtil.getApplicationBeanFromSession(session, request.getParameter("spName"));
     String spName = appBean.getServiceProvider().getApplicationName();
     Map<String, String> claimMapping = appBean.getClaimMapping();
+
     
     LocalAuthenticatorConfig[] localAuthenticatorConfigs = appBean.getLocalAuthenticatorConfigs();
     IdentityProvider[] federatedIdPs = appBean.getFederatedIdentityProviders();
@@ -105,6 +107,9 @@
     
     if (localAuthenticatorConfigs != null && localAuthenticatorConfigs.length > 0) {
         for (LocalAuthenticatorConfig auth : localAuthenticatorConfigs) {
+            if (auth.getName().equals(BACKUP_CODE_AUTHENTICATOR)) {
+                continue;
+            }
             localAuthTypes.append(startOption).append(Encode.forHtmlAttribute(auth.getName())).append(middleOption)
                 .append(Encode.forHtmlContent(auth.getDisplayName())).append(endOption);
         }

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -191,6 +191,14 @@
   "authentication.authenticator.totp.parameters.HideUserStoreFromDisplayInQRUrl": false,
   "authentication.authenticator.totp.parameters.Tags": "MFA",
 
+  "authentication.authenticator.backup_code.name": "backup-code-authenticator",
+  "authentication.authenticator.backup_code.enable": true,
+  "authentication.authenticator.backup_code.parameters.authenticationMandatory": true,
+  "authentication.authenticator.backup_code.parameters.BackupCodeAuthenticationEndpointURL": "authenticationendpoint/backup_code.do",
+  "authentication.authenticator.backup_code.parameters.BackupCodeAuthenticationEndpointErrorPage": "authenticationendpoint/backup_code_error.do",
+  "authentication.authenticator.backup_code.parameters.redirectToMultiOptionPageOnFailure": false,
+  "authentication.authenticator.backup_code.parameters.Tags": "MFA",
+
   "authentication.authenticator.x509_certificate.name": "x509CertificateAuthenticator",
   "authentication.authenticator.x509_certificate.enable": true,
   "authentication.authenticator.x509_certificate.parameters.AuthenticationEndpoint": "https://localhost:8443/x509-certificate-servlet",


### PR DESCRIPTION
### Proposed changes in this pull request

- Add backup code configuretions to default.json file
- Hide backup code authenticator from management console as it is not available for custom users

