### PR TITLE
Associate the federated user authenticated via organization login to the local user of the federated organization

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -384,7 +384,8 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                 String userTenantDomain = sequenceConfig.getAuthenticatedUser().getTenantDomain();
                 if (StringUtils.isNotEmpty(userTenantDomain)) {
                     if (StringUtils.isNotEmpty(spTenantDomain) && !spTenantDomain.equals
-                            (userTenantDomain)) {
+                            (userTenantDomain) && StringUtils.isEmpty(
+                            FrameworkUtils.fetchUserOrganizationClaimIfExist(sequenceConfig.getAuthenticatedUser()))) {
                         throw new FrameworkException("Service Provider tenant domain must be equal to user tenant " +
                                 "domain for non-SaaS applications");
                     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -659,8 +659,18 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                             StringUtils.isNotBlank(authHistory.getIdpName())) {
                         try {
                             if (FrameworkUtils.isIdpIdColumnAvailableInFedAuthTable()) {
-                                int idpId = Integer.parseInt(IdentityProviderManager.getInstance()
-                                        .getIdPByName(authHistory.getIdpName(), context.getTenantDomain()).getId());
+                                String id = IdentityProviderManager.getInstance()
+                                        .getIdPByName(authHistory.getIdpName(), context.getTenantDomain()).getId();
+                                if (id == null) {
+                                    /*
+                                        The tenant domain of the context might have changed during B2B organization
+                                        login flow. In that case tenant domain of the authentication request is used to
+                                        fetch IDP ID.
+                                     */
+                                    id = IdentityProviderManager.getInstance()
+                                            .getIdPByName(authHistory.getIdpName(), context.getAuthenticationRequest().getTenantDomain()).getId();
+                                }
+                                int idpId = Integer.parseInt(id);
                                 if (FrameworkUtils.isTenantIdColumnAvailableInFedAuthTable()) {
                                     storeFedAuthSessionWithTenantIdAndIdpId(context.getTenantDomain(),
                                             sessionContextKey, authHistory, idpId);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -301,6 +301,15 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
                     externalIdPConfig = ConfigurationFacade.getInstance()
                             .getIdPConfigByName(stepConfig.getAuthenticatedIdP(),
                                     context.getTenantDomain());
+                    if (externalIdPConfig == null) {
+                        /*
+                            The tenant domain of the context might have changed during B2B organization login flow.
+                            In that case tenant domain of the authenticatorConfig is used to fetch IDP configs.
+                        */
+                        externalIdPConfig = ConfigurationFacade.getInstance()
+                                .getIdPConfigByName(stepConfig.getAuthenticatedIdP(),
+                                        authenticatorConfig.getTenantDomain());
+                    }
                 } catch (IdentityProviderManagementException e) {
                     log.error("Exception while getting IdP by name", e);
                 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -142,6 +142,8 @@ public abstract class FrameworkConstants {
     public static final String ORGANIZATION_AUTHENTICATOR = "OrganizationAuthenticator";
     public static final String ORG_ID_PARAMETER = "orgId";
     public static final String USER_ORGANIZATION_CLAIM = "user_organization";
+    public static final String ORGANIZATION_ID_CLAIM = "org_id";
+
     public static final String SESSION_AUTH_HISTORY = "SESSION_AUTH_HISTORY";
 
     public static final String SERVICE_PROVIDER_SUBJECT_CLAIM_VALUE = "ServiceProviderSubjectClaimValue";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2895,6 +2895,19 @@ public class FrameworkUtils {
         return federatedAssociationManager;
     }
 
+    public static String fetchUserOrganizationClaimIfExist(AuthenticatedUser authenticatedUser) {
+
+        if (authenticatedUser == null || authenticatedUser.getUserAttributes() == null) {
+            return StringUtils.EMPTY;
+        }
+        for (Map.Entry<ClaimMapping, String> userAttributes : authenticatedUser.getUserAttributes().entrySet()) {
+            if ("user_organization".equals(userAttributes.getKey().getLocalClaim().getClaimUri())) {
+                return userAttributes.getValue();
+            }
+        }
+        return StringUtils.EMPTY;
+    }
+
     /**
      * Retrieves the unique user id of the given username. If the unique user id is not available, generate an id and
      * update the userid claim in read/write userstores.


### PR DESCRIPTION
### Proposed changes in this pull request

When user login the application via the organization login flow, the resolved scopes should be corresponds to the permissions the user is assigned in the federated organization. But, with the existing implementation, there is a need to switch the token to resolve the required scopes. This PR is initiated to associate the federated user with the local user who exists in the federated organization, so that there is no need for requesting for another token.