### PR TITLE
Add method to retrieve account verification status

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
@@ -102,9 +102,9 @@ public class PreferenceRetrievalClient {
     /**
      * Check send confirmation on account creation is enabled or not.
      *
-     * @param tenant tenant domain name.
-     * @return returns true if send confirmation on creation is enabled.
-     * @throws PreferenceRetrievalClientException
+     * @param tenant Tenant domain name.
+     * @return returns True if send confirmation on creation is enabled.
+     * @throws PreferenceRetrievalClientException If any PreferenceRetrievalClientException occurs.
      */
     public boolean checkSelfRegistrationSendConfirmationOnCreation(String tenant) throws PreferenceRetrievalClientException {
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
@@ -69,6 +69,7 @@ public class PreferenceRetrievalClient {
     private static final String TYPING_DNA_CONNECTOR = "typingdna-config";
     private static final String TYPING_DNA_PROPERTY = "adaptive_authentication.tdna.enable";
     private static final String AUTO_LOGIN_AFTER_SELF_SIGN_UP = "SelfRegistration.AutoLogin.Enable";
+    public static final String SEND_CONFIRMATION_ON_CREATION = "SelfRegistration.SendConfirmationOnCreation";
     private static final String AUTO_LOGIN_AFTER_PASSWORD_RECOVERY = "Recovery.AutoLogin.Enable";
 
     public static final String DEFAULT_AND_LOCALHOST = "DefaultAndLocalhost";
@@ -96,6 +97,18 @@ public class PreferenceRetrievalClient {
     public boolean checkSelfRegistrationLockOnCreation(String tenant) throws PreferenceRetrievalClientException {
 
         return checkPreference(tenant, SELF_SIGN_UP_CONNECTOR, SELF_SIGN_UP_LOCK_ON_CREATION_PROPERTY);
+    }
+
+    /**
+     * Check send confirmation on account creation is enabled or not.
+     *
+     * @param tenant tenant domain name.
+     * @return returns true if send confirmation on creation is enabled.
+     * @throws PreferenceRetrievalClientException
+     */
+    public boolean checkSelfRegistrationSendConfirmationOnCreation(String tenant) throws PreferenceRetrievalClientException {
+
+        return checkPreference(tenant, SELF_SIGN_UP_CONNECTOR, SEND_CONFIRMATION_ON_CREATION);
     }
 
     /**


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/15191

Need add a method to preference retrieval client of account recovery endpoint to retrieve the config value of the self-registration account verification from account recovery portal.