### PR TITLE
Resolve redirection inconsistency when user's account is locked.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
@@ -113,6 +113,7 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
                     // Decide whether we need to redirect to the login page to retry authentication.
                     boolean sendToMultiOptionPage =
                             isStepHasMultiOption(context) && isRedirectToMultiOptionPageOnFailure();
+                    context.setSendToMultiOptionPage(sendToMultiOptionPage);
                     context.setRetrying(retryAuthenticationEnabled());
                     if (retryAuthenticationEnabled(context) && !sendToMultiOptionPage) {
                         if (log.isDebugEnabled()) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
@@ -114,6 +114,8 @@ public class AuthenticationContext extends MessageContext implements Serializabl
 
     private final Map<String, List<String>> loggedOutAuthenticators = new HashMap<>();
 
+    private boolean sendToMultiOptionPage;
+
     public String getCallerPath() {
         return callerPath;
     }
@@ -436,6 +438,16 @@ public class AuthenticationContext extends MessageContext implements Serializabl
             requestedAcr = new ArrayList<>();
         }
         requestedAcr.add(acr);
+    }
+
+    public boolean isSendToMultiOptionPage() {
+
+        return sendToMultiOptionPage;
+    }
+
+    public void setSendToMultiOptionPage(boolean sendToMultiOptionPage) {
+
+        this.sendToMultiOptionPage = sendToMultiOptionPage;
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
@@ -440,11 +440,19 @@ public class AuthenticationContext extends MessageContext implements Serializabl
         requestedAcr.add(acr);
     }
 
+    /**
+     * Get value of sendToMultiOptionPage from the authentication context.
+     * @return boolean Whether the user should be redirected to the login page to retry the authentication.
+     */
     public boolean isSendToMultiOptionPage() {
 
         return sendToMultiOptionPage;
     }
 
+    /**
+     * Add value of sendToMultiOptionPage to the authentication context.
+     * @param sendToMultiOptionPage Whether the user should be redirected to the login page to retry the authentication.
+     */
     public void setSendToMultiOptionPage(boolean sendToMultiOptionPage) {
 
         this.sendToMultiOptionPage = sendToMultiOptionPage;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -1074,7 +1074,7 @@ public class DefaultStepHandler implements StepHandler {
     /**
      * Check whether the user should be redirected to the retry.jsp page when the user's account is locked.
      * This decision is taken based on three configuration options, redirectToMultiOptionPageOnFailure,
-     * showAuthFailureReasonOnLoginPage and redirectToRetryPageOnAccountLock.
+       showAuthFailureReasonOnLoginPage and redirectToRetryPageOnAccountLock.
      *
      * @param context  Authentication context.
      * @return boolean Whether the user should be directed to retry.jsp page or not.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -1082,18 +1082,19 @@ public class DefaultStepHandler implements StepHandler {
     private boolean isRedirectionToRetryPage(AuthenticationContext context) {
 
         boolean sendToMultiOptionPage = context.isSendToMultiOptionPage();
-        if (!sendToMultiOptionPage) {
-            Map<String, String> parameterMap = getAuthenticatorConfig().getParameterMap();
-            if (MapUtils.isNotEmpty(parameterMap)) {
-                String showAuthFailureReasonOnLoginPage =
-                        parameterMap.get(FrameworkConstants.SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE_CONF);
-                if (Boolean.parseBoolean(showAuthFailureReasonOnLoginPage)) {
-                    return false;
-                }
-                String redirectToRetryPageOnAccountLock =
-                        parameterMap.get(FrameworkConstants.REDIRECT_TO_RETRY_PAGE_ON_ACCOUNT_LOCK_CONF);
-                return Boolean.parseBoolean(redirectToRetryPageOnAccountLock);
+        if (sendToMultiOptionPage) {
+            return false;
+        }
+        Map<String, String> parameterMap = getAuthenticatorConfig().getParameterMap();
+        if (MapUtils.isNotEmpty(parameterMap)) {
+            String showAuthFailureReasonOnLoginPage =
+                    parameterMap.get(FrameworkConstants.SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE_CONF);
+            if (Boolean.parseBoolean(showAuthFailureReasonOnLoginPage)) {
+                return false;
             }
+            String redirectToRetryPageOnAccountLock =
+                    parameterMap.get(FrameworkConstants.REDIRECT_TO_RETRY_PAGE_ON_ACCOUNT_LOCK_CONF);
+            return Boolean.parseBoolean(redirectToRetryPageOnAccountLock);
         }
         return false;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -1006,7 +1006,7 @@ public class DefaultStepHandler implements StepHandler {
                 if (errorContextParams.stream().anyMatch(nameValuePair ->
                         FrameworkConstants.ERROR_CODE.equals(nameValuePair.getName()) &&
                                 UserCoreConstants.ErrorCode.USER_IS_LOCKED.equals(nameValuePair.getValue()))) {
-                    if (isRedirectionToRetryPage(context)) {
+                    if (isRedirectionToRetryPageOnAccountLock(context)) {
                         String retryPage = ConfigurationFacade.getInstance().getAuthenticationEndpointRetryURL();
                         return response.encodeRedirectURL(retryPage
                                 + ("?" + context.getContextIdIncludedQueryParams()))
@@ -1079,7 +1079,7 @@ public class DefaultStepHandler implements StepHandler {
      * @param context  Authentication context.
      * @return boolean Whether the user should be directed to retry.jsp page or not.
      */
-    private boolean isRedirectionToRetryPage(AuthenticationContext context) {
+    private boolean isRedirectionToRetryPageOnAccountLock(AuthenticationContext context) {
 
         boolean sendToMultiOptionPage = context.isSendToMultiOptionPage();
         if (sendToMultiOptionPage) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -66,6 +66,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -862,6 +863,7 @@ public class DefaultStepHandler implements StepHandler {
         // URL previously set by an authenticator and generates a query string to be appended to the new redirect URL.
         StringBuilder reCaptchaParamString = new StringBuilder("");
         StringBuilder errorParamString = new StringBuilder("");
+        List<NameValuePair> errorContextParams = new ArrayList<>();
         String basicAuthRedirectUrl = ((CommonAuthResponseWrapper) response).getRedirectURL();
         if (StringUtils.isNotBlank(basicAuthRedirectUrl)) {
             List<NameValuePair> queryParameters = new URIBuilder(basicAuthRedirectUrl).getQueryParams();
@@ -878,12 +880,12 @@ public class DefaultStepHandler implements StepHandler {
             }
 
             if (errorContext == null) {
-                List<NameValuePair> errorContextParams = queryParameters.stream()
+                 errorContextParams.addAll(queryParameters.stream()
                         .filter(param -> FrameworkConstants.ERROR_CODE.equals(param.getName()) ||
                                 FrameworkConstants.LOCK_REASON.equals(param.getName()) ||
                                 FrameworkConstants.REMAINING_ATTEMPTS.equals(param.getName()) ||
                                 FrameworkConstants.FAILED_USERNAME.equals(param.getName()))
-                        .collect(Collectors.toList());
+                        .collect(Collectors.toList()));
                 if (errorContextParams.size() > 0) {
                     for (NameValuePair errorParams : errorContextParams) {
                         errorParamString.append("&").append(errorParams.getName()).append("=")
@@ -1001,6 +1003,16 @@ public class DefaultStepHandler implements StepHandler {
                             reCaptchaParamString.toString();
                 }
             } else {
+                if (errorContextParams.stream().anyMatch(nameValuePair ->
+                        FrameworkConstants.ERROR_CODE.equals(nameValuePair.getName()) &&
+                                UserCoreConstants.ErrorCode.USER_IS_LOCKED.equals(nameValuePair.getValue()))) {
+                    if (isRedirectionToRetryPage(context)) {
+                        String retryPage = ConfigurationFacade.getInstance().getAuthenticationEndpointRetryURL();
+                        return response.encodeRedirectURL(retryPage
+                                + ("?" + context.getContextIdIncludedQueryParams()))
+                                + errorParamString;
+                    }
+                }
                 return response.encodeRedirectURL(loginPage + ("?" + context.getContextIdIncludedQueryParams())) +
                         "&authenticators=" + URLEncoder.encode(authenticatorNames, "UTF-8") + retryParam +
                         reCaptchaParamString.toString() + errorParamString;
@@ -1057,5 +1069,32 @@ public class DefaultStepHandler implements StepHandler {
             authConfig.setParameterMap(new HashMap());
         }
         return authConfig;
+    }
+
+    /**
+     * Check whether the user should be redirected to the retry.jsp page when the user's account is locked.
+     * This decision is taken based on three configuration options, redirectToMultiOptionPageOnFailure,
+     * showAuthFailureReasonOnLoginPage and redirectToRetryPageOnAccountLock.
+     *
+     * @param context  Authentication context.
+     * @return boolean Whether the user should be directed to retry.jsp page or not.
+     */
+    private boolean isRedirectionToRetryPage(AuthenticationContext context) {
+
+        boolean sendToMultiOptionPage = context.isSendToMultiOptionPage();
+        if (!sendToMultiOptionPage) {
+            Map<String, String> parameterMap = getAuthenticatorConfig().getParameterMap();
+            if (MapUtils.isNotEmpty(parameterMap)) {
+                String showAuthFailureReasonOnLoginPage =
+                        parameterMap.get(FrameworkConstants.SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE_CONF);
+                if ("true".equals(showAuthFailureReasonOnLoginPage)) {
+                    return false;
+                }
+                String redirectToRetryPageOnAccountLock =
+                        parameterMap.get(FrameworkConstants.REDIRECT_TO_RETRY_PAGE_ON_ACCOUNT_LOCK_CONF);
+                return !"false".equals(redirectToRetryPageOnAccountLock);
+            }
+        }
+        return false;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -1087,12 +1087,12 @@ public class DefaultStepHandler implements StepHandler {
             if (MapUtils.isNotEmpty(parameterMap)) {
                 String showAuthFailureReasonOnLoginPage =
                         parameterMap.get(FrameworkConstants.SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE_CONF);
-                if ("true".equals(showAuthFailureReasonOnLoginPage)) {
+                if (Boolean.parseBoolean(showAuthFailureReasonOnLoginPage)) {
                     return false;
                 }
                 String redirectToRetryPageOnAccountLock =
                         parameterMap.get(FrameworkConstants.REDIRECT_TO_RETRY_PAGE_ON_ACCOUNT_LOCK_CONF);
-                return !"false".equals(redirectToRetryPageOnAccountLock);
+                return Boolean.parseBoolean(redirectToRetryPageOnAccountLock);
             }
         }
         return false;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -87,6 +87,8 @@ public abstract class FrameworkConstants {
     public static final String BASIC_AUTHENTICATOR_CLASS = "BasicAuthenticator";
     public static final String LOCAL = "LOCAL";
     public static final String SHOW_AUTHFAILURE_RESON_CONFIG = "showAuthFailureReason";
+    public static final String SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE_CONF = "showAuthFailureReasonOnLoginPage";
+    public static final String REDIRECT_TO_RETRY_PAGE_ON_ACCOUNT_LOCK_CONF = "redirectToRetryPageOnAccountLock";
     public static final String AUTHENTICATED_USER = "AuthenticatedUser";
     public static final String CREATED_TIMESTAMP = "CreatedTimestamp";
     public static final String UPDATED_TIMESTAMP = "UpdatedTimestamp";

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -67,6 +67,7 @@
   "authentication.authenticator.basic.enable": true,
   "authentication.authenticator.basic.parameters.AuthMechanism": "basic",
   "authentication.authenticator.basic.parameters.Tags": "Username-Password",
+  "authentication.authenticator.basic.parameters.redirectToRetryPageOnAccountLock": "false",
 
   "authentication.authenticator.basic_request_path.name": "BasicAuthRequestPathAuthenticator",
   "authentication.authenticator.basic_request_path.enable": true,


### PR DESCRIPTION
**Purpose**

Fix the issue reported in https://github.com/wso2/product-is/issues/14221.
A new authenticator configuration is introduced to keep the existing behavior or enable the new behavior.

redirectToRetryPageOnAccountLock = false

In the following setting,

showAuthFailureReason = true
redirectToMultiOptionPageOnFailure = false
showAuthFailureReasonOnLoginPage = false

If the redirectToRetryPageOnAccountLock is set to false, the user will be redirected to the retry.jsp page if the adaptive authentication script is not defined (default)  and redirected to the login.jsp if the adaptive authentication script is added.

If the redirectToRetryPageOnAccountLock is set to true, the user will be redirected to the retry.jsp page regardless of adaptive authentication script’s existence. 
