### PR TITLE
set session data clean up based on the EXPIRY_TIME

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/db2/sessiondata-cleanup/db2-session-data-cleanup.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/db2/sessiondata-cleanup/db2-session-data-cleanup.sql
@@ -75,8 +75,8 @@ BEGIN
 	SET @operationCleanUpTempTableCount = 1;
 	SET @cleanUpCompleted = 1;
 
-	-- Session data older than 20160 minutes(14 days) will be removed.
-	SET @sessionCleanupTime = BIGINT(CURRENT TIMESTAMP - 14 DAYS);
+	-- Expired Session data older than 120 minutes(2 hours) will be removed.
+	SET @sessionCleanupTime = BIGINT(CURRENT TIMESTAMP - (2) HOUR);
 	-- Operational data older than 720 minutes(12 h) will be removed.
 	SET @operationCleanupTime = BIGINT(CURRENT TIMESTAMP - (12) HOUR);
 
@@ -96,7 +96,7 @@ BEGIN
 	WHILE (@sessionCleanUpTempTableCount > 0) DO
 		IF NOT (EXISTS (SELECT NAME FROM SYSIBM.SYSTABLES WHERE NAME= 'IDN_AUTH_SESSION_STORE_TMP')) THEN
 		    CREATE TABLE IDN_AUTH_SESSION_STORE_TMP AS (SELECT SESSION_ID FROM IDN_AUTH_SESSION_STORE) WITH NO DATA;
-			INSERT INTO IDN_AUTH_SESSION_STORE_TMP SELECT SESSION_ID FROM IDN_AUTH_SESSION_STORE WHERE TIME_CREATED < @sessionCleanupTime LIMIT @chunkLimit;
+			INSERT INTO IDN_AUTH_SESSION_STORE_TMP SELECT SESSION_ID FROM IDN_AUTH_SESSION_STORE WHERE EXPIRY_TIME < @sessionCleanupTime LIMIT @chunkLimit;
 		 	CREATE INDEX idn_auth_session_tmp_idx on IDN_AUTH_SESSION_STORE_TMP (SESSION_ID);
 		 	COMMIT;
 		END IF;

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/mysql/sessiondata-cleanup/mysql-session-data-cleanup.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/mysql/sessiondata-cleanup/mysql-session-data-cleanup.sql
@@ -61,8 +61,8 @@ CREATE PROCEDURE `CLEANUP_SESSION_DATA`()
     SET @operationCleanUpTempTableCount = 1;
     SET cleanUpCompleted = FALSE;
 
-    -- Session data older than 20160 minutes(14 days) will be removed.
-    SET @sessionCleanupTime = unix_timestamp()*1000000000 - (20160*60000000000);
+    -- Expired Session data older than 120 minutes(2 hours) will be removed.
+    SET @sessionCleanupTime = unix_timestamp()*1000000000 - (120*60000000000);
     -- Operational data older than 720 minutes(12 h) will be removed.
     SET @operationCleanupTime = unix_timestamp()*1000000000 - (720*60000000000);
 
@@ -84,7 +84,7 @@ CREATE PROCEDURE `CLEANUP_SESSION_DATA`()
     -- RUN UNTILL
     WHILE (@sessionCleanUpTempTableCount > 0) DO
 
-      CREATE TABLE IF NOT EXISTS IDN_AUTH_SESSION_STORE_TMP AS SELECT SESSION_ID FROM IDN_AUTH_SESSION_STORE where TIME_CREATED < @sessionCleanupTime limit chunkLimit;
+      CREATE TABLE IF NOT EXISTS IDN_AUTH_SESSION_STORE_TMP AS SELECT SESSION_ID FROM IDN_AUTH_SESSION_STORE where EXPIRY_TIME < @sessionCleanupTime limit chunkLimit;
       CREATE INDEX idn_auth_session_tmp_idx on IDN_AUTH_SESSION_STORE_TMP (SESSION_ID);
       COMMIT;
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/oracle/sessiondata-cleanup/oracle-sessiondata-cleanup.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/oracle/sessiondata-cleanup/oracle-sessiondata-cleanup.sql
@@ -36,7 +36,7 @@ CREATE OR REPLACE PROCEDURE wso2_session_cleanup_sp IS
     checkcount                       INT := 100;        -- SET CHECK COUNT FOR FINISH CLEANUP SCRIPT (CLEANUP ELIGIBLE SESSION COUNT SHOULD BE HIGHER THAN checkCount TO CONTINUE) [DEFAULT : 100]
     tracingenabled                   BOOLEAN := TRUE;   --  IF TRACE LOGGING IS ENABLED [DEFAULT : TRUE]
     sleeptime                        INT := 2;          -- Sleep time in seconds.
-    sessnclntiminminits              INT := 20160;      -- Session data older than 20160 minutes (14 days) will be removed.
+    sessnclntiminminits              INT := 120;      -- Expired Session data older than 120 minutes (2 hours) will be removed.
     opertnclntimeinminits            INT := 720;        -- Operational data older than 720 minutes (12 h) will be removed.
 
 BEGIN
@@ -86,7 +86,7 @@ BEGIN
 --        EXECUTE IMMEDIATE 'CREATE TABLE IDN_AUTH_SESSION_STORE_TMP AS SELECT SESSION_ID FROM IDN_AUTH_SESSION_STORE WHERE 1=2';
         EXECUTE IMMEDIATE 'CREATE TABLE IDN_AUTH_SESSION_STORE_TMP (ROW_ID rowid,SESSION_ID varchar(100),CONSTRAINT CHNK_IASS_PRI PRIMARY KEY (ROW_ID)) NOLOGGING';
 
-        EXECUTE IMMEDIATE 'INSERT INTO IDN_AUTH_SESSION_STORE_TMP SELECT rowid,SESSION_ID FROM IDN_AUTH_SESSION_STORE WHERE  rownum <= :chunklimit AND TIME_CREATED < :sessionCleanupTime'
+        EXECUTE IMMEDIATE 'INSERT INTO IDN_AUTH_SESSION_STORE_TMP SELECT rowid,SESSION_ID FROM IDN_AUTH_SESSION_STORE WHERE  rownum <= :chunklimit AND EXPIRY_TIME < :sessionCleanupTime'
         USING chunklimit, sessioncleanuptime;
         rowcount := SQL%rowcount;
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/postgresql/postgre-11x/sessiondata-cleanup/postgresql_11-session-data-cleanup.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/postgresql/postgre-11x/sessiondata-cleanup/postgresql_11-session-data-cleanup.sql
@@ -121,10 +121,10 @@ END IF;
 -- ------------------------------------------
 -- REMOVE SESSION DATA
 -- ------------------------------------------
--- Session data older than 20160 minutes(14 days) will be removed.
-sessionCleanupTime := (unix_timestamp*1000000000) - (20160*60000000000);
+-- Expired Session data older than 120 minutes(2 hours) will be removed.
+sessionCleanupTime := (unix_timestamp*1000000000) - (120*60000000000);
 
-purgingCondition := 'select session_id from idn_auth_session_store where time_created < '||sessionCleanupTime||'';
+purgingCondition := 'select session_id from idn_auth_session_store where expiry_time < '||sessionCleanupTime||'';
 
 IF (enableLog) THEN
     RAISE NOTICE '';

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/postgresql/postgre-9x/sessiondata-cleanup/postgresql-session-data-cleanup.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/stored-procedures/postgresql/postgre-9x/sessiondata-cleanup/postgresql-session-data-cleanup.sql
@@ -75,10 +75,10 @@ THEN
     purgeBseColmn := 'session_id';
 	purgeBseColmnType := 'varchar';
 
-  -- Session data older than 20160 minutes(14 days) will be removed.
-    sessionCleanupTime := (unix_timestamp*1000000000) - (20160*60000000000);
+  -- Expired Session data older than 120 minutes(2 hours) will be removed.
+    sessionCleanupTime := (unix_timestamp*1000000000) - (120*60000000000);
 
-    purgingCondition := 'select session_id from idn_auth_session_store where time_created < '||sessionCleanupTime||'';
+    purgingCondition := 'select session_id from idn_auth_session_store where expiry_time < '||sessionCleanupTime||'';
 
     IF (operationid = 1)
     THEN


### PR DESCRIPTION
### Proposed changes in this pull request

In the previous script, session data was cleaned up using the CREATED TIME and data was cleared after 14 days of the creation. The proposed solution clears the session data after 2 hours of EXPIRY_TIME.
Fix:- [#14713](https://github.com/wso2/product-is/issues/14713)
