### PR TITLE
Remove account lock component as a dependency for authentication framework

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
@@ -197,10 +197,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
-            <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.openjdk.nashorn</groupId>
             <artifactId>nashorn-core</artifactId>
             <scope>provided</scope>

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -62,9 +62,6 @@ import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
-import org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants;
-import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockServiceException;
-import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.exception.FederatedAssociationManagerException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
@@ -478,17 +475,38 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
         return federatedUsername;
     }
 
-    private boolean isAccountLocked(String username, String tenantDomain)
-            throws PostAuthenticationFailedException {
+//    private boolean isAccountLocked(String username, String tenantDomain)
+////            throws PostAuthenticationFailedException {
+////
+////        AccountLockService accountLockService = FrameworkServiceDataHolder.getInstance().getAccountLockService();
+////        try {
+////            return accountLockService.isAccountLocked(username, tenantDomain);
+////        } catch (AccountLockServiceException e) {
+////            throw new PostAuthenticationFailedException(
+////                    ErrorMessages.ERROR_WHILE_CHECKING_ACCOUNT_LOCK_STATUS.getCode(),
+////                    String.format(ErrorMessages.ERROR_WHILE_CHECKING_ACCOUNT_LOCK_STATUS.getMessage(), username),
+// e);
+////        }
+////    }
 
-        AccountLockService accountLockService = FrameworkServiceDataHolder.getInstance().getAccountLockService();
+    private boolean isAccountLocked(String username, String tenantDomain) throws PostAuthenticationFailedException {
+
         try {
-            return accountLockService.isAccountLocked(username, tenantDomain);
-        } catch (AccountLockServiceException e) {
+            UserRealm realm = (UserRealm) FrameworkServiceDataHolder.getInstance().getRealmService()
+                    .getTenantUserRealm(IdentityTenantUtil.getTenantId(tenantDomain));
+            UserStoreManager userStoreManager = realm.getUserStoreManager();
+            Map<String, String> claimValues = userStoreManager.getUserClaimValues(username, new String[]{
+                    FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI}, UserCoreConstants.DEFAULT_PROFILE);
+            if (claimValues != null && claimValues.size() > 0) {
+                String accountLockedClaim = claimValues.get(FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI);
+                return Boolean.parseBoolean(accountLockedClaim);
+            }
+        } catch (UserStoreException e) {
             throw new PostAuthenticationFailedException(
                     ErrorMessages.ERROR_WHILE_CHECKING_ACCOUNT_LOCK_STATUS.getCode(),
                     String.format(ErrorMessages.ERROR_WHILE_CHECKING_ACCOUNT_LOCK_STATUS.getMessage(), username), e);
         }
+        return false;
     }
 
     /**
@@ -505,9 +523,9 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                     .getTenantUserRealm(IdentityTenantUtil.getTenantId(tenantDomain));
             UserStoreManager userStoreManager = realm.getUserStoreManager();
             Map<String, String> claimValues = userStoreManager.getUserClaimValues(username, new String[]{
-                    AccountConstants.ACCOUNT_DISABLED_CLAIM}, UserCoreConstants.DEFAULT_PROFILE);
+                    FrameworkConstants.ACCOUNT_DISABLED_CLAIM_URI}, UserCoreConstants.DEFAULT_PROFILE);
             if (claimValues != null && claimValues.size() > 0) {
-                String accountDisabledClaim = claimValues.get(AccountConstants.ACCOUNT_DISABLED_CLAIM);
+                String accountDisabledClaim = claimValues.get(FrameworkConstants.ACCOUNT_DISABLED_CLAIM_URI);
                 return Boolean.parseBoolean(accountDisabledClaim);
             }
         } catch (UserStoreException e) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -475,20 +475,6 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
         return federatedUsername;
     }
 
-//    private boolean isAccountLocked(String username, String tenantDomain)
-////            throws PostAuthenticationFailedException {
-////
-////        AccountLockService accountLockService = FrameworkServiceDataHolder.getInstance().getAccountLockService();
-////        try {
-////            return accountLockService.isAccountLocked(username, tenantDomain);
-////        } catch (AccountLockServiceException e) {
-////            throw new PostAuthenticationFailedException(
-////                    ErrorMessages.ERROR_WHILE_CHECKING_ACCOUNT_LOCK_STATUS.getCode(),
-////                    String.format(ErrorMessages.ERROR_WHILE_CHECKING_ACCOUNT_LOCK_STATUS.getMessage(), username),
-// e);
-////        }
-////    }
-
     private boolean isAccountLocked(String username, String tenantDomain) throws PostAuthenticationFailedException {
 
         try {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -103,7 +103,6 @@ import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.functions.library.mgt.FunctionLibraryManagementService;
-import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
@@ -905,23 +904,6 @@ public class FrameworkServiceComponent {
     protected void unsetMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLogin) {
 
         FrameworkServiceDataHolder.getInstance().setMultiAttributeLoginService(null);
-    }
-
-
-    @Reference(
-            service = AccountLockService.class,
-            cardinality = ReferenceCardinality.MANDATORY,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetAccountLockService"
-    )
-    public void setAccountLockService(AccountLockService accountLockService) {
-
-        FrameworkServiceDataHolder.getInstance().setAccountLockService(accountLockService);
-    }
-
-    public void unsetAccountLockService(AccountLockService accountLockService) {
-
-        FrameworkServiceDataHolder.getInstance().setAccountLockService(null);
     }
 
     private AuthenticatorConfig getAuthenticatorConfig(String name) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
@@ -47,7 +47,6 @@ import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementServic
 import org.wso2.carbon.identity.core.handler.HandlerComparator;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.functions.library.mgt.FunctionLibraryManagementService;
-import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
@@ -101,7 +100,6 @@ public class FrameworkServiceDataHolder {
     private Map<String, SessionContextMgtListener> sessionContextMgtListeners = new HashMap<>();
     private SessionSerializer sessionSerializer;
 
-    private AccountLockService accountLockService;
     private JSExecutionSupervisor jsExecutionSupervisor;
     private IdpManager identityProviderManager = null;
 
@@ -576,16 +574,6 @@ public class FrameworkServiceDataHolder {
 
     public SessionSerializer getSessionSerializer() {
         return sessionSerializer;
-    }
-
-    public void setAccountLockService(AccountLockService accountLockService) {
-
-        this.accountLockService = accountLockService;
-    }
-
-    public AccountLockService getAccountLockService() {
-
-        return accountLockService;
     }
 
     public void setSessionSerializer(SessionSerializer sessionSerializer) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandlerTest.java
@@ -154,10 +154,6 @@ public class JITProvisioningPostAuthenticationHandlerTest extends AbstractFramew
         mockStatic(FrameworkServiceDataHolder.class);
         PowerMockito.when(FrameworkServiceDataHolder.getInstance()).thenReturn(frameworkServiceDataHolder);
 
-//        mockStatic(AccountLockService.class);
-//        when(frameworkServiceDataHolder.getAccountLockService()).thenReturn(accountLockService);
-//        when(accountLockService.isAccountLocked(anyString(), anyString())).thenReturn(false);
-
         RealmService mockRealmService = mock(RealmService.class);
         PowerMockito.when(FrameworkServiceDataHolder.getInstance().getRealmService()).thenReturn(mockRealmService);
         UserRealm mockUserRealm = mock(UserRealm.class);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandlerTest.java
@@ -46,9 +46,6 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants;
-import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockServiceException;
-import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManagerImpl;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.exception.FederatedAssociationManagerException;
@@ -80,8 +77,8 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 /**
  * This is a test class for {@link JITProvisioningPostAuthenticationHandler}.
  */
-@PrepareForTest({FrameworkUtils.class, ConfigurationFacade.class, AccountLockService.class,
-        FrameworkServiceDataHolder.class, IdentityTenantUtil.class})
+@PrepareForTest({FrameworkUtils.class, ConfigurationFacade.class, FrameworkServiceDataHolder.class,
+        IdentityTenantUtil.class})
 @PowerMockIgnore({"javax.xml.*", "org.mockito.*"})
 public class JITProvisioningPostAuthenticationHandlerTest extends AbstractFrameworkTest {
 
@@ -93,9 +90,6 @@ public class JITProvisioningPostAuthenticationHandlerTest extends AbstractFramew
 
     @Mock
     private FrameworkServiceDataHolder frameworkServiceDataHolder;
-
-    @Mock
-    private AccountLockService accountLockService;
 
     @BeforeClass
     protected void setupSuite() throws XMLStreamException, IdentityProviderManagementException {
@@ -146,7 +140,7 @@ public class JITProvisioningPostAuthenticationHandlerTest extends AbstractFramew
 
     @Test(description = "This test case tests the Post JIT provisioning handling flow with an authenticated user")
     public void testHandleWithAuthenticatedUserWithFederatedIdp() throws FrameworkException,
-            FederatedAssociationManagerException, AccountLockServiceException, UserStoreException, XMLStreamException,
+            FederatedAssociationManagerException, UserStoreException, XMLStreamException,
             IdentityProviderManagementException {
 
         AuthenticationContext context = processAndGetAuthenticationContext(sp, true, true);
@@ -160,9 +154,9 @@ public class JITProvisioningPostAuthenticationHandlerTest extends AbstractFramew
         mockStatic(FrameworkServiceDataHolder.class);
         PowerMockito.when(FrameworkServiceDataHolder.getInstance()).thenReturn(frameworkServiceDataHolder);
 
-        mockStatic(AccountLockService.class);
-        when(frameworkServiceDataHolder.getAccountLockService()).thenReturn(accountLockService);
-        when(accountLockService.isAccountLocked(anyString(), anyString())).thenReturn(false);
+//        mockStatic(AccountLockService.class);
+//        when(frameworkServiceDataHolder.getAccountLockService()).thenReturn(accountLockService);
+//        when(accountLockService.isAccountLocked(anyString(), anyString())).thenReturn(false);
 
         RealmService mockRealmService = mock(RealmService.class);
         PowerMockito.when(FrameworkServiceDataHolder.getInstance().getRealmService()).thenReturn(mockRealmService);
@@ -174,9 +168,13 @@ public class JITProvisioningPostAuthenticationHandlerTest extends AbstractFramew
         when(mockRealmService.getTenantUserRealm(anyInt())).thenReturn(mockUserRealm);
         when(mockUserRealm.getUserStoreManager()).thenReturn(mockUserStoreManager);
         when(mockUserStoreManager.getUserClaimValues(anyString(),
-                        eq(new String[]{AccountConstants.ACCOUNT_DISABLED_CLAIM}),
+                        eq(new String[]{FrameworkConstants.ACCOUNT_DISABLED_CLAIM_URI}),
                         eq(UserCoreConstants.DEFAULT_PROFILE))).thenReturn(mockClaimValues);
-        when(mockClaimValues.get(AccountConstants.ACCOUNT_DISABLED_CLAIM)).thenReturn("false");
+        when(mockClaimValues.get(FrameworkConstants.ACCOUNT_DISABLED_CLAIM_URI)).thenReturn("false");
+        when(mockUserStoreManager.getUserClaimValues(anyString(),
+                eq(new String[]{FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI}),
+                eq(UserCoreConstants.DEFAULT_PROFILE))).thenReturn(mockClaimValues);
+        when(mockClaimValues.get(FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI)).thenReturn("false");
 
         // Need to mock getIdPConfigByName with a null parameter.
         ConfigurationFacade configurationFacade = mock(ConfigurationFacade.class);

--- a/pom.xml
+++ b/pom.xml
@@ -1486,11 +1486,6 @@
                 <artifactId>org.wso2.carbon.user.mgt.workflow.stub</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
-                <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
-                <version>${account.lock.service.version}</version>
-            </dependency>
 
             <!--Feature Dependencies Ends-->
 
@@ -2040,7 +2035,6 @@
         <maven.checkstyleplugin.version>3.1.0</maven.checkstyleplugin.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
 
-        <account.lock.service.version>1.8.2</account.lock.service.version>
         <account.lock.service.imp.pkg.version.range>[1.4.23, 2.0.0)</account.lock.service.imp.pkg.version.range>
         <openjdk.nashorn.version>15.3</openjdk.nashorn.version>
     </properties>


### PR DESCRIPTION
### Proposed changes in this pull request

- Removing `org.wso2.carbon.identity.handler.event.account.lock` as a dependency for authentication framework component.

PR that introduced account lock as a dependency for authentication framework: https://github.com/wso2/carbon-identity-framework/pull/3598
