### PR TITLE
Improving Identity claim value encryption feature

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/constants/IdentityMgtConstants.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/constants/IdentityMgtConstants.java
@@ -96,6 +96,8 @@ public class IdentityMgtConstants {
 
     public static final String LAST_PASSWORD_UPDATE_TIME = "http://wso2.org/claims/identity/lastPasswordUpdateTime";
 
+    public static final String ENABLE_ENCRYPTION = "EnableEncryption";
+
     private IdentityMgtConstants() {
     }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityClaimValueEncryptionListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityClaimValueEncryptionListener.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.mgt.constants.IdentityMgtConstants;
 import org.wso2.carbon.identity.mgt.internal.IdentityMgtServiceDataHolder;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
@@ -214,9 +215,8 @@ public class IdentityClaimValueEncryptionListener extends AbstractIdentityUserOp
         if (claimURI.contains(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI_PREFIX)) {
             claimProperties = getClaimProperties(tenantDomain, claimURI);
         }
-        return Boolean.parseBoolean(claimProperties.get("EnableEncryption"));
+        return claimProperties.containsKey(IdentityMgtConstants.ENABLE_ENCRYPTION);
     }
-
 
     /**
      * Get claim properties of a claim in a given tenant.

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityClaimValueEncryptionListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityClaimValueEncryptionListener.java
@@ -32,7 +32,6 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.mgt.internal.IdentityMgtServiceDataHolder;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
-import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -60,7 +59,7 @@ public class IdentityClaimValueEncryptionListener extends AbstractIdentityUserOp
 
     @Override
     public boolean doPreAddUser(String userName, Object credential, String[] roleList, Map<String, String> claims,
-                                      String profile, UserStoreManager userStoreManager) throws UserStoreException {
+                                String profile, UserStoreManager userStoreManager) throws UserStoreException {
 
         try {
             if (!isEnable() || userStoreManager == null) {
@@ -80,7 +79,7 @@ public class IdentityClaimValueEncryptionListener extends AbstractIdentityUserOp
     public boolean doPreAddUserWithID(String userID, Object credential, String[] roleList, Map<String, String> claims,
                                       String profile, UserStoreManager userStoreManager) throws UserStoreException {
 
-        return doPreAddUser(null,credential, roleList, claims, profile, userStoreManager);
+        return doPreAddUser(null, credential, roleList, claims, profile, userStoreManager);
     }
 
     @Override
@@ -161,8 +160,8 @@ public class IdentityClaimValueEncryptionListener extends AbstractIdentityUserOp
     /**
      * Encrypt mapped claim values.
      *
-     * @param claims            Claim values to be encrypted.
-     * @param userStoreManager  User store manager.
+     * @param claims           Claim values to be encrypted.
+     * @param userStoreManager User store manager.
      * @throws UserStoreException
      */
     private void updateClaimValues(Map<String, String> claims, UserStoreManager userStoreManager)
@@ -175,7 +174,7 @@ public class IdentityClaimValueEncryptionListener extends AbstractIdentityUserOp
                 try {
                     claimValue = encryptClaimValue(claimValue);
                 } catch (CryptoException e) {
-                    LOG.error("Error occurred while encrypting claim value of claim " + claimURI , e);
+                    LOG.error("Error occurred while encrypting claim value of claim " + claimURI, e);
                     throw new CryptoException("Error occurred while encrypting claim value of claim " + claimURI, e);
                 }
                 claims.put(claimURI, claimValue);
@@ -200,11 +199,11 @@ public class IdentityClaimValueEncryptionListener extends AbstractIdentityUserOp
     /**
      * Check whether encryption is enabled for a given claim.
      *
-     * @param claimURI          Claim URI.
-     * @param userStoreManager  User store manager.
+     * @param claimURI         Claim URI.
+     * @param userStoreManager User store manager.
      * @return true if encryption is enabled for the claim.
      * @throws UserStoreException
-     * */
+     */
     private boolean checkEnableEncryption(String claimURI, UserStoreManager userStoreManager)
             throws UserStoreException {
 
@@ -223,6 +222,10 @@ public class IdentityClaimValueEncryptionListener extends AbstractIdentityUserOp
     private Map<String, String> getClaimProperties(String tenantDomain, String claimURI) {
 
         try {
+            if (IdentityMgtServiceDataHolder.getClaimManagementService() == null) {
+                LOG.error("ClaimManagementService is null");
+                throw new ClaimMetadataException("ClaimManagementService is null");
+            }
             List<LocalClaim> localClaims =
                     IdentityMgtServiceDataHolder.getClaimManagementService().getLocalClaims(tenantDomain);
             if (localClaims == null) {

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityClaimValueEncryptionListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityClaimValueEncryptionListener.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.mgt.internal.IdentityMgtServiceDataHolder;
+import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 
@@ -208,9 +209,14 @@ public class IdentityClaimValueEncryptionListener extends AbstractIdentityUserOp
             throws UserStoreException {
 
         String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
-        Map<String, String> claimProperties = getClaimProperties(tenantDomain, claimURI);
+        Map<String, String> claimProperties = new HashMap<>();
+
+        if (claimURI.contains(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI_PREFIX)) {
+            claimProperties = getClaimProperties(tenantDomain, claimURI);
+        }
         return Boolean.parseBoolean(claimProperties.get("EnableEncryption"));
     }
+
 
     /**
      * Get claim properties of a claim in a given tenant.

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -702,7 +702,6 @@
 				in your user store must be configured for this. -->
 				<AttributeID>totpSecretkey</AttributeID>
 				<Description>Claim to store the secret key</Description>
-				<EnableEncryption>true</EnableEncryption>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/identity/emailotp_disabled</ClaimURI>
@@ -736,7 +735,6 @@
 				in your user store must be configured for this. -->
 				<AttributeID>verifySecretkey</AttributeID>
 				<Description>Claim to store the secret key until verified</Description>
-				<EnableEncryption>true</EnableEncryption>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/identity/isLiteUser</ClaimURI>


### PR DESCRIPTION
### Proposed changes in this pull request

- Claim value encryption will be decided on the availability of the `EnableEncryption` claim property, and not the value of the property.
- Added null check for claimService.
- `EnableEncryption` property for secretkey and verifySecretKey claims will not be there by default for IS on-prem product, Customers need to add the property on a need basis.

