### PR TITLE
[6.0.x] Add configs for backward compatibility for legacy application token behaviour

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -650,6 +650,19 @@
 
         <!-- Configuration for allowing users to introspect tokens from other tenants. -->
         <AllowCrossTenantTokenIntrospection>true</AllowCrossTenantTokenIntrospection>
+
+        <!--
+        By enabling this property, client id will be used as the sub claim for the access tokens issued for the
+        authenticated applications.
+        Default value : false
+        -->
+        <UseClientIdAsSubClaimForAppTokens>false</UseClientIdAsSubClaimForAppTokens>
+
+        <!--
+        By enabling this property, username will be removed from the introspection response for application tokens.
+        Default value : false
+        -->
+        <RemoveUsernameFromIntrospectionResponseForAppTokens>false</RemoveUsernameFromIntrospectionResponseForAppTokens>
     </OAuth>
 
     <RestApiAuthentication>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -883,6 +883,19 @@
         -->
         <EnableJWTTokenValidationDuringIntrospection>{{oauth.enable_jwt_token_validation_during_introspection}}</EnableJWTTokenValidationDuringIntrospection>
 
+        <!--
+        By enabling this property, client id will be used as the sub claim for the access tokens issued for the
+        authenticated applications.
+        Default value : false
+        -->
+        <UseClientIdAsSubClaimForAppTokens>{{oauth.use_client_id_as_sub_claim_for_app_tokens}}</UseClientIdAsSubClaimForAppTokens>
+
+        <!--
+        By enabling this property, username will be removed from the introspection response for application tokens.
+        Default value : false
+        -->
+        <RemoveUsernameFromIntrospectionResponseForAppTokens>{{oauth.remove_username_from_introspection_response_for_app_tokens}}</RemoveUsernameFromIntrospectionResponseForAppTokens>
+
         {% if oauth.enable_system_level_internal_scope_management is defined %}
         <!--
         Configuration to maintain backward compatibility to manage the internal scope - permission  binding per tenant.

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -163,8 +163,8 @@
   "oauth.dcrm.application_role_permission_required_to_view": true,
 
   "oauth.enable_jwt_token_validation_during_introspection": true,
-  "oauth.use_client_id_as_sub_claim_for_app_tokens": true,
-  "oauth.remove_username_from_introspection_response_for_app_tokens": true,
+  "oauth.use_client_id_as_sub_claim_for_app_tokens": false,
+  "oauth.remove_username_from_introspection_response_for_app_tokens": false,
 
   "oauth.extensions.callback_handlers": [
       {

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -163,6 +163,8 @@
   "oauth.dcrm.application_role_permission_required_to_view": true,
 
   "oauth.enable_jwt_token_validation_during_introspection": true,
+  "oauth.use_client_id_as_sub_claim_for_app_tokens": true,
+  "oauth.remove_username_from_introspection_response_for_app_tokens": true,
 
   "oauth.extensions.callback_handlers": [
       {


### PR DESCRIPTION
### Proposed changes in this pull request

Merging the changes related to https://github.com/wso2/carbon-identity-framework/pull/4633 to 6.0.x branch.