### PR TITLE
Add config to define organization routing only supported API paths

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2021,6 +2021,10 @@
         </WebApp>
     </OrgContextsToRewrite>
 
+    <OrgRoutingOnlySupportedAPIPaths>
+        <Path>/api/server/v1/organizations</Path>
+    </OrgRoutingOnlySupportedAPIPaths>
+
     <!-- Server Synchronization Tolerance Configuration in seconds -->
     <ClockSkew>300</ClockSkew>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2755,6 +2755,10 @@
         </WebApp>
     </OrgContextsToRewrite>
 
+    <OrgRoutingOnlySupportedAPIPaths>
+        <Path>/api/server/v1/organizations</Path>
+    </OrgRoutingOnlySupportedAPIPaths>
+
     <!-- Server Synchronization Tolerance Configuration in seconds -->
     <ClockSkew>{{server.clock_skew}}</ClockSkew>
 


### PR DESCRIPTION
The newly added organization management REST API should be blocked for tenant specific routing API calls. This API is only supported via organization specific routing logic. Hence this config is added to block any tenant specific API calls made to the new endpoint which is embedded in api webapp.

Please note that this config is not configurable via the deployment.toml