### PR TITLE
Remove ignoring IDP properties from the IDP object

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
@@ -147,8 +147,7 @@ public class IdentityProvider implements Serializable {
     @XmlElement(name = "JustInTimeProvisioningConfig")
     private JustInTimeProvisioningConfig justInTimeProvisioningConfig;
 
-    @XmlTransient
-    @JsonIgnore
+    @XmlElement(name = "IdpProperties")
     private IdentityProviderProperty[] idpProperties = new IdentityProviderProperty[0];
 
     @JsonIgnore


### PR DESCRIPTION
Adding the `@XmlTransient` and `@JsonIgnore` tags for the idpProperties field of the IdentityProvider object removes that field when parsing the IDP object to a XML or JSON string. IDP properties should be added to the response when exporting resident IDP configs, therefore removing these annotations.

Related issue: https://github.com/wso2/product-is/issues/15695