### PR TITLE
Fix meta.version mapping

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -230,6 +230,13 @@
 				<ReadOnly/>
 			</Claim>
 			<Claim>
+				<ClaimURI>http://wso2.org/claims/metadata.version</ClaimURI>
+				<DisplayName>User Metadata - Version</DisplayName>
+				<AttributeID>meta.version</AttributeID>
+				<Description>User Account Metadata - Version</Description>
+				<ReadOnly/>
+			</Claim>
+			<Claim>
 				<ClaimURI>http://wso2.org/claims/location</ClaimURI>
 				<DisplayName>Location</DisplayName>
 				<AttributeID>location</AttributeID>
@@ -1873,7 +1880,7 @@
 				<Required />
 				<DisplayOrder>1</DisplayOrder>
 				<SupportedByDefault />
-				<MappedLocalClaim>http://wso2.org/claims/im</MappedLocalClaim>
+				<MappedLocalClaim>http://wso2.org/claims/metadata.version</MappedLocalClaim>
 			</Claim>
 			<Claim>
 				<ClaimURI>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.fax</ClaimURI>


### PR DESCRIPTION
### Proposed changes in this pull request

Currently meta.version is mapped with the `IM` attribute. Hence it appears as an editable field for the user. Moreover meta.version has no correlation with IM attribute according to the specification [1]. Due to this reasons we create a new local claim as `metadata.version` and map it with the SCIM `meta.version` claim.

[1] https://datatracker.ietf.org/doc/html/rfc7643#section-4.1.2

### Related issues: 
1. https://github.com/wso2/product-is/issues/13766
2. https://github.com/wso2/product-is/issues/13501
3. https://github.com/wso2/product-is/issues/13848