### PR TITLE
Get service provider by app-id and tenant domain

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -1816,7 +1816,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
             localServiceProvider.setDescription("Local Service Provider");
             applicationId = createServiceProvider(tenantDomain, localServiceProvider);
         }
-        return getApplication(applicationId);
+        return getApplication(applicationId, tenantDomain);
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request
With the organization management, the applications and app owner could resides in separate tenants. In that case, the newly introduced method to get service provider by app-id and tenant domain can be used.

### Related Issues
- https://github.com/wso2/product-is/issues/14335