### PR TITLE
Add claim management configs to identity.xml.j2

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3285,4 +3285,11 @@
         {% endfor %}
     </OrganizationLevelEmailBrandingFallbacks>
 
+    <!-- Claim Management Configuration. -->
+    {% if claim_mgt.bind_to_primary_userstore is defined %}
+    <ClaimManagement>
+        <BindToPrimaryUserStore>{{claim_mgt.bind_to_primary_userstore}}</BindToPrimaryUserStore>
+    </ClaimManagement>
+    {% endif %}
+
 </Server>


### PR DESCRIPTION
## Proposed changes in this pull request
$subject

### Related PR(s)
* https://github.com/wso2/identity-api-server/pull/440

*** Note
Once this is merged, we can enable the config to store local claims only in the Primary user store by adding the below config in `deployment.toml`
```
[claim_mgt]
bind_to_primary_userstore="true"
```