### PR TITLE
Encode form posts un-encoded HTML, XML or JSON input data

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/java/org/wso2/carbon/identity/application/mgt/ui/ApplicationBean.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/java/org/wso2/carbon/identity/application/mgt/ui/ApplicationBean.java
@@ -1139,7 +1139,9 @@ public class ApplicationBean {
         // update basic info.
         serviceProvider.setApplicationName(request.getParameter("spName"));
         serviceProvider.setDescription(request.getParameter("sp-description"));
-        serviceProvider.setCertificateContent(request.getParameter("sp-certificate"));
+        String spCertificate = request.getParameter("sp-certificate");
+        spCertificate = new String(Base64.getDecoder().decode(spCertificate), StandardCharsets.UTF_8);
+        serviceProvider.setCertificateContent(spCertificate);
 
         String jwks = request.getParameter("jwksUri");
         serviceProvider.setJwksUri(jwks);

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/add-service-provider.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/add-service-provider.jsp
@@ -106,6 +106,8 @@ function importAppOnclick() {
         location.href = '#';
         return false;
     } else {
+        var content = document.getElementById('sp-file-content').value;
+        document.getElementById('sp-file-content').value = btoa(content);
         $("#upload-sp-form").submit();
         return true;
     }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider-finish-ajaxprocessor.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider-finish-ajaxprocessor.jsp
@@ -29,6 +29,8 @@
 <%@page import="org.wso2.carbon.ui.CarbonUIMessage" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
 <%@ page import="org.wso2.carbon.utils.ServerConstants" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
+<%@ page import="java.util.Base64" %>
 <%@ page import="java.util.ResourceBundle" %>
 
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
@@ -59,6 +61,7 @@
                 appBean.updateLocalSp(request);
             } else {
                 String certString = request.getParameter("sp-certificate");
+                certString = new String(Base64.getDecoder().decode(certString), StandardCharsets.UTF_8);
                 String deleteCert = request.getParameter("deletePublicCert");
                 //validate public certificate content
                 if (StringUtils.isNotBlank(certString) && !Boolean.parseBoolean(deleteCert)) {

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider-update-ajaxprocessor.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider-update-ajaxprocessor.jsp
@@ -28,6 +28,8 @@
 <%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
 <%@ page import="org.wso2.carbon.utils.ServerConstants" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
+<%@ page import="java.util.Base64" %>
 <%@ page import="java.util.ResourceBundle" %>
 
 
@@ -56,6 +58,7 @@
                 appBean.updateLocalSp(request);
             } else {
                 String certString = request.getParameter("sp-certificate");
+                certString = new String(Base64.getDecoder().decode(certString), StandardCharsets.UTF_8);
                 String deleteCert = request.getParameter("deletePublicCert");
                 //validate public certificate content
                 if (StringUtils.isNotBlank(certString) && !Boolean.parseBoolean(deleteCert)) {

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-service-provider.jsp
@@ -555,15 +555,22 @@
                 }
                 CARBON.showConfirmationDialog(confirmationMessage,
                     function () {
+                        encodeSPCertificate();
                         document.getElementById("configure-sp-form").submit();
                     },
                     function () {
                         return false;
                     });
             } else {
+                encodeSPCertificate();
                 document.getElementById("configure-sp-form").submit();
             }
         }
+    }
+
+    function encodeSPCertificate() {
+        var spCertificate = document.getElementById('sp-certificate').value;
+        document.getElementById('sp-certificate').value = btoa(spCertificate);
     }
 
     function updateBeanAndRedirect(redirectURL) {

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/import-service-provider-finish-ajaxprocessor.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/import-service-provider-finish-ajaxprocessor.jsp
@@ -16,6 +16,8 @@
   ~  under the License.
   --%>
 
+<%@ page import="java.nio.charset.StandardCharsets"%>
+<%@ page import="java.util.Base64"%>
 <%@ page import="org.apache.axis2.context.ConfigurationContext"%>
 <%@ page import="org.owasp.encoder.Encode"%>
 <%@ page import="org.wso2.carbon.CarbonConstants"%>
@@ -36,6 +38,7 @@
         return;
     }
     String content = request.getParameter("sp-file-content");
+    content = new String(Base64.getDecoder().decode(content), StandardCharsets.UTF_8);
     String fileName = request.getParameter("sp-file-name");
     
     if (StringUtils.isNotEmpty(content)) {

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/resources/web/entitlement/update-policy-submit.jsp
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.ui/src/main/resources/web/entitlement/update-policy-submit.jsp
@@ -20,6 +20,8 @@
 <%@ page import="org.wso2.carbon.identity.entitlement.stub.dto.PolicyDTO"%>
 <%@ page import="org.wso2.carbon.identity.entitlement.ui.client.EntitlementPolicyAdminServiceClient"%>
 <%@ page import="org.wso2.carbon.ui.CarbonUIMessage"%>
+<%@ page import="java.nio.charset.StandardCharsets"%>
+<%@ page import="java.util.Base64"%>
 
 <%
 	String serverURL = CarbonUIUtil.getServerURL(config
@@ -52,7 +54,9 @@
             if(dto == null){
                 dto = new PolicyDTO();
             }
-            dto.setPolicy(request.getParameter("policy"));
+            String policy = request.getParameter("policy");
+            policy = new String(Base64.getDecoder().decode(policy), StandardCharsets.UTF_8);
+            dto.setPolicy(policy);
 			dto.setPolicyId(policyid);
             dto.setPolicyEditor("XML");
 			client.updatePolicy(dto);

--- a/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/src/main/resources/web/functions-library-mgt/add-functionlib-finish-ajaxprocessor.jsp
+++ b/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/src/main/resources/web/functions-library-mgt/add-functionlib-finish-ajaxprocessor.jsp
@@ -17,6 +17,8 @@
   --%>
 
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jstl/fmt" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
+<%@ page import="java.util.Base64" %>
 <%@ page import="org.apache.axis2.context.ConfigurationContext" %>
 <%@ page import="org.apache.axis2.transport.http.HTTPConstants" %>
 <%@ page import="org.apache.commons.lang.StringUtils" %>
@@ -46,6 +48,7 @@
     String functionLibName = request.getParameter(FUNCTION_LIBRARY_NAME);
     String description = request.getParameter(DESCRIPTION);
     String content = request.getParameter(SCRIPT_CONTENT);
+    content = new String(Base64.getDecoder().decode(content), StandardCharsets.UTF_8);
     
     if (StringUtils.isNotBlank(functionLibName) && StringUtils.isNotBlank(content)) {
         FunctionLibrary functionLibrary = new FunctionLibrary();

--- a/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/src/main/resources/web/functions-library-mgt/edit-functionlib-finish-ajaxprocessor.jsp
+++ b/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/src/main/resources/web/functions-library-mgt/edit-functionlib-finish-ajaxprocessor.jsp
@@ -27,6 +27,8 @@
 <%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
 <%@ page import="org.wso2.carbon.utils.ServerConstants" %>
 <%@ page import="java.util.ResourceBundle" %>
+<%@ page import="java.nio.charset.StandardCharsets" %>
+<%@ page import="java.util.Base64" %>
 <%@ page
         import="static org.wso2.carbon.identity.functions.library.mgt.ui.util.FunctionLibraryUIConstants.FUNCTION_LIBRARY_NAME" %>
 <%@ page
@@ -50,6 +52,7 @@
     String oldFunctionLibraryName = request.getParameter(OLD_FUNCTION_LIBRARY_NAME);
     String description = request.getParameter(DESCRIPTION);
     String content = request.getParameter(SCRIPT_CONTENT);
+    content = new String(Base64.getDecoder().decode(content), StandardCharsets.UTF_8);
     
     if (StringUtils.isNotBlank(functionLibraryName) && StringUtils.isNotBlank(content)) {
         

--- a/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/src/main/resources/web/functions-library-mgt/functions-library-mgt-add.jsp
+++ b/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/src/main/resources/web/functions-library-mgt/functions-library-mgt-add.jsp
@@ -79,6 +79,7 @@
                 } else {
                     try {
                         eval(prepareScript(content));
+                        encodeFunctionLibScript();
                         $("#add-functionlib-form").submit();
                         return true;
                     } catch (e) {

--- a/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/src/main/resources/web/functions-library-mgt/functions-library-mgt-edit.jsp
+++ b/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/src/main/resources/web/functions-library-mgt/functions-library-mgt-edit.jsp
@@ -107,6 +107,7 @@
                 }
 
                 function doEdit() {
+                    encodeFunctionLibScript();
                     $("#update-functionlib-form").submit();
                     return true;
                 }

--- a/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/src/main/resources/web/functions-library-mgt/js/function-lib-mgt.js
+++ b/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/src/main/resources/web/functions-library-mgt/js/function-lib-mgt.js
@@ -90,3 +90,7 @@ function getSelectedRange() {
 function checkEmptyEditorContent() {
     document.getElementById('scriptTextArea').value = doc.getValue();
 }
+
+function encodeFunctionLibScript() {
+    doc.setValue(btoa(doc.getValue()));
+}

--- a/components/policy-editor/org.wso2.carbon.policyeditor.ui/src/main/resources/web/policyeditor/js/policy-editor.js
+++ b/components/policy-editor/org.wso2.carbon.policyeditor.ui/src/main/resources/web/policyeditor/js/policy-editor.js
@@ -452,7 +452,7 @@ function postbackUpdatedPolicy() {
         + '<input type="hidden" name="policyid" value="' + policyId + '"/>';
 
     YAHOO.util.Event.onDOMReady(function() {
-        document.getElementById("policy-content").value = currentPolicyDoc.toString();
+        document.getElementById("policy-content").value = btoa(currentPolicyDoc.toString());
         document.postbackForm.submit();
     });
 


### PR DESCRIPTION
Resolves part of [product-is #13987](https://github.com/wso2/product-is/issues/13987)

Fixes the issue mentioned in product-is #13987 for 

- Add and update function libraries for adaptive authentication
- Configuring an SP using file configuration
- Upload SP certificate
- Adding and updating XACML policies

by base64 encoding the un-encoded HTML, XML or JSON input data