### PR TITLE
Add Field Validation Configuration Handler

### DIFF
--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationDataHolder.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationDataHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.input.validation.mgt.internal;
 
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.input.validation.mgt.model.FieldValidationConfigurationHandler;
 import org.wso2.carbon.identity.input.validation.mgt.model.Validator;
 
 import java.util.HashMap;
@@ -31,6 +32,7 @@ public class InputValidationDataHolder {
 
     private static ConfigurationManager configurationManager = null;
     private static Map<String, Validator> validators = new HashMap<>();
+    private static Map<String, FieldValidationConfigurationHandler> validationConfigurationHandler = new HashMap<>();
 
     /**
      * Get Configuration Manager.
@@ -55,5 +57,10 @@ public class InputValidationDataHolder {
     public static Map<String, Validator> getValidators() {
 
         return validators;
+    }
+
+    public static Map<String, FieldValidationConfigurationHandler> getFieldValidationConfigurationHandler() {
+
+        return validationConfigurationHandler;
     }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationDataHolder.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationDataHolder.java
@@ -32,7 +32,7 @@ public class InputValidationDataHolder {
 
     private static ConfigurationManager configurationManager = null;
     private static Map<String, Validator> validators = new HashMap<>();
-    private static Map<String, FieldValidationConfigurationHandler> validationConfigurationHandler = new HashMap<>();
+    private static Map<String, FieldValidationConfigurationHandler> validationConfigurationHandlers = new HashMap<>();
 
     /**
      * Get Configuration Manager.
@@ -59,8 +59,8 @@ public class InputValidationDataHolder {
         return validators;
     }
 
-    public static Map<String, FieldValidationConfigurationHandler> getFieldValidationConfigurationHandler() {
+    public static Map<String, FieldValidationConfigurationHandler> getFieldValidationConfigurationHandlers() {
 
-        return validationConfigurationHandler;
+        return validationConfigurationHandlers;
     }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationServiceComponent.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationServiceComponent.java
@@ -154,13 +154,13 @@ public class InputValidationServiceComponent {
     )
     protected void setFieldValidationConfigurationHandler(FieldValidationConfigurationHandler configurationHandler) {
 
-        InputValidationDataHolder.getFieldValidationConfigurationHandler().put(
+        InputValidationDataHolder.getFieldValidationConfigurationHandlers().put(
                 configurationHandler.getClass().getSimpleName(), configurationHandler);
     }
 
     protected void unsetFieldValidationConfigurationHandler(FieldValidationConfigurationHandler configurationHandler) {
 
-        InputValidationDataHolder.getFieldValidationConfigurationHandler()
+        InputValidationDataHolder.getFieldValidationConfigurationHandlers()
                 .remove(configurationHandler.getClass().getName());
     }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationServiceComponent.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationServiceComponent.java
@@ -29,7 +29,9 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.input.validation.mgt.listener.InputValidationListener;
+import org.wso2.carbon.identity.input.validation.mgt.model.FieldValidationConfigurationHandler;
 import org.wso2.carbon.identity.input.validation.mgt.model.Validator;
+import org.wso2.carbon.identity.input.validation.mgt.model.handlers.PasswordValidationConfigurationHandler;
 import org.wso2.carbon.identity.input.validation.mgt.model.validators.JsRegExValidator;
 import org.wso2.carbon.identity.input.validation.mgt.model.validators.LengthValidator;
 import org.wso2.carbon.identity.input.validation.mgt.model.validators.LowerCaseValidator;
@@ -61,6 +63,8 @@ public class InputValidationServiceComponent {
         try {
             context.getBundleContext().registerService(InputValidationManagementService.class.getName(),
                     new InputValidationManagementServiceImpl(), null);
+
+            // Register Validators.
             context.getBundleContext().registerService(Validator.class.getName(),
                     new LengthValidator(), null);
             context.getBundleContext().registerService(Validator.class.getName(),
@@ -79,6 +83,10 @@ public class InputValidationServiceComponent {
                     new JsRegExValidator(), null);
             context.getBundleContext().registerService(UserOperationEventListener.class.getName(),
                     new InputValidationListener(), null);
+
+            // Register field validation configuration handlers.
+            context.getBundleContext().registerService(FieldValidationConfigurationHandler.class.getName(),
+                    new PasswordValidationConfigurationHandler(), null);
         } catch (Throwable throwable) {
             log.error("Error while activating Input Validation Service Component.", throwable);
         }
@@ -135,5 +143,24 @@ public class InputValidationServiceComponent {
     protected void unsetValidator(Validator validator) {
 
         InputValidationDataHolder.getValidators().remove(validator.getClass().getName());
+    }
+
+    @Reference(
+            name = "field.validation.configuration.handler",
+            service = FieldValidationConfigurationHandler.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetFieldValidationConfigurationHandler"
+    )
+    protected void setFieldValidationConfigurationHandler(FieldValidationConfigurationHandler configurationHandler) {
+
+        InputValidationDataHolder.getFieldValidationConfigurationHandler().put(
+                configurationHandler.getClass().getSimpleName(), configurationHandler);
+    }
+
+    protected void unsetFieldValidationConfigurationHandler(FieldValidationConfigurationHandler configurationHandler) {
+
+        InputValidationDataHolder.getFieldValidationConfigurationHandler()
+                .remove(configurationHandler.getClass().getName());
     }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/FieldValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/FieldValidationConfigurationHandler.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.input.validation.mgt.model;
 
+import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtClientException;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtException;
 
 import java.util.List;
@@ -48,5 +49,5 @@ public interface FieldValidationConfigurationHandler {
      * @return  boolean
      */
     boolean validateValidatorConfiguration(List<RulesConfiguration> configurationList)
-            throws InputValidationMgtException;
+            throws InputValidationMgtClientException;
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/FieldValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/FieldValidationConfigurationHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.input.validation.mgt.model;
+
+import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtException;
+
+import java.util.List;
+
+/**
+ * Interface of Field Validation Configuration Handler.
+ */
+public interface FieldValidationConfigurationHandler {
+
+    /**
+     * Check whether the field can be handled by the handler.
+     *
+     * @param field     Name of the field.
+     * @return boolean
+     */
+    boolean canHandle(String field);
+
+    /**
+     * Retrieve default validator configuration for the field.
+     *
+     * @return  ValidationConfiguration
+     */
+    ValidationConfiguration getDefaultValidationConfiguration(String tenantDomain) throws InputValidationMgtException;
+
+    /**
+     * Validate whether given validator configuration are allowed.
+     *
+     * @return  boolean
+     */
+    boolean validateValidatorConfiguration(List<RulesConfiguration> configurationList)
+            throws InputValidationMgtException;
+}

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/AbstractFieldValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/AbstractFieldValidationConfigurationHandler.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.input.validation.mgt.model.handlers;
+
+import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtException;
+import org.wso2.carbon.identity.input.validation.mgt.model.FieldValidationConfigurationHandler;
+import org.wso2.carbon.identity.input.validation.mgt.model.RulesConfiguration;
+import org.wso2.carbon.identity.input.validation.mgt.model.ValidationConfiguration;
+import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.api.UserStoreException;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_GETTING_EXISTING_CONFIGURATIONS;
+
+/**
+ * Abstract Field Validation Configuration Handler.
+ */
+public class AbstractFieldValidationConfigurationHandler implements FieldValidationConfigurationHandler {
+
+    @Override
+    public boolean canHandle(String field) {
+
+        return true;
+    }
+
+    @Override
+    public ValidationConfiguration getDefaultValidationConfiguration(String tenantDomain) throws
+            InputValidationMgtException {
+
+        return new ValidationConfiguration();
+    }
+
+    protected RulesConfiguration getRuleConfig(String validatorName, String property, String value) {
+
+        RulesConfiguration rule = new RulesConfiguration();
+        rule.setValidatorName(validatorName);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(property, value);
+        rule.setProperties(properties);
+
+        return rule;
+    }
+
+    protected RealmConfiguration getRealmConfiguration(String tenantDomain) throws InputValidationMgtException {
+
+        try {
+            if (CarbonContext.getThreadLocalCarbonContext().getUserRealm() != null &&
+                    CarbonContext.getThreadLocalCarbonContext().getUserRealm().getRealmConfiguration() != null) {
+                return CarbonContext.getThreadLocalCarbonContext().getUserRealm().getRealmConfiguration();
+            } else {
+                throw new InputValidationMgtException(ERROR_GETTING_EXISTING_CONFIGURATIONS.getCode(),
+                        "Realm configuration is empty for tenant :" + tenantDomain);
+            }
+        } catch (UserStoreException e) {
+            throw new InputValidationMgtException(ERROR_GETTING_EXISTING_CONFIGURATIONS.getCode(),
+                    "Failed to get user realm for tenant :" + tenantDomain);
+        }
+    }
+
+    @Override
+    public boolean validateValidatorConfiguration(List<RulesConfiguration> configurationList)
+            throws InputValidationMgtException {
+
+        return true;
+    }
+}

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/AbstractFieldValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/AbstractFieldValidationConfigurationHandler.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.input.validation.mgt.model.handlers;
 
 import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtClientException;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtException;
 import org.wso2.carbon.identity.input.validation.mgt.model.FieldValidationConfigurationHandler;
 import org.wso2.carbon.identity.input.validation.mgt.model.RulesConfiguration;
@@ -79,7 +80,7 @@ public class AbstractFieldValidationConfigurationHandler implements FieldValidat
 
     @Override
     public boolean validateValidatorConfiguration(List<RulesConfiguration> configurationList)
-            throws InputValidationMgtException {
+            throws InputValidationMgtClientException {
 
         return true;
     }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/PasswordValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/PasswordValidationConfigurationHandler.java
@@ -21,6 +21,11 @@ package org.wso2.carbon.identity.input.validation.mgt.model.handlers;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtException;
 import org.wso2.carbon.identity.input.validation.mgt.model.RulesConfiguration;
 import org.wso2.carbon.identity.input.validation.mgt.model.ValidationConfiguration;
+import org.wso2.carbon.identity.input.validation.mgt.model.validators.LengthValidator;
+import org.wso2.carbon.identity.input.validation.mgt.model.validators.LowerCaseValidator;
+import org.wso2.carbon.identity.input.validation.mgt.model.validators.NumeralValidator;
+import org.wso2.carbon.identity.input.validation.mgt.model.validators.SpecialCharacterValidator;
+import org.wso2.carbon.identity.input.validation.mgt.model.validators.UpperCaseValidator;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.UserCoreConstants;
 
@@ -41,7 +46,7 @@ public class PasswordValidationConfigurationHandler extends AbstractFieldValidat
     @Override
     public boolean canHandle(String field) {
 
-        return PASSWORD.equals(field);
+        return PASSWORD.equalsIgnoreCase(field);
     }
 
     @Override
@@ -64,11 +69,11 @@ public class PasswordValidationConfigurationHandler extends AbstractFieldValidat
                 rules.add(getRuleConfig("JsRegExValidator", JS_REGEX, jsRegex));
                 configuration.setRegEx(rules);
             } else {
-                rules.add(getRuleConfig("LengthValidator", MIN_LENGTH, "8"));
-                rules.add(getRuleConfig("NumeralValidator", MIN_LENGTH, "1"));
-                rules.add(getRuleConfig("UpperCaseValidator", MIN_LENGTH, "1"));
-                rules.add(getRuleConfig("LowerCaseValidator", MIN_LENGTH, "1"));
-                rules.add(getRuleConfig("SpecialCharacterValidator", MIN_LENGTH, "1"));
+                rules.add(getRuleConfig(LengthValidator.class.getSimpleName(), MIN_LENGTH, "8"));
+                rules.add(getRuleConfig(NumeralValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                rules.add(getRuleConfig(UpperCaseValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                rules.add(getRuleConfig(LowerCaseValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                rules.add(getRuleConfig(SpecialCharacterValidator.class.getSimpleName(), MIN_LENGTH, "1"));
                 configuration.setRules(rules);
             }
             return configuration;

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/PasswordValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/PasswordValidationConfigurationHandler.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.input.validation.mgt.model.handlers;
+
+import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtException;
+import org.wso2.carbon.identity.input.validation.mgt.model.RulesConfiguration;
+import org.wso2.carbon.identity.input.validation.mgt.model.ValidationConfiguration;
+import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.UserCoreConstants;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.JAVA_REGEX_PATTERN;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.JS_REGEX;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.MIN_LENGTH;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.PASSWORD;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_GETTING_EXISTING_CONFIGURATIONS;
+
+/**
+ * Password Validation Configuration Handler.
+ */
+public class PasswordValidationConfigurationHandler extends AbstractFieldValidationConfigurationHandler {
+
+    @Override
+    public boolean canHandle(String field) {
+
+        return PASSWORD.equals(field);
+    }
+
+    @Override
+    public ValidationConfiguration getDefaultValidationConfiguration(String tenantDomain) throws
+            InputValidationMgtException {
+
+        ValidationConfiguration configuration = new ValidationConfiguration();
+        configuration.setField(PASSWORD);
+        List<RulesConfiguration> rules = new ArrayList<>();
+
+        try {
+            RealmConfiguration realmConfiguration = getRealmConfiguration(tenantDomain);
+            String javaRegex = realmConfiguration.getUserStoreProperty(UserCoreConstants
+                    .RealmConfig.PROPERTY_JAVA_REG_EX);
+            String jsRegex = realmConfiguration.
+                    getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_JS_REG_EX);
+
+            // Return the JsRegex if the default regex has been updated by the user.
+            if (!javaRegex.isEmpty() && !jsRegex.isEmpty() && !JAVA_REGEX_PATTERN.equals(javaRegex)) {
+                rules.add(getRuleConfig("JsRegExValidator", JS_REGEX, jsRegex));
+                configuration.setRegEx(rules);
+            } else {
+                rules.add(getRuleConfig("LengthValidator", MIN_LENGTH, "8"));
+                rules.add(getRuleConfig("NumeralValidator", MIN_LENGTH, "1"));
+                rules.add(getRuleConfig("UpperCaseValidator", MIN_LENGTH, "1"));
+                rules.add(getRuleConfig("LowerCaseValidator", MIN_LENGTH, "1"));
+                rules.add(getRuleConfig("SpecialCharacterValidator", MIN_LENGTH, "1"));
+                configuration.setRules(rules);
+            }
+            return configuration;
+        } catch (InputValidationMgtException e) {
+            throw new InputValidationMgtException(ERROR_GETTING_EXISTING_CONFIGURATIONS.getCode(), e.getMessage());
+        }
+    }
+}

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementService.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementService.java
@@ -75,4 +75,14 @@ public interface InputValidationManagementService {
      * @return configuration.
      */
     List<ValidationConfiguration> getConfigurationFromUserStore(String tenantDomain) throws InputValidationMgtException;
+
+    /**
+     * Method to get configuration from user store for a given field.
+     *
+     * @param tenantDomain  Tenant domain.
+     * @param field         Field configurations needs to be retrieved.
+     * @return configuration.
+     */
+    ValidationConfiguration getConfigurationFromUserStore(String tenantDomain, String field)
+            throws InputValidationMgtException;
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementServiceImpl.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementServiceImpl.java
@@ -134,9 +134,13 @@ public class InputValidationManagementServiceImpl implements InputValidationMana
     public ValidationConfiguration getConfigurationFromUserStore(String tenantDomain, String field)
             throws InputValidationMgtException {
 
-        FieldValidationConfigurationHandler handler = getFieldValidationConfigurationHandler().get(field);
-        // get all config validator and iterate
-        return handler.getDefaultValidationConfiguration(tenantDomain);
+        for (FieldValidationConfigurationHandler handler : getFieldValidationConfigurationHandler().values()) {
+            if (handler.canHandle(field.toLowerCase())) {
+                return handler.getDefaultValidationConfiguration(tenantDomain);
+            }
+        }
+        throw new InputValidationMgtException(ERROR_GETTING_EXISTING_CONFIGURATIONS.getCode(),
+                "Unable to find an FieldValidationConfigurationHandler for the % field.", field);
     }
 
     /**

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementServiceImpl.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementServiceImpl.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
-import static org.wso2.carbon.identity.input.validation.mgt.internal.InputValidationDataHolder.getFieldValidationConfigurationHandler;
+import static org.wso2.carbon.identity.input.validation.mgt.internal.InputValidationDataHolder.getFieldValidationConfigurationHandlers;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.REGEX;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.RULES;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.VALIDATION_TYPE;
@@ -134,7 +134,7 @@ public class InputValidationManagementServiceImpl implements InputValidationMana
     public ValidationConfiguration getConfigurationFromUserStore(String tenantDomain, String field)
             throws InputValidationMgtException {
 
-        for (FieldValidationConfigurationHandler handler : getFieldValidationConfigurationHandler().values()) {
+        for (FieldValidationConfigurationHandler handler : getFieldValidationConfigurationHandlers().values()) {
             if (handler.canHandle(field.toLowerCase())) {
                 return handler.getDefaultValidationConfiguration(tenantDomain);
             }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -35,7 +35,6 @@ public class Constants {
     public static final List<String> SUPPORTED_PARAMS =  Collections.unmodifiableList(
             new ArrayList<String>() {{
                 add(PASSWORD);
-                add(USERNAME);
             }});
 
     /**

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -18,7 +18,8 @@
 
 package org.wso2.carbon.identity.input.validation.mgt.utils;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.PASSWORD;
@@ -31,9 +32,11 @@ public class Constants {
 
     public static final String INPUT_VAL_CONFIG_RESOURCE_TYPE_NAME = "input-validation-configurations";
     public static final String INPUT_VAL_CONFIG_RESOURCE_NAME_PREFIX = "input-validation-configs-";
-    public static final List<String> SUPPORTED_PARAMS = Arrays.asList(
-            PASSWORD, USERNAME
-    );
+    public static final List<String> SUPPORTED_PARAMS =  Collections.unmodifiableList(
+            new ArrayList<String>() {{
+                add(PASSWORD);
+                add(USERNAME);
+            }});
 
     /**
      * Class contains the configuration related constants.


### PR DESCRIPTION
Add a Field Validation Configuration Handler to perform following actions:
- Retrieve configuration from the userstore for a field.
- Validate given validation configuration for a field.