### PR TITLE
Skip filtering application roles claim

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
@@ -358,11 +358,12 @@ public class DefaultClaimHandler implements ClaimHandler {
         localToSPClaimMappings.entrySet().stream().filter(entry -> StringUtils.isNotBlank(localUnfilteredClaims.
                 get(entry.getKey()))).forEach(entry -> {
                     spUnfilteredClaims.put(entry.getValue(), localUnfilteredClaims.get(entry.getKey()));
-                    if (StringUtils.isNotBlank(spRequestedClaimMappings.get(entry.getValue()))) {
+                    if (StringUtils.isNotBlank(spRequestedClaimMappings.get(entry.getValue())) ||
+                            FrameworkConstants.APP_ROLES_CLAIM.equals(entry.getKey())) {
                         spFilteredClaims.put(entry.getValue(), localUnfilteredClaims.get(entry.getKey()));
                     }
                 }
-        );
+                                             );
 
     }
 


### PR DESCRIPTION
For a federated user, Even if application roles are not requested by the application, it should not be filtered at the framework level to enable scope validation at the scope validation when issuing the token