### PR TITLE
Fix account recovery callback url default regex issue

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -282,7 +282,7 @@
   "scim2.consider_total_records_for_total_results_of_ldap": false,
 
   "identity_mgt.recovery.notification.manage_internally": true,
-  "identity_mgt.recovery.callback_url": "[${carbon.protocol}://${carbon.host}:${carbon.management.port}].*[/authenticationendpoint/login.do]*",
+  "identity_mgt.recovery.callback_url": "^${carbon.protocol}:\\/\\/${carbon.host}:${carbon.management.port}.*(?:\\/authenticationendpoint\\/login\\.do)?$",
   "identity_mgt.recovery.enable_detailed_error_messages": false,
   "identity_mgt.recovery.enable_auto_login": false,
   "identity_mgt.recovery.notify_user_existence": false,
@@ -362,7 +362,7 @@
   "identity_mgt.user_self_registration.notify_account_confirmation": false,
   "identity_mgt.user_self_registration.enable_recaptcha": true,
   "identity_mgt.user_self_registration.verification_email_validity": "$ref{identity_mgt.default_mail_validity_period}",
-  "identity_mgt.user_self_registration.callback_url": "[${carbon.protocol}://${carbon.host}:${carbon.management.port}].*[/authenticationendpoint/login.do]*",
+  "identity_mgt.user_self_registration.callback_url": "^${carbon.protocol}:\\/\\/${carbon.host}:${carbon.management.port}.*(?:\\/authenticationendpoint\\/login\\.do)?$",
   "identity_mgt.user_self_registration.enable_resend_confirmation_recaptcha": false,
   "identity_mgt.user_self_registration.auto_login.enable": false,
   "identity_mgt.user_self_registration.auto_login.alias_name": "wso2carbon",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -307,7 +307,7 @@
   "identity_mgt.lite_user_registration.recaptcha.enable": true,
   "identity_mgt.lite_user_registration.verification_email_validity": "1440m",
   "identity_mgt.lite_user_registration.verification_sms_validity": "1m",
-  "identity_mgt.lite_user_registration.callback_url": ".*",
+  "identity_mgt.lite_user_registration.callback_url": "^${carbon.protocol}:\\/\\/${carbon.host}:${carbon.management.port}.*(?:\\/authenticationendpoint\\/login\\.do)?$",
   "identity_mgt.lite_user_registration.resend_verification_on_user_existence":  false,
 
   "identity_mgt.password_reset_challenge_questions.enable_password_reset_challenge_questions": false,


### PR DESCRIPTION
### Proposed changes in this pull request

The default callback urls provided for `user account recovery`, `lite user registration`, `user self registration` features needed are getting updated with proper regex patterns as the previously had regex patterns didn't follow proper regex syntax and resulted in unexpected behaviours in the above flows.

All 3 regex were updated with this regex pattern: `^https:\/\/localhost:9443.*(?:\/authenticationendpoint\/login\.do)?$`

### Related Isuues
- https://github.com/wso2/product-is/issues/15658

### Related PRs
- https://github.com/wso2/product-is/pull/15670