### PR TITLE
Ignore resolving application roles for JIT provisioned users

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
@@ -1168,10 +1168,10 @@ public class DefaultClaimHandler implements ClaimHandler {
                                                     Map<String, String> allLocalClaims)
             throws FrameworkException {
 
-        /**
-         * If user is JIT provisioned, during the login flow, user's application roles are already resolved and added
-         * to application roles claim. Hence, no need to resolve application roles again.
-         */
+        /*
+        If user is JIT provisioned, during the login flow, user's application roles are already resolved and added
+        to application roles claim. Hence, no need to resolve application roles again.
+        */
         if (isUserJITProvisioned(allLocalClaims)) {
             return;
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
@@ -1168,6 +1168,13 @@ public class DefaultClaimHandler implements ClaimHandler {
                                                     Map<String, String> allLocalClaims)
             throws FrameworkException {
 
+        /**
+         * If user is JIT provisioned, during the login flow, user's application roles are already resolved and added
+         * to application roles claim. Hence, no need to resolve application roles again.
+         */
+        if (isUserJITProvisioned(allLocalClaims)) {
+            return;
+        }
         AuthenticatedUser authenticatedUser = getAuthenticatedUser(stepConfig, context);
         if (authenticatedUser == null) {
             return;
@@ -1182,6 +1189,22 @@ public class DefaultClaimHandler implements ClaimHandler {
                 }
             }
         }
+    }
+
+    /**
+     * Resolve if the user is JIT provisioned based on the IdP type claim.
+     *
+     * @param allLocalClaims All local claims of the current authenticated user.
+     * @return True if the user is JIT provisioned.
+     */
+    private boolean isUserJITProvisioned(Map<String, String> allLocalClaims) {
+
+        if (allLocalClaims == null || allLocalClaims.isEmpty()) {
+            return false;
+        }
+        return allLocalClaims.entrySet().stream()
+                .anyMatch(entry -> entry.getKey().equals(FrameworkConstants.IDP_TYPE_CLAIM)
+                        && !FrameworkConstants.JSAttributes.JS_LOCAL_IDP.equalsIgnoreCase(entry.getValue()));
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -41,6 +41,7 @@ public abstract class FrameworkConstants {
     public static final String EMAIL_ADDRESS_CLAIM = "http://wso2.org/claims/emailaddress";
     public static final String APP_ROLES_CLAIM = "http://wso2.org/claims/applicationRoles";
     public static final String PROVISIONED_SOURCE_ID_CLAIM = "http://wso2.org/claims/identity/userSourceId";
+    public static final String IDP_TYPE_CLAIM = "http://wso2.org/claims/identity/idpType";
     public static final String UNFILTERED_LOCAL_CLAIM_VALUES = "UNFILTERED_LOCAL_CLAIM_VALUES";
     public static final String UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES = "UNFILTERED_LOCAL_CLAIMS_FOR_NULL_VALUES";
     public static final String UNFILTERED_IDP_CLAIM_VALUES = "UNFILTERED_IDP_CLAIM_VALUES";


### PR DESCRIPTION
$Subject

- Logic to resolve application roles for the JIT provisioned users. 
- Application roles are resolved already from the federated users on each login in updated for the corrosponding local user.
- This will be retrieved from the userstore.