### PR TITLE
Revert "Fix syntax error in OAuthCallbackHandlers config"

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -496,7 +496,7 @@
 
         <OAuthCallbackHandlers>
            {% for callback_handler in oauth.extensions.callback_handlers %}
-              <OAuthCallbackHandler class="{{callback_handler.class}}">
+              <OAuthCallbackHandler Class="{{callback_handler.class}}">
                 {% if callback_handler.priority is defined %}
                     <Priority>{{callback_handler.priority}}</Priority>
                 {% endif %}


### PR DESCRIPTION
# Purpose
Reverts wso2/carbon-identity-framework#4517

# Reason
The change was done to match the documentation[1]. However, the implementation reads the class attribute with a capital 'C'. 

[1] https://is.docs.wso2.com/en/5.11.0/learn/extension-points-for-oauth/#oauth-callback-handler