### PR TITLE
Add config for disabling AppliesTo element

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -393,6 +393,8 @@ public class IdentityConstants {
         public static final String STS_IDENTITY_PROVIDER_URL = "SecurityTokenService.IdentityProviderURL";
         public static final String PASSIVE_STS_SLO_HOST_NAME_VERIFICATION_ENABLED =
                 "PassiveSTS.SLOHostNameVerificationEnabled";
+        public static final String PASSIVE_STS_DISABLE_APPLIES_TO_IN_RESPONSE =
+                "PassiveSTS.DisableAppliesToInPassiveSTSResponse";
     }
 
     /**

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -736,6 +736,7 @@
         <RetryURL>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/retry.do</RetryURL>
         <TokenStoreClassName>org.wso2.carbon.identity.sts.passive.utils.NoPersistenceTokenStore</TokenStoreClassName>
         <SLOHostNameVerificationEnabled>true</SLOHostNameVerificationEnabled>
+        <DisableAppliesToInPassiveSTSResponse>false</DisableAppliesToInPassiveSTSResponse>
     </PassiveSTS>
 
     <EntitlementSettings>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1022,6 +1022,7 @@
         <RetryURL>{{passive_sts.endpoints.retry}}</RetryURL>
         <TokenStoreClassName>{{passive_sts.token_store_class}}</TokenStoreClassName>
         <SLOHostNameVerificationEnabled>{{passive_sts.slo.host_name_verification}}</SLOHostNameVerificationEnabled>
+        <DisableAppliesToInPassiveSTSResponse>{{passive_sts.disable_applies_to_in_response}}</DisableAppliesToInPassiveSTSResponse>
     </PassiveSTS>
 
     <EntitlementSettings>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -249,6 +249,7 @@
 
   "passive_sts.token_store_class": "org.wso2.carbon.identity.sts.passive.utils.NoPersistenceTokenStore",
   "passive_sts.slo.host_name_verification": true,
+  "passive_sts.disable_applies_to_in_response": false,
 
   "passive_sts.endpoints.idp": "$ref{server.base_path}/passivests",
   "passive_sts.endpoints.retry": "$ref{server.base_path}/authenticationendpoint/retry.do",


### PR DESCRIPTION
## Purpose

Since the .Net framework does not support the latest WS-Policy namespace `http://www.w3.org/ns/ws-policy`, those applications will break when the `AppliesTo` element exists in the Passive STS response. By default, this element is set in the response. Since this element can be optional, this PR introduces a config which can be used by customers to disable the AppliesTo element in the response.
The following config can be used to disable it.
```
[passive_sts]
disable_applies_to_in_response = true
```

## Related PRs
- PR https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/133

## Related Issues
- Issue https://github.com/wso2/product-is/issues/15592