### PR TITLE
Fix NPE in username in patch

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -2334,7 +2334,7 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
         }
 
         try {
-            startTenantFlow(tenantDomain);
+            startTenantFlow(tenantDomain, username);
 
             ApplicationBasicInfo storedAppInfo = getApplicationBasicInfo(resourceId, tenantDomain);
             if (storedAppInfo == null) {


### PR DESCRIPTION
**Proposed changes in this pull request**
Due to the username being null in the tenanted flow initiated in the application patch request, throws 500 since the tenanted flow doesn't assign the username which initiates the request, which eventually used to update the permission path. 

**Fixes**
- https://github.com/wso2/product-is/issues/14892