### PR TITLE
Add a config to enable/disable Organization Management feature

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2069,6 +2069,10 @@
         <Path>/api/server/v1/organizations</Path>
     </OrgRoutingOnlySupportedAPIPaths>
 
+    <OrganizationManagement>
+        <Enable>false</Enable>
+    </OrganizationManagement>
+
     <!-- Server Synchronization Tolerance Configuration in seconds -->
     <ClockSkew>300</ClockSkew>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2070,7 +2070,7 @@
     </OrgRoutingOnlySupportedAPIPaths>
 
     <OrganizationManagement>
-        <Enable>false</Enable>
+        <Enable>true</Enable>
     </OrganizationManagement>
 
     <!-- Server Synchronization Tolerance Configuration in seconds -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2806,7 +2806,7 @@
     </OrgRoutingOnlySupportedAPIPaths>
 
     <OrganizationManagement>
-        <Enable>{{organization_management.enable | default(false)}}</Enable>
+        <Enable>{{organization_management.enable | default(true)}}</Enable>
     </OrganizationManagement>
 
     <!-- Server Synchronization Tolerance Configuration in seconds -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2719,10 +2719,13 @@
     -->
     <EnableFederatedUserAssociation>{{user.association.enable_for_federated_users}}</EnableFederatedUserAssociation>
 
-    <EnableTenantQualifiedUrls>{{tenant_context.enable_tenant_qualified_urls}}</EnableTenantQualifiedUrls>
-
-    <EnableTenantedSessions>{{tenant_context.enable_tenanted_sessions | default(false)}}</EnableTenantedSessions>
-
+    {% if organization_management.enable is true %}
+        <EnableTenantQualifiedUrls>true</EnableTenantQualifiedUrls>
+        <EnableTenantedSessions>true</EnableTenantedSessions>
+    {% else %}
+        <EnableTenantQualifiedUrls>{{tenant_context.enable_tenant_qualified_urls}}</EnableTenantQualifiedUrls>
+        <EnableTenantedSessions>{{tenant_context.enable_tenanted_sessions | default(false)}}</EnableTenantedSessions>
+    {% endif %}
 
     <!--
         When this property is set to 'true', if the username provided during the SaaS application authentication does
@@ -2801,6 +2804,10 @@
     <OrgRoutingOnlySupportedAPIPaths>
         <Path>/api/server/v1/organizations</Path>
     </OrgRoutingOnlySupportedAPIPaths>
+
+    <OrganizationManagement>
+        <Enable>{{organization_management.enable | default(false)}}</Enable>
+    </OrganizationManagement>
 
     <!-- Server Synchronization Tolerance Configuration in seconds -->
     <ClockSkew>{{server.clock_skew}}</ClockSkew>


### PR DESCRIPTION
### Proposed changes in this pull request
$Subject
Part of fix: https://github.com/wso2/product-is/issues/14219
By default, organization mgt is enabled in IS-6.0.0
By enabling organization mgt the following configs will automatically be enabled
(
```[tenant_context]
enable_tenant_qualified_urls = "true"
enable_tenanted_sessions = "true"
```
)
EnableTenantQualifiedUrls = true
EnableTenantedSessions = true

If you want to disable the organization mgt feature, add the following config to deployment.toml
```
[organization_management]
enable=false
```
