### PR TITLE
Prevent deleting claims if the claim is not coming in the IDP

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
@@ -190,6 +190,7 @@ public class DefaultClaimHandler implements ClaimHandler {
         } else if (idPClaimMappings.length > 0) {
             localToIdPClaimMap = FrameworkUtils.getClaimMappings(idPClaimMappings, true);
             if (useLocalClaimDialectForClaimMappings() && enableMergingCustomClaimMappingsWithDefaultMappings()) {
+                localToIdPClaimMap = filterLocaltoIdPClaimMap(localToIdPClaimMap, remoteClaims.keySet());
                 getMergedLocalIdpClaimMappings(authenticator.getClaimDialectURI(),
                         context.getTenantDomain(), localToIdPClaimMap, remoteClaims);
             }
@@ -255,6 +256,20 @@ public class DefaultClaimHandler implements ClaimHandler {
 
         return spFilteredClaims;
 
+    }
+
+    /**
+     * Filter local claim mapping only if the claim is there in remote claim set.
+     *
+     * @param localToIdPClaimMap    Local to IdP claim mapping.
+     * @param keySet                Claim keys of remote claim set.
+     * @return  the local to idp claim mappings which comes in the remote claims.
+     */
+    private Map<String, String> filterLocaltoIdPClaimMap(Map<String, String> localToIdPClaimMap, Set<String> keySet) {
+
+        return new HashMap<>(localToIdPClaimMap.entrySet().stream()
+                .filter(claimMap -> keySet.contains(claimMap.getValue()))
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
     }
 
     private void setMandatoryAndRequestedClaims(ApplicationConfig appConfig,


### PR DESCRIPTION
### Proposed changes in this pull request
Currently, when we do custom claim mapping to OIDC IdPs, and if that attribute is not coming in the federated claims, the local claim of that federated user gets deleted (even the `attribute_sync_method` is set to `PRESERVE_LOCAL`

This PR fixes the above issue