### PR TITLE
Add audit logs for session management

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.joda.time.DateTime;
+import org.json.JSONObject;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.database.utils.jdbc.exceptions.DataAccessException;
@@ -496,6 +497,11 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                 // store again. when replicate  cache is used. this may be needed.
                 FrameworkUtils.addSessionContextToCache(sessionContextKey, sessionContext, applicationTenantDomain,
                         context.getLoginTenantDomain());
+                // Since the session context is already available, audit log will be added with updated details.
+                addAuditLogs(SessionMgtConstants.UPDATE_SESSION_ACTION,
+                        authenticationResult.getSubject().getUserName(), sessionContextKey,
+                        authenticationResult.getSubject().getTenantDomain(), FrameworkUtils.getCorrelation(),
+                        updatedSessionTime, sessionContext.isRememberMe());
             } else {
                 analyticsSessionAction = FrameworkConstants.AnalyticsAttributes.SESSION_CREATE;
                 sessionContext = new SessionContext();
@@ -538,6 +544,12 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                         request, response, context);
                 FrameworkUtils.addSessionContextToCache(sessionContextKey, sessionContext, applicationTenantDomain,
                         context.getLoginTenantDomain());
+                // The session context will be stored from here. Since the audit log will be logged as a storing
+                // operation.
+                addAuditLogs(SessionMgtConstants.STORE_SESSION_ACTION,
+                        authenticationResult.getSubject().getUserName(), sessionContextKey,
+                        authenticationResult.getSubject().getTenantDomain(), FrameworkUtils.getCorrelation(),
+                        createdTimeMillis, sessionContext.isRememberMe());
                 setAuthCookie(request, response, context, sessionKey, applicationTenantDomain);
                 if (FrameworkServiceDataHolder.getInstance().isUserSessionMappingEnabled()) {
                     try {
@@ -1028,5 +1040,22 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             }
         }
         sessionContext.setAuthenticatedIdPsOfApp(applicationName, authenticatedIdPDataMap);
+    }
+
+    private void addAuditLogs(String sessionAction, String authenticatedUser, String sessionKey,
+                              String userTenantDomain, String traceId, Long lastAccessedTimestamp,
+                              boolean isRememberMe) {
+
+        JSONObject auditData = new JSONObject();
+        auditData.put(SessionMgtConstants.SESSION_CONTEXT_ID, sessionKey);
+        auditData.put(SessionMgtConstants.REMEMBER_ME, isRememberMe);
+        auditData.put(SessionMgtConstants.AUTHENTICATED_USER, authenticatedUser);
+        auditData.put(SessionMgtConstants.AUTHENTICATED_USER_TENANT_DOMAIN, userTenantDomain);
+        auditData.put(SessionMgtConstants.TRACE_ID, traceId);
+        /* When the action is StoreSession, the LastAccessedTimestamp means the session created timestamp. If the
+         action is UpdateSession, the LastAccessedTimestamp means the session's last accessed timestamp. */
+        auditData.put(SessionMgtConstants.SESSION_LAST_ACCESSED_TIMESTAMP, lastAccessedTimestamp);
+        AUDIT_LOG.info(String.format(SessionMgtConstants.AUDIT_MESSAGE_TEMPLATE, authenticatedUser,
+                sessionAction, auditData, SessionMgtConstants.SUCCESS));
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/ServerSessionManagementServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/ServerSessionManagementServiceImpl.java
@@ -21,6 +21,9 @@ package org.wso2.carbon.identity.application.authentication.framework.internal.i
 import org.apache.commons.lang.StringUtils;
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
+import org.json.JSONObject;
+import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.ServerSessionManagementService;
 import org.wso2.carbon.identity.application.authentication.framework.cache.SessionContextCache;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
@@ -28,6 +31,7 @@ import org.wso2.carbon.identity.application.authentication.framework.internal.Fr
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.authentication.framework.util.SessionMgtConstants;
 
 /**
  * A service to terminate the sessions of federated users
@@ -35,6 +39,8 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 public class ServerSessionManagementServiceImpl implements ServerSessionManagementService {
 
     private static Log log = LogFactory.getLog(ServerSessionManagementServiceImpl.class);
+
+    private static final org.apache.commons.logging.Log AUDIT_LOG = CarbonConstants.AUDIT_LOG;
 
     @Override
     public boolean removeSession(String sessionId) {
@@ -57,11 +63,11 @@ public class ServerSessionManagementServiceImpl implements ServerSessionManageme
      */
     private void terminateSession(SessionContext sessionContext, String sessionId) {
 
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
         if (FrameworkServiceDataHolder.getInstance().getAuthnDataPublisherProxy() != null && FrameworkServiceDataHolder
                 .getInstance().getAuthnDataPublisherProxy().isEnabled(null) && sessionContext != null) {
 
             Object authenticatedUserObj = sessionContext.getProperty(FrameworkConstants.AUTHENTICATED_USER);
-            AuthenticatedUser authenticatedUser = new AuthenticatedUser();
             if (authenticatedUserObj != null) {
                 authenticatedUser = (AuthenticatedUser) authenticatedUserObj;
             }
@@ -80,5 +86,21 @@ public class ServerSessionManagementServiceImpl implements ServerSessionManageme
         } else {
             SessionContextCache.getInstance().clearCacheEntry(sessionId);
         }
+        addAuditLogs(sessionId, CarbonContext.getThreadLocalCarbonContext().getUsername(),
+                authenticatedUser.getUserName(), (String) tenantDomainObj, FrameworkUtils.getCorrelation(),
+                System.currentTimeMillis());
+    }
+
+    private void addAuditLogs(String sessionKey, String initiator, String authenticatedUser, String userTenantDomain,
+                              String traceId, Long terminatedTimestamp) {
+
+        JSONObject auditData = new JSONObject();
+        auditData.put(SessionMgtConstants.SESSION_CONTEXT_ID, sessionKey);
+        auditData.put(SessionMgtConstants.AUTHENTICATED_USER, authenticatedUser);
+        auditData.put(SessionMgtConstants.AUTHENTICATED_USER_TENANT_DOMAIN, userTenantDomain);
+        auditData.put(SessionMgtConstants.TRACE_ID, traceId);
+        auditData.put(SessionMgtConstants.SESSION_TERMINATE_TIMESTAMP, terminatedTimestamp);
+        AUDIT_LOG.info(String.format(SessionMgtConstants.AUDIT_MESSAGE_TEMPLATE, initiator,
+                SessionMgtConstants.TERMINATE_SESSION_ACTION, auditData, SessionMgtConstants.SUCCESS));
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionMgtConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionMgtConstants.java
@@ -34,6 +34,20 @@ public class SessionMgtConstants {
     public static final String FEDERATED_IDP_NAME = "IDP_NAME";
     public static final String FEDERATED_AUTHENTICATOR_ID = "AUTHENTICATOR_ID";
     public static final String FEDERATED_PROTOCOL_TYPE = "PROTOCOL_TYPE";
+    public static final String AUDIT_MESSAGE_TEMPLATE = "Initiator : %s | Action : %s | Data : { %s } | Result : %s ";
+    public static final String SESSION_CONTEXT_ID = "sessionContextId";
+    public static final String REMEMBER_ME = "RememberMe";
+    public static final String SUCCESS = "Success";
+    public static final String AUTHENTICATED_USER = "AuthenticatedUser";
+    public static final String AUTHENTICATED_USER_TENANT_DOMAIN = "AuthenticatedUserTenantDomain";
+    public static final String TRACE_ID = "traceId";
+    public static final String STORE_SESSION_ACTION = "StoreSession";
+    public static final String UPDATE_SESSION_ACTION = "UpdateSession";
+    public static final String TERMINATE_SESSION_ACTION = "TerminateSession";
+    public static final String SESSION_LAST_ACCESSED_TIMESTAMP = "LastAccessedTimestamp";
+    public static final String SESSION_TERMINATE_TIMESTAMP = "TerminatedTimestamp";
+
+
 
     /**
      * Session management error messages.


### PR DESCRIPTION
### Proposed changes in this pull request

* Added the audit logs for the session management.
* Session add and session terminate with session ID and terminate all the session for a user are now have audit logs.