### PR TITLE
Adjusting pre and post listeners for get user with ID when using cursor pagination

### DIFF
--- a/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
@@ -296,6 +296,8 @@ public class IdentityEventConstants {
         public static final String LIMIT = "LIMIT";
         public static final String AUTHENTICATION_RESULT = "AUTHENTICATION_RESULT";
         public static final String OFFSET = "OFFSET";
+        public static final String CURSOR = "CURSOR";
+        public static final String DIRECTION = "DIRECTION";
         public static final String SORT_BY = "SORT_BY";
         public static final String SORT_ORDER = "SORT_ORDER";
         public static final String USER = "USER";

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityUserIdResolverListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityUserIdResolverListener.java
@@ -1050,6 +1050,29 @@ public class IdentityUserIdResolverListener extends AbstractIdentityUserOperatio
     }
 
     @Override
+    public boolean doPreGetUserList(Condition condition, String domain, String profileName, int limit, String cursor,
+                                    String direction, String sortBy, String sortOrder,
+                                    UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+
+        for (UserOperationEventListener listener : getUserStoreManagerListeners()) {
+            if (isNotAResolverListener(listener)) {
+                if (!((UniqueIDUserOperationEventListener) listener)
+                        .doPreGetUserListWithID(condition, domain, profileName, limit, cursor, direction, sortBy,
+                                sortOrder, userStoreManager)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    @Override
     public boolean doPreGetUserList(String claimUri, String claimValue, int limit, int offset,
                                     List<String> returnUserNameList, UserStoreManager userStoreManager)
             throws UserStoreException {
@@ -1136,6 +1159,32 @@ public class IdentityUserIdResolverListener extends AbstractIdentityUserOperatio
                 if (!((UniqueIDUserOperationEventListener) listener)
                         .doPostGetUserListWithID(condition, domain, profileName, limit, offset, sortBy, sortOrder,
                                 returnUsersList, userStoreManager)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean doPostGetUserList(Condition condition, String domain, String profileName, int limit, String cursor,
+                                     String direction, String sortBy, String sortOrder, String[] returnUserNameList,
+                                     UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+
+        List<User> returnUsersList = getUsersFromNames((AbstractUserStoreManager) userStoreManager,
+                Arrays.asList(returnUserNameList));
+
+        for (UserOperationEventListener listener : getUserStoreManagerListeners()) {
+            if (isNotAResolverListener(listener)) {
+                if (!((UniqueIDUserOperationEventListener) listener)
+                        .doPostGetUserListWithID(condition, domain, profileName, limit, cursor, direction, sortBy,
+                                sortOrder, returnUsersList, userStoreManager)) {
                     return false;
                 }
             }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityUserIdResolverListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityUserIdResolverListener.java
@@ -1058,7 +1058,6 @@ public class IdentityUserIdResolverListener extends AbstractIdentityUserOperatio
         if (!isEnable()) {
             return true;
         }
-
         for (UserOperationEventListener listener : getUserStoreManagerListeners()) {
             if (isNotAResolverListener(listener)) {
                 if (!((UniqueIDUserOperationEventListener) listener)
@@ -1068,7 +1067,6 @@ public class IdentityUserIdResolverListener extends AbstractIdentityUserOperatio
                 }
             }
         }
-
         return true;
     }
 
@@ -1176,10 +1174,8 @@ public class IdentityUserIdResolverListener extends AbstractIdentityUserOperatio
         if (!isEnable()) {
             return true;
         }
-
         List<User> returnUsersList = getUsersFromNames((AbstractUserStoreManager) userStoreManager,
                 Arrays.asList(returnUserNameList));
-
         for (UserOperationEventListener listener : getUserStoreManagerListeners()) {
             if (isNotAResolverListener(listener)) {
                 if (!((UniqueIDUserOperationEventListener) listener)
@@ -1189,7 +1185,6 @@ public class IdentityUserIdResolverListener extends AbstractIdentityUserOperatio
                 }
             }
         }
-
         return true;
     }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityUserIdResolverListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityUserIdResolverListener.java
@@ -1051,7 +1051,7 @@ public class IdentityUserIdResolverListener extends AbstractIdentityUserOperatio
 
     @Override
     public boolean doPreGetUserList(Condition condition, String domain, String profileName, int limit, String cursor,
-                                    String direction, String sortBy, String sortOrder,
+                                    UserCoreConstants.PaginationDirection direction, String sortBy, String sortOrder,
                                     UserStoreManager userStoreManager)
             throws UserStoreException {
 
@@ -1167,8 +1167,8 @@ public class IdentityUserIdResolverListener extends AbstractIdentityUserOperatio
 
     @Override
     public boolean doPostGetUserList(Condition condition, String domain, String profileName, int limit, String cursor,
-                                     String direction, String sortBy, String sortOrder, String[] returnUserNameList,
-                                     UserStoreManager userStoreManager)
+                                     UserCoreConstants.PaginationDirection direction, String sortBy, String sortOrder,
+                                     String[] returnUserNameList, UserStoreManager userStoreManager)
             throws UserStoreException {
 
         if (!isEnable()) {

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityUserNameResolverListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityUserNameResolverListener.java
@@ -1060,8 +1060,9 @@ public class IdentityUserNameResolverListener extends AbstractIdentityUserOperat
 
     @Override
     public boolean doPreGetUserListWithID(Condition condition, String domain, String profileName, int limit,
-                                          String cursor, String direction, String sortBy, String sortOrder,
-                                          UserStoreManager userStoreManager) throws UserStoreException {
+                                          String cursor, UserCoreConstants.PaginationDirection direction, String sortBy,
+                                          String sortOrder, UserStoreManager userStoreManager)
+            throws UserStoreException {
 
         if (!isEnable()) {
             return true;
@@ -1103,8 +1104,8 @@ public class IdentityUserNameResolverListener extends AbstractIdentityUserOperat
 
     @Override
     public boolean doPostGetUserListWithID(Condition condition, String domain, String profileName, int limit,
-                                           String cursor, String direction, String sortBy, String sortOrder,
-                                           List<User> users, UserStoreManager userStoreManager)
+                   String cursor, UserCoreConstants.PaginationDirection direction, String sortBy, String sortOrder,
+                   List<User> users, UserStoreManager userStoreManager)
             throws UserStoreException {
 
         if (!isEnable()) {

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityUserNameResolverListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityUserNameResolverListener.java
@@ -1059,6 +1059,27 @@ public class IdentityUserNameResolverListener extends AbstractIdentityUserOperat
     }
 
     @Override
+    public boolean doPreGetUserListWithID(Condition condition, String domain, String profileName, int limit,
+                                          String cursor, String direction, String sortBy, String sortOrder,
+                                          UserStoreManager userStoreManager) throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+
+        for (UserOperationEventListener listener : getUserStoreManagerListeners()) {
+            if (isNotAResolverListener(listener)) {
+                if (!listener.doPreGetUserList(condition, domain, profileName, limit, cursor, direction, sortBy,
+                        sortOrder, userStoreManager)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    @Override
     public boolean doPostGetUserListWithID(Condition condition, String domain, String profileName, int limit,
                                            int offset, String sortBy, String sortOrder, List<User> users,
                                            UserStoreManager userStoreManager)
@@ -1076,6 +1097,30 @@ public class IdentityUserNameResolverListener extends AbstractIdentityUserOperat
                 return listener
                         .doPostGetUserList(condition, domain, profileName, limit, offset, sortBy, sortOrder, userNames,
                                 userStoreManager);
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean doPostGetUserListWithID(Condition condition, String domain, String profileName, int limit,
+                                           String cursor, String direction, String sortBy, String sortOrder,
+                                           List<User> users, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+
+        List<String> userNamesList = users.stream().map(User::getUsername).collect(Collectors.toList());
+        String[] userNames = userNamesList.toArray(new String[0]);
+
+        for (UserOperationEventListener listener : getUserStoreManagerListeners()) {
+            if (isNotAResolverListener(listener)) {
+                return listener
+                        .doPostGetUserList(condition, domain, profileName, limit, cursor, direction, sortBy, sortOrder,
+                                userNames, userStoreManager);
             }
         }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityUserNameResolverListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityUserNameResolverListener.java
@@ -1066,7 +1066,6 @@ public class IdentityUserNameResolverListener extends AbstractIdentityUserOperat
         if (!isEnable()) {
             return true;
         }
-
         for (UserOperationEventListener listener : getUserStoreManagerListeners()) {
             if (isNotAResolverListener(listener)) {
                 if (!listener.doPreGetUserList(condition, domain, profileName, limit, cursor, direction, sortBy,
@@ -1075,7 +1074,6 @@ public class IdentityUserNameResolverListener extends AbstractIdentityUserOperat
                 }
             }
         }
-
         return true;
     }
 
@@ -1112,10 +1110,8 @@ public class IdentityUserNameResolverListener extends AbstractIdentityUserOperat
         if (!isEnable()) {
             return true;
         }
-
         List<String> userNamesList = users.stream().map(User::getUsername).collect(Collectors.toList());
         String[] userNames = userNamesList.toArray(new String[0]);
-
         for (UserOperationEventListener listener : getUserStoreManagerListeners()) {
             if (isNotAResolverListener(listener)) {
                 return listener
@@ -1123,7 +1119,6 @@ public class IdentityUserNameResolverListener extends AbstractIdentityUserOperat
                                 userNames, userStoreManager);
             }
         }
-
         return true;
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request
The purpose of this PR is for handlePreGetUserListWithID and handlePostGetUserListWithID to be functional and call the necessary listeners when requesting a cursor paginated request instead of an index paginated request.

## Related Issues
- https://github.com/wso2/product-is/issues/13294

## Dependant PRs

- [ ]  https://github.com/wso2/carbon-kernel/pull/3281
Requires the PaginationDirection enum from the carbon-kernel repository.

## Test environment
JDK 1.8, Ubuntu 20.04, WSO2IS-5.12.0-alpha14, MySQL 8.0.28.

