### PR TITLE
Fix authentication context not getting persisted after parameter filtering

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -338,6 +338,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
             }
         } finally {
             UserCoreUtil.setDomainInThreadLocal(null);
+            unwrapResponse(responseWrapper, sessionDataKey, response, context);
             if (context != null) {
                 // Mark this context left the thread. Now another thread can use this context.
                 context.setActiveInAThread(false);
@@ -359,7 +360,6 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     FrameworkUtils.removeALORCookie(request, response);
                 }
             }
-            unwrapResponse(responseWrapper, sessionDataKey, response, context);
         }
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

- In the current flow, once the parameters in the redirect URL are filtered, the context object is not persisted to the cache instead framework serves it from in-memory. Authentication Context should be persisted to the cache once the parameter filtering is done.

Filtering logic is applied [here](https://github.com/wso2/carbon-identity-framework/blob/master/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java#L373)



