### PR TITLE
Remove Field Input Validation API config and improve the logic

### DIFF
--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -37,6 +37,7 @@ public class Constants {
 
     public static final String INPUT_VAL_CONFIG_RESOURCE_TYPE_NAME = "input-validation-configurations";
     public static final String INPUT_VAL_CONFIG_RESOURCE_NAME_PREFIX = "input-validation-configs-";
+    public static final String SECONDARY_USER_STORE_DOMAIN_NAME = "DEFAULT";
     public static final List<String> SUPPORTED_PARAMS = Collections.unmodifiableList(
             new ArrayList<String>() {{
                 add(PASSWORD);


### PR DESCRIPTION
### Proposed changes in this pull request

Previously to set the userstore, retrieved configs from the identity.xml if it is configured, else set to the PRIMARY userstore. As the API is not yet exposed to product IS removed the config and improved the logic

