### PR TITLE
Add long wait status

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandler.java
@@ -562,6 +562,7 @@ public class GraphBasedSequenceHandler extends DefaultStepBasedSequenceHandler i
         if (longWaitStatus == null || longWaitStatus.getStatus() == LongWaitStatus.Status.UNKNOWN) {
             //This is a initiation of long wait
             longWaitStatus = new LongWaitStatus();
+            longWaitStatus.setStatus(LongWaitStatus.Status.WAITING);
             int tenantId = IdentityTenantUtil.getTenantId(context.getTenantDomain());
             longWaitStatusStoreService.addWait(tenantId, context.getContextIdentifier(), longWaitStatus);
             isWaiting = callExternalSystem(request, response, context, sequenceConfig, longWaitNode);


### PR DESCRIPTION
### Proposed changes in this pull request

At first wait status is null or Unknown(from the database we derive null status as UNKNOWN).  Its add to DB and cachel [here](https://github.com/wso2/carbon-identity-framework/blob/ccef0c92ba3cdfd5ff9406e16dbc162c0fe2cd53/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandler.java#L566).

Its added to cache and db. In our db we store this status as [binary value](https://github.com/wso2/carbon-identity-framework/blob/9a1b9bc1001401089255b616963f37e3c8e3c597/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/dao/impl/LongWaitStatusDAOImpl.java#L51).

If the status  is WAITING - 1
Else - 0 

ISSUE
So the status always 0 in db/Cache. When FE (longwait.jsp) calls backend to check the status periodically, it checks for the status and if the status is UNKNOWN or Null it [returns](https://github.com/wso2/carbon-identity-framework/blob/3f4c0bba3cf9002d84682d75ab0978453222f0f2/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/servlet/LongWaitStatusServlet.java#L94) as COMPLETED - So at first call from backend returns as completed even if the choreo result is waiting, 

FIX

Rather than modifying the exiting default constructor, we will set the status as WAITING in the handle wait method at initiation,
To fiix this we need to add status as WAITING. This status will be changed only when async sequence executer executes the method [run](https://github.com/wso2/carbon-identity-framework/blob/3f4c0bba3cf9002d84682d75ab0978453222f0f2/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/AsyncSequenceExecutor.java#L134).