### PR TITLE
[Public] Set service provider properties from existing service provider.

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -1301,6 +1301,7 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
             serviceProvider.setApplicationResourceId(savedSP.getApplicationResourceId());
             serviceProvider.setApplicationID(savedSP.getApplicationID());
             serviceProvider.setOwner(getUser(tenantDomain, username));
+            serviceProvider.setSpProperties(savedSP.getSpProperties());
 
             for (ApplicationMgtListener listener : listeners) {
                 if (listener.isEnable()) {


### PR DESCRIPTION
## Purpose
Fixes : https://github.com/wso2/product-is/issues/13884
U2 PR: https://github.com/wso2-support/carbon-identity-framework/pull/2343
Set SpProperties from the existing service provider when the object is created.

In the `updateApplicationCertificate()` method, if there is a certificate in the uploaded file, either the db entry is updated or a new db entry is added. To check whether there is a certificate for the service provider, certificateReferenceId in the serviceProviderProperties are used [1]. But these service provider properties are not updated from the existing service provider properties [2]. 
Set these service provider properties from existing service provider as the solution.

[1] https://github.com/wso2-support/carbon-identity-framework/blob/support-5.18.187.x-full/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java#L716-L740
[2] https://github.com/wso2-support/carbon-identity-framework/blob/support-5.18.186.x-full/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java#L1222-L1241