### PR TITLE
Add idle account identification to subPath context

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3134,6 +3134,7 @@
                     <Path>/api/users/v1/([^/]+)/sessions</Path>
                     <Path>/api/server/v1/admin-advisory-management</Path>
                     <Path>/api/server/v1/guests</Path>
+                    <Path>/api/idle-account-identification/v1/inactive-users</Path>
                 </SubPaths>
             </Context>
             <Context>


### PR DESCRIPTION
Related Issue:
- https://github.com/wso2/product-is/issues/16356

Add following paths to as the SubPaths of the context
- /api/idle-account-identification/v1/inactive-users