### PR TITLE
Bump kernel version to 4.7.0

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>application-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>application-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>application-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>

--- a/components/application-mgt/pom.xml
+++ b/components/application-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/pom.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>authentication-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>authentication-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/authentication-framework/pom.xml
+++ b/components/authentication-framework/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/captcha-mgt/org.wso2.carbon.captcha.mgt/pom.xml
+++ b/components/captcha-mgt/org.wso2.carbon.captcha.mgt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>captcha-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/captcha-mgt/pom.xml
+++ b/components/captcha-mgt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/carbon-authenticators/pom.xml
+++ b/components/carbon-authenticators/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/carbon-authenticators/thrift-authenticator/org.wso2.carbon.identity.authenticator.thrift/pom.xml
+++ b/components/carbon-authenticators/thrift-authenticator/org.wso2.carbon.identity.authenticator.thrift/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>thrift-authenticator</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/carbon-authenticators/thrift-authenticator/pom.xml
+++ b/components/carbon-authenticators/thrift-authenticator/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-authenticators</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/central-logger/org.wso2.carbon.identity.central.log.mgt/pom.xml
+++ b/components/central-logger/org.wso2.carbon.identity.central.log.mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>central-logger</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/central-logger/pom.xml
+++ b/components/central-logger/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-framework</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/claim-mgt/org.wso2.carbon.claim.mgt.ui/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.claim.mgt.ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>claim-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/claim-mgt/org.wso2.carbon.claim.mgt/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.claim.mgt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>claim-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt.ui/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt.ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>claim-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>claim-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/claim-mgt/pom.xml
+++ b/components/claim-mgt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/configuration-mgt/org.wso2.carbon.identity.api.server.configuration.mgt/pom.xml
+++ b/components/configuration-mgt/org.wso2.carbon.identity.api.server.configuration.mgt/pom.xml
@@ -23,11 +23,11 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>configuration-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.server.configuration.mgt</artifactId>
-    <version>5.22.4-SNAPSHOT</version>
+    <version>5.23.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Configuration Management API</name>
     <description>Identity Configuration Management API</description>

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/pom.xml
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>configuration-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.endpoint/pom.xml
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.endpoint/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>configuration-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/configuration-mgt/pom.xml
+++ b/components/configuration-mgt/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/pom.xml
+++ b/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>consent-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/consent-mgt/pom.xml
+++ b/components/consent-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/pom.xml
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>cors-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/cors-mgt/pom.xml
+++ b/components/cors-mgt/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/directory-server-manager/org.wso2.carbon.directory.server.manager.common/pom.xml
+++ b/components/directory-server-manager/org.wso2.carbon.directory.server.manager.common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>directory-server-manager</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/directory-server-manager/org.wso2.carbon.directory.server.manager.ui/pom.xml
+++ b/components/directory-server-manager/org.wso2.carbon.directory.server.manager.ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>directory-server-manager</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/directory-server-manager/org.wso2.carbon.directory.server.manager/pom.xml
+++ b/components/directory-server-manager/org.wso2.carbon.directory.server.manager/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>directory-server-manager</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/directory-server-manager/pom.xml
+++ b/components/directory-server-manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/entitlement/org.wso2.carbon.identity.api.server.entitlement/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.api.server.entitlement/pom.xml
@@ -23,11 +23,11 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>entitlement</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.server.entitlement</artifactId>
-    <version>5.22.4-SNAPSHOT</version>
+    <version>5.23.0-SNAPSHOT</version>
     <name>WSO2 Carbon - Entitlement REST API</name>
     <packaging>jar</packaging>
 

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.common/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>entitlement</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.endpoint/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.endpoint/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>entitlement</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.entitlement.endpoint</artifactId>

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.ui/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>entitlement</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>entitlement</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/entitlement/pom.xml
+++ b/components/entitlement/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/pom.xml
+++ b/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>functions-library-mgt</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt/pom.xml
+++ b/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>functions-library-mgt</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/functions-library-mgt/pom.xml
+++ b/components/functions-library-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/identity-core/org.wso2.carbon.identity.base/pom.xml
+++ b/components/identity-core/org.wso2.carbon.identity.base/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-core</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/identity-core/org.wso2.carbon.identity.core.ui/pom.xml
+++ b/components/identity-core/org.wso2.carbon.identity.core.ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-core</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/identity-core/org.wso2.carbon.identity.core/pom.xml
+++ b/components/identity-core/org.wso2.carbon.identity.core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-core</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/identity-core/pom.xml
+++ b/components/identity-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/identity-event/org.wso2.carbon.identity.event/pom.xml
+++ b/components/identity-event/org.wso2.carbon.identity.event/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-event</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/identity-event/pom.xml
+++ b/components/identity-event/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/pom.xml
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.ui/pom.xml
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.ui/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/pom.xml
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/identity-mgt/pom.xml
+++ b/components/identity-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/pom.xml
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-provider-management</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/pom.xml
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-provider-management</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/idp-mgt/pom.xml
+++ b/components/idp-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/multi-attribute-login/org.wso2.carbon.identity.multi.attribute.login.mgt/pom.xml
+++ b/components/multi-attribute-login/org.wso2.carbon.identity.multi.attribute.login.mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>multi-attribute-login</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/pom.xml
+++ b/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>multi-attribute-login</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/multi-attribute-login/pom.xml
+++ b/components/multi-attribute-login/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-framework</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/notification-mgt/org.wso2.carbon.identity.notification.mgt/pom.xml
+++ b/components/notification-mgt/org.wso2.carbon.identity.notification.mgt/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>notification-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/notification-mgt/pom.xml
+++ b/components/notification-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/policy-editor/org.wso2.carbon.policyeditor.ui/pom.xml
+++ b/components/policy-editor/org.wso2.carbon.policyeditor.ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>policy-editor</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/policy-editor/org.wso2.carbon.policyeditor/pom.xml
+++ b/components/policy-editor/org.wso2.carbon.policyeditor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>policy-editor</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/policy-editor/pom.xml
+++ b/components/policy-editor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/pom.xml
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>provisioning</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/provisioning/pom.xml
+++ b/components/provisioning/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/pom.xml
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>role-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/role-mgt/pom.xml
+++ b/components/role-mgt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/secret-mgt/org.wso2.carbon.identity.secret.mgt.core/pom.xml
+++ b/components/secret-mgt/org.wso2.carbon.identity.secret.mgt.core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>secret-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/secret-mgt/pom.xml
+++ b/components/secret-mgt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/security-mgt/org.wso2.carbon.security.mgt.ui/pom.xml
+++ b/components/security-mgt/org.wso2.carbon.security.mgt.ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>security-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/security-mgt/org.wso2.carbon.security.mgt/pom.xml
+++ b/components/security-mgt/org.wso2.carbon.security.mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>security-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/security-mgt/pom.xml
+++ b/components/security-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/template-mgt/org.wso2.carbon.identity.template.mgt.ui/pom.xml
+++ b/components/template-mgt/org.wso2.carbon.identity.template.mgt.ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>template-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/template-mgt/org.wso2.carbon.identity.template.mgt/pom.xml
+++ b/components/template-mgt/org.wso2.carbon.identity.template.mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>template-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/template-mgt/pom.xml
+++ b/components/template-mgt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/user-functionality-mgt/org.wso2.carbon.identity.user.functionality.mgt/pom.xml
+++ b/components/user-functionality-mgt/org.wso2.carbon.identity.user.functionality.mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>user-functionality-mgt</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/user-functionality-mgt/pom.xml
+++ b/components/user-functionality-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-framework</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/user-mgt/org.wso2.carbon.identity.user.profile.ui/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.identity.user.profile.ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/user-mgt/org.wso2.carbon.identity.user.profile/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.identity.user.profile/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/user-mgt/org.wso2.carbon.identity.user.registration/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.identity.user.registration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/user-mgt/org.wso2.carbon.user.mgt.common/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/user-mgt/org.wso2.carbon.user.mgt/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
 	      <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/user-mgt/pom.xml
+++ b/components/user-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration.deployer/pom.xml
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration.deployer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-store</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration.ui/pom.xml
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration.ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-store</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/pom.xml
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-store</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
 	    <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/user-store/org.wso2.carbon.identity.user.store.count/pom.xml
+++ b/components/user-store/org.wso2.carbon.identity.user.store.count/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-store</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/user-store/pom.xml
+++ b/components/user-store/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/pom.xml
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-workflow-mgt</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/pom.xml
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-workflow-mgt</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/workflow-mgt/pom.xml
+++ b/components/workflow-mgt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/application-mgt/org.wso2.carbon.identity.application.mgt.feature/pom.xml
+++ b/features/application-mgt/org.wso2.carbon.identity.application.mgt.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>application-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/application-mgt/org.wso2.carbon.identity.application.mgt.server.feature/pom.xml
+++ b/features/application-mgt/org.wso2.carbon.identity.application.mgt.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>application-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/application-mgt/org.wso2.carbon.identity.application.mgt.ui.feature/pom.xml
+++ b/features/application-mgt/org.wso2.carbon.identity.application.mgt.ui.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>application-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/application-mgt/pom.xml
+++ b/features/application-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/pom.xml
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>authentication-framework-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/authentication-framework/pom.xml
+++ b/features/authentication-framework/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/carbon-authenticators/pom.xml
+++ b/features/carbon-authenticators/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/carbon-authenticators/thrift-authenticator/org.wso2.carbon.identity.thrift.authentication.feature/pom.xml
+++ b/features/carbon-authenticators/thrift-authenticator/org.wso2.carbon.identity.thrift.authentication.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>thrift-authenticator-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/carbon-authenticators/thrift-authenticator/pom.xml
+++ b/features/carbon-authenticators/thrift-authenticator/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-authenticator-features</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/categories/authorization/pom.xml
+++ b/features/categories/authorization/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/categories/inbound-authentication/pom.xml
+++ b/features/categories/inbound-authentication/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/categories/inbound-provisioning/pom.xml
+++ b/features/categories/inbound-provisioning/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/categories/keystore-mgt/pom.xml
+++ b/features/categories/keystore-mgt/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/categories/notification-mgt/pom.xml
+++ b/features/categories/notification-mgt/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/categories/outbound-authentication/pom.xml
+++ b/features/categories/outbound-authentication/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/categories/outbound-provisioning/pom.xml
+++ b/features/categories/outbound-provisioning/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/categories/pom.xml
+++ b/features/categories/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/categories/user-mgt/pom.xml
+++ b/features/categories/user-mgt/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/categories/workflow/pom.xml
+++ b/features/categories/workflow/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/features/central-logger/org.wso2.carbon.identity.central.log.mgt.server.feature/pom.xml
+++ b/features/central-logger/org.wso2.carbon.identity.central.log.mgt.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>central-logger-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/central-logger/pom.xml
+++ b/features/central-logger/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.feature/pom.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>claim-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/pom.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>claim-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.ui.feature/pom.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.ui.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>claim-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/claim-mgt/pom.xml
+++ b/features/claim-mgt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.server.feature/pom.xml
+++ b/features/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.server.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>configuration-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/configuration-mgt/pom.xml
+++ b/features/configuration-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     

--- a/features/consent-mgt/org.wso2.carbon.identity.consent.mgt.server.feature/pom.xml
+++ b/features/consent-mgt/org.wso2.carbon.identity.consent.mgt.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-consent-mgt-aggregator</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/consent-mgt/pom.xml
+++ b/features/consent-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/cors-mgt/org.wso2.carbon.identity.cors.mgt.server.feature/pom.xml
+++ b/features/cors-mgt/org.wso2.carbon.identity.cors.mgt.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>cors-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/cors-mgt/pom.xml
+++ b/features/cors-mgt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/directory-server-manager/org.wso2.carbon.directory.service.mgr.feature/pom.xml
+++ b/features/directory-server-manager/org.wso2.carbon.directory.service.mgr.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>directory-server-manager-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/directory-server-manager/org.wso2.carbon.directory.service.mgr.server.feature/pom.xml
+++ b/features/directory-server-manager/org.wso2.carbon.directory.service.mgr.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>directory-server-manager-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/directory-server-manager/org.wso2.carbon.directory.service.mgr.ui.feature/pom.xml
+++ b/features/directory-server-manager/org.wso2.carbon.directory.service.mgr.ui.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>directory-server-manager-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/directory-server-manager/pom.xml
+++ b/features/directory-server-manager/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.feature/pom.xml
+++ b/features/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>functions-library-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.server.feature/pom.xml
+++ b/features/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>functions-library-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui.feature/pom.xml
+++ b/features/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>functions-library-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/functions-library-mgt/pom.xml
+++ b/features/functions-library-mgt/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.feature/pom.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-core-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/pom.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-core-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.ui.feature/pom.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.ui.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-core-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/identity-core/pom.xml
+++ b/features/identity-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/identity-event/org.wso2.carbon.identity.event.feature/pom.xml
+++ b/features/identity-event/org.wso2.carbon.identity.event.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-event-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/pom.xml
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-event-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/identity-event/pom.xml
+++ b/features/identity-event/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/identity-mgt/org.wso2.carbon.identity.mgt.feature/pom.xml
+++ b/features/identity-mgt/org.wso2.carbon.identity.mgt.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/identity-mgt/org.wso2.carbon.identity.mgt.server.feature/pom.xml
+++ b/features/identity-mgt/org.wso2.carbon.identity.mgt.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/identity-mgt/org.wso2.carbon.identity.mgt.ui.feature/pom.xml
+++ b/features/identity-mgt/org.wso2.carbon.identity.mgt.ui.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/identity-mgt/pom.xml
+++ b/features/identity-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/idp-mgt/org.wso2.carbon.idp.mgt.feature/pom.xml
+++ b/features/idp-mgt/org.wso2.carbon.idp.mgt.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-provider-management-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/idp-mgt/org.wso2.carbon.idp.mgt.server.feature/pom.xml
+++ b/features/idp-mgt/org.wso2.carbon.idp.mgt.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-provider-management-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/idp-mgt/org.wso2.carbon.idp.mgt.ui.feature/pom.xml
+++ b/features/idp-mgt/org.wso2.carbon.idp.mgt.ui.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-provider-management-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/idp-mgt/pom.xml
+++ b/features/idp-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/multi-attribute-login/org.wso2.carbon.identity.multi.attribute.login.mgt.server.feature/pom.xml
+++ b/features/multi-attribute-login/org.wso2.carbon.identity.multi.attribute.login.mgt.server.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>multi-attribute-login-feature</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt.server.feature/pom.xml
+++ b/features/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt.server.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>multi-attribute-login-feature</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/multi-attribute-login/pom.xml
+++ b/features/multi-attribute-login/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-framework</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/notification-mgt/org.wso2.carbon.identity.notification.mgt.feature/pom.xml
+++ b/features/notification-mgt/org.wso2.carbon.identity.notification.mgt.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-notification-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/notification-mgt/org.wso2.carbon.identity.notification.mgt.server.feature/pom.xml
+++ b/features/notification-mgt/org.wso2.carbon.identity.notification.mgt.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-notification-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/notification-mgt/pom.xml
+++ b/features/notification-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/provisioning/org.wso2.carbon.identity.provisioning.server.feature/pom.xml
+++ b/features/provisioning/org.wso2.carbon.identity.provisioning.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>provisioning-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/provisioning/pom.xml
+++ b/features/provisioning/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/role-mgt/org.wso2.carbon.identity.role.mgt.core.server.feature/pom.xml
+++ b/features/role-mgt/org.wso2.carbon.identity.role.mgt.core.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>role-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/role-mgt/pom.xml
+++ b/features/role-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/secret-mgt/org.wso2.carbon.identity.secret.mgt.core.server.feature/pom.xml
+++ b/features/secret-mgt/org.wso2.carbon.identity.secret.mgt.core.server.feature/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>secret-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/secret-mgt/pom.xml
+++ b/features/secret-mgt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/security-mgt/org.wso2.carbon.security.mgt.feature/pom.xml
+++ b/features/security-mgt/org.wso2.carbon.security.mgt.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>security-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/security-mgt/org.wso2.carbon.security.mgt.server.feature/pom.xml
+++ b/features/security-mgt/org.wso2.carbon.security.mgt.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>security-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/security-mgt/org.wso2.carbon.security.mgt.ui.feature/pom.xml
+++ b/features/security-mgt/org.wso2.carbon.security.mgt.ui.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>security-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/security-mgt/pom.xml
+++ b/features/security-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/template-mgt/org.wso2.carbon.identity.template.mgt.feature/pom.xml
+++ b/features/template-mgt/org.wso2.carbon.identity.template.mgt.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>template-management-feature</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/template-mgt/org.wso2.carbon.identity.template.mgt.server.feature/pom.xml
+++ b/features/template-mgt/org.wso2.carbon.identity.template.mgt.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>template-management-feature</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/template-mgt/org.wso2.carbon.identity.template.mgt.ui.feature/pom.xml
+++ b/features/template-mgt/org.wso2.carbon.identity.template.mgt.ui.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>template-management-feature</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/template-mgt/pom.xml
+++ b/features/template-mgt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/user-functionality-mgt/org.wso2.carbon.identity.user.functionality.mgt.feature/pom.xml
+++ b/features/user-functionality-mgt/org.wso2.carbon.identity.user.functionality.mgt.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>user-functionality-mgt-feature</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/user-functionality-mgt/org.wso2.carbon.identity.user.functionality.mgt.server.feature/pom.xml
+++ b/features/user-functionality-mgt/org.wso2.carbon.identity.user.functionality.mgt.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>user-functionality-mgt-feature</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/features/user-functionality-mgt/pom.xml
+++ b/features/user-functionality-mgt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-framework</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/user-mgt/org.wso2.carbon.identity.user.profile.feature/pom.xml
+++ b/features/user-mgt/org.wso2.carbon.identity.user.profile.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/user-mgt/org.wso2.carbon.identity.user.profile.server.feature/pom.xml
+++ b/features/user-mgt/org.wso2.carbon.identity.user.profile.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/user-mgt/org.wso2.carbon.identity.user.profile.ui.feature/pom.xml
+++ b/features/user-mgt/org.wso2.carbon.identity.user.profile.ui.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/user-mgt/org.wso2.carbon.identity.user.registration.feature/pom.xml
+++ b/features/user-mgt/org.wso2.carbon.identity.user.registration.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/user-mgt/org.wso2.carbon.identity.user.registration.server.feature/pom.xml
+++ b/features/user-mgt/org.wso2.carbon.identity.user.registration.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/user-mgt/org.wso2.carbon.identity.user.registration.ui.feature/pom.xml
+++ b/features/user-mgt/org.wso2.carbon.identity.user.registration.ui.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/user-mgt/org.wso2.carbon.user.mgt.feature/pom.xml
+++ b/features/user-mgt/org.wso2.carbon.user.mgt.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/user-mgt/org.wso2.carbon.user.mgt.server.feature/pom.xml
+++ b/features/user-mgt/org.wso2.carbon.user.mgt.server.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/user-mgt/org.wso2.carbon.user.mgt.ui.feature/pom.xml
+++ b/features/user-mgt/org.wso2.carbon.user.mgt.ui.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/user-mgt/pom.xml
+++ b/features/user-mgt/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/user-store/org.wso2.carbon.identity.user.store.configuration.server.feature/pom.xml
+++ b/features/user-store/org.wso2.carbon.identity.user.store.configuration.server.feature/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>user-store-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/user-store/pom.xml
+++ b/features/user-store/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.feature/pom.xml
+++ b/features/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.feature/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>workflow-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.server.feature/pom.xml
+++ b/features/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.server.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>workflow-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui.feature/pom.xml
+++ b/features/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>workflow-mgt-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/workflow-mgt/pom.xml
+++ b/features/workflow-mgt/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/xacml/org.wso2.carbon.identity.xacml.feature/pom.xml
+++ b/features/xacml/org.wso2.carbon.identity.xacml.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>xacml-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/xacml/org.wso2.carbon.identity.xacml.server.feature/pom.xml
+++ b/features/xacml/org.wso2.carbon.identity.xacml.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>xacml-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/xacml/org.wso2.carbon.identity.xacml.ui.feature/pom.xml
+++ b/features/xacml/org.wso2.carbon.identity.xacml.ui.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>xacml-feature</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/xacml/pom.xml
+++ b/features/xacml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <groupId>org.wso2.carbon.identity.framework</groupId>
     <artifactId>identity-framework</artifactId>
     <packaging>pom</packaging>
-    <version>5.22.4-SNAPSHOT</version>
+    <version>5.23.0-SNAPSHOT</version>
     <name>WSO2 Carbon - Platform Aggregator Pom</name>
     <url>http://wso2.org</url>
 
@@ -1735,8 +1735,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.7.0-beta6</carbon.kernel.version>
-        <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
+        <carbon.kernel.version>4.7.0</carbon.kernel.version>
+        <carbon.kernel.feature.version>4.7.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>
         <carbon.consent.mgt.imp.pkg.version.range>[1.0.0, 3.0.0)</carbon.consent.mgt.imp.pkg.version.range>

--- a/service-stubs/identity/org.wso2.carbon.claim.mgt.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.claim.mgt.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.directory.server.manager.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.directory.server.manager.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.application.authentication.framework.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.authentication.framework.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/service-stubs/identity/org.wso2.carbon.identity.application.default.authentication.sequence.mgt.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.default.authentication.sequence.mgt.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.claim.metadata.mgt.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.claim.metadata.mgt.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.entitlement.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.entitlement.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.functions.library.mgt.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.functions.library.mgt.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>carbon-service-stubs</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.governance.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.governance.stub/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.mgt.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.mgt.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.user.profile.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.user.profile.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.user.registration.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.user.registration.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.user.store.configuration.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.user.store.configuration.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.user.store.count.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.user.store.count.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.workflow.mgt.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.workflow.mgt.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>carbon-service-stubs</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.security.mgt.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.security.mgt.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.user.mgt.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.user.mgt.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.user.mgt.workflow.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.user.mgt.workflow.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>carbon-service-stubs</artifactId>
         <groupId>org.wso2.carbon.identity.framework</groupId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/service-stubs/identity/pom.xml
+++ b/service-stubs/identity/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/test-utils/org.wso2.carbon.identity.testutil/pom.xml
+++ b/test-utils/org.wso2.carbon.identity.testutil/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>identity-framework</artifactId>
-        <version>5.22.4-SNAPSHOT</version>
+        <version>5.23.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/test-utils/org.wso2.carbon.identity.testutil/src/main/java/org/wso2/carbon/identity/common/testng/MockInitialContextFactory.java
+++ b/test-utils/org.wso2.carbon.identity.testutil/src/main/java/org/wso2/carbon/identity/common/testng/MockInitialContextFactory.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.identity.common.testng;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.mockito.Mockito;


### PR DESCRIPTION
### Proposed changes in this pull request

- Bump kernel version to 4.7.0-beta
- Change org.apache.commons.dbcp.BasicDataSource -> org.apache.tomcat.dbcp.dbcp2.BasicDataSource to compatible with https://github.com/wso2/carbon-kernel/pull/3333