### PR TITLE
Add Support to Resolve Multiple Claim Dialects

### DIFF
--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/AbstractOutboundProvisioningConnector.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/AbstractOutboundProvisioningConnector.java
@@ -68,6 +68,18 @@ public abstract class AbstractOutboundProvisioningConnector implements Serializa
     }
 
     /**
+     * Override only if needed - if claims are controlled by the identity provider, this will return null.
+     * If it is connector specific this must return the corresponding claim dialects.
+     *
+     * @return
+     * @throws IdentityProvisioningException
+     */
+    public String[] getClaimDialectUris() throws IdentityProvisioningException {
+
+        return null;
+    }
+
+    /**
      * @return
      * @throws IdentityProvisioningException
      */


### PR DESCRIPTION
This PR adds support to obtain multiple claim dialect URIs from the outbound connector and get the claim mappings from all the dialects.

Related Issue: https://github.com/wso2/product-is/issues/14378