### PR TITLE
Add tenant id to the IDN_FED_AUTH_SESSION_MAPPING table to keep the tenant record

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -567,14 +567,31 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                     if (StringUtils.isNotBlank(authHistory.getIdpSessionIndex()) &&
                             StringUtils.isNotBlank(authHistory.getIdpName())) {
                         try {
-                            if (!userSessionStore.hasExistingFederatedAuthSession(authHistory.getIdpSessionIndex())) {
-                                userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory);
-                            } else {
-                                if (log.isDebugEnabled()) {
-                                    log.debug(String.format("Federated auth session with the id: %s already exists",
-                                            authHistory.getIdpSessionIndex()));
+                            if (FrameworkUtils.isTenantIdColumnAvailableInFedAuthTable()) {
+                                int tenantId = IdentityTenantUtil.getTenantId(context.getTenantDomain());
+                                if (!userSessionStore.isExistingFederatedAuthSessionAvailable(
+                                        authHistory.getIdpSessionIndex(), tenantId)) {
+                                    userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory,
+                                            tenantId);
+                                } else {
+                                    if (log.isDebugEnabled()) {
+                                        log.debug(String.format("Federated auth session with the id: %s already " +
+                                                "exists.", authHistory.getIdpSessionIndex()));
+                                    }
+                                    userSessionStore.updateFederatedAuthSessionInfo(sessionContextKey, authHistory,
+                                            tenantId);
                                 }
-                                userSessionStore.updateFederatedAuthSessionInfo(sessionContextKey, authHistory);
+                            } else {
+                                if (!userSessionStore.hasExistingFederatedAuthSession(
+                                        authHistory.getIdpSessionIndex())) {
+                                    userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory);
+                                } else {
+                                    if (log.isDebugEnabled()) {
+                                        log.debug(String.format("Federated auth session with the id: %s already " +
+                                                "exists.", authHistory.getIdpSessionIndex()));
+                                    }
+                                    userSessionStore.updateFederatedAuthSessionInfo(sessionContextKey, authHistory);
+                                }
                             }
                         } catch (UserSessionException e) {
                             throw new FrameworkException("Error while storing federated authentication session details "

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -349,6 +349,9 @@ public class FrameworkServiceComponent {
          */
         this.loadCodeForRequire();
 
+        // Check whether the TENANT_ID column is available in the IDN_FED_AUTH_SESSION_MAPPING table.
+        FrameworkUtils.checkIfTenantIdColumnIsAvailableInFedAuthTable();
+
         // Set user session mapping enabled.
         FrameworkServiceDataHolder.getInstance().setUserSessionMappingEnabled(FrameworkUtils
                 .isUserSessionMappingEnabled());

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
@@ -167,13 +167,26 @@ public class SQLQueries {
     public static final String SQL_STORE_FEDERATED_AUTH_SESSION_INFO = "INSERT INTO IDN_FED_AUTH_SESSION_MAPPING "
             + "(IDP_SESSION_ID, SESSION_ID, IDP_NAME,  AUTHENTICATOR_ID, PROTOCOL_TYPE) VALUES (?, ?, ?, ?, ?)";
 
+    // Store federated authentication session details to map the session context key with the idp session index.
+    public static final String SQL_STORE_FEDERATED_AUTH_SESSION_INFO_WITH_TENANT = "INSERT INTO " +
+            "IDN_FED_AUTH_SESSION_MAPPING (IDP_SESSION_ID, SESSION_ID, IDP_NAME,  AUTHENTICATOR_ID, " +
+            "PROTOCOL_TYPE, TENANT_ID) VALUES (?, ?, ?, ?, ?, ?)";
+
     // Get federated authentication session id using the idp session id.
     public static final String SQL_GET_FEDERATED_AUTH_SESSION_ID_BY_SESSION_ID = "SELECT SESSION_ID FROM " +
             "IDN_FED_AUTH_SESSION_MAPPING WHERE IDP_SESSION_ID = ?";
 
+    // Get federated authentication session id using the idp session id and the tenant id.
+    public static final String SQL_GET_FEDERATED_AUTH_SESSION_ID_BY_SESSION_ID_WITH_TENANT = "SELECT SESSION_ID " +
+            "FROM IDN_FED_AUTH_SESSION_MAPPING WHERE IDP_SESSION_ID = ? AND TENANT_ID = ?";
+
     // Update federated authentication session id using the idp session id.
     public static final String SQL_UPDATE_FEDERATED_AUTH_SESSION_INFO = "UPDATE IDN_FED_AUTH_SESSION_MAPPING SET " +
             "SESSION_ID=? WHERE IDP_SESSION_ID=?";
+
+    // Update federated authentication session id using the idp session id and the tenant id.
+    public static final String SQL_UPDATE_FEDERATED_AUTH_SESSION_INFO_WITH_TENANT = "UPDATE " +
+            "IDN_FED_AUTH_SESSION_MAPPING SET SESSION_ID=? WHERE IDP_SESSION_ID=? AND TENANT_ID = ?";
 
     // Get federated authentication session details if there is an already existing session.
     public static final String SQL_GET_FEDERATED_AUTH_SESSION_INFO_BY_SESSION_ID =

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -203,6 +203,7 @@ public class FrameworkUtils {
     private static final String CONTINUE_ON_CLAIM_HANDLING_ERROR = "ContinueOnClaimHandlingError";
     public static final String CORRELATION_ID_MDC = "Correlation-ID";
 
+    private static boolean isTenantIdColumnAvailableInFedAuthTable = false;
     public static final String ROOT_DOMAIN = "/";
 
     private FrameworkUtils() {
@@ -2752,6 +2753,24 @@ public class FrameworkUtils {
                     "Identity database.");
         }
         return false;
+    }
+
+    /**
+     * Checking whether the tenant id column is available in the IDN_FED_AUTH_SESSION_MAPPING table.
+     */
+    public static void checkIfTenantIdColumnIsAvailableInFedAuthTable() {
+
+        isTenantIdColumnAvailableInFedAuthTable = isTableColumnExists("IDN_FED_AUTH_SESSION_MAPPING", "TENANT_ID");
+    }
+
+    /**
+     * Return whether the tenant id column is available in the IDN_FED_AUTH_SESSION_MAPPING table.
+     *
+     * @return True if tenant id is available in IDN_FED_AUTH_SESSION_MAPPING table. Else return false.
+     */
+    public static boolean isTenantIdColumnAvailableInFedAuthTable() {
+
+        return isTenantIdColumnAvailableInFedAuthTable;
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes in this PR
* Fixes : https://github.com/wso2/product-is/issues/13465
* Fixing the NPE issue when performing a federated SLO between tenants.
* Introduced a new column called TENANT_ID in IDN_FED_AUTH_SESSION_MAPPING table to keep the tenant id of the corresponding federated session was created.
* These changes will add the tenant id when a federated auth session is added to the table and updated in the table.
* When searching, tenant id will be used as well.

## Related PRs
* Outbound SAML fix to retrieve the session details from the IDN_FED_AUTH_SESSION_MAPPING table[1].
* IDN_FED_AUTH_SESSION_MAPPING table column update PR[2].

## When should this PR be merged
* This framework PR needs to be merged before outbound saml PR[1].

[1] https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/144
[2] https://github.com/wso2/carbon-identity-framework/pull/4035