### PR TITLE
Ignore nonce cookie validation for whitelisted authenticators

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -210,6 +210,8 @@ public abstract class FrameworkConstants {
     public static final String INITIAL_CONTEXT = "initialContext";
     public static final String RESTART_LOGIN_FLOW_QUERY_PARAMS =
             "&authFailure=true&authFailureMsg=login.reinitiate.message";
+    public static final String NONCE_COOKIE_WHITELISTED_AUTHENTICATORS_CONFIG =
+            "SessionNonceCookie.WhitelistedAuthenticator";
 
     private FrameworkConstants() {
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionNonceCookieUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionNonceCookieUtil.java
@@ -30,8 +30,6 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import edu.emory.mathcs.backport.java.util.Arrays;
-
 /**
  * Handles session nonce cookie.
  * Session nonce cookie helps to mitigate the session hijacking.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionNonceCookieUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionNonceCookieUtil.java
@@ -23,7 +23,8 @@ import org.wso2.carbon.identity.application.authentication.framework.context.Aut
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
 
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.servlet.http.Cookie;
@@ -43,8 +44,8 @@ public class SessionNonceCookieUtil {
     public static final String NONCE_ERROR_CODE = "sessionNonceErrorCode";
 
     private static Boolean nonceCookieConfig;
-    private static final List<String> NONCE_COOKIE_WHITELISTED_AUTHENTICATORS = IdentityUtil.getPropertyAsList(
-            NONCE_COOKIE_WHITELISTED_AUTHENTICATORS_CONFIG);
+    private static final Set<String> NONCE_COOKIE_WHITELISTED_AUTHENTICATORS = new HashSet<>(
+            IdentityUtil.getPropertyAsList(NONCE_COOKIE_WHITELISTED_AUTHENTICATORS_CONFIG));
 
     /**
      * Get dynamic name for the nonce cookie

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionNonceCookieUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionNonceCookieUtil.java
@@ -30,6 +30,8 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.NONCE_COOKIE_WHITELISTED_AUTHENTICATORS_CONFIG;
+
 /**
  * Handles session nonce cookie.
  * Session nonce cookie helps to mitigate the session hijacking.
@@ -42,7 +44,7 @@ public class SessionNonceCookieUtil {
 
     private static Boolean nonceCookieConfig;
     private static final List<String> NONCE_COOKIE_WHITELISTED_AUTHENTICATORS = IdentityUtil.getPropertyAsList(
-            "SessionNonceCookie.WhitelistedAuthenticator");
+            NONCE_COOKIE_WHITELISTED_AUTHENTICATORS_CONFIG);
 
     /**
      * Get dynamic name for the nonce cookie

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionNonceCookieUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionNonceCookieUtil.java
@@ -23,11 +23,14 @@ import org.wso2.carbon.identity.application.authentication.framework.context.Aut
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import edu.emory.mathcs.backport.java.util.Arrays;
 
 /**
  * Handles session nonce cookie.
@@ -40,6 +43,8 @@ public class SessionNonceCookieUtil {
     public static final String NONCE_ERROR_CODE = "sessionNonceErrorCode";
 
     private static Boolean nonceCookieConfig;
+    private static final List<String> NONCE_COOKIE_WHITELISTED_AUTHENTICATORS = IdentityUtil.getPropertyAsList(
+            "SessionNonceCookie.WhitelistedAuthenticator");
 
     /**
      * Get dynamic name for the nonce cookie
@@ -87,6 +92,9 @@ public class SessionNonceCookieUtil {
                                               AuthenticationContext context) {
 
         if (!isNonceCookieEnabled()) {
+            return true;
+        }
+        if (NONCE_COOKIE_WHITELISTED_AUTHENTICATORS.contains(context.getCurrentAuthenticator())) {
             return true;
         }
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1899,9 +1899,12 @@
 
     <EnableSessionNonceCookie>{{session.nonce.cookie.enabled}}</EnableSessionNonceCookie>
 
-    {% if session.nonce.cookie.whitelist_authenticators is defined %}
+    {% if session.nonce.cookie.default_whitelist_authenticators is defined or session.nonce.cookie.whitelist_authenticators is defined %}
         <SessionNonceCookie>
-            {% for whitelist_authenticator in  session.nonce.cookie.whitelist_authenticators %}
+            {% for whitelist_authenticator in session.nonce.cookie.default_whitelist_authenticators %}
+            <WhitelistedAuthenticator>{{whitelist_authenticator}}</WhitelistedAuthenticator>
+            {% endfor %}
+            {% for whitelist_authenticator in session.nonce.cookie.whitelist_authenticators %}
             <WhitelistedAuthenticator>{{whitelist_authenticator}}</WhitelistedAuthenticator>
             {% endfor %}
         </SessionNonceCookie>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1899,6 +1899,14 @@
 
     <EnableSessionNonceCookie>{{session.nonce.cookie.enabled}}</EnableSessionNonceCookie>
 
+    {% if session.nonce.cookies.whitelist.authenticators is defined %}
+        <SessionNonceCookie>
+            {% for whitelist_authenticator in  session.nonce.cookies.whitelist.authenticators %}
+            <WhitelistedAuthenticator>{{whitelist_authenticator.name}}</WhitelistedAuthenticator>
+            {% endfor %}
+        </SessionNonceCookie>
+    {% endif %}
+
     <!-- Config to enable performing validations for expired authentication context cache entry. -->
     <EnableAuthenticationContextExpiryValidation>{{session.authentication.context.expiry.validation}}</EnableAuthenticationContextExpiryValidation>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1899,10 +1899,10 @@
 
     <EnableSessionNonceCookie>{{session.nonce.cookie.enabled}}</EnableSessionNonceCookie>
 
-    {% if session.nonce.cookies.whitelist.authenticators is defined %}
+    {% if session.nonce.cookie.whitelist_authenticators is defined %}
         <SessionNonceCookie>
-            {% for whitelist_authenticator in  session.nonce.cookies.whitelist.authenticators %}
-            <WhitelistedAuthenticator>{{whitelist_authenticator.name}}</WhitelistedAuthenticator>
+            {% for whitelist_authenticator in  session.nonce.cookie.whitelist_authenticators %}
+            <WhitelistedAuthenticator>{{whitelist_authenticator}}</WhitelistedAuthenticator>
             {% endfor %}
         </SessionNonceCookie>
     {% endif %}

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -28,6 +28,7 @@
   "session_data.session_data_persist.session_and_temp_data_separation_enabled.enable": false,
   "session_data.cleanup.pre_session_data_cleanup_thread_pool_size": "20",
   "session.nonce.cookie.enabled": true,
+  "session.nonce.cookie.whitelist_authenticators": ["MagicLinkAuthenticator"],
   "session.authentication.context.expiry.validation": true,
   "session.timeout.idle_session_timeout": "15m",
   "session.timeout.remember_me_session_timeout": "14d",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -28,7 +28,7 @@
   "session_data.session_data_persist.session_and_temp_data_separation_enabled.enable": false,
   "session_data.cleanup.pre_session_data_cleanup_thread_pool_size": "20",
   "session.nonce.cookie.enabled": true,
-  "session.nonce.cookie.whitelist_authenticators": ["MagicLinkAuthenticator"],
+  "session.nonce.cookie.default_whitelist_authenticators": ["MagicLinkAuthenticator"],
   "session.authentication.context.expiry.validation": true,
   "session.timeout.idle_session_timeout": "15m",
   "session.timeout.remember_me_session_timeout": "14d",


### PR DESCRIPTION
### Proposed changes in this pull request
* $subject
* Ignore the nonce cookie validation for whitelisted authenticators

Once this is deployed, we can configure the authenticators that we want to ignore the nonce cookie validation in the `deployement.toml`  as follows,

```
[session.nonce.cookie]
whitelist_authenticators=["Authenticator_1", "Authenticator_2"]
```