### PR TITLE
Fix multi attribute login issue when email otp as first factor

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
@@ -370,6 +371,16 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
         }
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
         try {
+            if (FrameworkServiceDataHolder.getInstance().getMultiAttributeLoginService().isEnabled(tenantDomain)) {
+                ResolvedUserResult resolvedUserResult = FrameworkServiceDataHolder.getInstance()
+                        .getMultiAttributeLoginService().resolveUser(MultitenantUtils.getTenantAwareUsername(
+                                authenticatedUser.getUserName()), tenantDomain);
+                if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS.
+                        equals(resolvedUserResult.getResolvedStatus())) {
+                    user = resolvedUserResult.getUser();
+                }
+                return user;
+            }
             UserRealm userRealm = FrameworkServiceDataHolder.getInstance().getRealmService()
                     .getTenantUserRealm(tenantId);
             if (userRealm != null) {


### PR DESCRIPTION
### Proposed changes in this pull request

- Add a user resolving logic when multi attribute login is enabled.
- This getUser method is used to resolve the users in the email otp authenticator in below two scenarios.
   - email otp as first factor
   - IDF as first factor and email otp as second factor.

### Related issue
- https://github.com/wso2/product-is/issues/16244

