### PR TITLE
[6.0.x] Update organization context rewrite properties.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2111,6 +2111,9 @@
                     <Path>/api/server/v1/email/template-types</Path>
                     <Path>/api/identity/recovery/v0.9</Path>
                     <Path>/api/identity/auth/v1.1</Path>
+                    <Path>/api/identity/consent-mgt/v1.0/consents</Path>
+                    <Path>/api/identity/user/v1.0/me</Path>
+                    <Path>/api/identity/user/v1.0/validate-username</Path>
                     <Path>/api/server/v1/authenticators</Path>
                     <Path>/api/server/v1/branding-preference</Path>
                     <Path>/api/server/v1/validation-rules</Path>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2988,6 +2988,9 @@
                     <Path>/api/server/v1/email/template-types</Path>
                     <Path>/api/identity/recovery/v0.9</Path>
                     <Path>/api/identity/auth/v1.1</Path>
+                    <Path>/api/identity/consent-mgt/v1.0/consents</Path>
+                    <Path>/api/identity/user/v1.0/me</Path>
+                    <Path>/api/identity/user/v1.0/validate-username</Path>
                     <Path>/api/server/v1/authenticators</Path>
                     <Path>/api/server/v1/branding-preference</Path>
                     <Path>/api/server/v1/validation-rules</Path>


### PR DESCRIPTION
## Description

Organization context rewrite rules are updated to allow sub organization signup flow to work correctly without giving 404 errors. Three sub paths were updated,
```
/api/identity/consent-mgt/v1.0/consents
/api/identity/user/v1.0/me
/api/identity/user/v1.0/validate-username
``` 

## Related PR
- https://github.com/wso2/carbon-identity-framework/pull/4776