### PR TITLE
Display message when authentication flow restarted

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -228,6 +228,9 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                         request.getAttribute(FrameworkConstants.RESTART_LOGIN_FLOW).equals("true")) {
                     context = (AuthenticationContext) context.getProperty(FrameworkConstants.INITIAL_CONTEXT);
                     context.initializeAnalyticsData();
+                    String contextIdIncludedQueryParams = context.getContextIdIncludedQueryParams();
+                    contextIdIncludedQueryParams += FrameworkConstants.RESTART_LOGIN_FLOW_QUERY_PARAMS;
+                    context.setContextIdIncludedQueryParams(contextIdIncludedQueryParams);
                 } else {
                     returning = true;
                 }
@@ -237,6 +240,14 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
             if (context != null) {
                 if (StringUtils.isNotBlank(context.getServiceProviderName())) {
                     MDC.put(SERVICE_PROVIDER_QUERY_KEY, context.getServiceProviderName());
+                }
+                // Remove `login.reinitiate.message` from the query params after the first step to prevent it from
+                // appearing in subsequent authentication steps.
+                if (context.getCurrentStep() == 1 && StringUtils.contains(context.getContextIdIncludedQueryParams(),
+                        FrameworkConstants.RESTART_LOGIN_FLOW_QUERY_PARAMS)) {
+                    String contextIdIncludedQueryParams = StringUtils.remove(context.getContextIdIncludedQueryParams(),
+                            FrameworkConstants.RESTART_LOGIN_FLOW_QUERY_PARAMS);
+                    context.setContextIdIncludedQueryParams(contextIdIncludedQueryParams);
                 }
                 // Monitor should be context itself as we need to synchronize only if the same context is used by two
                 // different threads.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -208,6 +208,8 @@ public abstract class FrameworkConstants {
     public static final String PRESERVE_LOCAL = "PRESERVE_LOCAL";
     public static final String RESTART_LOGIN_FLOW = "restartLoginFlow";
     public static final String INITIAL_CONTEXT = "initialContext";
+    public static final String RESTART_LOGIN_FLOW_QUERY_PARAMS =
+            "&authFailure=true&authFailureMsg=login.reinitiate.message";
 
     private FrameworkConstants() {
 


### PR DESCRIPTION
### Proposed changes in this pull request
 * Displaying a message to the user when the authentication flow got restarted due to the nonce validation failure