### PR TITLE
Introduce a config to preserve locally added claims of JIT provisiond users

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/ExternalIdPConfig.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/ExternalIdPConfig.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.JustInTimeProvisioningConfig;
 import org.wso2.carbon.identity.application.common.model.PermissionsAndRoleConfig;
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
+import org.wso2.carbon.idp.mgt.util.IdPManagementUtil;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.io.Serializable;
@@ -258,6 +259,9 @@ public class ExternalIdPConfig implements Serializable {
     public String getAttributeSyncMethod() {
 
         String method = FrameworkConstants.OVERRIDE_ALL;
+        if (IdPManagementUtil.isPreserveLocallyAddedClaims()) {
+            method = FrameworkConstants.PRESERVE_LOCAL;
+        }
         if (justInTimeProConfig != null &&
                 StringUtils.isNotEmpty(justInTimeProConfig.getAttributeSyncMethod())) {
             method = justInTimeProConfig.getAttributeSyncMethod();

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -3081,6 +3081,9 @@ public class IdPManagementDAO {
         IdentityProviderProperty attributeSyncMethod = new IdentityProviderProperty();
         attributeSyncMethod.setName(IdPManagementConstants.SYNC_ATTRIBUTE_METHOD);
         attributeSyncMethod.setValue(IdPManagementConstants.DEFAULT_SYNC_ATTRIBUTE);
+        if (IdPManagementUtil.isPreserveLocallyAddedClaims()) {
+            attributeSyncMethod.setValue(IdPManagementConstants.PRESERVE_LOCAL_ATTRIBUTE_SYNC);
+        }
 
         if (justInTimeProvisioningConfig != null && justInTimeProvisioningConfig.isProvisioningEnabled()) {
             passwordProvisioningProperty

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
@@ -95,6 +95,8 @@ public class IdPManagementConstants {
     public static final String RESET_PROVISIONING_ENTITIES_ON_CONFIG_UPDATE = "OutboundProvisioning"
             + ".ResetProvisioningEntitiesOnConfigUpdate";
     public static final String DEFAULT_SYNC_ATTRIBUTE = "OVERRIDE_ALL";
+    public static final String PRESERVE_LOCAL_ATTRIBUTE_SYNC = "PRESERVE_LOCAL";
+    public static final String PRESERVE_LOCALLY_ADDED_CLAIMS = "JITProvisioning.PreserveLocallyAddedClaims";
 
     // Outbound Provisioning Connectors
     public static final String GOOGLE = "googleapps";

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
@@ -39,6 +39,8 @@ import org.wso2.carbon.user.api.TenantManager;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.PRESERVE_LOCALLY_ADDED_CLAIMS;
+
 public class IdPManagementUtil {
 
     private static final Log log = LogFactory.getLog(IdPManagementUtil.class);
@@ -76,6 +78,20 @@ public class IdPManagementUtil {
                 localEntityId = "localhost";
             }
         return localEntityId;
+    }
+
+    /**
+     * Check whether the preserve locally added claims config is enabled for the Jit provisioned users.
+     * If the config is false this will keep the current default behavior. So it Deletes the existing local claims that
+     * are not coming in the federated login after the provisioning.
+     * If the above config is true this will preserve the locally added claims of Jit provisioned users. This will stop
+     * deleting the attributes that are not coming in the federated login after the provisioning.
+     *
+     * @return true if the preserve locally added claim config is enabled, else return false.
+     */
+    public static boolean isPreserveLocallyAddedClaims() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(PRESERVE_LOCALLY_ADDED_CLAIMS));
     }
 
     public static int getIdleSessionTimeOut(String tenantDomain) {

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1534,7 +1534,9 @@
                 <ClaimURI>{{claimuri}}</ClaimURI>
             {% endfor %}
         </IndelibleClaims>
-
+        {% if authentication.jit_provisioning.preserve_locally_added_claims is defined %}
+        <PreserveLocallyAddedClaims>{{authentication.jit_provisioning.preserve_locally_added_claims}}</PreserveLocallyAddedClaims>
+        {% endif %}
     </JITProvisioning>
 
     <!--Application management service configurations-->


### PR DESCRIPTION
### Proposed changes in this pull request

Introduce a config to preserve local claims of jit provisioned users.
    
```
[authentication.jit_provisioning]
preserve_locally_added_claims = true
```
      
- Default value for the above config is `false`. 
- If the above config is `false` this will preserve the current behavior. So it Deletes the existing local claims that are not coming in the federated login after the provisioning.
- If the above config is `true` this will preserve the local claims of JIt provisioned users. This will stop deleting the attributes that are not coming in the federated login after the provisioning. Assume if the user provisioned with an attribute `department` and that particular claim is not coming there after then that claim is not getting removed.


### Related Git Issue

- https://github.com/wso2/product-is/issues/16133

