### PR TITLE
Hide Editrow AA from carbon console if Nashorn not available

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-authentication-flow.jsp
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/configure-authentication-flow.jsp
@@ -521,6 +521,16 @@
                             }%>/> Enable Script Based Adaptive Authentication
                         </label>
                     </div>
+                    <div class="script-select-container" style="display: none;">
+                        <label class="noselect">
+                            <input id="enableAdaptive" name="enableAdaptive" type="checkbox" value="true"
+                            <%
+                                 if(FrameworkUtils.isAdaptiveAuthenticationAvailable()) {
+                            %>
+                                   checked="checked"
+                            <% } %>/> Enable Adaptive Authentication
+                        </label>
+                    </div>
                 </div>
                 <div style="clear:both"></div>
                 <!-- sectionSub Div -->

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/js/configure-authentication-flow.js
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/src/main/resources/web/application/js/configure-authentication-flow.js
@@ -622,6 +622,14 @@ $("#enableScript").click(function () {
 
 $("#editorRow").hide();
 checkScriptEnabled();
+checkAdaptiveEnabled();
+
+function checkAdaptiveEnabled() {
+    adaptiveEnabled = $("#enableAdaptive").is(":checked");
+    if (!adaptiveEnabled) {
+        $("#editorRow").hide();
+    }
+}
 
 function checkScriptEnabled() {
     scriptEnabled = $("#enableScript").is(":checked");


### PR DESCRIPTION
$sub

Issue: https://github.com/wso2/product-is/issues/14147

Tested flow:
@nirmal101 tested the flow in the Issue and verified it's fixed.


OS; Ubunthu 20.04
JDK: OpenJDK 17

- Create an app in carbon console without AA enabled
- Create an app in console without AA enabled

OIDC flow tested and AA is not viewed in UI.

- Create an app in carbon console with AA enabled
- Create an app in console with AA enabled

OIDC flow tested and AA is viewed in UI.



OS; Ubunthu 20.04
JDK: OracleJDK 17

- Create an app in carbon console without AA enabled
- Create an app in console without AA enabled

OIDC flow tested and AA is not viewed in UI.

- Create an app in carbon console with AA enabled
- Create an app in console with AA enabled
AA is not viewed in UI.