### PR TITLE
Fixing InboundConfiguration property export structure

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundAuthenticationRequestConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundAuthenticationRequestConfig.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.common.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
 
@@ -57,8 +58,11 @@ public class InboundAuthenticationRequestConfig implements Serializable {
     @XmlElement(name = "friendlyName")
     private String friendlyName;
 
-    @XmlElement(name = "inboundConfiguration")
+    @JsonIgnore
     private String inboundConfiguration;
+
+    @XmlElement(name = "InboundConfigurationProtocol")
+    private InboundConfigurationProtocol inboundConfigurationProtocol;
 
     @XmlElementWrapper(name = "Properties")
     @XmlElement(name = "Property")
@@ -207,4 +211,15 @@ public class InboundAuthenticationRequestConfig implements Serializable {
 
         this.inboundConfiguration = inboundConfiguration;
     }
+
+    public InboundConfigurationProtocol getInboundConfigurationProtocol() {
+
+        return this.inboundConfigurationProtocol;
+    }
+
+    public void setInboundConfigurationProtocol(InboundConfigurationProtocol inboundConfigurationProtocol) {
+
+        this.inboundConfigurationProtocol = inboundConfigurationProtocol;
+    }
+
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundAuthenticationRequestConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundAuthenticationRequestConfig.java
@@ -59,9 +59,10 @@ public class InboundAuthenticationRequestConfig implements Serializable {
     private String friendlyName;
 
     @JsonIgnore
+    @XmlElement(name = "inboundConfiguration", nillable = true)
     private String inboundConfiguration;
 
-    @XmlElement(name = "InboundConfigurationProtocol")
+    @XmlElement(name = "InboundConfigurationProtocol", nillable = true)
     private InboundConfigurationProtocol inboundConfigurationProtocol;
 
     @XmlElementWrapper(name = "Properties")

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundConfigurationProtocol.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundConfigurationProtocol.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.common.model;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * InboundConfigurationProtocol class is an abstract class
+ * that serves as the parent class for all inbound configurations.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "InboundConfigurationProtocol")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+public abstract class InboundConfigurationProtocol { }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -40,6 +40,8 @@ import org.wso2.carbon.identity.application.common.model.AuthenticationStep;
 import org.wso2.carbon.identity.application.common.model.DefaultAuthenticationSequence;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.ImportResponse;
+import org.wso2.carbon.identity.application.common.model.InboundAuthenticationConfig;
+import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
 import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.PermissionsAndRoleConfig;
@@ -2250,6 +2252,18 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
         try {
             JAXBContext jaxbContext = JAXBContext.newInstance(ServiceProvider.class);
             Marshaller marshaller = jaxbContext.createMarshaller();
+            marshaller.setListener(new Marshaller.Listener() {
+                @Override
+                public void beforeMarshal(Object source) {
+                    if (source instanceof InboundAuthenticationConfig) {
+                        InboundAuthenticationConfig config = (InboundAuthenticationConfig) source;
+                        for (InboundAuthenticationRequestConfig requestConfig
+                                : config.getInboundAuthenticationRequestConfigs()) {
+                            requestConfig.setInboundConfigurationProtocol(null);
+                        }
+                    }
+                }
+            });
             DocumentBuilderFactory docBuilderFactory = IdentityUtil.getSecuredDocumentBuilderFactory();
             Document document = docBuilderFactory.newDocumentBuilder().newDocument();
             marshaller.marshal(serviceProvider, document);

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -93,10 +93,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.lang.reflect.Field;

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -22,6 +22,7 @@ import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.SerializationUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.xerces.impl.Constants;
@@ -1515,7 +1516,7 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
             throws IdentityApplicationManagementException {
 
         ServiceProvider serviceProvider = getApplicationExcludingFileBasedSPs(applicationName, tenantDomain);
-        ServiceProvider serviceProviderCopy = deepCopyServiceProvider(serviceProvider);
+        ServiceProvider serviceProviderCopy = SerializationUtils.clone(serviceProvider);
 
         // Invoking the listeners.
         Collection<ApplicationMgtListener> listeners = getApplicationMgtListeners();
@@ -1526,28 +1527,6 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
         }
 
         return serviceProvider;
-    }
-
-    private ServiceProvider deepCopyServiceProvider(ServiceProvider serviceProvider)
-            throws IdentityApplicationManagementException {
-
-        try {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            ObjectOutputStream out = new ObjectOutputStream(bos);
-            out.writeObject(serviceProvider);
-            out.flush();
-            out.close();
-
-            ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
-            ObjectInputStream in = new ObjectInputStream(bis);
-            ServiceProvider serviceProviderCopy = (ServiceProvider) in.readObject();
-            in.close();
-            return serviceProviderCopy;
-        } catch (IOException | ClassNotFoundException e) {
-            String errorMsg = "Error in deep copying Service Provider " + serviceProvider.getApplicationName() + ".";
-            log.error(errorMsg, e);
-            throw new IdentityApplicationManagementException(errorMsg, e);
-        }
     }
 
     @Override

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -1526,7 +1526,7 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
             }
         }
 
-        return serviceProvider;
+        return serviceProviderCopy;
     }
 
     @Override

--- a/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
@@ -419,8 +419,12 @@
                     <xs:element minOccurs="0" name="inboundAuthType" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="inboundConfigType" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="inboundConfiguration" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="inboundConfigurationProtocol" nillable="true" type="ax2169:InboundConfigurationProtocol"/>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2169:Property"/>
                 </xs:sequence>
+            </xs:complexType>
+            <xs:complexType abstract="true" name="InboundConfigurationProtocol">
+                <xs:sequence/>
             </xs:complexType>
             <xs:complexType name="Property">
                 <xs:sequence>


### PR DESCRIPTION
## Purpose
Related to https://github.com/wso2/product-is/issues/15683

This PR resolves the issue of inboundConfiguration property being exported as an XML string instead of being broken down into properties when exporting service providers through the API.

## Goals
When exporting service providers through the API, the "inboundConfiguration" property is exported broken down into individual properties.

## Approach
inboundConfigurationProtocol abstract class property is added and inboundConfiguration is ignored during serialization. samlssoServiceProviderDTO, oAuthAppDO classes are updated to extend the new inboundConfigurationProtocol class.

## Related PRs
https://github.com/wso2/identity-api-server/pull/437
https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/391
https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2047