### PR TITLE
Change default URL parameter filtering behavior in authentication endpoint

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -1736,9 +1736,8 @@ public class FrameworkUtils {
         List<String> queryParams;
         String action;
         if (!configAvailable) {
-            queryParams = Arrays.asList("sessionDataKey", "sessionDataKeyConsent", "errorKey", "sp", "isSaaSApp",
-                    "tenantDomain", "t");
-            action = "include";
+            queryParams = Arrays.asList("loggedInUser");
+            action = "exclude";
         } else {
             queryParams = FileBasedConfigurationBuilder.getInstance()
                     .getAuthEndpointRedirectParams();


### PR DESCRIPTION
### Proposed changes in this pull request

Current default URL parameter filtering behavior is to include the given parameter. This will be changed to the previous behavior which excluded only the `loggedInUser`.  A config will be provided to enable the current URL parameter filtering behavior.

### Follow up actions

- Change the `infer.json`

