### PR TITLE
Move identity-mgt util to cxf runtime

### DIFF
--- a/features/identity-mgt/org.wso2.carbon.identity.mgt.server.feature/pom.xml
+++ b/features/identity-mgt/org.wso2.carbon.identity.mgt.server.feature/pom.xml
@@ -46,6 +46,24 @@
             <artifactId>org.wso2.carbon.identity.mgt.endpoint.util</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jersey.contribs</groupId>
+            <artifactId>jersey-multipart</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>kaptcha.wso2</groupId>
             <artifactId>kaptcha</artifactId>
         </dependency>
@@ -70,6 +88,30 @@
                                     <groupId>org.wso2.carbon.identity.framework</groupId>
                                     <artifactId>org.wso2.carbon.identity.mgt.endpoint.util</artifactId>
                                     <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${basedir}/src/main/resources/runtimes/cxf3</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.jersey</groupId>
+                                    <artifactId>jersey-client</artifactId>
+                                    <version>${jersey-version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${basedir}/src/main/resources/runtimes/cxf3</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.jersey</groupId>
+                                    <artifactId>jersey-core</artifactId>
+                                    <version>${jersey-version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${basedir}/src/main/resources/runtimes/cxf3</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.jersey.contribs</groupId>
+                                    <artifactId>jersey-multipart</artifactId>
+                                    <version>${jersey-version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${basedir}/src/main/resources/runtimes/cxf3</outputDirectory>

--- a/features/identity-mgt/org.wso2.carbon.identity.mgt.server.feature/pom.xml
+++ b/features/identity-mgt/org.wso2.carbon.identity.mgt.server.feature/pom.xml
@@ -54,6 +54,32 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wso2.carbon.identity.framework</groupId>
+                                    <artifactId>org.wso2.carbon.identity.mgt.endpoint.util</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${basedir}/src/main/resources/runtimes/cxf3</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
@@ -103,7 +129,6 @@
                             <bundles>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.mgt</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.captcha.mgt</bundleDef>
-                                <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.mgt.endpoint.util</bundleDef>
                                 <bundleDef>kaptcha.wso2:kaptcha</bundleDef>
                             </bundles>
                             <importFeatures>

--- a/features/identity-mgt/org.wso2.carbon.identity.mgt.server.feature/resources/p2.inf
+++ b/features/identity-mgt/org.wso2.carbon.identity.mgt.server.feature/resources/p2.inf
@@ -2,3 +2,7 @@ instructions.configure = \
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.mgt.server_${feature.version}/identity-mgt.properties,target:${installFolder}/../../conf/identity/identity-mgt.properties,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.mgt.server_${feature.version}/RecoveryEndpointConfig.properties,target:${installFolder}/../../conf/identity/RecoveryEndpointConfig.properties,overwrite:true); \
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.mgt.server_${feature.version}/RecoveryEndpointConfig.properties.j2,target:${installFolder}/../../resources/conf/templates/repository/conf/identity/RecoveryEndpointConfig.properties.j2,overwrite:true);\
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../lib/); \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../lib/runtimes/); \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../lib/runtimes/cxf3/); \
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.mgt.server_${feature.version}/runtimes/cxf3/,target:${installFolder}/../../../lib/runtimes/cxf3/,overwrite:true);\

--- a/pom.xml
+++ b/pom.xml
@@ -1558,6 +1558,12 @@
                 <artifactId>jersey-multipart</artifactId>
                 <version>${jersey-version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.sun.jersey</groupId>
+                <artifactId>jersey-core</artifactId>
+                <version>${jersey-version}</version>
+            </dependency>
+
 
             <!-- JSON processing: jackson -->
             <dependency>


### PR DESCRIPTION
### Proposed changes in this pull request

Move org.wso2.carbon.identity.mgt.endpoint.util util to cxf runtime from the plugins.

At the moment is jar is duplicated in the required webapps and the jar in the plugins is not anyway working due to missing dependencies in the OSGi runtime. Below error is observed if only the jar in the plugins folder is used.
`java.lang.NoClassDefFoundError: org/apache/cxf/jaxrs/provider/json/JSONProvider`

This PR will follow up with another PR to remove the duplicated jar files from the web apps.