### PR TITLE
Allow to resolve `authenticationOptions` based on authenticator name or display name

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
@@ -245,6 +245,7 @@ public abstract class JsGraphBuilder implements JsBaseGraphBuilder {
     protected void filterOptions(Map<String, Map<String, String>> authenticationOptions, StepConfig stepConfig) {
 
         Map<String, Set<String>> filteredOptions = new HashMap<>();
+        final String[] authenticatorNameResolver = new String[1];
         authenticationOptions.forEach((id, option) -> {
             String idp = option.get(FrameworkConstants.JSAttributes.IDP);
             String authenticator = option.get(FrameworkConstants.JSAttributes.AUTHENTICATOR);
@@ -255,8 +256,13 @@ public abstract class JsGraphBuilder implements JsBaseGraphBuilder {
             if (StringUtils.isNotBlank(idp)) {
                 filteredOptions.putIfAbsent(idp, new HashSet<>());
                 if (StringUtils.isNotBlank(authenticator)) {
-                    filteredOptions.get(idp).add(authenticator.toLowerCase());
+                    filteredOptions.get(idp).add(authenticator);
                 }
+            }
+            if (StringUtils.isNotBlank(
+                    option.get(FrameworkConstants.JSAttributes.AUTHENTICATOR_NAME_RESOLVER_PARAM))) {
+                authenticatorNameResolver[0] = option.get(FrameworkConstants.JSAttributes.
+                        AUTHENTICATOR_NAME_RESOLVER_PARAM);
             }
         });
         if (log.isDebugEnabled()) {
@@ -280,19 +286,31 @@ public abstract class JsGraphBuilder implements JsBaseGraphBuilder {
                     }
                     removeOption = true;
                 } else if (!authenticators.isEmpty()) {
-                    // Both idp and authenticator present, but authenticator is given by display name due to the fact
-                    // that it is the one available at UI. Should translate the display name to actual name, and
-                    // keep/remove option
+                    // Both idp and authenticator present.
                     removeOption = true;
 
                     if (FrameworkConstants.LOCAL_IDP_NAME.equals(idpName)) {
                         List<LocalAuthenticatorConfig> localAuthenticators = ApplicationAuthenticatorService
                             .getInstance().getLocalAuthenticators();
                         for (LocalAuthenticatorConfig localAuthenticatorConfig : localAuthenticators) {
-                            if (authenticatorConfig.getName().equals(localAuthenticatorConfig.getName()) &&
-                                authenticators.contains(localAuthenticatorConfig.getDisplayName().toLowerCase())) {
-                                removeOption = false;
-                                break;
+                            if (StringUtils.isNotBlank(authenticatorNameResolver[0]) &&
+                                    authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
+                                            AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE)) {
+                                if (authenticatorConfig.getName().equals(localAuthenticatorConfig.getName()) &&
+                                        authenticators.contains(localAuthenticatorConfig.getName())) {
+                                    removeOption = false;
+                                    break;
+                                }
+                            } else {
+                                // If the authenticatorNameResolver is not defined or is equal to the authenticator
+                                // display name, authenticator display name will be used to resolve the
+                                // authentication options.
+                                // Should translate the display name to actual name, and keep/remove option.
+                                if (authenticatorConfig.getName().equals(localAuthenticatorConfig.getName()) &&
+                                        authenticators.contains(localAuthenticatorConfig.getDisplayName())) {
+                                    removeOption = false;
+                                    break;
+                                }
                             }
                         }
                         if (log.isDebugEnabled()) {
@@ -307,10 +325,24 @@ public abstract class JsGraphBuilder implements JsBaseGraphBuilder {
                     } else {
                         for (FederatedAuthenticatorConfig federatedAuthConfig
                                 : idp.getFederatedAuthenticatorConfigs()) {
-                            if (authenticatorConfig.getName().equals(federatedAuthConfig.getName()) &&
-                                authenticators.contains(federatedAuthConfig.getDisplayName().toLowerCase())) {
-                                removeOption = false;
-                                break;
+                            if (StringUtils.isNotBlank(authenticatorNameResolver[0]) &&
+                                    authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
+                                            AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE)) {
+                                if (authenticatorConfig.getName().equals(federatedAuthConfig.getName()) &&
+                                        authenticators.contains(federatedAuthConfig.getName())) {
+                                    removeOption = false;
+                                    break;
+                                }
+                            } else {
+                                // If the authenticatorNameResolver is not defined or is equal to the authenticator
+                                // display name, authenticator display name will be used to resolve the
+                                // authentication options.
+                                // Should translate the display name to actual name, and keep/remove option.
+                                if (authenticatorConfig.getName().equals(federatedAuthConfig.getName()) &&
+                                        authenticators.contains(federatedAuthConfig.getDisplayName())) {
+                                    removeOption = false;
+                                    break;
+                                }
                             }
                         }
                         if (log.isDebugEnabled()) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
@@ -247,6 +247,29 @@ public abstract class JsGraphBuilder implements JsBaseGraphBuilder {
         Map<String, Set<String>> filteredOptions = new HashMap<>();
         final String[] authenticatorNameResolver = new String[1];
         authenticationOptions.forEach((id, option) -> {
+            String authenticatorNameResolverParam = option.get(FrameworkConstants.JSAttributes.
+                    AUTHENTICATOR_NAME_RESOLVER_PARAM);
+            if (StringUtils.isNotBlank(authenticatorNameResolverParam)) {
+                authenticatorNameResolver[0] = authenticatorNameResolverParam;
+            }
+        });
+        if (StringUtils.isBlank(authenticatorNameResolver[0])) {
+            authenticatorNameResolver[0] =
+                    FrameworkConstants.JSAttributes.AUTHENTICATOR_NAME_RESOLVER_DISPLAY_NAME_VALUE;
+        } else {
+            if (!authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
+                    AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE) && !authenticatorNameResolver[0].equals(
+                            FrameworkConstants.JSAttributes.AUTHENTICATOR_NAME_RESOLVER_DISPLAY_NAME_VALUE)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Invalid value provided for " + FrameworkConstants.JSAttributes.
+                            AUTHENTICATOR_NAME_RESOLVER_PARAM + ". Defaulting to authenticator display name.");
+                }
+                authenticatorNameResolver[0] =
+                        FrameworkConstants.JSAttributes.AUTHENTICATOR_NAME_RESOLVER_DISPLAY_NAME_VALUE;
+            }
+        }
+
+        authenticationOptions.forEach((id, option) -> {
             String idp = option.get(FrameworkConstants.JSAttributes.IDP);
             String authenticator = option.get(FrameworkConstants.JSAttributes.AUTHENTICATOR);
             if (StringUtils.isNotBlank(authenticator) && StringUtils.isBlank(idp)) {
@@ -256,13 +279,13 @@ public abstract class JsGraphBuilder implements JsBaseGraphBuilder {
             if (StringUtils.isNotBlank(idp)) {
                 filteredOptions.putIfAbsent(idp, new HashSet<>());
                 if (StringUtils.isNotBlank(authenticator)) {
-                    filteredOptions.get(idp).add(authenticator);
+                    if (authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
+                            AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE)) {
+                        filteredOptions.get(idp).add(authenticator);
+                    } else {
+                        filteredOptions.get(idp).add(authenticator.toLowerCase());
+                    }
                 }
-            }
-            if (StringUtils.isNotBlank(
-                    option.get(FrameworkConstants.JSAttributes.AUTHENTICATOR_NAME_RESOLVER_PARAM))) {
-                authenticatorNameResolver[0] = option.get(FrameworkConstants.JSAttributes.
-                        AUTHENTICATOR_NAME_RESOLVER_PARAM);
             }
         });
         if (log.isDebugEnabled()) {
@@ -293,9 +316,8 @@ public abstract class JsGraphBuilder implements JsBaseGraphBuilder {
                         List<LocalAuthenticatorConfig> localAuthenticators = ApplicationAuthenticatorService
                             .getInstance().getLocalAuthenticators();
                         for (LocalAuthenticatorConfig localAuthenticatorConfig : localAuthenticators) {
-                            if (StringUtils.isNotBlank(authenticatorNameResolver[0]) &&
-                                    authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
-                                            AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE)) {
+                            if (authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
+                                    AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE)) {
                                 if (authenticatorConfig.getName().equals(localAuthenticatorConfig.getName()) &&
                                         authenticators.contains(localAuthenticatorConfig.getName())) {
                                     removeOption = false;
@@ -307,7 +329,8 @@ public abstract class JsGraphBuilder implements JsBaseGraphBuilder {
                                 // authentication options.
                                 // Should translate the display name to actual name, and keep/remove option.
                                 if (authenticatorConfig.getName().equals(localAuthenticatorConfig.getName()) &&
-                                        authenticators.contains(localAuthenticatorConfig.getDisplayName())) {
+                                        authenticators.contains(localAuthenticatorConfig.getDisplayName().
+                                                toLowerCase())) {
                                     removeOption = false;
                                     break;
                                 }
@@ -325,9 +348,8 @@ public abstract class JsGraphBuilder implements JsBaseGraphBuilder {
                     } else {
                         for (FederatedAuthenticatorConfig federatedAuthConfig
                                 : idp.getFederatedAuthenticatorConfigs()) {
-                            if (StringUtils.isNotBlank(authenticatorNameResolver[0]) &&
-                                    authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
-                                            AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE)) {
+                            if (authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
+                                    AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE)) {
                                 if (authenticatorConfig.getName().equals(federatedAuthConfig.getName()) &&
                                         authenticators.contains(federatedAuthConfig.getName())) {
                                     removeOption = false;
@@ -339,7 +361,7 @@ public abstract class JsGraphBuilder implements JsBaseGraphBuilder {
                                 // authentication options.
                                 // Should translate the display name to actual name, and keep/remove option.
                                 if (authenticatorConfig.getName().equals(federatedAuthConfig.getName()) &&
-                                        authenticators.contains(federatedAuthConfig.getDisplayName())) {
+                                        authenticators.contains(federatedAuthConfig.getDisplayName().toLowerCase())) {
                                     removeOption = false;
                                     break;
                                 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsNashornGraphBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsNashornGraphBuilder.java
@@ -394,6 +394,7 @@ public class JsNashornGraphBuilder extends JsGraphBuilder {
     protected void filterOptions(Map<String, Map<String, String>> authenticationOptions, StepConfig stepConfig) {
 
         Map<String, Set<String>> filteredOptions = new HashMap<>();
+        final String[] authenticatorNameResolver = new String[1];
         authenticationOptions.forEach((id, option) -> {
             String idp = option.get(FrameworkConstants.JSAttributes.IDP);
             String authenticator = option.get(FrameworkConstants.JSAttributes.AUTHENTICATOR);
@@ -404,8 +405,13 @@ public class JsNashornGraphBuilder extends JsGraphBuilder {
             if (StringUtils.isNotBlank(idp)) {
                 filteredOptions.putIfAbsent(idp, new HashSet<>());
                 if (StringUtils.isNotBlank(authenticator)) {
-                    filteredOptions.get(idp).add(authenticator.toLowerCase());
+                    filteredOptions.get(idp).add(authenticator);
                 }
+            }
+            if (StringUtils.isNotBlank(
+                    option.get(FrameworkConstants.JSAttributes.AUTHENTICATOR_NAME_RESOLVER_PARAM))) {
+                authenticatorNameResolver[0] = option.get(FrameworkConstants.JSAttributes.
+                        AUTHENTICATOR_NAME_RESOLVER_PARAM);
             }
         });
         if (log.isDebugEnabled()) {
@@ -429,19 +435,31 @@ public class JsNashornGraphBuilder extends JsGraphBuilder {
                     }
                     removeOption = true;
                 } else if (!authenticators.isEmpty()) {
-                    // Both idp and authenticator present, but authenticator is given by display name due to the fact
-                    // that it is the one available at UI. Should translate the display name to actual name, and
-                    // keep/remove option
+                    // Both idp and authenticator present.
                     removeOption = true;
 
                     if (FrameworkConstants.LOCAL_IDP_NAME.equals(idpName)) {
                         List<LocalAuthenticatorConfig> localAuthenticators = ApplicationAuthenticatorService
                             .getInstance().getLocalAuthenticators();
                         for (LocalAuthenticatorConfig localAuthenticatorConfig : localAuthenticators) {
-                            if (authenticatorConfig.getName().equals(localAuthenticatorConfig.getName()) &&
-                                authenticators.contains(localAuthenticatorConfig.getDisplayName().toLowerCase())) {
-                                removeOption = false;
-                                break;
+                            if (StringUtils.isNotBlank(authenticatorNameResolver[0]) &&
+                                    authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
+                                            AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE)) {
+                                if (authenticatorConfig.getName().equals(localAuthenticatorConfig.getName()) &&
+                                        authenticators.contains(localAuthenticatorConfig.getName())) {
+                                    removeOption = false;
+                                    break;
+                                }
+                            } else {
+                                // If the authenticatorNameResolver is not defined or is equal to the authenticator
+                                // display name, authenticator display name will be used to resolve the
+                                // authentication options.
+                                // Should translate the display name to actual name, and keep/remove option.
+                                if (authenticatorConfig.getName().equals(localAuthenticatorConfig.getName()) &&
+                                        authenticators.contains(localAuthenticatorConfig.getDisplayName())) {
+                                    removeOption = false;
+                                    break;
+                                }
                             }
                         }
                         if (log.isDebugEnabled()) {
@@ -456,10 +474,24 @@ public class JsNashornGraphBuilder extends JsGraphBuilder {
                     } else {
                         for (FederatedAuthenticatorConfig federatedAuthConfig
                                 : idp.getFederatedAuthenticatorConfigs()) {
-                            if (authenticatorConfig.getName().equals(federatedAuthConfig.getName()) &&
-                                authenticators.contains(federatedAuthConfig.getDisplayName().toLowerCase())) {
-                                removeOption = false;
-                                break;
+                            if (StringUtils.isNotBlank(authenticatorNameResolver[0]) &&
+                                    authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
+                                            AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE)) {
+                                if (authenticatorConfig.getName().equals(federatedAuthConfig.getName()) &&
+                                        authenticators.contains(federatedAuthConfig.getName())) {
+                                    removeOption = false;
+                                    break;
+                                }
+                            } else {
+                                // If the authenticatorNameResolver is not defined or is equal to the authenticator
+                                // display name, authenticator display name will be used to resolve the
+                                // authentication options.
+                                // Should translate the display name to actual name, and keep/remove option.
+                                if (authenticatorConfig.getName().equals(federatedAuthConfig.getName()) &&
+                                        authenticators.contains(federatedAuthConfig.getDisplayName())) {
+                                    removeOption = false;
+                                    break;
+                                }
                             }
                         }
                         if (log.isDebugEnabled()) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/openjdk/nashorn/JsOpenJdkNashornGraphBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/openjdk/nashorn/JsOpenJdkNashornGraphBuilder.java
@@ -418,6 +418,29 @@ public class JsOpenJdkNashornGraphBuilder extends JsGraphBuilder {
         Map<String, Set<String>> filteredOptions = new HashMap<>();
         final String[] authenticatorNameResolver = new String[1];
         authenticationOptions.forEach((id, option) -> {
+            String authenticatorNameResolverParam = option.get(FrameworkConstants.JSAttributes.
+                    AUTHENTICATOR_NAME_RESOLVER_PARAM);
+            if (StringUtils.isNotBlank(authenticatorNameResolverParam)) {
+                authenticatorNameResolver[0] = authenticatorNameResolverParam;
+            }
+        });
+        if (StringUtils.isBlank(authenticatorNameResolver[0])) {
+            authenticatorNameResolver[0] =
+                    FrameworkConstants.JSAttributes.AUTHENTICATOR_NAME_RESOLVER_DISPLAY_NAME_VALUE;
+        } else {
+            if (!authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
+                    AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE) && !authenticatorNameResolver[0].equals(
+                    FrameworkConstants.JSAttributes.AUTHENTICATOR_NAME_RESOLVER_DISPLAY_NAME_VALUE)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Invalid value provided for " + FrameworkConstants.JSAttributes.
+                            AUTHENTICATOR_NAME_RESOLVER_PARAM + ". Defaulting to authenticator display name.");
+                }
+                authenticatorNameResolver[0] =
+                        FrameworkConstants.JSAttributes.AUTHENTICATOR_NAME_RESOLVER_DISPLAY_NAME_VALUE;
+            }
+        }
+
+        authenticationOptions.forEach((id, option) -> {
             String idp = option.get(FrameworkConstants.JSAttributes.IDP);
             String authenticator = option.get(FrameworkConstants.JSAttributes.AUTHENTICATOR);
             if (StringUtils.isNotBlank(authenticator) && StringUtils.isBlank(idp)) {
@@ -427,13 +450,13 @@ public class JsOpenJdkNashornGraphBuilder extends JsGraphBuilder {
             if (StringUtils.isNotBlank(idp)) {
                 filteredOptions.putIfAbsent(idp, new HashSet<>());
                 if (StringUtils.isNotBlank(authenticator)) {
-                    filteredOptions.get(idp).add(authenticator);
+                    if (authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
+                            AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE)) {
+                        filteredOptions.get(idp).add(authenticator);
+                    } else {
+                        filteredOptions.get(idp).add(authenticator.toLowerCase());
+                    }
                 }
-            }
-            if (StringUtils.isNotBlank(
-                    option.get(FrameworkConstants.JSAttributes.AUTHENTICATOR_NAME_RESOLVER_PARAM))) {
-                authenticatorNameResolver[0] = option.get(FrameworkConstants.JSAttributes.
-                        AUTHENTICATOR_NAME_RESOLVER_PARAM);
             }
         });
         if (log.isDebugEnabled()) {
@@ -464,9 +487,8 @@ public class JsOpenJdkNashornGraphBuilder extends JsGraphBuilder {
                         List<LocalAuthenticatorConfig> localAuthenticators = ApplicationAuthenticatorService
                             .getInstance().getLocalAuthenticators();
                         for (LocalAuthenticatorConfig localAuthenticatorConfig : localAuthenticators) {
-                            if (StringUtils.isNotBlank(authenticatorNameResolver[0]) &&
-                                    authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
-                                            AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE)) {
+                            if (authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
+                                    AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE)) {
                                 if (authenticatorConfig.getName().equals(localAuthenticatorConfig.getName()) &&
                                         authenticators.contains(localAuthenticatorConfig.getName())) {
                                     removeOption = false;
@@ -478,7 +500,8 @@ public class JsOpenJdkNashornGraphBuilder extends JsGraphBuilder {
                                 // authentication options.
                                 // Should translate the display name to actual name, and keep/remove option.
                                 if (authenticatorConfig.getName().equals(localAuthenticatorConfig.getName()) &&
-                                        authenticators.contains(localAuthenticatorConfig.getDisplayName())) {
+                                        authenticators.contains(localAuthenticatorConfig.getDisplayName().
+                                                toLowerCase())) {
                                     removeOption = false;
                                     break;
                                 }
@@ -496,9 +519,8 @@ public class JsOpenJdkNashornGraphBuilder extends JsGraphBuilder {
                     } else {
                         for (FederatedAuthenticatorConfig federatedAuthConfig
                                 : idp.getFederatedAuthenticatorConfigs()) {
-                            if (StringUtils.isNotBlank(authenticatorNameResolver[0]) &&
-                                    authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
-                                            AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE)) {
+                            if (authenticatorNameResolver[0].equals(FrameworkConstants.JSAttributes.
+                                    AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE)) {
                                 if (authenticatorConfig.getName().equals(federatedAuthConfig.getName()) &&
                                         authenticators.contains(federatedAuthConfig.getName())) {
                                     removeOption = false;
@@ -510,7 +532,7 @@ public class JsOpenJdkNashornGraphBuilder extends JsGraphBuilder {
                                 // authentication options.
                                 // Should translate the display name to actual name, and keep/remove option.
                                 if (authenticatorConfig.getName().equals(federatedAuthConfig.getName()) &&
-                                        authenticators.contains(federatedAuthConfig.getDisplayName())) {
+                                        authenticators.contains(federatedAuthConfig.getDisplayName().toLowerCase())) {
                                     removeOption = false;
                                     break;
                                 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -512,6 +512,9 @@ public abstract class FrameworkConstants {
         public static final String IDP = "idp";
         public static final String AUTHENTICATOR = "authenticator";
         public static final String AUTHENTICATION_OPTIONS = "authenticationOptions";
+        public static final String AUTHENTICATOR_NAME_RESOLVER_PARAM = "authenticatorNameResolver";
+        public static final String AUTHENTICATOR_NAME_RESOLVER_AUTHENTICATOR_NAME_VALUE = "AUTHENTICATOR_NAME";
+        public static final String AUTHENTICATOR_NAME_RESOLVER_DISPLAY_NAME_VALUE = "AUTHENTICATOR_DISPLAY_NAME";
         public static final String STEP_OPTIONS = "stepOptions";
         public static final String AUTHENTICATOR_PARAMS = "authenticatorParams";
         public static final String FORCE_AUTH_PARAM = "forceAuth";


### PR DESCRIPTION
Currently in adaptive scripts we use authenticator friendly names to resolve `authenticationOptions` parameter. However this raises troubles when the authenticator display names get changed.
We should use authenticator names instead of friendly names in adaptive scripts. Friendly names should be expect to change.
To preserve backward compatibility, we are introducing a new parameter to resolve the authenticator identifier.

Example:
```js
executeStep(1, {
    authenticationOptions: [
        { idp: "LOCAL" }, 
        { authenticator: "sms-otp-authenticator" }, 
        { authenticatorNameResolver: "AUTHENTICATOR_NAME" }
    ]
}, {
    onSuccess: function (context) {
        // Do something on success
    }
});
```

### Related issue
- https://github.com/wso2/product-is/issues/14843

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
