### PR TITLE
[6.x.x] Improving Identity claim value encryption feature

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/constants/IdentityMgtConstants.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/constants/IdentityMgtConstants.java
@@ -96,6 +96,8 @@ public class IdentityMgtConstants {
 
     public static final String LAST_PASSWORD_UPDATE_TIME = "http://wso2.org/claims/identity/lastPasswordUpdateTime";
 
+    public static final String ENABLE_ENCRYPTION = "EnableEncryption";
+
     private IdentityMgtConstants() {
     }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityClaimValueEncryptionListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityClaimValueEncryptionListener.java
@@ -29,7 +29,9 @@ import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.mgt.constants.IdentityMgtConstants;
 import org.wso2.carbon.identity.mgt.internal.IdentityMgtServiceDataHolder;
+import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
@@ -208,8 +210,12 @@ public class IdentityClaimValueEncryptionListener extends AbstractIdentityUserOp
             throws UserStoreException {
 
         String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
-        Map<String, String> claimProperties = getClaimProperties(tenantDomain, claimURI);
-        return Boolean.parseBoolean(claimProperties.get("EnableEncryption"));
+        Map<String, String> claimProperties = new HashMap<>();
+
+        if (claimURI.contains(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI_PREFIX)) {
+            claimProperties = getClaimProperties(tenantDomain, claimURI);
+        }
+        return claimProperties.containsKey(IdentityMgtConstants.ENABLE_ENCRYPTION);
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

- Claim value encryption will be limited to identity claims and encryption decided on the availability of the `EnableEncryption` claim property, and not the value of the property.
- Added null check for claimService.
- `EnableEncryption` property for secretkey and verifySecretKey claims will not be there by default for IS on-prem product, Customers need to add the property on a need basis.

### Master branch PR

- [https://github.com/wso2/carbon-identity-framework/pull/4674](https://github.com/wso2/carbon-identity-framework/pull/4674)