### PR TITLE
Resolve self registration flow failure after changing the hostname and removing the localhost from SAN

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
@@ -295,7 +295,7 @@ public class PreferenceRetrievalClient {
                                              String propertyName)
             throws PreferenceRetrievalClientException {
 
-        try (CloseableHttpClient httpclient = HttpClientBuilder.create().useSystemProperties().build()) {
+        try (CloseableHttpClient httpclient = createHttpClientBuilderWithHV().build()) {
             String endpoint = getUserGovernanceEndpoint(tenant);
             HttpGet get = new HttpGet(endpoint);
             setAuthorizationHeader(get);


### PR DESCRIPTION
#### Proposed changes in this pull request:

According to  https://is.docs.wso2.com/en/latest/deploy/enable-hostname-verification/#configure-hostname-verification localhost should not require hostname verification. 
But after removing localhost from SAN, the self registration flow which uses the internal hostname fails. This is due to not using the HTTP client introduced by https://github.com/wso2/carbon-identity-framework/pull/4262 for  internal API calls. 

From this PR, we add the customised HTTP client for GET api call for "/api/server/v1/identity-governance" in https://github.com/wso2/carbon-identity-framework/blob/480abb5d255739eb2ac3183055f7030bf9d87b94/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java#L327 

#### Related issues : 

https://github.com/wso2/product-is/issues/16181 

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
