### PR TITLE
Populate CM_PII_CATEGORY table when requested claims are added

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/SSOConsentServiceImpl.java
@@ -669,13 +669,8 @@ public class SSOConsentServiceImpl implements SSOConsentService {
             try {
                 piiCategory = getConsentManager().getPIICategoryByName(requestedClaim.getClaimUri());
             } catch (ConsentManagementClientException e) {
-
-                if (isInvalidPIICategoryError(e)) {
-                    piiCategory = addPIICategoryForClaim(requestedClaim);
-                } else {
-                    throw new SSOConsentServiceException("Consent PII category error", "Error while retrieving" +
-                            " PII category: " + DEFAULT_PURPOSE_CATEGORY, e);
-                }
+                throw new SSOConsentServiceException("Consent PII category error", "Error while retrieving" +
+                        " PII category: " + DEFAULT_PURPOSE_CATEGORY, e);
             } catch (ConsentManagementException e) {
                 throw new SSOConsentServiceException("Consent PII category error", "Error while retrieving " +
                         "PII category: " + DEFAULT_PURPOSE_CATEGORY, e);
@@ -685,25 +680,6 @@ public class SSOConsentServiceImpl implements SSOConsentService {
             piiCategoryIds.add(piiCategoryValidity);
         }
         return piiCategoryIds;
-    }
-
-    private PIICategory addPIICategoryForClaim(ClaimMetaData claim) throws SSOConsentServiceException {
-
-        PIICategory piiCategory;
-        PIICategory piiCategoryInput = new PIICategory(claim.getClaimUri(), claim.getDescription(), false, claim
-                .getDisplayName());
-        try {
-            piiCategory = getConsentManager().addPIICategory(piiCategoryInput);
-        } catch (ConsentManagementException e) {
-            throw new SSOConsentServiceException("Consent PII category error", "Error while adding" +
-                    " PII category:" + DEFAULT_PURPOSE_CATEGORY, e);
-        }
-        return piiCategory;
-    }
-
-    private boolean isInvalidPIICategoryError(ConsentManagementClientException e) {
-
-        return ERROR_CODE_PII_CAT_NAME_INVALID.getCode().equals(e.getErrorCode());
     }
 
     private PurposeCategory getDefaultPurposeCategory() throws SSOConsentServiceException {
@@ -1114,6 +1090,7 @@ public class SSOConsentServiceImpl implements SSOConsentService {
     private ClaimMetaData buildClaimMetaData(int claimId, LocalClaim localClaim, String claimURI) {
 
         ClaimMetaData claimMetaData = new ClaimMetaData();
+
         claimMetaData.setId(claimId);
         claimMetaData.setClaimUri(claimURI);
         String displayName = localClaim.getClaimProperties().get(DISPLAY_NAME_PROPERTY);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/constant/SSOConsentConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/consent/constant/SSOConsentConstants.java
@@ -27,6 +27,7 @@ public class SSOConsentConstants {
     public static final String CONSENT_VALIDITY_TYPE_VALID_UNTIL_INDEFINITE = "INDEFINITE";
     public static final String CONFIG_ELEM_CONSENT = "Consent";
     public static final String CONFIG_ELEM_ENABLE_SSO_CONSENT_MANAGEMENT = "EnableSSOConsentManagement";
+    public static final String CONFIG_ELEM_POPULATE_PII_CATEGORIES_AT_RUNTIME = "PopulatePIICategoriesAtRuntime";
     public static final String CONFIG_PROMPT_SUBJECT_CLAIM_REQUESTED_CONSENT =
             "Consent.PromptSubjectClaimRequestedConsent";
     public static final String USERNAME_CLAIM = "http://wso2.org/claims/username";

--- a/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/pom.xml
+++ b/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/pom.xml
@@ -109,6 +109,7 @@
                             org.wso2.carbon.identity.event.event;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.handler;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.common;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.common.model;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.mgt.listener;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.base;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.consent.mgt.core;version="${carbon.consent.mgt.imp.pkg.version.range}",
@@ -121,6 +122,7 @@
                             org.apache.commons.logging; version="${import.package.version.commons.logging}",
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.claim.metadata.mgt.*; version="${carbon.identity.package.import.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.consent.mgt.internal,

--- a/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/internal/IdentityConsentDataHolder.java
+++ b/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/internal/IdentityConsentDataHolder.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.consent.mgt.internal;
 import org.wso2.carbon.consent.mgt.core.ConsentManager;
 import org.wso2.carbon.consent.mgt.core.PrivilegedConsentManager;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.SSOConsentService;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 
 /**
  * Holds data for Identity Consent Mgt component.
@@ -31,6 +32,8 @@ public class IdentityConsentDataHolder {
     private ConsentManager consentManager = null;
     private PrivilegedConsentManager privilegedConsentManager = null;
     private SSOConsentService ssoConsentService = null;
+
+    private ClaimMetadataManagementService claimMetadataManagementService;
 
     private IdentityConsentDataHolder() {
 
@@ -95,4 +98,14 @@ public class IdentityConsentDataHolder {
         this.ssoConsentService = ssoConsentService;
     }
 
+    public ClaimMetadataManagementService getClaimMetadataManagementService() {
+
+        return claimMetadataManagementService;
+    }
+
+    public void setClaimMetadataManagementService(
+            ClaimMetadataManagementService claimMetadataManagementService) {
+
+        this.claimMetadataManagementService = claimMetadataManagementService;
+    }
 }

--- a/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/internal/IdentityConsentServiceComponent.java
+++ b/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/internal/IdentityConsentServiceComponent.java
@@ -30,8 +30,10 @@ import org.wso2.carbon.consent.mgt.core.ConsentManager;
 import org.wso2.carbon.consent.mgt.core.PrivilegedConsentManager;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.SSOConsentService;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.consent.mgt.handler.ConsentDeletionUserEventHandler;
 import org.wso2.carbon.identity.consent.mgt.listener.ConsentDeletionAppMgtListener;
+import org.wso2.carbon.identity.consent.mgt.listener.PIICategoryAppMgtListener;
 import org.wso2.carbon.identity.consent.mgt.listener.TenantConsentMgtListener;
 import org.wso2.carbon.identity.consent.mgt.services.ConsentUtilityService;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
@@ -58,6 +60,8 @@ public class IdentityConsentServiceComponent {
                     new ConsentDeletionUserEventHandler(), null);
             ctxt.getBundleContext().registerService(ApplicationMgtListener.class.getName(),
                     new ConsentDeletionAppMgtListener(), null);
+            ctxt.getBundleContext().registerService(ApplicationMgtListener.class.getName(),
+                    new PIICategoryAppMgtListener(), null);
             ctxt.getBundleContext().registerService(TenantMgtListener.class.getName(), new TenantConsentMgtListener()
                     , null);
             ctxt.getBundleContext().registerService(ConsentUtilityService.class.getName(), new ConsentUtilityService
@@ -125,6 +129,24 @@ public class IdentityConsentServiceComponent {
     protected void unsetSSOConsentService(SSOConsentService ssoConsentService) {
 
         IdentityConsentDataHolder.getInstance().setSSOConsentService(null);
+    }
+
+    @Reference(
+            name = "claim.meta.mgt.service",
+            service = ClaimMetadataManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetClaimMetaMgtService"
+    )
+    protected void setClaimMetaMgtService(ClaimMetadataManagementService claimMetaMgtService) {
+
+        IdentityConsentDataHolder.getInstance().setClaimMetadataManagementService(
+                claimMetaMgtService);
+    }
+
+    protected void unsetClaimMetaMgtService(ClaimMetadataManagementService claimMetaMgtService) {
+
+        IdentityConsentDataHolder.getInstance().setClaimMetadataManagementService(null);
     }
 
     @Reference(

--- a/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/listener/ConsentDeletionAppMgtListener.java
+++ b/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/listener/ConsentDeletionAppMgtListener.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.consent.mgt.core.ConsentManager;
 import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementException;
 import org.wso2.carbon.consent.mgt.core.model.ReceiptListResponse;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.listener.AbstractApplicationMgtListener;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
 import org.wso2.carbon.identity.consent.mgt.IdentityConsentMgtUtils;
@@ -97,17 +98,18 @@ public class ConsentDeletionAppMgtListener extends AbstractApplicationMgtListene
     /**
      * When an application is deleted, it will delete all relevant receipts issued againsed that application.
      *
-     * @param applicationName Name of the application which is getting deleted.
+     * @param serviceProvider Application which is getting deleted.
      * @param tenantDomain    Tenant domain of the application.
      * @param userName        Username of the person who does the deletion.
      * @return true.
      * @throws IdentityApplicationManagementException IdentityApplicationManagementException.
      */
     @Override
-    public boolean doPostDeleteApplication(String applicationName, String tenantDomain, String userName)
+    public boolean doPostDeleteApplication(ServiceProvider serviceProvider, String tenantDomain, String userName)
             throws IdentityApplicationManagementException {
 
         ConsentManager consentManager = IdentityConsentDataHolder.getInstance().getConsentManager();
+        String applicationName = serviceProvider.getApplicationName();
 
         if (log.isDebugEnabled()) {
             log.debug(String.format("Deleting consents on deletion of application: %s, in tenant domain: %s.",
@@ -122,7 +124,7 @@ public class ConsentDeletionAppMgtListener extends AbstractApplicationMgtListene
             }
             receiptListResponses.forEach(rethrowConsumer(receiptListResponse -> {
                 if (log.isDebugEnabled()) {
-                    log.debug(String.format("Deleting receipt with id : %s, issued for user: ", receiptListResponse
+                    log.debug(String.format("Deleting receipt with id : %s, issued for user: %s", receiptListResponse
                             .getConsentReceiptId(), receiptListResponse.getPiiPrincipalId()));
                 }
                 consentManager.deleteReceipt(receiptListResponse.getConsentReceiptId());

--- a/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/listener/PIICategoryAppMgtListener.java
+++ b/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/listener/PIICategoryAppMgtListener.java
@@ -34,9 +34,11 @@ import org.wso2.carbon.identity.consent.mgt.internal.IdentityConsentDataHolder;
 
 import java.util.List;
 
+import static org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants.DESCRIPTION_PROPERTY;
+
 /**
- * Takes care of deleting consents / receipts which are issued against a service provider. When the service provider
- * is deleted, consents issued against the service provider will be deleted through this listener.
+ * Takes care of populating PII categories in the database when the service provider
+ * is updated with requested claims.
  */
 public class PIICategoryAppMgtListener extends AbstractApplicationMgtListener {
 
@@ -71,7 +73,7 @@ public class PIICategoryAppMgtListener extends AbstractApplicationMgtListener {
     /**
      * Overridden the default value.
      *
-     * @return
+     * @return the order of the listener.
      */
     @Override
     public int getDefaultOrderId() {
@@ -79,6 +81,15 @@ public class PIICategoryAppMgtListener extends AbstractApplicationMgtListener {
         return 908;
     }
 
+    /**
+     * Add PII categories when the requested claims are added after creating an application
+     *
+     * @param serviceProvider {@link ServiceProvider}
+     * @param tenantDomain    Tenant domain
+     * @param userName        Username
+     * @return true if the operation is successful
+     * @throws IdentityApplicationManagementException when an exception occurs while adding PII categories
+     */
     public boolean doPostCreateApplication(ServiceProvider serviceProvider, String tenantDomain, String userName)
             throws IdentityApplicationManagementException {
 
@@ -86,6 +97,15 @@ public class PIICategoryAppMgtListener extends AbstractApplicationMgtListener {
         return true;
     }
 
+    /**
+     * Add PII categories when the requested claims are added after updating an application
+     *
+     * @param serviceProvider {@link ServiceProvider}
+     * @param tenantDomain    Tenant domain
+     * @param userName        Username
+     * @return true if the operation is successful
+     * @throws IdentityApplicationManagementException when an exception occurs while adding PII categories
+     */
     public boolean doPostUpdateApplication(ServiceProvider serviceProvider, String tenantDomain, String userName)
             throws IdentityApplicationManagementException {
 
@@ -114,15 +134,14 @@ public class PIICategoryAppMgtListener extends AbstractApplicationMgtListener {
                     if (claim != null) {
                         try {
                             PIICategory piiCategoryInput =
-                                    new PIICategory(claimUri, claim.getClaimProperty("Description"), false, claim
-                                            .getClaimProperty("DisplayName"));
+                                    new PIICategory(claimUri, claim.getClaimProperty(DESCRIPTION_PROPERTY), false,
+                                            claim.getClaimProperty(DESCRIPTION_PROPERTY));
                             if (!getConsentManager().isPIICategoryExists(claimUri)) {
                                 getConsentManager().addPIICategory(piiCategoryInput);
                             }
                         } catch (ConsentManagementException e) {
                             throw new IdentityApplicationManagementException("Consent PII category error",
-                                    "Error while adding" +
-                                            " PII category:" + DEFAULT_PURPOSE_CATEGORY, e);
+                                    "Error while adding PII category:" + DEFAULT_PURPOSE_CATEGORY, e);
                         }
                     }
                 }

--- a/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/listener/PIICategoryAppMgtListener.java
+++ b/components/consent-mgt/org.wso2.carbon.identity.consent.mgt/src/main/java/org/wso2/carbon/identity/consent/mgt/listener/PIICategoryAppMgtListener.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.consent.mgt.listener;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.consent.mgt.core.ConsentManager;
+import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementException;
+import org.wso2.carbon.consent.mgt.core.model.PIICategory;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.mgt.listener.AbstractApplicationMgtListener;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.consent.mgt.IdentityConsentMgtUtils;
+import org.wso2.carbon.identity.consent.mgt.internal.IdentityConsentDataHolder;
+
+import java.util.List;
+
+/**
+ * Takes care of deleting consents / receipts which are issued against a service provider. When the service provider
+ * is deleted, consents issued against the service provider will be deleted through this listener.
+ */
+public class PIICategoryAppMgtListener extends AbstractApplicationMgtListener {
+
+    private static final Log log = LogFactory.getLog(PIICategoryAppMgtListener.class);
+
+    private static final String DEFAULT_PURPOSE_CATEGORY = "DEFAULT";
+
+    /**
+     * Overridden to check the configuration for this listener enabling and also to check whether globally consent
+     * feature enable
+     *
+     * @return Whether this listener is enabled or not
+     */
+    public boolean isEnable() {
+
+        boolean isListenerEnabledFromConfigs = super.isEnable();
+        boolean isConsentEnabledSystemWide = IdentityConsentMgtUtils.isConsentEnabled();
+        if (log.isDebugEnabled()) {
+            log.debug("Is listener enabled from configs: " + isListenerEnabledFromConfigs);
+            log.debug("Is consent enabled system wide: " + isConsentEnabledSystemWide);
+        }
+        if (isConsentEnabledSystemWide && isListenerEnabledFromConfigs) {
+            if (log.isDebugEnabled()) {
+                log.debug("Listener is enabled and consent is enabled system wide. Hence returning true for " +
+                        "isEnabled");
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Overridden the default value.
+     *
+     * @return
+     */
+    @Override
+    public int getDefaultOrderId() {
+
+        return 908;
+    }
+
+    public boolean doPostCreateApplication(ServiceProvider serviceProvider, String tenantDomain, String userName)
+            throws IdentityApplicationManagementException {
+
+        addPIICategoryForRequestedClaims(serviceProvider, tenantDomain);
+        return true;
+    }
+
+    public boolean doPostUpdateApplication(ServiceProvider serviceProvider, String tenantDomain, String userName)
+            throws IdentityApplicationManagementException {
+
+        addPIICategoryForRequestedClaims(serviceProvider, tenantDomain);
+        return true;
+    }
+
+    private void addPIICategoryForRequestedClaims(ServiceProvider serviceProvider, String tenantDomain)
+            throws IdentityApplicationManagementException {
+
+        if (serviceProvider.getClaimConfig() != null) {
+            serviceProvider.getClaimConfig().getClaimMappings();
+
+            try {
+                List<LocalClaim> localClaims =
+                        IdentityConsentDataHolder.getInstance().getClaimMetadataManagementService()
+                                .getLocalClaims(tenantDomain);
+                for (ClaimMapping claimMapping : serviceProvider.getClaimConfig().getClaimMappings()) {
+                    String claimUri = claimMapping.getLocalClaim().getClaimUri();
+
+                    LocalClaim claim = localClaims.stream()
+                            .filter(localClaim -> localClaim.getClaimURI().equals(claimUri))
+                            .findFirst()
+                            .orElse(null);
+
+                    if (claim != null) {
+                        try {
+                            PIICategory piiCategoryInput =
+                                    new PIICategory(claimUri, claim.getClaimProperty("Description"), false, claim
+                                            .getClaimProperty("DisplayName"));
+                            if (!getConsentManager().isPIICategoryExists(claimUri)) {
+                                getConsentManager().addPIICategory(piiCategoryInput);
+                            }
+                        } catch (ConsentManagementException e) {
+                            throw new IdentityApplicationManagementException("Consent PII category error",
+                                    "Error while adding" +
+                                            " PII category:" + DEFAULT_PURPOSE_CATEGORY, e);
+                        }
+                    }
+                }
+            } catch (ClaimMetadataException e) {
+                throw new IdentityApplicationManagementException("Error while getting local claims", e);
+            }
+        }
+    }
+
+    private ConsentManager getConsentManager() {
+
+        return IdentityConsentDataHolder.getInstance().getConsentManager();
+    }
+}

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -715,6 +715,8 @@
         <EnableSSOConsentManagement>true</EnableSSOConsentManagement>
         <!--Specify whether consent should be prompted for subject claim uri if configured as a requested claim.-->
         <PromptSubjectClaimRequestedConsent>true</PromptSubjectClaimRequestedConsent>
+        <!--Specify if the PII Categories can be populated at runtime.-->
+        <PopulatePIICategoriesAtRuntime>true</PopulatePIICategoriesAtRuntime>
     </Consent>
 
     <SecurityTokenService>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1001,6 +1001,8 @@
         <EnableSSOConsentManagement>{{authentication.consent.prompt}}</EnableSSOConsentManagement>
         <!--Specify whether consent should be prompted for subject claim uri if configured as a requested claim.-->
         <PromptSubjectClaimRequestedConsent>{{authentication.consent.subject.prompt}}</PromptSubjectClaimRequestedConsent>
+        <!--Specify if the PII Categories can be populated at runtime.-->
+        <PopulatePIICategoriesAtRuntime>{{authentication.consent.pii_categories.populate_at_runtime}}</PopulatePIICategoriesAtRuntime>
     </Consent>
 
     <SecurityTokenService>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1,6 +1,7 @@
 {
   "authentication.consent.prompt": true,
   "authentication.consent.subject.prompt": true,
+  "authentication.consent.pii_categories.populate_at_runtime": true,
   "authentication.map_federated_users_to_local": false,
   "authentication.enable_scope_based_claim_filtering": true,
   "authentication.allow_sp_requested_fed_claims_only": true,


### PR DESCRIPTION
### Proposed changes in this pull request

- If the Identity Server distribution is used in a deployment where the control-plane and the data-plane are separated out, CM_PII_CATEGORY table is populated from both of the planes. When 
  - consent purpose is added from the control-plane this table is populated 
  - a user accepts a consent in the data-pane this table is populated, if the relevant entry is not available in the database.
- With this change, CM_PII_CATEGORY will be populated once the requested claims are added for the application configurations, removing the requirement to add them in the runtime.
- For the backward compatibility, we can allow to write the records at the runtime.