### PR TITLE
Add Enable PKCE checkbox in OIDC federated flow

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
@@ -229,6 +229,7 @@ public class IdentityApplicationConstants {
             public static final String IS_BASIC_AUTH_ENABLED = "IsBasicAuthEnabled";
             public static final String QUERY_PARAMS = "commonAuthQueryParams";
             public static final String IS_PKCE_ENABLED = "IsPKCEEnabled";
+            public static final Object IS_PKCE_ENABLED_PARAM_NAME = "oidcPKCEEnabled";
         }
 
         /**

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
@@ -228,6 +228,7 @@ public class IdentityApplicationConstants {
             public static final String IS_USER_ID_IN_CLAIMS = "IsUserIdInClaims";
             public static final String IS_BASIC_AUTH_ENABLED = "IsBasicAuthEnabled";
             public static final String QUERY_PARAMS = "commonAuthQueryParams";
+            public static final String IS_PKCE_ENABLED = "IsPKCEEnabled";
         }
 
         /**

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/java/org/wso2/carbon/idp/mgt/ui/util/IdPManagementUIUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/java/org/wso2/carbon/idp/mgt/ui/util/IdPManagementUIUtil.java
@@ -1415,6 +1415,15 @@ public class IdPManagementUIUtil {
         }
         properties[10] = property;
 
+        property = new Property();
+        property.setName(IdentityApplicationConstants.Authenticator.OIDC.IS_PKCE_ENABLED);
+        if (paramMap.get("oidcPKCEEnabled") != null && "on".equals(paramMap.get("oidcPKCEEnabled"))) {
+            property.setValue("true");
+        } else {
+            property.setValue("false");
+        }
+        properties[10] = property;
+
         oidcAuthnConfig.setProperties(properties);
         FederatedAuthenticatorConfig[] authenticators = fedIdp.getFederatedAuthenticatorConfigs();
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/java/org/wso2/carbon/idp/mgt/ui/util/IdPManagementUIUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/java/org/wso2/carbon/idp/mgt/ui/util/IdPManagementUIUtil.java
@@ -30,6 +30,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.idp.xsd.CertificateInfo;
 import org.wso2.carbon.identity.application.common.model.idp.xsd.Claim;
 import org.wso2.carbon.identity.application.common.model.idp.xsd.ClaimConfig;
@@ -83,6 +84,12 @@ public class IdPManagementUIUtil {
     public static final String PAGE_NUMBER = "pageNumber";
 
     public static final String IDP_LIST_UNIQUE_ID = "idpUniqueIdMap";
+
+    public static final String CHECKBOX_ON = "on";
+
+    public static final String PROPERTY_TRUE = "true";
+
+    public static final String PROPERTY_FALSE = "false";
 
     /**
      * Validates an URI.
@@ -1417,10 +1424,11 @@ public class IdPManagementUIUtil {
 
         property = new Property();
         property.setName(IdentityApplicationConstants.Authenticator.OIDC.IS_PKCE_ENABLED);
-        if (paramMap.get("oidcPKCEEnabled") != null && "on".equals(paramMap.get("oidcPKCEEnabled"))) {
-            property.setValue("true");
-        } else {
-            property.setValue("false");
+        property.setValue(PROPERTY_FALSE);
+        if (paramMap.get(IdentityApplicationConstants.Authenticator.OIDC.IS_PKCE_ENABLED_PARAM_NAME) != null
+                && CHECKBOX_ON.equals(
+                        paramMap.get(IdentityApplicationConstants.Authenticator.OIDC.IS_PKCE_ENABLED_PARAM_NAME))) {
+            property.setValue(PROPERTY_TRUE);
         }
         properties[10] = property;
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/java/org/wso2/carbon/idp/mgt/ui/util/IdPManagementUIUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/java/org/wso2/carbon/idp/mgt/ui/util/IdPManagementUIUtil.java
@@ -30,7 +30,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
-import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.idp.xsd.CertificateInfo;
 import org.wso2.carbon.identity.application.common.model.idp.xsd.Claim;
 import org.wso2.carbon.identity.application.common.model.idp.xsd.ClaimConfig;

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/org/wso2/carbon/idp/mgt/ui/i18n/Resources.properties
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/org/wso2/carbon/idp/mgt/ui/i18n/Resources.properties
@@ -171,6 +171,8 @@ oidc.user.id.location.help=Specifies the location to find the user identifier in
 oidc.enable.basicauth=Enable HTTP basic auth for client authentication
 oidc.enable.basicauth.help=Specifies that HTTP basic authentication should be used for client authentication, else \
   client credentials will be included in the request body
+oidc.enable.pkce=Enable PKCE
+oidc.enable.pkce.help=Specifies that PKCE should be used for client authentication
 passive.sts.config=WS-Federation (Passive) Configuration
 passive.sts.local.config=WS-Federation (Passive) Configuration
 sts.local.config=Security Token Service Configuration

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-oidc.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-oidc.jsp
@@ -43,6 +43,7 @@
     boolean isOIDCEnabled = Boolean.parseBoolean(request.getParameter("isOIDCEnabled"));
     boolean isOIDCDefault = Boolean.parseBoolean(request.getParameter("isOIDCDefault"));
     boolean isOIDCBasicAuthEnabled = false;
+    boolean isOIDCPKCEEnabled = false;
     String clientId = null;
     String clientSecret = null;
     String authzUrl = null;
@@ -132,6 +133,11 @@
                     if (basicAuthEnabledProp != null) {
                         isOIDCBasicAuthEnabled = Boolean.parseBoolean(basicAuthEnabledProp.getValue());
                     }
+                    Property pkceEnabledProp = IdPManagementUIUtil.getProperty(fedAuthnConfig.getProperties(),
+                            OIDC.IS_PKCE_ENABLED);
+                    if (pkceEnabledProp != null) {
+                        isOIDCPKCEEnabled = Boolean.parseBoolean(pkceEnabledProp.getValue());
+                    }
                 }
             }
         }
@@ -184,6 +190,10 @@
     }
     if (scopes == null) {
         scopes = StringUtils.EMPTY;
+    }
+    String oidcPKCEEnabledChecked = StringUtils.EMPTY;
+    if (isOIDCPKCEEnabled) {
+        oidcPKCEEnabledChecked = "checked=\'checked\'";
     }
     if (oidcQueryParam == null) {
         oidcQueryParam = StringUtils.EMPTY;
@@ -375,6 +385,18 @@
                                type="checkbox" <%=oidcBasicAuthEnabledChecked%> />
                         <span style="display:inline-block" class="sectionHelp">
                                     <fmt:message key='oidc.enable.basicauth.help'/>
+                        </span>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td class="leftCol-med labelField"><fmt:message key='oidc.enable.pkce'/>:</td>
+                <td>
+                    <div class="sectionCheckbox">
+                        <input id="oidcPKCEEnabled" name="oidcPKCEEnabled"
+                               type="checkbox" <%=oidcPKCEEnabledChecked%> />
+                        <span style="display:inline-block" class="sectionHelp">
+                                    <fmt:message key='oidc.enable.pkce.help'/>
                         </span>
                     </div>
                 </td>


### PR DESCRIPTION
### Proposed changes in this pull request

This PR introduces a checkbox to enable/disable PKCE in IDP OIDC federated login flow. Upon enabling this checkbox, the relevant `code_verifier` and `code_challenge` values are added to authentication and token requests.

Related to https://github.com/wso2/api-manager/issues/1613

The backend code changes can be found at https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/141.
