### PR TITLE
Change action trigger of workflow sync-with-master

### DIFF
--- a/.github/workflows/sync-with-master.yml
+++ b/.github/workflows/sync-with-master.yml
@@ -2,7 +2,9 @@
 name: Sync PR from master
 
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - master
 


### PR DESCRIPTION
Run the action only when a PR merges