### PR TITLE
Add support to use ServiceURLBuilder for backend redirections

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -53,6 +53,7 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.authentication.framework.util.LoginContextManagementUtil;
 import org.wso2.carbon.identity.application.authentication.framework.util.SessionMgtConstants;
 import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.idp.mgt.util.IdPManagementUtil;
@@ -887,11 +888,9 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
         }
 
         // redirect to the caller
-        String redirectURL;
-        String commonauthCallerPath = context.getCallerPath();
-
         try {
             String queryParamsString = "";
+            String redirectURL = FrameworkUtils.buildCallerPathRedirectURL(context.getCallerPath(), context);
             if (context.getCallerSessionKey() != null) {
                 queryParamsString = FrameworkConstants.SESSION_DATA_KEY + "=" +
                         URLEncoder.encode(context.getCallerSessionKey(), "UTF-8");
@@ -900,9 +899,9 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             if (StringUtils.isNotEmpty(rememberMeParam)) {
                 queryParamsString += "&" + rememberMeParam;
             }
-            redirectURL = FrameworkUtils.appendQueryParamsStringToUrl(commonauthCallerPath, queryParamsString);
+            redirectURL = FrameworkUtils.appendQueryParamsStringToUrl(redirectURL, queryParamsString);
             response.sendRedirect(redirectURL);
-        } catch (IOException e) {
+        } catch (IOException | URLBuilderException e) {
             throw new FrameworkException(e.getMessage(), e);
         }
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
@@ -51,6 +51,7 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
@@ -272,7 +273,6 @@ public class DefaultLogoutRequestHandler implements LogoutRequestHandler {
         // attributes
         request.setAttribute(FrameworkConstants.ResponseParams.LOGGED_OUT, isLoggedOut);
 
-        String redirectURL;
 
         if (isLoggedOut && !isValidCallerPath(context)) {
             if (log.isDebugEnabled()) {
@@ -282,6 +282,15 @@ public class DefaultLogoutRequestHandler implements LogoutRequestHandler {
             context.setCallerPath(getDefaultLogoutReturnUrl());
         }
 
+        String redirectURL;
+        try {
+            redirectURL = FrameworkUtils.buildCallerPathRedirectURL(context.getCallerPath(), context);
+        } catch (URLBuilderException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error occurred while generating redirect URL.", e);
+            }
+            redirectURL = context.getCallerPath();
+        }
         if (context.getCallerSessionKey() != null) {
             request.setAttribute(FrameworkConstants.SESSION_DATA_KEY, context.getCallerSessionKey());
 
@@ -304,7 +313,7 @@ public class DefaultLogoutRequestHandler implements LogoutRequestHandler {
 
             String sessionDataKeyParam = FrameworkConstants.SESSION_DATA_KEY + "=" +
                     URLEncoder.encode(context.getCallerSessionKey(), "UTF-8");
-            redirectURL = FrameworkUtils.appendQueryParamsStringToUrl(context.getCallerPath(), sessionDataKeyParam);
+            redirectURL = FrameworkUtils.appendQueryParamsStringToUrl(redirectURL, sessionDataKeyParam);
         } else {
             redirectURL = context.getCallerPath();
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -171,6 +171,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Application.CONSOLE_APP_PATH;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Application.MY_ACCOUNT_APP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Application.MY_ACCOUNT_APP_PATH;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.CONTEXT_PROP_INVALID_EMAIL_USERNAME;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Config.USER_SESSION_MAPPING_ENABLED;
@@ -3247,5 +3248,37 @@ public class FrameworkUtils {
             }
         }
         return requestedScopeClaims;
+    }
+
+    /**
+     * Util function to build caller patch redirect URLs using ServiceURLBuilder.
+     *
+     * @param callerPath        Application caller path.
+     * @param context           Authentication context.
+     * @return  reirect URL.
+     * @throws URLBuilderException  throw if an error occurred during URL generation.
+     */
+    public static String buildCallerPathRedirectURL(String callerPath, AuthenticationContext context)
+            throws URLBuilderException {
+
+        String serviceProvider = null;
+        if (context.getSequenceConfig() != null && context.getSequenceConfig().getApplicationConfig() != null) {
+            serviceProvider = context.getSequenceConfig().getApplicationConfig().getApplicationName();
+        }
+        /*
+         Skip My Account application redirections to use ServiceURLBuilder for URL generation
+         since My Account is SaaS.
+         */
+        if (!MY_ACCOUNT_APP.equals(serviceProvider)) {
+            if (callerPath != null && callerPath.startsWith("/t/")) {
+                String callerTenant = callerPath.split("/")[2];
+                String callerPathWithoutTenant = callerPath.replaceFirst("/t/[^/]+/", "/");
+                String redirectURL = ServiceURLBuilder.create().addPath(callerPathWithoutTenant)
+                        .setTenant(callerTenant, true)
+                        .build().getAbsolutePublicURL();
+                return redirectURL;
+            }
+        }
+        return callerPath;
     }
 }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
@@ -24,9 +24,6 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.core.ServiceURL;
-import org.wso2.carbon.identity.core.ServiceURLBuilder;
-import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.internal.IdentityCoreServiceComponent;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -55,6 +52,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
     protected String fragment;
     protected String[] urlPaths;
     protected String tenant;
+    protected boolean mandateTenantedPath = false;
     protected Map<String, String> parameters = new HashMap<>();
     protected Map<String, String> fragmentParams = new HashMap<>();
 
@@ -124,7 +122,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         StringBuilder resolvedUrlStringBuilder = new StringBuilder();
 
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && !resolvedUrlContext.startsWith("t/")) {
-            if (isNotSuperTenant(tenantDomain)) {
+            if (mandateTenantedPath || isNotSuperTenant(tenantDomain)) {
                 resolvedUrlStringBuilder.append("/t/").append(tenantDomain);
             }
         }
@@ -192,6 +190,14 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
     public ServiceURLBuilder setTenant(String tenantDomain) {
 
         this.tenant = tenantDomain;
+        return this;
+    }
+
+    @Override
+    public ServiceURLBuilder setTenant(String tenantDomain, boolean mandateTenantedPath) {
+
+        this.tenant = tenantDomain;
+        this.mandateTenantedPath = mandateTenantedPath;
         return this;
     }
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURLBuilder.java
@@ -83,6 +83,19 @@ public interface ServiceURLBuilder {
     }
 
     /**
+     * This is an overload of method setTenant(String tenantDomain). This method has an additional param to mandate
+     * tenanted path appending for URLs.
+     *
+     * @param tenantDomain          Tenant domain.
+     * @param mandateTenantedPath   Mandate tenanted path appending for the URL.
+     * @return  {@link ServiceURLBuilder}
+     */
+    default ServiceURLBuilder setTenant(String tenantDomain, boolean mandateTenantedPath) {
+
+        return this;
+    }
+
+    /**
      * Returns a ServiceURL with the protocol, hostname, port, proxy context path, a web context
      * root and the tenant domain (appended if required).
      *


### PR DESCRIPTION
### Proposed changes in this pull request
- This PR adds support to use `ServiceURLBuilder` for creating backend redirection URLs.
- A new default method `setTenant(String tenantDomain, boolean mandateTenantedPath)` was introduced to the `ServiceURLBuilder` interface to mandate tenanted path appending for super-tenant URLs.