### PR TITLE
Add configuration to enable realm user field based WWW-Authenticate header

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -654,6 +654,11 @@
 
     </OAuth>
 
+    <WWWAuthenticate>
+        <!-- Configuration for allowing to add realm user in WWW-Authenticate header. -->
+        <AddRealmUser>false</AddRealmUser>
+    </WWWAuthenticate>
+
     <MultifactorAuthentication>
         <!--Enable>false</Enable-->
         <XMPPSettings>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -654,10 +654,10 @@
 
     </OAuth>
 
-    <WWWAuthenticate>
-        <!-- Configuration for allowing to add realm user in WWW-Authenticate header. -->
-        <AddRealmUser>false</AddRealmUser>
-    </WWWAuthenticate>
+    <RestApiAuthentication>
+        <!-- Configuration for removing realm user field in WWW-Authenticate header. -->
+        <RemoveRealmUserFromError>true</RemoveRealmUserFromError>
+    </RestApiAuthentication>
 
     <MultifactorAuthentication>
         <!--Enable>false</Enable-->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -655,8 +655,8 @@
     </OAuth>
 
     <RestApiAuthentication>
-        <!-- Configuration for removing realm user field in WWW-Authenticate header. -->
-        <RemoveRealmUserFromError>true</RemoveRealmUserFromError>
+        <!-- Configuration for adding realm user field in WWW-Authenticate header. -->
+        <AddRealmUserToError>false</AddRealmUserToError>
     </RestApiAuthentication>
 
     <MultifactorAuthentication>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -900,10 +900,10 @@
 
     </OAuth>
 
-    <WWWAuthenticate>
-            <!-- Configuration for allowing to add realm user in WWW-Authenticate header. -->
-            <AddRealmUser>{{www_authenticate.add_realm_user}}</AddRealmUser>
-    </WWWAuthenticate>
+    <RestApiAuthentication>
+            <!-- Configuration for removing realm user field in WWW-Authenticate header. -->
+            <RemoveRealmUserFromError>{{rest_api_authentication.remove_realm_user_from_error}}</RemoveRealmUserFromError>
+    </RestApiAuthentication>
 
     <!--
     Configuration to select JS engine for Adaptive authentication feature.

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -901,8 +901,8 @@
     </OAuth>
 
     <RestApiAuthentication>
-            <!-- Configuration for removing realm user field in WWW-Authenticate header. -->
-            <RemoveRealmUserFromError>{{rest_api_authentication.remove_realm_user_from_error}}</RemoveRealmUserFromError>
+            <!-- Configuration for adding realm user field in WWW-Authenticate header. -->
+            <AddRealmUserToError>{{rest_api_authentication.add_realm_user_to_error}}</AddRealmUserToError>
     </RestApiAuthentication>
 
     <!--

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -899,6 +899,12 @@
         <AllowCrossTenantTokenIntrospection>{{oauth.introspect.allow_cross_tenant}}</AllowCrossTenantTokenIntrospection>
 
     </OAuth>
+
+    <WWWAuthenticate>
+            <!-- Configuration for allowing to add realm user in WWW-Authenticate header. -->
+            <AddRealmUser>{{www_authenticate.add_realm_user}}</AddRealmUser>
+    </WWWAuthenticate>
+
     <!--
     Configuration to select JS engine for Adaptive authentication feature.
     Currently we are supporting OpenJDK Nashorn engine("openjdkNashorn") and JDK Nashorn Engine(Default).

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -209,7 +209,7 @@
   "oauth.oidc.fapi.enable_ciba_profile": false,
   "oauth.oidc.fapi.enable_security_profile": false,
 
-  "rest_api_authentication.remove_realm_user_from_error": true,
+  "rest_api_authentication.add_realm_user_to_error": false,
 
   "saml.entity_id": "${carbon.host}",
   "saml.attribute_claim_dialect": "http://wso2.org/claims",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -209,6 +209,8 @@
   "oauth.oidc.fapi.enable_ciba_profile": false,
   "oauth.oidc.fapi.enable_security_profile": false,
 
+  "www_authenticate.add_realm_user": false,
+
   "saml.entity_id": "${carbon.host}",
   "saml.attribute_claim_dialect": "http://wso2.org/claims",
   "saml.slo.retry_attempts": "5",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -209,7 +209,7 @@
   "oauth.oidc.fapi.enable_ciba_profile": false,
   "oauth.oidc.fapi.enable_security_profile": false,
 
-  "www_authenticate.add_realm_user": false,
+  "rest_api_authentication.remove_realm_user_from_error": true,
 
   "saml.entity_id": "${carbon.host}",
   "saml.attribute_claim_dialect": "http://wso2.org/claims",


### PR DESCRIPTION
### Proposed changes in this pull request

Adds the following config to enable `realm user` field based WWW-Authenticate header for error responses for REST API authentication. 
```
[rest_api_authentication]
add_realm_user_to_error = true
```
The default value would be `false` for which the header won't be sent.

### When should this PR be merged

This PR should be merged before https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/212

