### PR TITLE
Fix multiple tenant domain appending to subject claim

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -412,7 +412,8 @@ public class AuthenticatedUser extends User {
             }
             if (useTenantDomainInLocalSubjectIdentifier && StringUtils.isNotEmpty(tenantDomain) &&
                     StringUtils.isNotEmpty(authenticatedSubjectIdentifier) &&
-                    StringUtils.countMatches(authenticatedSubjectIdentifier, "@") < 2) {
+                    StringUtils.countMatches(authenticatedSubjectIdentifier,
+                            UserCoreConstants.TENANT_DOMAIN_COMBINER) < 2) {
                 authenticatedSubjectIdentifier = UserCoreUtil.addTenantDomainToEntry(authenticatedSubjectIdentifier,
                         tenantDomain);
             }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -411,7 +411,8 @@ public class AuthenticatedUser extends User {
                 authenticatedSubjectIdentifier = IdentityUtil.addDomainToName(userName, userStoreDomain);
             }
             if (useTenantDomainInLocalSubjectIdentifier && StringUtils.isNotEmpty(tenantDomain) &&
-                    StringUtils.isNotEmpty(authenticatedSubjectIdentifier)) {
+                    StringUtils.isNotEmpty(authenticatedSubjectIdentifier) &&
+                    StringUtils.countMatches(authenticatedSubjectIdentifier, "@") < 2) {
                 authenticatedSubjectIdentifier = UserCoreUtil.addTenantDomainToEntry(authenticatedSubjectIdentifier,
                         tenantDomain);
             }


### PR DESCRIPTION
## Description
Temporary fix for multiple tenant domains being appended to subject claim in the userinfo response. Complete solution is tracked [here](https://github.com/wso2/product-is/issues/16423).

## Related issue
- https://github.com/wso2/product-is/issues/16423