### PR TITLE
Fix the Issue of Ignoring Tenant Domain appended to Non-SaaS Username

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -128,6 +128,7 @@ public class IdentityUtil {
     private static final String ENABLE_SELF_SIGN_UP_ENDPOINT = "EnableSelfSignUpEndpoint";
     private static final String ENABLE_EMAIL_USERNAME = "EnableEmailUserName";
     private static final String DISABLE_EMAIL_USERNAME_VALIDATION = "DisableEmailUserNameValidation";
+    private static final String ENABLE_TENANT_VALIDATION_FOR_NONSAAS_USERNAME = "EnableTenantValidationForNonSaaSUsername";
     private static Log log = LogFactory.getLog(IdentityUtil.class);
     private static Map<String, Object> configuration = new HashMap<>();
     private static Map<IdentityEventListenerConfigKey, IdentityEventListenerConfig> eventListenerConfiguration = new
@@ -1247,6 +1248,18 @@ public class IdentityUtil {
         String disableEmailUsernameValidationProperty = ServerConfiguration.getInstance()
                 .getFirstProperty(DISABLE_EMAIL_USERNAME_VALIDATION);
         return Boolean.parseBoolean(disableEmailUsernameValidationProperty);
+    }
+
+    /**
+     * Returns whether tenant validation is enabled for usernames of non SaaS applications.
+     *
+     * @return true if tenant validation is enabled for non SaaS username. False if it is not.
+     */
+    public static boolean isTenantValidationForNonSaaSUsernameEnabled() {
+
+        String enableTenantValidationForNonSaaSUsernameProperty = ServerConfiguration.getInstance()
+                .getFirstProperty(ENABLE_TENANT_VALIDATION_FOR_NONSAAS_USERNAME);
+        return Boolean.parseBoolean(enableTenantValidationForNonSaaSUsernameProperty);
     }
 
      /**

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementServiceUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementServiceUtil.java
@@ -265,6 +265,9 @@ public class IdentityManagementServiceUtil {
             user.setTenantDomain(MultitenantUtils.getTenantDomain(username));
         } else {
             user.setTenantDomain(tenantDomain);
+            if (IdentityUtil.isTenantValidationForNonSaaSUsernameEnabled()) {
+                user.setUsername(UserCoreUtil.removeDomainFromName(username));
+            }
         }
         user.setRealm(userStoreDomain);
         return user;


### PR DESCRIPTION
With the previous implementation, during password recovery or self-registration flows for non-SaaS applications, if a username with a tenant domain is given as input, the tenant domain will be ignored and the flow will be continued using username with the app's tenant domain.
For ex: For a non-saas app in super tenant during self registration flow, if we use the username `john@foo.com`, a user will be created with the username `john` in the super tenant (ignoring the @foo.com part).
For the same app in recovery flow, entering `john@foo.com` will send a recovery email to the user account john in the super tenant.

With this fix, for non saas apps the whole input will be considered as username without removing the part after the @ mark. Therefore in above scenario, if we enter `john@foo.com` as username for a non saas app in super tenant, a user will be registered with the username `john@foo.com` in the super tenant. And entering `john@foo.com` in recovery flow will send the recovery mail to user account`john@foo.com` in super tenant.

A new deployment.toml config will be introduced to preserve backward compatibility by: https://github.com/wso2/carbon-kernel/pull/3646

The following config can be added to disable the above change and preserve the previous behaviour:

```
[tenant_mgt]
enable_tenant_validation_for_nonsaas_username = false
```

Related Issue: https://github.com/wso2/product-is/issues/16228