### PR TITLE
Add api/idle-account-identification/v1/inactive-users

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2844,6 +2844,10 @@
         <Resource context="(.*)/fileupload/resource(.*)" secured="true" http-method="all">
             <Permissions>/permission/admin/manage</Permissions>
         </Resource>
+        <Resource context="(.*)/api/idle-account-identification/v1/inactive-users(.*)" secured="true" http-method="GET">
+            <Permissions>/permission/admin/manage/identity/usermgt/list</Permissions>
+            <Scopes>internal_user_mgt_list</Scopes>
+        </Resource>
         <Resource context="(.*)/filedownload(.*)" secured="false" http-method="all"/>
         <Resource context="(.*)/logincontext(.*)" secured="false" http-method="all"/>
         <Resource context="(.*)/longwaitstatus(.*)" secured="false" http-method="GET"/>


### PR DESCRIPTION
Related Issue:
https://github.com/wso2/product-is/issues/16356

Provide idle account identification API support to retrieve the list of users who have not successfully logged after given time stamp.

Related PRs:
- https://github.com/wso2-extensions/identity-governance/pull/733
- https://github.com/wso2/identity-api-server/pull/470