### PR TITLE
Disable user-approval tab by default in console ui

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -700,7 +700,7 @@
   "console.applications.scopes.update": ["internal_application_mgt_update"],
   "console.applications.scopes.delete": ["internal_application_mgt_delete"],
   "console.applications.ui.certificate_alias_enabled": false,
-  "console.approvals.enabled": true,
+  "console.approvals.enabled": false,
   "console.approvals.scopes.create": ["internal_humantask_view"],
   "console.approvals.scopes.read": ["internal_humantask_view"],
   "console.approvals.scopes.update": ["internal_humantask_view"],


### PR DESCRIPTION
Hide the user approval tab by default in carbon-console. To enable it back again, add the following to `deploymet.toml`.

```
[console.approvals]
enabled=true
```