### PR TITLE
Get sp app with app-id and tenant domain

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
@@ -63,9 +63,10 @@ public interface ApplicationDAO {
      * Get service provider resides in given tenant domain.
      *
      * @param applicationId The application id.
-     * @param tenantDomain  The tenant domain of the application resides.
+     * @param tenantDomain  The tenant domain where the application resides.
      * @return Service provider.
-     * @throws IdentityApplicationManagementException
+     * @throws IdentityApplicationManagementException throws when an error occurs in retrieving service provider with
+     *                                                all the configurations.
      */
     default ServiceProvider getApplication(int applicationId, String tenantDomain)
             throws IdentityApplicationManagementException {

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
@@ -49,14 +49,19 @@ public interface ApplicationDAO {
             throws IdentityApplicationManagementException;
 
     /**
+     * Get service provider when the application resides in the same tenant of the request initiated.
+     *
      * @param applicationId
      * @return
      * @throws IdentityApplicationManagementException
+     * @deprecated please use #getApplication(applicationId, tenantDomain)
      */
     @Deprecated
     ServiceProvider getApplication(int applicationId) throws IdentityApplicationManagementException;
 
     /**
+     * Get service provider resides in given tenant domain.
+     *
      * @param applicationId The application id.
      * @param tenantDomain  The tenant domain of the application resides.
      * @return

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
@@ -53,7 +53,20 @@ public interface ApplicationDAO {
      * @return
      * @throws IdentityApplicationManagementException
      */
+    @Deprecated
     ServiceProvider getApplication(int applicationId) throws IdentityApplicationManagementException;
+
+    /**
+     * @param applicationId The application id.
+     * @param tenantDomain  The tenant domain of the application resides.
+     * @return
+     * @throws IdentityApplicationManagementException
+     */
+    default ServiceProvider getApplication(int applicationId, String tenantDomain)
+            throws IdentityApplicationManagementException {
+
+        return null;
+    }
 
     /**
      * @return

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
@@ -51,10 +51,10 @@ public interface ApplicationDAO {
     /**
      * Get service provider when the application resides in the same tenant of the request initiated.
      *
-     * @param applicationId
-     * @return
+     * @param applicationId The application id.
+     * @return Service provider.
      * @throws IdentityApplicationManagementException
-     * @deprecated please use #getApplication(applicationId, tenantDomain)
+     * @deprecated with getApplication(applicationId, tenantDomain) method.
      */
     @Deprecated
     ServiceProvider getApplication(int applicationId) throws IdentityApplicationManagementException;
@@ -64,7 +64,7 @@ public interface ApplicationDAO {
      *
      * @param applicationId The application id.
      * @param tenantDomain  The tenant domain of the application resides.
-     * @return
+     * @return Service provider.
      * @throws IdentityApplicationManagementException
      */
     default ServiceProvider getApplication(int applicationId, String tenantDomain)

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -2132,9 +2132,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
     public ServiceProvider getApplication(int applicationId, String tenantDomain)
             throws IdentityApplicationManagementException {
 
-        Connection connection = IdentityDatabaseUtil.getDBConnection(false);
-        try {
-
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
             // Load basic application data
             ServiceProvider serviceProvider = getBasicApplicationData(applicationId, connection);
             if (serviceProvider == null) {
@@ -2192,8 +2190,6 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         } catch (SQLException | CertificateRetrievingException e) {
             throw new IdentityApplicationManagementException("Failed to get service provider with id: " + applicationId,
                     e);
-        } finally {
-            IdentityApplicationManagementUtil.closeConnection(connection);
         }
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

The SaaS apps can be shared across sub organizations by the admin user who owned the SaaS app. The fragment apps created after the organization sharing also owned by the admin of the SaaS app. When retrieving the fragment applications, the app owner's tenant domain can't be used anymore as the fragmented app is assigned against the corresponding sub organization. (In the SP_INBOUND_AUTH table)

Introduced a new method to get the Service provider by the applicationId and tenant domain it resides.

### Related Issues
- https://github.com/wso2/product-is/issues/14335