### PR TITLE
Override doOptions method to remove TRACE header

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/servlet/CommonAuthenticationServlet.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/servlet/CommonAuthenticationServlet.java
@@ -56,4 +56,10 @@ public class CommonAuthenticationServlet extends HttpServlet {
         }
         FrameworkUtils.getRequestCoordinator().handle(request, response);
     }
+
+    @Override
+    protected void doOptions(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        resp.setHeader("Allow", "GET, POST, HEAD, OPTIONS");
+    }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
Override doOptions method to remove TRACE header as TRACE is allowed by default in HttpServlet.doOptions method [1].

[1] https://github.com/javaee/servlet-spec/blob/d3d0f3ba4dc9256122f01ebdd4be4fae2a586df3/src/main/java/javax/servlet/http/HttpServlet.java#L491