### PR TITLE
Revert "fix scim2 group & role issue"

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/pom.xml
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/pom.xml
@@ -100,10 +100,6 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.event</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
-            <artifactId>org.wso2.carbon.identity.scim2.common</artifactId>
-        </dependency>
     </dependencies>
 
     <build>
@@ -137,8 +133,7 @@
                             org.wso2.carbon.database.utils.*;version="${org.wso2.carbon.database.utils.version.range}",
                             org.wso2.carbon.identity.core.util;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.*; version="${carbon.identity.package.import.version.range}",
-                            org.wso2.carbon.identity.central.log.mgt.utils;version="${carbon.identity.package.import.version.range}",
-                            org.wso2.carbon.identity.scim2.common.utils; version="${org.wso2.carbon.identity.scim2.common.version.range}"
+                            org.wso2.carbon.identity.central.log.mgt.utils;version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.role.mgt.core.internal,

--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/dao/RoleDAOImpl.java
@@ -45,7 +45,6 @@ import org.wso2.carbon.identity.role.mgt.core.UserBasicInfo;
 import org.wso2.carbon.identity.role.mgt.core.internal.RoleManagementServiceComponentHolder;
 import org.wso2.carbon.identity.role.mgt.core.util.GroupIDResolver;
 import org.wso2.carbon.identity.role.mgt.core.util.UserIDResolver;
-import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -1480,8 +1479,7 @@ public class RoleDAOImpl implements RoleDAO {
                             + tenantDomain;
             throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(), errorMessage, e);
         }
-        // Verify whether the roleName is either null or it's not contain any prefix Application/Internal
-        if (roleName == null || !SCIMCommonUtils.isHybridRole(roleName)) {
+        if (roleName == null) {
             String errorMessage = "A role doesn't exist with id: " + roleID + " in the tenantDomain: " + tenantDomain;
             throw new IdentityRoleManagementClientException(ROLE_NOT_FOUND.getCode(), errorMessage);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -1758,13 +1758,6 @@
                 <artifactId>xmlbeans</artifactId>
                 <version>${xmlbeans.version}</version>
             </dependency>
-
-            <!-- Identity inbound provisioning scim2 component -->
-            <dependency>
-                <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
-                <artifactId>org.wso2.carbon.identity.scim2.common</artifactId>
-                <version>${org.wso2.carbon.identity.scim2.common.version}</version>
-            </dependency>
         </dependencies>
 
     </dependencyManagement>
@@ -1817,9 +1810,6 @@
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>
-
-        <org.wso2.carbon.identity.scim2.common.version>3.4.18</org.wso2.carbon.identity.scim2.common.version>
-        <org.wso2.carbon.identity.scim2.common.version.range>[3.0.0, 4.0.0)</org.wso2.carbon.identity.scim2.common.version.range>
 
         <!--Carbon registry version-->
         <org.wso2.carbon.registry.version>4.8.12</org.wso2.carbon.registry.version>


### PR DESCRIPTION
Reverts wso2/carbon-identity-framework#4838

# Failure
Following error is occurring in jenkins build (But the local build was successfull).

[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] BUILD FAILURE
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] Total time:  05:15 min
[INFO] [INFO] Finished at: 2023-08-07T05:12:30Z
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [ERROR] Failed to execute goal on project org.wso2.carbon.identity.role.mgt.core: Could not resolve dependencies for project org.wso2.carbon.identity.framework:org.wso2.carbon.identity.role.mgt.core:bundle:5.25.273: The following artifacts could not be resolved: org.wso2.carbon.identity.framework:org.wso2.carbon.identity.claim.metadata.mgt:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.identity.user.store.configuration:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.idp.mgt:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.identity.role.mgt.core:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.identity.secret.mgt.core:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.identity.mgt:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.captcha.mgt:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.identity.application.authentication.framework:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.identity.application.mgt:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.security.mgt:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.identity.user.profile:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.identity.functions.library.mgt:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.identity.multi.attribute.login.mgt:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.claim.mgt:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.identity.configuration.mgt.core:jar:5.25.273, org.wso2.carbon.identity.framework:org.wso2.carbon.identity.notification.mgt:jar:5.25.273: Could not find artifact org.wso2.carbon.identity.framework:org.wso2.carbon.identity.claim.metadata.mgt:jar:5.25.273 in wso2.releases 

# Root Cause
There is a circular dependency between scim2 repo and framework. Which should be removed.