### PR TITLE
[6.x.x] Improving Identity claim value encryption feature

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/constants/IdentityMgtConstants.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/constants/IdentityMgtConstants.java
@@ -96,6 +96,8 @@ public class IdentityMgtConstants {
 
     public static final String LAST_PASSWORD_UPDATE_TIME = "http://wso2.org/claims/identity/lastPasswordUpdateTime";
 
+    public static final String ENABLE_ENCRYPTION = "EnableEncryption";
+
     private IdentityMgtConstants() {
     }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityClaimValueEncryptionListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityClaimValueEncryptionListener.java
@@ -29,7 +29,9 @@ import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.mgt.constants.IdentityMgtConstants;
 import org.wso2.carbon.identity.mgt.internal.IdentityMgtServiceDataHolder;
+import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
@@ -79,7 +81,7 @@ public class IdentityClaimValueEncryptionListener extends AbstractIdentityUserOp
     public boolean doPreAddUserWithID(String userID, Object credential, String[] roleList, Map<String, String> claims,
                                       String profile, UserStoreManager userStoreManager) throws UserStoreException {
 
-        return doPreAddUser(null,credential, roleList, claims, profile, userStoreManager);
+        return doPreAddUser(null, credential, roleList, claims, profile, userStoreManager);
     }
 
     @Override
@@ -174,7 +176,7 @@ public class IdentityClaimValueEncryptionListener extends AbstractIdentityUserOp
                 try {
                     claimValue = encryptClaimValue(claimValue);
                 } catch (CryptoException e) {
-                    LOG.error("Error occurred while encrypting claim value of claim " + claimURI , e);
+                    LOG.error("Error occurred while encrypting claim value of claim " + claimURI, e);
                     throw new CryptoException("Error occurred while encrypting claim value of claim " + claimURI, e);
                 }
                 claims.put(claimURI, claimValue);
@@ -208,8 +210,12 @@ public class IdentityClaimValueEncryptionListener extends AbstractIdentityUserOp
             throws UserStoreException {
 
         String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
-        Map<String, String> claimProperties = getClaimProperties(tenantDomain, claimURI);
-        return Boolean.parseBoolean(claimProperties.get("EnableEncryption"));
+        Map<String, String> claimProperties = new HashMap<>();
+
+        if (claimURI.contains(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI_PREFIX)) {
+            claimProperties = getClaimProperties(tenantDomain, claimURI);
+        }
+        return claimProperties.containsKey(IdentityMgtConstants.ENABLE_ENCRYPTION);
     }
 
     /**

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -702,7 +702,6 @@
 				in your user store must be configured for this. -->
 				<AttributeID>totpSecretkey</AttributeID>
 				<Description>Claim to store the secret key</Description>
-				<EnableEncryption>true</EnableEncryption>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/identity/emailotp_disabled</ClaimURI>
@@ -736,7 +735,6 @@
 				in your user store must be configured for this. -->
 				<AttributeID>verifySecretkey</AttributeID>
 				<Description>Claim to store the secret key until verified</Description>
-				<EnableEncryption>true</EnableEncryption>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/identity/isLiteUser</ClaimURI>


### PR DESCRIPTION
### Proposed changes in this pull request

- Claim value encryption will be decided on the availability of the `EnableEncryption` claim property, and not the value of the property.
- Added null check for claimService.
- `EnableEncryption` property for secretkey and verifySecretKey claims will not be there by default for IS on-prem product, Customers need to add the property on a need basis.

### Master branch PR

- [https://github.com/wso2/carbon-identity-framework/pull/4674](https://github.com/wso2/carbon-identity-framework/pull/4674)