### PR TITLE
Improvement to check authenticator prerequisites before appending to redirection URL

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/ApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/ApplicationAuthenticator.java
@@ -109,4 +109,16 @@ public interface ApplicationAuthenticator extends Serializable {
 
         return new String[0];
     }
+
+    /**
+     * Check whether user satisfies all the pre-requisites of the authenticator to be authenticated with.
+     *
+     * @param request       Request which comes to the framework for authentication.
+     * @param context       Authentication context.
+     * @return boolean if satisfies all the pre-requisites of the authenticator.
+     */
+    default boolean isSatisfyAuthenticatorPrerequisites(HttpServletRequest request, AuthenticationContext context)
+            throws AuthenticationFailedException {
+        return true;
+    }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
@@ -46,6 +46,7 @@ import java.util.function.Supplier;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.DefaultUrlContexts.ACCOUNT_RECOVERY_ENDPOINT_PATH;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.DefaultUrlContexts.AUTHENTICATION_ENDPOINT;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.DefaultUrlContexts.AUTHENTICATION_ENDPOINT_DYNAMIC_PROMPT;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.DefaultUrlContexts.AUTHENTICATION_ENDPOINT_ERROR;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.DefaultUrlContexts.AUTHENTICATION_ENDPOINT_MISSING_CLAIMS_PROMPT;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.DefaultUrlContexts.AUTHENTICATION_ENDPOINT_RETRY;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.DefaultUrlContexts.AUTHENTICATION_ENDPOINT_WAIT;
@@ -195,6 +196,12 @@ public class ConfigurationFacade {
 
         return buildUrl(AUTHENTICATION_ENDPOINT_RETRY,
                 FileBasedConfigurationBuilder.getInstance()::getAuthenticationEndpointRetryURL);
+    }
+
+    public String getAuthenticationEndpointErrorURL() {
+
+        return buildUrl(AUTHENTICATION_ENDPOINT_ERROR,
+                FileBasedConfigurationBuilder.getInstance()::getAuthenticationEndpointErrorURL);
     }
 
     public String getAuthenticationEndpointWaitURL() {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/builder/FileBasedConfigurationBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/builder/FileBasedConfigurationBuilder.java
@@ -71,6 +71,7 @@ public class FileBasedConfigurationBuilder {
 
     private String authenticationEndpointURL;
     private String authenticationEndpointRetryURL;
+    private String authenticationEndpointErrorURL;
     private String authenticationEndpointWaitURL;
     private String identifierFirstConfirmationURL;
     private String authenticationEndpointPromptURL;
@@ -176,6 +177,7 @@ public class FileBasedConfigurationBuilder {
             //########### Read Authentication Endpoint URL ###########
             readAuthenticationEndpointURL(rootElement);
             readAuthenticationEndpointRetryURL(rootElement);
+            readAuthenticationEndpointErrorURL(rootElement);
             readAuthenticationEndpointWaitURL(rootElement);
             readIdentifierFirstConfirmationURL(rootElement);
             readAuthenticationEndpointPromptURL(rootElement);
@@ -593,6 +595,15 @@ public class FileBasedConfigurationBuilder {
         }
     }
 
+    private void readAuthenticationEndpointErrorURL(OMElement documentElement) {
+        OMElement authEndpointErrorURLElem = documentElement.getFirstChildWithName(IdentityApplicationManagementUtil.
+                getQNameWithIdentityApplicationNS(FrameworkConstants.Config.QNAME_AUTHENTICATION_ENDPOINT_ERROR_URL));
+
+        if (authEndpointErrorURLElem != null) {
+            authenticationEndpointErrorURL = IdentityUtil.fillURLPlaceholders(authEndpointErrorURLElem.getText());
+        }
+    }
+
     private void readAuthenticationEndpointWaitURL(OMElement documentElement) {
         OMElement authEndpointWaitURLElem = documentElement.getFirstChildWithName(IdentityApplicationManagementUtil.
                 getQNameWithIdentityApplicationNS(FrameworkConstants.Config.QNAME_AUTHENTICATION_ENDPOINT_WAIT_URL));
@@ -981,6 +992,14 @@ public class FileBasedConfigurationBuilder {
 
     public void setAuthenticationEndpointRetryURL(String authenticationEndpointRetryURL) {
         this.authenticationEndpointRetryURL = authenticationEndpointRetryURL;
+    }
+
+    public String getAuthenticationEndpointErrorURL() {
+        return authenticationEndpointErrorURL;
+    }
+
+    public void setAuthenticationEndpointErrorURL(String authenticationEndpointErrorURL) {
+        this.authenticationEndpointErrorURL = authenticationEndpointErrorURL;
     }
 
     public String getAuthenticationEndpointWaitURL() {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -342,7 +342,7 @@ public class DefaultStepHandler implements StepHandler {
                 */
                 if (filteredAuthConfigList.isEmpty() & !authConfigList.isEmpty()) {
                     try {
-                        String errorPage = ConfigurationFacade.getInstance().getAuthenticationEndpointRetryURL();
+                        String errorPage = ConfigurationFacade.getInstance().getAuthenticationEndpointErrorURL();
                         URIBuilder uriBuilder = new URIBuilder(errorPage);
 
                         if (IdentityTenantUtil.isTenantedSessionsEnabled()) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -69,6 +69,7 @@ public abstract class FrameworkConstants {
     public static final String REMAINING_ATTEMPTS = "remainingAttempts";
     public static final String FAILED_USERNAME = "failedUsername";
     public static final String LOCK_REASON = "lockedReason";
+    public static final String NOT_SATISFY_PREREQUISITES_REASON = "NotSatisfyAuthenticatorPrerequisitesReason";
 
     // This is to support sign-up form to be displayed in the provisioning flow, as when trying to displaying the
     // sign-up form, we validate whether self-sign up is enabled.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -259,7 +259,6 @@ public abstract class FrameworkConstants {
         // Constant definitions for other QNames
         public static final String QNAME_AUTHENTICATION_ENDPOINT_URL = "AuthenticationEndpointURL";
         public static final String QNAME_AUTHENTICATION_ENDPOINT_RETRY_URL = "AuthenticationEndpointRetryURL";
-
         public static final String QNAME_AUTHENTICATION_ENDPOINT_ERROR_URL = "AuthenticationEndpointErrorURL";
         public static final String QNAME_AUTHENTICATION_ENDPOINT_WAIT_URL = "AuthenticationEndpointWaitURL";
         public static final String QNAME_AUTHENTICATION_ENDPOINT_IDF_CONFIRM_URL = "IdentifierFirstConfirmationURL";
@@ -448,7 +447,6 @@ public abstract class FrameworkConstants {
 
         public static final String AUTHENTICATION_ENDPOINT = "/authenticationendpoint/login.do";
         public static final String AUTHENTICATION_ENDPOINT_RETRY = "/authenticationendpoint/retry.do";
-
         public static final String AUTHENTICATION_ENDPOINT_ERROR = "/authenticationendpoint/error.do";
         public static final String AUTHENTICATION_ENDPOINT_WAIT = "/authenticationendpoint/wait.do";
         public static final String IDENTIFIER_FIRST_CONFIRMATION = "/authenticationendpoint/idf-confirm.do";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -259,6 +259,8 @@ public abstract class FrameworkConstants {
         // Constant definitions for other QNames
         public static final String QNAME_AUTHENTICATION_ENDPOINT_URL = "AuthenticationEndpointURL";
         public static final String QNAME_AUTHENTICATION_ENDPOINT_RETRY_URL = "AuthenticationEndpointRetryURL";
+
+        public static final String QNAME_AUTHENTICATION_ENDPOINT_ERROR_URL = "AuthenticationEndpointErrorURL";
         public static final String QNAME_AUTHENTICATION_ENDPOINT_WAIT_URL = "AuthenticationEndpointWaitURL";
         public static final String QNAME_AUTHENTICATION_ENDPOINT_IDF_CONFIRM_URL = "IdentifierFirstConfirmationURL";
         public static final String QNAME_AUTHENTICATION_ENDPOINT_PROMPT_URL = "AuthenticationEndpointPromptURL";
@@ -446,6 +448,8 @@ public abstract class FrameworkConstants {
 
         public static final String AUTHENTICATION_ENDPOINT = "/authenticationendpoint/login.do";
         public static final String AUTHENTICATION_ENDPOINT_RETRY = "/authenticationendpoint/retry.do";
+
+        public static final String AUTHENTICATION_ENDPOINT_ERROR = "/authenticationendpoint/error.do";
         public static final String AUTHENTICATION_ENDPOINT_WAIT = "/authenticationendpoint/wait.do";
         public static final String IDENTIFIER_FIRST_CONFIRMATION = "/authenticationendpoint/idf-confirm.do";
         public static final String AUTHENTICATION_ENDPOINT_DYNAMIC_PROMPT = "/authenticationendpoint/dynamic_prompt.do";


### PR DESCRIPTION
When building redirection URL for next authentication step, check whether user satisfies all the prerequisites of the each authenticator and append only filtered authenticators to the URL.