### PR TITLE
Add User Store Validation during Self-registration

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointConstants.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointConstants.java
@@ -91,6 +91,7 @@ public class IdentityManagementEndpointConstants {
     public static final String SUPER_TENANT = "carbon.super";
     public static final String PRIMARY_USER_STORE_DOMAIN = "PRIMARY";
     public static final String TENANT_DOMAIN = "tenantdomain";
+    public static final String REALM = "realm";
 
     public static final String TENANT_DOMAIN_SEPARATOR = "@";
     public static final String USER_STORE_DOMAIN_SEPARATOR = "/";

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/SelfRegistrationMgtClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/SelfRegistrationMgtClient.java
@@ -316,6 +316,14 @@ public class SelfRegistrationMgtClient {
                 properties.put(tenantProperty);
             }
 
+            if (StringUtils.isNotBlank(user.getRealm())) {
+                JSONObject realmProperty = new JSONObject();
+                realmProperty.put(IdentityManagementEndpointConstants.KEY,
+                        IdentityManagementEndpointConstants.REALM);
+                realmProperty.put(IdentityManagementEndpointConstants.VALUE, user.getRealm());
+                properties.put(realmProperty);
+            }
+
             userObject.put(PROPERTIES, properties);
             // Get tenant qualified endpoint.
             HttpPost post = new HttpPost(getUserAPIEndpoint(user.getTenantDomain()));

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/constants/SelfRegistrationStatusCodes.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/constants/SelfRegistrationStatusCodes.java
@@ -31,4 +31,5 @@ public class SelfRegistrationStatusCodes {
     public static final String ERROR_CODE_SELF_REGISTRATION_DISABLED = "60003";
     public static final String CODE_USER_NAME_INVALID = "60004";
     public static final String ERROR_CODE_INVALID_EMAIL_USERNAME = "60005";
+    public static final String ERROR_CODE_INVALID_USERSTORE = "60006";
 }


### PR DESCRIPTION
This PR adds support to validate the userstore entered with the username during self user registration. The realm property of the user object contains the userstore and it will be added to the user object entity that is sent to validate the username.

Related issue: https://github.com/wso2/product-is/issues/13797