### PR TITLE
Add post validation configuration update handler.

### DIFF
--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/pom.xml
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/pom.xml
@@ -80,6 +80,10 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.mgt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.claim.metadata.mgt</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -110,6 +114,7 @@
                             org.apache.commons.logging; version="${import.package.version.commons.logging}",
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.claim.metadata.mgt.*;version="${carbon.identity.package.import.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.input.validation.mgt.internal,

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationDataHolder.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.input.validation.mgt.internal;
 
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.input.validation.mgt.model.FieldValidationConfigurationHandler;
 import org.wso2.carbon.identity.input.validation.mgt.model.Validator;
@@ -30,9 +31,21 @@ import java.util.Map;
  */
 public class InputValidationDataHolder {
 
+    private static InputValidationDataHolder instance = new InputValidationDataHolder();
     private static ConfigurationManager configurationManager = null;
+    private ClaimMetadataManagementService claimMetadataManagementService;
     private static Map<String, Validator> validators = new HashMap<>();
     private static Map<String, FieldValidationConfigurationHandler> validationConfigurationHandlers = new HashMap<>();
+
+    /**
+     * Get InputValidationDataHolder instance.
+     *
+     * @return InputValidationDataHolder.
+     */
+    public static InputValidationDataHolder getInstance() {
+
+        return instance;
+    }
 
     /**
      * Get Configuration Manager.
@@ -62,5 +75,25 @@ public class InputValidationDataHolder {
     public static Map<String, FieldValidationConfigurationHandler> getFieldValidationConfigurationHandlers() {
 
         return validationConfigurationHandlers;
+    }
+
+    /**
+     * Get claim metadata management service.
+     *
+     * @return claim metadata management service.
+     */
+    public ClaimMetadataManagementService getClaimMetadataManagementService() {
+
+        return claimMetadataManagementService;
+    }
+
+    /**
+     * Set claim metadata management service.
+     *
+     * @param claimMetadataManagementService    Claim metadata management service.
+     */
+    public void setClaimMetadataManagementService(ClaimMetadataManagementService claimMetadataManagementService) {
+
+        this.claimMetadataManagementService = claimMetadataManagementService;
     }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationServiceComponent.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationServiceComponent.java
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.input.validation.mgt.listener.InputValidationListener;
 import org.wso2.carbon.identity.input.validation.mgt.model.FieldValidationConfigurationHandler;
@@ -172,5 +173,23 @@ public class InputValidationServiceComponent {
 
         InputValidationDataHolder.getFieldValidationConfigurationHandlers()
                 .remove(configurationHandler.getClass().getName());
+    }
+
+    @Reference(
+            name = "claim.meta.mgt.service",
+            service = ClaimMetadataManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetClaimMetaMgtService"
+    )
+    protected void setClaimMetaMgtService(ClaimMetadataManagementService claimMetaMgtService) {
+
+        InputValidationDataHolder.getInstance().setClaimMetadataManagementService(
+                claimMetaMgtService);
+    }
+
+    protected void unsetClaimMetaMgtService(ClaimMetadataManagementService claimMetaMgtService) {
+
+        InputValidationDataHolder.getInstance().setClaimMetadataManagementService(null);
     }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/FieldValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/FieldValidationConfigurationHandler.java
@@ -58,7 +58,7 @@ public interface FieldValidationConfigurationHandler {
      * @param tenantDomain      Tenant Domain.
      * @param configuration     Updated validation configuration.
      */
-    default void postValidationConfigurationUpdateHandler(String tenantDomain, ValidationConfiguration configuration)
+    default void handlePostValidationConfigurationUpdate(String tenantDomain, ValidationConfiguration configuration)
             throws InputValidationMgtServerException {
     }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/FieldValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/FieldValidationConfigurationHandler.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.input.validation.mgt.model;
 
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtClientException;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtException;
+import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtServerException;
 
 import java.util.List;
 
@@ -50,4 +51,14 @@ public interface FieldValidationConfigurationHandler {
      */
     boolean validateValidationConfiguration(List<RulesConfiguration> configurationList)
             throws InputValidationMgtClientException;
+
+    /**
+     * Perform post actions after validation configuration are updated.
+     *
+     * @param tenantDomain      Tenant Domain.
+     * @param configuration     Updated validation configuration.
+     */
+    default void postValidationConfigurationUpdateHandler(String tenantDomain, ValidationConfiguration configuration)
+            throws InputValidationMgtServerException {
+    }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
@@ -41,9 +41,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.DEFAULT_EMAIL_JS_REGEX_PATTERN;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.EMAIL_FORMAT_VALIDATOR;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.ENABLE_VALIDATOR;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.JS_REGEX;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.USERNAME;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.EMAIL_CLAIM_URI;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_GETTING_EXISTING_CONFIGURATIONS;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_INVALID_VALIDATORS_COMBINATION;
 import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.PROPERTY_USER_NAME_JS_REG;
@@ -175,7 +177,7 @@ public class UsernameValidationConfigurationHandler extends AbstractFieldValidat
              Set required and support by default properties of the email attribute to true, when username field
              validation configurations are set to emailFormatValidator.
              */
-            if ("EmailFormatValidator".equals(rule.getValidatorName())) {
+            if (rule != null && EMAIL_FORMAT_VALIDATOR.equals(rule.getValidatorName())) {
                 if (Boolean.parseBoolean(rule.getProperties().get(ENABLE_VALIDATOR))) {
                     try {
                         updateEmailClaim(tenantDomain);
@@ -194,14 +196,20 @@ public class UsernameValidationConfigurationHandler extends AbstractFieldValidat
      * @param tenantDomain   Tenant Domain.
      */
     private void updateEmailClaim(String tenantDomain) throws ClaimMetadataException {
+
         List<LocalClaim> localClaimList = InputValidationDataHolder.getInstance()
-        .getClaimMetadataManagementService().getLocalClaims(tenantDomain);
+                .getClaimMetadataManagementService().getLocalClaims(tenantDomain);
+
+        if (localClaimList.isEmpty()) {
+            return;
+        }
+
         for (LocalClaim claim : localClaimList) {
-            if (StringUtils.equals(claim.getClaimURI(), "http://wso2.org/claims/emailaddress")) {
+            if (StringUtils.equals(claim.getClaimURI(), EMAIL_CLAIM_URI)) {
                 claim.setClaimProperty("Required", Boolean.TRUE.toString());
                 claim.setClaimProperty("SupportedByDefault", Boolean.TRUE.toString());
                 InputValidationDataHolder.getInstance().getClaimMetadataManagementService()
-                .updateLocalClaim(claim, tenantDomain);
+                        .updateLocalClaim(claim, tenantDomain);
                 break;
             }
         }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
@@ -169,7 +169,7 @@ public class UsernameValidationConfigurationHandler extends AbstractFieldValidat
      * @param configuration     Updated validation configuration.
      */
     @Override
-    public void postValidationConfigurationUpdateHandler(String tenantDomain, ValidationConfiguration configuration)
+    public void handlePostValidationConfigurationUpdate(String tenantDomain, ValidationConfiguration configuration)
             throws InputValidationMgtServerException {
 
         for (RulesConfiguration rule: configuration.getRules()) {

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementServiceImpl.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementServiceImpl.java
@@ -52,6 +52,7 @@ import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Erro
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_NO_CONFIGURATIONS_FOUND;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_WHILE_ADDING_CONFIGURATIONS;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_WHILE_UPDATING_CONFIGURATIONS;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.FIELD_VALIDATION_CONFIG_HANDLER_MAP;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.INPUT_VAL_CONFIG_RESOURCE_NAME_PREFIX;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.INPUT_VAL_CONFIG_RESOURCE_TYPE_NAME;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.SUPPORTED_PARAMS;
@@ -221,6 +222,15 @@ public class InputValidationManagementServiceImpl implements InputValidationMana
             // Update the existing resource.
             updatedResource = updateResource(newResource, tenantDomain);
         }
+
+        // Execute post actions of validation configuration update.
+        FieldValidationConfigurationHandler handler = InputValidationDataHolder
+                .getFieldValidationConfigurationHandlers().get(FIELD_VALIDATION_CONFIG_HANDLER_MAP.get(
+                configuration.getField()));
+        if (handler != null) {
+            handler.postValidationConfigurationUpdateHandler(tenantDomain, configuration);
+        }
+
         return buildValidationConfigFromResource(updatedResource);
     }
 

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementServiceImpl.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementServiceImpl.java
@@ -228,7 +228,7 @@ public class InputValidationManagementServiceImpl implements InputValidationMana
                 .getFieldValidationConfigurationHandlers().get(FIELD_VALIDATION_CONFIG_HANDLER_MAP.get(
                 configuration.getField()));
         if (handler != null) {
-            handler.postValidationConfigurationUpdateHandler(tenantDomain, configuration);
+            handler.handlePostValidationConfigurationUpdate(tenantDomain, configuration);
         }
 
         return buildValidationConfigFromResource(updatedResource);

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -47,11 +47,15 @@ public class Constants {
                 put(USERNAME, UsernameValidationConfigurationHandler.class.getSimpleName());
                 put(PASSWORD, PasswordValidationConfigurationHandler.class.getSimpleName());
             }});
+    public static final String EMAIL_CLAIM_URI = "http://wso2.org/claims/emailaddress";
 
     /**
      * Class contains the configuration related constants.
      */
     public static class Configs {
+
+        // Validator names.
+        public static final String EMAIL_FORMAT_VALIDATOR = "EmailFormatValidator";
 
         // Keys for password rules validation.
         public static final String ERROR_CODE_PREFIX = "INM-";

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -18,9 +18,14 @@
 
 package org.wso2.carbon.identity.input.validation.mgt.utils;
 
+import org.wso2.carbon.identity.input.validation.mgt.model.handlers.PasswordValidationConfigurationHandler;
+import org.wso2.carbon.identity.input.validation.mgt.model.handlers.UsernameValidationConfigurationHandler;
+
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.PASSWORD;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.USERNAME;
@@ -36,6 +41,11 @@ public class Constants {
             new ArrayList<String>() {{
                 add(PASSWORD);
                 add(USERNAME);
+            }});
+    public static final Map<String, String> FIELD_VALIDATION_CONFIG_HANDLER_MAP =
+            Collections.unmodifiableMap(new HashMap<String, String>() {{
+                put(USERNAME, UsernameValidationConfigurationHandler.class.getSimpleName());
+                put(PASSWORD, PasswordValidationConfigurationHandler.class.getSimpleName());
             }});
 
     /**


### PR DESCRIPTION
When admin enables email as username option for username format configurations, we need to set required and support by default properties of the email attribute to true, when username field validation configurations are set to emailFormatValidator.

To perform those post actions add post validation configuration update handler.