### PR TITLE
Fix organization qualified request caller path issue

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -589,7 +589,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
 
         if (IdentityTenantUtil.isTenantedSessionsEnabled()) {
             String loginTenantDomain = context.getLoginTenantDomain();
-            if (!callerPath.startsWith(FrameworkConstants.TENANT_CONTEXT_PREFIX + loginTenantDomain + "/")) {
+            if (!callerPath.startsWith(FrameworkConstants.TENANT_CONTEXT_PREFIX + loginTenantDomain + "/") &&
+                    !callerPath.startsWith(FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX + loginTenantDomain + "/")) {
                 callerPath = FrameworkConstants.TENANT_CONTEXT_PREFIX + loginTenantDomain + callerPath;
             }
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -175,6 +175,8 @@ public abstract class FrameworkConstants {
     public static final String TENANT_CONTEXT_PREFIX = "/t/";
     public static final String ORGANIZATION_CONTEXT_PREFIX = "/o/";
 
+    public static final String ORGANIZATION_CONTEXT_PREFIX = "/o/";
+
     public static final String USER_TENANT_DOMAIN = "user-tenant-domain";
 
     public static final String BASIC_AUTH_MECHANISM = "basic";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -175,8 +175,6 @@ public abstract class FrameworkConstants {
     public static final String TENANT_CONTEXT_PREFIX = "/t/";
     public static final String ORGANIZATION_CONTEXT_PREFIX = "/o/";
 
-    public static final String ORGANIZATION_CONTEXT_PREFIX = "/o/";
-
     public static final String USER_TENANT_DOMAIN = "user-tenant-domain";
 
     public static final String BASIC_AUTH_MECHANISM = "basic";

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
@@ -124,11 +124,12 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && !resolvedUrlContext.startsWith("t/") &&
                 !resolvedUrlContext.startsWith("o/")) {
             if (mandateTenantedPath || isNotSuperTenant(tenantDomain)) {
-                // When requesting from an organization qualified url, the service urls should be organization qualified
-                // except when the service url should build for super tenant domain.
-                String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
-                if (organizationId != null && isNotSuperTenant(tenantDomain)) {
-                    resolvedUrlStringBuilder.append("/o/").append(organizationId);
+                /**
+                 * Set service urls organization qualified during the identity federation with organization login.
+                 */
+                if (StringUtils.equals(PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId(),
+                        tenantDomain)) {
+                    resolvedUrlStringBuilder.append("/o/").append(tenantDomain);
                 } else {
                     resolvedUrlStringBuilder.append("/t/").append(tenantDomain);
                 }


### PR DESCRIPTION
### Proposed changes in this pull request

As shown in the following figure, the `oauth2/authorize` request is organization qualified, and the response should be redirected to the main application owned organization's commonauth endpoint as tenant qualified request. 

![Untitled Diagram-Page-9](https://user-images.githubusercontent.com/35717390/205802833-38830f8f-9a3f-4a47-a879-5ebb72cae3b1.jpg)

The proposed change arise new concern if the SaaS app is owned by a sub organization. At the end of the federation the redirection should happen for the SaaS app owned sub organization and as mentioned above the org qualifier of the request and the org qualifier of the response redirection are not same, hence the redirection will happen with tenant qualified path. Should check it is even fine if that happen and more specifically SaaS app will not owned by sub organizations. (But PCC would get impacted, there fore better to check)