### PR TITLE
Skip username validation for jit provisioning

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -228,11 +228,12 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                 boolean userWorkflowEngaged = false;
                 try {
                     /*
-                    This thread local is set to skip the password pattern validation even if the password
+                    This thread local is set to skip the username and password pattern validation even if the password
                     is generated, or user entered one. If it is required to check password pattern validation,
                     need to write a provisioning handler extending the "DefaultProvisioningHandler".
                      */
                     UserCoreUtil.setSkipPasswordPatternValidationThreadLocal(true);
+                    UserCoreUtil.setSkipUsernamePatternValidationThreadLocal(true);
                     if (FrameworkUtils.isJITProvisionEnhancedFeatureEnabled()) {
                         setJitProvisionedSource(tenantDomain, idp, userClaims);
                     }
@@ -250,6 +251,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                     }
                 } finally {
                     UserCoreUtil.removeSkipPasswordPatternValidationThreadLocal();
+                    UserCoreUtil.removeSkipUsernamePatternValidationThreadLocal();
                 }
 
                 if (userWorkflowEngaged ||


### PR DESCRIPTION
### Proposed changes in this pull request

Unique identifier is returned as subject identifier for a federated user during JIT provisioning. Therefore this PR skip the username regex validation during JIT provisioning flow.


### When should this PR be merged
Need to merge after merging the relevant kernal PR https://github.com/wso2/carbon-kernel/pull/3263
