### PR TITLE
Add config for skip oidc clams for CC in JWT Token Issuer

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -220,6 +220,10 @@
         <!-- If enabled, resident Idp entity id will be honoured as the issuer location in OpenId Connect Discovery -->
         <UseEntityIdAsIssuerInOidcDiscovery>true</UseEntityIdAsIssuerInOidcDiscovery>
 
+        <!-- If enabled, OIDC claims will be skipped when requesting token for client credential grant type
+             currently used by JWT token issuer for issuing access token-->
+        <SkipOIDCClaimsForClientCredentialGrant>true</SkipOIDCClaimsForClientCredentialGrant>
+
         <!-- Default validity period for Authorization Code in seconds -->
         <AuthorizationCodeDefaultValidityPeriod>300</AuthorizationCodeDefaultValidityPeriod>
         <!-- Default validity period for application access tokens in seconds -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -264,6 +264,10 @@
         <!-- If enabled, resident Idp entity id will be honoured as the issuer location in OpenId Connect Discovery -->
         <UseEntityIdAsIssuerInOidcDiscovery>{{oauth.use_entityid_as_issuer_in_oidc_discovery}}</UseEntityIdAsIssuerInOidcDiscovery>
 
+        <!-- If enabled, OIDC claims will be skipped when requesting token for client credential grant type
+             currently used by JWT token issuer for issuing access token-->
+        <SkipOIDCClaimsForClientCredentialGrant>{{oauth.grant_type.client_credentials.skip_oidc_claims}}</SkipOIDCClaimsForClientCredentialGrant>
+
         <!-- Default validity period for Authorization Code in seconds -->
         <AuthorizationCodeDefaultValidityPeriod>{{oauth.token_validation.authorization_code_validity}}</AuthorizationCodeDefaultValidityPeriod>
         <!-- Default validity period for application access tokens in seconds -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -138,6 +138,7 @@
   "oauth.grant_type.client_credentials.grant_handler": "org.wso2.carbon.identity.oauth2.token.handlers.grant.ClientCredentialsGrantHandler",
   "oauth.grant_type.client_credentials.allow_refresh_tokens": false,
   "oauth.grant_type.client_credentials.allow_id_token": false,
+  "oauth.grant_type.client_credentials.skip_oidc_claims": false,
   "oauth.grant_type.saml_bearer.enable": true,
   "oauth.grant_type.saml_bearer.grant_handler": "org.wso2.carbon.identity.oauth2.token.handlers.grant.saml.SAML2BearerGrantHandler",
   "oauth.grant_type.iwa_ntlm.enable": true,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -138,7 +138,7 @@
   "oauth.grant_type.client_credentials.grant_handler": "org.wso2.carbon.identity.oauth2.token.handlers.grant.ClientCredentialsGrantHandler",
   "oauth.grant_type.client_credentials.allow_refresh_tokens": false,
   "oauth.grant_type.client_credentials.allow_id_token": false,
-  "oauth.grant_type.client_credentials.skip_oidc_claims": false,
+  "oauth.grant_type.client_credentials.skip_oidc_claims": true,
   "oauth.grant_type.saml_bearer.enable": true,
   "oauth.grant_type.saml_bearer.grant_handler": "org.wso2.carbon.identity.oauth2.token.handlers.grant.saml.SAML2BearerGrantHandler",
   "oauth.grant_type.iwa_ntlm.enable": true,


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/16129
Sibling PR: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2132

Configuration:
SkipOIDCCliamsForClientCredentialGrant - When its true, by using the CC grant type we can’t retrieve any OIDC claims in the access token using JWT Token Issuer, which will skip loading service provider from the database.