### PR TITLE
Fix behaviour of return_only_mapped_local_roles property

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -298,14 +298,24 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
                     String idpRoleClaimUri = getIdpRoleClaimUri(stepConfig, context);
 
                     // Get the mapped user roles according to the mapping in the IDP configuration.
-                    // Include the unmapped roles as it is.
-                    List<String> identityProviderMappedUserRolesUnmappedInclusive = getIdentityProvideMappedUserRoles(
-                            externalIdPConfig, extAttibutesValueMap, idpRoleClaimUri, returnOnlyMappedLocalRoles);
+                    // If no mapping is provided, return all IDP roles as they are.
+                    List<String> identityProviderMappedUserRolesUnmappedInclusive;
+                    if (MapUtils.isEmpty(externalIdPConfig.getRoleMappings())) {
+                        identityProviderMappedUserRolesUnmappedInclusive = getIdentityProvideMappedUserRoles(
+                                externalIdPConfig, extAttibutesValueMap, idpRoleClaimUri, false);
+                    } else {
+                        identityProviderMappedUserRolesUnmappedInclusive = getIdentityProvideMappedUserRoles(
+                                externalIdPConfig, extAttibutesValueMap, idpRoleClaimUri, returnOnlyMappedLocalRoles);
+                    }
 
                     String serviceProviderMappedUserRoles = getServiceProviderMappedUserRoles(sequenceConfig,
                             identityProviderMappedUserRolesUnmappedInclusive);
                     if (StringUtils.isNotBlank(idpRoleClaimUri)
                             && StringUtils.isNotBlank(serviceProviderMappedUserRoles)) {
+                        extAttibutesValueMap.put(idpRoleClaimUri, serviceProviderMappedUserRoles);
+                    }
+
+                    if (returnOnlyMappedLocalRoles && StringUtils.isBlank(serviceProviderMappedUserRoles)) {
                         extAttibutesValueMap.put(idpRoleClaimUri, serviceProviderMappedUserRoles);
                     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

We have the following property in IDP role mapping.

```
[idp_role_management]
return_only_mapped_local_roles = true
```
When this is added, the following will be the behavior.

1. If there is no IDP role mapping added, the server will return all IDP roles as they are.
2. If there is IDP role mapping and matching mapping is present, the server will send only the matched and mapped local roles.
3. If there is IDP role mapping and no matching mapping is present, the server will not send any roles.

Refers https://github.com/wso2/product-is/issues/11941