### PR TITLE
Force login when organization login is the authenticated IdP

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -263,7 +263,10 @@ public class DefaultStepHandler implements StepHandler {
                         .iterator().next();
                 String idp = entry.getKey();
                 AuthenticatorConfig authenticatorConfig = entry.getValue();
-
+                /**
+                 * TODO: This organization login specific logic should be moved out of authentication framework.
+                 * This is tracked with https://github.com/wso2/product-is/issues/15922
+                 */
                 boolean isOrganizationLogin = isLoggedInWithOrganizationLogin(authenticatorConfig);
 
                 if (context.isReAuthenticate() || isOrganizationLogin) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -53,6 +53,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Commo
 import org.wso2.carbon.identity.application.authentication.framework.store.UserSessionStore;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
@@ -263,7 +264,9 @@ public class DefaultStepHandler implements StepHandler {
                 String idp = entry.getKey();
                 AuthenticatorConfig authenticatorConfig = entry.getValue();
 
-                if (context.isReAuthenticate()) {
+                boolean isOrganizationLogin = isLoggedInWithOrganizationLogin(authenticatorConfig);
+
+                if (context.isReAuthenticate() || isOrganizationLogin) {
 
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Re-authenticating with " + idp + " IdP");
@@ -274,6 +277,11 @@ public class DefaultStepHandler implements StepHandler {
                                 idp, context.getTenantDomain()));
                     } catch (IdentityProviderManagementException e) {
                         LOG.error("Exception while getting IdP by name", e);
+                    }
+
+                    if (isOrganizationLogin) {
+                        AuthenticatedIdPData authenticatedIdPData = authenticatedIdPs.get(idp);
+                        setLoggedInOrgIdInRequest(authenticatedIdPData, request);
                     }
                     doAuthentication(request, response, context, authenticatorConfig);
                     return;
@@ -1296,5 +1304,40 @@ public class DefaultStepHandler implements StepHandler {
                 ("accountrecoveryendpoint/confirmrecovery.do?" + context.getContextIdIncludedQueryParams()))
                 + "&username=" + URLEncoder.encode(username, "UTF-8") + "&confirmation=" + otp
                 + "&callback=" + URLEncoder.encode(callback, "UTF-8") + reCaptchaParamString.toString();
+    }
+
+    /**
+     * Check whether the user is logged in with organization login.
+     *
+     * @param authenticatorConfig Authenticator config.
+     * @return Whether the authenticator is organization authenticator or not.
+     */
+    private boolean isLoggedInWithOrganizationLogin(AuthenticatorConfig authenticatorConfig) {
+
+        if (authenticatorConfig == null) {
+            return false;
+        }
+        return FrameworkConstants.ORGANIZATION_AUTHENTICATOR.equals(authenticatorConfig.getName());
+    }
+
+    /**
+     * Set the logged in organization id in the request as an attribute.
+     *
+     * @param authenticatedIdPData Authenticated IDP data.
+     * @param request              HTTP servlet request.
+     */
+    private void setLoggedInOrgIdInRequest(AuthenticatedIdPData authenticatedIdPData, HttpServletRequest request) {
+
+        AuthenticatedUser authenticatedUser = authenticatedIdPData.getUser();
+        Map<ClaimMapping, String> userAttributes = authenticatedUser.getUserAttributes();
+        for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
+            ClaimMapping claimMapping = entry.getKey();
+            if (FrameworkConstants.USER_ORGANIZATION_CLAIM.equals(claimMapping.getLocalClaim().getClaimUri())) {
+                String organizationId = entry.getValue();
+                if (StringUtils.isNotBlank(organizationId)) {
+                    request.setAttribute(FrameworkConstants.ORG_ID_PARAMETER, organizationId);
+                }
+            }
+        }
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -134,6 +134,9 @@ public abstract class FrameworkConstants {
 
     public static final String AUTHENTICATION_CONTEXT_PROPERTIES = "AUTHENTICATION_CONTEXT_PROPERTIES";
     public static final String ORGANIZATION_USER_PROPERTIES = "ORGANIZATION_USER_PROPERTIES";
+    public static final String ORGANIZATION_AUTHENTICATOR = "OrganizationAuthenticator";
+    public static final String ORG_ID_PARAMETER = "orgId";
+    public static final String USER_ORGANIZATION_CLAIM = "user_organization";
     public static final String SESSION_AUTH_HISTORY = "SESSION_AUTH_HISTORY";
 
     public static final String SERVICE_PROVIDER_SUBJECT_CLAIM_VALUE = "ServiceProviderSubjectClaimValue";


### PR DESCRIPTION
### Proposed changes in this pull request
$Subject

With this PR, when a session exists for a sub organization user, organization id is added to the organization login request and  organization login is initiated
This will not prompt to enter organization name since the request has user_organization but at sub org level, if applications have different authentication methods, user will be prompted for login.