### PR TITLE
Add the authenticated authenticator to the step object in Adaptive script

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornAuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornAuthenticationContext.java
@@ -176,7 +176,7 @@ public class JsNashornAuthenticationContext extends JsAuthenticationContext impl
     protected String getAuthenticatedAuthenticatorOfCurrentStep() {
 
         if (getContext().getSequenceConfig() == null) {
-            //Sequence config is not yet initialized
+            // Sequence config is not yet initialized.
             return null;
         }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornAuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornAuthenticationContext.java
@@ -73,7 +73,7 @@ public class JsNashornAuthenticationContext extends JsAuthenticationContext impl
                 return new JsNashornSteps(getWrapped());
             case FrameworkConstants.JSAttributes.JS_CURRENT_STEP:
                 return new JsNashornStep(getContext(), getContext().getCurrentStep(),
-                        getAuthenticatedIdPOfCurrentStep());
+                        getAuthenticatedIdPOfCurrentStep(), getAuthenticatedAuthenticatorOfCurrentStep());
             case FrameworkConstants.JSAttributes.JS_CURRENT_KNOWN_SUBJECT:
                 StepConfig stepConfig = getCurrentSubjectIdentifierStep();
                 if (stepConfig != null) {
@@ -157,7 +157,6 @@ public class JsNashornAuthenticationContext extends JsAuthenticationContext impl
         }
     }
 
-
     protected String getAuthenticatedIdPOfCurrentStep() {
 
         if (getContext().getSequenceConfig() == null) {
@@ -169,6 +168,22 @@ public class JsNashornAuthenticationContext extends JsAuthenticationContext impl
                 .get(getContext().getCurrentStep());
         if (stepConfig != null) {
             return stepConfig.getAuthenticatedIdP();
+        }
+        return null;
+
+    }
+
+    protected String getAuthenticatedAuthenticatorOfCurrentStep() {
+
+        if (getContext().getSequenceConfig() == null) {
+            //Sequence config is not yet initialized
+            return null;
+        }
+
+        StepConfig stepConfig = getContext().getSequenceConfig().getStepMap()
+                .get(getContext().getCurrentStep());
+        if (stepConfig != null) {
+            return stepConfig.getAuthenticatedAutenticator().getName();
         }
         return null;
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornAuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornAuthenticationContext.java
@@ -182,11 +182,8 @@ public class JsNashornAuthenticationContext extends JsAuthenticationContext impl
 
         StepConfig stepConfig = getContext().getSequenceConfig().getStepMap()
                 .get(getContext().getCurrentStep());
-        if (stepConfig != null) {
-            return stepConfig.getAuthenticatedAutenticator().getName();
-        }
-        return null;
 
+        return stepConfig != null ? stepConfig.getAuthenticatedAutenticator().getName() : null;
     }
 
     protected StepConfig getCurrentSubjectIdentifierStep() {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornStep.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornStep.java
@@ -43,16 +43,19 @@ public class JsNashornStep extends AbstractJSContextMemberObject implements Abst
 
     private int step;
     private String authenticatedIdp;
+    private String authenticatedAuthenticator;
 
-    public JsNashornStep(int step, String authenticatedIdp) {
+    public JsNashornStep(int step, String authenticatedIdp, String authenticatedAuthenticator) {
 
         this.step = step;
         this.authenticatedIdp = authenticatedIdp;
+        this.authenticatedAuthenticator = authenticatedAuthenticator;
     }
 
-    public JsNashornStep(AuthenticationContext context, int step, String authenticatedIdp) {
+    public JsNashornStep(AuthenticationContext context, int step, String authenticatedIdp,
+                         String authenticatedAuthenticator) {
 
-        this(step, authenticatedIdp);
+        this(step, authenticatedIdp, authenticatedAuthenticator);
         initializeContext(context);
     }
 
@@ -64,6 +67,8 @@ public class JsNashornStep extends AbstractJSContextMemberObject implements Abst
                 return new JsNashornAuthenticatedUser(getContext(), getSubject(), step, authenticatedIdp);
             case FrameworkConstants.JSAttributes.JS_AUTHENTICATED_IDP:
                 return authenticatedIdp;
+            case FrameworkConstants.JSAttributes.JS_AUTHENTICATOR:
+                return authenticatedAuthenticator;
             case FrameworkConstants.JSAttributes.JS_AUTHENTICATION_OPTIONS:
                 return getOptions();
             default:
@@ -78,6 +83,8 @@ public class JsNashornStep extends AbstractJSContextMemberObject implements Abst
             case FrameworkConstants.JSAttributes.JS_AUTHENTICATED_SUBJECT:
                 return true;
             case FrameworkConstants.JSAttributes.JS_AUTHENTICATED_IDP:
+                return true;
+            case FrameworkConstants.JSAttributes.JS_AUTHENTICATOR:
                 return true;
             default:
                 return AbstractJsObject.super.hasMember(name);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornStep.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornStep.java
@@ -45,11 +45,25 @@ public class JsNashornStep extends AbstractJSContextMemberObject implements Abst
     private String authenticatedIdp;
     private String authenticatedAuthenticator;
 
+    @Deprecated
+    public JsNashornStep(int step, String authenticatedIdp) {
+
+        this.step = step;
+        this.authenticatedIdp = authenticatedIdp;
+    }
+
     public JsNashornStep(int step, String authenticatedIdp, String authenticatedAuthenticator) {
 
         this.step = step;
         this.authenticatedIdp = authenticatedIdp;
         this.authenticatedAuthenticator = authenticatedAuthenticator;
+    }
+
+    @Deprecated
+    public JsNashornStep(AuthenticationContext context, int step, String authenticatedIdp) {
+
+        this(step, authenticatedIdp, null);
+        initializeContext(context);
     }
 
     public JsNashornStep(AuthenticationContext context, int step, String authenticatedIdp,

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornSteps.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornSteps.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.application.authentication.framework.config.mod
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.AbstractJSContextMemberObject;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
@@ -59,10 +60,10 @@ public class JsNashornSteps extends AbstractJSContextMemberObject implements Abs
         if (getContext() == null) {
             return AbstractJsObject.super.getSlot(step);
         } else {
-            return new JsNashornStep(getContext(), step, getAuthenticatedIdPOfStep(step));
+            return new JsNashornStep(getContext(), step, getAuthenticatedIdPOfStep(step),
+                    getAuthenticatedAuthenticatorOfStep(step));
         }
     }
-
 
     private String getAuthenticatedIdPOfStep(int step) {
 
@@ -74,5 +75,19 @@ public class JsNashornSteps extends AbstractJSContextMemberObject implements Abs
         Optional<StepConfig> optionalStepConfig = getContext().getSequenceConfig().getStepMap().values().stream()
                 .filter(stepConfig -> stepConfig.getOrder() == step).findFirst();
         return optionalStepConfig.map(StepConfig::getAuthenticatedIdP).orElse(null);
+    }
+
+    private String getAuthenticatedAuthenticatorOfStep(int step) {
+
+        if (getContext().getSequenceConfig() == null) {
+            //Sequence config is not yet initialized
+            return null;
+        }
+
+        Optional<StepConfig> optionalStepConfig = getContext().getSequenceConfig().getStepMap().values().stream()
+                .filter(stepConfig -> stepConfig.getOrder() == step).findFirst();
+        AuthenticatorConfig authenticatorConfig = optionalStepConfig.map(StepConfig::getAuthenticatedAutenticator)
+                .orElse(null);
+        return authenticatorConfig != null ? authenticatorConfig.getName() : null;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornSteps.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornSteps.java
@@ -68,7 +68,7 @@ public class JsNashornSteps extends AbstractJSContextMemberObject implements Abs
     private String getAuthenticatedIdPOfStep(int step) {
 
         if (getContext().getSequenceConfig() == null) {
-            // Sequence config is not yet initialized.
+            //Sequence config is not yet initialized
             return null;
         }
 
@@ -80,7 +80,7 @@ public class JsNashornSteps extends AbstractJSContextMemberObject implements Abs
     private String getAuthenticatedAuthenticatorOfStep(int step) {
 
         if (getContext().getSequenceConfig() == null) {
-            //Sequence config is not yet initialized
+            // Sequence config is not yet initialized.
             return null;
         }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornSteps.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornSteps.java
@@ -68,7 +68,7 @@ public class JsNashornSteps extends AbstractJSContextMemberObject implements Abs
     private String getAuthenticatedIdPOfStep(int step) {
 
         if (getContext().getSequenceConfig() == null) {
-            //Sequence config is not yet initialized
+            // Sequence config is not yet initialized.
             return null;
         }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornAuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornAuthenticationContext.java
@@ -183,11 +183,7 @@ public class JsOpenJdkNashornAuthenticationContext extends JsAuthenticationConte
 
         StepConfig stepConfig = getContext().getSequenceConfig().getStepMap()
                 .get(getContext().getCurrentStep());
-        if (stepConfig != null) {
-            return stepConfig.getAuthenticatedAutenticator().getName();
-        }
-        return null;
-
+        return stepConfig != null ? stepConfig.getAuthenticatedAutenticator().getName() : null;
     }
 
     protected StepConfig getCurrentSubjectIdentifierStep() {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornAuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornAuthenticationContext.java
@@ -177,7 +177,7 @@ public class JsOpenJdkNashornAuthenticationContext extends JsAuthenticationConte
     protected String getAuthenticatedAuthenticatorOfCurrentStep() {
 
         if (getContext().getSequenceConfig() == null) {
-            //Sequence config is not yet initialized
+            // Sequence config is not yet initialized.
             return null;
         }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornAuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornAuthenticationContext.java
@@ -74,7 +74,7 @@ public class JsOpenJdkNashornAuthenticationContext extends JsAuthenticationConte
                 return new JsOpenJdkNashornSteps(getWrapped());
             case FrameworkConstants.JSAttributes.JS_CURRENT_STEP:
                 return new JsOpenJdkNashornStep(getContext(), getContext().getCurrentStep(),
-                        getAuthenticatedIdPOfCurrentStep());
+                        getAuthenticatedIdPOfCurrentStep(), getAuthenticatedAuthenticatorOfCurrentStep());
             case FrameworkConstants.JSAttributes.JS_CURRENT_KNOWN_SUBJECT:
                 StepConfig stepConfig = getCurrentSubjectIdentifierStep();
                 if (stepConfig != null) {
@@ -158,7 +158,6 @@ public class JsOpenJdkNashornAuthenticationContext extends JsAuthenticationConte
         }
     }
 
-
     protected String getAuthenticatedIdPOfCurrentStep() {
 
         if (getContext().getSequenceConfig() == null) {
@@ -170,6 +169,22 @@ public class JsOpenJdkNashornAuthenticationContext extends JsAuthenticationConte
                 .get(getContext().getCurrentStep());
         if (stepConfig != null) {
             return stepConfig.getAuthenticatedIdP();
+        }
+        return null;
+
+    }
+
+    protected String getAuthenticatedAuthenticatorOfCurrentStep() {
+
+        if (getContext().getSequenceConfig() == null) {
+            //Sequence config is not yet initialized
+            return null;
+        }
+
+        StepConfig stepConfig = getContext().getSequenceConfig().getStepMap()
+                .get(getContext().getCurrentStep());
+        if (stepConfig != null) {
+            return stepConfig.getAuthenticatedAutenticator().getName();
         }
         return null;
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornStep.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornStep.java
@@ -43,16 +43,19 @@ public class JsOpenJdkNashornStep extends AbstractJSContextMemberObject implemen
 
     private int step;
     private String authenticatedIdp;
+    private String authenticatedAuthenticator;
 
-    public JsOpenJdkNashornStep(int step, String authenticatedIdp) {
+    public JsOpenJdkNashornStep(int step, String authenticatedIdp, String authenticatedAuthenticator) {
 
         this.step = step;
         this.authenticatedIdp = authenticatedIdp;
+        this.authenticatedAuthenticator = authenticatedAuthenticator;
     }
 
-    public JsOpenJdkNashornStep(AuthenticationContext context, int step, String authenticatedIdp) {
+    public JsOpenJdkNashornStep(AuthenticationContext context, int step, String authenticatedIdp,
+                                String authenticatedAuthenticator) {
 
-        this(step, authenticatedIdp);
+        this(step, authenticatedIdp, authenticatedAuthenticator);
         initializeContext(context);
     }
 
@@ -64,6 +67,8 @@ public class JsOpenJdkNashornStep extends AbstractJSContextMemberObject implemen
                 return new JsOpenJdkNashornAuthenticatedUser(getContext(), getSubject(), step, authenticatedIdp);
             case FrameworkConstants.JSAttributes.JS_AUTHENTICATED_IDP:
                 return authenticatedIdp;
+            case FrameworkConstants.JSAttributes.JS_AUTHENTICATOR:
+                return authenticatedAuthenticator;
             case FrameworkConstants.JSAttributes.JS_AUTHENTICATION_OPTIONS:
                 return getOptions();
             default:
@@ -78,6 +83,8 @@ public class JsOpenJdkNashornStep extends AbstractJSContextMemberObject implemen
             case FrameworkConstants.JSAttributes.JS_AUTHENTICATED_SUBJECT:
                 return true;
             case FrameworkConstants.JSAttributes.JS_AUTHENTICATED_IDP:
+                return true;
+            case FrameworkConstants.JSAttributes.JS_AUTHENTICATOR:
                 return true;
             default:
                 return AbstractOpenJdkNashornJsObject.super.hasMember(name);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornStep.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornStep.java
@@ -45,11 +45,25 @@ public class JsOpenJdkNashornStep extends AbstractJSContextMemberObject implemen
     private String authenticatedIdp;
     private String authenticatedAuthenticator;
 
+    @Deprecated
+    public JsOpenJdkNashornStep(int step, String authenticatedIdp) {
+
+        this.step = step;
+        this.authenticatedIdp = authenticatedIdp;
+    }
+
     public JsOpenJdkNashornStep(int step, String authenticatedIdp, String authenticatedAuthenticator) {
 
         this.step = step;
         this.authenticatedIdp = authenticatedIdp;
         this.authenticatedAuthenticator = authenticatedAuthenticator;
+    }
+
+    @Deprecated
+    public JsOpenJdkNashornStep(AuthenticationContext context, int step, String authenticatedIdp) {
+
+        this(step, authenticatedIdp, null);
+        initializeContext(context);
     }
 
     public JsOpenJdkNashornStep(AuthenticationContext context, int step, String authenticatedIdp,
@@ -132,4 +146,21 @@ public class JsOpenJdkNashornStep extends AbstractJSContextMemberObject implemen
                 })));
         return optionsList;
     }
+
+    protected String getAuthenticatedAuthenticatorOfCurrentStep(AuthenticationContext context) {
+
+        if (context.getSequenceConfig() == null) {
+            //Sequence config is not yet initialized
+            return null;
+        }
+
+        StepConfig stepConfig = context.getSequenceConfig().getStepMap()
+                .get(context.getCurrentStep());
+        if (stepConfig != null) {
+            return stepConfig.getAuthenticatedAutenticator().getName();
+        }
+        return null;
+
+    }
+
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornStep.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornStep.java
@@ -146,21 +146,4 @@ public class JsOpenJdkNashornStep extends AbstractJSContextMemberObject implemen
                 })));
         return optionsList;
     }
-
-    protected String getAuthenticatedAuthenticatorOfCurrentStep(AuthenticationContext context) {
-
-        if (context.getSequenceConfig() == null) {
-            //Sequence config is not yet initialized
-            return null;
-        }
-
-        StepConfig stepConfig = context.getSequenceConfig().getStepMap()
-                .get(context.getCurrentStep());
-        if (stepConfig != null) {
-            return stepConfig.getAuthenticatedAutenticator().getName();
-        }
-        return null;
-
-    }
-
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornSteps.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornSteps.java
@@ -80,7 +80,7 @@ public class JsOpenJdkNashornSteps extends AbstractJSContextMemberObject impleme
     private String getAuthenticatedAuthenticatorOfStep(int step) {
 
         if (getContext().getSequenceConfig() == null) {
-            //Sequence config is not yet initialized
+            // Sequence config is not yet initialized.
             return null;
         }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornSteps.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornSteps.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.application.authentication.framework.config.mod
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.AbstractJSContextMemberObject;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
@@ -59,10 +60,10 @@ public class JsOpenJdkNashornSteps extends AbstractJSContextMemberObject impleme
         if (getContext() == null) {
             return AbstractOpenJdkNashornJsObject.super.getSlot(step);
         } else {
-            return new JsOpenJdkNashornStep(getContext(), step, getAuthenticatedIdPOfStep(step));
+            return new JsOpenJdkNashornStep(getContext(), step, getAuthenticatedIdPOfStep(step),
+                    getAuthenticatedAuthenticatorOfStep(step));
         }
     }
-
 
     private String getAuthenticatedIdPOfStep(int step) {
 
@@ -74,5 +75,19 @@ public class JsOpenJdkNashornSteps extends AbstractJSContextMemberObject impleme
         Optional<StepConfig> optionalStepConfig = getContext().getSequenceConfig().getStepMap().values().stream()
                 .filter(stepConfig -> stepConfig.getOrder() == step).findFirst();
         return optionalStepConfig.map(StepConfig::getAuthenticatedIdP).orElse(null);
+    }
+
+    private String getAuthenticatedAuthenticatorOfStep(int step) {
+
+        if (getContext().getSequenceConfig() == null) {
+            //Sequence config is not yet initialized
+            return null;
+        }
+
+        Optional<StepConfig> optionalStepConfig = getContext().getSequenceConfig().getStepMap().values().stream()
+                .filter(stepConfig -> stepConfig.getOrder() == step).findFirst();
+        AuthenticatorConfig authenticatorConfig = optionalStepConfig.map(StepConfig::getAuthenticatedAutenticator)
+                .orElse(null);
+        return authenticatorConfig != null ? authenticatorConfig.getName() : null;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -522,6 +522,7 @@ public abstract class FrameworkConstants {
         public static final String JS_LOCAL_ROLES = "roles";
         public static final String JS_CLAIMS = "claims";
         public static final String JS_AUTHENTICATED_IDP = "idp";
+        public static final String JS_AUTHENTICATOR = "authenticator";
         public static final String JS_AUTHENTICATION_OPTIONS = "options";
         public static final String JS_LOCAL_IDP = "local";
         public static final String JS_FEDERATED_IDP = "federated";


### PR DESCRIPTION
### Proposed changes in this pull request

- Currently, we can only get the subject and the authenticated idp from the step object.
- From this changes, We introduced the authenticated authenticator name to the step object.
- After this changes you will be able to get the authenticator name of the last step as below from the adaptive script.
```
context.steps[step_no].authenticator
```
- Add an unit test