### PR TITLE
Upgrade opensaml version to 3.3.1.wso2v6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1887,7 +1887,7 @@
         <orbit.version.commons.fileuploader>1.2.0.wso2v1</orbit.version.commons.fileuploader>
         <opensaml.version>3.3.1</opensaml.version>
         <shibboleth.version>7.3.0</shibboleth.version>
-        <opensaml2.wso2.version>3.3.1.wso2v5</opensaml2.wso2.version>
+        <opensaml2.wso2.version>3.3.1.wso2v6</opensaml2.wso2.version>
         <opensaml2.wso2.osgi.version.range>[3.3.1,3.4.0)</opensaml2.wso2.osgi.version.range>
         <joda.version>2.9.4</joda.version>
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>


### PR DESCRIPTION
### Proposed changes in this pull request
Upgrade opensaml version to 3.3.1.wso2v6 which upgrades org.owasp.esapi:esapi to 2.4.0.0 from 2.2.3.1