### PR TITLE
Log sessionExtenderClientException as debug logs

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityServlet.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityServlet.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
+import org.wso2.carbon.identity.application.authentication.framework.session.extender.exception.SessionExtenderClientException;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.io.IOException;
@@ -107,7 +108,11 @@ public class IdentityServlet extends HttpServlet {
             }
             return responseBuilder.build();
         } catch (FrameworkException e) {
-            log.error("Failed to process IdentityRequest", e);
+            if (e instanceof SessionExtenderClientException) {
+                log.debug("Failed to process IdentityRequest", e);
+            } else {
+                log.error("Failed to process IdentityRequest", e);
+            }
             responseFactory = getIdentityResponseFactory(e);
             responseBuilder = responseFactory.handleException(e);
             if (responseBuilder == null) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityServlet.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityServlet.java
@@ -23,7 +23,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
-import org.wso2.carbon.identity.application.authentication.framework.session.extender.exception.SessionExtenderClientException;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.io.IOException;
@@ -108,8 +107,10 @@ public class IdentityServlet extends HttpServlet {
             }
             return responseBuilder.build();
         } catch (FrameworkException e) {
-            if (e instanceof SessionExtenderClientException) {
-                log.debug("Failed to process IdentityRequest", e);
+            if (e instanceof FrameworkClientException) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Failed to process IdentityRequest", e);
+                }
             } else {
                 log.error("Failed to process IdentityRequest", e);
             }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -348,7 +348,7 @@ public class SessionDataStore {
             }
         } catch (ClassNotFoundException | IOException | SQLException | SessionSerializerException |
                 IdentityApplicationManagementException e) {
-            log.error("Error while retrieving session data", e);
+            log.debug("Error while retrieving session data", e);
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, resultSet, preparedStatement);
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -348,7 +348,9 @@ public class SessionDataStore {
             }
         } catch (ClassNotFoundException | IOException | SQLException | SessionSerializerException |
                 IdentityApplicationManagementException e) {
-            log.debug("Error while retrieving session data", e);
+            if (log.isDebugEnabled()) {
+                log.debug("Error while retrieving session data", e);
+            }
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, resultSet, preparedStatement);
         }


### PR DESCRIPTION
### Proposed changes in this pull request
There are lot of error logs gets printed for sessionExtenderClientException that throws as a results of de serialization errors for the session object. 
Related PR: https://github.com/wso2-enterprise/asgardeo-account-lookup/pull/66

**Related issue**
https://github.com/wso2-enterprise/asgardeo-product/issues/10674