### PR TITLE
Improve user ID resolve logic to resolve user from ancestor organizations

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -108,6 +108,8 @@ import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.functions.library.mgt.FunctionLibraryManagementService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
@@ -1058,5 +1060,42 @@ public class FrameworkServiceComponent {
             log.debug("Unsetting the configuration manager in Application Authentication Framework bundle.");
         }
         FrameworkServiceDataHolder.getInstance().setConfigurationManager(null);
+    }
+
+    @Reference(name = "identity.organization.management.component",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager")
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        FrameworkServiceDataHolder.getInstance().setOrganizationManager(organizationManager);
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        FrameworkServiceDataHolder.getInstance().setOrganizationManager(null);
+    }
+
+    @Reference(
+            name = "organization.user.resident.resolver.service",
+            service = OrganizationUserResidentResolverService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationUserResidentResolverService"
+    )
+    protected void setOrganizationUserResidentResolverService(
+            OrganizationUserResidentResolverService organizationUserResidentResolverService) {
+
+        log.debug("Setting the organization user resident resolver service.");
+        FrameworkServiceDataHolder.getInstance().setOrganizationUserResidentResolverService(
+                organizationUserResidentResolverService);
+    }
+
+    protected void unsetOrganizationUserResidentResolverService(
+            OrganizationUserResidentResolverService organizationUserResidentResolverService) {
+
+        log.debug("Unset organization user resident resolver service.");
+        FrameworkServiceDataHolder.getInstance().setOrganizationUserResidentResolverService(null);
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
@@ -52,6 +52,8 @@ import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.functions.library.mgt.FunctionLibraryManagementService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
@@ -112,6 +114,8 @@ public class FrameworkServiceDataHolder {
 
     private boolean isAdaptiveAuthenticationAvailable = false;
     private boolean isOrganizationManagementEnable = false;
+    private OrganizationManager organizationManager;
+    private OrganizationUserResidentResolverService organizationUserResidentResolverService;
 
     private FrameworkServiceDataHolder() {
 
@@ -680,6 +684,47 @@ public class FrameworkServiceDataHolder {
         if (organizationManagementInitializeService != null) {
             isOrganizationManagementEnable = organizationManagementInitializeService.isOrganizationManagementEnabled();
         }
+    }
+
+    /**
+     * Get {@link OrganizationManager}.
+     *
+     * @return organization manager instance {@link OrganizationManager}.
+     */
+    public OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    /**
+     * Set {@link OrganizationManager}.
+     *
+     * @param organizationManager Instance of {@link OrganizationManager}.
+     */
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+
+        this.organizationManager = organizationManager;
+    }
+
+    /**
+     * Get {@link OrganizationUserResidentResolverService}.
+     *
+     * @return organization user resident resolver instance {@link OrganizationUserResidentResolverService}.
+     */
+    public OrganizationUserResidentResolverService getOrganizationUserResidentResolverService() {
+
+        return organizationUserResidentResolverService;
+    }
+
+    /**
+     * Set {@link OrganizationUserResidentResolverService}.
+     *
+     * @param organizationUserResidentResolverService Instance of {@link OrganizationUserResidentResolverService}.
+     */
+    public void setOrganizationUserResidentResolverService(
+            OrganizationUserResidentResolverService organizationUserResidentResolverService) {
+
+        this.organizationUserResidentResolverService = organizationUserResidentResolverService;
     }
 
     public IdpManager getIdentityProviderManager() {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -183,19 +183,20 @@ public class AuthenticatedUser extends User {
                     Extract user id from the authenticated subject identifier assuming user ID set as a part of the
                     subject identifier.
                 */
-                String mayBeUserId = authenticatedSubjectIdentifier.split(UserCoreConstants.TENANT_DOMAIN_COMBINER)[0];
-                if (mayBeUserId.contains(CarbonConstants.DOMAIN_SEPARATOR)) {
-                    mayBeUserId = mayBeUserId.split(CarbonConstants.DOMAIN_SEPARATOR)[1];
+                String potentialUserId = authenticatedSubjectIdentifier.split(UserCoreConstants.TENANT_DOMAIN_COMBINER)[0];
+                if (potentialUserId.contains(CarbonConstants.DOMAIN_SEPARATOR)) {
+                    potentialUserId = potentialUserId.split(CarbonConstants.DOMAIN_SEPARATOR)[1];
                 }
                 Optional<String> userResideOrgId = FrameworkServiceDataHolder.getInstance()
                         .getOrganizationUserResidentResolverService()
-                        .resolveResidentOrganization(mayBeUserId, organizationId);
+                        .resolveResidentOrganization(potentialUserId, organizationId);
                 if (userResideOrgId.isPresent()) {
-                    return mayBeUserId;
+                    return potentialUserId;
                 }
             }
         } catch (OrganizationManagementException e) {
-            log.debug("Error while resolving the user id from ancestor organizations.");
+            log.error("Error occurred while resolving the user's resident organization by user ID from ancestor " +
+                    "organizations");
         }
         return null;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -183,7 +183,8 @@ public class AuthenticatedUser extends User {
                     Extract user id from the authenticated subject identifier assuming user ID set as a part of the
                     subject identifier.
                 */
-                String potentialUserId = authenticatedSubjectIdentifier.split(UserCoreConstants.TENANT_DOMAIN_COMBINER)[0];
+                String potentialUserId =
+                        authenticatedSubjectIdentifier.split(UserCoreConstants.TENANT_DOMAIN_COMBINER)[0];
                 if (potentialUserId.contains(CarbonConstants.DOMAIN_SEPARATOR)) {
                     potentialUserId = potentialUserId.split(CarbonConstants.DOMAIN_SEPARATOR)[1];
                 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2013, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2013-2023, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
### Proposed changes in this pull request

The user ID resolving part should be improved to resolve the users from the ancestor organizations, when the b2b organization management is enabled.

