### PR TITLE
Add FrameworkResourceNotFound exception

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/FrameworkResourceNotFoundException.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/FrameworkResourceNotFoundException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.inbound;
+
+import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+
+/**
+ * Framework resource not found exception.
+ */
+public class FrameworkResourceNotFoundException extends FrameworkException {
+
+    public FrameworkResourceNotFoundException(String message) {
+        super(message);
+    }
+
+    public FrameworkResourceNotFoundException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public FrameworkResourceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FrameworkResourceNotFoundException(String errorCode, String message, Throwable cause) {
+        super(errorCode, message, cause);
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/HttpIdentityRequestFactory.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/HttpIdentityRequestFactory.java
@@ -142,6 +142,18 @@ public class HttpIdentityRequestFactory extends AbstractIdentityHandler {
         return builder;
     }
 
+    public HttpIdentityResponse.HttpIdentityResponseBuilder handleException(
+                                                                    FrameworkResourceNotFoundException exception,
+                                                                    HttpServletRequest request,
+                                                                    HttpServletResponse response) {
+
+        HttpIdentityResponse.HttpIdentityResponseBuilder builder =
+                new HttpIdentityResponse.HttpIdentityResponseBuilder();
+        builder.setStatusCode(404);
+        builder.setBody(exception.getMessage());
+        return builder;
+    }
+
     public HttpIdentityResponse.HttpIdentityResponseBuilder handleException(RuntimeException exception,
                                                                             HttpServletRequest request,
                                                                             HttpServletResponse response) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityProcessCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityProcessCoordinator.java
@@ -41,7 +41,7 @@ public class IdentityProcessCoordinator {
             }
             return processor.process(identityRequest).build();
         } else {
-            throw FrameworkRuntimeException.error("No IdentityProcessor found to process the request");
+            throw new FrameworkResourceNotFoundException("No IdentityProcessor found to process the request");
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityServlet.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/inbound/IdentityServlet.java
@@ -106,6 +106,12 @@ public class IdentityServlet extends HttpServlet {
                 throw FrameworkRuntimeException.error(message);
             }
             return responseBuilder.build();
+        } catch (FrameworkResourceNotFoundException e) {
+            responseBuilder = factory.handleException(e, request, response);
+            if (responseBuilder == null) {
+                throw FrameworkRuntimeException.error("HttpIdentityResponseBuilder is Null. Cannot proceed!!", e);
+            }
+            return responseBuilder.build();
         } catch (FrameworkException e) {
             if (e instanceof FrameworkClientException) {
                 if (log.isDebugEnabled()) {


### PR DESCRIPTION
> Return FrameworkResourceNotFoundException when there are no identity processors that can handle the incoming identity request.
> Fix https://github.com/wso2/api-manager/issues/906