### PR TITLE
Improve retrieving default configurations

### DIFF
--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/AbstractFieldValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/AbstractFieldValidationConfigurationHandler.java
@@ -71,7 +71,7 @@ public class AbstractFieldValidationConfigurationHandler implements FieldValidat
             // Retrieve configs from secondary userstore if configured in the identity.xml, else from PRIMARY userstore.
             UserRealm realm = (UserRealm) CarbonContext.getThreadLocalCarbonContext().getUserRealm();
             String secondaryUserStoreName =
-                    IdentityUtil.getProperty("inputValidation.defaultConfigurations.secondaryUserStore");
+                    IdentityUtil.getProperty("FieldInputValidation.DefaultConfigurations.SecondaryUserStoreName");
             if (realm != null && StringUtils.isNotBlank(secondaryUserStoreName)
                     && realm.getUserStoreManager().getSecondaryUserStoreManager(secondaryUserStoreName) != null) {
                 return realm.getUserStoreManager().getSecondaryUserStoreManager(

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
@@ -108,11 +108,9 @@ public class UsernameValidationConfigurationHandler extends AbstractFieldValidat
                     if (validatorNames.contains(LengthValidator.class.getSimpleName())) {
                         validConfigurations += 1;
                         validatorNames.remove(LengthValidator.class.getSimpleName());
-                    }
-                } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug("LengthValidator must be configured along with the AlphanumericValidator for " +
-                                "username.");
+                    } else {
+                        throw new InputValidationMgtClientException(ERROR_INVALID_VALIDATORS_COMBINATION.getCode(),
+                            "LengthValidator must be configured along with the AlphanumericValidator for username.");
                     }
                 }
                 validatorNames.remove(AlphanumericValidator.class.getSimpleName());
@@ -139,7 +137,7 @@ public class UsernameValidationConfigurationHandler extends AbstractFieldValidat
                 return PROPERTY_USER_NAME_WITH_EMAIL_JS_REG_EX;
             }
             if (StringUtils.isBlank(realmConfig.getUserStoreProperty(PROPERTY_USER_NAME_JS_REG_EX))
-                    && StringUtils.isBlank(realmConfig.getUserStoreProperty(PROPERTY_USER_NAME_JS_REG_EX))) {
+                    && StringUtils.isBlank(realmConfig.getUserStoreProperty(PROPERTY_USER_NAME_JS_REG))) {
                 return UserCoreConstants.RealmConfig.EMAIL_VALIDATION_REGEX;
             }
         }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -62,10 +62,11 @@ public class Constants {
         public static final String JAVA_REGEX_PATTERN = "^((?=.*\\d)(?=.*[a-z])(?=.*[A-Z])).{8,100}$";
         public static final String DEFAULT_ALPHANUMERIC_REGEX_PATTERN = "^[a-zA-Z0-9]*$";
         public static final String DEFAULT_EMAIL_JAVA_REGEX_PATTERN =
-                "^[\\u00C0-\\u00FF\\w&&[^.+\\-_]](?:(?![.+\\-_]{2})[\\u00C0-\\u00FF\\w.+\\-]){0,63}(?<![+.\\-_])@" +
-                        "(?![+.\\-_])[\\w.+\\-]+\\.[a-zA-Z]{2,10}";
+            "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![.+\\-_]{2})[\\u00C0-\\u00FF\\w.+\\-]){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0" +
+            "-9]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";
         public static final String DEFAULT_EMAIL_JS_REGEX_PATTERN =
-                "^[\\u00C0-\\u00FFa-zA-Z0-9.+\\-_]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,10}$";
+            "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![.+\\-_]{2})[\\u00C0-\\u00FF\\w.+\\-]){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0" +
+            "-9]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";
     }
 
     /**


### PR DESCRIPTION
Following changes done:
1. When retrieving default configurations from the userstore, retrieve them from userstore if configured in identity.xml, else retrieve from PRIMARY userstore.
2. Update default username regex
3. Throw error if lengthValidator is not configured with Alphanumeric validator for username