### PR TITLE
Unifying API path regex patterns

### DIFF
--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -223,7 +223,7 @@
   "account_recovery.endpoint.auth.hash":"66cd9688a2ae068244ea01e70f0e230f5623b7fa4cdecb65070a09ec06452262",
 
   "authorization_control.skip_authorization.client_authentication.name":"ClientAuthentication",
-  "authorization_control.skip_authorization.client_authentication.allowedEndpoints": "(.*)/accountrecoveryendpoint(.*),(.*)/api/identity/recovery/(.*),(.*)/data/AuthRequestKey/(.*),(.*)/applications(.*),(.*)/identity-governance(.*),(.*)/user/(.*)/validate-username(.*),(.*)/consent-mgt/v(.*)/consents/(.*),(.*)/user/v(.*)/me(.*),(.*)/identity/auth/v(.*)/data/(.*),(.*)/identity/user/v(.*)/validate-code,(.*)/api/server/v(.*)/identity-providers(.*),(.*)/api/identity/auth/(.*)/context(.*)",
+  "authorization_control.skip_authorization.client_authentication.allowedEndpoints": "\"(.*)/accountrecoveryendpoint(.*),(.*)/api/identity/recovery(.*),(.*)/data/AuthRequestKey/(.*),(.*)/api/server/v(.*)/applications(.*),(.*)/api/server/v(.*)/identity-governance(.*),(.*)/api/server/v(.*)/identity-providers(.*),(.*)/api/identity/consent-mgt/v(.*)/consents(.*),(.*)/api/identity/user/v(.*),(.*)/api/identity/auth/v(.*)",
 
   "jit_provisioning.indelible_claims.claim_uris": [
     "http://wso2.org/claims/userid",


### PR DESCRIPTION
Related PRl:
- https://github.com/wso2/product-is/issues/16501

Unifying the API path regex patterns which add to the default.json to allow to authorization with client authentication by default.