### PR TITLE
Fix tenant domain append for organization management related resource urls

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
@@ -121,7 +121,8 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         String resolvedUrlContext = buildUrlPath(urlPaths);
         StringBuilder resolvedUrlStringBuilder = new StringBuilder();
 
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && !resolvedUrlContext.startsWith("t/")) {
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && !resolvedUrlContext.startsWith("t/") &&
+                !resolvedUrlContext.startsWith("o/")) {
             if (mandateTenantedPath || isNotSuperTenant(tenantDomain)) {
                 resolvedUrlStringBuilder.append("/t/").append(tenantDomain);
             }


### PR DESCRIPTION
### Proposed changes in this pull request
Stop appending tenant path for organization management related resources when tenant qualified urls enabled.

### Related Issues
https://github.com/wso2/product-is/issues/14359

