### PR TITLE
Add fed IDP_ID column to IDN_FED_AUTH_SESSION_MAPPING table

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -665,7 +665,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
 
         UserSessionStore userSessionStore = UserSessionStore.getInstance();
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-        if (!userSessionStore.hasExistingFederatedAuthSession(authHistory.getIdpSessionIndex(), tenantId)) {
+        if (!userSessionStore.isExistingFederatedAuthSessionAvailable(authHistory.getIdpSessionIndex(), tenantId)) {
             userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory, tenantId);
         } else {
             if (log.isDebugEnabled()) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -653,8 +653,8 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory);
         } else {
             if (log.isDebugEnabled()) {
-                log.debug(String.format("Federated auth session with the id: %s already " +
-                        "exists.", authHistory.getIdpSessionIndex()));
+                log.debug("Federated auth session with the id: "+ authHistory.getIdpSessionIndex() +" already " +
+                        "exists.");
             }
             userSessionStore.updateFederatedAuthSessionInfo(sessionContextKey, authHistory);
         }
@@ -669,8 +669,8 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory, tenantId);
         } else {
             if (log.isDebugEnabled()) {
-                log.debug(String.format("Federated auth session with the id: %s already " +
-                        "exists.", authHistory.getIdpSessionIndex()));
+                log.debug("Federated auth session with the id: "+ authHistory.getIdpSessionIndex() +" already " +
+                        "exists.");
             }
             userSessionStore.updateFederatedAuthSessionInfo(sessionContextKey, authHistory,
                     tenantId);
@@ -701,13 +701,12 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
         if (userSessionStore.hasExistingFederatedAuthSession(authHistory.getIdpSessionIndex(), tenantId, idpId)) {
             if (log.isDebugEnabled()) {
-                log.debug(String.format("Federated auth session with the id: %s already exists for IDP Id: %s",
+                log.debug(String.format("Federated auth session with the session id: %s and idp id: %s already exists.",
                         authHistory.getIdpSessionIndex(), idpId));
             }
             userSessionStore.updateFederatedAuthSessionInfo(sessionContextKey, authHistory, tenantId, idpId);
         } else {
-            userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory,
-                    tenantId, idpId);
+            userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory, tenantId, idpId);
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -58,6 +58,8 @@ import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.idp.mgt.util.IdPManagementUtil;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
 import org.wso2.carbon.user.core.config.UserStorePreferenceOrderSupplier;
@@ -584,38 +586,29 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             // Check whether the authentication flow includes a SAML federated IdP and
             // store the saml index with the session context key for the single logout.
             if (context.getAuthenticationStepHistory() != null) {
-                UserSessionStore userSessionStore = UserSessionStore.getInstance();
                 for (AuthHistory authHistory : context.getAuthenticationStepHistory()) {
                     if (StringUtils.isNotBlank(authHistory.getIdpSessionIndex()) &&
                             StringUtils.isNotBlank(authHistory.getIdpName())) {
                         try {
-                            if (FrameworkUtils.isTenantIdColumnAvailableInFedAuthTable()) {
-                                int tenantId = IdentityTenantUtil.getTenantId(context.getTenantDomain());
-                                if (!userSessionStore.isExistingFederatedAuthSessionAvailable(
-                                        authHistory.getIdpSessionIndex(), tenantId)) {
-                                    userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory,
-                                            tenantId);
+                            if (FrameworkUtils.isIdpIdColumnAvailableInFedAuthTable()) {
+                                int idpId = Integer.parseInt(IdentityProviderManager.getInstance()
+                                        .getIdPByName(authHistory.getIdpName(), context.getTenantDomain()).getId());
+                                if (FrameworkUtils.isTenantIdColumnAvailableInFedAuthTable()) {
+                                    storeFedAuthSessionWithTenantIdAndIdpId(context.getTenantDomain(),
+                                            sessionContextKey, authHistory, idpId);
                                 } else {
-                                    if (log.isDebugEnabled()) {
-                                        log.debug(String.format("Federated auth session with the id: %s already " +
-                                                "exists.", authHistory.getIdpSessionIndex()));
-                                    }
-                                    userSessionStore.updateFederatedAuthSessionInfo(sessionContextKey, authHistory,
-                                            tenantId);
+                                    storeFedAuthSessionWithIdpId(context.getTenantDomain(), sessionContextKey,
+                                            authHistory);
                                 }
                             } else {
-                                if (!userSessionStore.hasExistingFederatedAuthSession(
-                                        authHistory.getIdpSessionIndex())) {
-                                    userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory);
+                                if (FrameworkUtils.isTenantIdColumnAvailableInFedAuthTable()) {
+                                    storeFedAuthSessionWithTenantId(context.getTenantDomain(), sessionContextKey,
+                                            authHistory);
                                 } else {
-                                    if (log.isDebugEnabled()) {
-                                        log.debug(String.format("Federated auth session with the id: %s already " +
-                                                "exists.", authHistory.getIdpSessionIndex()));
-                                    }
-                                    userSessionStore.updateFederatedAuthSessionInfo(sessionContextKey, authHistory);
+                                    storeFedAuthSessionMapping(sessionContextKey, authHistory);
                                 }
                             }
-                        } catch (UserSessionException e) {
+                        } catch (UserSessionException | IdentityProviderManagementException e) {
                             throw new FrameworkException("Error while storing federated authentication session details "
                                     + "of the authenticated user to the database", e);
                         }
@@ -649,6 +642,73 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
         }
 
         sendResponse(request, response, context);
+    }
+
+    private void storeFedAuthSessionMapping(String sessionContextKey, AuthHistory authHistory)
+            throws UserSessionException {
+
+        UserSessionStore userSessionStore = UserSessionStore.getInstance();
+        if (!userSessionStore.hasExistingFederatedAuthSession(
+                authHistory.getIdpSessionIndex())) {
+            userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Federated auth session with the id: %s already " +
+                        "exists.", authHistory.getIdpSessionIndex()));
+            }
+            userSessionStore.updateFederatedAuthSessionInfo(sessionContextKey, authHistory);
+        }
+    }
+
+    private void storeFedAuthSessionWithTenantId(String tenantDomain, String sessionContextKey,
+             AuthHistory authHistory) throws UserSessionException {
+
+        UserSessionStore userSessionStore = UserSessionStore.getInstance();
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        if (!userSessionStore.hasExistingFederatedAuthSession(authHistory.getIdpSessionIndex(), tenantId)) {
+            userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory, tenantId);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Federated auth session with the id: %s already " +
+                        "exists.", authHistory.getIdpSessionIndex()));
+            }
+            userSessionStore.updateFederatedAuthSessionInfo(sessionContextKey, authHistory,
+                    tenantId);
+        }
+    }
+
+    private void storeFedAuthSessionWithIdpId(String tenantDomain, String sessionContextKey,
+            AuthHistory authHistory) throws UserSessionException, IdentityProviderManagementException {
+
+        UserSessionStore userSessionStore = UserSessionStore.getInstance();
+        int idpId = Integer.parseInt(IdentityProviderManager.getInstance()
+                .getIdPByName(authHistory.getIdpName(), tenantDomain).getId());
+        if (!userSessionStore.hasExistingFederatedAuthSessionWithIdpId(authHistory.getIdpSessionIndex(), idpId)) {
+            userSessionStore.storeFederatedAuthSessionInfoWithIdpId(sessionContextKey, authHistory, idpId);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Federated auth session with the session id: %s and idp id: %s already exists.",
+                        authHistory.getIdpSessionIndex(), idpId));
+            }
+            userSessionStore.updateFederatedAuthSessionInfoWithIdpId(sessionContextKey, authHistory, idpId);
+        }
+    }
+
+    private void storeFedAuthSessionWithTenantIdAndIdpId(String tenantDomain, String sessionContextKey,
+             AuthHistory authHistory, int idpId) throws UserSessionException {
+
+        UserSessionStore userSessionStore = UserSessionStore.getInstance();
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        if (userSessionStore.hasExistingFederatedAuthSession(authHistory.getIdpSessionIndex(), tenantId, idpId)) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Federated auth session with the id: %s already exists for IDP Id: %s",
+                        authHistory.getIdpSessionIndex(), idpId));
+            }
+            userSessionStore.updateFederatedAuthSessionInfo(sessionContextKey, authHistory, tenantId, idpId);
+        } else {
+            userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory,
+                    tenantId, idpId);
+        }
     }
 
     private void handleSessionContextUpdate(String requestType, String sessionContextKey, SessionContext sessionContext,

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -653,7 +653,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory);
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("Federated auth session with the id: "+ authHistory.getIdpSessionIndex() +" already " +
+                log.debug("Federated auth session with the id: " + authHistory.getIdpSessionIndex() + " already " +
                         "exists.");
             }
             userSessionStore.updateFederatedAuthSessionInfo(sessionContextKey, authHistory);
@@ -669,7 +669,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             userSessionStore.storeFederatedAuthSessionInfo(sessionContextKey, authHistory, tenantId);
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("Federated auth session with the id: "+ authHistory.getIdpSessionIndex() +" already " +
+                log.debug("Federated auth session with the id: " + authHistory.getIdpSessionIndex() + " already " +
                         "exists.");
             }
             userSessionStore.updateFederatedAuthSessionInfo(sessionContextKey, authHistory,

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -622,6 +622,15 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
 
             context.setLogoutRequest(true);
 
+            /*
+             * Set special property fedIdpId used to remove the entry in fed_auth_session_mapping table
+             * in the special case of SAML SLO when same fed idp is configured twice.
+             */
+
+            if (StringUtils.isNotBlank(request.getParameter(FrameworkConstants.FED_IDP_ID))) {
+                context.setProperty(FrameworkConstants.FED_IDP_ID, request.getParameter(FrameworkConstants.FED_IDP_ID));
+            }
+
             if (context.getRelyingParty() == null || context.getRelyingParty().trim().length() == 0) {
 
                 if (log.isDebugEnabled()) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -364,7 +364,9 @@ public class FrameworkServiceComponent {
 
         // Check whether the TENANT_ID column is available in the IDN_FED_AUTH_SESSION_MAPPING table.
         FrameworkUtils.checkIfTenantIdColumnIsAvailableInFedAuthTable();
-
+        // Check whether the IDP_ID column is available in the IDN_FED_AUTH_SESSION_MAPPING table.
+        FrameworkUtils.checkIfIdpIdColumnIsAvailableInFedAuthTable();
+        
         // Set user session mapping enabled.
         FrameworkServiceDataHolder.getInstance().setUserSessionMappingEnabled(FrameworkUtils
                 .isUserSessionMappingEnabled());

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
@@ -189,12 +189,12 @@ public class SQLQueries {
 
     // Store federated authentication session details to map the session context key with the idp session index.
     public static final String SQL_STORE_FEDERATED_AUTH_SESSION_INFO_WITH_TENANT = "INSERT INTO " +
-            "IDN_FED_AUTH_SESSION_MAPPING (IDP_SESSION_ID, SESSION_ID, IDP_NAME,  AUTHENTICATOR_ID, " +
+            "IDN_FED_AUTH_SESSION_MAPPING (IDP_SESSION_ID, SESSION_ID, IDP_NAME, AUTHENTICATOR_ID, " +
             "PROTOCOL_TYPE, TENANT_ID) VALUES (?, ?, ?, ?, ?, ?)";
 
     // Store federated authentication session details to map the session context key with the idp session index.
     public static final String SQL_STORE_FEDERATED_AUTH_SESSION_INFO_WITH_IDP_ID = "INSERT INTO " +
-            "IDN_FED_AUTH_SESSION_MAPPING (IDP_SESSION_ID, SESSION_ID, IDP_NAME,  AUTHENTICATOR_ID, " +
+            "IDN_FED_AUTH_SESSION_MAPPING (IDP_SESSION_ID, SESSION_ID, IDP_NAME, AUTHENTICATOR_ID, " +
             "PROTOCOL_TYPE, IDP_ID) VALUES (?, ?, ?, ?, ?, ?)";
 
     // Store federated authentication session details to map the session context key with the idp session index.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
@@ -214,7 +214,7 @@ public class SQLQueries {
     public static final String SQL_GET_FEDERATED_AUTH_SESSION_ID_BY_SESSION_ID_WITH_IDP_ID = "SELECT SESSION_ID " +
             "FROM IDN_FED_AUTH_SESSION_MAPPING WHERE IDP_SESSION_ID = ? AND IDP_ID = ?";
 
-    // Get federated authentication session id using the idp session id.
+    // Get federated authentication session id using the idp session id, tenant id and idp id.
     public static final String SQL_GET_FEDERATED_AUTH_SESSION_ID_BY_SESSION_ID_WITH_TENANT_AND_IDP_ID = "SELECT " +
             "SESSION_ID FROM IDN_FED_AUTH_SESSION_MAPPING WHERE IDP_SESSION_ID = ? AND TENANT_ID = ? AND IDP_ID = ?";
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SQLQueries.java
@@ -185,12 +185,22 @@ public class SQLQueries {
 
     // Store federated authentication session details to map the session context key with the idp session index.
     public static final String SQL_STORE_FEDERATED_AUTH_SESSION_INFO = "INSERT INTO IDN_FED_AUTH_SESSION_MAPPING "
-            + "(IDP_SESSION_ID, SESSION_ID, IDP_NAME,  AUTHENTICATOR_ID, PROTOCOL_TYPE) VALUES (?, ?, ?, ?, ?)";
+            + "(IDP_SESSION_ID, SESSION_ID, IDP_NAME, AUTHENTICATOR_ID, PROTOCOL_TYPE) VALUES (?, ?, ?, ?, ?)";
 
     // Store federated authentication session details to map the session context key with the idp session index.
     public static final String SQL_STORE_FEDERATED_AUTH_SESSION_INFO_WITH_TENANT = "INSERT INTO " +
             "IDN_FED_AUTH_SESSION_MAPPING (IDP_SESSION_ID, SESSION_ID, IDP_NAME,  AUTHENTICATOR_ID, " +
             "PROTOCOL_TYPE, TENANT_ID) VALUES (?, ?, ?, ?, ?, ?)";
+
+    // Store federated authentication session details to map the session context key with the idp session index.
+    public static final String SQL_STORE_FEDERATED_AUTH_SESSION_INFO_WITH_IDP_ID = "INSERT INTO " +
+            "IDN_FED_AUTH_SESSION_MAPPING (IDP_SESSION_ID, SESSION_ID, IDP_NAME,  AUTHENTICATOR_ID, " +
+            "PROTOCOL_TYPE, IDP_ID) VALUES (?, ?, ?, ?, ?, ?)";
+
+    // Store federated authentication session details to map the session context key with the idp session index.
+    public static final String SQL_STORE_FEDERATED_AUTH_SESSION_INFO_WITH_TENANT_AND_IDP_ID = "INSERT INTO " +
+            "IDN_FED_AUTH_SESSION_MAPPING (IDP_SESSION_ID, SESSION_ID, IDP_NAME, AUTHENTICATOR_ID, PROTOCOL_TYPE, " +
+            "TENANT_ID, IDP_ID) VALUES (?, ?, ?, ?, ?, ?, ?)";
 
     // Get federated authentication session id using the idp session id.
     public static final String SQL_GET_FEDERATED_AUTH_SESSION_ID_BY_SESSION_ID = "SELECT SESSION_ID FROM " +
@@ -200,13 +210,29 @@ public class SQLQueries {
     public static final String SQL_GET_FEDERATED_AUTH_SESSION_ID_BY_SESSION_ID_WITH_TENANT = "SELECT SESSION_ID " +
             "FROM IDN_FED_AUTH_SESSION_MAPPING WHERE IDP_SESSION_ID = ? AND TENANT_ID = ?";
 
+    // Get federated authentication session id using the idp session id and the idp id.
+    public static final String SQL_GET_FEDERATED_AUTH_SESSION_ID_BY_SESSION_ID_WITH_IDP_ID = "SELECT SESSION_ID " +
+            "FROM IDN_FED_AUTH_SESSION_MAPPING WHERE IDP_SESSION_ID = ? AND IDP_ID = ?";
+
+    // Get federated authentication session id using the idp session id.
+    public static final String SQL_GET_FEDERATED_AUTH_SESSION_ID_BY_SESSION_ID_WITH_TENANT_AND_IDP_ID = "SELECT " +
+            "SESSION_ID FROM IDN_FED_AUTH_SESSION_MAPPING WHERE IDP_SESSION_ID = ? AND TENANT_ID = ? AND IDP_ID = ?";
+
     // Update federated authentication session id using the idp session id.
     public static final String SQL_UPDATE_FEDERATED_AUTH_SESSION_INFO = "UPDATE IDN_FED_AUTH_SESSION_MAPPING SET " +
-            "SESSION_ID=? WHERE IDP_SESSION_ID=?";
+            "SESSION_ID=? WHERE IDP_SESSION_ID = ?";
 
     // Update federated authentication session id using the idp session id and the tenant id.
     public static final String SQL_UPDATE_FEDERATED_AUTH_SESSION_INFO_WITH_TENANT = "UPDATE " +
-            "IDN_FED_AUTH_SESSION_MAPPING SET SESSION_ID=? WHERE IDP_SESSION_ID=? AND TENANT_ID = ?";
+            "IDN_FED_AUTH_SESSION_MAPPING SET SESSION_ID = ? WHERE IDP_SESSION_ID= ? AND TENANT_ID = ?";
+
+    // Update federated authentication session id using the idp session id and the idp id.
+    public static final String SQL_UPDATE_FEDERATED_AUTH_SESSION_INFO_WITH_IDP_ID = "UPDATE " +
+            "IDN_FED_AUTH_SESSION_MAPPING SET SESSION_ID = ? WHERE IDP_SESSION_ID = ? AND IDP_ID = ?";
+
+    // Update federated authentication session id using the idp session id, the tenant id, and the idp id.
+    public static final String SQL_UPDATE_FEDERATED_AUTH_SESSION_INFO_WITH_TENANT_AND_IDP_ID = "UPDATE " +
+            "IDN_FED_AUTH_SESSION_MAPPING SET SESSION_ID = ? WHERE IDP_SESSION_ID = ? AND TENANT_ID = ? IDP_ID = ?";
 
     // Get federated authentication session details if there is an already existing session.
     public static final String SQL_GET_FEDERATED_AUTH_SESSION_INFO_BY_SESSION_ID =
@@ -215,7 +241,11 @@ public class SQLQueries {
 
     // Remove federated authentication session details of a given session context key.
     public static final String SQL_DELETE_FEDERATED_AUTH_SESSION_INFO = "DELETE FROM IDN_FED_AUTH_SESSION_MAPPING"
-            + " WHERE SESSION_ID=?";
+            + " WHERE SESSION_ID = ?";
+
+    // Remove federated authentication session details of a given session context key and idp id.
+    public static final String SQL_DELETE_FEDERATED_AUTH_SESSION_INFO_WITH_IDP_ID = "DELETE FROM " +
+            "IDN_FED_AUTH_SESSION_MAPPING WHERE SESSION_ID = ? AND IDP_ID = ?";
 
     public static final String SQL_GET_ACTIVE_SESSION_COUNT_BY_TENANT =
             "SELECT COUNT( DISTINCT IDN_AUTH_SESSION_META_DATA.SESSION_ID) " +

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -891,6 +891,67 @@ public class UserSessionStore {
     }
 
     /**
+     * Store session details with the given session context key for the federated IdP's session ID.
+     *
+     * @param sessionContextKey Session Context Key.
+     * @param authHistory       History of the authentication flow.
+     * @param idpId             Federated IDP ID.
+     * @throws UserSessionException Error while storing session details.
+     */
+    public void storeFederatedAuthSessionInfoWithIdpId(String sessionContextKey, AuthHistory authHistory, int idpId)
+            throws UserSessionException {
+
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(true);
+             PreparedStatement prepStmt = connection
+                     .prepareStatement(SQLQueries.SQL_STORE_FEDERATED_AUTH_SESSION_INFO_WITH_IDP_ID)) {
+            prepStmt.setString(1, authHistory.getIdpSessionIndex());
+            prepStmt.setString(2, sessionContextKey);
+            prepStmt.setString(3, authHistory.getIdpName());
+            prepStmt.setString(4, authHistory.getAuthenticatorName());
+            prepStmt.setString(5, authHistory.getRequestType());
+            prepStmt.setInt(6, idpId);
+            prepStmt.execute();
+            IdentityDatabaseUtil.commitTransaction(connection);
+        } catch (SQLException e) {
+            String msg = String.format("Error while adding session details of the session index: %s, IdP: %s " +
+                    "and IdP ID: %s.", sessionContextKey, authHistory.getIdpName(), idpId);
+            throw new UserSessionException(msg, e);
+        }
+    }
+
+    /**
+     * Store session details if not exist of a given session context key to map the session context key with
+     * the federated IdP's session ID.
+     *
+     * @param sessionContextKey Session Context Key.
+     * @param authHistory       History of the authentication flow.
+     * @param tenantId          Tenant id.
+     * @param idpId             Federated IdP id.
+     * @throws UserSessionException Error while storing session details.
+     */
+    public void storeFederatedAuthSessionInfo(String sessionContextKey, AuthHistory authHistory, int tenantId,
+                                              int idpId) throws UserSessionException {
+
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false);
+             PreparedStatement prepStmt = connection
+                     .prepareStatement(SQLQueries.SQL_STORE_FEDERATED_AUTH_SESSION_INFO_WITH_TENANT_AND_IDP_ID)) {
+            prepStmt.setString(1, authHistory.getIdpSessionIndex());
+            prepStmt.setString(2, sessionContextKey);
+            prepStmt.setString(3, authHistory.getIdpName());
+            prepStmt.setString(4, authHistory.getAuthenticatorName());
+            prepStmt.setString(5, authHistory.getRequestType());
+            prepStmt.setInt(6, tenantId);
+            prepStmt.setInt(7, idpId);
+            prepStmt.execute();
+        } catch (SQLException e) {
+            String msg = String.format("Error while adding session details of the session index: %s, IdP: %s " +
+                    "and tenant id: %s.", sessionContextKey, authHistory.getIdpName(), tenantId);
+            throw new UserSessionException(msg, e);
+        }
+    }
+
+
+    /**
      * Update session details of a given session context key to map the current session context key with
      * the federated IdP's session ID.
      *
@@ -942,6 +1003,64 @@ public class UserSessionStore {
     }
 
     /**
+     * Update session details of a given session context key to map the current session context key with
+     * the federated IdP's session ID.
+     *
+     * @param sessionContextKey Session Context Key.
+     * @param authHistory       History of the authentication flow.
+     * @param idpId             Federated IDP id.
+     * @throws UserSessionException Error while storing session details.
+     */
+    public void updateFederatedAuthSessionInfoWithIdpId(String sessionContextKey, AuthHistory authHistory, int idpId)
+            throws UserSessionException {
+
+        JdbcTemplate jdbcTemplate = JdbcUtils.getNewTemplate();
+        try {
+            jdbcTemplate.executeUpdate(
+                    SQLQueries.SQL_UPDATE_FEDERATED_AUTH_SESSION_INFO_WITH_IDP_ID, preparedStatement -> {
+                        preparedStatement.setString(1, sessionContextKey);
+                        preparedStatement.setString(2, authHistory.getIdpSessionIndex());
+                        preparedStatement.setInt(3, idpId);
+                    });
+        } catch (DataAccessException e) {
+            String msg = String.format("Error while updating %s of session: %s in table " +
+                            "IDN_FED_AUTH_SESSION_MAPPING for idp id %s.", sessionContextKey,
+                    authHistory.getIdpSessionIndex(), idpId);
+            throw new UserSessionException(msg, e);
+        }
+    }
+
+    /**
+     * Update session details of a given session context key to map the current session context key with
+     * the federated IdP's session ID.
+     *
+     * @param sessionContextKey Session Context Key.
+     * @param authHistory       History of the authentication flow.
+     * @param tenantId          Tenant id.
+     * @param idpId             Federated IdP id.
+     * @throws UserSessionException Error while storing session details.
+     */
+    public void updateFederatedAuthSessionInfo(String sessionContextKey, AuthHistory authHistory, int tenantId,
+            int idpId) throws UserSessionException {
+
+        JdbcTemplate jdbcTemplate = JdbcUtils.getNewTemplate();
+        try {
+            jdbcTemplate.executeUpdate(
+                    SQLQueries.SQL_UPDATE_FEDERATED_AUTH_SESSION_INFO_WITH_TENANT_AND_IDP_ID, preparedStatement -> {
+                        preparedStatement.setString(1, sessionContextKey);
+                        preparedStatement.setString(2, authHistory.getIdpSessionIndex());
+                        preparedStatement.setInt(3, tenantId);
+                        preparedStatement.setInt(4, idpId);
+                    });
+        } catch (DataAccessException e) {
+            String msg = String.format("Error while updating %s of session: %s in table " +
+                            "IDN_FED_AUTH_SESSION_MAPPING for tenant id %s and idp id %s", sessionContextKey,
+                    authHistory.getIdpSessionIndex(), tenantId, idpId);
+            throw new UserSessionException(msg, e);
+        }
+    }
+
+    /**
      * Check whether there is already existing federated auth session with the given session index.
      *
      * @param idpSessionIndex IDP session index.
@@ -975,7 +1094,7 @@ public class UserSessionStore {
      * @return True if a federated auth session found with the given session index.
      * @throws UserSessionException If an error occurred while checking for an federated auth session.
      */
-    public boolean isExistingFederatedAuthSessionAvailable(String idpSessionIndex, int tenantId)
+    public boolean hasExistingFederatedAuthSession(String idpSessionIndex, int tenantId)
             throws UserSessionException {
 
         boolean isExisting = false;
@@ -998,6 +1117,69 @@ public class UserSessionStore {
     }
 
     /**
+     * Check whether there is already existing federated auth session with the given session index and the idp id.
+     *
+     * @param idpSessionIndex IDP session index.
+     * @param idpId           Federated IDP ID.
+     * @return True if a federated auth session found with the given session index.
+     * @throws UserSessionException If an error occurred while checking for an federated auth session.
+     */
+    public boolean hasExistingFederatedAuthSessionWithIdpId(String idpSessionIndex, int idpId)
+            throws UserSessionException {
+
+        boolean isExisting = false;
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false);
+             PreparedStatement prepStmt = connection.prepareStatement(
+                     SQLQueries.SQL_GET_FEDERATED_AUTH_SESSION_ID_BY_SESSION_ID_WITH_IDP_ID)) {
+            prepStmt.setString(1, idpSessionIndex);
+            prepStmt.setInt(2, idpId);
+            try (ResultSet resultSet = prepStmt.executeQuery()) {
+                if (resultSet.next()) {
+                    isExisting = true;
+                }
+            }
+        } catch (SQLException e) {
+            String msg = String.format("Error occurred while checking for a federated auth session with " +
+                    "session index: %s and idp id: %s", idpSessionIndex, idpId);
+            throw new UserSessionException(msg, e);
+        }
+        return isExisting;
+    }
+
+    /**
+     * Check whether there is already existing federated auth session with the given session index, tenant id and
+     * idp id.
+     *
+     * @param idpSessionIndex IDP session index.
+     * @param tenantId        Tenant id.
+     * @param idpId           Federated IDP id.
+     * @return True if a federated auth session found with the given session index.
+     * @throws UserSessionException If an error occurred while checking for an federated auth session.
+     */
+    public boolean hasExistingFederatedAuthSession(String idpSessionIndex, int tenantId, int idpId)
+            throws UserSessionException {
+
+        boolean isExisting = false;
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false);
+             PreparedStatement prepStmt = connection.prepareStatement(
+                     SQLQueries.SQL_GET_FEDERATED_AUTH_SESSION_ID_BY_SESSION_ID_WITH_TENANT_AND_IDP_ID)) {
+            prepStmt.setString(1, idpSessionIndex);
+            prepStmt.setInt(2, tenantId);
+            prepStmt.setInt(3, idpId);
+            try (ResultSet resultSet = prepStmt.executeQuery()) {
+                if (resultSet.next()) {
+                    isExisting = true;
+                }
+            }
+        } catch (SQLException e) {
+            String msg = String.format("Error occurred while checking for a federated auth session with " +
+                    "session index: %s ,tenant id: %s and idp id: %s", idpSessionIndex, tenantId, idpId);
+            throw new UserSessionException(msg, e);
+        }
+        return isExisting;
+    }
+
+    /**
      * Remove federated authentication session details of a given session context key.
      *
      * @param sessionContextKey Session Context Key.
@@ -1009,6 +1191,33 @@ public class UserSessionStore {
             try (PreparedStatement prepStmt
                          = connection.prepareStatement(SQLQueries.SQL_DELETE_FEDERATED_AUTH_SESSION_INFO)) {
                 prepStmt.setString(1, sessionContextKey);
+                prepStmt.execute();
+                IdentityDatabaseUtil.commitTransaction(connection);
+            } catch (SQLException e1) {
+                IdentityDatabaseUtil.rollbackTransaction(connection);
+                throw new UserSessionException("Error while removing federated authentication session details of " +
+                        "the session index:" + sessionContextKey, e1);
+            }
+        } catch (SQLException e) {
+            throw new UserSessionException("Error while removing federated authentication session details of " +
+                    "the session index:" + sessionContextKey, e);
+        }
+    }
+
+    /**
+     * Remove federated authentication session details of a given session context key.
+     *
+     * @param sessionContextKey     Session Context Key.
+     * @param idpId                 ID of the federated IdP.
+     * @throws UserSessionException Error while deleting session details of a given session id.
+     */
+    public void removeFederatedAuthSessionInfo(String sessionContextKey, int idpId) throws UserSessionException {
+
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(true)) {
+            try (PreparedStatement prepStmt
+                         = connection.prepareStatement(SQLQueries.SQL_DELETE_FEDERATED_AUTH_SESSION_INFO_WITH_IDP_ID)) {
+                prepStmt.setString(1, sessionContextKey);
+                prepStmt.setInt(2, idpId);
                 prepStmt.execute();
                 IdentityDatabaseUtil.commitTransaction(connection);
             } catch (SQLException e1) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -950,7 +950,6 @@ public class UserSessionStore {
         }
     }
 
-
     /**
      * Update session details of a given session context key to map the current session context key with
      * the federated IdP's session ID.
@@ -1094,7 +1093,7 @@ public class UserSessionStore {
      * @return True if a federated auth session found with the given session index.
      * @throws UserSessionException If an error occurred while checking for an federated auth session.
      */
-    public boolean hasExistingFederatedAuthSession(String idpSessionIndex, int tenantId)
+    public boolean isExistingFederatedAuthSessionAvailable(String idpSessionIndex, int tenantId)
             throws UserSessionException {
 
         boolean isExisting = false;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -117,6 +117,7 @@ public abstract class FrameworkConstants {
     public static final String REQUEST_PARAM_AUTH_FLOW_ID = "authFlowId";
     public static final String MAPPED_ATTRIBUTES = "MappedAttributes";
     public static final String IDP_ID = "idpId";
+    public static final String FED_IDP_ID = "fedIdpId";
     public static final String ASSOCIATED_ID = "associatedID";
 
     public static final String JIT_PROVISIONING_FLOW = "JITProvisioningFlow";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -205,6 +205,7 @@ public class FrameworkUtils {
     public static final String CORRELATION_ID_MDC = "Correlation-ID";
 
     private static boolean isTenantIdColumnAvailableInFedAuthTable = false;
+    private static boolean isIdpIdColumnAvailableInFedAuthTable = false;
     public static final String ROOT_DOMAIN = "/";
 
     private static final String HASH_CHAR = "#";
@@ -2805,6 +2806,24 @@ public class FrameworkUtils {
     public static boolean isTenantIdColumnAvailableInFedAuthTable() {
 
         return isTenantIdColumnAvailableInFedAuthTable;
+    }
+
+    /**
+     * Checking whether the idp id column is available in the IDN_FED_AUTH_SESSION_MAPPING table.
+     */
+    public static void checkIfIdpIdColumnIsAvailableInFedAuthTable() {
+
+        isIdpIdColumnAvailableInFedAuthTable = isTableColumnExists("IDN_FED_AUTH_SESSION_MAPPING", "IDP_ID");
+    }
+
+    /**
+     * Return whether the idp id column is available in the IDN_FED_AUTH_SESSION_MAPPING table.
+     *
+     * @return True if idp id is available in IDN_FED_AUTH_SESSION_MAPPING table. Else return false.
+     */
+    public static boolean isIdpIdColumnAvailableInFedAuthTable() {
+
+        return isIdpIdColumnAvailableInFedAuthTable;
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes in this PR

- Fixes : https://github.com/wso2/product-is/issues/15649 (NPE while processing SLO request from federated IDP when the same IDP is configured twice.)
- Introduces a new column called IDP_ID in IDN_FED_AUTH_SESSION_MAPPING table to keep the IDP ID of the federated IDP.
- The changes described below will be activated only if the IDP_ID column exists in IDN_FED_AUTH_SESSION_MAPPING table.
- Adds the IDP ID when a federated auth session is added to the table and updated in the table.
- When removing an entry, IDP ID will be used as well.
- In the case of a logout request initiated by the federated IDP side, is sessionContext is not set, a special parameter FED IDP ID sent by outbound SAML authenticator is used to determine the IDP_ID of the entry to be removed.

## Related PRs

Outbound SAML fix to retrieve the session details from the IDN_FED_AUTH_SESSION_MAPPING table [1].
IDN_FED_AUTH_SESSION_MAPPING table column update PR [2].

## When should this PR be merged
This PR should be merged before merging [1].

[1] https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/161
[2] https://github.com/wso2/carbon-identity-framework/pull/4559
