### PR TITLE
Extend export/import file formats for Identity tool cli

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/pom.xml
@@ -53,6 +53,10 @@
             <groupId>org.wso2.orbit.javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/pom.xml
@@ -96,7 +96,9 @@
                             org.wso2.carbon.identity.core.model; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.persistence; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}",
-                            org.wso2.carbon.identity.core.cache; version="${carbon.identity.package.import.version.range}"
+                            org.wso2.carbon.identity.core.cache; version="${carbon.identity.package.import.version.range}",
+
+                            com.fasterxml.jackson.annotation; version="${com.fasterxml.jackson.annotation.version.range}"
                         </Import-Package>
                         <Export-Package>
                             org.wso2.carbon.identity.application.common.*; version="${carbon.identity.package.export.version}"

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.common.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -41,6 +42,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "FederatedAuthenticatorConfig")
+@JsonIgnoreProperties(value = {"valid"})
 public class FederatedAuthenticatorConfig implements Serializable {
 
     private static final long serialVersionUID = -2361107623257323257L;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.application.common.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.identity.application.common.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.common.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.databinding.annotation.IgnoreNullElement;
 import org.apache.commons.collections.CollectionUtils;
@@ -90,6 +91,7 @@ public class IdentityProvider implements Serializable {
     private static final String TEMPLATE_ID = "TemplateId";
 
     @XmlTransient
+    @JsonIgnore
     private String id;
 
     @XmlElement(name = "IdentityProviderName")
@@ -146,7 +148,10 @@ public class IdentityProvider implements Serializable {
     private JustInTimeProvisioningConfig justInTimeProvisioningConfig;
 
     @XmlTransient
+    @JsonIgnore
     private IdentityProviderProperty[] idpProperties = new IdentityProviderProperty[0];
+
+    @JsonIgnore
     private CertificateInfo[] certificateInfoArray = new CertificateInfo[0];
 
     @IgnoreNullElement
@@ -155,6 +160,7 @@ public class IdentityProvider implements Serializable {
 
     @IgnoreNullElement
     @XmlTransient
+    @JsonIgnore
     private String resourceId;
 
     @IgnoreNullElement

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.application.common.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.databinding.annotation.IgnoreNullElement;
 import org.apache.commons.collections.CollectionUtils;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.identity.application.common.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.databinding.annotation.IgnoreNullElement;
 import org.apache.commons.collections.CollectionUtils;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
@@ -36,11 +36,14 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * Local authenticator configuration of an application.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "LocalAuthenticatorConfig")
+@JsonIgnoreProperties(value = {"valid"})
 public class LocalAuthenticatorConfig implements Serializable {
 
     private static final long serialVersionUID = 3363298518257599291L;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.application.common.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -35,8 +37,6 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
  * Local authenticator configuration of an application.

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.identity.application.common.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ProvisioningConnectorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ProvisioningConnectorConfig.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.common.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -33,6 +34,8 @@ import java.util.List;
 /**
  * Provisioning connector configuration.
  */
+
+@JsonIgnoreProperties(value = {"valid"})
 public class ProvisioningConnectorConfig implements Serializable {
 
     private static final long serialVersionUID = -4569973060498183209L;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ProvisioningConnectorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ProvisioningConnectorConfig.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.application.common.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ProvisioningConnectorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ProvisioningConnectorConfig.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.identity.application.common.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ServiceProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ServiceProvider.java
@@ -35,6 +35,8 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * Application configuration.
  */
@@ -67,6 +69,7 @@ public class ServiceProvider implements Serializable {
     private String jwksUri;
 
     @XmlTransient
+    @JsonIgnore
     private User owner;
 
     @XmlTransient

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ServiceProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ServiceProvider.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.identity.application.common.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.databinding.annotation.IgnoreNullElement;
 import org.apache.commons.collections.CollectionUtils;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ServiceProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ServiceProvider.java
@@ -17,6 +17,8 @@
  */
 package org.wso2.carbon.identity.application.common.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.databinding.annotation.IgnoreNullElement;
 import org.apache.commons.collections.CollectionUtils;
@@ -34,8 +36,6 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
  * Application configuration.

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ServiceProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ServiceProvider.java
@@ -54,6 +54,7 @@ public class ServiceProvider implements Serializable {
     private static final String IS_MANAGEMENT_APP = "IsManagementApp";
 
     @XmlTransient
+    @JsonIgnore
     private int applicationID = 0;
 
     @XmlElement(name = "ApplicationName")
@@ -73,6 +74,7 @@ public class ServiceProvider implements Serializable {
     private User owner;
 
     @XmlTransient
+    @JsonIgnore
     private String tenantDomain;
 
     @XmlElement(name = "InboundAuthenticationConfig")
@@ -101,10 +103,12 @@ public class ServiceProvider implements Serializable {
     private boolean saasApp;
 
     @XmlTransient
+    @JsonIgnore
     private ServiceProviderProperty[] spProperties = new ServiceProviderProperty[0];
 
     @IgnoreNullElement
     @XmlTransient
+    @JsonIgnore
     private String applicationResourceId;
 
     @IgnoreNullElement

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
@@ -229,6 +229,8 @@
                             org.wso2.carbon.identity.central.log.mgt.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.organization.management.service; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
+                            org.yaml.snakeyaml.constructor,
+                            org.yaml.snakeyaml,
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.application.mgt.internal,

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
@@ -229,9 +229,10 @@
                             org.wso2.carbon.identity.central.log.mgt.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.organization.management.service; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
-                            org.yaml.snakeyaml.constructor,
-                            org.yaml.snakeyaml.error,
-                            org.yaml.snakeyaml,
+
+                            org.yaml.snakeyaml.constructor; version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml.error; version="${org.yaml.snakeyaml.version.range}",
+                            org.yaml.snakeyaml; version="${org.yaml.snakeyaml.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.application.mgt.internal,

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
@@ -230,6 +230,7 @@
                             org.wso2.carbon.identity.organization.management.service; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
                             org.yaml.snakeyaml.constructor,
+                            org.yaml.snakeyaml.error,
                             org.yaml.snakeyaml,
                         </Import-Package>
                         <Export-Package>

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
@@ -257,6 +257,13 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
         return null;
     }
 
+
+    public ServiceProvider exportSPFromAppID(String applicationId, boolean exportSecrets,
+                                               String tenantDomain) throws IdentityApplicationManagementException {
+
+        return null;
+    }
+
     /**
      * Export Service Provider application.
      *
@@ -267,6 +274,18 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
      * @throws IdentityApplicationManagementException Identity Application Management Exception
      */
     public abstract String exportSPApplication(String applicationName, boolean exportSecrets, String tenantDomain)
+            throws IdentityApplicationManagementException;
+
+    /**
+     * Export Service Provider application.
+     *
+     * @param applicationName name of the SP
+     * @param exportSecrets   is export the secrets
+     * @param tenantDomain    tenant Domain
+     * @return xml string of the SP
+     * @throws IdentityApplicationManagementException Identity Application Management Exception
+     */
+    public abstract ServiceProvider exportSP(String applicationName, boolean exportSecrets, String tenantDomain)
             throws IdentityApplicationManagementException;
 
     /**

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
@@ -257,7 +257,15 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
         return null;
     }
 
-
+    /**
+     * Export Service Provider application using application ID.
+     *
+     * @param applicationId ID of the SP.
+     * @param exportSecrets Specify whether to export the secrets or not.
+     * @param tenantDomain  Tenant domain.
+     * @return Service Provider.
+     * @throws IdentityApplicationManagementException Identity Application Management Exception.
+     */
     public ServiceProvider exportSPFromAppID(String applicationId, boolean exportSecrets,
                                                String tenantDomain) throws IdentityApplicationManagementException {
 
@@ -279,11 +287,11 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
     /**
      * Export Service Provider application.
      *
-     * @param applicationName name of the SP
-     * @param exportSecrets   is export the secrets
-     * @param tenantDomain    tenant Domain
-     * @return xml string of the SP
-     * @throws IdentityApplicationManagementException Identity Application Management Exception
+     * @param applicationName name of the SP.
+     * @param exportSecrets   is export the secrets.
+     * @param tenantDomain    tenant Domain.
+     * @return Service Provider.
+     * @throws IdentityApplicationManagementException Identity Application Management Exception.
      */
     public abstract ServiceProvider exportSP(String applicationName, boolean exportSecrets, String tenantDomain)
             throws IdentityApplicationManagementException;
@@ -298,19 +306,20 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
      * @return ImportResponse
      * @throws IdentityApplicationManagementException Identity Application Management Exception
      */
+    @Deprecated
     public abstract ImportResponse importSPApplication(SpFileContent spFileContent, String tenantDomain, String
             username, boolean isUpdate) throws IdentityApplicationManagementException;
 
     /**
      * Import Service Provider application from file.
      *
-     * @param spFileContent xml string of the SP and file name
-     * @param tenantDomain  tenant Domain
-     * @param username      username
-     * @param fileType      file type
-     * @param isUpdate      isUpdate
-     * @return ImportResponse
-     * @throws IdentityApplicationManagementException Identity Application Management Exception
+     * @param spFileContent xml string of the SP and file name.
+     * @param tenantDomain  tenant Domain.
+     * @param username      username.
+     * @param fileType      file type.
+     * @param isUpdate      isUpdate.
+     * @return ImportResponse.
+     * @throws IdentityApplicationManagementException Identity Application Management Exception.
      */
     public abstract ImportResponse importSPApplication(SpFileContent spFileContent, String tenantDomain, String
             username, String fileType, boolean isUpdate) throws IdentityApplicationManagementException;

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
@@ -300,25 +300,9 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
      * @param isUpdate      Whether to update an existing Service Provider or create a new one.
      * @return ImportResponse
      * @throws IdentityApplicationManagementException Identity Application Management Exception.
-     * @deprecated Use {@link #importSPApplication(SpFileContent, String, String, String, boolean)} instead.
      */
-    @Deprecated
     public abstract ImportResponse importSPApplication(SpFileContent spFileContent, String tenantDomain, String
             username, boolean isUpdate) throws IdentityApplicationManagementException;
-
-    /**
-     * Import Service Provider application from file.
-     *
-     * @param spFileContent XML string of the Service Provider and file name.
-     * @param tenantDomain  Tenant Domain name.
-     * @param username      User performing the operation.
-     * @param fileType      Type of file being imported.
-     * @param isUpdate      Whether to update an existing Service Provider or create a new one.
-     * @return ImportResponse.
-     * @throws IdentityApplicationManagementException Identity Application Management Exception.
-     */
-    public abstract ImportResponse importSPApplication(SpFileContent spFileContent, String tenantDomain, String
-            username, String fileType, boolean isUpdate) throws IdentityApplicationManagementException;
 
     /**
      * Import Service Provider application from object.

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
@@ -302,6 +302,20 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
             username, boolean isUpdate) throws IdentityApplicationManagementException;
 
     /**
+     * Import Service Provider application from file.
+     *
+     * @param spFileContent xml string of the SP and file name
+     * @param tenantDomain  tenant Domain
+     * @param username      username
+     * @param fileType      file type
+     * @param isUpdate      isUpdate
+     * @return ImportResponse
+     * @throws IdentityApplicationManagementException Identity Application Management Exception
+     */
+    public abstract ImportResponse importSPApplication(SpFileContent spFileContent, String tenantDomain, String
+            username, String fileType, boolean isUpdate) throws IdentityApplicationManagementException;
+
+    /**
      * Import Service Provider application from object.
      *
      * @param serviceProvider

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
@@ -251,11 +251,9 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
      * @return XML string of the Service Provider.
      * @throws IdentityApplicationManagementException Identity Application Management Exception
      */
-    public String exportSPApplicationFromAppID(String applicationId, boolean exportSecrets,
-                                               String tenantDomain) throws IdentityApplicationManagementException {
-
-        return null;
-    }
+    public abstract String exportSPApplicationFromAppID(String applicationId, boolean exportSecrets,
+                                                        String tenantDomain)
+            throws IdentityApplicationManagementException;
 
     /**
      * Export Service Provider application using application ID.
@@ -266,11 +264,8 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
      * @return Service Provider.
      * @throws IdentityApplicationManagementException Identity Application Management Exception.
      */
-    public ServiceProvider exportSPFromAppID(String applicationId, boolean exportSecrets,
-                                               String tenantDomain) throws IdentityApplicationManagementException {
-
-        return null;
-    }
+    public abstract ServiceProvider exportSPFromAppID(String applicationId, boolean exportSecrets, String tenantDomain)
+            throws IdentityApplicationManagementException;
 
     /**
      * Export Service Provider application.

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
@@ -245,10 +245,10 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
     /**
      * Export Service Provider application using application ID.
      *
-     * @param applicationId ID of the SP
-     * @param exportSecrets Specify whether to export the secrets or not.
-     * @param tenantDomain  Tenant domain
-     * @return xml string of the SP
+     * @param applicationId ID of the Service Provider.
+     * @param exportSecrets Whether to export the secrets or not.
+     * @param tenantDomain  Tenant domain name.
+     * @return XML string of the Service Provider.
      * @throws IdentityApplicationManagementException Identity Application Management Exception
      */
     public String exportSPApplicationFromAppID(String applicationId, boolean exportSecrets,
@@ -260,9 +260,9 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
     /**
      * Export Service Provider application using application ID.
      *
-     * @param applicationId ID of the SP.
-     * @param exportSecrets Specify whether to export the secrets or not.
-     * @param tenantDomain  Tenant domain.
+     * @param applicationId ID of the Service Provider.
+     * @param exportSecrets Whether to export the secrets or not.
+     * @param tenantDomain  Tenant domain name.
      * @return Service Provider.
      * @throws IdentityApplicationManagementException Identity Application Management Exception.
      */
@@ -275,10 +275,10 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
     /**
      * Export Service Provider application.
      *
-     * @param applicationName name of the SP
-     * @param exportSecrets   is export the secrets
-     * @param tenantDomain    tenant Domain
-     * @return xml string of the SP
+     * @param applicationName Name of the Service Provider.
+     * @param exportSecrets   Whether to export the secrets or not.
+     * @param tenantDomain    Tenant domain name.
+     * @return XML string of the Service Provider.
      * @throws IdentityApplicationManagementException Identity Application Management Exception
      */
     public abstract String exportSPApplication(String applicationName, boolean exportSecrets, String tenantDomain)
@@ -287,9 +287,9 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
     /**
      * Export Service Provider application.
      *
-     * @param applicationName name of the SP.
-     * @param exportSecrets   is export the secrets.
-     * @param tenantDomain    tenant Domain.
+     * @param applicationName Name of the Service Provider.
+     * @param exportSecrets   Whether to export the secrets or not.
+     * @param tenantDomain    Tenant domain name.
      * @return Service Provider.
      * @throws IdentityApplicationManagementException Identity Application Management Exception.
      */
@@ -299,12 +299,13 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
     /**
      * Import Service Provider application from file.
      *
-     * @param spFileContent xml string of the SP and file name
-     * @param tenantDomain  tenant Domain
-     * @param username      username
-     * @param isUpdate      isUpdate
+     * @param spFileContent XML string of the Service Provider and file name.
+     * @param tenantDomain  Tenant Domain name.
+     * @param username      User performing the operation.
+     * @param isUpdate      Whether to update an existing Service Provider or create a new one.
      * @return ImportResponse
-     * @throws IdentityApplicationManagementException Identity Application Management Exception
+     * @throws IdentityApplicationManagementException Identity Application Management Exception.
+     * @deprecated Use {@link #importSPApplication(SpFileContent, String, String, String, boolean)} instead.
      */
     @Deprecated
     public abstract ImportResponse importSPApplication(SpFileContent spFileContent, String tenantDomain, String
@@ -313,11 +314,11 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
     /**
      * Import Service Provider application from file.
      *
-     * @param spFileContent xml string of the SP and file name.
-     * @param tenantDomain  tenant Domain.
-     * @param username      username.
-     * @param fileType      file type.
-     * @param isUpdate      isUpdate.
+     * @param spFileContent XML string of the Service Provider and file name.
+     * @param tenantDomain  Tenant Domain name.
+     * @param username      User performing the operation.
+     * @param fileType      Type of file being imported.
+     * @param isUpdate      Whether to update an existing Service Provider or create a new one.
      * @return ImportResponse.
      * @throws IdentityApplicationManagementException Identity Application Management Exception.
      */
@@ -327,10 +328,10 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
     /**
      * Import Service Provider application from object.
      *
-     * @param serviceProvider
-     * @param tenantDomain
-     * @param username
-     * @param isUpdate
+     * @param serviceProvider Service Provider object.
+     * @param tenantDomain    Tenant Domain name.
+     * @param username        User performing the operation.
+     * @param isUpdate        Whether to update an existing Service Provider or create a new one.
      * @return ImportResponse
      * @throws IdentityApplicationManagementException
      */

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -1330,7 +1330,7 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
 
         if (log.isDebugEnabled()) {
             log.debug("Importing service provider from file " + spFileContent.getFileName()
-                       + " file type " + fileType);
+                       + " of file type " + fileType);
         }
 
         if (StringUtils.isEmpty(spFileContent.getContent())) {
@@ -1375,16 +1375,7 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
     public ImportResponse importSPApplication(ServiceProvider serviceProvider, String tenantDomain, String username,
                                               boolean isUpdate) throws IdentityApplicationManagementException {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Importing service provider from object " + serviceProvider.getApplicationName());
-        }
-
         ImportResponse importResponse = importApplication(serviceProvider, tenantDomain, username, isUpdate);
-
-        if (log.isDebugEnabled()) {
-            log.debug(String.format("Service provider %s@%s created successfully from object",
-                    serviceProvider.getApplicationName(), tenantDomain));
-        }
 
         return importResponse;
     }
@@ -1508,16 +1499,13 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
     public ServiceProvider exportSPFromAppID(String applicationId, boolean exportSecrets,
                                                String tenantDomain) throws IdentityApplicationManagementException {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Exporting service provider from application ID " + applicationId);
-        }
-
         ApplicationBasicInfo application = getApplicationBasicInfoByResourceId(applicationId, tenantDomain);
 
         if (application == null) {
             throw buildClientException(APPLICATION_NOT_FOUND, "Application could not be found " +
                     "for the provided resourceId: " + applicationId);
         }
+
         String appName = application.getApplicationName();
 
         try {
@@ -1525,9 +1513,6 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
             return exportSP(appName, exportSecrets, tenantDomain);
         } finally {
             endTenantFlow();
-            if (log.isDebugEnabled()) {
-                log.debug(String.format("Service provider %s@%s exported successfully", appName, tenantDomain));
-            }
         }
 
     }
@@ -1560,21 +1545,14 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
     public ServiceProvider exportSP(String applicationName, boolean exportSecrets, String tenantDomain)
             throws IdentityApplicationManagementException {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Exporting service provider " + applicationName + " from tenant " + tenantDomain);
-        }
-
         ServiceProvider serviceProvider = getApplicationExcludingFileBasedSPs(applicationName, tenantDomain);
+
         // Invoking the listeners.
         Collection<ApplicationMgtListener> listeners = getApplicationMgtListeners();
         for (ApplicationMgtListener listener : listeners) {
             if (listener.isEnable()) {
                 listener.doExportServiceProvider(serviceProvider, exportSecrets);
             }
-        }
-
-        if (log.isDebugEnabled()) {
-            log.debug(String.format("Service provider %s@%s exported successfully", applicationName, tenantDomain));
         }
 
         return serviceProvider;

--- a/pom.xml
+++ b/pom.xml
@@ -1966,7 +1966,6 @@
         <com.fasterxml.jackson.databind.version>2.14.0-rc2</com.fasterxml.jackson.databind.version>
         <com.fasterxml.jackson.jaxrs-json-provider-version>2.13.0</com.fasterxml.jackson.jaxrs-json-provider-version>
         <com.fasterxml.jackson.annotation.version.range>[2.13.0, 2.14.0)</com.fasterxml.jackson.annotation.version.range>
-        <org.yaml.snakeyaml.version.range>[1.5.2.wso2v1, 2.0.0)</org.yaml.snakeyaml.version.range>
 
         <apache.wink.version>1.1.3-incubating</apache.wink.version>
         <msf4j.version>2.7.0</msf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1965,6 +1965,8 @@
         <com.fasterxml.jackson.annotation.version>2.13.0</com.fasterxml.jackson.annotation.version>
         <com.fasterxml.jackson.databind.version>2.14.0-rc2</com.fasterxml.jackson.databind.version>
         <com.fasterxml.jackson.jaxrs-json-provider-version>2.13.0</com.fasterxml.jackson.jaxrs-json-provider-version>
+        <com.fasterxml.jackson.annotation.version.range>[2.13.0, 2.14.0)</com.fasterxml.jackson.annotation.version.range>
+        <org.yaml.snakeyaml.version.range>[1.5.2.wso2v1, 2.0.0)</org.yaml.snakeyaml.version.range>
 
         <apache.wink.version>1.1.3-incubating</apache.wink.version>
         <msf4j.version>2.7.0</msf4j.version>


### PR DESCRIPTION
## Purpose
Related to https://github.com/wso2/product-is/issues/15461

Add support for SP configurations export/import in XML, YAML, and JSON file formats.

## Goals
When the required file type is given, this will import Service Providers in either XML (unmarshalling), YAML (deserialization), or JSON (object mapping) file formats.

## Approach
The **unmarshalSP()** method will handle XML files, **deserializationSP()** will handle YAML files, and **objectMapperSP()** will handle JSON files.

## Related PRs
https://github.com/wso2/carbon-identity-framework/compare/master...indeewari:carbon-identity-framework:identity_tool_cli