### PR TITLE
Fix error when storing session data due to incorrect tenant domain

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthAssociationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthAssociationHandler.java
@@ -153,10 +153,10 @@ public class PostAuthAssociationHandler extends AbstractPostAuthnHandler {
 
         SequenceConfig sequenceConfig = context.getSequenceConfig();
         UserCoreUtil.setDomainInThreadLocal(UserCoreUtil.extractDomainFromName(associatedLocalUserName));
-        String fullQualifiedAssociatedUserId = FrameworkUtils.prependUserStoreDomainToName(
+        String fullQualifiedAssociatedUsername = FrameworkUtils.prependUserStoreDomainToName(
                 associatedLocalUserName + UserCoreConstants.TENANT_DOMAIN_COMBINER + context.getTenantDomain());
         AuthenticatedUser user =
-                AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(fullQualifiedAssociatedUserId);
+                AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(fullQualifiedAssociatedUsername);
         sequenceConfig.setAuthenticatedUser(user);
         stepConfig.setAuthenticatedUser(user);
         sequenceConfig.getApplicationConfig().setMappedSubjectIDSelected(true);
@@ -172,7 +172,7 @@ public class PostAuthAssociationHandler extends AbstractPostAuthnHandler {
             }
         }
         // in this case associatedID is a local user name - belongs to a tenant in IS.
-        String tenantDomain = MultitenantUtils.getTenantDomain(associatedLocalUserName);
+        String tenantDomain = MultitenantUtils.getTenantDomain(fullQualifiedAssociatedUsername);
         Map<String, Object> authProperties = context.getProperties();
 
         if (authProperties == null) {


### PR DESCRIPTION
### Proposed changes in this pull request

This PR fixes the issue related to correct tenant domain is not resolved in `PostAuthAssociationHandler` since the username given to `MultitenantUtils.getTenantDomain` doesn't include the tenant domain and it gives super tenant for all other tenants. To fix this issue, we are giving tenant qualified username instead of tenant aware username to `MultitenantUtils.getTenantDomain` method.

Related Issues:
https://github.com/wso2/product-is/issues/16499