### PR TITLE
Add PAR ep url to resident idp

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
@@ -323,6 +323,7 @@ public class IdentityApplicationConstants {
         public static final String CLIENT_ID = "ClientId";
         public static final String CLIENT_SECRET = "ClientSecret";
         public static final String OAUTH2_AUTHZ_URL = "OAuth2AuthzEPUrl";
+        public static final String OAUTH2_PAR_URL = "OAuth2ParEPUrl";
         public static final String OAUTH2_TOKEN_URL = "OAuth2TokenEPUrl";
         public static final String OAUTH2_REVOKE_URL = "OAuth2RevokeEPUrl";
         public static final String OAUTH2_INTROSPECT_URL = "OAuth2IntrospectEPUrl";

--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -363,6 +363,7 @@ public class IdentityConstants {
         public static final String OAUTH1_AUTHORIZE_URL = "OAuth.OAuth1AuthorizeUrl";
         public static final String OAUTH1_ACCESSTOKEN_URL = "OAuth.OAuth1AccessTokenUrl";
         public static final String OAUTH2_AUTHZ_EP_URL = "OAuth.OAuth2AuthzEPUrl";
+        public static final String OAUTH2_PAR_EP_URL = "OAuth.OAuth2ParEPUrl";
         public static final String OAUTH2_TOKEN_EP_URL = "OAuth.OAuth2TokenEPUrl";
         public static final String OAUTH2_USERINFO_EP_URL = "OAuth.OAuth2UserInfoEPUrl";
         public static final String OAUTH2_REVOKE_EP_URL = "OAuth.OAuth2RevokeEPUrl";
@@ -378,6 +379,7 @@ public class IdentityConstants {
         public static final String AUTHORIZE_URL = "oauth/authorize-url";
         public static final String ACCESS_TOKEN = "oauth/access-token";
         public static final String AUTHORIZE = "oauth2/authorize";
+        public static final String PAR = "oauth2/par";
         public static final String TOKEN = "oauth2/token";
         public static final String REVOKE = "oauth2/revoke";
         public static final String INTROSPECT = "oauth2/introspect";

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/org/wso2/carbon/idp/mgt/ui/i18n/Resources.properties
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/org/wso2/carbon/idp/mgt/ui/i18n/Resources.properties
@@ -149,6 +149,7 @@ oidc.default=Default
 oidc.default.help=Specifies if OpenID Connect is the default
 authz.endpoint=Authorization Endpoint URL
 authz.endpoint.help=Enter OAuth2/OpenID Connect authorization endpoint URL value
+par.endpoint=Pushed Authorization Request Endpoint URL
 token.endpoint=Token Endpoint URL
 revoke.endpoint=Token Revocation Endpoint URL
 introspect.endpoint=Token Introspection Endpoint URL

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-local.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-local.jsp
@@ -89,6 +89,7 @@
     String oauth1AuthorizeUrl = null;
     String oauth1AccessTokenUrl = null;
     String authzUrl = null;
+    String parUrl = null;
     String tokenUrl = null;
     String revokeUrl = null;
     String introspectUrl = null;
@@ -160,6 +161,8 @@
             oidcIdpEntityId = IdPManagementUIUtil.getProperty(properties, "IdPEntityId").getValue();
             authzUrl = IdPManagementUIUtil.getProperty(properties,
                     IdentityApplicationConstants.Authenticator.OIDC.OAUTH2_AUTHZ_URL).getValue();
+            parUrl = IdPManagementUIUtil.getProperty(properties,
+                    IdentityApplicationConstants.Authenticator.OIDC.OAUTH2_PAR_URL).getValue();
             tokenUrl = IdPManagementUIUtil.getProperty(properties,
                     IdentityApplicationConstants.Authenticator.OIDC.OAUTH2_TOKEN_URL).getValue();
             revokeUrl = IdPManagementUIUtil.getProperty(properties,
@@ -678,6 +681,10 @@ function removeDefaultAuthSeq() {
                         <tr>
                             <td class="leftCol-med labelField"><fmt:message key='authz.endpoint'/>:</td>
                             <td><%=Encode.forHtmlContent(authzUrl)%></td>
+                        </tr>
+                        <tr>
+                            <td class="leftCol-med labelField"><fmt:message key='par.endpoint'/>:</td>
+                            <td><%=Encode.forHtmlContent(parUrl)%></td>
                         </tr>
                         <tr>
                             <td class="leftCol-med labelField"><fmt:message key='token.endpoint'/>:</td>

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -132,6 +132,7 @@ public class IdentityProviderManager implements IdpManager {
         String oauth1AuthorizeUrl;
         String oauth1AccessTokenUrl;
         String oauth2AuthzEPUrl;
+        String oauth2ParEPUrl;
         String oauth2TokenEPUrl;
         String oauth2RevokeEPUrl;
         String oauth2IntrospectEpUrl;
@@ -154,6 +155,7 @@ public class IdentityProviderManager implements IdpManager {
         oauth1AuthorizeUrl = IdentityUtil.getProperty(IdentityConstants.OAuth.OAUTH1_AUTHORIZE_URL);
         oauth1AccessTokenUrl = IdentityUtil.getProperty(IdentityConstants.OAuth.OAUTH1_ACCESSTOKEN_URL);
         oauth2AuthzEPUrl = IdentityUtil.getProperty(IdentityConstants.OAuth.OAUTH2_AUTHZ_EP_URL);
+        oauth2ParEPUrl = IdentityUtil.getProperty(IdentityConstants.OAuth.OAUTH2_PAR_EP_URL);
         oauth2TokenEPUrl = IdentityUtil.getProperty(IdentityConstants.OAuth.OAUTH2_TOKEN_EP_URL);
         oauth2UserInfoEPUrl = IdentityUtil.getProperty(IdentityConstants.OAuth.OAUTH2_USERINFO_EP_URL);
         oidcCheckSessionEPUrl = IdentityUtil.getProperty(IdentityConstants.OAuth.OIDC_CHECK_SESSION_EP_URL);
@@ -188,6 +190,7 @@ public class IdentityProviderManager implements IdpManager {
         }
 
         oauth2AuthzEPUrl = resolveAbsoluteURL(IdentityConstants.OAuth.AUTHORIZE, oauth2AuthzEPUrl, tenantDomain);
+        oauth2ParEPUrl = resolveAbsoluteURL(IdentityConstants.OAuth.PAR, oauth2ParEPUrl, tenantDomain);
         oauth2TokenEPUrl = resolveAbsoluteURL(IdentityConstants.OAuth.TOKEN, oauth2TokenEPUrl, tenantDomain);
         oauth2RevokeEPUrl = resolveAbsoluteURL(IdentityConstants.OAuth.REVOKE, oauth2RevokeEPUrl, tenantDomain);
         oauth2IntrospectEpUrl = resolveAbsoluteURL(IdentityConstants.OAuth.INTROSPECT, oauth2IntrospectEpUrl,
@@ -377,6 +380,10 @@ public class IdentityProviderManager implements IdpManager {
         Property authzUrlProp = resolveFedAuthnProperty(oauth2AuthzEPUrl, oidcFedAuthn,
                 IdentityApplicationConstants.Authenticator.OIDC.OAUTH2_AUTHZ_URL);
         propertiesList.add(authzUrlProp);
+
+        Property parUrlProp = resolveFedAuthnProperty(oauth2ParEPUrl, oidcFedAuthn,
+                IdentityApplicationConstants.OAuth2.OAUTH2_PAR_URL);
+        propertiesList.add(parUrlProp);
 
         Property tokenUrlProp = resolveFedAuthnProperty(oauth2TokenEPUrl, oidcFedAuthn,
                 IdentityApplicationConstants.Authenticator.OIDC.OAUTH2_TOKEN_URL);

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -196,6 +196,7 @@
         <OAuth1AuthorizeUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth/authorize-url</OAuth1AuthorizeUrl>
         <OAuth1AccessTokenUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth/access-token</OAuth1AccessTokenUrl>
         <OAuth2AuthzEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/authorize</OAuth2AuthzEPUrl>
+        <OAuth2ParEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/par</OAuth2ParEPUrl>
         <OAuth2TokenEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/token</OAuth2TokenEPUrl>
         <OAuth2RevokeEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/revoke</OAuth2RevokeEPUrl>
         <OAuth2IntrospectEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/introspect</OAuth2IntrospectEPUrl>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -239,6 +239,7 @@
         <OAuth1AuthorizeUrl>{{oauth.endpoints.oauth1_authorize_url}}</OAuth1AuthorizeUrl>
         <OAuth1AccessTokenUrl>{{oauth.endpoints.oauth1_access_token_url}}</OAuth1AccessTokenUrl>
         <OAuth2AuthzEPUrl>{{oauth.endpoints.oauth2_authz_url}}</OAuth2AuthzEPUrl>
+        <OAuth2ParEPUrl>{{oauth.endpoints.oauth2_par_url}}</OAuth2ParEPUrl>
         <OAuth2TokenEPUrl>{{oauth.endpoints.oauth2_token_url}}</OAuth2TokenEPUrl>
         <OAuth2RevokeEPUrl>{{oauth.endpoints.oauth2_revoke_url}}</OAuth2RevokeEPUrl>
         <OAuth2IntrospectEPUrl>{{oauth.endpoints.oauth2_introspect_url}}</OAuth2IntrospectEPUrl>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -85,6 +85,7 @@
   "oauth.endpoints.oauth1_authorize_url": "$ref{server.base_path}/oauth/authorize-url",
   "oauth.endpoints.oauth1_access_token_url": "$ref{server.base_path}/oauth/access-token",
   "oauth.endpoints.oauth2_authz_url": "$ref{server.base_path}/oauth2/authorize",
+  "oauth.endpoints.oauth2_par_url": "$ref{server.base_path}/oauth2/par",
   "oauth.endpoints.oauth2_token_url": "$ref{server.base_path}/oauth2/token",
   "oauth.endpoints.oauth2_revoke_url": "$ref{server.base_path}/oauth2/revoke",
   "oauth.endpoints.oauth2_introspect_url": "$ref{server.base_path}/oauth2/introspect",

--- a/test-utils/org.wso2.carbon.identity.testutil/src/main/resources/repository/conf/identity/identity.xml
+++ b/test-utils/org.wso2.carbon.identity.testutil/src/main/resources/repository/conf/identity/identity.xml
@@ -138,6 +138,7 @@
         <OAuth1AuthorizeUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth/authorize-url</OAuth1AuthorizeUrl>
         <OAuth1AccessTokenUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth/access-token</OAuth1AccessTokenUrl>
         <OAuth2AuthzEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/authorize</OAuth2AuthzEPUrl>
+        <OAuth2ParEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/par</OAuth2ParEPUrl>
         <OAuth2TokenEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/token</OAuth2TokenEPUrl>
         <OAuth2RevokeEPUrll>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/revoke</OAuth2RevokeEPUrll>
         <OAuth2IntrospectEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/introspect</OAuth2IntrospectEPUrl>


### PR DESCRIPTION
### Proposed changes in this pull request

This PR adds the PAR endpoint to OAuth2 Configuration of the resident IdP.
It also introduces a config that can be used to configure the PAR endpoint as follows.

```
[oauth]
endpoints.oauth2_par_url = "https://localhost:9443/oauth2/par"
```

### Related Issues
- Issue https://github.com/wso2/product-is/issues/16549
