### PR TITLE
Add configuration to enable server side restriction for CORS

### DIFF
--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/Constants.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/Constants.java
@@ -79,6 +79,7 @@ public class Constants {
         public static final String SUPPORTS_CREDENTIALS = "supportsCredentials";
         public static final String MAX_AGE = "maxAge";
         public static final String TAG_REQUESTS = "tagRequests";
+        public static final String ENABLE_SERVER_SIDE_RESTRICTION = "enableServerSideRestriction";
 
         private CORSConfigurationAttributes() {
 

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/function/CORSConfigurationToResourceAdd.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/function/CORSConfigurationToResourceAdd.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 import static org.wso2.carbon.identity.cors.mgt.core.internal.Constants.CORSConfigurationAttributes.ALLOW_ANY_ORIGIN;
 import static org.wso2.carbon.identity.cors.mgt.core.internal.Constants.CORSConfigurationAttributes.ALLOW_GENERIC_HTTP_REQUESTS;
 import static org.wso2.carbon.identity.cors.mgt.core.internal.Constants.CORSConfigurationAttributes.ALLOW_SUBDOMAINS;
+import static org.wso2.carbon.identity.cors.mgt.core.internal.Constants.CORSConfigurationAttributes.ENABLE_SERVER_SIDE_RESTRICTION;
 import static org.wso2.carbon.identity.cors.mgt.core.internal.Constants.CORSConfigurationAttributes.EXPOSED_HEADERS;
 import static org.wso2.carbon.identity.cors.mgt.core.internal.Constants.CORSConfigurationAttributes.MAX_AGE;
 import static org.wso2.carbon.identity.cors.mgt.core.internal.Constants.CORSConfigurationAttributes.SUPPORTED_HEADERS;
@@ -63,6 +64,8 @@ public class CORSConfigurationToResourceAdd implements Function<CORSConfiguratio
         addAttribute(attributes, SUPPORTS_CREDENTIALS, String.valueOf(corsConfiguration.isSupportsCredentials()));
         addAttribute(attributes, MAX_AGE, String.valueOf(corsConfiguration.getMaxAge()));
         addAttribute(attributes, TAG_REQUESTS, String.valueOf(corsConfiguration.isTagRequests()));
+        addAttribute(attributes, ENABLE_SERVER_SIDE_RESTRICTION,
+                String.valueOf(corsConfiguration.isEnableServerSideRestriction()));
 
         resourceAdd.setAttributes(attributes);
 

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/function/ResourceToCORSConfiguration.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/function/ResourceToCORSConfiguration.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import static org.wso2.carbon.identity.cors.mgt.core.internal.Constants.CORSConfigurationAttributes.ALLOW_ANY_ORIGIN;
 import static org.wso2.carbon.identity.cors.mgt.core.internal.Constants.CORSConfigurationAttributes.ALLOW_GENERIC_HTTP_REQUESTS;
 import static org.wso2.carbon.identity.cors.mgt.core.internal.Constants.CORSConfigurationAttributes.ALLOW_SUBDOMAINS;
+import static org.wso2.carbon.identity.cors.mgt.core.internal.Constants.CORSConfigurationAttributes.ENABLE_SERVER_SIDE_RESTRICTION;
 import static org.wso2.carbon.identity.cors.mgt.core.internal.Constants.CORSConfigurationAttributes.EXPOSED_HEADERS;
 import static org.wso2.carbon.identity.cors.mgt.core.internal.Constants.CORSConfigurationAttributes.MAX_AGE;
 import static org.wso2.carbon.identity.cors.mgt.core.internal.Constants.CORSConfigurationAttributes.SUPPORTED_HEADERS;
@@ -64,6 +65,8 @@ public class ResourceToCORSConfiguration implements Function<Resource, CORSConfi
             corsConfiguration.setSupportsCredentials(Boolean.parseBoolean(attributeMap.get(SUPPORTS_CREDENTIALS)));
             corsConfiguration.setMaxAge(Integer.parseInt(attributeMap.get(MAX_AGE)));
             corsConfiguration.setTagRequests(Boolean.parseBoolean(attributeMap.get(TAG_REQUESTS)));
+            corsConfiguration.setEnableServerSideRestriction(Boolean.parseBoolean(
+                    attributeMap.get(ENABLE_SERVER_SIDE_RESTRICTION)));
         }
 
         return corsConfiguration;

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/util/CORSConfigurationUtils.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/util/CORSConfigurationUtils.java
@@ -117,6 +117,8 @@ public class CORSConfigurationUtils {
             corsConfiguration.setTagRequests(Boolean.parseBoolean(IdentityUtil.getProperty(
                     IdentityConstants.CORS.TAG_REQUESTS)));
 
+            corsConfiguration.setEnableServerSideRestriction(Boolean.parseBoolean((IdentityUtil.getProperty(
+                    IdentityConstants.CORS.ENABLE_SERVER_SIDE_RESTRICTION))));
         }
 
         return corsConfiguration;

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/model/CORSConfiguration.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/model/CORSConfiguration.java
@@ -86,6 +86,11 @@ public class CORSConfiguration {
     private boolean tagRequests;
 
     /**
+     * Enable the server side request blocking behaviour for CORS requests which are not allowed.
+     */
+    private boolean enableServerSideRestriction;
+
+    /**
      * Default constructor.
      */
     public CORSConfiguration() {
@@ -193,5 +198,15 @@ public class CORSConfiguration {
     public void setTagRequests(boolean tagRequests) {
 
         this.tagRequests = tagRequests;
+    }
+
+    public boolean isEnableServerSideRestriction() {
+
+        return enableServerSideRestriction;
+    }
+
+    public void setEnableServerSideRestriction(boolean enableServerSideRestriction) {
+
+        this.enableServerSideRestriction = enableServerSideRestriction;
     }
 }

--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -529,6 +529,8 @@ public class IdentityConstants {
         public static final String SUPPORTS_CREDENTIALS = "CORS.SupportsCredentials";
         public static final String MAX_AGE = "CORS.MaxAge";
         public static final String TAG_REQUESTS = "CORS.TagRequests";
+
+        public static final String ENABLE_SERVER_SIDE_RESTRICTION = "CORS.EnableServerSideRestriction";
     }
 
     /**

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3053,6 +3053,7 @@
         <SupportsCredentials>{{cors.supports_credentials}}</SupportsCredentials>
         <MaxAge>{{cors.max_age}}</MaxAge>
         <TagRequests>{{cors.tag_requests}}</TagRequests>
+        <EnableServerSideRestriction>{{cors.enable_server_side_restriction}}</EnableServerSideRestriction>
     </CORS>
 
     <LegacyFeatures>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -878,6 +878,7 @@
   "cors.supports_credentials": true,
   "cors.max_age": -1,
   "cors.tag_requests": false,
+  "cors.enable_server_side_restriction": false,
   "audit.log.contextual_param.params": [],
   "common_auth_caller_path.enable_common_auth_caller_path_validation": true,
   "axis2.transport_sender.local.name": "local",


### PR DESCRIPTION
### Proposed changes in this pull request
Add configuration to enable server side restriction in cors

Default value for `cors.enable_server_side_restriction` : `false`

**Related Issue:** wso2/product-is#14490

