### PR TITLE
Fix federated IDP logout issue after force authentication of another service provider

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
@@ -756,6 +756,21 @@ public class AuthenticationContext extends MessageContext implements Serializabl
     }
 
     /**
+     * Check whether the authenticator is already logged out.
+     *
+     * @param idpName Identity provider name.
+     * @param authenticatorName Authenticator name.
+     * @return true if the authenticator already logged out. False otherwise.
+     */
+    public boolean isLoggedOutAuthenticator(String idpName, String authenticatorName) {
+
+        if (loggedOutAuthenticators.containsKey(idpName)) {
+            return loggedOutAuthenticators.get(idpName).contains(authenticatorName);
+        }
+        return false;
+    }
+
+    /**
      * Clears all currently logged out authenticators from the context.
      */
     public void clearLoggedOutAuthenticators() {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
@@ -112,6 +112,8 @@ public class AuthenticationContext extends MessageContext implements Serializabl
 
     private List<String> executedPostAuthHandlers = new ArrayList<>();
 
+    private final Map<String, List<String>> loggedOutAuthenticators = new HashMap<>();
+
     public String getCallerPath() {
         return callerPath;
     }
@@ -724,5 +726,40 @@ public class AuthenticationContext extends MessageContext implements Serializabl
     public void setLoginTenantDomain(String loginTenantDomain) {
 
         this.loginTenantDomain = loginTenantDomain;
+    }
+
+    /**
+     * Get currently logged out authenticators with IDPs.
+     * @return logged out authenticators.
+     */
+    public Map<String, List<String>> getLoggedOutAuthenticators() {
+
+        return loggedOutAuthenticators;
+    }
+
+    /**
+     * Add a logged out authenticator providing the IDP name. Method creates a new list and appends the
+     * authenticator if no entry for the IDP.
+     *
+     * @param idpName Identity provider name.
+     * @param  authenticatorName Authenticator name.
+     */
+    public void addLoggedOutAuthenticator(String idpName, String authenticatorName) {
+
+        if (loggedOutAuthenticators.containsKey(idpName)) {
+            loggedOutAuthenticators.get(idpName).add(authenticatorName);
+        } else {
+            List<String> authenticators = new ArrayList<>();
+            authenticators.add(authenticatorName);
+            loggedOutAuthenticators.put(idpName, authenticators);
+        }
+    }
+
+    /**
+     * Clears all currently logged out authenticators from the context.
+     */
+    public void clearLoggedOutAuthenticators() {
+
+        loggedOutAuthenticators.clear();
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
@@ -729,15 +729,6 @@ public class AuthenticationContext extends MessageContext implements Serializabl
     }
 
     /**
-     * Get currently logged out authenticators with IDPs.
-     * @return logged out authenticators.
-     */
-    public Map<String, List<String>> getLoggedOutAuthenticators() {
-
-        return loggedOutAuthenticators;
-    }
-
-    /**
      * Add a logged out authenticator providing the IDP name. Method creates a new list and appends the
      * authenticator if no entry for the IDP.
      *

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
@@ -220,10 +220,7 @@ public class DefaultLogoutRequestHandler implements LogoutRequestHandler {
                     String authenticatorName = authenticator.getName();
 
                     // Check whether the IDP and related authenticator is already logged out.
-                    List<String> previouslyLoggedOutAuthenticators =
-                            context.getLoggedOutAuthenticators().get(authenticatedIdPName);
-                    if (previouslyLoggedOutAuthenticators != null
-                            && previouslyLoggedOutAuthenticators.contains(authenticatorName)) {
+                    if (context.isLoggedOutAuthenticator(authenticatedIdPName, authenticatorName)) {
                         continue;
                     }
 


### PR DESCRIPTION
### Proposed changes in this pull request
During the logout flow, DefaultLogoutRequestHandler.handle() method tries to find out whether there's a previous authenticated session in the context and if found only, it calls the authenticator.process() method. When processing the authenticator, if it's a logout request, the authenticator will call the initiateLogoutRequest method of the SAMLSSOAuthenticator which will then send logout requests for external IDPs.

Since force authentication skips the existing session and creates a new one, inside the authentication context, new session will only be associated with the force authenticated app (OIDC app). Hence when it tries to retrieve previous authenticated sequence using the application which sends the logout request (SAML app), it won't be able to find the IDP (which is associated with the previous session). Therefore the authenticator process method will not be called for the federated idp.

In the SAML logout flow it can be observed that the federated IDP is existing as a previous authenticated IDP in the context. So as a fix, from the DefaultLogoutRequestHandler, if we cannot find a previous authenticated session, but previous authenticated IDPs are existing in the authentication context, we can try to call authenticator.process() function for each IDP. This will initiate logout flow for the SAML federated IDP.

#### Related Issues
- https://github.com/wso2/product-is/issues/13696

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
