### PR TITLE
Support attribute sync mechanism for oidc IdPs

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/JustInTimeProvisioningConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/JustInTimeProvisioningConfig.java
@@ -49,6 +49,8 @@ public class JustInTimeProvisioningConfig extends InboundProvisioningConfig impl
     private boolean promptConsent = false;
     @XmlElement(name = "EnableAssociateLocalUser")
     private boolean associateLocalUserEnabled = false;
+    @XmlElement(name = "SyncAttributeMethod")
+    private String syncAttributeMethod;
 
     /*
      * <JustInTimeProvisioningConfig> <UserStoreClaimUri></UserStoreClaimUri>
@@ -142,6 +144,21 @@ public class JustInTimeProvisioningConfig extends InboundProvisioningConfig impl
     public boolean isAssociateLocalUserEnabled() {
 
         return associateLocalUserEnabled;
+    }
+
+    /**
+     * To associate existing local user when JIT user provisioning is enabled.
+     *
+     * @param syncAttributeMethod to specify whether to associate existing local user when JIT user provisioning.
+     */
+    public void setSyncAttributeMethod(String syncAttributeMethod) {
+
+        this.syncAttributeMethod = syncAttributeMethod;
+    }
+
+    public String getSyncAttributeMethod() {
+
+        return syncAttributeMethod;
     }
 
     /**

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/JustInTimeProvisioningConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/JustInTimeProvisioningConfig.java
@@ -49,8 +49,8 @@ public class JustInTimeProvisioningConfig extends InboundProvisioningConfig impl
     private boolean promptConsent = false;
     @XmlElement(name = "EnableAssociateLocalUser")
     private boolean associateLocalUserEnabled = false;
-    @XmlElement(name = "SyncAttributeMethod")
-    private String syncAttributeMethod;
+    @XmlElement(name = "AttributeSyncMethod")
+    private String attributeSyncMethod;
 
     /*
      * <JustInTimeProvisioningConfig> <UserStoreClaimUri></UserStoreClaimUri>
@@ -149,11 +149,11 @@ public class JustInTimeProvisioningConfig extends InboundProvisioningConfig impl
     /**
      * To sync attributes coming from the federated identity providers.
      *
-     * @param syncAttributeMethod to specify way on how to sync the attributes.
+     * @param attributeSyncMethod to specify way on how to sync the attributes.
      */
-    public void setSyncAttributeMethod(String syncAttributeMethod) {
+    public void setSyncAttributeMethod(String attributeSyncMethod) {
 
-        this.syncAttributeMethod = syncAttributeMethod;
+        this.attributeSyncMethod = attributeSyncMethod;
     }
 
     /**
@@ -163,7 +163,7 @@ public class JustInTimeProvisioningConfig extends InboundProvisioningConfig impl
      */
     public String getSyncAttributeMethod() {
 
-        return syncAttributeMethod;
+        return attributeSyncMethod;
     }
 
     /**

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/JustInTimeProvisioningConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/JustInTimeProvisioningConfig.java
@@ -50,7 +50,7 @@ public class JustInTimeProvisioningConfig extends InboundProvisioningConfig impl
     @XmlElement(name = "EnableAssociateLocalUser")
     private boolean associateLocalUserEnabled = false;
     @XmlElement(name = "AttributeSyncMethod")
-    private String attributeSyncMethod = "OVERRIDE_ALL";
+    private String attributeSyncMethod;
 
     /*
      * <JustInTimeProvisioningConfig> <UserStoreClaimUri></UserStoreClaimUri>

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/JustInTimeProvisioningConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/JustInTimeProvisioningConfig.java
@@ -50,7 +50,7 @@ public class JustInTimeProvisioningConfig extends InboundProvisioningConfig impl
     @XmlElement(name = "EnableAssociateLocalUser")
     private boolean associateLocalUserEnabled = false;
     @XmlElement(name = "AttributeSyncMethod")
-    private String attributeSyncMethod;
+    private String attributeSyncMethod = "OVERRIDE_ALL";
 
     /*
      * <JustInTimeProvisioningConfig> <UserStoreClaimUri></UserStoreClaimUri>

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/JustInTimeProvisioningConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/JustInTimeProvisioningConfig.java
@@ -147,15 +147,20 @@ public class JustInTimeProvisioningConfig extends InboundProvisioningConfig impl
     }
 
     /**
-     * To associate existing local user when JIT user provisioning is enabled.
+     * To sync attributes coming from the federated identity providers.
      *
-     * @param syncAttributeMethod to specify whether to associate existing local user when JIT user provisioning.
+     * @param syncAttributeMethod to specify way on how to sync the attributes.
      */
     public void setSyncAttributeMethod(String syncAttributeMethod) {
 
         this.syncAttributeMethod = syncAttributeMethod;
     }
 
+    /**
+     * Get the attribute sync method.
+     *
+     * @return attribute sync method.
+     */
     public String getSyncAttributeMethod() {
 
         return syncAttributeMethod;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/JustInTimeProvisioningConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/JustInTimeProvisioningConfig.java
@@ -151,7 +151,7 @@ public class JustInTimeProvisioningConfig extends InboundProvisioningConfig impl
      *
      * @param attributeSyncMethod to specify way on how to sync the attributes.
      */
-    public void setSyncAttributeMethod(String attributeSyncMethod) {
+    public void setAttributeSyncMethod(String attributeSyncMethod) {
 
         this.attributeSyncMethod = attributeSyncMethod;
     }
@@ -161,7 +161,7 @@ public class JustInTimeProvisioningConfig extends InboundProvisioningConfig impl
      *
      * @return attribute sync method.
      */
-    public String getSyncAttributeMethod() {
+    public String getAttributeSyncMethod() {
 
         return attributeSyncMethod;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/ExternalIdPConfig.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/ExternalIdPConfig.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.application.authentication.framework.config.model;
 
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.model.Claim;
 import org.wso2.carbon.identity.application.common.model.ClaimConfig;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
@@ -247,6 +248,15 @@ public class ExternalIdPConfig implements Serializable {
     public boolean isAssociateLocalUserEnabled() {
 
         return justInTimeProConfig != null && justInTimeProConfig.isAssociateLocalUserEnabled();
+    }
+
+    public String getSyncAttributesMethod() {
+
+        String method = FrameworkConstants.SYNC_ALL;
+        if (justInTimeProConfig != null && justInTimeProConfig.getSyncAttributeMethod() != null) {
+            method = justInTimeProConfig.getSyncAttributeMethod();
+        }
+        return method;
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/ExternalIdPConfig.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/ExternalIdPConfig.java
@@ -250,6 +250,11 @@ public class ExternalIdPConfig implements Serializable {
         return justInTimeProConfig != null && justInTimeProConfig.isAssociateLocalUserEnabled();
     }
 
+    /**
+     * Get attribute sync method.
+     *
+     * @return attribute sync method.
+     */
     public String getAttributeSyncMethod() {
 
         String method = FrameworkConstants.SYNC_ALL;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/ExternalIdPConfig.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/ExternalIdPConfig.java
@@ -257,7 +257,7 @@ public class ExternalIdPConfig implements Serializable {
      */
     public String getAttributeSyncMethod() {
 
-        String method = FrameworkConstants.SYNC_ALL;
+        String method = FrameworkConstants.OVERRIDE_ALL;
         if (justInTimeProConfig != null &&
                 StringUtils.isNotEmpty(justInTimeProConfig.getAttributeSyncMethod())) {
             method = justInTimeProConfig.getAttributeSyncMethod();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/ExternalIdPConfig.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/ExternalIdPConfig.java
@@ -253,7 +253,8 @@ public class ExternalIdPConfig implements Serializable {
     public String getSyncAttributesMethod() {
 
         String method = FrameworkConstants.SYNC_ALL;
-        if (justInTimeProConfig != null && justInTimeProConfig.getSyncAttributeMethod() != null) {
+        if (justInTimeProConfig != null &&
+                StringUtils.isNotEmpty(justInTimeProConfig.getSyncAttributeMethod())) {
             method = justInTimeProConfig.getSyncAttributeMethod();
         }
         return method;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/ExternalIdPConfig.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/ExternalIdPConfig.java
@@ -250,12 +250,12 @@ public class ExternalIdPConfig implements Serializable {
         return justInTimeProConfig != null && justInTimeProConfig.isAssociateLocalUserEnabled();
     }
 
-    public String getSyncAttributesMethod() {
+    public String getAttributeSyncMethod() {
 
         String method = FrameworkConstants.SYNC_ALL;
         if (justInTimeProConfig != null &&
-                StringUtils.isNotEmpty(justInTimeProConfig.getSyncAttributeMethod())) {
-            method = justInTimeProConfig.getSyncAttributeMethod();
+                StringUtils.isNotEmpty(justInTimeProConfig.getAttributeSyncMethod())) {
+            method = justInTimeProConfig.getAttributeSyncMethod();
         }
         return method;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -112,7 +112,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
 
         RegistryService registryService = FrameworkServiceComponent.getRegistryService();
         RealmService realmService = FrameworkServiceComponent.getRealmService();
-        String syncMethod = IdentityUtil.threadLocalProperties.get()
+        String attributeSyncMethod = IdentityUtil.threadLocalProperties.get()
                 .get(FrameworkConstants.ATTRIBUTE_SYNC_METHOD).toString();
         try {
             int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
@@ -159,7 +159,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                 user claim update scenario.
                  */
                 IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.JIT_PROVISIONING_FLOW, true);
-                if (!userClaims.isEmpty() && !FrameworkConstants.SYNC_NONE.equals(syncMethod)) {
+                if (!userClaims.isEmpty() && !FrameworkConstants.SYNC_NONE.equals(attributeSyncMethod)) {
                     /*
                     In the syncing process of existing claim mappings with IDP claim mappings for JIT provisioned user,
                     To delete corresponding existing claim mapping, if any IDP claim mapping is absence.
@@ -177,10 +177,11 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                                 || indelibleClaimSet.contains(claim.getClaimUri()) ||
                                 userClaims.containsKey(claim.getClaimUri()));
 
-                        // Do not delete the claims updated locally if the syncMethod os set to persist the local
-                        // claims.
-                        if (FrameworkConstants.PRESERVE_LOCAL.equals(syncMethod)) {
-                            toBeDeletedFromExistingUserClaims.removeIf(claim -> !attributes.containsKey(claim.getClaimUri()));
+                        // Do not delete the claims updated locally if the attributeSyncMethod is set to preserve
+                        // the local claims.
+                        if (FrameworkConstants.PRESERVE_LOCAL.equals(attributeSyncMethod)) {
+                            toBeDeletedFromExistingUserClaims.removeIf(claim -> !attributes
+                                    .containsKey(claim.getClaimUri()));
                         }
 
                         for (Claim claim : toBeDeletedFromExistingUserClaims) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -159,7 +159,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                 user claim update scenario.
                  */
                 IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.JIT_PROVISIONING_FLOW, true);
-                if (!userClaims.isEmpty() && !syncMethod.equals(FrameworkConstants.SYNC_NONE)) {
+                if (!userClaims.isEmpty() && !FrameworkConstants.SYNC_NONE.equals(syncMethod)) {
                     /*
                     In the syncing process of existing claim mappings with IDP claim mappings for JIT provisioned user,
                     To delete corresponding existing claim mapping, if any IDP claim mapping is absence.
@@ -179,7 +179,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
 
                         // Do not delete the claims updated locally if the syncMethod os set to persist the local
                         // claims.
-                        if (syncMethod.equals(FrameworkConstants.PRESERVE_LOCAL)) {
+                        if (FrameworkConstants.PRESERVE_LOCAL.equals(syncMethod)) {
                             toBeDeletedFromExistingUserClaims.removeIf(claim -> !attributes.containsKey(claim.getClaimUri()));
                         }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -615,7 +615,7 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
             IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.IDP_TO_LOCAL_ROLE_MAPPING,
                     idpToLocalRoleMapping);
             IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.ATTRIBUTE_SYNC_METHOD,
-                    context.getExternalIdP().getSyncAttributesMethod());
+                    context.getExternalIdP().getAttributeSyncMethod());
             FrameworkUtils.getProvisioningHandler()
                     .handle(mappedRoles, subjectIdentifier, extAttributesValueMap, userStoreDomain,
                             context.getTenantDomain());

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -614,6 +614,8 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
 
             IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.IDP_TO_LOCAL_ROLE_MAPPING,
                     idpToLocalRoleMapping);
+            IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.ATTRIBUTE_SYNC_METHOD,
+                    context.getExternalIdP().getSyncAttributesMethod());
             FrameworkUtils.getProvisioningHandler()
                     .handle(mappedRoles, subjectIdentifier, extAttributesValueMap, userStoreDomain,
                             context.getTenantDomain());

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -201,7 +201,7 @@ public abstract class FrameworkConstants {
 
     // Attribute sync related constants.
     public static final String ATTRIBUTE_SYNC_METHOD = "attributeSyncMethod";
-    public static final String SYNC_ALL = "ALL";
+    public static final String SYNC_ALL = "OVERRIDE_ALL";
     public static final String SYNC_NONE = "NONE";
     public static final String PRESERVE_LOCAL = "PRESERVE_LOCAL";
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -205,7 +205,6 @@ public abstract class FrameworkConstants {
     public static final String SYNC_NONE = "NONE";
     public static final String PRESERVE_LOCAL = "PRESERVE_LOCAL";
 
-
     private FrameworkConstants() {
 
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -201,7 +201,7 @@ public abstract class FrameworkConstants {
 
     // Attribute sync related constants.
     public static final String ATTRIBUTE_SYNC_METHOD = "attributeSyncMethod";
-    public static final String SYNC_ALL = "OVERRIDE_ALL";
+    public static final String OVERRIDE_ALL = "OVERRIDE_ALL";
     public static final String SYNC_NONE = "NONE";
     public static final String PRESERVE_LOCAL = "PRESERVE_LOCAL";
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -199,6 +199,13 @@ public abstract class FrameworkConstants {
     public static final String OPENJDK_NASHORN = "openjdkNashorn";
     public static final String NASHORN = "nashorn";
 
+    // Attribute sync related constants.
+    public static final String ATTRIBUTE_SYNC_METHOD = "attributeSyncMethod";
+    public static final String SYNC_ALL = "ALL";
+    public static final String SYNC_NONE = "NONE";
+    public static final String PRESERVE_LOCAL = "PRESERVE_LOCAL";
+
+
     private FrameworkConstants() {
 
     }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -2186,7 +2186,7 @@ public class IdPManagementDAO {
                             .setAssociateLocalUserEnabled(Boolean.parseBoolean(identityProviderProperty.getValue()));
                 } else if (IdPManagementConstants.SYNC_ATTRIBUTE_METHOD
                         .equals(identityProviderProperty.getName())) {
-                    justInTimeProvisioningConfig.setSyncAttributeMethod(identityProviderProperty.getValue());
+                    justInTimeProvisioningConfig.setAttributeSyncMethod(identityProviderProperty.getValue());
                 }
             });
         }
@@ -2852,7 +2852,7 @@ public class IdPManagementDAO {
             modifyUserNameProperty.setValue(String.valueOf(justInTimeProvisioningConfig.isModifyUserNameAllowed()));
             promptConsentProperty.setValue(String.valueOf(justInTimeProvisioningConfig.isPromptConsent()));
             associateLocalUser.setValue(String.valueOf(justInTimeProvisioningConfig.isAssociateLocalUserEnabled()));
-            syncAttribute.setValue(justInTimeProvisioningConfig.getSyncAttributeMethod());
+            syncAttribute.setValue(justInTimeProvisioningConfig.getAttributeSyncMethod());
         }
         identityProviderProperties.add(passwordProvisioningProperty);
         identityProviderProperties.add(modifyUserNameProperty);

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -2184,6 +2184,9 @@ public class IdPManagementDAO {
                         .equals(IdPManagementConstants.ASSOCIATE_LOCAL_USER_ENABLED)) {
                     justInTimeProvisioningConfig
                             .setAssociateLocalUserEnabled(Boolean.parseBoolean(identityProviderProperty.getValue()));
+                } else if (identityProviderProperty.getName()
+                        .equals(IdPManagementConstants.SYNC_ATTRIBUTE_METHOD)) {
+                    justInTimeProvisioningConfig.setSyncAttributeMethod(identityProviderProperty.getValue());
                 }
             });
         }
@@ -2197,6 +2200,8 @@ public class IdPManagementDAO {
                         .equals(IdPManagementConstants.PASSWORD_PROVISIONING_ENABLED) || identityProviderProperty
                         .getName().equals(IdPManagementConstants.PROMPT_CONSENT_ENABLED) ||
                         IdPManagementConstants.ASSOCIATE_LOCAL_USER_ENABLED
+                                .equals(identityProviderProperty.getName()) ||
+                        IdPManagementConstants.SYNC_ATTRIBUTE_METHOD
                                 .equals(identityProviderProperty.getName())));
         return identityProviderProperties;
     }
@@ -2837,17 +2842,23 @@ public class IdPManagementDAO {
         associateLocalUser.setName(IdPManagementConstants.ASSOCIATE_LOCAL_USER_ENABLED);
         associateLocalUser.setValue("false");
 
+        IdentityProviderProperty syncAttribute = new IdentityProviderProperty();
+        syncAttribute.setName(IdPManagementConstants.SYNC_ATTRIBUTE_METHOD);
+        syncAttribute.setValue("ALL");
+
         if (justInTimeProvisioningConfig != null && justInTimeProvisioningConfig.isProvisioningEnabled()) {
             passwordProvisioningProperty
                     .setValue(String.valueOf(justInTimeProvisioningConfig.isPasswordProvisioningEnabled()));
             modifyUserNameProperty.setValue(String.valueOf(justInTimeProvisioningConfig.isModifyUserNameAllowed()));
             promptConsentProperty.setValue(String.valueOf(justInTimeProvisioningConfig.isPromptConsent()));
             associateLocalUser.setValue(String.valueOf(justInTimeProvisioningConfig.isAssociateLocalUserEnabled()));
+            syncAttribute.setValue(justInTimeProvisioningConfig.getSyncAttributeMethod());
         }
         identityProviderProperties.add(passwordProvisioningProperty);
         identityProviderProperties.add(modifyUserNameProperty);
         identityProviderProperties.add(promptConsentProperty);
         identityProviderProperties.add(associateLocalUser);
+        identityProviderProperties.add(syncAttribute);
         return identityProviderProperties;
     }
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -2842,9 +2842,9 @@ public class IdPManagementDAO {
         associateLocalUser.setName(IdPManagementConstants.ASSOCIATE_LOCAL_USER_ENABLED);
         associateLocalUser.setValue("false");
 
-        IdentityProviderProperty syncAttribute = new IdentityProviderProperty();
-        syncAttribute.setName(IdPManagementConstants.SYNC_ATTRIBUTE_METHOD);
-        syncAttribute.setValue(IdPManagementConstants.DEFAULT_SYNC_ATTRIBUTE);
+        IdentityProviderProperty attributeSyncMethod = new IdentityProviderProperty();
+        attributeSyncMethod.setName(IdPManagementConstants.SYNC_ATTRIBUTE_METHOD);
+        attributeSyncMethod.setValue(IdPManagementConstants.DEFAULT_SYNC_ATTRIBUTE);
 
         if (justInTimeProvisioningConfig != null && justInTimeProvisioningConfig.isProvisioningEnabled()) {
             passwordProvisioningProperty
@@ -2852,13 +2852,13 @@ public class IdPManagementDAO {
             modifyUserNameProperty.setValue(String.valueOf(justInTimeProvisioningConfig.isModifyUserNameAllowed()));
             promptConsentProperty.setValue(String.valueOf(justInTimeProvisioningConfig.isPromptConsent()));
             associateLocalUser.setValue(String.valueOf(justInTimeProvisioningConfig.isAssociateLocalUserEnabled()));
-            syncAttribute.setValue(justInTimeProvisioningConfig.getAttributeSyncMethod());
+            attributeSyncMethod.setValue(justInTimeProvisioningConfig.getAttributeSyncMethod());
         }
         identityProviderProperties.add(passwordProvisioningProperty);
         identityProviderProperties.add(modifyUserNameProperty);
         identityProviderProperties.add(promptConsentProperty);
         identityProviderProperties.add(associateLocalUser);
-        identityProviderProperties.add(syncAttribute);
+        identityProviderProperties.add(attributeSyncMethod);
         return identityProviderProperties;
     }
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -2184,8 +2184,8 @@ public class IdPManagementDAO {
                         .equals(IdPManagementConstants.ASSOCIATE_LOCAL_USER_ENABLED)) {
                     justInTimeProvisioningConfig
                             .setAssociateLocalUserEnabled(Boolean.parseBoolean(identityProviderProperty.getValue()));
-                } else if (identityProviderProperty.getName()
-                        .equals(IdPManagementConstants.SYNC_ATTRIBUTE_METHOD)) {
+                } else if (IdPManagementConstants.SYNC_ATTRIBUTE_METHOD
+                        .equals(identityProviderProperty.getName())) {
                     justInTimeProvisioningConfig.setSyncAttributeMethod(identityProviderProperty.getValue());
                 }
             });
@@ -2844,7 +2844,7 @@ public class IdPManagementDAO {
 
         IdentityProviderProperty syncAttribute = new IdentityProviderProperty();
         syncAttribute.setName(IdPManagementConstants.SYNC_ATTRIBUTE_METHOD);
-        syncAttribute.setValue("ALL");
+        syncAttribute.setValue(IdPManagementConstants.DEFAULT_SYNC_ATTRIBUTE);
 
         if (justInTimeProvisioningConfig != null && justInTimeProvisioningConfig.isProvisioningEnabled()) {
             passwordProvisioningProperty

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
@@ -92,7 +92,7 @@ public class IdPManagementConstants {
     public static final String TEMPLATE_ID_IDP_PROPERTY_DISPLAY_NAME = "Template Id";
     public static final String RESET_PROVISIONING_ENTITIES_ON_CONFIG_UPDATE = "OutboundProvisioning"
             + ".ResetProvisioningEntitiesOnConfigUpdate";
-    public static final String DEFAULT_SYNC_ATTRIBUTE = "ALL";
+    public static final String DEFAULT_SYNC_ATTRIBUTE = "OVERRIDE_ALL";
 
     // Outbound Provisioning Connectors
     public static final String GOOGLE = "googleapps";

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
@@ -92,6 +92,7 @@ public class IdPManagementConstants {
     public static final String TEMPLATE_ID_IDP_PROPERTY_DISPLAY_NAME = "Template Id";
     public static final String RESET_PROVISIONING_ENTITIES_ON_CONFIG_UPDATE = "OutboundProvisioning"
             + ".ResetProvisioningEntitiesOnConfigUpdate";
+    public static final String DEFAULT_SYNC_ATTRIBUTE = "ALL";
 
     // Outbound Provisioning Connectors
     public static final String GOOGLE = "googleapps";

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
@@ -87,7 +87,7 @@ public class IdPManagementConstants {
     public static final String MODIFY_USERNAME_ENABLED = "MODIFY_USERNAME_ENABLED";
     public static final String PROMPT_CONSENT_ENABLED = "PROMPT_CONSENT_ENABLED";
     public static final String ASSOCIATE_LOCAL_USER_ENABLED = "ASSOCIATE_LOCAL_USER_ENABLED";
-
+    public static final String SYNC_ATTRIBUTE_METHOD = "SYNC_ATTRIBUTE_METHOD";
     public static final String TEMPLATE_ID_IDP_PROPERTY_NAME = "templateId";
     public static final String TEMPLATE_ID_IDP_PROPERTY_DISPLAY_NAME = "Template Id";
     public static final String RESET_PROVISIONING_ENTITIES_ON_CONFIG_UPDATE = "OutboundProvisioning"

--- a/service-stubs/identity/org.wso2.carbon.identity.application.default.authentication.sequence.mgt.stub/src/main/resources/IdentityDefaultSeqManagementService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.default.authentication.sequence.mgt.stub/src/main/resources/IdentityDefaultSeqManagementService.wsdl
@@ -255,10 +255,10 @@
                     <xs:extension base="ax2177:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
-                            <xs:element minOccurs="0" name="attributeSyncMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="modifyUserNameAllowed" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="passwordProvisioningEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="promptConsent" type="xs:boolean"/>
+                            <xs:element minOccurs="0" name="syncAttributeMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="userStoreClaimUri" nillable="true" type="xs:string"/>
                         </xs:sequence>
                     </xs:extension>

--- a/service-stubs/identity/org.wso2.carbon.identity.application.default.authentication.sequence.mgt.stub/src/main/resources/IdentityDefaultSeqManagementService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.default.authentication.sequence.mgt.stub/src/main/resources/IdentityDefaultSeqManagementService.wsdl
@@ -255,10 +255,10 @@
                     <xs:extension base="ax2177:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
+                            <xs:element minOccurs="0" name="attributeSyncMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="modifyUserNameAllowed" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="passwordProvisioningEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="promptConsent" type="xs:boolean"/>
-                            <xs:element minOccurs="0" name="syncAttributeMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="userStoreClaimUri" nillable="true" type="xs:string"/>
                         </xs:sequence>
                     </xs:extension>

--- a/service-stubs/identity/org.wso2.carbon.identity.application.default.authentication.sequence.mgt.stub/src/main/resources/IdentityDefaultSeqManagementService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.default.authentication.sequence.mgt.stub/src/main/resources/IdentityDefaultSeqManagementService.wsdl
@@ -255,6 +255,7 @@
                     <xs:extension base="ax2177:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
+                            <xs:element minOccurs="0" name="attributeSyncMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="modifyUserNameAllowed" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="passwordProvisioningEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="promptConsent" type="xs:boolean"/>

--- a/service-stubs/identity/org.wso2.carbon.identity.application.default.authentication.sequence.mgt.stub/src/main/resources/IdentityDefaultSeqManagementService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.default.authentication.sequence.mgt.stub/src/main/resources/IdentityDefaultSeqManagementService.wsdl
@@ -255,7 +255,7 @@
                     <xs:extension base="ax2177:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
-                            <xs:element minOccurs="0" name="attributeSyncMethod" type="xs:string"/>
+                            <xs:element minOccurs="0" name="attributeSyncMethod" nillable="true" type="xs:string"/>
                             <xs:element minOccurs="0" name="modifyUserNameAllowed" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="passwordProvisioningEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="promptConsent" type="xs:boolean"/>

--- a/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
@@ -554,10 +554,10 @@
                     <xs:extension base="ax2169:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
-                            <xs:element minOccurs="0" name="attributeSyncMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="modifyUserNameAllowed" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="passwordProvisioningEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="promptConsent" type="xs:boolean"/>
+                            <xs:element minOccurs="0" name="syncAttributeMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="userStoreClaimUri" nillable="true" type="xs:string"/>
                         </xs:sequence>
                     </xs:extension>

--- a/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
@@ -554,7 +554,7 @@
                     <xs:extension base="ax2169:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
-                            <xs:element minOccurs="0" name="attributeSyncMethod" type="xs:string"/>
+                            <xs:element minOccurs="0" name="attributeSyncMethod" nillable="true" type="xs:string"/>
                             <xs:element minOccurs="0" name="modifyUserNameAllowed" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="passwordProvisioningEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="promptConsent" type="xs:boolean"/>

--- a/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
@@ -554,6 +554,7 @@
                     <xs:extension base="ax2169:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
+                            <xs:element minOccurs="0" name="attributeSyncMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="modifyUserNameAllowed" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="passwordProvisioningEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="promptConsent" type="xs:boolean"/>

--- a/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
@@ -554,10 +554,10 @@
                     <xs:extension base="ax2169:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
+                            <xs:element minOccurs="0" name="attributeSyncMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="modifyUserNameAllowed" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="passwordProvisioningEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="promptConsent" type="xs:boolean"/>
-                            <xs:element minOccurs="0" name="syncAttributeMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="userStoreClaimUri" nillable="true" type="xs:string"/>
                         </xs:sequence>
                     </xs:extension>

--- a/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
@@ -134,10 +134,10 @@
                     <xs:extension base="ax2437:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
+                            <xs:element minOccurs="0" name="attributeSyncMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="modifyUserNameAllowed" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="passwordProvisioningEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="promptConsent" type="xs:boolean"/>
-                            <xs:element minOccurs="0" name="syncAttributeMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="userStoreClaimUri" nillable="true" type="xs:string"/>
                         </xs:sequence>
                     </xs:extension>

--- a/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
@@ -134,10 +134,10 @@
                     <xs:extension base="ax2437:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
-                            <xs:element minOccurs="0" name="attributeSyncMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="modifyUserNameAllowed" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="passwordProvisioningEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="promptConsent" type="xs:boolean"/>
+                            <xs:element minOccurs="0" name="syncAttributeMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="userStoreClaimUri" nillable="true" type="xs:string"/>
                         </xs:sequence>
                     </xs:extension>

--- a/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
@@ -134,7 +134,7 @@
                     <xs:extension base="ax2437:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
-                            <xs:element minOccurs="0" name="attributeSyncMethod" type="xs:string"/>
+                            <xs:element minOccurs="0" name="attributeSyncMethod" nillable="true" type="xs:string"/>
                             <xs:element minOccurs="0" name="modifyUserNameAllowed" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="passwordProvisioningEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="promptConsent" type="xs:boolean"/>

--- a/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
@@ -134,6 +134,7 @@
                     <xs:extension base="ax2437:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
+                            <xs:element minOccurs="0" name="attributeSyncMethod" type="xs:string"/>
                             <xs:element minOccurs="0" name="modifyUserNameAllowed" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="passwordProvisioningEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="promptConsent" type="xs:boolean"/>


### PR DESCRIPTION
### Proposed changes in this pull request

With this PR, we handle attribute sync in 3 ways.
The attribute sync method can be one of: `OVERRIDE_ALL`, `NONE`, `PRESERVE_LOCAL`

- OVERRIDE_ALL : This will preserve the current behavior. All the attributes gets updated with the attributes from federated IDP upon each login
- NONE : This will stop the attribute updation on each login
- PRESERVE_LOCAL : This will stop updating the attributes that are not coming in the federated login after the provisioning. Assume if the user provisioned with an attribute `department` and that particular claim is not coming there after then that claim is not getting removed.
