### PR TITLE
Add config to backward compatibility of filter query params from consent page url

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/builder/FileBasedConfigurationBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/builder/FileBasedConfigurationBuilder.java
@@ -78,6 +78,7 @@ public class FileBasedConfigurationBuilder {
     private String authenticationEndpointMissingClaimsURL;
     private boolean allowCustomClaimMappingsForAuthenticators = false;
     private boolean allowMergingCustomClaimMappingsWithDefaultClaimMappings = false;
+    private boolean allowConsentPageRedirectParams = false;
 
     /**
      * List of URLs that receive the tenant list
@@ -227,6 +228,9 @@ public class FileBasedConfigurationBuilder {
 
             //########## Read Authentication Claim Dialect Merge Configs ###########
             readAllowMergingCustomClaimMappingsWithDefaultClaimMappings(rootElement);
+
+            //########## Read Allow Consent Page Redirect Params Configs ###########
+            readAllowConsentPageRedirectParams(rootElement);
         } catch (XMLStreamException e) {
             log.error("Error reading the " + IdentityApplicationConstants.APPLICATION_AUTHENTICATION_CONGIG, e);
         } catch (Exception e) {
@@ -514,6 +518,17 @@ public class FileBasedConfigurationBuilder {
                     this.authEndpointRedirectParams.add(redirectParamName);
                 }
             }
+        }
+    }
+
+    private void readAllowConsentPageRedirectParams(OMElement documentElement) {
+
+        OMElement element = documentElement.getFirstChildWithName(IdentityApplicationManagementUtil.
+                getQNameWithIdentityApplicationNS(
+                        FrameworkConstants.Config.QNAME_ALLOW_CONSENT_PAGE_REDIRECT_PARAMS));
+
+        if (element != null) {
+            allowConsentPageRedirectParams = Boolean.valueOf(element.getText());
         }
     }
 
@@ -1135,6 +1150,15 @@ public class FileBasedConfigurationBuilder {
         }
     }
 
+    /**
+     * Indicates whether the query params are allowed in the consent page.
+     *
+     * @return True if query params are allowed in consent page redirect url.
+     */
+    public boolean isConsentPageRedirectParamsAllowed() {
+
+        return allowConsentPageRedirectParams;
+    }
     /**
      * Indicates whether a custom claim dialect can be used instead
      * of the authenticator's claim dialect.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -287,6 +287,8 @@ public abstract class FrameworkConstants {
                 "AllowCustomClaimMappingsForAuthenticators";
         public static final String QNAME_MERGE_AUTHENTICATOR_CUSTOM_CLAIM_MAPPINGS_WITH_DEFAULT =
                 "AllowMergingCustomClaimMappingsWithDefaultClaimMappings";
+        public static final String QNAME_ALLOW_CONSENT_PAGE_REDIRECT_PARAMS =
+                "AllowConsentPageRedirectParams";
 
         /**
          * Configuration name for the collection of urls for receiving tenant list

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml
@@ -261,5 +261,5 @@
     Default value: false
     -->
     <!--<AllowMergingCustomClaimMappingsWithDefaultClaimMappings>true</AllowMergingCustomClaimMappingsWithDefaultClaimMappings>-->
-
+    <AllowConsentPageRedirectParams>false</AllowConsentPageRedirectParams>
 </ApplicationAuthentication>

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml.j2
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml.j2
@@ -163,8 +163,8 @@
     </AuthenticationEndpointRedirectParams>
     {% endif %}
 
-    {% if authentication.endpoint.enable_consent_page_redirect_params.allowConsentPageRedirectParams is defined %}
-            <AllowConsentPageRedirectParams>{{authentication.endpoint.enable_consent_page_redirect_params.allowConsentPageRedirectParams}}</AllowConsentPageRedirectParams>
+    {% if authentication.endpoint.consent_page_redirect_params.allow is defined %}
+            <AllowConsentPageRedirectParams>{{authentication.endpoint.consent_page_redirect_params.allow}}</AllowConsentPageRedirectParams>
         {% endif %}
 
     {% if authentication.endpoint.enable_custom_claim_mappings is defined %}

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml.j2
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml.j2
@@ -164,8 +164,8 @@
     {% endif %}
 
     {% if authentication.endpoint.consent_page_redirect_params.allow is defined %}
-            <AllowConsentPageRedirectParams>{{authentication.endpoint.consent_page_redirect_params.allow}}</AllowConsentPageRedirectParams>
-        {% endif %}
+    <AllowConsentPageRedirectParams>{{authentication.endpoint.consent_page_redirect_params.allow}}</AllowConsentPageRedirectParams>
+    {% endif %}
 
     {% if authentication.endpoint.enable_custom_claim_mappings is defined %}
     <AllowCustomClaimMappingsForAuthenticators>{{authentication.endpoint.enable_custom_claim_mappings}}</AllowCustomClaimMappingsForAuthenticators>

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml.j2
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/application-authentication.xml.j2
@@ -163,6 +163,10 @@
     </AuthenticationEndpointRedirectParams>
     {% endif %}
 
+    {% if authentication.endpoint.enable_consent_page_redirect_params.allowConsentPageRedirectParams is defined %}
+            <AllowConsentPageRedirectParams>{{authentication.endpoint.enable_consent_page_redirect_params.allowConsentPageRedirectParams}}</AllowConsentPageRedirectParams>
+        {% endif %}
+
     {% if authentication.endpoint.enable_custom_claim_mappings is defined %}
     <AllowCustomClaimMappingsForAuthenticators>{{authentication.endpoint.enable_custom_claim_mappings}}</AllowCustomClaimMappingsForAuthenticators>
     {% endif %}

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -57,6 +57,7 @@
     "password",
     "SAMLRequest"
   ],
+  "authentication.endpoint.enable_consent_page_redirect_params.allowConsentPageRedirectParams": false,
 
   "authentication.authenticator.basic.name": "BasicAuthenticator",
   "authentication.authenticator.basic.enable": true,

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -57,7 +57,7 @@
     "password",
     "SAMLRequest"
   ],
-  "authentication.endpoint.enable_consent_page_redirect_params.allowConsentPageRedirectParams": false,
+  "authentication.endpoint.consent_page_redirect_params.allow": false,
 
   "authentication.authenticator.basic.name": "BasicAuthenticator",
   "authentication.authenticator.basic.enable": true,


### PR DESCRIPTION
### Purpose
$subject

### Changes from the PR
- The default behaviour of the consent page url is changed from https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2020
- Previously all the query parameters are appended to the consent page url.
- Now, all the query parameters are filtered from the consent page url except sessionDataKeyConsent query param by default.
- So to keep the backward compatibility, from this PR , we introduced the below config.
- If some one needs to keep the previous behavior, needs to add the below config to deployment.toml file

```
[authentication.endpoint.consent_page_redirect_params]
allow = true
```