### PR TITLE
Expose Local and outbound config and cliam config form application mgt service

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
@@ -94,11 +94,11 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
             throws IdentityApplicationManagementException;
 
     /**
-     * Get Application  LocalAndOutboundAuthenticationConfig for given application name
+     * Get Application  LocalAndOutboundAuthenticationConfig for given application name.
      *
-     * @param applicationName Application Name
-     * @param tenantDomain Tenant Domain
-     * @return ServiceProvider
+     * @param applicationName Application Name.
+     * @param tenantDomain Tenant Domain.
+     * @return ServiceProvider.
      * @throws org.wso2.carbon.identity.application.common.IdentityApplicationManagementException
      */
     public abstract LocalAndOutboundAuthenticationConfig getApplicationLocalAndOutboundAuthenticationConfig
@@ -106,11 +106,11 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
             throws IdentityApplicationManagementException;
 
     /**
-     * Get Application  ClaimConfig for given application name
+     * Get Application  ClaimConfig for given application name.
      *
-     * @param applicationName Application Name
-     * @param tenantDomain Tenant Domain
-     * @return ServiceProvider
+     * @param applicationName Application Name.
+     * @param tenantDomain Tenant Domain.
+     * @return ServiceProvider.
      * @throws org.wso2.carbon.identity.application.common.IdentityApplicationManagementException
      */
     public abstract ClaimConfig getApplicationClaimConfig

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementService.java
@@ -21,8 +21,10 @@ import org.apache.commons.lang.NotImplementedException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
 import org.wso2.carbon.identity.application.common.model.AuthenticationStep;
+import org.wso2.carbon.identity.application.common.model.ClaimConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.ImportResponse;
+import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
@@ -89,6 +91,30 @@ public abstract class ApplicationManagementService implements ApplicationPaginat
      * @throws org.wso2.carbon.identity.application.common.IdentityApplicationManagementException
      */
     public abstract ServiceProvider getApplicationExcludingFileBasedSPs(String applicationName, String tenantDomain)
+            throws IdentityApplicationManagementException;
+
+    /**
+     * Get Application  LocalAndOutboundAuthenticationConfig for given application name
+     *
+     * @param applicationName Application Name
+     * @param tenantDomain Tenant Domain
+     * @return ServiceProvider
+     * @throws org.wso2.carbon.identity.application.common.IdentityApplicationManagementException
+     */
+    public abstract LocalAndOutboundAuthenticationConfig getApplicationLocalAndOutboundAuthenticationConfig
+            (String applicationName, String tenantDomain)
+            throws IdentityApplicationManagementException;
+
+    /**
+     * Get Application  ClaimConfig for given application name
+     *
+     * @param applicationName Application Name
+     * @param tenantDomain Tenant Domain
+     * @return ServiceProvider
+     * @throws org.wso2.carbon.identity.application.common.IdentityApplicationManagementException
+     */
+    public abstract ClaimConfig getApplicationClaimConfig
+            (String applicationName, String tenantDomain)
             throws IdentityApplicationManagementException;
 
     /**

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.IdentityApplicationRegistrationFailureException;
 import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
 import org.wso2.carbon.identity.application.common.model.AuthenticationStep;
+import org.wso2.carbon.identity.application.common.model.ClaimConfig;
 import org.wso2.carbon.identity.application.common.model.DefaultAuthenticationSequence;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.ImportResponse;
@@ -269,6 +270,41 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
 
         return serviceProvider;
     }
+
+    @Override
+    public LocalAndOutboundAuthenticationConfig getApplicationLocalAndOutboundAuthenticationConfig
+            (String applicationName, String tenantDomain) throws IdentityApplicationManagementException {
+
+        LocalAndOutboundAuthenticationConfig localAndOutboundAuthenticationConfig;
+
+        try {
+            startTenantFlow(tenantDomain);
+            ApplicationDAO appDAO = ApplicationMgtSystemConfig.getInstance().getApplicationDAO();
+            localAndOutboundAuthenticationConfig = appDAO.getApplicationLocalAndOutboundAuthenticationConfig
+                    (applicationName, tenantDomain);
+        } finally {
+            endTenantFlow();
+        }
+
+        return localAndOutboundAuthenticationConfig;
+    }
+
+    @Override
+    public ClaimConfig getApplicationClaimConfig(String applicationName, String tenantDomain)
+            throws IdentityApplicationManagementException {
+
+        ClaimConfig claimConfig;
+
+        try {
+            startTenantFlow(tenantDomain);
+            ApplicationDAO appDAO = ApplicationMgtSystemConfig.getInstance().getApplicationDAO();
+            claimConfig = appDAO.getApplicationClaimConfig
+                    (applicationName, tenantDomain);
+        } finally {
+            endTenantFlow();
+        }
+
+        return claimConfig;    }
 
     @Override
     public ApplicationBasicInfo[] getAllApplicationBasicInfo(String tenantDomain, String username)

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.application.mgt.dao;
 import org.apache.commons.lang.NotImplementedException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
+import org.wso2.carbon.identity.application.common.model.ClaimConfig;
 import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 
@@ -47,6 +48,26 @@ public interface ApplicationDAO {
      * @throws IdentityApplicationManagementException
      */
     ServiceProvider getApplication(String applicationName, String tenantDomain)
+            throws IdentityApplicationManagementException;
+
+    /**
+     * Get service provider LocalAndOutboundAuthenticationConfig.
+     * @param applicationName Application name.
+     * @return LocalAndOutboundAuthenticationConfig.
+     * @throws IdentityApplicationManagementException IdentityApplicationManagementException.
+     */
+    LocalAndOutboundAuthenticationConfig getApplicationLocalAndOutboundAuthenticationConfig
+            (String applicationName, String tenantDomain)
+            throws IdentityApplicationManagementException;
+
+
+    /**
+     * Get service provider Claim config.
+     * @param applicationName Application name.
+     * @return LocalAndOutboundAuthenticationConfig.
+     * @throws IdentityApplicationManagementException IdentityApplicationManagementException.
+     */
+    ClaimConfig getApplicationClaimConfig (String applicationName, String tenantDomain)
             throws IdentityApplicationManagementException;
 
     /**

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/ApplicationDAO.java
@@ -52,6 +52,7 @@ public interface ApplicationDAO {
 
     /**
      * Get service provider LocalAndOutboundAuthenticationConfig.
+     *
      * @param applicationName Application name.
      * @return LocalAndOutboundAuthenticationConfig.
      * @throws IdentityApplicationManagementException IdentityApplicationManagementException.
@@ -63,6 +64,7 @@ public interface ApplicationDAO {
 
     /**
      * Get service provider Claim config.
+     *
      * @param applicationName Application name.
      * @return LocalAndOutboundAuthenticationConfig.
      * @throws IdentityApplicationManagementException IdentityApplicationManagementException.

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -1676,6 +1676,43 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         return getApplication(applicationId);
     }
 
+    @Override
+    public LocalAndOutboundAuthenticationConfig getApplicationLocalAndOutboundAuthenticationConfig
+            (String applicationName, String tenantDomain) throws IdentityApplicationManagementException {
+
+        int applicationId = getApplicationIdByName(applicationName, tenantDomain);
+        Connection connection = IdentityDatabaseUtil.getDBConnection(false);
+        LocalAndOutboundAuthenticationConfig localAndOutboundAuthenticationConfig;
+        try {
+            ServiceProvider serviceProvider = getBasicApplicationData(applicationId, connection);
+            if (serviceProvider == null) {
+                return null;
+            }
+            localAndOutboundAuthenticationConfig = serviceProvider.getLocalAndOutBoundAuthenticationConfig();
+            return localAndOutboundAuthenticationConfig;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            IdentityDatabaseUtil.closeConnection(connection);
+        }
+    }
+
+    @Override
+    public ClaimConfig getApplicationClaimConfig(String applicationName, String tenantDomain)
+            throws IdentityApplicationManagementException {
+
+        int applicationId = getApplicationIdByName(applicationName, tenantDomain);
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        Connection connection = IdentityDatabaseUtil.getDBConnection(false);
+        ClaimConfig claimConfig;
+        try {
+            claimConfig = getClaimConfiguration(applicationId, connection, tenantId);
+            return claimConfig;
+        }  finally {
+            IdentityDatabaseUtil.closeConnection(connection);
+        }
+    }
+
     private ServiceProviderProperty[] prepareLocalSpProperties() {
 
         ServiceProviderProperty[] serviceProviderProperties = new ServiceProviderProperty[1];

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -2280,6 +2280,10 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                         getBooleanValue(rs.getString(ApplicationTableColumns.ENABLE_AUTHORIZATION)));
                 localAndOutboundAuthenticationConfig.setSubjectClaimUri(
                         rs.getString(ApplicationTableColumns.SUBJECT_CLAIM_URI));
+                localAndOutboundAuthenticationConfig.setUseTenantDomainInLocalSubjectIdentifier("1"
+                        .equals(rs.getString(ApplicationTableColumns.IS_USE_TENANT_DOMAIN_SUBJECT)));
+                localAndOutboundAuthenticationConfig.setUseUserstoreDomainInLocalSubjectIdentifier("1"
+                        .equals(rs.getString(ApplicationTableColumns.IS_USE_USER_DOMAIN_SUBJECT)));
                 serviceProvider.setLocalAndOutBoundAuthenticationConfig(localAndOutboundAuthenticationConfig);
 
                 serviceProvider.setSaasApp(getBooleanValue(rs.getString(ApplicationTableColumns.IS_SAAS_APP)));

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/FileBasedApplicationDAO.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/FileBasedApplicationDAO.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.application.mgt.dao.impl;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
+import org.wso2.carbon.identity.application.common.model.ClaimConfig;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
 import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
@@ -55,6 +56,20 @@ public class FileBasedApplicationDAO extends AbstractApplicationDAOImpl {
             throws IdentityApplicationManagementException {
 
         return ApplicationManagementServiceComponent.getFileBasedSPs().get(applicationName);
+    }
+
+    @Override
+    public LocalAndOutboundAuthenticationConfig getApplicationLocalAndOutboundAuthenticationConfig
+            (String applicationName, String tenantDomain) throws IdentityApplicationManagementException {
+
+        throw new IdentityApplicationManagementException("Not supported in file based dao.");
+    }
+
+    @Override
+    public ClaimConfig getApplicationClaimConfig(String applicationName, String tenantDomain)
+            throws IdentityApplicationManagementException {
+
+        throw new IdentityApplicationManagementException("Not supported in file based dao.");
     }
 
     @Override

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/ClaimConfigByIDCache.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/ClaimConfigByIDCache.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.identity.application.mgt.internal.cache;
+
+import org.wso2.carbon.identity.core.cache.BaseCache;
+
+/**
+ * Cache for ClaimConfigByIDCache.
+ */
+public class ClaimConfigByIDCache extends
+        BaseCache<ClaimConfigByIDCacheKey, ClaimConfigByIDCacheEntry> {
+
+    public static final String SP_CACHE_NAME = "ServiceProviderCache.ID";
+
+    private static volatile ClaimConfigByIDCache instance;
+
+    private ClaimConfigByIDCache() {
+
+        super(SP_CACHE_NAME);
+    }
+
+    public static ClaimConfigByIDCache getInstance() {
+
+        if (instance == null) {
+            synchronized (ClaimConfigByIDCache.class) {
+                if (instance == null) {
+                    instance = new ClaimConfigByIDCache();
+                }
+            }
+        }
+        return instance;
+    }
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/ClaimConfigByIDCache.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/ClaimConfigByIDCache.java
@@ -1,19 +1,19 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.application.mgt.internal.cache;

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/ClaimConfigByIDCacheEntry.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/ClaimConfigByIDCacheEntry.java
@@ -1,19 +1,19 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.application.mgt.internal.cache;

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/ClaimConfigByIDCacheEntry.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/ClaimConfigByIDCacheEntry.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.identity.application.mgt.internal.cache;
+
+import org.wso2.carbon.identity.application.common.model.ClaimConfig;
+import org.wso2.carbon.identity.core.cache.CacheEntry;
+/**
+ * Cache entry when Claim config is loaded as Application ID.
+ */
+public class ClaimConfigByIDCacheEntry extends CacheEntry {
+
+    private static final long serialVersionUID = 5060231898427225662L;
+    private ClaimConfig claimConfig;
+
+    public ClaimConfigByIDCacheEntry
+            (ClaimConfig claimConfig) {
+
+        this.claimConfig = claimConfig;
+    }
+
+    public ClaimConfig getClaimConfig() {
+
+        return claimConfig;
+    }
+
+    public void setClaimConfig (ClaimConfig claimConfig) {
+
+        this.claimConfig = claimConfig;
+    }
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/ClaimConfigByIDCacheKey.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/ClaimConfigByIDCacheKey.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.identity.application.mgt.internal.cache;
+
+import org.wso2.carbon.identity.core.cache.CacheKey;
+
+/**
+ * Cache key for ClaimConfigByIDCache.
+ */
+public class ClaimConfigByIDCacheKey extends CacheKey {
+
+    private static final long serialVersionUID = 6638400636618465149L;
+    private String serviceProviderName;
+    private String tenantDomain;
+
+    public ClaimConfigByIDCacheKey(String serviceProviderName, String tenantDomain) {
+
+        this.serviceProviderName = serviceProviderName;
+        if (tenantDomain != null) {
+            this.tenantDomain = tenantDomain.toLowerCase();
+        }
+    }
+
+    public String getServiceProviderName() {
+
+        return serviceProviderName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        ClaimConfigByIDCacheKey that = (ClaimConfigByIDCacheKey) o;
+
+        if (!serviceProviderName.equals(that.serviceProviderName)) {
+            return false;
+        }
+        return tenantDomain.equals(that.tenantDomain);
+    }
+
+    @Override
+    public int hashCode() {
+
+        int result = super.hashCode();
+        result = 31 * result + serviceProviderName.hashCode();
+        result = 31 * result + tenantDomain.hashCode();
+        return result;
+    }
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/ClaimConfigByIDCacheKey.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/ClaimConfigByIDCacheKey.java
@@ -1,19 +1,19 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.application.mgt.internal.cache;

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/LocalAndOutBoundConfigByIDCache.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/LocalAndOutBoundConfigByIDCache.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.identity.application.mgt.internal.cache;
+
+import org.wso2.carbon.identity.core.cache.BaseCache;
+
+/**
+ * Cache for LocalAndOutBoundConfigByIDCache.
+ */
+public class LocalAndOutBoundConfigByIDCache extends
+        BaseCache<LocalAndOutBoundConfigByIDCacheKey, LocalAndOutBoundConfigByIDCacheEntry> {
+
+    public static final String SP_CACHE_NAME = "ServiceProviderCache.ID";
+
+    private static volatile LocalAndOutBoundConfigByIDCache instance;
+
+    private LocalAndOutBoundConfigByIDCache() {
+
+        super(SP_CACHE_NAME);
+    }
+
+    public static LocalAndOutBoundConfigByIDCache getInstance() {
+
+        if (instance == null) {
+            synchronized (LocalAndOutBoundConfigByIDCache.class) {
+                if (instance == null) {
+                    instance = new LocalAndOutBoundConfigByIDCache();
+                }
+            }
+        }
+        return instance;
+    }
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/LocalAndOutBoundConfigByIDCache.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/LocalAndOutBoundConfigByIDCache.java
@@ -1,19 +1,19 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.application.mgt.internal.cache;

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/LocalAndOutBoundConfigByIDCacheEntry.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/LocalAndOutBoundConfigByIDCacheEntry.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.mgt.internal.cache;
+
+import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
+import org.wso2.carbon.identity.core.cache.CacheEntry;
+
+/**
+ * Cache entry when Local and Outbound Authentication config is loaded as Application ID.
+ */
+public class LocalAndOutBoundConfigByIDCacheEntry extends CacheEntry {
+
+    private static final long serialVersionUID = 5060231898427225662L;
+    private LocalAndOutboundAuthenticationConfig localAndOutboundAuthenticationConfig;
+
+    public LocalAndOutBoundConfigByIDCacheEntry
+            (LocalAndOutboundAuthenticationConfig localAndOutboundAuthenticationConfig) {
+
+        this.localAndOutboundAuthenticationConfig = localAndOutboundAuthenticationConfig;
+    }
+
+    public LocalAndOutboundAuthenticationConfig getLocalAndOutboundAuthenticationConfig() {
+
+        return localAndOutboundAuthenticationConfig;
+    }
+
+    public void setLocalAndOutboundAuthenticationConfig
+            (LocalAndOutboundAuthenticationConfig localAndOutboundAuthenticationConfig) {
+
+        this.localAndOutboundAuthenticationConfig = localAndOutboundAuthenticationConfig;
+    }
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/LocalAndOutBoundConfigByIDCacheKey.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/cache/LocalAndOutBoundConfigByIDCacheKey.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.mgt.internal.cache;
+
+import org.wso2.carbon.identity.core.cache.CacheKey;
+
+/**
+ * Cache key when Local and Outbound Authentication config is loaded as Application ID.
+ */
+public class LocalAndOutBoundConfigByIDCacheKey extends CacheKey {
+
+    private static final long serialVersionUID = 6638400636618465149L;
+    private String serviceProviderName;
+    private String tenantDomain;
+
+    public LocalAndOutBoundConfigByIDCacheKey(String serviceProviderName, String tenantDomain) {
+
+        this.serviceProviderName = serviceProviderName;
+        if (tenantDomain != null) {
+            this.tenantDomain = tenantDomain.toLowerCase();
+        }
+    }
+
+    public String getServiceProviderName() {
+
+        return serviceProviderName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        LocalAndOutBoundConfigByIDCacheKey that = (LocalAndOutBoundConfigByIDCacheKey) o;
+
+        if (!serviceProviderName.equals(that.serviceProviderName)) {
+            return false;
+        }
+        return tenantDomain.equals(that.tenantDomain);
+    }
+
+    @Override
+    public int hashCode() {
+
+        int result = super.hashCode();
+        result = 31 * result + serviceProviderName.hashCode();
+        result = 31 * result + tenantDomain.hashCode();
+        return result;
+    }
+}


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/16129

This is an alternate soluciton of https://github.com/wso2/carbon-identity-framework/pull/4786

As explained in the Issue, we plan to introduce two methods in the application mgt service which exposes a service provider claim configuration and local and outbound service. 

Loaded service provider configs will be stored in a dedicated cache for future reference.

