### PR TITLE
Change the template-wf-wizard.jsp file to skip the validation of the newly added workflow  mediator  template  form

### DIFF
--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/template-wf-wizard.jsp
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/template-wf-wizard.jsp
@@ -239,7 +239,14 @@
 
         var stepOrder = 0;
         function nextWizard(){
-            if(!validateInputs()){
+        <%
+        boolean intTemp = true;
+        if(template !=null && template.getName().equals("External Workflow Template")){
+            intTemp = false;
+        }
+        %>
+            var abc = "<%=intTemp%>";
+            if(abc != "false" && !validateInputs()){
                 alert("Required fields are missing");
                 return ;
             }

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/template-wf-wizard.jsp
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/template-wf-wizard.jsp
@@ -246,6 +246,7 @@
         }
         %>
             var mediatorTemplate = "<%=mediatorTemplate%>";
+            // validation logic not compatible with the mediatorTemplate.
             if(mediatorTemplate != "true" && !validateInputs()){
                 alert("Required fields are missing");
                 return ;

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/template-wf-wizard.jsp
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/template-wf-wizard.jsp
@@ -241,12 +241,12 @@
         function nextWizard(){
         <%
         boolean intTemp = true;
-        if(template !=null && template.getName().equals("External Workflow Template")){
+        if(template !=null && template.getName().equals("Workflow Mediator")){
             intTemp = false;
         }
         %>
-            var abc = "<%=intTemp%>";
-            if(abc != "false" && !validateInputs()){
+            var tempStatus = "<%=intTemp%>";
+            if(tempStatus != "false" && !validateInputs()){
                 alert("Required fields are missing");
                 return ;
             }

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/template-wf-wizard.jsp
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/src/main/resources/web/workflow-mgt/template-wf-wizard.jsp
@@ -240,13 +240,13 @@
         var stepOrder = 0;
         function nextWizard(){
         <%
-        boolean intTemp = true;
+        boolean mediatorTemplate = false;
         if(template !=null && template.getName().equals("Workflow Mediator")){
-            intTemp = false;
+            mediatorTemplate = true;
         }
         %>
-            var tempStatus = "<%=intTemp%>";
-            if(tempStatus != "false" && !validateInputs()){
+            var mediatorTemplate = "<%=mediatorTemplate%>";
+            if(mediatorTemplate != "true" && !validateInputs()){
                 alert("Required fields are missing");
                 return ;
             }


### PR DESCRIPTION
WSO2 currently utilizes a multi-step approval template for managing workflow processes. With the introduction of a new workflow mediator template, we aim to skip the complex validation process only when the new template is selected.







