### PR TITLE
Error handle for username being null in invalid OTP flows

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -100,6 +100,8 @@ public class DefaultStepHandler implements StepHandler {
     private static final String SUCCESS = "Success";
     private static final String FAILURE = "Failure";
 
+    private static final String USERNAME = "username";
+
     public static DefaultStepHandler getInstance() {
 
         if (instance == null) {
@@ -962,6 +964,7 @@ public class DefaultStepHandler implements StepHandler {
         retryParam = handleIdentifierFirstLogin(context, retryParam);
         String otp = (String) context.getProperty(FrameworkConstants.PASSWORD_PROPERTY);
         context.getProperties().remove(FrameworkConstants.PASSWORD_PROPERTY);
+        String username = request.getParameter(USERNAME);
 
         // If recaptcha is enabled and the Basic Authenticator is in the authenticator list for this page, the recaptcha
         // params set by the Basic Authenticator need to be added to new URL generated for the multi option page.
@@ -994,7 +997,7 @@ public class DefaultStepHandler implements StepHandler {
                                 FrameworkConstants.REMAINING_ATTEMPTS.equals(param.getName()) ||
                                 FrameworkConstants.FAILED_USERNAME.equals(param.getName()))
                         .collect(Collectors.toList()));
-                if (errorContextParams.size() > 0) {
+                if (!errorContextParams.isEmpty()) {
                     for (NameValuePair errorParams : errorContextParams) {
                         errorParamString.append("&").append(errorParams.getName()).append("=")
                                 .append(errorParams.getValue());
@@ -1025,82 +1028,76 @@ public class DefaultStepHandler implements StepHandler {
                 int remainingAttempts = errorContext.getMaximumLoginAttempts() - errorContext.getFailedLoginAttempts();
 
                 if (LOG.isDebugEnabled()) {
-                    StringBuilder debugString = new StringBuilder();
-                    debugString.append("Identity error message context is not null. Error details are as follows.");
-                    debugString.append("errorCode : " + errorCode + "\n");
-                    debugString.append("username : " + request.getParameter("username") + "\n");
-                    debugString.append("remainingAttempts : " + remainingAttempts);
-                    LOG.debug(debugString.toString());
+                    String debugString = "Identity error message context is not null. Error details are as follows." +
+                            "errorCode : " + errorCode + "\n" +
+                            "username : " + username + "\n" +
+                            "remainingAttempts : " + remainingAttempts;
+                    LOG.debug(debugString);
                 }
 
                 if (UserCoreConstants.ErrorCode.INVALID_CREDENTIAL.equals(errorCode)) {
-                    retryParam = retryParam + "&errorCode=" + errorCode + "&failedUsername=" + URLEncoder.encode
-                            (request.getParameter("username"), "UTF-8") + "&remainingAttempts=" + remainingAttempts;
+                    retryParam = String.format("%s&errorCode=%s&remainingAttempts=%d", retryParam, errorCode,
+                            remainingAttempts);
+                    if (username != null) {
+                        retryParam = String.format("%s&failedUsername=%s", retryParam, URLEncoder.encode(username,
+                                "UTF-8"));
+                    }
                     return response.encodeRedirectURL(loginPage + ("?" + context.getContextIdIncludedQueryParams()))
                             + "&authenticators=" + URLEncoder.encode(authenticatorNames, "UTF-8") + retryParam +
                             reCaptchaParamString.toString();
+
                 } else if (UserCoreConstants.ErrorCode.USER_IS_LOCKED.equals(errorCode)) {
                     String redirectURL;
+                    redirectURL = response.encodeRedirectURL(loginPage
+                            + ("?" + context.getContextIdIncludedQueryParams()))
+                            + String.format(
+                                "&errorCode=%s&authenticators=%s",
+                                errorCode, URLEncoder.encode(authenticatorNames, "UTF-8"))
+                            + retryParam + reCaptchaParamString;
                     if (remainingAttempts == 0) {
-                        if (StringUtils.isBlank(reason)) {
-                            redirectURL = response.encodeRedirectURL(loginPage + ("?"
-                                    + context.getContextIdIncludedQueryParams())) + "&errorCode=" + errorCode
-                                    + "&failedUsername=" + URLEncoder.encode(request.getParameter("username"), "UTF-8")
-                                    + "&remainingAttempts=0" + "&authenticators="
-                                    + URLEncoder.encode(authenticatorNames, "UTF-8") + retryParam
-                                    + reCaptchaParamString;
-                        } else {
-                            redirectURL = response.encodeRedirectURL(loginPage + ("?"
-                                    + context.getContextIdIncludedQueryParams())) + "&errorCode=" + errorCode
-                                    + "&lockedReason=" + reason + "&failedUsername="
-                                    + URLEncoder.encode(request.getParameter("username"), "UTF-8")
-                                    + "&remainingAttempts=0" + "&authenticators="
-                                    + URLEncoder.encode(authenticatorNames, "UTF-8") + retryParam
-                                    + reCaptchaParamString;
-                        }
-                    } else {
-                        if (StringUtils.isBlank(reason)) {
-                            redirectURL = response.encodeRedirectURL(loginPage + ("?"
-                                    + context.getContextIdIncludedQueryParams())) + "&errorCode=" + errorCode
-                                    + "&failedUsername=" + URLEncoder.encode(request.getParameter("username"), "UTF-8")
-                                    + "&authenticators=" + URLEncoder.encode(authenticatorNames, "UTF-8")
-                                    + retryParam + reCaptchaParamString;
-                        } else {
-                            redirectURL = response.encodeRedirectURL(loginPage + ("?" + context
-                                    .getContextIdIncludedQueryParams())) + "&errorCode=" + errorCode + "&lockedReason="
-                                    + reason + "&failedUsername=" + URLEncoder.encode(request.getParameter("username"),
-                                    "UTF-8") + "&authenticators=" +
-                                    URLEncoder.encode(authenticatorNames, "UTF-8") + retryParam +
-                                    reCaptchaParamString.toString();
-                        }
+                        redirectURL = String.format("%s&remainingAttempts=0", redirectURL);
+                    }
+                    if (!StringUtils.isBlank(reason)) {
+                        redirectURL = String.format("%s&lockedReason=%s", redirectURL, reason);
+                    }
+                    if (username != null) {
+                        redirectURL = String.format("%s&failedUsername=%s", redirectURL, URLEncoder.encode(username,
+                                "UTF-8"));
                     }
                     return redirectURL;
+
                 } else if (IdentityCoreConstants.USER_ACCOUNT_NOT_CONFIRMED_ERROR_CODE.equals(errorCode)) {
                     retryParam = "&authFailure=true&authFailureMsg=account.confirmation.pending";
-                    String username = request.getParameter("username");
-
                     Object domain = IdentityUtil.threadLocalProperties.get().get(RE_CAPTCHA_USER_DOMAIN);
                     if (domain != null) {
                         username = IdentityUtil.addDomainToName(username, domain.toString());
                     }
 
-                    retryParam = retryParam + "&errorCode=" + errorCode + "&failedUsername=" + URLEncoder.encode
-                            (username, "UTF-8");
+                    retryParam = String.format("%s&errorCode=%s", retryParam, errorCode);
+                    if (username != null) {
+                        retryParam = String.format("%s&failedUsername=%s", retryParam, URLEncoder.encode(username,
+                                "UTF-8"));
+                    }
                     return response.encodeRedirectURL(loginPage + ("?" + context.getContextIdIncludedQueryParams()))
                             + "&authenticators=" + URLEncoder.encode(authenticatorNames, "UTF-8") + retryParam +
                             reCaptchaParamString.toString();
+
                 } else if (IdentityCoreConstants.USER_INVALID_CREDENTIALS.equals(errorCode)) {
                     retryParam = "&authFailure=true&authFailureMsg=login.fail.message";
-                    String username = request.getParameter("username");
                     Object domain = IdentityUtil.threadLocalProperties.get().get(RE_CAPTCHA_USER_DOMAIN);
                     if (domain != null) {
                         username = IdentityUtil.addDomainToName(username, domain.toString());
                     }
-                    retryParam = retryParam + "&errorCode=" + errorCode + "&failedUsername=" + URLEncoder.encode
-                            (username, "UTF-8");
+
+                    retryParam = retryParam + "&errorCode=" + errorCode;
+                    if (username != null) {
+                        retryParam = String.format("%s&failedUsername=%s", retryParam, URLEncoder.encode(username,
+                                "UTF-8"));
+                    }
                     return response.encodeRedirectURL(loginPage + ("?" + context.getContextIdIncludedQueryParams()))
                             + "&authenticators=" + URLEncoder.encode(authenticatorNames, "UTF-8") + retryParam +
                             reCaptchaParamString.toString();
+
                 } else if (IdentityCoreConstants.ADMIN_FORCED_USER_PASSWORD_RESET_VIA_OTP_ERROR_CODE
                         .equals(errorCode)) {
                     return getRedirectURLForcedPasswordResetOTP(request, response, context, authenticatorNames,
@@ -1109,8 +1106,12 @@ public class DefaultStepHandler implements StepHandler {
                     if (StringUtils.isNotBlank(retryParam) && StringUtils.isNotBlank(reason)) {
                         retryParam = "&authFailure=true&authFailureMsg=" + URLEncoder.encode(reason, "UTF-8");
                     }
-                    retryParam += "&errorCode=" + errorCode + "&failedUsername=" + URLEncoder.encode
-                            (request.getParameter("username"), "UTF-8");
+
+                    retryParam = retryParam + "&errorCode=" + errorCode;
+                    if (username != null) {
+                        retryParam = String.format("%s&failedUsername=%s", retryParam, URLEncoder.encode(username,
+                                "UTF-8"));
+                    }
                     return response.encodeRedirectURL(loginPage + ("?" + context.getContextIdIncludedQueryParams()))
                             + "&authenticators=" + URLEncoder.encode(authenticatorNames, "UTF-8") + retryParam +
                             reCaptchaParamString.toString();
@@ -1134,10 +1135,16 @@ public class DefaultStepHandler implements StepHandler {
             String errorCode = errorContext != null ? errorContext.getErrorCode() : null;
             if (UserCoreConstants.ErrorCode.USER_IS_LOCKED.equals(errorCode)) {
                 String redirectURL;
-                redirectURL = response.encodeRedirectURL(loginPage + ("?" + context.getContextIdIncludedQueryParams()
-                )) + "&failedUsername=" + URLEncoder.encode(request.getParameter("username"), "UTF-8") +
-                        "&authenticators=" + URLEncoder.encode(authenticatorNames, "UTF-8") + retryParam +
-                        reCaptchaParamString.toString();
+                redirectURL = response.encodeRedirectURL(loginPage + ("?"
+                        + context.getContextIdIncludedQueryParams()))
+                        + "&authenticators=" + URLEncoder.encode(authenticatorNames, "UTF-8")
+                        + retryParam + reCaptchaParamString.toString();
+
+                if (username != null) {
+                    redirectURL = String.format("%s&failedUsername=%s", redirectURL, URLEncoder.encode(username,
+                            "UTF-8"));
+                }
+
                 return redirectURL;
 
             } else if (IdentityCoreConstants.ADMIN_FORCED_USER_PASSWORD_RESET_VIA_OTP_ERROR_CODE.equals(errorCode)) {


### PR DESCRIPTION
### Proposed changes in this pull request

This PR fixes the error occured when an invalid email OTP is entered. The user was being redirected to a "Something went wrong" page.  This was because the query param being not having the username parameter and it caused a NULL pointer exception when the NULL variable being added to the URL encoder method.

- Handled the issue by Ignore sending failedUsername query param when it is NULL. 
- The codebase was refactored due to excess number of nested conditions.

### When should this PR be merged
- None.

### Follow up actions
- None

### Checklist (for reviewing)

#### General

- [x] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [x] **Is the PR labeled correctly?**

#### Functionality

- [x] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [x] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [x] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [x] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [x] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [x] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [x] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [x] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [x] **Are all UI and API inputs run through forms or serializers?**
- [x] **Are all external inputs validated and sanitized appropriately?**
- [x] **Does all branching logic have a default case?**
- [x] **Does this solution handle outliers and edge cases gracefully?**
- [x] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [x] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [x] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [x] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
