### PR TITLE
Fix templateId Property Duplicating Issue

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -2230,7 +2230,10 @@ public class IdPManagementDAO {
     private void addTemplateIdProperty(List<IdentityProviderProperty> identityProviderProperties,
                                                            IdentityProvider identityProvider) {
 
-        if (StringUtils.isNotBlank(identityProvider.getTemplateId())) {
+        boolean containsTemplateIdProperty = identityProviderProperties.stream().anyMatch(identityProviderProperty ->
+                TEMPLATE_ID_IDP_PROPERTY_NAME.equals(identityProviderProperty.getName()));
+
+        if (StringUtils.isNotBlank(identityProvider.getTemplateId()) && !containsTemplateIdProperty) {
             IdentityProviderProperty templateIdProperty = new IdentityProviderProperty();
             templateIdProperty.setName(TEMPLATE_ID_IDP_PROPERTY_NAME);
             templateIdProperty.setDisplayName(TEMPLATE_ID_IDP_PROPERTY_DISPLAY_NAME);


### PR DESCRIPTION
When adding a new IDP using the rest api, if the identity provider object contains a value for both templateId primary field and templateId property inside idpProperties, the `addTemplateIdProperty` will add the templateId as another property to idpProperties resulting in duplicated properties for templateId. This will cause a primary key violation issue when adding the idp properties to the DB. 
This PR adds the logic to check whether templateId property already exists in idp properties and only add it if it doesn't.