### PR TITLE
My account application o/path support for sub organisation users

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2046,6 +2046,9 @@
             <Context>
                 <BasePath>/console/</BasePath>
             </Context>
+            <Context>
+                <BasePath>/myaccount/</BasePath>
+            </Context>
         </WebApp>
         <Servlet>
             <Context>/commonauth(.*)</Context>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2023,6 +2023,7 @@
                     <Path>/scim2/Groups</Path>
                     <Path>/scim2/Users</Path>
                     <Path>/scim2/Schemas</Path>
+                    <Path>/scim2/Me</Path>
                 </SubPaths>
             </Context>
             <Context>
@@ -2041,6 +2042,14 @@
                     <Path>/api/server/v1/configs/authenticators</Path>
                     <Path>/api/server/v1/userstores</Path>
                     <Path>/api/server/v1/claim-dialects</Path>
+                    <Path>/api/server/v1/configs/home-realm-identifiers</Path>
+                    <Path>/api/server/v1/identity-governance/preferences</Path>
+                    <Path>/api/users/v1/me</Path>
+                    <Path>/api/users/v2/me/webauthn</Path>
+                    <Path>/api/identity/user/v1.0/me</Path>
+                    <Path>/api/identity/consent-mgt/v1.0/consents</Path>
+                    <Path>/api/identity/typingdna/v1.0/me/typingpatterns</Path>
+                    <Path>/api/identity/typingdna/v1.0/server/typingdnaConfig</Path>
                 </SubPaths>
             </Context>
             <Context>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2764,6 +2764,7 @@
                     <Path>/scim2/Groups</Path>
                     <Path>/scim2/Users</Path>
                     <Path>/scim2/Schemas</Path>
+                    <Path>/scim2/Me</Path>
                 </SubPaths>
             </Context>
             <Context>
@@ -2782,6 +2783,14 @@
                     <Path>/api/server/v1/configs/authenticators</Path>
                     <Path>/api/server/v1/userstores</Path>
                     <Path>/api/server/v1/claim-dialects</Path>
+                    <Path>/api/server/v1/configs/home-realm-identifiers</Path>
+                    <Path>/api/server/v1/identity-governance/preferences</Path>
+                    <Path>/api/users/v1/me</Path>
+                    <Path>/api/users/v2/me/webauthn</Path>
+                    <Path>/api/identity/user/v1.0/me</Path>
+                    <Path>/api/identity/consent-mgt/v1.0/consents</Path>
+                    <Path>/api/identity/typingdna/v1.0/me/typingpatterns</Path>
+                    <Path>/api/identity/typingdna/v1.0/server/typingdnaConfig</Path>
                 </SubPaths>
             </Context>
             <Context>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2787,6 +2787,9 @@
             <Context>
                 <BasePath>/console/</BasePath>
             </Context>
+            <Context>
+                <BasePath>/myaccount/</BasePath>
+            </Context>
         </WebApp>
         <Servlet>
         {% for servlet in organization_context.rewrite.servlets %}


### PR DESCRIPTION
### Proposed changes in this pull request

- MyAccount URI for the users residing in sub-organizations show t/ paths instead of o/ paths.

### When should this PR be merged

- Once the PR for the frontend changes is merged to support this purpose.
