### PR TITLE
Enable account lock for totp authenticator

### DIFF
--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -186,6 +186,7 @@
   "authentication.authenticator.totp.parameters.redirectToMultiOptionPageOnFailure": false,
   "authentication.authenticator.totp.parameters.AllowSendingVerificationCodeByEmail": false,
   "authentication.authenticator.totp.parameters.HideUserStoreFromDisplayInQRUrl": false,
+  "authentication.authenticator.totp.parameters.EnableAccountLockingForFailedAttempts": true,
   "authentication.authenticator.totp.parameters.Tags": "MFA",
 
   "authentication.authenticator.backup_code.name": "backup-code-authenticator",


### PR DESCRIPTION
### Proposed changes in this pull request
> Enable account lock for totp authenticator

### Related PRs
Merge this PR after merging : https://github.com/wso2-extensions/identity-outbound-auth-totp/pull/133

### Related Issues
- https://github.com/wso2/product-is/issues/14777