### PR TITLE
Fix for organization qualified carbon.super service url building issue

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
@@ -124,7 +124,8 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && !resolvedUrlContext.startsWith("t/") &&
                 !resolvedUrlContext.startsWith("o/")) {
             if (mandateTenantedPath || isNotSuperTenant(tenantDomain)) {
-                if (PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId() != null) {
+                if (PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId() != null &&
+                        isNotSuperTenant(tenantDomain)) {
                     resolvedUrlStringBuilder.append("/o/").append(tenantDomain);
                 } else {
                     resolvedUrlStringBuilder.append("/t/").append(tenantDomain);

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
@@ -124,9 +124,11 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && !resolvedUrlContext.startsWith("t/") &&
                 !resolvedUrlContext.startsWith("o/")) {
             if (mandateTenantedPath || isNotSuperTenant(tenantDomain)) {
-                if (PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId() != null &&
-                        isNotSuperTenant(tenantDomain)) {
-                    resolvedUrlStringBuilder.append("/o/").append(tenantDomain);
+                // When requesting from an organization qualified url, the service urls should be organization qualified
+                // except when the service url should build for super tenant domain.
+                String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
+                if (organizationId != null && isNotSuperTenant(tenantDomain)) {
+                    resolvedUrlStringBuilder.append("/o/").append(organizationId);
                 } else {
                     resolvedUrlStringBuilder.append("/t/").append(tenantDomain);
                 }


### PR DESCRIPTION
### Proposed changes in this pull request

When login to super tenant owned service provider apps while tenanted session enabled, the commonauth endpoint send the sessionDataKey as a redirection for authorize endpoint as shown in below figure. The authorize endpoint url is tenant qualified as `t/carbon.super`. The service url builder improvement to support organization qualified urls in this https://github.com/wso2/carbon-identity-framework/pull/4229 fails for the above mentioned situations by updating the `t/carbon.super` to `o/carbon.super` and it causes for a failure. This PR is sent as a fix for that.

![Untitled Diagram-Page-4](https://user-images.githubusercontent.com/35717390/188561404-a7502431-c382-4365-9210-69ee17f04d04.jpg)


### Expected behaviour

![Untitled Diagram-Page-2 (4)](https://user-images.githubusercontent.com/35717390/187452213-343a7152-ffcd-4b0b-934d-371f56e967be.jpg)

### Related Issues
 - https://github.com/wso2-enterprise/identity-org-mgt-connector/issues/17