### PR TITLE
Add config for disabling password policy validation

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1224,6 +1224,11 @@
 
     </SCIM2>
 
+      <PasswordPolicy>
+        <PasswordPolicyValidationHandler>
+            <Enable>{{identity_mgt.password_policy.password_policy_validation_handler.enable}}</Enable>
+        </PasswordPolicyValidationHandler>
+      </PasswordPolicy>
       <Recovery>
         <ReCaptcha>
             <Password>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -295,6 +295,7 @@
   "scim2.consider_max_limit_for_total_results": false,
   "scim2.consider_total_records_for_total_results_of_ldap": false,
 
+  "identity_mgt.password_policy.password_policy_validation_handler.enable": false,
   "identity_mgt.recovery.notification.manage_internally": true,
   "identity_mgt.recovery.callback_url": "[${carbon.protocol}://${carbon.host}:${carbon.management.port}].*[/authenticationendpoint/login.do]*",
   "identity_mgt.recovery.enable_detailed_error_messages": false,


### PR DESCRIPTION
### Proposed changes in this pull request

With https://github.com/wso2/product-is/issues/16323, we are going to use an input validation handler to handle the password field. Thus, we are deprecating this policy handler. Policy handler can be enabled by following config:

```
[identity_mgt.password_policy.password_policy_validation_handler]
enable=true 
```

Sibiling PR: https://github.com/wso2-extensions/identity-governance/pull/741