### PR TITLE
Add i18n mappings for invalid client in tenant

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtil.java
@@ -293,6 +293,8 @@ public class AuthenticationEndpointUtil {
                 return Constants.ErrorToi18nMappingConstants.SUSPICIOUS_AUTHENTICATION_ATTEMPTS_SUSPICIOUS_AUTHENTICATION_ATTEMPTS_DESCRIPTION_I18N_KEY;
             case Constants.ErrorToi18nMappingConstants.AUTHENTICATION_FAILED_NO_REGISTERED_DEVICE_FOUND:
                 return Constants.ErrorToi18nMappingConstants.NO_REGISTERED_DEVICE_FOUND_I18N_KEY;
+            case Constants.ErrorToi18nMappingConstants.INVALID_CLIENT_IN_TENANT:
+                return Constants.ErrorToi18nMappingConstants.INVALID_CLIENT_IN_TENANT_I18N_KEY;
             default:
                 return Constants.ErrorToi18nMappingConstants.INCORRECT_ERROR_MAPPING_KEY;
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/Constants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/Constants.java
@@ -245,6 +245,8 @@ public class Constants {
                 "authentication.failed_no.registered.device.found";
         public static final String NO_REGISTERED_DEVICE_FOUND_I18N_KEY =
                 "no.registered.device.found";
+        public static final String INVALID_CLIENT_IN_TENANT = "invalid_client_no.valid.client.in.tenant";
+        public static final String INVALID_CLIENT_IN_TENANT_I18N_KEY = "no.valid.client.in.tenant";
 
         private ErrorToi18nMappingConstants() {
 


### PR DESCRIPTION
### Proposed changes in this pull request

* Added i18n mappings for the error message which is displayed when the client is invalid for a tenant.

### When should this PR be merged
