### PR TITLE
Add a comment about duplicating BaseCache implementation at org-mgt-service

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/cache/BaseCache.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/cache/BaseCache.java
@@ -40,6 +40,7 @@ import javax.cache.Caching;
 
 /**
  * A base class for all cache implementations in Identity modules. This maintains  caches in the tenanted space.
+ * A copy of this class is maintained at org.wso2.carbon.identity.organization.management.service.cache component.
  *
  * @param <K> cache key type.
  * @param <V> cache value type.


### PR DESCRIPTION
### Proposed changes in this pull request

A copy of this BaseCache class is duplicated at org.wso2.carbon.identity.organization.management.service.cache component to use as the base for the cache implementation in the organization management service through [identity-organization-management-core#51](https://github.com/wso2-extensions/identity-organization-management-core/pull/51)

Adding a comment about the duplication here as well for future reference. 