### PR TITLE
Change updateServiceProvider method for SAML configs

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/SAMLSSOServiceProviderManager.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/SAMLSSOServiceProviderManager.java
@@ -72,16 +72,17 @@ public class SAMLSSOServiceProviderManager {
      * Update a saml service provider if already exists.
      *
      * @param serviceProviderDO     Service provider information object.
+     * @param currentIssuer         Issuer of the service provider before the update.
      * @param tenantId              Tenant ID.
      * @return True if success.
      * @throws IdentityException Error when updating the SAML service provider.
      */
-    public boolean updateServiceProvider(SAMLSSOServiceProviderDO serviceProviderDO, int tenantId)
+    public boolean updateServiceProvider(SAMLSSOServiceProviderDO serviceProviderDO, String currentIssuer, int tenantId)
             throws IdentityException {
 
         try {
             SAMLSSOServiceProviderDAO serviceProviderDAO = buildSAMLSSOProvider(tenantId);
-            return serviceProviderDAO.updateServiceProvider(serviceProviderDO);
+            return serviceProviderDAO.updateServiceProvider(serviceProviderDO, currentIssuer);
         } catch (RegistryException e) {
             LOG.error("Error while updating service provider", e);
             throw new IdentityException("Error while retrieving registry", e);

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAO.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderDAO.java
@@ -526,7 +526,9 @@ public class SAMLSSOServiceProviderDAO extends AbstractDAO<SAMLSSOServiceProvide
             if (isIssuerUpdated) {
                 registry.delete(currentPath);
             }
-            // Update the current resource. If the resource does not exist, it will be created.
+            // Update the resource.
+            // If the issuer is updated, new resource will be created.
+            // If the issuer is not updated, existing resource will be updated.
             registry.put(newPath, resource);
             if (log.isDebugEnabled()) {
                 if (StringUtils.isNotBlank(serviceProviderDO.getIssuerQualifier())) {


### PR DESCRIPTION
### Proposed changes in this pull request
Change updateServiceProvider method  for SAML configs by adding currentIssuer parameter to check if the issuer exists in update operation

### Related PR
- https://github.com/wso2/carbon-identity-framework/pull/4753
