### PR TITLE
Add new methods to get External Workflow Identifier and Template id from Workflow Id

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/pom.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>application-mgt</artifactId>

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/pom.xml
@@ -14,8 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.wso2.carbon.identity.framework</groupId>
         <artifactId>application-mgt</artifactId>

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementService.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementService.java
@@ -99,7 +99,7 @@ public interface WorkflowManagementService {
      * Get External workflow Identifier from workflow ID.
      *
      * @param workflowId workflow ID retrieve from workflow request
-     * @return Template ID
+     * @return WorkflowIdentifier which deployed in remotely
      * @throws WorkflowException
      */
     String getExternalWorkflowId(String workflowId) throws WorkflowException;
@@ -156,7 +156,6 @@ public interface WorkflowManagementService {
      * @param tenantId  Tenant ID
      * @return
      * @throws WorkflowException
-     * @deprecated Use {@link #listPaginatedWorkflows(int, int, int, String)} instead.
      */
     @Deprecated
     List<Workflow> listWorkflows(int tenantId) throws WorkflowException;
@@ -231,7 +230,6 @@ public interface WorkflowManagementService {
      * @param tenantId  Tenant ID
      * @return
      * @throws WorkflowException
-     * @deprecated Use {@link #listPaginatedAssociations(int, int, int, String)} instead.
      */
     @Deprecated
     List<Association> listAllAssociations(int tenantId) throws WorkflowException;

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementService.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementService.java
@@ -96,20 +96,13 @@ public interface WorkflowManagementService {
                      List<Parameter> parameterList, int tenantId) throws WorkflowException;
 
     /**
-     *Get Template ID from workflow Id
+     * Get External workflow Identifier from workflow ID.
+     *
      * @param workflowId workflow ID retrieve from workflow request
      * @return Template ID
      * @throws WorkflowException
      */
-    String getTemplateId(String workflowId) throws  WorkflowException;
-
-    /**
-     * Get external Workflow Identifier (Workflow Deploy ID)
-     * @param workflowId workflow ID retrieve from workflow request
-     * @return External Workflow Identifier
-     * @throws WorkflowException
-     */
-    String getExternalWorkflowId(String workflowId) throws  WorkflowException;
+    String getExternalWorkflowId(String workflowId) throws WorkflowException;
 
     /**
      * Retrieve workflow from workflow ID
@@ -163,6 +156,7 @@ public interface WorkflowManagementService {
      * @param tenantId  Tenant ID
      * @return
      * @throws WorkflowException
+     * @deprecated Use {@link #listPaginatedWorkflows(int, int, int, String)} instead.
      */
     @Deprecated
     List<Workflow> listWorkflows(int tenantId) throws WorkflowException;
@@ -237,6 +231,7 @@ public interface WorkflowManagementService {
      * @param tenantId  Tenant ID
      * @return
      * @throws WorkflowException
+     * @deprecated Use {@link #listPaginatedAssociations(int, int, int, String)} instead.
      */
     @Deprecated
     List<Association> listAllAssociations(int tenantId) throws WorkflowException;

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementService.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementService.java
@@ -95,8 +95,20 @@ public interface WorkflowManagementService {
     void addWorkflow(Workflow workflowDTO,
                      List<Parameter> parameterList, int tenantId) throws WorkflowException;
 
+    /**
+     *Get Template ID from workflow Id
+     * @param workflowId workflow ID retrieve from workflow request
+     * @return Template ID
+     * @throws WorkflowException
+     */
     String getTemplateId(String workflowId) throws  WorkflowException;
 
+    /**
+     * Get external Workflow Identifier (Workflow Deploy ID)
+     * @param workflowId workflow ID retrieve from workflow request
+     * @return External Workflow Identifier
+     * @throws WorkflowException
+     */
     String getExternalWorkflowId(String workflowId) throws  WorkflowException;
 
     /**

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementService.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementService.java
@@ -30,7 +30,7 @@ import org.wso2.carbon.identity.workflow.mgt.exception.WorkflowException;
 
 import java.util.Collections;
 import java.util.List;
-
+import java.util.SimpleTimeZone;
 
 public interface WorkflowManagementService {
 
@@ -95,6 +95,11 @@ public interface WorkflowManagementService {
      */
     void addWorkflow(Workflow workflowDTO,
                      List<Parameter> parameterList, int tenantId) throws WorkflowException;
+    String getWorkflowName(String requestId) throws WorkflowException;
+
+    String getTemplateId(String workflowId) throws  WorkflowException;
+
+    String getExternalWorkflowId(String workflowId) throws  WorkflowException;
 
     /**
      * Retrieve workflow from workflow ID

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementService.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementService.java
@@ -30,7 +30,6 @@ import org.wso2.carbon.identity.workflow.mgt.exception.WorkflowException;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.SimpleTimeZone;
 
 public interface WorkflowManagementService {
 
@@ -95,7 +94,6 @@ public interface WorkflowManagementService {
      */
     void addWorkflow(Workflow workflowDTO,
                      List<Parameter> parameterList, int tenantId) throws WorkflowException;
-    String getWorkflowName(String requestId) throws WorkflowException;
 
     String getTemplateId(String workflowId) throws  WorkflowException;
 

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementServiceImpl.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementServiceImpl.java
@@ -73,7 +73,7 @@ public class WorkflowManagementServiceImpl implements WorkflowManagementService 
     WorkflowDAO workflowDAO = new WorkflowDAO();
     AssociationDAO associationDAO = new AssociationDAO();
     private RequestEntityRelationshipDAO requestEntityRelationshipDAO = new RequestEntityRelationshipDAO();
-    WorkflowRequestDAO workflowRequestDAO = new WorkflowRequestDAO();
+    private WorkflowRequestDAO workflowRequestDAO = new WorkflowRequestDAO();
     private WorkflowRequestAssociationDAO workflowRequestAssociationDAO = new WorkflowRequestAssociationDAO();
 
 
@@ -384,13 +384,7 @@ public class WorkflowManagementServiceImpl implements WorkflowManagementService 
     }
 
     @Override
-    public String getTemplateId(String workflowId) throws WorkflowException {
-
-        return workflowRequestDAO.retrieveTemplateId(workflowId);
-    }
-
-    @Override
-    public String getExternalWorkflowId(String workflowId) throws WorkflowException{
+    public String getExternalWorkflowId(String workflowId) throws WorkflowException {
 
         return workflowRequestDAO.retrieveExternalWorkflowId(workflowId);
     }

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementServiceImpl.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementServiceImpl.java
@@ -73,7 +73,7 @@ public class WorkflowManagementServiceImpl implements WorkflowManagementService 
     WorkflowDAO workflowDAO = new WorkflowDAO();
     AssociationDAO associationDAO = new AssociationDAO();
     private RequestEntityRelationshipDAO requestEntityRelationshipDAO = new RequestEntityRelationshipDAO();
-    private WorkflowRequestDAO workflowRequestDAO = new WorkflowRequestDAO();
+    WorkflowRequestDAO workflowRequestDAO = new WorkflowRequestDAO();
     private WorkflowRequestAssociationDAO workflowRequestAssociationDAO = new WorkflowRequestAssociationDAO();
 
 
@@ -385,10 +385,14 @@ public class WorkflowManagementServiceImpl implements WorkflowManagementService 
 
     @Override
     public String getTemplateId(String workflowId) throws WorkflowException {
-        return WorkflowRequestDAO.retrieveTemplateId(workflowId);
+
+        return workflowRequestDAO.retrieveTemplateId(workflowId);
     }
+
+    @Override
     public String getExternalWorkflowId(String workflowId) throws WorkflowException{
-        return WorkflowRequestDAO.retrieveExternalWorkflowId(workflowId);
+
+        return workflowRequestDAO.retrieveExternalWorkflowId(workflowId);
     }
 
     @Override

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementServiceImpl.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementServiceImpl.java
@@ -384,6 +384,20 @@ public class WorkflowManagementServiceImpl implements WorkflowManagementService 
     }
 
     @Override
+    public String getWorkflowName(String requestId) throws WorkflowException {
+
+        return workflowRequestDAO.retrieveWorkflowName(requestId);
+    }
+
+    @Override
+    public String getTemplateId(String workflowId) throws WorkflowException {
+        return WorkflowRequestDAO.retrieveTemplateId(workflowId);
+    }
+    public String getExternalWorkflowId(String workflowId) throws WorkflowException{
+        return workflowRequestDAO.retrieveExternalWorkflowId(workflowId);
+    }
+
+    @Override
     public void addAssociation(String associationName, String workflowId, String eventId, String condition) throws
             WorkflowException {
 

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementServiceImpl.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementServiceImpl.java
@@ -384,17 +384,11 @@ public class WorkflowManagementServiceImpl implements WorkflowManagementService 
     }
 
     @Override
-    public String getWorkflowName(String requestId) throws WorkflowException {
-
-        return workflowRequestDAO.retrieveWorkflowName(requestId);
-    }
-
-    @Override
     public String getTemplateId(String workflowId) throws WorkflowException {
         return WorkflowRequestDAO.retrieveTemplateId(workflowId);
     }
     public String getExternalWorkflowId(String workflowId) throws WorkflowException{
-        return workflowRequestDAO.retrieveExternalWorkflowId(workflowId);
+        return WorkflowRequestDAO.retrieveExternalWorkflowId(workflowId);
     }
 
     @Override

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementServiceImpl.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/WorkflowManagementServiceImpl.java
@@ -386,7 +386,9 @@ public class WorkflowManagementServiceImpl implements WorkflowManagementService 
     @Override
     public String getExternalWorkflowId(String workflowId) throws WorkflowException {
 
-        return workflowRequestDAO.retrieveExternalWorkflowId(workflowId);
+        return workflowRequestDAO.retrieveExternalWorkflowId(workflowId)
+                .orElseThrow(() -> new InternalWorkflowException(String.format("External workflow identifier " +
+                        "not found for the workflow id: %s",workflowId)));
     }
 
     @Override

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/dao/WorkflowRequestDAO.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/dao/WorkflowRequestDAO.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.identity.workflow.mgt.dto.WorkflowRequest;
 import org.wso2.carbon.identity.workflow.mgt.exception.InternalWorkflowException;
 import org.wso2.carbon.identity.workflow.mgt.exception.WorkflowException;
 import org.wso2.carbon.identity.workflow.mgt.util.SQLConstants;
+import org.wso2.carbon.identity.workflow.mgt.util.WFConstant;
 import org.wso2.carbon.identity.workflow.mgt.util.WorkflowRequestStatus;
 
 import java.io.ByteArrayInputStream;
@@ -38,6 +39,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+
+import static org.wso2.carbon.identity.workflow.mgt.util.SQLConstants.EXTERNAL_WORKFLOW_IDENTIFIER;
 
 public class WorkflowRequestDAO {
 
@@ -130,7 +133,7 @@ public class WorkflowRequestDAO {
      * Retrieve the External Workflow Identifier from Workflow ID.
      *
      * @param workflowId workflow ID retrieve from workflow request
-     * @return External Workflow Identifier
+     * @return External Workflow Identifier that is generated when a workflow is deployed externally
      * @throws InternalWorkflowException
      */
     public String retrieveExternalWorkflowId(String workflowId) throws InternalWorkflowException {
@@ -143,12 +146,13 @@ public class WorkflowRequestDAO {
         try {
             prepStmt = connection.prepareStatement(query);
             prepStmt.setString(1, workflowId);
+            prepStmt.setString(2,EXTERNAL_WORKFLOW_IDENTIFIER);
             rs = prepStmt.executeQuery();
             if (rs.next()) {
                 return rs.getString(SQLConstants.PARAM_VALUE_COLUMN);
             }
         } catch (SQLException e) {
-            throw new InternalWorkflowException("Error when executing the sql query:" + query, e);
+             throw new InternalWorkflowException(WFConstant.Exceptions.SQL_ERROR_GETTING_EXTERNAL_WORKFLOW_IDENTIFIER, e);
 
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, null, prepStmt);
@@ -157,37 +161,6 @@ public class WorkflowRequestDAO {
 
     }
 
-    /**
-     * Retrieve the Template ID from Request ID.
-     *
-     * @param workflowID workflow ID retrieve from workflow request
-     * @return Return the Template id
-     * @throws InternalWorkflowException
-     */
-    public String retrieveTemplateId(String workflowID) throws InternalWorkflowException {
-
-        Connection connection = IdentityDatabaseUtil.getDBConnection(false);
-        PreparedStatement prepStmt = null;
-        ResultSet rs = null;
-
-        String query = SQLConstants.GET_TEMPLATE_ID_QUERY;
-        try {
-            prepStmt = connection.prepareStatement(query);
-            prepStmt.setString(1, workflowID);
-            rs = prepStmt.executeQuery();
-            if (rs.next()) {
-                return rs.getString(SQLConstants.TEMPLATE_ID_COLUMN);
-            }
-        } catch (SQLException e) {
-
-            throw new InternalWorkflowException("Error when executing the sql query:" + query, e);
-
-        } finally {
-            IdentityDatabaseUtil.closeAllConnections(connection, null, prepStmt);
-        }
-        return null;
-
-    }
     /**
      * Get status of a request.
      *

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/dao/WorkflowRequestDAO.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/dao/WorkflowRequestDAO.java
@@ -125,7 +125,80 @@ public class WorkflowRequestDAO {
         }
         return null;
     }
+    public String retrieveWorkflowName(String subject) throws InternalWorkflowException {
 
+        Connection connection = IdentityDatabaseUtil.getDBConnection(false);
+        PreparedStatement prepStmt = null;
+        ResultSet rs = null;
+
+        String query = SQLConstants.GET_WORKFLOW_ID_QUERY;
+        try {
+            prepStmt = connection.prepareStatement(query);
+            prepStmt.setString(1, subject);
+            log.info("request id:" +subject+"-------------");
+            rs = prepStmt.executeQuery();
+            if (rs.next()) {
+                return rs.getString(SQLConstants.WORKFLOWID_COLUMN);
+            }
+        } catch (SQLException e) {
+
+            throw new InternalWorkflowException("Error when executing the sql query:" + query, e);
+
+        } finally {
+            IdentityDatabaseUtil.closeAllConnections(connection, null, prepStmt);
+        }
+        return null;
+
+    }
+    public static String retrieveExternalWorkflowId(String workflowId) throws InternalWorkflowException {
+
+        Connection connection = IdentityDatabaseUtil.getDBConnection(false);
+        PreparedStatement prepStmt = null;
+        ResultSet rs = null;
+
+        String query = SQLConstants.GET_WORKFLOW_ID_QUERY;
+        try {
+            prepStmt = connection.prepareStatement(query);
+            prepStmt.setString(1, workflowId);
+            rs = prepStmt.executeQuery();
+            if (rs.next()) {
+                return rs.getString(SQLConstants.WORKFLOWID_COLUMN);
+            }
+        } catch (SQLException e) {
+
+            throw new InternalWorkflowException("Error when executing the sql query:" + query, e);
+
+        } finally {
+            IdentityDatabaseUtil.closeAllConnections(connection, null, prepStmt);
+        }
+        return null;
+
+    }
+    public static String retrieveTemplateId(String workflowID) throws InternalWorkflowException {
+
+        Connection connection = IdentityDatabaseUtil.getDBConnection(false);
+        PreparedStatement prepStmt = null;
+        ResultSet rs = null;
+
+        String query = SQLConstants.GET_TEMPLATE_ID_QUERY;
+        try {
+            prepStmt = connection.prepareStatement(query);
+            prepStmt.setString(1, workflowID);
+            log.info("request id:" +workflowID+"-------------");
+            rs = prepStmt.executeQuery();
+            if (rs.next()) {
+                return rs.getString(SQLConstants.TEMPLATEID_COLUMN);
+            }
+        } catch (SQLException e) {
+
+            throw new InternalWorkflowException("Error when executing the sql query:" + query, e);
+
+        } finally {
+            IdentityDatabaseUtil.closeAllConnections(connection, null, prepStmt);
+        }
+        return null;
+
+    }
     /**
      * Get status of a request.
      *

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/dao/WorkflowRequestDAO.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/dao/WorkflowRequestDAO.java
@@ -125,31 +125,7 @@ public class WorkflowRequestDAO {
         }
         return null;
     }
-    public String retrieveWorkflowName(String subject) throws InternalWorkflowException {
 
-        Connection connection = IdentityDatabaseUtil.getDBConnection(false);
-        PreparedStatement prepStmt = null;
-        ResultSet rs = null;
-
-        String query = SQLConstants.GET_WORKFLOW_ID_QUERY;
-        try {
-            prepStmt = connection.prepareStatement(query);
-            prepStmt.setString(1, subject);
-            log.info("request id:" +subject+"-------------");
-            rs = prepStmt.executeQuery();
-            if (rs.next()) {
-                return rs.getString(SQLConstants.WORKFLOWID_COLUMN);
-            }
-        } catch (SQLException e) {
-
-            throw new InternalWorkflowException("Error when executing the sql query:" + query, e);
-
-        } finally {
-            IdentityDatabaseUtil.closeAllConnections(connection, null, prepStmt);
-        }
-        return null;
-
-    }
     public static String retrieveExternalWorkflowId(String workflowId) throws InternalWorkflowException {
 
         Connection connection = IdentityDatabaseUtil.getDBConnection(false);
@@ -184,7 +160,6 @@ public class WorkflowRequestDAO {
         try {
             prepStmt = connection.prepareStatement(query);
             prepStmt.setString(1, workflowID);
-            log.info("request id:" +workflowID+"-------------");
             rs = prepStmt.executeQuery();
             if (rs.next()) {
                 return rs.getString(SQLConstants.TEMPLATEID_COLUMN);

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/dao/WorkflowRequestDAO.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/dao/WorkflowRequestDAO.java
@@ -39,6 +39,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Optional;
 
 import static org.wso2.carbon.identity.workflow.mgt.util.SQLConstants.EXTERNAL_WORKFLOW_IDENTIFIER;
 
@@ -136,8 +137,9 @@ public class WorkflowRequestDAO {
      * @return External Workflow Identifier that is generated when a workflow is deployed externally
      * @throws InternalWorkflowException
      */
-    public String retrieveExternalWorkflowId(String workflowId) throws InternalWorkflowException {
+    public Optional<String> retrieveExternalWorkflowId(String workflowId) throws InternalWorkflowException {
 
+        String externalWorkflowID = null;
         Connection connection = IdentityDatabaseUtil.getDBConnection(false);
         PreparedStatement prepStmt = null;
         ResultSet rs = null;
@@ -149,7 +151,7 @@ public class WorkflowRequestDAO {
             prepStmt.setString(2,EXTERNAL_WORKFLOW_IDENTIFIER);
             rs = prepStmt.executeQuery();
             if (rs.next()) {
-                return rs.getString(SQLConstants.PARAM_VALUE_COLUMN);
+                externalWorkflowID = rs.getString(SQLConstants.PARAM_VALUE_COLUMN);
             }
         } catch (SQLException e) {
              throw new InternalWorkflowException(WFConstant.Exceptions.SQL_ERROR_GETTING_EXTERNAL_WORKFLOW_IDENTIFIER, e);
@@ -157,8 +159,7 @@ public class WorkflowRequestDAO {
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, null, prepStmt);
         }
-        return null;
-
+        return Optional.ofNullable(externalWorkflowID);
     }
 
     /**

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/dao/WorkflowRequestDAO.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/dao/WorkflowRequestDAO.java
@@ -126,7 +126,14 @@ public class WorkflowRequestDAO {
         return null;
     }
 
-    public static String retrieveExternalWorkflowId(String workflowId) throws InternalWorkflowException {
+    /**
+     * Retrieve the External Workflow Identifier from Workflow ID.
+     *
+     * @param workflowId workflow ID retrieve from workflow request
+     * @return External Workflow Identifier
+     * @throws InternalWorkflowException
+     */
+    public String retrieveExternalWorkflowId(String workflowId) throws InternalWorkflowException {
 
         Connection connection = IdentityDatabaseUtil.getDBConnection(false);
         PreparedStatement prepStmt = null;
@@ -138,10 +145,9 @@ public class WorkflowRequestDAO {
             prepStmt.setString(1, workflowId);
             rs = prepStmt.executeQuery();
             if (rs.next()) {
-                return rs.getString(SQLConstants.WORKFLOWID_COLUMN);
+                return rs.getString(SQLConstants.PARAM_VALUE_COLUMN);
             }
         } catch (SQLException e) {
-
             throw new InternalWorkflowException("Error when executing the sql query:" + query, e);
 
         } finally {
@@ -150,7 +156,15 @@ public class WorkflowRequestDAO {
         return null;
 
     }
-    public static String retrieveTemplateId(String workflowID) throws InternalWorkflowException {
+
+    /**
+     * Retrieve the Template ID from Request ID.
+     *
+     * @param workflowID workflow ID retrieve from workflow request
+     * @return Return the Template id
+     * @throws InternalWorkflowException
+     */
+    public String retrieveTemplateId(String workflowID) throws InternalWorkflowException {
 
         Connection connection = IdentityDatabaseUtil.getDBConnection(false);
         PreparedStatement prepStmt = null;
@@ -162,7 +176,7 @@ public class WorkflowRequestDAO {
             prepStmt.setString(1, workflowID);
             rs = prepStmt.executeQuery();
             if (rs.next()) {
-                return rs.getString(SQLConstants.TEMPLATEID_COLUMN);
+                return rs.getString(SQLConstants.TEMPLATE_ID_COLUMN);
             }
         } catch (SQLException e) {
 

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/util/SQLConstants.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/util/SQLConstants.java
@@ -56,14 +56,14 @@ public class SQLConstants {
     public static final String REQUEST_STATUS_COLUMN = "STATUS";
     public static final String REQUEST_ID_COLUMN = "REQUEST_ID";
     public static final String CREATED_BY_COLUMN = "CREATED_BY";
-
+    public static final String EXTERNAL_WORKFLOW_IDENTIFIER = "ExternalWorkflowIdentifier";
     public static final String ADD_WORKFLOW_REQUEST_QUERY = "INSERT INTO WF_REQUEST(UUID, CREATED_BY, OPERATION_TYPE," +
             " CREATED_AT, UPDATED_AT, REQUEST, STATUS, TENANT_ID) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
 
     public static final String GET_WORKFLOW_REQUEST_QUERY = "SELECT UUID, REQUEST, STATUS, CREATED_BY FROM WF_REQUEST" +
             " WHERE UUID = ?";
     public static final String GET_WORKFLOW_ID_QUERY = "SELECT PARAM_VALUE FROM WF_WORKFLOW_CONFIG_PARAM WHERE " +
-            "WORKFLOW_ID  = ? AND PARAM_NAME = 'ExternalWorkflowIdentifier'";
+            "WORKFLOW_ID  = ? AND PARAM_NAME = ? ";
     public static final String GET_TEMPLATE_ID_QUERY = "SELECT TEMPLATE_ID FROM WF_WORKFLOW WHERE ID = ? ";
     public static final String UPDATE_STATUS_OF_REQUEST = "UPDATE WF_REQUEST SET STATUS = ? , UPDATED_AT = ? WHERE " +
             "UUID = ?";

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/util/SQLConstants.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/util/SQLConstants.java
@@ -57,18 +57,14 @@ public class SQLConstants {
     public static final String REQUEST_ID_COLUMN = "REQUEST_ID";
     public static final String CREATED_BY_COLUMN = "CREATED_BY";
 
-    public static  final String WORKFLOWID_COLUMN = "PARAM_VALUE";
-    public static final String TEMPLATEID_COLUMN = "TEMPLATE_ID";
-
     public static final String ADD_WORKFLOW_REQUEST_QUERY = "INSERT INTO WF_REQUEST(UUID, CREATED_BY, OPERATION_TYPE," +
             " CREATED_AT, UPDATED_AT, REQUEST, STATUS, TENANT_ID) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
 
     public static final String GET_WORKFLOW_REQUEST_QUERY = "SELECT UUID, REQUEST, STATUS, CREATED_BY FROM WF_REQUEST" +
             " WHERE UUID = ?";
     public static final String GET_WORKFLOW_ID_QUERY = "SELECT PARAM_VALUE FROM WF_WORKFLOW_CONFIG_PARAM WHERE " +
-            "WORKFLOW_ID  = ?" +
-            " AND PARAM_NAME ='ExternalWorkflowIdentifier'";
-    public static final String GET_TEMPLATE_ID_QUERY="SELECT TEMPLATE_ID FROM WF_WORKFLOW WHERE ID=? ";
+            "WORKFLOW_ID  = ? AND PARAM_NAME = 'ExternalWorkflowIdentifier'";
+    public static final String GET_TEMPLATE_ID_QUERY = "SELECT TEMPLATE_ID FROM WF_WORKFLOW WHERE ID = ? ";
     public static final String UPDATE_STATUS_OF_REQUEST = "UPDATE WF_REQUEST SET STATUS = ? , UPDATED_AT = ? WHERE " +
             "UUID = ?";
 

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/util/SQLConstants.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/util/SQLConstants.java
@@ -57,13 +57,18 @@ public class SQLConstants {
     public static final String REQUEST_ID_COLUMN = "REQUEST_ID";
     public static final String CREATED_BY_COLUMN = "CREATED_BY";
 
+    public static  final String WORKFLOWID_COLUMN = "PARAM_VALUE";
+    public static final String TEMPLATEID_COLUMN = "TEMPLATE_ID";
 
     public static final String ADD_WORKFLOW_REQUEST_QUERY = "INSERT INTO WF_REQUEST(UUID, CREATED_BY, OPERATION_TYPE," +
             " CREATED_AT, UPDATED_AT, REQUEST, STATUS, TENANT_ID) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
 
     public static final String GET_WORKFLOW_REQUEST_QUERY = "SELECT UUID, REQUEST, STATUS, CREATED_BY FROM WF_REQUEST" +
             " WHERE UUID = ?";
-
+    public static final String GET_WORKFLOW_ID_QUERY = "SELECT PARAM_VALUE FROM WF_WORKFLOW_CONFIG_PARAM WHERE " +
+            "WORKFLOW_ID  = ?" +
+            " AND PARAM_NAME ='ExternalWorkflowIdentifier'";
+    public static final String GET_TEMPLATE_ID_QUERY="SELECT TEMPLATE_ID FROM WF_WORKFLOW WHERE ID=? ";
     public static final String UPDATE_STATUS_OF_REQUEST = "UPDATE WF_REQUEST SET STATUS = ? , UPDATED_AT = ? WHERE " +
             "UUID = ?";
 

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/util/WFConstant.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/util/WFConstant.java
@@ -85,6 +85,8 @@ public class WFConstant {
         public static final String SQL_ERROR_LISTING_WORKFLOWS =  "SQL error when getting workflows from DB";
         public static final String ERROR_GETTING_WORKFLOW_COUNT =  "Server error while getting workflows count for the tenantId: ";
         public static final String SQL_ERROR_GETTING_WORKFLOW_COUNT =  "SQL error when getting workflows count.";
+        public static final String SQL_ERROR_GETTING_EXTERNAL_WORKFLOW_IDENTIFIER = "SQL error when getting external" +
+                " workflow  identifier";
 
         public static final String ERROR_INVALID_LIMIT = "Invalid limit requested. The limit should "
                 + "be a value greater than 0.";


### PR DESCRIPTION
## Implement a method to retrieve External Workflow Id  

The getExternalWorkflowId function retrieves the external workflow identifier associated with a given workflow id. This unique identifier corresponds to the deployed workflow id in an external BPS engine.

For an example external workflow identifier of  a workflow deployed in Camunda :

![image](https://user-images.githubusercontent.com/62257561/235153595-7589f068-6808-4e0f-b99b-3ac06117c1ad.png)




