### PR TITLE
Improve unique claim pom

### DIFF
--- a/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/pom.xml
+++ b/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/pom.xml
@@ -72,7 +72,7 @@
                             org.wso2.carbon.identity.claim.metadata.mgt.*;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.package.import.version.range}",
-                            org.wso2.carbon.identity.mgt.*; version="${carbon.identity.package.export.version}",
+                            org.wso2.carbon.identity.mgt.*; version="${carbon.identity.package.import.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.unique.claim.mgt.internal,


### PR DESCRIPTION
### Proposed changes in this pull request

Currently, org.wso2.carbon.identity.unique.claim.mgt component expects a specific version of org.wso2.carbon.identity.mgt component. But due to the management process, this is not scalable for versioning.

hence with this fix we are modifying the pom.xml.
