### PR TITLE
Enable oragnization paths for oauth2 endpoints

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2052,6 +2052,9 @@
                 <BasePath>/scim2/</BasePath>
             </Context>
             <Context>
+                <BasePath>/oauth2/</BasePath>
+            </Context>
+            <Context>
                 <BasePath>/api/</BasePath>
                 <SubPaths>
                     <Path>/api/server/v1/identity-providers</Path>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2785,6 +2785,9 @@
                 <BasePath>/scim2/</BasePath>
             </Context>
             <Context>
+                <BasePath>/oauth2/</BasePath>
+            </Context>
+            <Context>
                 <BasePath>/api/</BasePath>
                 <SubPaths>
                     <Path>/api/server/v1/identity-providers</Path>


### PR DESCRIPTION
### Proposed changes in this pull request
Enable o/<org-id> request paths for the OAuth related endpoints.

### Related Issues
https://github.com/wso2/product-is/issues/14099
