### PR TITLE
Move allow cross tenant introspection config inside OAuth

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -634,6 +634,10 @@
         Default value : false
         -->
         <!--<DropUnregisteredScopes>true</DropUnregisteredScopes>-->
+
+        <!-- Configuration for allowing users to introspect tokens from other tenants. -->
+        <AllowCrossTenantTokenIntrospection>true</AllowCrossTenantTokenIntrospection>
+
     </OAuth>
 
     <MultifactorAuthentication>
@@ -2101,6 +2105,4 @@
     <!-- Configuration to enable or disable claim filtering based on scope. -->
     <EnableScopeBasedClaimFiltering>true</EnableScopeBasedClaimFiltering>
 
-    <!-- Configuration for allowing users to introspect tokens from other tenants. -->
-    <AllowCrossTenantTokenIntrospection>true</AllowCrossTenantTokenIntrospection>
 </Server>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -880,6 +880,10 @@
         {% if oauth.client_id_validation_regex is defined %}
         <ClientIdValidationRegex>{{oauth.client_id_validation_regex}}</ClientIdValidationRegex>
         {% endif %}
+
+        <!-- Configuration for allowing users to introspect tokens from other tenants. -->
+        <AllowCrossTenantTokenIntrospection>{{oauth.introspect.allow_cross_tenant}}</AllowCrossTenantTokenIntrospection>
+
     </OAuth>
 
     <MultifactorAuthentication>
@@ -3016,9 +3020,6 @@
     {% else %}
     <UseLegacyLocalizationClaim>false</UseLegacyLocalizationClaim>
     {% endif %}
-
-    <!-- Configuration for allowing users to introspect tokens from other tenants. -->
-    <AllowCrossTenantTokenIntrospection>{{oauth.introspect.allow_cross_tenant}}</AllowCrossTenantTokenIntrospection>
 
     <!-- Configuration to enable or disable claim filtering based on scope. -->
     <EnableScopeBasedClaimFiltering>{{authentication.enable_scope_based_claim_filtering}}</EnableScopeBasedClaimFiltering>


### PR DESCRIPTION
### Proposed changes in this pull request

- As `AllowCrossTenantIntrospection` config is related to OAuth, move that inside OAuth
- Can disallow admins from different tenants to introspect tokens of other tenants by adding the following config to the
<IS-HOME>/repository/conf/deployment.toml.

```
[oauth.introspect]
allow_cross_tenant = false
```

### Related issue 
https://github.com/wso2/product-is/issues/13683
