### PR TITLE
Add config to support organization context rewrite

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1985,15 +1985,13 @@
     <OrgContextsToRewrite>
         <WebApp>
             <Context>
-                <BasePath>/api/identity/organization-mgt/v1.0/</BasePath>
-            </Context>
-            <Context>
                 <BasePath>/scim2/</BasePath>
             </Context>
             <Context>
                 <BasePath>/api/</BasePath>
                 <SubPaths>
                     <Path>/api/server/v1/identity-providers</Path>
+                    <Path>/api/server/v1/organizations</Path>
                 </SubPaths>
             </Context>
         </WebApp>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1982,6 +1982,23 @@
         </OverwriteDispatch>
     </TenantContextsToRewrite>
 
+    <OrgContextsToRewrite>
+        <WebApp>
+            <Context>
+                <BasePath>/api/identity/organization-mgt/v1.0/</BasePath>
+            </Context>
+            <Context>
+                <BasePath>/scim2/</BasePath>
+            </Context>
+            <Context>
+                <BasePath>/api/</BasePath>
+                <SubPaths>
+                    <Path>/api/server/v1/identity-providers</Path>
+                </SubPaths>
+            </Context>
+        </WebApp>
+    </OrgContextsToRewrite>
+
     <!-- Server Synchronization Tolerance Configuration in seconds -->
     <ClockSkew>300</ClockSkew>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2703,6 +2703,35 @@
         </OverwriteDispatch>
     </TenantContextsToRewrite>
 
+    <OrgContextsToRewrite>
+        <WebApp>
+        {% for organization_context in organization_context.rewrite %}
+        {% for base_path in organization_context.base_path %}
+            <Context>
+                <BasePath>{{base_path}}</BasePath>
+                <SubPaths>
+                {% for sub_path in organization_context.sub_paths %}
+                    <Path>{{sub_path}}</Path>
+                {% endfor %}
+                </SubPaths>
+            </Context>
+        {% endfor %}
+        {% endfor %}
+            <Context>
+                <BasePath>/api/identity/organization-mgt/v1.0/</BasePath>
+            </Context>
+            <Context>
+                <BasePath>/scim2/</BasePath>
+            </Context>
+            <Context>
+                <BasePath>/api/</BasePath>
+                <SubPaths>
+                    <Path>/api/server/v1/identity-providers</Path>
+                </SubPaths>
+            </Context>
+        </WebApp>
+    </OrgContextsToRewrite>
+
     <!-- Server Synchronization Tolerance Configuration in seconds -->
     <ClockSkew>{{server.clock_skew}}</ClockSkew>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2718,15 +2718,13 @@
         {% endfor %}
         {% endfor %}
             <Context>
-                <BasePath>/api/identity/organization-mgt/v1.0/</BasePath>
-            </Context>
-            <Context>
                 <BasePath>/scim2/</BasePath>
             </Context>
             <Context>
                 <BasePath>/api/</BasePath>
                 <SubPaths>
                     <Path>/api/server/v1/identity-providers</Path>
+                    <Path>/api/server/v1/organizations</Path>
                 </SubPaths>
             </Context>
         </WebApp>


### PR DESCRIPTION
Issue: https://github.com/wso2/product-is/issues/13953

Sample toml config:
```
[[organization_context.rewrite]]
base_path = "/api/"
sub_paths = ["/api/server/v1/identity-providers", "/api/server/v1/applications"]
```