### PR TITLE
Handle wso2carbon-local-sp owner wso2.system.user

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -914,8 +914,12 @@ public class ApplicationMgtUtil {
     public static String getUserTenantDomain(String tenantDomain, String username)
             throws IdentityApplicationManagementException {
 
-        return getUser(tenantDomain, username).orElseThrow(() -> new IdentityApplicationManagementException("Error " +
-                "resolving user.")).getTenantDomain();
+        if (CarbonConstants.REGISTRY_SYSTEM_USERNAME.equals(username)) {
+            return tenantDomain;
+        } else {
+            return getUser(tenantDomain, username).orElseThrow(() -> new IdentityApplicationManagementException(
+                    "Error resolving user.")).getTenantDomain();
+        }
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request
Resolve the tenant domain as the tenant domain of the existing flow for `wso2.system.user` who set as owner of `wso2carbon-local-sp` on its creation.

### Related Issues
[wso2/product-is #14337](https://github.com/wso2/product-is/issues/14337)