### PR TITLE
Improve session and temp data storing

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -147,6 +147,7 @@ public class SessionDataStore {
     private boolean sessionDataCleanupEnabled = true;
     private boolean operationDataCleanupEnabled = false;
     private static boolean tempDataCleanupEnabled = false;
+    private static boolean sessionAndTempDataSeparationEnabled = false;
 
     static {
         try {
@@ -163,6 +164,9 @@ public class SessionDataStore {
             if (StringUtils.isNotBlank(isTempDataCleanupEnabledVal)) {
                 tempDataCleanupEnabled = Boolean.parseBoolean(isTempDataCleanupEnabledVal);
             }
+
+            sessionAndTempDataSeparationEnabled = Boolean.parseBoolean(IdentityUtil
+                    .getProperty("JDBCPersistenceManager.SessionDataPersist.SessionAndTempDataSeparation.Enable"));
 
             String maxTempDataPoolSizeValue
                     = IdentityUtil.getProperty("JDBCPersistenceManager.SessionDataPersist.TempDataCleanup.PoolSize");
@@ -699,7 +703,7 @@ public class SessionDataStore {
 
     private String getSessionStoreDBQuery(String query, String type) {
 
-        if (tempDataCleanupEnabled && isTempCache(type)) {
+        if ((sessionAndTempDataSeparationEnabled || tempDataCleanupEnabled) && isTempCache(type)) {
             query = replaceTableName(query);
         }
         return query;

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -57,6 +57,9 @@
                 and would be deleted during cleanup task -->
                 <CleanUpTimeout>{{session_data.cleanup.expire_pre_session_data_after}}</CleanUpTimeout>
             </TempDataCleanup>
+            <SessionAndTempDataSeparation>
+                <Enable>{{session_data.session_data_persist.session_and_temp_data_separation_enabled.enable}}</Enable>
+            </SessionAndTempDataSeparation>
             <UserSessionMapping>
                 <Enable>{{session_data.persistence.enable_user_session_mapping}}</Enable>
             </UserSessionMapping>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -25,6 +25,7 @@
   "session_data.cleanup.clean_expired_session_data_in_chunks_of": "8192",
   "session_data.cleanup.clean_logged_out_sessions_at_immediate_cycle": true,
   "session_data.cleanup.enable_pre_session_data_cleanup": true,
+  "session_data.session_data_persist.session_and_temp_data_separation_enabled.enable": false,
   "session_data.cleanup.pre_session_data_cleanup_thread_pool_size": "20",
   "session.nonce.cookie.enabled": true,
   "session.authentication.context.expiry.validation": true,


### PR DESCRIPTION
Persisting the authentication context data and the session data separately.
- The authentication context data and the session data are stored separately when the internal cleanup is enabled on the tables IDN_AUTH_TEMP_SESSION_STORE and IDN_AUTH_SESSION_STORE respectively (default behavior) [1].
- However, when it's disabled, all the data will be stored in IDN_AUTH_SESSION_STORE.
- Therefore, it can be improved to store it separately even when the internal cleanup is disabled, in order to clean the data separately.


Introduce a new config to resolve above issue.
