### PR TITLE
[Bug-fix] Fix JSON exception bug when rules not available

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/ValidationConfigurationRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/ValidationConfigurationRetrievalClient.java
@@ -116,9 +116,11 @@ public class ValidationConfigurationRetrievalClient {
             for (int i = 0; i < configurations.length(); i++) {
                 JSONObject config = (JSONObject) configurations.get(i);
                 if (((String)config.get("field")).equalsIgnoreCase("password")) {
-                    JSONArray rules = (JSONArray) config.get("rules");
-                    for (int j = 0; j < rules.length(); j++) {
-                        addRuleToConfiguration(rules.getJSONObject(j), passwordConfig);
+                    if (config.has("rules")) {
+                        JSONArray rules = (JSONArray) config.get("rules");
+                        for (int j = 0; j < rules.length(); j++) {
+                            addRuleToConfiguration(rules.getJSONObject(j), passwordConfig);
+                        }
                     }
                 }
             }
@@ -151,9 +153,11 @@ public class ValidationConfigurationRetrievalClient {
             for (int i = 0; i < configurations.length(); i++) {
                 JSONObject config = (JSONObject) configurations.get(i);
                 if (((String)config.get("field")).equalsIgnoreCase("username")) {
-                    JSONArray rules = (JSONArray) config.get("rules");
-                    for (int j = 0; j < rules.length(); j++) {
-                        addRuleToConfiguration(rules.getJSONObject(j), usernameConfig);
+                    if (config.has("rules")) {
+                        JSONArray rules = (JSONArray) config.get("rules");
+                        for (int j = 0; j < rules.length(); j++) {
+                            addRuleToConfiguration(rules.getJSONObject(j), usernameConfig);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Proposed changes in this pull request
When rules were not available in the configuration (ex: in a fresh pack only regex validator was available), 
```
config.get("rules");
```
throws JSON exception.

Fix: Add a has check before get rules json object