### PR TITLE
Avoid outbound provisioning when provisioning is not enabled

### DIFF
--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisioningUtil.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisioningUtil.java
@@ -24,7 +24,11 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.common.model.OutboundProvisioningConfig;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
@@ -543,5 +547,38 @@ public class ProvisioningUtil {
                     .parseBoolean(IdentityUtil.getProperty(USE_USER_TENANT_DOMAIN_FOR_OUTBOUND_PROVISIONING_IN_SAAS_APPS));
         }
         return userTenantBasedProvisioningThreadEnabled;
+    }
+
+    /**
+     * Check whether the outbound provisioning is enabled for the service provider.
+     *
+     * @param serviceProviderIdentifier service provider.
+     * @param tenantDomainName          tenant domain name.
+     * @throws IdentityApplicationManagementException
+     */
+    public static boolean isOutboundProvisioningEnabled(String serviceProviderIdentifier,
+                                                        String tenantDomainName) throws IdentityApplicationManagementException {
+
+        ServiceProvider serviceProvider = ApplicationManagementService.getInstance()
+                .getServiceProvider(serviceProviderIdentifier, tenantDomainName);
+
+        OutboundProvisioningConfig outboundProvisioningConfiguration = serviceProvider
+                .getOutboundProvisioningConfig();
+
+        if (outboundProvisioningConfiguration == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("No outbound provisioning configuration defined for local service provider.");
+            }
+            return false;
+        }
+
+        // Check whether the provisioning is configured for the service provider.
+        IdentityProvider[] provisionningIdPList = outboundProvisioningConfiguration
+                .getProvisioningIdentityProviders();
+
+        if (provisionningIdPList != null && provisionningIdPList.length == 0) {
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

currently we're retrieving the userlist [1] regardless of whether outbound provisioning is configured. This will significantly impact the performance when we have a large number of users. To avoid this will execute the provisioning [2] only when outbound provisioning is configured.

Related issue: https://github.com/wso2/product-is/issues/15987

[1] https://github.com/wso2/carbon-identity-framework/blob/v5.18.187/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/DefaultInboundUserProvisioningListener.java#L415
[2] https://github.com/wso2/carbon-identity-framework/blob/v5.18.187/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/DefaultInboundUserProvisioningListener.java#L415-L474


### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [x ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [x] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
