### PR TITLE
Move up oragnization management configs related identity configurations

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1847,6 +1847,30 @@
             <Permissions>none</Permissions>
             <Scopes>internal_login</Scopes>
         </Resource>
+        <Resource context="(.*)/api/server/v1/organizations" secured="true" http-method="GET">
+            <Permissions>/permission/admin/manage/identity/organizationmgt/view</Permissions>
+            <Scopes>internal_organization_view</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v1/organizations/(.*)" secured="true" http-method="GET">
+            <Permissions>/permission/admin/manage/identity/organizationmgt/view</Permissions>
+            <Scopes>internal_organization_view</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v1/organizations" secured="true" http-method="POST">
+            <Permissions>/permission/admin/manage/identity/organizationmgt/create</Permissions>
+            <Scopes>internal_organization_create</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v1/organizations/(.*)" secured="true" http-method="PATCH">
+            <Permissions>/permission/admin/manage/identity/organizationmgt/update</Permissions>
+            <Scopes>internal_organization_update</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v1/organizations/(.*)" secured="true" http-method="PUT">
+            <Permissions>/permission/admin/manage/identity/organizationmgt/update</Permissions>
+            <Scopes>internal_organization_update</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v1/organizations/(.*)" secured="true" http-method="DELETE">
+            <Permissions>/permission/admin/manage/identity/organizationmgt/delete</Permissions>
+            <Scopes>internal_organization_delete</Scopes>
+        </Resource>
         <Resource context="(.*)/api/users/v1/(.*)" secured="true" http-method="all">
             <Permissions>/permission/admin/manage/identity</Permissions>
             <Scopes>internal_identity_mgt_view</Scopes>
@@ -1871,31 +1895,6 @@
         <Resource context="(.*)/api/identity/typingdna/v1.0/(.*)" secured="true" http-method="GET, DELETE">
             <Permissions>none</Permissions>
             <Scopes>internal_login</Scopes>
-        </Resource>
-
-        <Resource context="(.*)/api/server/v1/organizations" secured="true" http-method="GET">
-            <Permissions>/permission/admin/manage/identity/organizationmgt/view</Permissions>
-            <Scopes>internal_organization_view</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/organizations/(.*)" secured="true" http-method="GET">
-            <Permissions>/permission/admin/manage/identity/organizationmgt/view</Permissions>
-            <Scopes>internal_organization_view</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/organizations" secured="true" http-method="POST">
-            <Permissions>/permission/admin/manage/identity/organizationmgt/create</Permissions>
-            <Scopes>internal_organization_create</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/organizations/(.*)" secured="true" http-method="PATCH">
-            <Permissions>/permission/admin/manage/identity/organizationmgt/update</Permissions>
-            <Scopes>internal_organization_update</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/organizations/(.*)" secured="true" http-method="PUT">
-            <Permissions>/permission/admin/manage/identity/organizationmgt/update</Permissions>
-            <Scopes>internal_organization_update</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/organizations/(.*)" secured="true" http-method="DELETE">
-            <Permissions>/permission/admin/manage/identity/organizationmgt/delete</Permissions>
-            <Scopes>internal_organization_delete</Scopes>
         </Resource>
 
         <Resource context="/carbon(.*)" secured="false" http-method="all"/>


### PR DESCRIPTION
 - The below resource config is applicable for the organization management related urls and get the precedence instead of the resource configs defined for organization management endpoints. Therefore the organization role management resource config is moved to the top of the below resource config.

```
<Resource context="(.*)/api/server/v1/(?!(tenants|channel-verified-tenants))(.*)" secured="true" http-method="all">
        <Permissions>/permission/admin/manage/identity/</Permissions>
        <Scopes>internal_identity_mgt_view</Scopes>
        <Scopes>internal_identity_mgt_update</Scopes>
        <Scopes>internal_identity_mgt_create</Scopes>
        <Scopes>internal_identity_mgt_delete</Scopes>
</Resource>