### PR TITLE
Improve retrieval client to honour JS Regex Validation

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/ValidationConfigurationRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/ValidationConfigurationRetrievalClient.java
@@ -63,6 +63,7 @@ public class ValidationConfigurationRetrievalClient {
     private static final String VALIDATOR = "enable.validator";
     private static final String EMAIL_VALIDATOR_KEY = "emailFormatValidator";
     private static final String ALPHANUMERIC_VALIDATOR_KEY = "alphanumericFormatValidator";
+    private static final String JS_REG_EX_VALIDATOR_KEY = "JsRegExValidator";
 
     /**
      * Get validation configurations.
@@ -155,6 +156,11 @@ public class ValidationConfigurationRetrievalClient {
                 if (((String)config.get("field")).equalsIgnoreCase("username")) {
                     if (config.has("rules")) {
                         JSONArray rules = (JSONArray) config.get("rules");
+                        for (int j = 0; j < rules.length(); j++) {
+                            addRuleToConfiguration(rules.getJSONObject(j), usernameConfig);
+                        }
+                    } else if (config.has("regEx")) {
+                        JSONArray rules = (JSONArray) config.get("regEx");
                         for (int j = 0; j < rules.length(); j++) {
                             addRuleToConfiguration(rules.getJSONObject(j), usernameConfig);
                         }
@@ -269,6 +275,22 @@ public class ValidationConfigurationRetrievalClient {
         } else if (name.equalsIgnoreCase("EmailFormatValidator")) {
             addBooleanValue(VALIDATOR, (JSONArray) rule.get(PROPERTIES), config,
                     EMAIL_VALIDATOR_KEY);
+        } else if (name.equalsIgnoreCase(JS_REG_EX_VALIDATOR_KEY)) {
+            enableRegExValidation(rule, config);
+        }
+    }
+
+    private void enableRegExValidation(JSONObject rule, JSONObject config) {
+
+        config.put(JS_REG_EX_VALIDATOR_KEY, true);
+        if (rule.has(PROPERTIES)) {
+            JSONArray properties = (JSONArray) rule.get(PROPERTIES);
+            for(int i = 0; i < properties.length(); i++) {
+                JSONObject property = properties.getJSONObject(i);
+                if (((String)property.get("key")).equalsIgnoreCase("regex")) {
+                    config.put("regex", property.get("value"));
+                }
+            }
         }
     }
 }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/ValidationConfigurationRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/ValidationConfigurationRetrievalClient.java
@@ -279,7 +279,12 @@ public class ValidationConfigurationRetrievalClient {
             enableRegExValidation(rule, config);
         }
     }
-
+    /**
+     * Method to add a rule to the regex validation configuration json.
+     *
+     * @param rule      Rule need to be added to the regex validation configuration.
+     * @param config    Configuration object.
+     */
     private void enableRegExValidation(JSONObject rule, JSONObject config) {
 
         config.put(JS_REG_EX_VALIDATOR_KEY, true);


### PR DESCRIPTION
### Proposed changes in this pull request
Fixes https://github.com/wso2/product-is/issues/16631

### Fix
Check for JSRegEx validator and send a json response like below to JSP file

```
{"regex":"^[\\S]{3,50}$","JsRegExValidator":true}

```

We need to imporve the jsp file to handle above response