### PR TITLE
Update IS_SECRET value for identity providers in all flows

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -3123,14 +3123,14 @@ public class IdentityProviderManager implements IdpManager {
     private void setConfidentialStatusFromMeta(IdentityProvider identityProvider)
             throws IdentityProviderManagementException {
 
-        FederatedAuthenticatorConfig[] metaFederatedAuthenticatorConfigs = getAllFederatedAuthenticators();
+        FederatedAuthenticatorConfig[] metaFedAuthConfigs = getAllFederatedAuthenticators();
         Arrays.asList(identityProvider.getFederatedAuthenticatorConfigs()).forEach(fedAuthConfig -> {
-            Optional<FederatedAuthenticatorConfig> metaFedAuthConfig =
-                    Arrays.stream(metaFederatedAuthenticatorConfigs).filter(metaFed -> metaFed.getName()
+            Optional<FederatedAuthenticatorConfig> optionalMetaFedAuthConfig =
+                    Arrays.stream(metaFedAuthConfigs).filter(metaFed -> metaFed.getName()
                             .equals(fedAuthConfig.getName())).findAny();
-            metaFedAuthConfig.ifPresent(
-                    federatedAuthenticatorConfig -> Arrays.asList(fedAuthConfig.getProperties()).forEach(prop -> {
-                        Property metaProperty = Arrays.stream(federatedAuthenticatorConfig.getProperties())
+            optionalMetaFedAuthConfig.ifPresent(
+                    metaFedAuthConfig -> Arrays.asList(fedAuthConfig.getProperties()).forEach(prop -> {
+                        Property metaProperty = Arrays.stream(metaFedAuthConfig.getProperties())
                                 .filter(metaProp -> (metaProp.getName().equals(prop.getName()))).findAny().orElse(null);
                         if (metaProperty != null && metaProperty.isConfidential()) {
                             prop.setConfidential(true);

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2014, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -1,17 +1,17 @@
-/*
- * Copyright (c) 2014 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+/**
+ * Copyright (c) 2014, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -25,7 +25,6 @@ import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.identity.application.common.ApplicationAuthenticatorService;
@@ -2055,7 +2054,6 @@ public class IdentityProviderManager implements IdpManager {
             throws IdentityProviderManagementException {
 
         markConfidentialPropertiesUsingMetadata(identityProvider);
-
         validateAddIdPInputValues(identityProvider.getIdentityProviderName(), tenantDomain);
         validateOutboundProvisioningRoles(identityProvider, tenantDomain);
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -2054,7 +2054,7 @@ public class IdentityProviderManager implements IdpManager {
     public IdentityProvider addIdPWithResourceId(IdentityProvider identityProvider, String tenantDomain)
             throws IdentityProviderManagementException {
 
-        setConfidentialStatusFromMeta(identityProvider);
+        markConfidentialPropertiesUsingMetadata(identityProvider);
 
         validateAddIdPInputValues(identityProvider.getIdentityProviderName(), tenantDomain);
         validateOutboundProvisioningRoles(identityProvider, tenantDomain);
@@ -2365,7 +2365,7 @@ public class IdentityProviderManager implements IdpManager {
     public IdentityProvider updateIdPByResourceId(String resourceId, IdentityProvider
             newIdentityProvider, String tenantDomain) throws IdentityProviderManagementException {
 
-        setConfidentialStatusFromMeta(newIdentityProvider);
+        markConfidentialPropertiesUsingMetadata(newIdentityProvider);
         // Invoking the pre listeners.
         Collection<IdentityProviderMgtListener> listeners = IdPManagementServiceComponent.getIdpMgtListeners();
         for (IdentityProviderMgtListener listener : listeners) {
@@ -3119,7 +3119,7 @@ public class IdentityProviderManager implements IdpManager {
      * Set the confidential status of federated authenticator properties using metadata.
      * @param identityProvider Identity Provider.
      */
-    private void setConfidentialStatusFromMeta(IdentityProvider identityProvider)
+    private void markConfidentialPropertiesUsingMetadata(IdentityProvider identityProvider)
             throws IdentityProviderManagementException {
 
         Map<String, List<String>> metaFedAuthConfigMap = createFedAuthConfidentialPropsMap();

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -3133,6 +3133,8 @@ public class IdentityProviderManager implements IdpManager {
 
     /**
      * Create map of federated authenticator name to list of confidential properties.
+     *
+     * @return HashMap mapping federated authenticator name to a list of confidential property names.
      */
     private Map<String, List<String>> createFedAuthConfidentialPropsMap() throws IdentityProviderManagementException {
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -85,7 +85,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -102,7 +102,6 @@ public class IdentityProviderManager implements IdpManager {
     private static final String OPENID_IDP_ENTITY_ID = "IdPEntityId";
     private static CacheBackedIdPMgtDAO dao = new CacheBackedIdPMgtDAO(new IdPManagementDAO());
     private static volatile IdentityProviderManager instance = new IdentityProviderManager();
-    private static Map<String, List<String>> metaFedAuthConfigMap = new HashMap<>();
 
     private IdentityProviderManager() {
 
@@ -3124,7 +3123,7 @@ public class IdentityProviderManager implements IdpManager {
     private void setConfidentialStatusFromMeta(IdentityProvider identityProvider)
             throws IdentityProviderManagementException {
 
-        populateFedAuthConfidentialPropsMap();
+        Map<String, List<String>> metaFedAuthConfigMap = createFedAuthConfidentialPropsMap();
         Arrays.asList(identityProvider.getFederatedAuthenticatorConfigs()).forEach(fedAuthConfig -> {
             List<String> secretProperties = metaFedAuthConfigMap.get(fedAuthConfig.getName());
                 Arrays.asList(fedAuthConfig.getProperties()).forEach(prop -> {
@@ -3138,19 +3137,19 @@ public class IdentityProviderManager implements IdpManager {
     /**
      * Create map of federated authenticator name to list of confidential properties.
      */
-    private void populateFedAuthConfidentialPropsMap() throws IdentityProviderManagementException {
+    private Map<String, List<String>> createFedAuthConfidentialPropsMap() throws IdentityProviderManagementException {
 
-        if (metaFedAuthConfigMap.isEmpty()) {
-            FederatedAuthenticatorConfig[] metaFedAuthConfigs = getAllFederatedAuthenticators();
-            for (FederatedAuthenticatorConfig metaFedAuthConfig : metaFedAuthConfigs) {
-                List<String> secretProperties = new ArrayList<>();
-                for (Property property : metaFedAuthConfig.getProperties()) {
-                    if (property.isConfidential()) {
-                        secretProperties.add(property.getName());
-                    }
+        Map<String, List<String>> metaFedAuthConfigMap = new HashMap<>();
+        FederatedAuthenticatorConfig[] metaFedAuthConfigs = getAllFederatedAuthenticators();
+        for (FederatedAuthenticatorConfig metaFedAuthConfig : metaFedAuthConfigs) {
+            List<String> secretProperties = new ArrayList<>();
+            for (Property property : metaFedAuthConfig.getProperties()) {
+                if (property.isConfidential()) {
+                    secretProperties.add(property.getName());
                 }
-                metaFedAuthConfigMap.put(metaFedAuthConfig.getName(), secretProperties);
             }
+            metaFedAuthConfigMap.put(metaFedAuthConfig.getName(), secretProperties);
         }
+        return metaFedAuthConfigMap;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

Currently the IS_SECRET value is not being set to true for the following cases:
1. Creating a federated IdP through the REST API
2. Creating a custom federated IdP through the management console

This PR introduces a fix where the isConfidential status of IdP properties (which corresponds to the IS_SECRET value stored in the database) are updated according to the meta data of that IdP at the OSGi level.

### Related Issues
- Issue https://github.com/wso2-enterprise/asgardeo-product/issues/14164

