### PR TITLE
Overload getSessionByUserId to pass the tenant domain

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/UserSessionManagementService.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/UserSessionManagementService.java
@@ -57,6 +57,15 @@ public interface UserSessionManagementService {
     }
 
     /**
+     * Get all the active sessions of the given user ID.
+     * @param userId Unique ID of the user.
+     * @param tenantDomain Tenant domain of the user.
+     * @return List of user session objects.
+     * @throws SessionManagementException if the session retrieval fails.
+     */
+    List<UserSession> getSessionsByUserId(String userId, String tenantDomain) throws SessionManagementException;
+
+    /**
      * Terminate all the active sessions of the given user ID.
      *
      * @param userId Unique ID of the user.


### PR DESCRIPTION
### Proposed changes in this pull request

$subject
Addresses https://github.com/wso2/product-is/issues/15223

As of now, the tenant domain in the getSessionByUserId is retrieved from the Privileged Carbon Context. But this leads to [1], where the super tenant domain is retrieved in tenanted sessions. Hence, we are passing the tenant domain from the context in https://github.com/wso2-extensions/identity-local-auth-basicauth/pull/166

### Related PRs
https://github.com/wso2-extensions/identity-local-auth-basicauth/pull/166