### PR TITLE
Set organization qualified path for commonAuthId cookie for the organization qualified request

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -888,7 +888,11 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
         }
         String path = null;
         if (IdentityTenantUtil.isTenantedSessionsEnabled()) {
-            path = FrameworkConstants.TENANT_CONTEXT_PREFIX + context.getLoginTenantDomain() + "/";
+            if (FrameworkUtils.isOrganizationQualifiedRequest()) {
+                path = FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX + context.getLoginTenantDomain() + "/";
+            } else {
+                path = FrameworkConstants.TENANT_CONTEXT_PREFIX + context.getLoginTenantDomain() + "/";
+            }
         }
         FrameworkUtils.storeAuthCookie(request, response, sessionKey, authCookieAge, path);
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -170,6 +170,7 @@ public abstract class FrameworkConstants {
     public static final int MAX_RETRY_TIME = 3;
 
     public static final String TENANT_CONTEXT_PREFIX = "/t/";
+    public static final String ORGANIZATION_CONTEXT_PREFIX = "/o/";
 
     public static final String USER_TENANT_DOMAIN = "user-tenant-domain";
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -763,6 +763,10 @@ public class FrameworkUtils {
         removeCookie(req, resp, FrameworkConstants.COMMONAUTH_COOKIE, SameSiteCookie.NONE);
     }
 
+    public static boolean isOrganizationQualifiedRequest() {
+
+        return PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId() != null;
+    }
     /**
      * Remove the auth cookie in the tenanted path.
      *
@@ -772,7 +776,12 @@ public class FrameworkUtils {
      */
     public static void removeAuthCookie(HttpServletRequest req, HttpServletResponse resp, String tenantDomain) {
 
-        String path = FrameworkConstants.TENANT_CONTEXT_PREFIX + tenantDomain + "/";
+        String path;
+        if (isOrganizationQualifiedRequest()) {
+            path = FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX + tenantDomain + "/";
+        } else {
+            path = FrameworkConstants.TENANT_CONTEXT_PREFIX + tenantDomain + "/";
+        }
         removeCookie(req, resp, FrameworkConstants.COMMONAUTH_COOKIE, SameSiteCookie.NONE, path);
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -95,7 +95,7 @@ import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENA
 @WithCarbonHome
 @PrepareForTest({SameSiteCookie.class, SessionContextCache.class, AuthenticationResultCache.class,
         AuthenticationContextCache.class, IdentityTenantUtil.class})
-@PowerMockIgnore({"javax.net.*", "javax.security.*", "javax.crypto.*", "javax.xml.*"})
+@PowerMockIgnore({"javax.net.*", "javax.security.*", "javax.crypto.*", "javax.xml.*", "org.xml.*", "org.w3c.dom.*"})
 public class FrameworkUtilsTest extends PowerMockIdentityBaseTest {
 
     private static final String ROOT_DOMAIN = "/";


### PR DESCRIPTION
### Proposed changes in this pull request

For the organization qualified requests, the url paths will be prefixed with `o/<org-id>`. Hence the cookie set in the browser should be set accordingly.  

Added the following powermock ignore statements as a fix for the following test failures.
![Screenshot 2022-11-28 at 06 56 46](https://user-images.githubusercontent.com/35717390/204173068-e5582403-1148-45c4-829f-589a474d0621.png)
![Screenshot 2022-11-28 at 06 54 58](https://user-images.githubusercontent.com/35717390/204173075-df680797-2796-408b-a7ab-d0a99e1d207b.png)

Example usage - https://github.com/wso2/carbon-identity-framework/blob/master/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/cache/BaseCacheTest.java#L44
