### PR TITLE
Add authentication service

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/ApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/ApplicationAuthenticator.java
@@ -21,10 +21,12 @@ package org.wso2.carbon.identity.application.authentication.framework;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorData;
 import org.wso2.carbon.identity.application.common.model.Property;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -120,5 +122,26 @@ public interface ApplicationAuthenticator extends Serializable {
     default boolean isSatisfyAuthenticatorPrerequisites(HttpServletRequest request, AuthenticationContext context)
             throws AuthenticationFailedException {
         return true;
+    }
+
+    /**
+     * Check whether the authenticator supports API based authentication.
+     *
+     * @return true if the authenticator supports API based authentication.
+     */
+    default boolean isAPIBasedAuthenticationSupported() {
+
+        return false;
+    }
+
+    /**
+     * Get the authentication initiation data.
+     *
+     * @param context Authentication context.
+     * @return AuthenticatorData containing authentication initiation data.
+     */
+    default Optional<AuthenticatorData> getAuthInitiationData(AuthenticationContext context) {
+
+        return Optional.empty();
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationService.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationService.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.cache.AuthenticationResultCacheEntry;
+import org.wso2.carbon.identity.application.authentication.framework.exception.auth.service.AuthServiceException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationResult;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorData;
+import org.wso2.carbon.identity.application.authentication.framework.model.auth.service.AuthServiceErrorInfo;
+import org.wso2.carbon.identity.application.authentication.framework.model.auth.service.AuthServiceRequest;
+import org.wso2.carbon.identity.application.authentication.framework.model.auth.service.AuthServiceRequestWrapper;
+import org.wso2.carbon.identity.application.authentication.framework.model.auth.service.AuthServiceResponse;
+import org.wso2.carbon.identity.application.authentication.framework.model.auth.service.AuthServiceResponseData;
+import org.wso2.carbon.identity.application.authentication.framework.model.auth.service.AuthServiceResponseWrapper;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.authentication.framework.util.auth.service.AuthServiceConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.auth.service.AuthServiceUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * The authentication service class.
+ * The class uses request and response wrappers to communicate with the authentication framework.
+ */
+public class AuthenticationService {
+
+    private static final Log LOG = LogFactory.getLog(AuthenticationService.class);
+    private final CommonAuthenticationHandler commonAuthenticationHandler = new CommonAuthenticationHandler();
+
+    /**
+     * Handles the authentication request.
+     *
+     * @param authRequest The authentication request.
+     * @return The authentication response.
+     * @throws AuthServiceException If an error occurs while handling the authentication request.
+     */
+    public AuthServiceResponse handleAuthentication(AuthServiceRequest authRequest) throws AuthServiceException {
+
+        AuthServiceRequestWrapper wrappedRequest = getWrappedRequest(authRequest.getRequest(),
+                authRequest.getParameters());
+        AuthServiceResponseWrapper wrappedResponse = getWrappedResponse(authRequest.getResponse());
+        try {
+            commonAuthenticationHandler.doPost(wrappedRequest, wrappedResponse);
+        } catch (ServletException | IOException e) {
+            throw new AuthServiceException("Error while handling authentication request.", e);
+        }
+
+        return processCommonAuthResponse(wrappedRequest, wrappedResponse);
+    }
+
+    private AuthServiceRequestWrapper getWrappedRequest(HttpServletRequest request, Map<String, String[]> parameters) {
+
+        return new AuthServiceRequestWrapper(request, parameters);
+    }
+
+    private AuthServiceResponseWrapper getWrappedResponse(HttpServletResponse response) {
+
+        return new AuthServiceResponseWrapper(response);
+    }
+
+    private AuthServiceResponse processCommonAuthResponse(AuthServiceRequestWrapper request,
+                                                          AuthServiceResponseWrapper response)
+            throws AuthServiceException {
+
+        AuthServiceResponse authServiceResponse = new AuthServiceResponse();
+
+        if (isAuthFlowSuccessful(request)) {
+            handleSuccessAuthResponse(request, response, authServiceResponse);
+        } else if (isAuthFlowFailed(request, response)) {
+            handleFailedAuthResponse(request, response, authServiceResponse);
+        } else if (isAuthFlowIncomplete(request)) {
+            handleIntermediateAuthResponse(request, response, authServiceResponse);
+        } else {
+            throw new AuthServiceException("Unknown authentication flow status: " + request.getAuthFlowStatus());
+        }
+
+        return authServiceResponse;
+    }
+
+    private void handleIntermediateAuthResponse(AuthServiceRequestWrapper request, AuthServiceResponseWrapper response,
+                                                AuthServiceResponse authServiceResponse) throws AuthServiceException {
+
+        authServiceResponse.setSessionDataKey(response.getSessionDataKey());
+        authServiceResponse.setFlowStatus(AuthServiceConstants.FlowStatus.INCOMPLETE);
+        AuthServiceResponseData responseData = new AuthServiceResponseData();
+        boolean isMultiOptionsResponse = request.isMultiOptionsResponse();
+
+        List<AuthenticatorData> authenticatorDataList;
+        if (isMultiOptionsResponse) {
+            responseData.setAuthenticatorSelectionRequired(true);
+            authenticatorDataList = getAuthenticatorBasicData(response.getAuthenticators());
+        } else {
+            authenticatorDataList = request.getAuthInitiationData();
+        }
+        responseData.setAuthenticatorOptions(authenticatorDataList);
+        authServiceResponse.setData(responseData);
+    }
+
+    private void handleSuccessAuthResponse(AuthServiceRequestWrapper request, AuthServiceResponseWrapper response,
+                                           AuthServiceResponse authServiceResponse) throws AuthServiceException {
+
+        authServiceResponse.setSessionDataKey(getFlowCompletionSessionDataKey(request, response));
+        authServiceResponse.setFlowStatus(AuthServiceConstants.FlowStatus.SUCCESS_COMPLETED);
+    }
+
+    private void handleFailedAuthResponse(AuthServiceRequestWrapper request, AuthServiceResponseWrapper response,
+                                          AuthServiceResponse authServiceResponse) throws AuthServiceException {
+
+        // TODO: Improve error handling. Different authenticator seems to pass errors in slightly different ways.
+        String errorCode = null;
+        String errorMessage = null;
+        if (request.isAuthFlowConcluded()) {
+            authServiceResponse.setSessionDataKey(getFlowCompletionSessionDataKey(request, response));
+            authServiceResponse.setFlowStatus(AuthServiceConstants.FlowStatus.FAIL_COMPLETED);
+            AuthenticationResult authenticationResult = getAuthenticationResult(request, response);
+            if (authenticationResult != null) {
+                errorCode = (String) authenticationResult.getProperty(FrameworkConstants.AUTH_ERROR_CODE);
+                errorMessage = (String) authenticationResult.getProperty(FrameworkConstants.AUTH_ERROR_MSG);
+            }
+        } else {
+            authServiceResponse.setSessionDataKey(response.getSessionDataKey());
+            authServiceResponse.setFlowStatus(AuthServiceConstants.FlowStatus.FAIL_INCOMPLETE);
+            List<AuthenticatorData> authenticatorDataList = request.getAuthInitiationData();
+            AuthServiceResponseData responseData = new AuthServiceResponseData(authenticatorDataList);
+            authServiceResponse.setData(responseData);
+            errorCode = getErrorCode(response);
+            errorMessage = getErrorMessage(response);
+        }
+
+        if (StringUtils.isBlank(errorCode)) {
+            errorCode = AuthServiceConstants.ERROR_CODE_UNKNOWN_ERROR;
+        }
+
+        if (StringUtils.isBlank(errorMessage)) {
+            errorMessage = AuthServiceConstants.ERROR_MSG_UNKNOWN_ERROR;
+        }
+
+        AuthServiceErrorInfo errorInfo = new AuthServiceErrorInfo(errorCode, errorMessage);
+        authServiceResponse.setErrorInfo(errorInfo);
+    }
+
+    private String getErrorCode(AuthServiceResponseWrapper response) throws AuthServiceException {
+
+        Map<String, String> queryParams = AuthServiceUtils.extractQueryParams(response.getRedirectURL());
+        return queryParams.get(AuthServiceConstants.ERROR_CODE_PARAM);
+    }
+
+    private String getErrorMessage(AuthServiceResponseWrapper response) throws AuthServiceException {
+
+        Map<String, String> queryParams = AuthServiceUtils.extractQueryParams(response.getRedirectURL());
+        return queryParams.get(AuthServiceConstants.AUTH_FAILURE_MSG_PARAM);
+    }
+
+    private List<AuthenticatorData> getAuthenticatorBasicData(String authenticatorList) throws AuthServiceException {
+
+        List<AuthenticatorData> authenticatorDataList = new ArrayList<>();
+        String[] authenticatorAndIdpsArr = StringUtils.split(authenticatorList,
+                AuthServiceConstants.AUTHENTICATOR_SEPARATOR);
+        for (String authenticatorAndIdps : authenticatorAndIdpsArr) {
+            String[] authenticatorIdpSeperatedArr = StringUtils.split(authenticatorAndIdps,
+                    AuthServiceConstants.AUTHENTICATOR_IDP_SEPARATOR);
+            String name = authenticatorIdpSeperatedArr[0];
+            ApplicationAuthenticator authenticator = FrameworkUtils.getAppAuthenticatorByName(name);
+            if (authenticator == null) {
+                throw new AuthServiceException("Authenticator not found for name: " + name);
+            }
+
+            if (!authenticator.isAPIBasedAuthenticationSupported()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Authenticator: " + name + " does not support API based authentication.");
+                }
+                continue;
+            }
+            // The first element is the authenticator name hence its skipped to get the idp.
+            for (int i = 1; i < authenticatorIdpSeperatedArr.length; i++) {
+                String idp = authenticatorIdpSeperatedArr[i];
+                AuthenticatorData authenticatorData = new AuthenticatorData();
+                authenticatorData.setName(name);
+                authenticatorData.setIdp(idp);
+                authenticatorData.setDisplayName(authenticator.getFriendlyName());
+
+                authenticatorDataList.add(authenticatorData);
+            }
+        }
+        return authenticatorDataList;
+    }
+
+    private boolean isAuthFlowSuccessful(AuthServiceRequestWrapper request) {
+
+        return AuthenticatorFlowStatus.SUCCESS_COMPLETED == request.getAuthFlowStatus();
+    }
+
+    private boolean isAuthFlowFailed(AuthServiceRequestWrapper request, AuthServiceResponseWrapper response)
+            throws AuthServiceException {
+
+        return AuthenticatorFlowStatus.FAIL_COMPLETED == request.getAuthFlowStatus() || response.isErrorResponse();
+    }
+
+    private boolean isAuthFlowIncomplete(AuthServiceRequestWrapper request) {
+
+        return AuthenticatorFlowStatus.INCOMPLETE == request.getAuthFlowStatus();
+    }
+
+    private String getFlowCompletionSessionDataKey(AuthServiceRequestWrapper request,
+                                                   AuthServiceResponseWrapper response) throws AuthServiceException {
+
+        String completionSessionDataKey = (String) request.getAttribute(FrameworkConstants.SESSION_DATA_KEY);
+        if (StringUtils.isBlank(completionSessionDataKey)) {
+            completionSessionDataKey = response.getSessionDataKey();
+        }
+
+        return completionSessionDataKey;
+    }
+
+    private AuthenticationResult getAuthenticationResult(AuthServiceRequestWrapper request,
+                                                         AuthServiceResponseWrapper response)
+            throws AuthServiceException {
+
+        AuthenticationResult authenticationResult =
+                (AuthenticationResult) request.getAttribute(FrameworkConstants.RequestAttribute.AUTH_RESULT);
+        if (authenticationResult == null) {
+            AuthenticationResultCacheEntry authenticationResultCacheEntry =
+                    FrameworkUtils.getAuthenticationResultFromCache(getFlowCompletionSessionDataKey(request, response));
+            if (authenticationResultCacheEntry != null) {
+                authenticationResult = authenticationResultCacheEntry.getResult();
+            }
+        }
+        return authenticationResult;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/exception/auth/service/AuthServiceClientException.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/exception/auth/service/AuthServiceClientException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.exception.auth.service;
+
+/**
+ * Client exception class for authentication service.
+ */
+public class AuthServiceClientException extends AuthServiceException {
+
+    private static final long serialVersionUID = -7083696038928722512L;
+
+    public AuthServiceClientException(String message) {
+
+        super(message);
+    }
+
+    public AuthServiceClientException(String errorCode, String message) {
+
+        super(errorCode, message);
+    }
+
+    public AuthServiceClientException(String message, Throwable cause) {
+
+        super(message, cause);
+    }
+
+    public AuthServiceClientException(String errorCode, String message, Throwable cause) {
+
+        super(errorCode, message, cause);
+    }
+}
+

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/exception/auth/service/AuthServiceException.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/exception/auth/service/AuthServiceException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.exception.auth.service;
+
+import org.wso2.carbon.identity.base.IdentityException;
+
+/**
+ * Exception class for authentication service.
+ */
+public class AuthServiceException extends IdentityException {
+
+    private static final long serialVersionUID = 90220434357504216L;
+
+    public AuthServiceException(String message) {
+
+        super(message);
+    }
+
+    public AuthServiceException(String errorCode, String message) {
+
+        super(errorCode, message);
+    }
+
+    public AuthServiceException(String message, Throwable cause) {
+
+        super(message, cause);
+    }
+
+    public AuthServiceException(String errorCode, String message, Throwable cause) {
+
+        super(errorCode, message, cause);
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -363,6 +363,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
 
         SequenceConfig sequenceConfig = context.getSequenceConfig();
         sequenceConfig.setCompleted(false);
+        request.setAttribute(FrameworkConstants.IS_AUTH_FLOW_CONCLUDED, true);
 
         AuthenticationResult authenticationResult = new AuthenticationResult();
         boolean isAuthenticated = context.isRequestAuthenticated();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatorData.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatorData.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Holds the data related to an authenticator during an authentication flow.
+ * Contains data specific to authentication flow.
+ */
+public class AuthenticatorData {
+
+    private String name;
+    private String displayName;
+    private String idp;
+    private List<AuthenticatorParamMetadata> authParams = new ArrayList<>();
+    private Map<String, String> additionalData = new HashMap<>();
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public String getDisplayName() {
+
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+
+        this.displayName = displayName;
+    }
+
+    public String getIdp() {
+
+        return idp;
+    }
+
+    public void setIdp(String idp) {
+
+        this.idp = idp;
+    }
+
+    public List<AuthenticatorParamMetadata> getAuthParams() {
+
+        return authParams;
+    }
+
+    public void setAuthParams(List<AuthenticatorParamMetadata> authParams) {
+
+        this.authParams = authParams;
+    }
+
+    public Map<String, String> getAdditionalData() {
+
+        return additionalData;
+    }
+
+    public void setAdditionalData(Map<String, String> additionalData) {
+
+        this.additionalData = additionalData;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatorParamMetadata.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatorParamMetadata.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.model;
+
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+
+/**
+ * Contains the metadata of an auth related parameter used in an authenticator.
+ */
+public class AuthenticatorParamMetadata {
+
+    private String name;
+    private FrameworkConstants.AuthenticatorParamType type;
+    private boolean isConfidential = false;
+    private int paramOrder;
+    private int paramGroup = 0;
+
+    public AuthenticatorParamMetadata(String name, FrameworkConstants.AuthenticatorParamType type, int paramOrder) {
+
+        this.name = name;
+        this.type = type;
+        this.paramOrder = paramOrder;
+    }
+
+    public AuthenticatorParamMetadata(String name, FrameworkConstants.AuthenticatorParamType type, int paramOrder,
+                                      boolean isConfidential) {
+
+        this.name = name;
+        this.type = type;
+        this.paramOrder = paramOrder;
+        this.isConfidential = isConfidential;
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public FrameworkConstants.AuthenticatorParamType getType() {
+
+        return type;
+    }
+
+    public void setType(FrameworkConstants.AuthenticatorParamType type) {
+
+        this.type = type;
+    }
+
+    public boolean isConfidential() {
+
+        return isConfidential;
+    }
+
+    public void setConfidential(boolean confidential) {
+
+        isConfidential = confidential;
+    }
+
+    public int getParamOrder() {
+
+        return paramOrder;
+    }
+
+    public void setParamOrder(int paramOrder) {
+
+        this.paramOrder = paramOrder;
+    }
+
+    public int getParamGroup() {
+
+        return paramGroup;
+    }
+
+    public void setParamGroup(int paramGroup) {
+
+        this.paramGroup = paramGroup;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/auth/service/AuthServiceErrorInfo.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/auth/service/AuthServiceErrorInfo.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.model.auth.service;
+
+/**
+ * Class for the error info object that is sent from the authentication service.
+ */
+public class AuthServiceErrorInfo {
+
+    private String errorCode;
+    private String errorMessage;
+
+    public AuthServiceErrorInfo() {
+
+    }
+
+    public AuthServiceErrorInfo(String errorCode, String errorMessage) {
+
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorCode() {
+
+        return errorCode;
+    }
+
+    public void setErrorCode(String errorCode) {
+
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorMessage() {
+
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+
+        this.errorMessage = errorMessage;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/auth/service/AuthServiceRequest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/auth/service/AuthServiceRequest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.model.auth.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Class for the request object that is passed to the authentication service.
+ */
+public class AuthServiceRequest {
+
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private Map<String, String[]> parameters = new HashMap<>();
+
+    public AuthServiceRequest(HttpServletRequest request, HttpServletResponse response) {
+
+        this.request = request;
+        this.response = response;
+    }
+
+    public AuthServiceRequest(HttpServletRequest request, HttpServletResponse response,
+                              Map<String, String[]> parameters) {
+
+        this.request = request;
+        this.response = response;
+        this.parameters = parameters;
+    }
+
+    public HttpServletRequest getRequest() {
+
+        return request;
+    }
+
+    public HttpServletResponse getResponse() {
+
+        return response;
+    }
+
+    public void setParameters(Map<String, String[]> parameters) {
+
+        this.parameters = parameters;
+    }
+
+    public Map<String, String[]> getParameters() {
+
+        return parameters;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/auth/service/AuthServiceRequestWrapper.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/auth/service/AuthServiceRequestWrapper.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.model.auth.service;
+
+import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorData;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.auth.service.AuthServiceConstants;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+/**
+ * A HttpServletRequest wrapper to be used in authentication service.
+ */
+public class AuthServiceRequestWrapper extends HttpServletRequestWrapper {
+
+    private Map<String, String[]> parameters = new HashMap<>();
+
+    public AuthServiceRequestWrapper(HttpServletRequest request, Map<String, String[]> parameters) {
+
+        super(request);
+        this.parameters = parameters;
+        setSessionDataKey(parameters);
+        skipNonceCookieValidation();
+    }
+
+    @Override
+    public String getParameter(String name) {
+
+        if (this.parameters.containsKey(name) && this.parameters.get(name).length > 0) {
+            return this.parameters.get(name)[0];
+        }
+        return super.getParameter(name);
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+
+        Map<String, String[]> paramMap = new HashMap<>(super.getParameterMap());
+        paramMap.putAll(this.parameters);
+
+        return paramMap;
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+
+        Set<String> paramNames = new HashSet<>(this.parameters.keySet());
+        paramNames.addAll(Collections.list(super.getParameterNames()));
+
+        return Collections.enumeration(paramNames);
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+
+        if (this.parameters.containsKey(name)) {
+            return this.parameters.get(name);
+        }
+
+        return super.getParameterValues(name);
+    }
+
+    /**
+     * Get the authentication initiation data related to
+     * any authenticators engaged in the request flow.
+     *
+     * @return List of {@link AuthenticatorData} objects.
+     */
+    public List<AuthenticatorData> getAuthInitiationData() {
+
+        List<AuthenticatorData> authenticatorData =
+                (List<AuthenticatorData>) getAttribute(AuthServiceConstants.AUTH_SERVICE_AUTH_INITIATION_DATA);
+        return authenticatorData != null ? authenticatorData : Collections.emptyList();
+    }
+
+    /**
+     * Check whether the request is a multi options response.
+     * This check is done by checking the presence of the
+     * attribute {@link FrameworkConstants#IS_MULTI_OPS_RESPONSE}
+     * from the request.
+     *
+     * @return true if the attribute is present, false otherwise.
+     */
+    public boolean isMultiOptionsResponse() {
+
+        return Boolean.TRUE.equals(getAttribute(FrameworkConstants.IS_MULTI_OPS_RESPONSE));
+    }
+
+    /**
+     * Get the authenticator flow status.
+     * This check is done by checking the presence of the
+     * attribute {@link FrameworkConstants.RequestParams#FLOW_STATUS}
+     * from the request.
+     *
+     * @return {@link AuthenticatorFlowStatus} if the attribute is present, null otherwise.
+     */
+    public AuthenticatorFlowStatus getAuthFlowStatus() {
+
+        return (AuthenticatorFlowStatus) getAttribute(FrameworkConstants.RequestParams.FLOW_STATUS);
+    }
+
+    /**
+     * Check whether the complete authentication flow is concluded.
+     *
+     * @return true if the flow is concluded, false otherwise.
+     */
+    public boolean isAuthFlowConcluded() {
+
+        return Boolean.TRUE.equals(getAttribute(FrameworkConstants.IS_AUTH_FLOW_CONCLUDED));
+    }
+
+    private void setSessionDataKey(Map<String, String[]> parameters) {
+
+        if (parameters.containsKey(AuthServiceConstants.FLOW_ID)) {
+            this.parameters.put(FrameworkConstants.SESSION_DATA_KEY, parameters.get(AuthServiceConstants.FLOW_ID));
+        }
+    }
+
+    private void skipNonceCookieValidation() {
+
+        this.setAttribute(FrameworkConstants.SKIP_NONCE_COOKIE_VALIDATION, true);
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/auth/service/AuthServiceResponse.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/auth/service/AuthServiceResponse.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.model.auth.service;
+
+import org.wso2.carbon.identity.application.authentication.framework.util.auth.service.AuthServiceConstants;
+
+import java.util.Optional;
+
+/**
+ * Class for the response object that is passed from the authentication service.
+ */
+public class AuthServiceResponse {
+
+    private String sessionDataKey;
+    private AuthServiceConstants.FlowStatus flowStatus;
+    private AuthServiceResponseData data;
+    private AuthServiceErrorInfo errorInfo;
+
+    public String getSessionDataKey() {
+
+        return sessionDataKey;
+    }
+
+    public void setSessionDataKey(String sessionDataKey) {
+
+        this.sessionDataKey = sessionDataKey;
+    }
+
+    public AuthServiceConstants.FlowStatus getFlowStatus() {
+
+        return flowStatus;
+    }
+
+    public void setFlowStatus(AuthServiceConstants.FlowStatus flowStatus) {
+
+        this.flowStatus = flowStatus;
+    }
+
+    /**
+     * Get the response data related to auth service.
+     * Data will be null if the flow status is not
+     * {@link AuthServiceConstants.FlowStatus#INCOMPLETE} or
+     * {@link AuthServiceConstants.FlowStatus#FAIL_INCOMPLETE}.
+     *
+     * @return Optional of AuthServiceResponseData.
+     */
+    public Optional<AuthServiceResponseData> getData() {
+
+        return Optional.ofNullable(data);
+    }
+
+    public void setData(AuthServiceResponseData data) {
+
+        this.data = data;
+    }
+
+    /**
+     * Get the error info related to auth service.
+     * Error info will be null if the flow status is
+     * not {@link AuthServiceConstants.FlowStatus#FAIL_COMPLETED} or
+     * {@link AuthServiceConstants.FlowStatus#FAIL_INCOMPLETE}.
+     *
+     * @return Optional of AuthServiceErrorInfo.
+     */
+    public Optional<AuthServiceErrorInfo> getErrorInfo() {
+
+        return Optional.ofNullable(errorInfo);
+    }
+
+    public void setErrorInfo(AuthServiceErrorInfo errorInfo) {
+
+        this.errorInfo = errorInfo;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/auth/service/AuthServiceResponseData.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/auth/service/AuthServiceResponseData.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.model.auth.service;
+
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorData;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class containing authentication data that is used to communicate intermediate authentication steps.
+ */
+public class AuthServiceResponseData {
+
+    private boolean isAuthenticatorSelectionRequired = false;
+    private List<AuthenticatorData> authenticatorOptions = new ArrayList<>();
+
+    public AuthServiceResponseData() {
+
+    }
+
+    public AuthServiceResponseData(List<AuthenticatorData> authenticatorOptions) {
+
+        this.authenticatorOptions = authenticatorOptions;
+    }
+
+    public boolean isAuthenticatorSelectionRequired() {
+
+        return isAuthenticatorSelectionRequired;
+    }
+
+    public void setAuthenticatorSelectionRequired(boolean authenticatorSelectionRequired) {
+
+        isAuthenticatorSelectionRequired = authenticatorSelectionRequired;
+    }
+
+    public List<AuthenticatorData> getAuthenticatorOptions() {
+
+        return authenticatorOptions;
+    }
+
+    public void setAuthenticatorOptions(List<AuthenticatorData> authenticatorOptions) {
+
+        this.authenticatorOptions = authenticatorOptions;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/auth/service/AuthServiceResponseWrapper.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/auth/service/AuthServiceResponseWrapper.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.model.auth.service;
+
+import org.wso2.carbon.identity.application.authentication.framework.exception.auth.service.AuthServiceException;
+import org.wso2.carbon.identity.application.authentication.framework.model.CommonAuthResponseWrapper;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.auth.service.AuthServiceConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.auth.service.AuthServiceUtils;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A HttpServletResponseWrapper wrapper to be used in authentication service.
+ */
+public class AuthServiceResponseWrapper extends CommonAuthResponseWrapper {
+
+    private static final String LOCATION_HEADER = "location";
+
+    public AuthServiceResponseWrapper(HttpServletResponse response) {
+
+        super(response);
+    }
+
+    /**
+     * Get the value of the authenticators query param in the redirect URL.
+     *
+     * @return String of authenticators and related IdPs engaged in the authentication flow.
+     * @throws AuthServiceException
+     */
+    public String getAuthenticators() throws AuthServiceException {
+
+        Map<String, String> queryParams = AuthServiceUtils.extractQueryParams(getRedirectURL());
+        return queryParams.get(AuthServiceConstants.AUTHENTICATORS);
+    }
+
+    /**
+     * Get the sessionDataKey related to the authentication flow.
+     *
+     * @return String of sessionDataKey.
+     * @throws AuthServiceException
+     */
+    public String getSessionDataKey() throws AuthServiceException {
+
+        Map<String, String> queryParams = AuthServiceUtils.extractQueryParams(getRedirectURL());
+        return queryParams.get(FrameworkConstants.SESSION_DATA_KEY);
+    }
+
+    /**
+     * Check if the response is an error response.
+     * This is determined by checking the existence and the value of the
+     * query param {@link AuthServiceConstants#AUTH_FAILURE_PARAM}.
+     *
+     * @return true if the response is an error response.
+     * @throws AuthServiceException
+     */
+    public boolean isErrorResponse() throws AuthServiceException {
+
+        Map<String, String> queryParams = AuthServiceUtils.extractQueryParams(getRedirectURL());
+        return Boolean.parseBoolean(queryParams.get(AuthServiceConstants.AUTH_FAILURE_PARAM));
+    }
+
+    @Override
+    public String getRedirectURL() {
+
+        String redirectUrl = super.getRedirectURL();
+        if (redirectUrl == null) {
+            redirectUrl = getHeader(LOCATION_HEADER);
+        }
+        return redirectUrl;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -73,6 +73,9 @@ public abstract class FrameworkConstants {
     public static final String FAILED_USERNAME = "failedUsername";
     public static final String LOCK_REASON = "lockedReason";
     public static final String NOT_SATISFY_PREREQUISITES_REASON = "NotSatisfyAuthenticatorPrerequisitesReason";
+    public static final String SKIP_NONCE_COOKIE_VALIDATION = "SkipNonceCookieValidation";
+    public static final String IS_MULTI_OPS_RESPONSE = "isMultiOptionsResponse";
+    public static final String IS_AUTH_FLOW_CONCLUDED = "isAuthFlowConcluded";
 
     // This is to support sign-up form to be displayed in the provisioning flow, as when trying to displaying the
     // sign-up form, we validate whether self-sign up is enabled.
@@ -722,5 +725,14 @@ public abstract class FrameworkConstants {
             public static final String HANDLE_MISSING_CLAIMS = "handle-missing-claims";
             public static final String PROCESS_CLAIM_CONSENT = "process-claim-consent";
         }
+    }
+
+    /**
+     * Enum for authenticator param type.
+     */
+    public enum AuthenticatorParamType {
+
+        STRING,
+        INTEGER,
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/LoginContextManagementUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/LoginContextManagementUtil.java
@@ -54,6 +54,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.getMyAccountURL;
 import static org.wso2.carbon.identity.application.authentication.framework.util.SessionNonceCookieUtil.getNonceCookieName;
 import static org.wso2.carbon.identity.application.authentication.framework.util.SessionNonceCookieUtil.isNonceCookieEnabled;
+import static org.wso2.carbon.identity.application.authentication.framework.util.SessionNonceCookieUtil.isNonceCookieValidationSkipped;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.DEFAULT_SP_CONFIG;
 
 /**
@@ -362,7 +363,7 @@ public class LoginContextManagementUtil {
         if (FrameworkUtils.isAuthenticationContextExpiryEnabled() && isValidRequest) {
             isValidRequest = FrameworkUtils.getCurrentStandardNano() <= context.getExpiryTime();
         }
-        if (isNonceCookieEnabled() && isValidRequest) {
+        if (isNonceCookieEnabled() && !isNonceCookieValidationSkipped(request) && isValidRequest) {
             Cookie nonceCookie = FrameworkUtils.getCookie(request, getNonceCookieName(context));
             isValidRequest = nonceCookie != null && StringUtils.isNotBlank(nonceCookie.getValue());
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionNonceCookieUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionNonceCookieUtil.java
@@ -92,7 +92,7 @@ public class SessionNonceCookieUtil {
     public static boolean validateNonceCookie(HttpServletRequest request,
                                               AuthenticationContext context) {
 
-        if (!isNonceCookieEnabled()) {
+        if (!isNonceCookieEnabled() || isNonceCookieValidationSkipped(request)) {
             return true;
         }
         if (NONCE_COOKIE_WHITELISTED_AUTHENTICATORS.contains(context.getCurrentAuthenticator())) {
@@ -143,6 +143,17 @@ public class SessionNonceCookieUtil {
             nonceCookieConfig = Boolean.parseBoolean(IdentityUtil.getProperty(NONCE_COOKIE_CONFIG));
         }
         return nonceCookieConfig;
+    }
+
+    /**
+     * Check if nonce cookie validation should be skipped based on the request.
+     *
+     * @param request Http servlet request.
+     * @return True if nonce cookie validation should be skipped.
+     */
+    public static boolean isNonceCookieValidationSkipped(HttpServletRequest request) {
+
+        return Boolean.TRUE.equals(request.getAttribute(FrameworkConstants.SKIP_NONCE_COOKIE_VALIDATION));
     }
 
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/auth/service/AuthServiceConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/auth/service/AuthServiceConstants.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.util.auth.service;
+
+/**
+ * Constants class for Auth Service.
+ */
+public class AuthServiceConstants {
+
+    /**
+     * Enum for flow status.
+     */
+    public enum FlowStatus {
+
+        SUCCESS_COMPLETED,
+        FAIL_COMPLETED,
+        FAIL_INCOMPLETE,
+        INCOMPLETE
+    }
+
+    public static final String AUTH_SERVICE_AUTH_INITIATION_DATA = "authServiceAuthInitiationData";
+    public static final String AUTHENTICATORS = "authenticators";
+    public static final String FLOW_ID = "flowId";
+    public static final String AUTHENTICATOR_SEPARATOR = ";";
+    public static final String AUTHENTICATOR_IDP_SEPARATOR = ":";
+    public static final String AUTH_FAILURE_PARAM = "authFailure";
+    public static final String AUTH_FAILURE_MSG_PARAM = "authFailureMsg";
+    public static final String ERROR_CODE_PARAM = "errorCode";
+    public static final String ERROR_CODE_UNKNOWN_ERROR = "UNKNOWN_ERROR";
+    public static final String ERROR_MSG_UNKNOWN_ERROR = "Unknown error occurred.";
+
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/auth/service/AuthServiceUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/auth/service/AuthServiceUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.util.auth.service;
+
+import org.wso2.carbon.identity.application.authentication.framework.exception.auth.service.AuthServiceException;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.UTF_8;
+
+/**
+ * Utility class for Auth Service.
+ */
+public class AuthServiceUtils {
+
+    /**
+     * Extract query params from the provided url.
+     *
+     * @param url Url to extract query params.
+     * @return Map of query params.
+     * @throws AuthServiceException if error occurred while extracting query params.
+     */
+    public static Map<String, String> extractQueryParams(String url) throws AuthServiceException {
+
+        Map<String, String> queryParams = new HashMap<>();
+        try {
+            URI uri = new URI(url);
+            String query = uri.getQuery();
+            String[] pairs = query.split("&");
+            for (String pair : pairs) {
+                int idx = pair.indexOf("=");
+                queryParams.put(URLDecoder.decode(pair.substring(0, idx), UTF_8),
+                        URLDecoder.decode(pair.substring(idx + 1), UTF_8));
+            }
+        } catch (URISyntaxException | UnsupportedEncodingException e) {
+            throw new AuthServiceException("Error while extracting query params from provided url.", e);
+        }
+        return queryParams;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultRequestCoordinator;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorData;
+import org.wso2.carbon.identity.application.authentication.framework.model.auth.service.AuthServiceErrorInfo;
+import org.wso2.carbon.identity.application.authentication.framework.model.auth.service.AuthServiceRequest;
+import org.wso2.carbon.identity.application.authentication.framework.model.auth.service.AuthServiceResponse;
+import org.wso2.carbon.identity.application.authentication.framework.model.auth.service.AuthServiceResponseData;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.authentication.framework.util.auth.service.AuthServiceConstants;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Unit tests for {@link AuthenticationService}.
+ */
+@PrepareForTest({FrameworkUtils.class, ConfigurationFacade.class})
+@PowerMockIgnore({"org.mockito.*"})
+public class AuthenticationServiceTest extends AbstractFrameworkTest {
+
+    private static final Log log = LogFactory.getLog(AuthenticationServiceTest.class);
+    private static final String MULTI_OPS_AUTHENTICATORS = "OpenIDConnectAuthenticator:google:google_myaccount;" +
+            "BasicAuthenticator:LOCAL;FIDOAuthenticator:LOCAL";
+    private static final String SINGLE_AUTHENTICATOR = "BasicAuthenticator:LOCAL";
+    private static final String SESSION_DATA_KEY = "4458306a-5e77-497f-be67-8ccbec6ff6d0";
+    private static final String FINAL_SESSION_DATA_KEY = "bcf793dc-4ea9-4324-a485-7d20999a063e";
+    private static final String LOCATION_HEADER = "location";
+    private static final String ERROR_MSG_LOGIN_FAIL = "login.fail.message";
+
+    @Mock
+    HttpServletRequest request;
+
+    @Mock
+    HttpServletResponse response;
+
+    @BeforeMethod
+    public void init() throws IOException {
+
+        MockitoAnnotations.initMocks(this);
+        mockStatic(ConfigurationFacade.class);
+        ConfigurationFacade configurationFacade = mock(ConfigurationFacade.class);
+        PowerMockito.when(ConfigurationFacade.getInstance()).thenReturn(configurationFacade);
+
+        mockStatic(FrameworkUtils.class);
+        DefaultRequestCoordinator defaultRequestCoordinator = mock(DefaultRequestCoordinator.class);
+        PowerMockito.when(FrameworkUtils.getRequestCoordinator()).thenReturn(defaultRequestCoordinator);
+        PowerMockito.when(FrameworkUtils.getMaxInactiveInterval()).thenReturn(-1);
+
+        doNothing().when(defaultRequestCoordinator).handle(request, response);
+    }
+
+    @DataProvider(name = "authProvider")
+    public Object[][] authProvider() {
+
+        // boolean isMultiOpsResponse, String redirectUrl, Object authenticatorFlowStatus, Object authServiceFlowStatus,
+        // String sessionDataKey, String authenticatorList
+        return new Object[][]{
+                {true, getIntermediateRedirectUrl(SESSION_DATA_KEY, MULTI_OPS_AUTHENTICATORS),
+                        AuthenticatorFlowStatus.INCOMPLETE, AuthServiceConstants.FlowStatus.INCOMPLETE,
+                        SESSION_DATA_KEY, MULTI_OPS_AUTHENTICATORS},
+                {false, getIntermediateRedirectUrl(SESSION_DATA_KEY, SINGLE_AUTHENTICATOR),
+                        AuthenticatorFlowStatus.INCOMPLETE, AuthServiceConstants.FlowStatus.INCOMPLETE,
+                        SESSION_DATA_KEY, SINGLE_AUTHENTICATOR},
+                {false, getFinalRedirectUrl(FINAL_SESSION_DATA_KEY),
+                        AuthenticatorFlowStatus.SUCCESS_COMPLETED, AuthServiceConstants.FlowStatus.SUCCESS_COMPLETED,
+                        FINAL_SESSION_DATA_KEY, StringUtils.EMPTY}
+        };
+    }
+
+    @Test(dataProvider = "authProvider")
+    public void testHandleAuthentication(boolean isMultiOpsResponse, String redirectUrl,
+                                         Object authenticatorFlowStatus,
+                                         Object authServiceFlowStatus, String sessionDataKey,
+                                         String authenticatorList) throws Exception {
+
+        AuthenticationService authenticationService = new AuthenticationService();
+        AuthServiceRequest authServiceRequest = new AuthServiceRequest(request, response);
+        when(request.getAttribute(FrameworkConstants.IS_MULTI_OPS_RESPONSE)).thenReturn(isMultiOpsResponse);
+        when(request.getAttribute(FrameworkConstants.RequestParams.FLOW_STATUS)).thenReturn(authenticatorFlowStatus);
+        if (isMultiOpsResponse) {
+            List<AuthenticatorData> authenticatorDataMap = getMultiOpsAuthenticatorData(authenticatorList);
+            for (AuthenticatorData authenticatorData : authenticatorDataMap) {
+                when(FrameworkUtils.getAppAuthenticatorByName(authenticatorData.getName()))
+                        .thenReturn(new MockApiBasedAuthenticator(authenticatorData.getName()));
+            }
+        }
+        List<AuthenticatorData> expected = getAuthenticatorData(authenticatorList);
+        if (AuthenticatorFlowStatus.INCOMPLETE == authenticatorFlowStatus && !isMultiOpsResponse) {
+            when(request.getAttribute(AuthServiceConstants.AUTH_SERVICE_AUTH_INITIATION_DATA)).thenReturn(expected);
+        }
+        when(response.getHeader(LOCATION_HEADER)).thenReturn(redirectUrl);
+        AuthServiceResponse authServiceResponse = authenticationService.handleAuthentication(authServiceRequest);
+
+        Assert.assertEquals(authServiceResponse.getSessionDataKey(), sessionDataKey);
+        Assert.assertEquals(authServiceResponse.getFlowStatus(), authServiceFlowStatus);
+        Optional<AuthServiceResponseData> authServiceResponseData = authServiceResponse.getData();
+        if (AuthServiceConstants.FlowStatus.SUCCESS_COMPLETED == authServiceFlowStatus) {
+            Assert.assertFalse(authServiceResponseData.isPresent(), "Expected authServiceResponseData to be" +
+                    " null as the flow is compete.");
+        } else {
+            if (!authServiceResponseData.isPresent()) {
+                Assert.fail("Expected authServiceResponseData to be present as the flow is incomplete.");
+            }
+            Assert.assertEquals(authServiceResponseData.get().isAuthenticatorSelectionRequired(), isMultiOpsResponse);
+            List<AuthenticatorData> actual = authServiceResponseData.get().getAuthenticatorOptions();
+            validateReturnedAuthenticators(actual, expected, isMultiOpsResponse);
+        }
+    }
+
+    @DataProvider(name = "authProviderForFailures")
+    public Object[][] authProviderForFailures() {
+
+        // String redirectUrl, Object authenticatorFlowStatus, Object authServiceFlowStatus,
+        // String sessionDataKey, String authenticatorList, String errorCode,String errorMsg
+        return new Object[][]{
+                {getFailureRedirectUrl(SESSION_DATA_KEY, SINGLE_AUTHENTICATOR, ERROR_MSG_LOGIN_FAIL),
+                        AuthenticatorFlowStatus.INCOMPLETE, AuthServiceConstants.FlowStatus.FAIL_INCOMPLETE,
+                        SESSION_DATA_KEY, SINGLE_AUTHENTICATOR, AuthServiceConstants.ERROR_CODE_UNKNOWN_ERROR,
+                        ERROR_MSG_LOGIN_FAIL},
+                {getFinalRedirectUrl(FINAL_SESSION_DATA_KEY),
+                        AuthenticatorFlowStatus.FAIL_COMPLETED, AuthServiceConstants.FlowStatus.FAIL_COMPLETED,
+                        FINAL_SESSION_DATA_KEY, StringUtils.EMPTY, AuthServiceConstants.ERROR_CODE_UNKNOWN_ERROR,
+                        AuthServiceConstants.ERROR_MSG_UNKNOWN_ERROR},
+        };
+    }
+
+    @Test(dataProvider = "authProviderForFailures")
+    public void testNegativeHandleAuthentication(String redirectUrl, Object authenticatorFlowStatus,
+                                                 Object authServiceFlowStatus, String sessionDataKey,
+                                                 String authenticatorList, String errorCode, String errorMsg)
+            throws Exception {
+
+        AuthenticationService authenticationService = new AuthenticationService();
+        AuthServiceRequest authServiceRequest = new AuthServiceRequest(request, response);
+        when(request.getAttribute(FrameworkConstants.IS_MULTI_OPS_RESPONSE)).thenReturn(false);
+        when(request.getAttribute(FrameworkConstants.RequestParams.FLOW_STATUS)).thenReturn(authenticatorFlowStatus);
+        List<AuthenticatorData> expected = getAuthenticatorData(authenticatorList);
+        if (AuthenticatorFlowStatus.INCOMPLETE == authenticatorFlowStatus) {
+            when(request.getAttribute(AuthServiceConstants.AUTH_SERVICE_AUTH_INITIATION_DATA)).thenReturn(expected);
+        } else {
+            when(request.getAttribute(FrameworkConstants.IS_AUTH_FLOW_CONCLUDED)).thenReturn(true);
+        }
+        when(response.getHeader(LOCATION_HEADER)).thenReturn(redirectUrl);
+        AuthServiceResponse authServiceResponse = authenticationService.handleAuthentication(authServiceRequest);
+
+        Assert.assertEquals(authServiceResponse.getSessionDataKey(), sessionDataKey);
+        Assert.assertEquals(authServiceResponse.getFlowStatus(), authServiceFlowStatus);
+        Optional<AuthServiceResponseData> authServiceResponseData = authServiceResponse.getData();
+        Optional<AuthServiceErrorInfo> authServiceErrorInfo = authServiceResponse.getErrorInfo();
+        Assert.assertTrue(authServiceErrorInfo.isPresent(), "Expected authServiceErrorInfo to be present as the " +
+                "flow is an failure flow.");
+        Assert.assertEquals(authServiceErrorInfo.get().getErrorCode(), errorCode);
+        Assert.assertEquals(authServiceErrorInfo.get().getErrorMessage(), errorMsg);
+
+        if (AuthServiceConstants.FlowStatus.FAIL_COMPLETED == authServiceFlowStatus) {
+            Assert.assertFalse(authServiceResponseData.isPresent(), "Expected authServiceResponseData to be" +
+                    " null as the flow is compete.");
+        } else {
+            if (!authServiceResponseData.isPresent()) {
+                Assert.fail("Expected authServiceResponseData to be present as the flow is incomplete.");
+            }
+            Assert.assertFalse(authServiceResponseData.get().isAuthenticatorSelectionRequired());
+            List<AuthenticatorData> actual = authServiceResponseData.get().getAuthenticatorOptions();
+            validateReturnedAuthenticators(actual, expected, false);
+        }
+    }
+
+    private void validateReturnedAuthenticators(List<AuthenticatorData> actual, List<AuthenticatorData> expected,
+                                                boolean isMultiOps) {
+
+        if (actual.size() != expected.size()) {
+            Assert.fail("Expected authenticator list size is " + expected.size() + " but actual size is "
+                    + actual.size());
+        }
+
+        if (isMultiOps) {
+            boolean hasAuthParams = expected.stream()
+                    .anyMatch(authenticatorData -> !authenticatorData.getAuthParams().isEmpty());
+            if (hasAuthParams) {
+                Assert.fail("Request is multi option but authenticator data contains auth params.");
+            }
+        }
+
+        for (AuthenticatorData expectedAuthenticatorData : expected) {
+            boolean isNameMatch = actual.stream().anyMatch(actualAuthenticatorData ->
+                    expectedAuthenticatorData.getName().equals(actualAuthenticatorData.getName()));
+            boolean isDisplayNameMatch = actual.stream().anyMatch(actualAuthenticatorData ->
+                    expectedAuthenticatorData.getDisplayName().equals(actualAuthenticatorData.getDisplayName()));
+            boolean isIdpNameMatch = actual.stream().anyMatch(actualAuthenticatorData ->
+                    expectedAuthenticatorData.getIdp().equals(actualAuthenticatorData.getIdp()));
+
+            Assert.assertTrue(isNameMatch, "Expected authenticator name is not present in the actual " +
+                    "authenticator list");
+            Assert.assertTrue(isDisplayNameMatch, "Expected authenticator display name is not present in the actual " +
+                    "authenticator list");
+            Assert.assertTrue(isIdpNameMatch, "Expected authenticator idp name is not present in the actual " +
+                    "authenticator list");
+        }
+    }
+
+    private String getIntermediateRedirectUrl(String sessionDataKey, String authenticators) {
+
+        return "/authenticationendpoint/login" +
+                ".do?client_id=zhcEOyGulBfPryTXxoftrlXAq4Qa&commonAuthCallerPath=%2Foauth2%2Fauthorize&forceAuth" +
+                "=false&passiveAuth=false&redirect_uri=http%3A%2F%2Fexample" +
+                ".com&response_type=code&scope=openid+internal_login&state=request_0&tenantDomain=carbon" +
+                ".super&sessionDataKey=" + sessionDataKey + "&relyingParty" +
+                "=zhcEOyGulBfPryTXxoftrlXAq4Qa&type=oidc&sp=sample&isSaaSApp=false&authenticators" +
+                "=" + authenticators;
+
+    }
+
+    private String getFinalRedirectUrl(String sessionDataKey) {
+
+        return "/oauth2/authorize?sessionDataKey=" + sessionDataKey;
+    }
+
+    private String getFailureRedirectUrl(String sessionDataKey, String authenticators, String errorMsg) {
+
+        return "/authenticationendpoint/login" +
+                ".do?client_id=MY_ACCOUNT&code_challenge=zgULEfTaVz4ITrtk__ib2TN_v7yRh_zVj1hw70UzAP4" +
+                "&code_challenge_method=S256&commonAuthCallerPath=%2Foauth2%2Fauthorize&forceAuth=false&passiveAuth" +
+                "=false&redirect_uri=https%3A%2F%2Flocalhost%3A9443%2Fmyaccount&response_mode=form_post&response_type" +
+                "=code&scope=openid+openid+SYSTEM&state=request_0&tenantDomain=carbon.super&sessionDataKey=" +
+                sessionDataKey + "&relyingParty=MY_ACCOUNT&type=oidc&sp=My+Account&isSaaSApp=true&inputType=idf" +
+                "&authenticators=" + authenticators + "&authFailure=true&authFailureMsg=" + errorMsg;
+    }
+
+    private List<AuthenticatorData> getMultiOpsAuthenticatorData(String authenticatorList) {
+
+        if (StringUtils.isBlank(authenticatorList)) {
+            return new ArrayList<>();
+        }
+
+        return Arrays.stream(authenticatorList.split(AuthServiceConstants.AUTHENTICATOR_SEPARATOR))
+                .map(authenticator -> {
+                    AuthenticatorData authenticatorData = new AuthenticatorData();
+                    authenticatorData.setName(authenticator.split(AuthServiceConstants.AUTHENTICATOR_IDP_SEPARATOR)[0]);
+                    authenticatorData.setDisplayName(authenticatorData.getName());
+                    return authenticatorData;
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<AuthenticatorData> getAuthenticatorData(String authenticatorList) {
+
+        List<AuthenticatorData> authenticatorDataList = new ArrayList<>();
+        String[] authenticatorAndIdpsArr = StringUtils.split(authenticatorList,
+                AuthServiceConstants.AUTHENTICATOR_SEPARATOR);
+        for (String authenticatorAndIdps : authenticatorAndIdpsArr) {
+            String[] authenticatorIdpSeperatedArr = StringUtils.split(authenticatorAndIdps,
+                    AuthServiceConstants.AUTHENTICATOR_IDP_SEPARATOR);
+            for (int i = 1; i < authenticatorIdpSeperatedArr.length; i++) {
+                String name = authenticatorIdpSeperatedArr[0];
+                String idp = authenticatorIdpSeperatedArr[i];
+                ApplicationAuthenticator authenticator = new MockApiBasedAuthenticator(name, idp);
+                AuthenticatorData authenticatorData = new AuthenticatorData();
+                authenticatorData.setName(name);
+                authenticatorData.setIdp(idp);
+                authenticatorData.setDisplayName(authenticator.getFriendlyName());
+                authenticatorDataList.add(authenticatorData);
+            }
+        }
+        return authenticatorDataList;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/MockApiBasedAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/MockApiBasedAuthenticator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework;
+
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorData;
+
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Mock API based authenticator.
+ */
+public class MockApiBasedAuthenticator extends AbstractApplicationAuthenticator {
+
+    private String name;
+    private AuthenticatorData authenticatorData;
+    private boolean isAPIBasedAuthenticationSupported = true;
+
+    public MockApiBasedAuthenticator(String name) {
+
+        this.name = name;
+    }
+
+    public MockApiBasedAuthenticator(String name, String idp) {
+
+        this.name = name;
+        this.authenticatorData = new AuthenticatorData();
+        this.authenticatorData.setName(name);
+        this.authenticatorData.setDisplayName(getFriendlyName());
+        this.authenticatorData.setIdp(idp);
+    }
+
+    @Override
+    protected void processAuthenticationResponse(HttpServletRequest request, HttpServletResponse response,
+                                                 AuthenticationContext context) throws AuthenticationFailedException {
+
+    }
+
+    @Override
+    public boolean canHandle(HttpServletRequest request) {
+
+        return false;
+    }
+
+    @Override
+    public String getContextIdentifier(HttpServletRequest request) {
+
+        return null;
+    }
+
+    @Override
+    public String getName() {
+
+        return this.name;
+    }
+
+    @Override
+    public String getFriendlyName() {
+
+        return this.name + "-friendlyName";
+    }
+
+    @Override
+    public boolean isAPIBasedAuthenticationSupported() {
+
+        return isAPIBasedAuthenticationSupported;
+    }
+
+    @Override
+    public Optional<AuthenticatorData> getAuthInitiationData(AuthenticationContext context) {
+
+        return Optional.ofNullable(this.authenticatorData);
+    }
+
+    public void setAPIBasedAuthenticationSupported(boolean isAPIBasedAuthenticationSupported) {
+
+        this.isAPIBasedAuthenticationSupported = isAPIBasedAuthenticationSupported;
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/testng.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/testng.xml
@@ -65,6 +65,7 @@
             <class name="org.wso2.carbon.identity.application.authentication.framework.session.extender.response.SessionExtenderErrorResponseTest"/>
 
             <class name="org.wso2.carbon.identity.application.authentication.framework.dao.impl.UserSessionDAOImplTest"/>
+            <class name="org.wso2.carbon.identity.application.authentication.framework.AuthenticationServiceTest"/>
         </classes>
     </test>
     <test name="IdentityFrameworkTestsWithDataSources" preserve-order="false" parallel="false">


### PR DESCRIPTION
### Proposed changes in this pull request
Introduces the core component required for https://github.com/wso2/product-is/issues/15684

This PR introduces an authentication service. The service atm uses request and response wrappers and internally calls the common auth handler to perform authentication. The service is introduced to provide a JAVA API to perform authentication that is not heavily bound to the HTTP request. While the service currently rely on the HTTP request and response internally the service sends back the authentication decisions using java objects.
