### PR TITLE
Adding template of post authentication handler implemented to reset failed login lockout count claim

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -149,6 +149,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
         AuthenticationContext context = null;
         String sessionDataKey = request.getParameter("sessionDataKey");
         try {
+            IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.AUTHENTICATION_FRAMEWORK_FLOW, true);
             AuthenticationRequestCacheEntry authRequest = null;
             boolean returning = false;
             // Check whether this is the start of the authentication flow.
@@ -373,6 +374,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                 FrameworkUtils.sendToRetryPage(request, responseWrapper, context);
             }
         } finally {
+            IdentityUtil.threadLocalProperties.get().remove(FrameworkConstants.AUTHENTICATION_FRAMEWORK_FLOW);
             UserCoreUtil.setDomainInThreadLocal(null);
             unwrapResponse(responseWrapper, sessionDataKey, response, context);
             if (context != null) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -166,6 +166,9 @@ public abstract class FrameworkConstants {
     // Idp to local role mapping thread local identifier.
     public static final String IDP_TO_LOCAL_ROLE_MAPPING = "idpToLocalRoleMapping";
 
+    // Authentication flow thread local identifier.
+    public static final String AUTHENTICATION_FRAMEWORK_FLOW = "authenticationFrameworkFlow";
+
     // Maximum retry times for session data store.
     public static final int MAX_RETRY_TIME = 3;
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1133,6 +1133,9 @@
         <EventListener type="org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
                        name="org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.PostAuthenticatedSubjectIdentifierHandler"
                        orderId="30" enable="true"/>
+        <EventListener type="org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
+                       name="org.wso2.carbon.identity.handler.event.account.lock.handlers.PostAuthnFailedLockoutClaimHandler"
+                       orderId="21" enable="true"/>
 
         <!-- Special UserOperationEventListeners to preserve the backward compatibility with the new unique user ID
         related APIs  -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1562,6 +1562,11 @@
                        name="org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.PostAuthenticatedSubjectIdentifierHandler"
                        orderId="{{event.default_listener.subject_identifier_handler.priority}}"
                        enable="{{event.default_listener.subject_identifier_handler.enable}}"/>
+        <EventListener id="failed_lockout_count_handler"
+                       type="org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
+                       name="org.wso2.carbon.identity.handler.event.account.lock.handlers.PostAuthnFailedLockoutClaimHandler"
+                       orderId="{{event.default_listener.failed_lockout_count_handler.priority}}"
+                       enable="{{event.default_listener.failed_lockout_count_handler.enable}}"/>
 
         <!-- Special UserOperationEventListeners to preserve the backward compatibility with the new unique user ID
                 related APIs  -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -435,6 +435,8 @@
   "event.default_listener.post_auth_association_handler.enable": true,
   "event.default_listener.subject_identifier_handler.priority": "30",
   "event.default_listener.subject_identifier_handler.enable": true,
+  "event.default_listener.failed_lockout_count_handler.priority": "21",
+  "event.default_listener.failed_lockout_count_handler.enable": true,
   "event.default_listener.user_mgt_audit_logger.priority": "0",
   "event.default_listener.user_mgt_audit_logger.enable": false,
   "event.default_listener.user_management_audit_logger.priority": "1",


### PR DESCRIPTION
### Proposed changes in this pull request

[List all changes you want to add here. If you fixed an issue, please
add a reference to that issue as well.]

- This PR contains templates added to files such as `identity.xml`, `identity.xml.j2`, `default.json` related to the newly introduced post authentication handler named `PostAuthnFailedLockoutClaimHandler`

PR of the post authentication handler: https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/119