### PR TITLE
Fix the issue with getting the roles when seconday user store is disconnected

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/RoleConstants.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/RoleConstants.java
@@ -72,6 +72,8 @@ public class RoleConstants {
         public static final String ATTR_VALUE = "ATTR_VALUE";
         public static final String ROLE_NAME = "ROLE_NAME";
         public static final String NEW_ROLE_NAME = "NEW_ROLE_NAME";
+        public static final String USER_NOT_FOUND_ERROR_MESSAGE = "A user doesn't exist with name: %s " +
+                "in the tenantDomain: %s";
 
         private RoleTableColumns() {
 

--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/util/UserIDResolver.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/util/UserIDResolver.java
@@ -34,6 +34,7 @@ import java.util.List;
 import static org.wso2.carbon.identity.role.mgt.core.RoleConstants.Error.INVALID_REQUEST;
 import static org.wso2.carbon.identity.role.mgt.core.RoleConstants.Error.OPERATION_NOT_SUPPORTED;
 import static org.wso2.carbon.identity.role.mgt.core.RoleConstants.Error.UNEXPECTED_SERVER_ERROR;
+import static org.wso2.carbon.identity.role.mgt.core.RoleConstants.RoleTableColumns.USER_NOT_FOUND_ERROR_MESSAGE;
 
 /**
  * UserIDResolver Implementation of the {@link IDResolver} interface.
@@ -75,7 +76,7 @@ public class UserIDResolver implements IDResolver {
 
         String id = resolveIDFromUserName(name);
         if (id == null) {
-            String errorMessage = "A user doesn't exist with name: " + name + " in the tenantDomain: " + tenantDomain;
+            String errorMessage = String.format(USER_NOT_FOUND_ERROR_MESSAGE, name, tenantDomain);
             throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
         }
         return id;


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves https://github.com/wso2/product-is/issues/15217

The issue is when we list all the users who are having the particular role, the secindary user store user id is trying to be retrieved and hence ended up with the above error.

**Solution**
When listing out the users of a role, skip the error if the user id is not found so that other users can be listed down.


