### PR TITLE
Skip adding permission for applications created in organizations.

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -78,6 +78,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.registry.api.RegistryException;
 import org.wso2.carbon.registry.core.RegistryConstants;
 import org.wso2.carbon.user.api.ClaimMapping;
+import org.wso2.carbon.user.api.Tenant;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserCoreConstants;
@@ -1949,16 +1950,18 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
             // First we need to create a role with the application name. Only the users in this role will be able to
             // edit/update the application.
             ApplicationMgtUtil.createAppRole(applicationName, username);
-            try {
-                PermissionsAndRoleConfig permissionAndRoleConfig = serviceProvider.getPermissionAndRoleConfig();
-                ApplicationMgtUtil.storePermissions(applicationName, username, permissionAndRoleConfig);
-            } catch (IdentityApplicationManagementException ex) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Creating application: " + applicationName + " in tenantDomain: " + tenantDomain +
-                            " failed. Rolling back by cleaning up partially created data.");
+            if (tenantNotAssociatedWithOrg(tenantDomain)) {
+                try {
+                    PermissionsAndRoleConfig permissionAndRoleConfig = serviceProvider.getPermissionAndRoleConfig();
+                    ApplicationMgtUtil.storePermissions(applicationName, username, permissionAndRoleConfig);
+                } catch (IdentityApplicationManagementException ex) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Creating application: " + applicationName + " in tenantDomain: " + tenantDomain +
+                                " failed. Rolling back by cleaning up partially created data.");
+                    }
+                    deleteApplicationRole(applicationName);
+                    throw ex;
                 }
-                deleteApplicationRole(applicationName);
-                throw ex;
             }
 
             try {
@@ -2149,6 +2152,21 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
                 log.error(errorMsg, e);
                 throw new IdentityApplicationManagementException(errorMsg, e);
             }
+        }
+    }
+
+    private boolean tenantNotAssociatedWithOrg(String tenantDomain) throws IdentityApplicationManagementException {
+
+        int tenantID = IdentityTenantUtil.getTenantId(tenantDomain);
+        try {
+            Tenant tenant =
+                    ApplicationManagementServiceComponentHolder.getInstance().getRealmService().getTenantManager()
+                            .getTenant(tenantID);
+            return StringUtils.isBlank(tenant.getAssociatedOrganizationUUID());
+        } catch (UserStoreException e) {
+            String errorMsg =
+                    String.format("Error while retrieving details of the application tenant: %s", tenantDomain);
+            throw new IdentityApplicationManagementException(errorMsg, e);
         }
     }
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -1950,7 +1950,7 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
             // First we need to create a role with the application name. Only the users in this role will be able to
             // edit/update the application.
             ApplicationMgtUtil.createAppRole(applicationName, username);
-            if (tenantNotAssociatedWithOrg(tenantDomain)) {
+            if (!isOrganization(tenantDomain)) {
                 try {
                     PermissionsAndRoleConfig permissionAndRoleConfig = serviceProvider.getPermissionAndRoleConfig();
                     ApplicationMgtUtil.storePermissions(applicationName, username, permissionAndRoleConfig);
@@ -2155,14 +2155,14 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
         }
     }
 
-    private boolean tenantNotAssociatedWithOrg(String tenantDomain) throws IdentityApplicationManagementException {
+    private boolean isOrganization(String tenantDomain) throws IdentityApplicationManagementException {
 
         int tenantID = IdentityTenantUtil.getTenantId(tenantDomain);
         try {
             Tenant tenant =
                     ApplicationManagementServiceComponentHolder.getInstance().getRealmService().getTenantManager()
                             .getTenant(tenantID);
-            return StringUtils.isBlank(tenant.getAssociatedOrganizationUUID());
+            return StringUtils.isNotBlank(tenant.getAssociatedOrganizationUUID());
         } catch (UserStoreException e) {
             String errorMsg =
                     String.format("Error while retrieving details of the application tenant: %s", tenantDomain);

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1861,7 +1861,7 @@
             <Permissions>/permission/admin/manage/identity/rolemgt/view</Permissions>
             <Scopes>internal_role_mgt_view</Scopes>
         </Resource>
-        <Resource context="(.*)/api/server/v1/organizations/(.*)/roles/(.*)" secured="true" http-method="POST">
+        <Resource context="(.*)/api/server/v1/organizations/(.*)/roles" secured="true" http-method="POST">
             <Permissions>/permission/admin/manage/identity/rolemgt/create</Permissions>
             <Scopes>internal_role_mgt_create</Scopes>
         </Resource>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2545,7 +2545,7 @@
             <Permissions>/permission/admin/manage/identity/rolemgt/view</Permissions>
             <Scopes>internal_role_mgt_view</Scopes>
         </Resource>
-        <Resource context="(.*)/api/server/v1/organizations/(.*)/roles/(.*)" secured="true" http-method="POST">
+        <Resource context="(.*)/api/server/v1/organizations/(.*)/roles" secured="true" http-method="POST">
             <Permissions>/permission/admin/manage/identity/rolemgt/create</Permissions>
             <Scopes>internal_role_mgt_create</Scopes>
         </Resource>

--- a/pom.xml
+++ b/pom.xml
@@ -1726,7 +1726,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.7.0-beta</carbon.kernel.version>
+        <carbon.kernel.version>4.7.0-beta6</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>


### PR DESCRIPTION
### Proposed changes in this pull request
When creating the organization, admin of the organization will be the creator of the organization. 
Since the creator is not within the same tenant / organization, creating the application permissions in registry is failing. Adding this PR to skip creating the permission in registry if the tenant has an associated organization.