### PR TITLE
Remove service path from the URL builder

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/Constants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/Constants.java
@@ -66,6 +66,7 @@ public class Constants {
     public static final String CONFIG_APP_PASSWORD = "app.password";
     public static final String CONFIG_SERVER_ORIGIN = "identity.server.origin";
     public static final String CONFIG_GOOGLE_ONETAP_RESTRICTED_BROWSERS = "google.social.onetap.restricted_browsers";
+    public static final String SERVICE_CONTEXT_PATH = "/services";
 
     private Constants() {
 
@@ -99,7 +100,7 @@ public class Constants {
         public static final String TLS_PROTOCOL = "tls.protocol";
 
         // Service URL constants
-        public static final String TENANT_MGT_ADMIN_SERVICE_URL = "/services/TenantMgtAdminService/retrieveTenants";
+        public static final String TENANT_MGT_ADMIN_SERVICE_URL = "/TenantMgtAdminService/retrieveTenants";
 
         // String constants for SOAP response processing
         public static final String RETURN = "return";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/TenantDataManager.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/TenantDataManager.java
@@ -147,8 +147,9 @@ public class TenantDataManager {
 
                         // Build the service URL of tenant management admin service
                         StringBuilder builder = new StringBuilder();
-                        serviceURL = builder.append(getPropertyValue(Constants.SERVICES_URL)).append(Constants.TenantConstants
-                                .TENANT_MGT_ADMIN_SERVICE_URL).toString();
+                    serviceURL = builder.append(getPropertyValue(Constants.SERVICES_URL))
+                            .append(Constants.SERVICE_CONTEXT_PATH)
+                            .append(Constants.TenantConstants.TENANT_MGT_ADMIN_SERVICE_URL).toString();
 
                         initialized = true;
                 }
@@ -198,8 +199,7 @@ public class TenantDataManager {
      */
     protected static String getPropertyValue(String key) {
         if ((Constants.SERVICES_URL.equals(key)) && !prop.containsKey(Constants.SERVICES_URL)) {
-            String serviceUrl = IdentityUtil.getServicePath();
-            return IdentityUtil.getServerURL(serviceUrl, true, true);
+            return IdentityUtil.getServerURL("", true, true);
         }
         return prop.getProperty(key);
     }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointConstants.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointConstants.java
@@ -39,13 +39,13 @@ public class IdentityManagementEndpointConstants {
     }
 
     public static final class ServiceEndpoints {
-        public static final String USER_REGISTRATION_SERVICE = "/services/UserRegistrationAdminService" +
+        public static final String USER_REGISTRATION_SERVICE = "/UserRegistrationAdminService" +
                 ".UserRegistrationAdminServiceHttpsSoap11Endpoint/";
-        public static final String USER_INFORMATION_RECOVERY_SERVICE = "/services/UserInformationRecoveryService" +
+        public static final String USER_INFORMATION_RECOVERY_SERVICE = "/UserInformationRecoveryService" +
                 ".UserInformationRecoveryServiceHttpsSoap11Endpoint/";
-        public static final String USER_IDENTITY_MANAGEMENT_SERVICE = "/services/UserIdentityManagementAdminService" +
+        public static final String USER_IDENTITY_MANAGEMENT_SERVICE = "/UserIdentityManagementAdminService" +
                 ".UserIdentityManagementAdminServiceHttpsSoap11Endpoint/";
-        public static final String IDENTITY_PROVIDER_MANAGEMENT_SERVICE = "/services/IdentityProviderMgtService" +
+        public static final String IDENTITY_PROVIDER_MANAGEMENT_SERVICE = "/IdentityProviderMgtService" +
                 ".IdentityProviderMgtServiceHttpsSoap11Endpoint/";
     }
 
@@ -117,6 +117,8 @@ public class IdentityManagementEndpointConstants {
     public static final String UTF_8 = "UTF-8";
 
     public static final String CALLBACK = "callback";
+
+    public static final String SERVICE_CONTEXT_PATH = "/services";
 
     public static class Consent {
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementServiceUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementServiceUtil.java
@@ -129,7 +129,7 @@ public class IdentityManagementServiceUtil {
                     .getProperty(IdentityManagementEndpointConstants.ServiceConfigConstants.SERVICE_CONTEXT_URL);
             contextURL = serviceContextURL;
             this.serviceContextURL = StringUtils.isBlank(serviceContextURL) ? ServiceURLBuilder.create().
-                    addPath(IdentityUtil.getServicePath()).build().getAbsoluteInternalURL() : serviceContextURL;
+                    build().getAbsoluteInternalURL() : serviceContextURL;
 
         } catch (IOException e) {
             log.error("Failed to load service configurations.", e);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/CallBackValidator.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/CallBackValidator.java
@@ -68,6 +68,7 @@ public class CallBackValidator {
         // Build the service URL of idp management admin service
         StringBuilder builder = new StringBuilder();
         String serviceURL = builder.append(IdentityManagementServiceUtil.getInstance().getServiceContextURL())
+                .append(IdentityManagementEndpointConstants.SERVICE_CONTEXT_PATH)
                 .append(IdentityManagementEndpointConstants.ServiceEndpoints.IDENTITY_PROVIDER_MANAGEMENT_SERVICE)
                 .toString().replaceAll("(?<!(http:|https:))//", "/");
         try {

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/serviceclient/UserIdentityManagementAdminServiceClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/serviceclient/UserIdentityManagementAdminServiceClient.java
@@ -46,6 +46,7 @@ public class UserIdentityManagementAdminServiceClient {
         String serviceURL = null;
 
         serviceURL = builder.append(IdentityManagementServiceUtil.getInstance().getServiceContextURL())
+                            .append(IdentityManagementEndpointConstants.SERVICE_CONTEXT_PATH)
                             .append(IdentityManagementEndpointConstants.ServiceEndpoints.USER_IDENTITY_MANAGEMENT_SERVICE)
                             .toString().replaceAll("(?<!(http:|https:))//", "/");
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/serviceclient/UserInformationRecoveryClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/serviceclient/UserInformationRecoveryClient.java
@@ -50,9 +50,10 @@ public class UserInformationRecoveryClient {
         StringBuilder builder = new StringBuilder();
         String serviceURL = null;
 
-        serviceURL = builder.append(IdentityManagementServiceUtil.getInstance().getServiceContextURL()).append
-                (IdentityManagementEndpointConstants.ServiceEndpoints.USER_INFORMATION_RECOVERY_SERVICE).toString()
-                            .replaceAll("(?<!(http:|https:))//", "/");
+        serviceURL = builder.append(IdentityManagementServiceUtil.getInstance().getServiceContextURL())
+                .append(IdentityManagementEndpointConstants.SERVICE_CONTEXT_PATH)
+                .append(IdentityManagementEndpointConstants.ServiceEndpoints.USER_INFORMATION_RECOVERY_SERVICE)
+                .toString().replaceAll("(?<!(http:|https:))//", "/");
 
         stub = new UserInformationRecoveryServiceStub(serviceURL);
         ServiceClient client = stub._getServiceClient();

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/serviceclient/UserRegistrationAdminServiceClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/serviceclient/UserRegistrationAdminServiceClient.java
@@ -48,6 +48,7 @@ public class UserRegistrationAdminServiceClient {
         String serviceURL = null;
 
         serviceURL = builder.append(IdentityManagementServiceUtil.getInstance().getServiceContextURL())
+                            .append(IdentityManagementEndpointConstants.SERVICE_CONTEXT_PATH)
                             .append(IdentityManagementEndpointConstants.ServiceEndpoints.USER_REGISTRATION_SERVICE)
                             .toString().replaceAll("(?<!(http:|https:))//", "/");
 


### PR DESCRIPTION
**Describe:**
Append service context path separately and remove service path from the URL builder

$subject as when service URL not defined the the URL builder returns service URL with the service path.

Resolves: https://github.com/wso2/product-is/issues/15892

Tested flows:
1. [Username recovery flow](https://is.docs.wso2.com/en/5.11.0/learn/username-recovery/#try-out-username-recovery)
2. [List tenant flow](https://is.docs.wso2.com/en/6.0.0/references/extend/customize-the-authentication-endpoint/#load-tenants-into-the-dropdown-in-the-login-page-of-the-authentication-endpoint-web-application)

Related issues: https://github.com/wso2/product-is/issues/15771, https://github.com/wso2/product-is/issues/15808