### PR TITLE
Validate by converting js regex to java regex pattern

### DIFF
--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/validators/JsRegExValidator.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/validators/JsRegExValidator.java
@@ -18,14 +18,19 @@
 
 package org.wso2.carbon.identity.input.validation.mgt.model.validators;
 
+import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtClientException;
 import org.wso2.carbon.identity.input.validation.mgt.model.Property;
 import org.wso2.carbon.identity.input.validation.mgt.model.ValidationContext;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.JS_REGEX;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_CODE_REGEX_MISMATCH;
 
 /**
  * JavaScript regex validator.
@@ -35,7 +40,26 @@ public class JsRegExValidator extends AbstractRegExValidator {
     @Override
     public boolean validate(ValidationContext context) throws InputValidationMgtClientException {
 
-        // This is a FE validator.
+        // Validate against the Java regex in the BE.
+        String value = context.getValue();
+        boolean valid = false;
+        Map<String, String> attributesMap = context.getProperties();
+        String javaRegex = StringUtils.EMPTY;
+
+        if (attributesMap.containsKey(JS_REGEX)) {
+            String jsRegex = attributesMap.get(JS_REGEX);
+            // Convert to Java regex.
+            javaRegex = jsRegex.replaceAll("//", "/");
+
+            Pattern pattern = Pattern.compile(javaRegex);
+            Matcher matcher = pattern.matcher(value);
+            valid = matcher.matches();
+        }
+        if (!valid) {
+            throw new InputValidationMgtClientException(ERROR_CODE_REGEX_MISMATCH.getCode(),
+                    ERROR_CODE_REGEX_MISMATCH.getMessage(),
+                    String.format(ERROR_CODE_REGEX_MISMATCH.getDescription(), context.getField(), javaRegex));
+        }
         return true;
     }
 

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -126,6 +126,9 @@ public class Constants {
         ERROR_CODE_CONFIGURE_EITHER_RULES_OR_REGEX("60020",
                 "Invalid configuration format",
                 "Validation configurations can be configured with one of them: rules or regex."),
+        ERROR_CODE_REGEX_MISMATCH("60021",
+                "Regex mismatch",
+                "The %s should satisfy the %s pattern."),
         // Server Errors.
         ERROR_GETTING_EXISTING_CONFIGURATIONS("65001",
                 "Unable to get input validation configurations.",


### PR DESCRIPTION
### Proposed changes in this pull request

Use the JS regex pattern to do the BE validation by converting it to java regex.