### PR TITLE
Add filter method to remove query params from consent page

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/builder/FileBasedConfigurationBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/builder/FileBasedConfigurationBuilder.java
@@ -77,6 +77,7 @@ public class FileBasedConfigurationBuilder {
     private String authenticationEndpointMissingClaimsURL;
     private boolean allowCustomClaimMappingsForAuthenticators = false;
     private boolean allowMergingCustomClaimMappingsWithDefaultClaimMappings = false;
+    private boolean allowConsentPageRedirectParams = false;
 
     /**
      * List of URLs that receive the tenant list
@@ -225,6 +226,10 @@ public class FileBasedConfigurationBuilder {
 
             //########## Read Authentication Claim Dialect Merge Configs ###########
             readAllowMergingCustomClaimMappingsWithDefaultClaimMappings(rootElement);
+
+            //########## Read Allow Consent Page Redirect Params Configs ###########
+            readAllowConsentPageRedirectParams(rootElement);
+
         } catch (XMLStreamException e) {
             log.error("Error reading the " + IdentityApplicationConstants.APPLICATION_AUTHENTICATION_CONGIG, e);
         } catch (Exception e) {
@@ -512,6 +517,17 @@ public class FileBasedConfigurationBuilder {
                     this.authEndpointRedirectParams.add(redirectParamName);
                 }
             }
+        }
+    }
+
+    private void readAllowConsentPageRedirectParams(OMElement documentElement) {
+
+        OMElement element = documentElement.getFirstChildWithName(IdentityApplicationManagementUtil.
+                getQNameWithIdentityApplicationNS(
+                        FrameworkConstants.Config.QNAME_ALLOW_CONSENT_PAGE_REDIRECT_PARAMS));
+
+        if (element != null) {
+            allowConsentPageRedirectParams = Boolean.valueOf(element.getText());
         }
     }
 
@@ -1136,5 +1152,15 @@ public class FileBasedConfigurationBuilder {
     public boolean isMergingCustomClaimMappingsWithDefaultClaimMappingsAllowed() {
 
         return allowMergingCustomClaimMappingsWithDefaultClaimMappings;
+    }
+
+    /**
+     * Indicates whether the query params are allowed in the consent page.
+     *
+     * @return True if query params are allowed in consent page redirect url.
+     */
+    public boolean isConsentPageRedirectParamsAllowed() {
+
+        return allowConsentPageRedirectParams;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -273,6 +273,8 @@ public abstract class FrameworkConstants {
         public static final String QNAME_SEQUENCES = "Sequences";
         public static final String QNAME_AUTH_ENDPOINT_QUERY_PARAMS = "AuthenticationEndpointQueryParams";
         public static final String QNAME_AUTH_ENDPOINT_REDIRECT_PARAMS = "AuthenticationEndpointRedirectParams";
+        public static final String QNAME_ALLOW_CONSENT_PAGE_REDIRECT_PARAMS =
+                "AllowConsentPageRedirectParams";
         public static final String QNAME_FILTERING_ENABLED_HOST_NAMES = "FilteringEnabledHostNames";
         public static final String QNAME_ALLOW_AUTHENTICATOR_CUSTOM_CLAIM_MAPPINGS =
                 "AllowCustomClaimMappingsForAuthenticators";

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml
@@ -261,5 +261,5 @@
     Default value: false
     -->
     <!--<AllowMergingCustomClaimMappingsWithDefaultClaimMappings>true</AllowMergingCustomClaimMappingsWithDefaultClaimMappings>-->
-
+    <AllowConsentPageRedirectParams>false</AllowConsentPageRedirectParams>
 </ApplicationAuthentication>

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml.j2
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml.j2
@@ -163,6 +163,10 @@
     </AuthenticationEndpointRedirectParams>
     {% endif %}
 
+    {% if authentication.endpoint.enable_consent_page_redirect_params.allowConsentPageRedirectParams is defined %}
+        <AllowConsentPageRedirectParams>{{authentication.endpoint.enable_consent_page_redirect_params.allowConsentPageRedirectParams}}</AllowConsentPageRedirectParams>
+    {% endif %}
+
     {% if authentication.endpoint.enable_custom_claim_mappings is defined %}
     <AllowCustomClaimMappingsForAuthenticators>{{authentication.endpoint.enable_custom_claim_mappings}}</AllowCustomClaimMappingsForAuthenticators>
     {% endif %}

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -57,6 +57,7 @@
     "password",
     "SAMLRequest"
   ],
+  "authentication.endpoint.enable_consent_page_redirect_params.allowConsentPageRedirectParams": false,
 
   "authentication.authenticator.basic.name": "BasicAuthenticator",
   "authentication.authenticator.basic.enable": true,


### PR DESCRIPTION
### Proposed changes in this pull request

- Introduced a new method to filter the consent page redirect params without reading a filebased configuration
- After this change the **all redirect params are filtered from the consent page redirect url by default**.
- For the sake of backward compatibility, introduced a config to keep the previous behavior.

    - Add the below config to append the query params to the consent page url
    
      ```
      [authentication.endpoint.enable_consent_page_redirect_params]
      allowConsentPageRedirectParams = true
      
      ```
    - After adding this config to allow query params to consent url, we can filter required query params using the below exisitng config
    
    ```
      [authentication.endpoint.redirect_params]
      filter_policy = "include"
      remove_on_consume_from_api = "true"
      parameters = ["sessionDataKey"]

    ```


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
