### PR TITLE
Fix issue on empty extension type dir

### DIFF
--- a/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/main/java/org/wso2/carbon/identity/extension/mgt/ExtensionStore.java
+++ b/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/main/java/org/wso2/carbon/identity/extension/mgt/ExtensionStore.java
@@ -54,13 +54,21 @@ public interface ExtensionStore {
     ExtensionInfo getExtensionByTypeAndId(String extensionType, String extensionId) throws ExtensionManagementException;
 
     /**
+     * Add new extension type.
+     *
+     * @param extensionType Type of the extension.
+     */
+    void addExtensionType(String extensionType);
+
+    /**
      * Add a new extension.
      *
      * @param extensionType Type of the extension.
      * @param extensionId Id of the extension.
      * @param extensionInfo ExtensionInfo object.
      */
-    void addExtension(String extensionType, String extensionId, ExtensionInfo extensionInfo) throws ExtensionManagementException;
+    void addExtension(String extensionType, String extensionId, ExtensionInfo extensionInfo)
+            throws ExtensionManagementException;
 
     /**
      * Get template of a specific extension by type and id.
@@ -78,7 +86,8 @@ public interface ExtensionStore {
      * @param extensionId Id of the extension.
      * @param extensionTemplate Template of the extension.
      */
-    void addTemplate(String extensionType, String extensionId, JSONObject extensionTemplate) throws ExtensionManagementException;
+    void addTemplate(String extensionType, String extensionId, JSONObject extensionTemplate)
+            throws ExtensionManagementException;
 
     /**
      * Get metadata of a specific extension by type and id.
@@ -96,6 +105,7 @@ public interface ExtensionStore {
      * @param extensionId Id of the extension.
      * @param extensionMetadata Metadata of the extension.
      */
-    void addMetadata(String extensionType, String extensionId, JSONObject extensionMetadata) throws ExtensionManagementException;
+    void addMetadata(String extensionType, String extensionId, JSONObject extensionMetadata)
+            throws ExtensionManagementException;
 
 }

--- a/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/main/java/org/wso2/carbon/identity/extension/mgt/ExtensionStoreImpl.java
+++ b/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/main/java/org/wso2/carbon/identity/extension/mgt/ExtensionStoreImpl.java
@@ -77,12 +77,26 @@ public class ExtensionStoreImpl implements ExtensionStore {
      * @return ExtensionInfo object.
      */
     @Override
-    public ExtensionInfo getExtensionByTypeAndId(String extensionType, String extensionId) throws ExtensionManagementException {
+    public ExtensionInfo getExtensionByTypeAndId(String extensionType, String extensionId)
+            throws ExtensionManagementException {
 
         if (!extensionInfoList.containsKey(extensionType)) {
             throw new ExtensionManagementException("Invalid extension type: " + extensionType);
         }
         return extensionInfoList.get(extensionType).get(extensionId);
+    }
+
+    /**
+     * Add new extension type.
+     *
+     * @param extensionType Type of the extension.
+     */
+    @Override
+    public void addExtensionType(String extensionType) {
+
+        if (!extensionInfoList.containsKey(extensionType)) {
+            extensionInfoList.put(extensionType, new HashMap<>());
+        }
     }
 
     /**
@@ -93,10 +107,11 @@ public class ExtensionStoreImpl implements ExtensionStore {
      * @param extensionInfo ExtensionInfo object.
      */
     @Override
-    public void addExtension(String extensionType, String extensionId, ExtensionInfo extensionInfo) {
+    public void addExtension(String extensionType, String extensionId, ExtensionInfo extensionInfo)
+            throws ExtensionManagementException {
 
         if (!extensionInfoList.containsKey(extensionType)) {
-            extensionInfoList.put(extensionType, new HashMap<>());
+            throw new ExtensionManagementException("Invalid extension type: " + extensionType);
         }
         extensionInfoList.get(extensionType).put(extensionId, extensionInfo);
     }

--- a/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/main/java/org/wso2/carbon/identity/extension/mgt/internal/ExtensionManagerComponent.java
+++ b/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/main/java/org/wso2/carbon/identity/extension/mgt/internal/ExtensionManagerComponent.java
@@ -137,6 +137,8 @@ public class ExtensionManagerComponent {
                 continue;
             }
 
+            ExtensionManagerDataHolder.getInstance().getExtensionStore().addExtensionType(extensionType);
+
             // Load extensions from the given extension type directory.
             try (Stream<Path> directories = Files.list(path).filter(Files::isDirectory)) {
                 directories.forEach(extensionDirectory -> {


### PR DESCRIPTION
### Proposed changes in this pull request

When we configure an extension type and when the extension type directory is empty it returns `500` error on listing the extensions.

- Sample API call to list extensions: `https://localhost:9443/t/carbon.super/api/server/v1/extensions/identity-verification-providers`


From this fix it will return an empty array on returning the list of the extensions of that particular extension type when the directory is empty.

