### PR TITLE
Filter applications by SAML issuer

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
@@ -92,6 +92,7 @@ public class IdentityApplicationConstants {
 
     // Service Provider configuration options that are stored as SP properites.
     public static final String JWKS_URI_SP_PROPERTY_NAME = "jwksURI";
+    public static final String NAME_SP_PROPERTY_NAME = "name";
     public static final String CLIENT_ID_SP_PROPERTY_NAME = "clientId";
     public static final String ISSUER_SP_PROPERTY_NAME = "issuer";
     public static final String TEMPLATE_ID_SP_PROPERTY_NAME = "templateId";

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -127,6 +127,7 @@ import static org.wso2.carbon.identity.application.common.util.IdentityApplicati
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.IS_MANAGEMENT_APP_SP_PROPERTY_DISPLAY_NAME;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.IS_MANAGEMENT_APP_SP_PROPERTY_NAME;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.JWKS_URI_SP_PROPERTY_NAME;
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.NAME_SP_PROPERTY_NAME;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.TEMPLATE_ID_SP_PROPERTY_DISPLAY_NAME;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.TEMPLATE_ID_SP_PROPERTY_NAME;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.LOCAL_SP;
@@ -173,9 +174,9 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
     private static final Map<String, String> SUPPORTED_SEARCH_ATTRIBUTE_MAP = new HashMap<>();
 
     static {
-        SUPPORTED_SEARCH_ATTRIBUTE_MAP.put("name", "SP_APP.APP_NAME");
-        SUPPORTED_SEARCH_ATTRIBUTE_MAP.put("clientId", "SP_INBOUND_AUTH.INBOUND_AUTH_KEY");
-        SUPPORTED_SEARCH_ATTRIBUTE_MAP.put("issuer", "SP_INBOUND_AUTH.INBOUND_AUTH_KEY");
+        SUPPORTED_SEARCH_ATTRIBUTE_MAP.put(NAME_SP_PROPERTY_NAME, "SP_APP.APP_NAME");
+        SUPPORTED_SEARCH_ATTRIBUTE_MAP.put(CLIENT_ID_SP_PROPERTY_NAME, "SP_INBOUND_AUTH.INBOUND_AUTH_KEY");
+        SUPPORTED_SEARCH_ATTRIBUTE_MAP.put(ISSUER_SP_PROPERTY_NAME, "SP_INBOUND_AUTH.INBOUND_AUTH_KEY");
     }
 
     public ApplicationDAOImpl() {
@@ -3280,6 +3281,8 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
 
         if (CLIENT_ID_SP_PROPERTY_NAME.equals(searchField)) {
             formattedFilterString = "(" + formattedFilterString + " AND SP_INBOUND_AUTH.INBOUND_AUTH_TYPE = 'oauth2')";
+        } else if (ISSUER_SP_PROPERTY_NAME.equals(searchField)) {
+            formattedFilterString = "(" + formattedFilterString + " AND SP_INBOUND_AUTH.INBOUND_AUTH_TYPE = 'samlsso')";
         }
         return formattedFilterString;
     }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -101,6 +101,7 @@ import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -112,6 +113,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Objects.isNull;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.ADVANCED_CONFIG;
@@ -168,11 +170,12 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
     private static final String FILTER_ENDS_WITH = "ew";
     private static final String FILTER_EQUALS = "eq";
     private static final String FILTER_CONTAINS = "co";
-    private static final Map<String, String> SEARCH_SUPPORTED_FIELD_MAP = new HashMap<>();
+    private static final Map<String, String> SUPPORTED_SEARCH_ATTRIBUTE_MAP = new HashMap<>();
 
     static {
-        SEARCH_SUPPORTED_FIELD_MAP.put("name", "SP_APP.APP_NAME");
-        SEARCH_SUPPORTED_FIELD_MAP.put("clientId", "SP_INBOUND_AUTH.INBOUND_AUTH_KEY");
+        SUPPORTED_SEARCH_ATTRIBUTE_MAP.put("name", "SP_APP.APP_NAME");
+        SUPPORTED_SEARCH_ATTRIBUTE_MAP.put("clientId", "SP_INBOUND_AUTH.INBOUND_AUTH_KEY");
+        SUPPORTED_SEARCH_ATTRIBUTE_MAP.put("issuer", "SP_INBOUND_AUTH.INBOUND_AUTH_KEY");
     }
 
     public ApplicationDAOImpl() {
@@ -3214,7 +3217,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         if (StringUtils.isBlank(filter) || filter.equals(ASTERISK)) {
             filterData.setFilterString("SP_APP.APP_NAME LIKE ?");
             filterData.addFilterValue("%");
-        } else if (!(SEARCH_SUPPORTED_FIELD_MAP.keySet().contains(filter.trim().split(" ")[0]))) {
+        } else if (!(SUPPORTED_SEARCH_ATTRIBUTE_MAP.keySet().contains(filter.trim().split(" ")[0]))) {
             // This formatting is to facilitate the search bar in carbon/application/list-service-providers.
             if (filter.contains(ASTERISK)) {
                 filterData.setFilterString("SP_APP.APP_NAME LIKE ?");
@@ -3227,35 +3230,39 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
             try {
                 FilterTreeBuilder filterTreeBuilder = new FilterTreeBuilder(filter);
                 Node rootNode = filterTreeBuilder.buildTree();
-                if (rootNode instanceof ExpressionNode) {
-                    ExpressionNode expressionNode = (ExpressionNode) rootNode;
-
-                    filterData.setFilterString(generateFilterStringForBackend(expressionNode.getAttributeValue(),
-                            expressionNode.getOperation()));
-                    filterData.addFilterValue(generateFilterValueForBackend(expressionNode.getOperation(),
-                            expressionNode.getValue()));
-                } else {
-                    // Currently, supports only filters with one AND/OR operation.
-                    // Have to recursively traverse the filter tree to support more than one operation.
-                    OperationNode operationNode = (OperationNode) rootNode;
-                    ExpressionNode expressionLeftNode = (ExpressionNode) rootNode.getLeftNode();
-                    ExpressionNode expressionRightNode = (ExpressionNode) rootNode.getRightNode();
-
-                    String formattedLeftNodeString = generateFilterStringForBackend(
-                            expressionLeftNode.getAttributeValue(), expressionLeftNode.getOperation());
-                    String formattedRightNodeString = generateFilterStringForBackend(
-                            expressionRightNode.getAttributeValue(), expressionRightNode.getOperation());
-
-                    filterData.setFilterString(formattedLeftNodeString + " " +
-                            operationNode.getOperation() + " " + formattedRightNodeString);
-                    filterData.addFilterValue(generateFilterValueForBackend(expressionLeftNode.getOperation(),
-                            expressionLeftNode.getValue()));
-                    filterData.addFilterValue(generateFilterValueForBackend(expressionRightNode.getOperation(),
-                            expressionRightNode.getValue()));
-                }
+                filterData = getFilterDataFromFilterTree(rootNode);
             } catch (IOException | IdentityException e) {
                 log.error("Error occurred while converting filter query with tree builder.", e);
             }
+        }
+        return filterData;
+    }
+
+    private FilterData getFilterDataFromFilterTree(Node rootNode) {
+
+        FilterData filterData = new FilterData();
+
+        if (rootNode instanceof ExpressionNode) {
+            ExpressionNode expressionNode = (ExpressionNode) rootNode;
+
+            filterData.setFilterString(generateFilterStringForBackend(expressionNode.getAttributeValue(),
+                    expressionNode.getOperation()));
+            filterData.addFilterValue(generateFilterValueForBackend(expressionNode.getOperation(),
+                    expressionNode.getValue()));
+        } else {
+            OperationNode operationNode = (OperationNode) rootNode;
+            Node leftNode = rootNode.getLeftNode();
+            Node rightNode = rootNode.getRightNode();
+
+            FilterData leftNodeFilterData = getFilterDataFromFilterTree(leftNode);
+            FilterData rightNodeFilterData = getFilterDataFromFilterTree(rightNode);
+
+            filterData.setFilterString(leftNodeFilterData.getFilterString() + " " +
+                    operationNode.getOperation() + " " + rightNodeFilterData.getFilterString());
+            filterData.setFilterValues(
+                    Stream.of(leftNodeFilterData.getFilterValues(), rightNodeFilterData.getFilterValues())
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toList()));
         }
         return filterData;
     }
@@ -3264,7 +3271,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
 
         // Format the filter attribute and condition to fit in a SQL where clause.
         String formattedFilterString;
-        String realSearchField = SEARCH_SUPPORTED_FIELD_MAP.get(searchField);
+        String realSearchField = SUPPORTED_SEARCH_ATTRIBUTE_MAP.get(searchField);
         if (searchOperation.equals(FILTER_EQUALS)) {
             formattedFilterString = realSearchField + " = ?";
         } else {

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
@@ -98,8 +98,11 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
     private static final String APPLICATION_NAME_FILTER_1 = "name ew application1";
     private static final String APPLICATION_NAME_FILTER_2 = "name co 2";
     private static final String APPLICATION_CLIENT_ID_FILTER = "clientId co %s";
+    private static final String APPLICATION_ISSUER_FILTER = "issuer co %s";
     private static final String APPLICATION_NAME_OR_CLIENT_ID_FILTER = "name co sampleAppName or clientId eq %s";
     private static final String APPLICATION_NAME_AND_CLIENT_ID_FILTER = "name co application1 and clientId eq %s";
+    private static final String APPLICATION_NAME_OR_ISSUER_FILTER = "name co sampleAppName or issuer eq %s";
+    private static final String APPLICATION_NAME_AND_ISSUER_FILTER = "name co application1 and issuer eq %s";
     private static final String IDP_NAME_1 = "Test IdP 1";
     private static final String IDP_NAME_2 = "Test IdP 2";
     private static final String USERNAME_1 = "user 1";
@@ -343,7 +346,7 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
     }
 
     @Test
-    public void testGetApplicationBasicInfoWithFilterOffsetLimit() throws IdentityApplicationManagementException {
+    public void testGetOAuth2ApplicationBasicInfoWithFilterOffsetLimit() throws IdentityApplicationManagementException {
 
         ServiceProvider inputSP1 = new ServiceProvider();
         inputSP1.setApplicationName(APPLICATION_NAME_1);
@@ -402,6 +405,65 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
     }
 
     @Test
+    public void testGetSAMLApplicationBasicInfoWithFilterOffsetLimit() throws IdentityApplicationManagementException {
+
+        ServiceProvider inputSP1 = new ServiceProvider();
+        inputSP1.setApplicationName(APPLICATION_NAME_1);
+        addApplicationConfigurations(inputSP1);
+        setApplicationInboundAuthConfigs(inputSP1, APPLICATION_INBOUND_AUTH_KEY_1, "samlsso");
+
+        ServiceProvider inputSP2 = new ServiceProvider();
+        inputSP2.setApplicationName(APPLICATION_NAME_2);
+        addApplicationConfigurations(inputSP2);
+        setApplicationInboundAuthConfigs(inputSP2, APPLICATION_INBOUND_AUTH_KEY_2, "samlsso");
+
+        // Adding application.
+        applicationManagementService.createApplication(inputSP1, SUPER_TENANT_DOMAIN_NAME, USERNAME_1);
+        applicationManagementService.createApplication(inputSP2, SUPER_TENANT_DOMAIN_NAME, USERNAME_1);
+
+        // Test get applications with name filter.
+        ApplicationBasicInfo[] applicationBasicInfo = applicationManagementService.getApplicationBasicInfo
+                (SUPER_TENANT_DOMAIN_NAME, USERNAME_1, APPLICATION_NAME_FILTER_1, 0, 5);
+        Assert.assertEquals(applicationBasicInfo[0].getApplicationName(), APPLICATION_NAME_1);
+
+        applicationBasicInfo = applicationManagementService.getApplicationBasicInfo
+                (SUPER_TENANT_DOMAIN_NAME, USERNAME_1, APPLICATION_NAME_FILTER_2, 0, 5);
+        Assert.assertEquals(applicationBasicInfo[0].getApplicationName(), APPLICATION_NAME_2);
+
+        // Test get applications with issuer filter.
+        applicationBasicInfo = applicationManagementService.getApplicationBasicInfo
+                (SUPER_TENANT_DOMAIN_NAME, USERNAME_1,
+                        String.format(APPLICATION_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_1), 0, 5);
+        Assert.assertEquals(applicationBasicInfo[0].getApplicationName(), APPLICATION_NAME_1);
+
+        applicationBasicInfo = applicationManagementService.getApplicationBasicInfo
+                (SUPER_TENANT_DOMAIN_NAME, USERNAME_1,
+                        String.format(APPLICATION_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_2), 0, 5);
+        Assert.assertEquals(applicationBasicInfo[0].getApplicationName(), APPLICATION_NAME_2);
+
+        // Test get applications with name or issuer filter.
+        applicationBasicInfo = applicationManagementService.getApplicationBasicInfo
+                (SUPER_TENANT_DOMAIN_NAME, USERNAME_1,
+                        String.format(APPLICATION_NAME_OR_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_1), 0, 5);
+        Assert.assertEquals(applicationBasicInfo[0].getApplicationName(), APPLICATION_NAME_1);
+
+        applicationBasicInfo = applicationManagementService.getApplicationBasicInfo
+                (SUPER_TENANT_DOMAIN_NAME, USERNAME_1,
+                        String.format(APPLICATION_NAME_OR_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_2), 0, 5);
+        Assert.assertEquals(applicationBasicInfo[0].getApplicationName(), APPLICATION_NAME_2);
+
+        // Test get applications with name and issuer filter.
+        applicationBasicInfo = applicationManagementService.getApplicationBasicInfo
+                (SUPER_TENANT_DOMAIN_NAME, USERNAME_1,
+                        String.format(APPLICATION_NAME_AND_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_1), 0, 5);
+        Assert.assertEquals(applicationBasicInfo[0].getApplicationName(), APPLICATION_NAME_1);
+        Assert.assertEquals(applicationBasicInfo[0].getIssuer(), APPLICATION_INBOUND_AUTH_KEY_1);
+
+        // Deleting all added applications.
+        applicationManagementService.deleteApplications(SUPER_TENANT_ID);
+    }
+
+    @Test
     public void testGetCountOfAllApplications() throws IdentityApplicationManagementException {
 
         addApplications();
@@ -413,7 +475,7 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
     }
 
     @Test
-    public void testGetCountOfApplicationsWithFilter() throws IdentityApplicationManagementException {
+    public void testGetCountOfOAuth2ApplicationsWithFilter() throws IdentityApplicationManagementException {
 
         ServiceProvider inputSP1 = new ServiceProvider();
         inputSP1.setApplicationName(APPLICATION_NAME_1);
@@ -452,6 +514,45 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
                 USERNAME_1, String.format(APPLICATION_NAME_AND_CLIENT_ID_FILTER, APPLICATION_INBOUND_AUTH_KEY_1)), 1);
         Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME,
                 USERNAME_1,  String.format(APPLICATION_NAME_AND_CLIENT_ID_FILTER, APPLICATION_INBOUND_AUTH_KEY_2)), 0);
+
+        // Deleting all added applications.
+        applicationManagementService.deleteApplications(SUPER_TENANT_ID);
+    }
+
+    @Test
+    public void testGetCountOfSAMLApplicationsWithFilter() throws IdentityApplicationManagementException {
+
+        ServiceProvider inputSP1 = new ServiceProvider();
+        inputSP1.setApplicationName(APPLICATION_NAME_1);
+        addApplicationConfigurations(inputSP1);
+        setApplicationInboundAuthConfigs(inputSP1, APPLICATION_INBOUND_AUTH_KEY_1, "samlsso");
+
+        ServiceProvider inputSP2 = new ServiceProvider();
+        inputSP2.setApplicationName(APPLICATION_NAME_2);
+        addApplicationConfigurations(inputSP2);
+        setApplicationInboundAuthConfigs(inputSP2, APPLICATION_INBOUND_AUTH_KEY_2, "samlsso");
+
+        // Adding application.
+        applicationManagementService.createApplication(inputSP1, SUPER_TENANT_DOMAIN_NAME, USERNAME_1);
+        applicationManagementService.createApplication(inputSP2, SUPER_TENANT_DOMAIN_NAME, USERNAME_1);
+
+        // Test get count of applications with issuer filter.
+        Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME,
+                USERNAME_1, String.format(APPLICATION_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_1)), 1);
+        Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME,
+                USERNAME_1, String.format(APPLICATION_ISSUER_FILTER, RANDOM_STRING)), 0);
+
+        // Test get count of applications with name or issuer filter.
+        Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME,
+                USERNAME_1, String.format(APPLICATION_NAME_OR_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_1)), 1);
+        Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME,
+                USERNAME_1,  String.format(APPLICATION_ISSUER_FILTER, RANDOM_STRING)), 0);
+
+        // Test get count of applications with name and issuer filter.
+        Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME,
+                USERNAME_1, String.format(APPLICATION_NAME_AND_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_1)), 1);
+        Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME,
+                USERNAME_1,  String.format(APPLICATION_NAME_AND_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_2)), 0);
 
         // Deleting all added applications.
         applicationManagementService.deleteApplications(SUPER_TENANT_ID);

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
@@ -101,6 +101,10 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
     private static final String APPLICATION_ISSUER_FILTER = "issuer co %s";
     private static final String APPLICATION_NAME_OR_CLIENT_ID_FILTER = "name co sampleAppName or clientId eq %s";
     private static final String APPLICATION_NAME_AND_CLIENT_ID_FILTER = "name co application1 and clientId eq %s";
+    private static final String APPLICATION_NAME_AND_CLIENT_ID_OR_ISSUER_FILTER =
+            "name co application1 and clientId eq %s or issuer eq %s";
+    private static final String APPLICATION_NAME_AND_ISSUER_OR_CLIENT_ID_FILTER =
+            "name co application1 and issuer eq %s or clientId eq %s";
     private static final String APPLICATION_NAME_OR_ISSUER_FILTER = "name co sampleAppName or issuer eq %s";
     private static final String APPLICATION_NAME_AND_ISSUER_FILTER = "name co application1 and issuer eq %s";
     private static final String IDP_NAME_1 = "Test IdP 1";
@@ -400,6 +404,14 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
         Assert.assertEquals(applicationBasicInfo[0].getApplicationName(), APPLICATION_NAME_1);
         Assert.assertEquals(applicationBasicInfo[0].getClientId(), APPLICATION_INBOUND_AUTH_KEY_1);
 
+        // Test get applications with name and clientId or issuer filter.
+        applicationBasicInfo = applicationManagementService.getApplicationBasicInfo
+                (SUPER_TENANT_DOMAIN_NAME, USERNAME_1,
+                        String.format(APPLICATION_NAME_AND_CLIENT_ID_OR_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_1,
+                                APPLICATION_INBOUND_AUTH_KEY_1), 0, 5);
+        Assert.assertEquals(applicationBasicInfo[0].getApplicationName(), APPLICATION_NAME_1);
+        Assert.assertEquals(applicationBasicInfo[0].getClientId(), APPLICATION_INBOUND_AUTH_KEY_1);
+
         // Deleting all added applications.
         applicationManagementService.deleteApplications(SUPER_TENANT_ID);
     }
@@ -459,6 +471,14 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
         Assert.assertEquals(applicationBasicInfo[0].getApplicationName(), APPLICATION_NAME_1);
         Assert.assertEquals(applicationBasicInfo[0].getIssuer(), APPLICATION_INBOUND_AUTH_KEY_1);
 
+        // Test get applications with name and clientId or issuer filter.
+        applicationBasicInfo = applicationManagementService.getApplicationBasicInfo
+                (SUPER_TENANT_DOMAIN_NAME, USERNAME_1,
+                        String.format(APPLICATION_NAME_AND_CLIENT_ID_OR_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_1,
+                                APPLICATION_INBOUND_AUTH_KEY_1), 0, 5);
+        Assert.assertEquals(applicationBasicInfo[0].getApplicationName(), APPLICATION_NAME_1);
+        Assert.assertEquals(applicationBasicInfo[0].getIssuer(), APPLICATION_INBOUND_AUTH_KEY_1);
+
         // Deleting all added applications.
         applicationManagementService.deleteApplications(SUPER_TENANT_ID);
     }
@@ -507,13 +527,21 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
         Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME,
                 USERNAME_1, String.format(APPLICATION_NAME_OR_CLIENT_ID_FILTER, APPLICATION_INBOUND_AUTH_KEY_1)), 1);
         Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME,
-                USERNAME_1,  String.format(APPLICATION_CLIENT_ID_FILTER, RANDOM_STRING)), 0);
+                USERNAME_1, String.format(APPLICATION_CLIENT_ID_FILTER, RANDOM_STRING)), 0);
 
         // Test get count of applications with name and clientId filter.
         Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME,
                 USERNAME_1, String.format(APPLICATION_NAME_AND_CLIENT_ID_FILTER, APPLICATION_INBOUND_AUTH_KEY_1)), 1);
         Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME,
-                USERNAME_1,  String.format(APPLICATION_NAME_AND_CLIENT_ID_FILTER, APPLICATION_INBOUND_AUTH_KEY_2)), 0);
+                USERNAME_1, String.format(APPLICATION_NAME_AND_CLIENT_ID_FILTER, APPLICATION_INBOUND_AUTH_KEY_2)), 0);
+
+        // Test get count of applications with name and clientId or issuer filter.
+        Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME, USERNAME_1,
+                String.format(APPLICATION_NAME_AND_CLIENT_ID_OR_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_1,
+                        APPLICATION_INBOUND_AUTH_KEY_2)), 1);
+        Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME, USERNAME_1,
+                String.format(APPLICATION_NAME_AND_CLIENT_ID_OR_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_2,
+                        APPLICATION_INBOUND_AUTH_KEY_1)), 0);
 
         // Deleting all added applications.
         applicationManagementService.deleteApplications(SUPER_TENANT_ID);
@@ -553,6 +581,14 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
                 USERNAME_1, String.format(APPLICATION_NAME_AND_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_1)), 1);
         Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME,
                 USERNAME_1,  String.format(APPLICATION_NAME_AND_ISSUER_FILTER, APPLICATION_INBOUND_AUTH_KEY_2)), 0);
+
+        // Test get count of applications with name and issuer or clientId filter.
+        Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME, USERNAME_1,
+                String.format(APPLICATION_NAME_AND_ISSUER_OR_CLIENT_ID_FILTER, APPLICATION_INBOUND_AUTH_KEY_1,
+                        APPLICATION_INBOUND_AUTH_KEY_2)), 1);
+        Assert.assertEquals(applicationManagementService.getCountOfApplications(SUPER_TENANT_DOMAIN_NAME, USERNAME_1,
+                String.format(APPLICATION_NAME_AND_ISSUER_OR_CLIENT_ID_FILTER, APPLICATION_INBOUND_AUTH_KEY_2,
+                        APPLICATION_INBOUND_AUTH_KEY_1)), 0);
 
         // Deleting all added applications.
         applicationManagementService.deleteApplications(SUPER_TENANT_ID);


### PR DESCRIPTION
### Proposed changes in this pull request
- Allow filter query to contain any number of 'and', 'or' operations.
- Added SAML issuer as an application filter attribute.

### Related Issues
Fixes [asgardeo-product/#11894](https://github.com/wso2-enterprise/asgardeo-product/issues/11894)
