### PR TITLE
Remove attributes from self registration form added by default

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -100,7 +100,7 @@
 				<AttributeID>url</AttributeID>
 				<Description>URL</Description>
 				<DisplayOrder>10</DisplayOrder>
-				<SupportedByDefault/>
+				<SupportedByDefault />
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/gender</ClaimURI>

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -42,7 +42,6 @@
 				<AttributeID>organizationName</AttributeID>
 				<Description>Organization</Description>
 				<DisplayOrder>3</DisplayOrder>
-				<SupportedByDefault />
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/streetaddress</ClaimURI>
@@ -94,7 +93,6 @@
 				<AttributeID>im</AttributeID>
 				<Description>IM</Description>
 				<DisplayOrder>9</DisplayOrder>
-				<SupportedByDefault />
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/url</ClaimURI>
@@ -102,7 +100,6 @@
 				<AttributeID>url</AttributeID>
 				<Description>URL</Description>
 				<DisplayOrder>10</DisplayOrder>
-				<SupportedByDefault />
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/gender</ClaimURI>

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -100,6 +100,7 @@
 				<AttributeID>url</AttributeID>
 				<Description>URL</Description>
 				<DisplayOrder>10</DisplayOrder>
+				<SupportedByDefault/>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/gender</ClaimURI>


### PR DESCRIPTION
### Proposed changes in this pull request
This PR will remove adding `Organization` and `IM` attributes to the self registration form by default.
This will fix the issue https://github.com/wso2/product-is/issues/14015

### Related Issues
https://github.com/wso2/product-is/issues/13795

