### PR TITLE
Remove unintended setting setSkipPasswordPatternValidationThreadLocal

### DIFF
--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/listener/InputValidationListener.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/listener/InputValidationListener.java
@@ -141,7 +141,6 @@ public class InputValidationListener extends AbstractIdentityUserOperationEventL
         List<ValidationConfiguration> configurations;
         try {
             configurations = inputValidationMgtService.getInputValidationConfiguration(tenantDomain);
-            UserCoreUtil.setSkipPasswordPatternValidationThreadLocal(true);
 
             /* Validate provide value for each field in the `inputValuesForFieldsMap` against the configurations of the
              corresponding field. */


### PR DESCRIPTION
As we are required to set setSkipPasswordPatternValidationThreadLocal to true only if validations are found (which is done by 
https://github.com/Thisara-Welmilla/carbon-identity-framework/blob/6d16c89ac549e5e8f5c6db820cc906e8c5bcf8d3/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/listener/InputValidationListener.java#L153) Therefore removing unintended setSkipPasswordPatternValidationThreadLocal.