### PR TITLE
Permission check to access share application endpoint.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1906,8 +1906,8 @@
             <Scopes>internal_organization_create</Scopes>
         </Resource>
         <Resource context="(.*)/api/server/v1/organizations/(.*)/share" secured="true" http-method="POST">
-            <Permissions>/permission/admin/manage/identity/organizationmgt/update</Permissions>
-            <Scopes>internal_organization_update</Scopes>
+            <Permissions>/permission/admin/manage/identity/applicationmgt/update</Permissions>
+            <Scopes>internal_application_mgt_update</Scopes>
         </Resource>
         <Resource context="(.*)/api/server/v1/organizations/(.*)" secured="true" http-method="PATCH">
             <Permissions>/permission/admin/manage/identity/organizationmgt/update</Permissions>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1905,6 +1905,10 @@
             <Permissions>/permission/admin/manage/identity/organizationmgt/create</Permissions>
             <Scopes>internal_organization_create</Scopes>
         </Resource>
+        <Resource context="(.*)/api/server/v1/organizations/(.*)/share" secured="true" http-method="POST">
+            <Permissions>/permission/admin/manage/identity/organizationmgt/update</Permissions>
+            <Scopes>internal_organization_update</Scopes>
+        </Resource>
         <Resource context="(.*)/api/server/v1/organizations/(.*)" secured="true" http-method="PATCH">
             <Permissions>/permission/admin/manage/identity/organizationmgt/update</Permissions>
             <Scopes>internal_organization_update</Scopes>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2590,8 +2590,8 @@
             <Scopes>internal_organization_create</Scopes>
         </Resource>
         <Resource context="(.*)/api/server/v1/organizations/(.*)/share" secured="true" http-method="POST">
-            <Permissions>/permission/admin/manage/identity/organizationmgt/update</Permissions>
-            <Scopes>internal_organization_update</Scopes>
+            <Permissions>/permission/admin/manage/identity/applicationmgt/update</Permissions>
+            <Scopes>internal_application_mgt_update</Scopes>
         </Resource>
         <Resource context="(.*)/api/server/v1/organizations/(.*)" secured="true" http-method="PATCH">
             <Permissions>/permission/admin/manage/identity/organizationmgt/update</Permissions>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2589,6 +2589,10 @@
             <Permissions>/permission/admin/manage/identity/organizationmgt/create</Permissions>
             <Scopes>internal_organization_create</Scopes>
         </Resource>
+        <Resource context="(.*)/api/server/v1/organizations/(.*)/share" secured="true" http-method="POST">
+            <Permissions>/permission/admin/manage/identity/organizationmgt/update</Permissions>
+            <Scopes>internal_organization_update</Scopes>
+        </Resource>
         <Resource context="(.*)/api/server/v1/organizations/(.*)" secured="true" http-method="PATCH">
             <Permissions>/permission/admin/manage/identity/organizationmgt/update</Permissions>
             <Scopes>internal_organization_update</Scopes>


### PR DESCRIPTION
### Proposed changes in this pull request
Adding permission check to restrict sharing application to child organization. `/permission/admin/manage/identity/organizationmgt/update` permission is required for application sharing.