### PR TITLE
Add method to the PreferenceClient to get multi attribute login attributes

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
@@ -198,7 +198,6 @@ public class PreferenceRetrievalClient {
             return optional.get();
         } 
         return null;
-    
     }
 
     /**

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
@@ -196,9 +196,9 @@ public class PreferenceRetrievalClient {
                 MULTI_ATTRIBUTE_LOGIN_ALLOWED_ATTRIBUTES_PROPERTY);
         if (optional.isPresent()) {
             return optional.get();
-        } else {
-            return null;
-        }
+        } 
+        return null;
+    
     }
 
     /**

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
@@ -67,6 +67,8 @@ public class PreferenceRetrievalClient {
     private static final String RECOVERY_CONNECTOR = "account-recovery";
     private static final String LITE_USER_CONNECTOR = "lite-user-sign-up";
     private static final String MULTI_ATTRIBUTE_LOGIN_HANDLER = "multiattribute.login.handler";
+    private static final String MULTI_ATTRIBUTE_LOGIN_ALLOWED_ATTRIBUTES_PROPERTY =
+            "account.multiattributelogin.handler.allowedattributes";
     private static final String PROPERTY_NAME = "name";
     private static final String PROPERTY_ID = "id";
     private static final String PROPERTY_VALUE = "value";
@@ -179,6 +181,24 @@ public class PreferenceRetrievalClient {
     public boolean checkMultiAttributeLogin(String tenant) throws PreferenceRetrievalClientException {
 
         return checkPreference(tenant, MULTI_ATTRIBUTE_LOGIN_HANDLER, MULTI_ATTRIBUTE_LOGIN_PROPERTY);
+    }
+
+    /**
+     * Get the multi attribute login allowed attributes
+     *
+     * @param tenant tenant domain name.
+     * @return set of attributes allowed for multi attribute login.
+     * @throws PreferenceRetrievalClientException
+     */
+    public String checkMultiAttributeLoginProperty(String tenant) throws PreferenceRetrievalClientException {
+
+        Optional<String> optional = getPropertyValue(tenant, ACCOUNT_MGT_GOVERNANCE, MULTI_ATTRIBUTE_LOGIN_HANDLER,
+                MULTI_ATTRIBUTE_LOGIN_ALLOWED_ATTRIBUTES_PROPERTY);
+        if (optional.isPresent()) {
+            return optional.get();
+        } else {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request
- To dynamically generate the login identifier label, we need the attributes allowed as login identifiers.
- Add a method to the PreferenceRetrievalClient to read that property