### PR TITLE
Introduce Configuration to Restrict SP Requested Claims

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -57,6 +57,8 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.CONFIG_RESTRICT_SP_REQUESTED_CLAIM_FILTERING;
+
 /**
  * Default implementation of step based sequence handler.
  */
@@ -67,6 +69,7 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
     private static final String SEND_ONLY_LOCALLY_MAPPED_ROLES_OF_IDP = "FederatedRoleManagement"
             + ".ReturnOnlyMappedLocalRoles";
     private static boolean returnOnlyMappedLocalRoles = false;
+    private static boolean restrictSPRequestedClaimFiltering = true;
 
     public static DefaultStepBasedSequenceHandler getInstance() {
 
@@ -85,6 +88,10 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
         if (IdentityUtil.getProperty(SEND_ONLY_LOCALLY_MAPPED_ROLES_OF_IDP) != null) {
             returnOnlyMappedLocalRoles = Boolean
                     .parseBoolean(IdentityUtil.getProperty(SEND_ONLY_LOCALLY_MAPPED_ROLES_OF_IDP));
+        }
+        if (StringUtils.isNotBlank(IdentityUtil.getProperty(CONFIG_RESTRICT_SP_REQUESTED_CLAIM_FILTERING))) {
+            restrictSPRequestedClaimFiltering =
+                    Boolean.parseBoolean(IdentityUtil.getProperty(CONFIG_RESTRICT_SP_REQUESTED_CLAIM_FILTERING));
         }
     }
 
@@ -345,7 +352,8 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
                         // send all local mapped claim values or idp claim values
                         ApplicationConfig appConfig = context.getSequenceConfig().getApplicationConfig();
                         if (MapUtils.isEmpty(appConfig.getRequestedClaimMappings()) &&
-                                !isSPStandardClaimDialect(context.getRequestType())) {
+                                (!restrictSPRequestedClaimFiltering ||
+                                        !isSPStandardClaimDialect(context.getRequestType()))) {
 
                             if (MapUtils.isNotEmpty(localClaimValues)) {
                                 mappedAttrs = localClaimValues;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -57,7 +57,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.CONFIG_RESTRICT_SP_REQUESTED_CLAIM_FILTERING;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.CONFIG_ALLOW_SP_REQUESTED_FED_CLAIMS_ONLY;
 
 /**
  * Default implementation of step based sequence handler.
@@ -69,7 +69,7 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
     private static final String SEND_ONLY_LOCALLY_MAPPED_ROLES_OF_IDP = "FederatedRoleManagement"
             + ".ReturnOnlyMappedLocalRoles";
     private static boolean returnOnlyMappedLocalRoles = false;
-    private static boolean restrictSPRequestedClaimFiltering = true;
+    private static boolean allowSPRequestedFedClaimsOnly = true;
 
     public static DefaultStepBasedSequenceHandler getInstance() {
 
@@ -89,9 +89,9 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
             returnOnlyMappedLocalRoles = Boolean
                     .parseBoolean(IdentityUtil.getProperty(SEND_ONLY_LOCALLY_MAPPED_ROLES_OF_IDP));
         }
-        if (StringUtils.isNotBlank(IdentityUtil.getProperty(CONFIG_RESTRICT_SP_REQUESTED_CLAIM_FILTERING))) {
-            restrictSPRequestedClaimFiltering =
-                    Boolean.parseBoolean(IdentityUtil.getProperty(CONFIG_RESTRICT_SP_REQUESTED_CLAIM_FILTERING));
+        if (StringUtils.isNotBlank(IdentityUtil.getProperty(CONFIG_ALLOW_SP_REQUESTED_FED_CLAIMS_ONLY))) {
+            allowSPRequestedFedClaimsOnly =
+                    Boolean.parseBoolean(IdentityUtil.getProperty(CONFIG_ALLOW_SP_REQUESTED_FED_CLAIMS_ONLY));
         }
     }
 
@@ -352,7 +352,7 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
                         // send all local mapped claim values or idp claim values
                         ApplicationConfig appConfig = context.getSequenceConfig().getApplicationConfig();
                         if (MapUtils.isEmpty(appConfig.getRequestedClaimMappings()) &&
-                                (!restrictSPRequestedClaimFiltering ||
+                                (!allowSPRequestedFedClaimsOnly ||
                                         !isSPStandardClaimDialect(context.getRequestType()))) {
 
                             if (MapUtils.isNotEmpty(localClaimValues)) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -131,6 +131,7 @@ public abstract class FrameworkConstants {
 
     public static final String SERVICE_PROVIDER_SUBJECT_CLAIM_VALUE = "ServiceProviderSubjectClaimValue";
     public static final String CONFIG_ENABLE_SCOPE_BASED_CLAIM_FILTERING = "EnableScopeBasedClaimFiltering";
+    public static final String CONFIG_RESTRICT_SP_REQUESTED_CLAIM_FILTERING = "RestrictSPRequestedClaimFiltering";
 
     public static final String REMEMBER_ME_OPT_ON = "on";
     public static final String LAST_FAILED_AUTHENTICATOR = "LastFailedAuthenticator";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -131,7 +131,7 @@ public abstract class FrameworkConstants {
 
     public static final String SERVICE_PROVIDER_SUBJECT_CLAIM_VALUE = "ServiceProviderSubjectClaimValue";
     public static final String CONFIG_ENABLE_SCOPE_BASED_CLAIM_FILTERING = "EnableScopeBasedClaimFiltering";
-    public static final String CONFIG_RESTRICT_SP_REQUESTED_CLAIM_FILTERING = "RestrictSPRequestedClaimFiltering";
+    public static final String CONFIG_ALLOW_SP_REQUESTED_FED_CLAIMS_ONLY = "AllowSPRequestedFedClaimsOnly";
 
     public static final String REMEMBER_ME_OPT_ON = "on";
     public static final String LAST_FAILED_AUTHENTICATOR = "LastFailedAuthenticator";

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2174,8 +2174,8 @@
     <!-- Configuration to enable or disable claim filtering based on scope. -->
     <EnableScopeBasedClaimFiltering>true</EnableScopeBasedClaimFiltering>
 
-    <!-- Configuration to strictly restrict claim filtering only as requested by SP. -->
-    <RestrictSPRequestedClaimFiltering>true</RestrictSPRequestedClaimFiltering>
+    <!-- Configuration to allow only SP requested claims during federated flow. -->
+    <AllowSPRequestedFedClaimsOnly>true</AllowSPRequestedFedClaimsOnly>
 
     <!-- Configuration to show the pending user information during the authentication failure attempts. -->
     <ShowPendingUserInformation>true</ShowPendingUserInformation>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2174,6 +2174,9 @@
     <!-- Configuration to enable or disable claim filtering based on scope. -->
     <EnableScopeBasedClaimFiltering>true</EnableScopeBasedClaimFiltering>
 
+    <!-- Configuration to strictly restrict claim filtering only as requested by SP. -->
+    <RestrictSPRequestedClaimFiltering>true</RestrictSPRequestedClaimFiltering>
+
     <!-- Configuration to show the pending user information during the authentication failure attempts. -->
     <ShowPendingUserInformation>true</ShowPendingUserInformation>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3107,6 +3107,9 @@
     <!-- Configuration to enable or disable claim filtering based on scope. -->
     <EnableScopeBasedClaimFiltering>{{authentication.enable_scope_based_claim_filtering}}</EnableScopeBasedClaimFiltering>
 
+    <!-- Configuration to strictly restrict claim filtering only as requested by SP. -->
+    <RestrictSPRequestedClaimFiltering>{{authentication.restrict_sp_requested_claim_filtering}}</RestrictSPRequestedClaimFiltering>
+
     {% if stored_procedure_dao is defined %}
     <!-- Stored Procedure supported DAO Implementation of Identity components.
     To enable this, the corresponding Stored Procedure supported DAO extension has to be added to product.   -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3107,8 +3107,8 @@
     <!-- Configuration to enable or disable claim filtering based on scope. -->
     <EnableScopeBasedClaimFiltering>{{authentication.enable_scope_based_claim_filtering}}</EnableScopeBasedClaimFiltering>
 
-    <!-- Configuration to strictly restrict claim filtering only as requested by SP. -->
-    <RestrictSPRequestedClaimFiltering>{{authentication.restrict_sp_requested_claim_filtering}}</RestrictSPRequestedClaimFiltering>
+    <!-- Configuration to allow only SP requested claims during federated flow. -->
+    <AllowSPRequestedFedClaimsOnly>{{authentication.allow_sp_requested_fed_claims_only}}</AllowSPRequestedFedClaimsOnly>
 
     {% if stored_procedure_dao is defined %}
     <!-- Stored Procedure supported DAO Implementation of Identity components.

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -3,7 +3,7 @@
   "authentication.consent.subject.prompt": true,
   "authentication.map_federated_users_to_local": false,
   "authentication.enable_scope_based_claim_filtering": true,
-  "authentication.restrict_sp_requested_claim_filtering": true,
+  "authentication.allow_sp_requested_fed_claims_only": true,
 
   "identity.data_source": "jdbc/WSO2IdentityDB",
   "identity_data_source.skip_db_schema_creation": false,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -3,6 +3,7 @@
   "authentication.consent.subject.prompt": true,
   "authentication.map_federated_users_to_local": false,
   "authentication.enable_scope_based_claim_filtering": true,
+  "authentication.restrict_sp_requested_claim_filtering": true,
 
   "identity.data_source": "jdbc/WSO2IdentityDB",
   "identity_data_source.skip_db_schema_creation": false,


### PR DESCRIPTION
This PR introduces a new config: `authentication.allow_sp_requested_fed_claims_only` which strictly restricts the claims sent to the application during federated flow. By default this config is enabled and therefore when no requested claims are configured for a SP, no claims received from the federated Idp will be sent to the app. By disabling this config, all the claims received from the external Idp will be sent to the app without any filtering.

This is related to providing backward compatibility to changes introduced by https://github.com/wso2/carbon-identity-framework/pull/3351.

Related issue: https://github.com/wso2/product-is/issues/14447