### PR TITLE
Remove org level external consent url existence in application mgt

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
@@ -122,6 +122,10 @@
             <artifactId>org.wso2.carbon.identity.claim.metadata.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.consent.server.configs.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.utils</groupId>
             <artifactId>org.wso2.carbon.database.utils</artifactId>
         </dependency>
@@ -223,6 +227,7 @@
                             org.wso2.carbon.identity.claim.metadata.mgt.model; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt.exception; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt.listener; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.consent.server.configs.mgt.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.consent.mgt.core.*; version="${carbon.consent.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.database.utils.*;version="${org.wso2.carbon.database.utils.version.range}",

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
@@ -122,10 +122,6 @@
             <artifactId>org.wso2.carbon.identity.claim.metadata.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.consent.server.configs.mgt</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.utils</groupId>
             <artifactId>org.wso2.carbon.database.utils</artifactId>
         </dependency>
@@ -227,7 +223,6 @@
                             org.wso2.carbon.identity.claim.metadata.mgt.model; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt.exception; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt.listener; version="${carbon.identity.package.import.version.range}",
-                            org.wso2.carbon.identity.consent.server.configs.mgt.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.consent.mgt.core.*; version="${carbon.consent.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.database.utils.*;version="${org.wso2.carbon.database.utils.version.range}",

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -42,7 +42,6 @@ import org.wso2.carbon.identity.application.common.model.SpFileStream;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.application.mgt.dao.ApplicationDAO;
 import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponentHolder;
-import org.wso2.carbon.identity.consent.server.configs.mgt.exceptions.ConsentServerConfigsMgtException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
@@ -952,28 +951,5 @@ public class ApplicationMgtUtil {
             log.error("Error while converting service provider object to json.");
         }
         return StringUtils.EMPTY;
-    }
-
-    /**
-     * Get the external consent page url configured for the tenant domain.
-     *
-     * @param tenantDomain Tenant Domain.
-     * @return External consent page url.
-     * @throws IdentityApplicationManagementClientException IdentityApplicationManagementClientException.
-     */
-    public static String resolveExternalConsentPageUrl(String tenantDomain) throws
-            IdentityApplicationManagementClientException {
-
-        String externalConsentPageUrl = "";
-        try {
-            externalConsentPageUrl = ApplicationManagementServiceComponentHolder.
-                    getConsentServerConfigsManagementService().getExternalConsentPageUrl(tenantDomain);
-
-        } catch (ConsentServerConfigsMgtException e) {
-            throw new IdentityApplicationManagementClientException("Error while retrieving external consent page url " +
-                    "from the configuration store for tenant domain : " + tenantDomain, e);
-        }
-
-        return externalConsentPageUrl;
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -42,7 +42,6 @@ import org.wso2.carbon.identity.application.common.model.SpFileStream;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.application.mgt.dao.ApplicationDAO;
 import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponentHolder;
-import org.wso2.carbon.identity.consent.server.configs.mgt.exceptions.ConsentServerConfigsMgtException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
@@ -954,26 +953,4 @@ public class ApplicationMgtUtil {
         return StringUtils.EMPTY;
     }
 
-    /**
-     * Get the external consent page url configured for the tenant domain.
-     *
-     * @param tenantDomain Tenant Domain.
-     * @return External consent page url.
-     * @throws IdentityApplicationManagementClientException IdentityApplicationManagementClientException.
-     */
-    public static String resolveExternalConsentPageUrl(String tenantDomain) throws
-            IdentityApplicationManagementClientException {
-
-        String externalConsentPageUrl = "";
-        try {
-            externalConsentPageUrl = ApplicationManagementServiceComponentHolder.
-                    getConsentServerConfigsManagementService().getExternalConsentPageUrl(tenantDomain);
-
-        } catch (ConsentServerConfigsMgtException e) {
-            throw new IdentityApplicationManagementClientException("Error while retrieving external consent page url " +
-                    "from the configuration store for tenant domain : " + tenantDomain, e);
-        }
-
-        return externalConsentPageUrl;
-    }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.application.common.model.SpFileStream;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.application.mgt.dao.ApplicationDAO;
 import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponentHolder;
+import org.wso2.carbon.identity.consent.server.configs.mgt.exceptions.ConsentServerConfigsMgtException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
@@ -953,4 +954,26 @@ public class ApplicationMgtUtil {
         return StringUtils.EMPTY;
     }
 
+    /**
+     * Get the external consent page url configured for the tenant domain.
+     *
+     * @param tenantDomain Tenant Domain.
+     * @return External consent page url.
+     * @throws IdentityApplicationManagementClientException IdentityApplicationManagementClientException.
+     */
+    public static String resolveExternalConsentPageUrl(String tenantDomain) throws
+            IdentityApplicationManagementClientException {
+
+        String externalConsentPageUrl = "";
+        try {
+            externalConsentPageUrl = ApplicationManagementServiceComponentHolder.
+                    getConsentServerConfigsManagementService().getExternalConsentPageUrl(tenantDomain);
+
+        } catch (ConsentServerConfigsMgtException e) {
+            throw new IdentityApplicationManagementClientException("Error while retrieving external consent page url " +
+                    "from the configuration store for tenant domain : " + tenantDomain, e);
+        }
+
+        return externalConsentPageUrl;
+    }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponent.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponent.java
@@ -58,7 +58,6 @@ import org.wso2.carbon.identity.application.mgt.validator.ApplicationValidator;
 import org.wso2.carbon.identity.application.mgt.validator.DefaultApplicationValidator;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.listener.ClaimMetadataMgtListener;
-import org.wso2.carbon.identity.consent.server.configs.mgt.services.ConsentServerConfigsManagementService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
 import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
@@ -456,38 +455,4 @@ public class ApplicationManagementServiceComponent {
             log.debug("Removed application permission provider.");
         }
     }
-
-    @Reference(
-            name = "consent.server.configs.mgt.service",
-            service = ConsentServerConfigsManagementService.class,
-            cardinality = ReferenceCardinality.MANDATORY,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetConsentServerConfigsManagementService"
-    )
-
-    /**
-     * This method is used to set the Consent Server Configs Management Service.
-     *
-     * @param consentServerConfigsManagementService The Consent Server Configs Management Service which needs to be set.
-     */
-    protected void setConsentServerConfigsManagementService(ConsentServerConfigsManagementService
-                                                                    consentServerConfigsManagementService) {
-
-        ApplicationManagementServiceComponentHolder.setConsentServerConfigsManagementService(
-                consentServerConfigsManagementService);
-        log.debug("Setting the Consent Server Configs Management.");
-    }
-
-    /**
-     * This method is used to unset the Consent Server Configs Management Service.
-     *
-     * @param consentServerConfigsManagementService The Consent Server Configs Management Service which needs to unset.
-     */
-    protected void unsetConsentServerConfigsManagementService(ConsentServerConfigsManagementService
-                                                                      consentServerConfigsManagementService) {
-
-        ApplicationManagementServiceComponentHolder.setConsentServerConfigsManagementService(null);
-        log.debug("Unsetting the Consent Server Configs Management.");
-    }
-
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponent.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponent.java
@@ -58,6 +58,7 @@ import org.wso2.carbon.identity.application.mgt.validator.ApplicationValidator;
 import org.wso2.carbon.identity.application.mgt.validator.DefaultApplicationValidator;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.listener.ClaimMetadataMgtListener;
+import org.wso2.carbon.identity.consent.server.configs.mgt.services.ConsentServerConfigsManagementService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
 import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
@@ -455,4 +456,38 @@ public class ApplicationManagementServiceComponent {
             log.debug("Removed application permission provider.");
         }
     }
+
+    @Reference(
+            name = "consent.server.configs.mgt.service",
+            service = ConsentServerConfigsManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetConsentServerConfigsManagementService"
+    )
+
+    /**
+     * This method is used to set the Consent Server Configs Management Service.
+     *
+     * @param consentServerConfigsManagementService The Consent Server Configs Management Service which needs to be set.
+     */
+    protected void setConsentServerConfigsManagementService(ConsentServerConfigsManagementService
+                                                                    consentServerConfigsManagementService) {
+
+        ApplicationManagementServiceComponentHolder.setConsentServerConfigsManagementService(
+                consentServerConfigsManagementService);
+        log.debug("Setting the Consent Server Configs Management.");
+    }
+
+    /**
+     * This method is used to unset the Consent Server Configs Management Service.
+     *
+     * @param consentServerConfigsManagementService The Consent Server Configs Management Service which needs to unset.
+     */
+    protected void unsetConsentServerConfigsManagementService(ConsentServerConfigsManagementService
+                                                                      consentServerConfigsManagementService) {
+
+        ApplicationManagementServiceComponentHolder.setConsentServerConfigsManagementService(null);
+        log.debug("Unsetting the Consent Server Configs Management.");
+    }
+
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponentHolder.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponentHolder.java
@@ -21,7 +21,6 @@ import org.wso2.carbon.consent.mgt.core.ConsentManager;
 import org.wso2.carbon.identity.application.mgt.AbstractInboundAuthenticatorConfig;
 import org.wso2.carbon.identity.application.mgt.provider.ApplicationPermissionProvider;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
-import org.wso2.carbon.identity.consent.server.configs.mgt.services.ConsentServerConfigsManagementService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
 import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.registry.api.RegistryService;
@@ -60,8 +59,6 @@ public class ApplicationManagementServiceComponentHolder {
     private ApplicationPermissionProvider applicationPermissionProvider;
 
     private boolean isOrganizationManagementEnable = false;
-
-    private static ConsentServerConfigsManagementService consentServerConfigsManagementService;
 
     private ApplicationManagementServiceComponentHolder() {
 
@@ -251,27 +248,5 @@ public class ApplicationManagementServiceComponentHolder {
     public ApplicationPermissionProvider getApplicationPermissionProvider() {
 
         return applicationPermissionProvider;
-    }
-
-    /**
-     * Get Consent Server Configs Management Service.
-     *
-     * @return Consent Server Configs Management Service.
-     */
-    public static ConsentServerConfigsManagementService getConsentServerConfigsManagementService() {
-
-        return ApplicationManagementServiceComponentHolder.consentServerConfigsManagementService;
-    }
-
-    /**
-     * Set Consent Server Configs Management Service.
-     *
-     * @param consentServerConfigsManagementService Consent Server Configs Management Service.
-     */
-    public static void setConsentServerConfigsManagementService(ConsentServerConfigsManagementService
-                                                                        consentServerConfigsManagementService) {
-
-        ApplicationManagementServiceComponentHolder.consentServerConfigsManagementService =
-                consentServerConfigsManagementService;
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponentHolder.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponentHolder.java
@@ -21,6 +21,7 @@ import org.wso2.carbon.consent.mgt.core.ConsentManager;
 import org.wso2.carbon.identity.application.mgt.AbstractInboundAuthenticatorConfig;
 import org.wso2.carbon.identity.application.mgt.provider.ApplicationPermissionProvider;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.consent.server.configs.mgt.services.ConsentServerConfigsManagementService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
 import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.registry.api.RegistryService;
@@ -59,6 +60,8 @@ public class ApplicationManagementServiceComponentHolder {
     private ApplicationPermissionProvider applicationPermissionProvider;
 
     private boolean isOrganizationManagementEnable = false;
+
+    private static ConsentServerConfigsManagementService consentServerConfigsManagementService;
 
     private ApplicationManagementServiceComponentHolder() {
 
@@ -248,5 +251,27 @@ public class ApplicationManagementServiceComponentHolder {
     public ApplicationPermissionProvider getApplicationPermissionProvider() {
 
         return applicationPermissionProvider;
+    }
+
+    /**
+     * Get Consent Server Configs Management Service.
+     *
+     * @return Consent Server Configs Management Service.
+     */
+    public static ConsentServerConfigsManagementService getConsentServerConfigsManagementService() {
+
+        return ApplicationManagementServiceComponentHolder.consentServerConfigsManagementService;
+    }
+
+    /**
+     * Set Consent Server Configs Management Service.
+     *
+     * @param consentServerConfigsManagementService Consent Server Configs Management Service.
+     */
+    public static void setConsentServerConfigsManagementService(ConsentServerConfigsManagementService
+                                                                        consentServerConfigsManagementService) {
+
+        ApplicationManagementServiceComponentHolder.consentServerConfigsManagementService =
+                consentServerConfigsManagementService;
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/validator/DefaultApplicationValidator.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/validator/DefaultApplicationValidator.java
@@ -45,7 +45,6 @@ import org.wso2.carbon.identity.application.common.model.script.AuthenticationSc
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
-import org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil;
 import org.wso2.carbon.identity.application.mgt.dao.ApplicationDAO;
 import org.wso2.carbon.identity.application.mgt.dao.impl.ApplicationDAOImpl;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementServiceImpl;
@@ -93,8 +92,6 @@ public class DefaultApplicationValidator implements ApplicationValidator {
     private static final String ROLE_NOT_AVAILABLE = "Local Role %s is not available in the server.";
     private static final String GROUPS_ARE_PROHIBITED_FOR_ROLE_MAPPING = "Groups including: %s, are " +
             "prohibited for role mapping. Use roles instead.";
-    private static final String EXTERNAL_CONSENT_PAGE_URL_NOT_AVAILABLE =
-            "External consent page URL is not available in the server to enable external consent page.";
     public static final String IS_HANDLER = "IS_HANDLER";
     private static Pattern loopPattern;
     private static final int MODE_DEFAULT = 1;
@@ -136,10 +133,6 @@ public class DefaultApplicationValidator implements ApplicationValidator {
         if (isAuthenticationScriptAvailableConfig(serviceProvider)) {
             validateAdaptiveAuthScript(validationErrors,
                     serviceProvider.getLocalAndOutBoundAuthenticationConfig().getAuthenticationScriptConfig());
-        }
-        if (serviceProvider.getLocalAndOutBoundAuthenticationConfig() != null) {
-            validateUseExternalConsentPage(validationErrors, serviceProvider.getLocalAndOutBoundAuthenticationConfig()
-                    .isUseExternalConsentPage(), tenantDomain);
         }
 
         return validationErrors;
@@ -280,27 +273,6 @@ public class DefaultApplicationValidator implements ApplicationValidator {
         }
         if (!isAuthenticatorIncluded.get()) {
             validationMsg.add("No authenticator have been registered in the authentication flow.");
-        }
-    }
-
-    /** Validate external consent page related configurations and append to the validation msg list.
-     *
-     * @param validationMsg                validation error messages
-     * @param isUseExternalConsentPage     whether use external consent page
-     * @param tenantDomain                 tenant domain
-     */
-    private void validateUseExternalConsentPage(List<String> validationMsg, Boolean isUseExternalConsentPage,
-                                                String tenantDomain) {
-
-        if (!isUseExternalConsentPage) {
-            return;
-        }
-        try {
-            String externalConsentPageUrl = ApplicationMgtUtil.resolveExternalConsentPageUrl(tenantDomain);
-        } catch (IdentityApplicationManagementException e) {
-            String errorMsg = String.format(EXTERNAL_CONSENT_PAGE_URL_NOT_AVAILABLE);
-            log.error(errorMsg, e);
-            validationMsg.add(errorMsg);
         }
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Previously done some validation for check the existence of the org level consent url in application mgt when enabling `useExternalConsentPage` configuration in app wise.

- Remove this validation because no longer needed that validation in application creation and update. It will check in run time.

