### PR TITLE
Adding consider total records for total results of ldap configuration.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -838,7 +838,6 @@
         -->
 <!--        <ConsiderMaxLimitForTotalResult>{{scim2.consider_max_limit_for_total_results}}</ConsiderMaxLimitForTotalResult>-->
 
-
         <!--
           If you want to get the total records matching the client query as 'totalResult' for LDAP when filter criteria is given
           then enable this property value.

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -837,6 +837,17 @@
            Supported versions : IS 5.11.0 onwards
         -->
 <!--        <ConsiderMaxLimitForTotalResult>{{scim2.consider_max_limit_for_total_results}}</ConsiderMaxLimitForTotalResult>-->
+
+
+        <!--
+          If you want to get the total records matching the client query as 'totalResult' for LDAP when filter criteria is given
+          then enable this property value.
+          Please note that for the request without filtering, LDAP will give items per page as 'totalResult' regardless of this property value.
+          Default value : false
+          Supported versions : IS 5.10.0 onwards
+        -->
+        <!--<ConsiderTotalRecordsForTotalResultOfLDAP>false</ConsiderTotalRecordsForTotalResultOfLDAP>-->
+
     </SCIM2>
 
     <!--Recovery>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1093,6 +1093,16 @@
            Supported versions : IS 5.11.0 onwards
         -->
         <ConsiderMaxLimitForTotalResult>{{scim2.consider_max_limit_for_total_results}}</ConsiderMaxLimitForTotalResult>
+
+        <!--
+             If you want to get the total records matching the client query as 'totalResult' for LDAP when filter criteria is given
+             then enable this property value.
+             Please note that for the request without filtering, LDAP will give items per page as 'totalResult' regardless of this property value.
+             Default value : false
+             Supported versions : IS 5.10.0 onwards
+        -->
+        <ConsiderTotalRecordsForTotalResultOfLDAP>{{scim2.consider_total_records_for_total_results_of_ldap}}</ConsiderTotalRecordsForTotalResultOfLDAP>
+
     </SCIM2>
 
       <Recovery>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -272,6 +272,7 @@
   "scim2.return_updated_group_in_group_patch_response": true,
   "scim2.remove_duplicate_users_in_users_response": false,
   "scim2.consider_max_limit_for_total_results": false,
+  "scim2.consider_total_records_for_total_results_of_ldap": false,
 
   "identity_mgt.recovery.notification.manage_internally": true,
   "identity_mgt.recovery.callback_url": ".*",


### PR DESCRIPTION
**purpose**
Related issue - https://github.com/wso2/product-is/issues/12813#issuecomment-1143122185
Configuration related to the PR  https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/427 

The following configuration should be added to deployment.toml file to enable/disable the consideration of total records matching the client query for total results of ldap.
(To consider the total records matching the client query to 'totalResult' parameter, variable should be set to true)

[scim2]
consider_total_records_for_total_results_of_ldap = false