### PR TITLE
Configure features for organization management

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -85,6 +85,29 @@
       "event.default_recorder.user_delete_event.write_to_separate_csv.path": "${carbon.home}/repository/logs/delete-records.csv"
     }
   },
+
+  "console.org_mgt.additional_features.enabled": {
+    "true": {
+      "console.user_stores.enabled": true,
+      "console.certificates.enabled": true,
+      "console.secrets_management.enabled": true,
+      "console.oidc_scopes.enabled": true,
+      "console.governance_connectors.enabled": true,
+      "console.email_templates.enabled": true,
+      "console.attribute_dialects.enabled": true
+    },
+    "false": {
+      "console.user_stores.enabled": false,
+      "console.certificates.enabled": false,
+      "console.secrets_management.enabled": false,
+      "console.oidc_scopes.enabled": false,
+      "console.governance_connectors.enabled": false,
+      "console.email_templates.enabled": false,
+      "console.attribute_dialects.enabled": false,
+      "console.product_version.configs.productVersion": ""
+    }
+  },
+
   "identity_mgt.email_sender": {
     "internal": {
       "identity_mgt.recovery.notification.manage_internally": true,


### PR DESCRIPTION
### Proposed changes in this pull request

>The following features can be enabled/disabled by a group config

Attributes
Certificates
Email templates
Governance connectors
Scopes
Secrets management
User stores

#### Documentation
>Relevant documentation will need to be updated to inform users of the new group config when the organization management feature is enabled.
>In deployment.toml file the following configuration will disable all the features included in the group config.
```
[console.org_mgt.additional_features]
enabled = "false"
```