### PR TITLE
masking IDP properties in IDP flow updated fix

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/listener/IDPMgtAuditLogger.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/listener/IDPMgtAuditLogger.java
@@ -43,7 +43,7 @@ public class IDPMgtAuditLogger extends AbstractIdentityProviderMgtListener {
             " | Result : %s ";
     private final String SUCCESS = "Success";
 
-    // Properties with following key values will not be printed in logs.
+    // Properties with the following key values will not be printed in audit logs.
     private static final Set<String> UNLOGGABLE_PARAMS = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList("ClientSecret", "SPNPassword", "APISecret", "scim2-password", "sf-password",
                     "sf-client-secret", "scim-password", "scim-default-pwd", "scim2-default-pwd")));
@@ -256,7 +256,7 @@ public class IDPMgtAuditLogger extends AbstractIdentityProviderMgtListener {
                     data.append(", Properties:[");
                     joiner = "";
                     for (Property property : authConfig.getProperties()) {
-                        if (!isSensitiveParam(property.getName())) {
+                        if (!UNLOGGABLE_PARAMS.contains(property.getName())) {
                             data.append(joiner);
                             joiner = ", ";
                             data.append("{").append(property.getName()).append(":").append(
@@ -285,7 +285,7 @@ public class IDPMgtAuditLogger extends AbstractIdentityProviderMgtListener {
                     data.append(", Properties:[");
                     joiner = "";
                     for (Property property : provConfig.getProvisioningProperties()) {
-                        if (!isSensitiveParam(property.getName())) {
+                        if (!UNLOGGABLE_PARAMS.contains(property.getName())) {
                             data.append(joiner);
                             joiner = ", ";
                             data.append("{").append(property.getName()).append(":").append(
@@ -320,7 +320,7 @@ public class IDPMgtAuditLogger extends AbstractIdentityProviderMgtListener {
             data.append(", IDP Properties:[");
             String joiner = "";
             for (IdentityProviderProperty property : idpProperties) {
-                if (!isSensitiveParam(property.getName())) {
+                if (!UNLOGGABLE_PARAMS.contains(property.getName())) {
                     data.append(joiner);
                     joiner = ", ";
                     data.append("{").append(property.getName()).append(":").append(
@@ -330,17 +330,5 @@ public class IDPMgtAuditLogger extends AbstractIdentityProviderMgtListener {
             data.append("]");
         }
         return data.toString();
-    }
-
-    /**
-     * Returns whether the given key is contained in the defined UNLOGGABLE_PARAMS set.
-     *
-     * @param key Key value that needs to be verified.
-     *
-     * @return true if the provided key contains in the UNLOGGABLE_PARAMS, otherwise false.
-     */
-    private static boolean isSensitiveParam(String key) {
-
-        return UNLOGGABLE_PARAMS.contains(key);
     }
 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/listener/IDPMgtAuditLogger.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/listener/IDPMgtAuditLogger.java
@@ -43,7 +43,7 @@ public class IDPMgtAuditLogger extends AbstractIdentityProviderMgtListener {
             " | Result : %s ";
     private final String SUCCESS = "Success";
 
-//    Properties with following key values will not be printed in logs.
+    // Properties with following key values will not be printed in logs.
     private static final Set<String> UNLOGGABLE_PARAMS = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList("ClientSecret", "SPNPassword", "APISecret", "scim2-password", "sf-password",
                     "sf-client-secret", "scim-password", "scim-default-pwd", "scim2-default-pwd")));

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1401,6 +1401,12 @@
         </Audit>
     </Authentication>
 
+    <!--
+        Enabling this configuration will do the following modifications to the logs.
+            1. Initiator of the audit logs will be changed to userId if userId is resolvable.
+            2. Initiator of the audit logs will be a masked username in the scenarios where userId is not resolvable.
+            3. PII, user claims and other sensitive information will be masked from logs.
+     -->
     <MaskingLogs>
     	    {% if masking_logs.enabled is defined %}
             <Enabled>{{masking_logs.enabled}}</Enabled>


### PR DESCRIPTION
### Proposed changes in this pull request

With this fix,

- all the IDP properties will be masked from audit logs irrespective of the masking_logs configuration value.
- known credentials properties will not be printed in audit logs.
- if a new IDP is introduced to the application in the future credentials of those also will be masked if they are not in the format of known properties. If they compile with one of those properties those values also will not be printed.
