### PR TITLE
Disable IDP when Default Authenticators are not Available 

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/ApplicationIdentityProviderMgtListener.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/ApplicationIdentityProviderMgtListener.java
@@ -64,6 +64,9 @@ public class ApplicationIdentityProviderMgtListener extends AbstractIdentityProv
             if (identityProvider.getResourceId() == null && idpId != null) {
                 identityProvider.setResourceId(idpId);
             }
+            if (identityProvider.getDefaultAuthenticatorConfig() == null) {
+                identityProvider.setEnable(false);
+            }
             int offset = 0;
             do {
                 connectedApplications =

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/ApplicationIdentityProviderMgtListener.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/ApplicationIdentityProviderMgtListener.java
@@ -64,9 +64,6 @@ public class ApplicationIdentityProviderMgtListener extends AbstractIdentityProv
             if (identityProvider.getResourceId() == null && idpId != null) {
                 identityProvider.setResourceId(idpId);
             }
-            if (identityProvider.getDefaultAuthenticatorConfig() == null) {
-                identityProvider.setEnable(false);
-            }
             int offset = 0;
             do {
                 connectedApplications =
@@ -309,6 +306,9 @@ public class ApplicationIdentityProviderMgtListener extends AbstractIdentityProv
                     throw new IdentityProviderManagementException("Error in disabling default federated authenticator" +
                             " as it is referred by service providers.");
                 }
+            } else {
+                throw new IdentityProviderManagementException("Error in disabling default federated authenticator" +
+                        " as it is referred by service providers.");
             }
         }
     }


### PR DESCRIPTION
Resolves: https://github.com/wso2/product-is/issues/13771

When updating an IDP, before updating the configurations of applications that are already using that IDP, this PR adds an validation and throws an exception if a user tries to disable all the authenticators for that IDP.
The existing validation only checks if a user tries to disable the IDP and throws an exception if the IDP is already used by a SP. This PR makes sure at least 1 authenticator is enabled for an IDP if it is already used by a SP.