### PR TITLE
Add feature to send OTPs in e-mail verifications.

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -99,6 +99,8 @@ public class IdentityProviderManager implements IdpManager {
 
     private static final Log log = LogFactory.getLog(IdentityProviderManager.class);
     private static final String OPENID_IDP_ENTITY_ID = "IdPEntityId";
+    private static final int OTP_CODE_MIN_LENGTH = 4;
+    private static final int OTP_CODE_MAX_LENGTH = 10;
     private static CacheBackedIdPMgtDAO dao = new CacheBackedIdPMgtDAO(new IdPManagementDAO());
     private static volatile IdentityProviderManager instance = new IdentityProviderManager();
 
@@ -987,6 +989,13 @@ public class IdentityProviderManager implements IdpManager {
                     }
                 }
 
+            }
+            if (isAnOTPLengthConfig(idpProp)) {
+                if (StringUtils.isEmpty(idpProp.getValue()) || !StringUtils.isNumeric(idpProp.getValue()) ||
+                        Integer.parseInt(idpProp.getValue().trim()) < OTP_CODE_MIN_LENGTH ||
+                        Integer.parseInt(idpProp.getValue().trim()) > OTP_CODE_MAX_LENGTH) {
+                    throw new IdentityProviderManagementException("Invalid OTP length");
+                }
             }
         }
         // invoking the pre listeners
@@ -3110,5 +3119,23 @@ public class IdentityProviderManager implements IdpManager {
             throw new IdentityProviderManagementException("Error while configuring metadata", e);
         }
         return propertyWithName;
+    }
+
+    /**
+     * Check whether the identity property is an OTP length property.
+     *
+     * @param property  Identity Provider property.
+     * @return true if the identity property is OTP length property, otherwise false.
+     */
+    private boolean isAnOTPLengthConfig(IdentityProviderProperty property) {
+
+        if (StringUtils.equals(property.getName(), "SelfRegistration.OTP.OTPLength") ||
+                StringUtils.equals(property.getName(), "LiteRegistration.OTP.OTPLength") ||
+                StringUtils.equals(property.getName(), "EmailVerification.OTP.OTPLength") ||
+                StringUtils.equals(property.getName(), "UserClaimUpdate.OTP.OTPLength") ||
+                StringUtils.equals(property.getName(), "Recovery.Notification.Password.OTP.OTPLength")) {
+            return true;
+        }
+        return false;
     }
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1147,6 +1147,13 @@
                 <ExpiryTime>
                     <smsOtp>{{identity_mgt.password_reset_sms.sms_otp_validity}}</smsOtp>
                 </ExpiryTime>
+                <OTP>
+                    <SendOTPInEmail>{{identity_mgt.password_reset_email.otp.send_otp_in_email}}</SendOTPInEmail>
+                    <UseUppercaseInOtp>{{identity_mgt.password_reset_email.otp.use_uppercase_in_otp}}</UseUppercaseInOtp>
+                    <UseLowercaseInOtp>{{identity_mgt.password_reset_email.otp.use_lowercase_in_otp}}</UseLowercaseInOtp>
+                    <UseNumericInOtp>{{identity_mgt.password_reset_email.otp.use_numeric_in_otp}}</UseNumericInOtp>
+                    <OTPLength>{{identity_mgt.password_reset_email.otp.otp_length}}</OTPLength>
+                </OTP>
                 <smsOtp>
                     <Regex>{{identity_mgt.password_reset_sms.sms_otp_regex}}</Regex>
                 </smsOtp>
@@ -1229,6 +1236,13 @@
 
     <EmailVerification>
         <Enable>{{identity_mgt.user_onboarding.enable_email_verification}}</Enable>
+        <OTP>
+            <SendOTPInEmail>{{identity_mgt.user_onboarding.otp.send_otp_in_email}}</SendOTPInEmail>
+            <UseUppercaseInOtp>{{identity_mgt.user_onboarding.otp.use_uppercase_in_otp}}</UseUppercaseInOtp>
+            <UseLowercaseInOtp>{{identity_mgt.user_onboarding.otp.use_lowercase_in_otp}}</UseLowercaseInOtp>
+            <UseNumericInOtp>{{identity_mgt.user_onboarding.otp.use_numeric_in_otp}}</UseNumericInOtp>
+            <OTPLength>{{identity_mgt.user_onboarding.otp.otp_length}}</OTPLength>
+        </OTP>
         <ExpiryTime>{{identity_mgt.user_onboarding.verification_email_validity}}</ExpiryTime>
         <LockOnCreation>{{identity_mgt.user_onboarding.lock_on_creation}}</LockOnCreation>
         <Notification>
@@ -1249,6 +1263,13 @@
 
     <SelfRegistration>
         <Enable>{{identity_mgt.user_self_registration.allow_self_registration}}</Enable>
+        <OTP>
+            <SendOTPInEmail>{{identity_mgt.user_self_registration.otp.send_otp_in_email}}</SendOTPInEmail>
+            <UseUppercaseInOtp>{{identity_mgt.user_self_registration.otp.use_uppercase_in_otp}}</UseUppercaseInOtp>
+            <UseLowercaseInOtp>{{identity_mgt.user_self_registration.otp.use_lowercase_in_otp}}</UseLowercaseInOtp>
+            <UseNumericInOtp>{{identity_mgt.user_self_registration.otp.use_numeric_in_otp}}</UseNumericInOtp>
+            <OTPLength>{{identity_mgt.user_self_registration.otp.otp_length}}</OTPLength>
+        </OTP>
         <EnableAccountLockForVerifiedPreferredChannel>{{identity_mgt.user_self_registration.enable_account_lock_for_verified_preferred_channel}}</EnableAccountLockForVerifiedPreferredChannel>
         <API>
             <EnableDetailedResponseBody>{{identity_mgt.user_self_registration.enable_detailed_api_response}}</EnableDetailedResponseBody>
@@ -1313,6 +1334,13 @@
                 </VerificationCode>
              </VerificationOnUpdate>
         </Claim>
+        <OTP>
+            <SendOTPInEmail>{{identity_mgt.user_claim_update.otp.send_otp_in_email}}</SendOTPInEmail>
+            <UseUppercaseInOtp>{{identity_mgt.user_claim_update.otp.use_uppercase_in_otp}}</UseUppercaseInOtp>
+            <UseLowercaseInOtp>{{identity_mgt.user_claim_update.otp.use_lowercase_in_otp}}</UseLowercaseInOtp>
+            <UseNumericInOtp>{{identity_mgt.user_claim_update.otp.use_numeric_in_otp}}</UseNumericInOtp>
+            <OTPLength>{{identity_mgt.user_claim_update.otp.otp_length}}</OTPLength>
+        </OTP>
         <!-- When updating the claim value, the verification notification can be controlled by sending an additional
         temporary claim ('verifyEmail'/'verifyMobile') along with the update request. To enable this option,
         'UseVerifyClaim' should be set to true. -->


### PR DESCRIPTION
This is implemented as fix to the https://github.com/wso2/product-is/issues/14808

Follow are the changes introducing through this PR.

1. Validation to validate the input values of OTP length fields introduced through [1].
2. Include OTP config properties to identity.xml.j2 file. 

Below flows are affected by these changes.

Self Registration
Lite Registration
Ask Password
User Claim Update.
Notification based Password Recovery

[1] https://github.com/wso2-extensions/identity-governance/pull/617