### PR TITLE
Fix syntax error in OAuthCallbackHandlers config

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -496,7 +496,7 @@
 
         <OAuthCallbackHandlers>
            {% for callback_handler in oauth.extensions.callback_handlers %}
-              <OAuthCallbackHandler Class="{{callback_handler.class}}">
+              <OAuthCallbackHandler class="{{callback_handler.class}}">
                 {% if callback_handler.priority is defined %}
                     <Priority>{{callback_handler.priority}}</Priority>
                 {% endif %}


### PR DESCRIPTION
## Purpose
Change OAUthCallbackHandlers in configuration identity.xml.j2 file to fix syntax issues.

## Related issue

- https://github.com/wso2/product-is/issues/15676

## Related PR 
- https://github.com/wso2/carbon-identity-framework/pull/4506