### PR TITLE
Change default from JsRegex validator to alphanumeric validator

### DIFF
--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
@@ -92,11 +92,7 @@ public class UsernameValidationConfigurationHandler extends AbstractFieldValidat
     private boolean isAlphaNumericValidationByDefault() {
 
         String defaultValidator = IdentityUtil.getProperty(INPUT_VALIDATION_DEFAULT_VALIDATOR);
-        if (defaultValidator != null) {
-            return StringUtils.equalsIgnoreCase(ALPHA_NUMERIC, defaultValidator);
-        }
-        // Config is not set. Hence going with email validator By default.
-        return false;
+        return StringUtils.equalsIgnoreCase(ALPHA_NUMERIC, defaultValidator);
     }
 
     @Override

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
@@ -41,7 +41,6 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import java.util.ArrayList;
 import java.util.List;
 
-import static java.lang.Boolean.parseBoolean;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.ALPHA_NUMERIC;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.EMAIL_FORMAT_VALIDATOR;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.ENABLE_VALIDATOR;
@@ -111,12 +110,12 @@ public class UsernameValidationConfigurationHandler extends AbstractFieldValidat
         validator is set to true along with Length Validator. */
         for (RulesConfiguration configuration: configurationList) {
             if (EmailFormatValidator.class.getSimpleName().equals(configuration.getValidatorName())) {
-                if (parseBoolean(configuration.getProperties().get(ENABLE_VALIDATOR))) {
+                if (Boolean.parseBoolean(configuration.getProperties().get(ENABLE_VALIDATOR))) {
                     validConfigurations += 1;
                 }
                 validatorNames.remove(EmailFormatValidator.class.getSimpleName());
             } else if (AlphanumericValidator.class.getSimpleName().equals(configuration.getValidatorName())) {
-                if (parseBoolean(configuration.getProperties().get(ENABLE_VALIDATOR))) {
+                if (Boolean.parseBoolean(configuration.getProperties().get(ENABLE_VALIDATOR))) {
                     if (validatorNames.contains(LengthValidator.class.getSimpleName())) {
                         validConfigurations += 1;
                         validatorNames.remove(LengthValidator.class.getSimpleName());
@@ -184,7 +183,7 @@ public class UsernameValidationConfigurationHandler extends AbstractFieldValidat
              validation configurations are set to emailFormatValidator.
              */
             if (rule != null && EMAIL_FORMAT_VALIDATOR.equals(rule.getValidatorName())) {
-                if (parseBoolean(rule.getProperties().get(ENABLE_VALIDATOR))) {
+                if (Boolean.parseBoolean(rule.getProperties().get(ENABLE_VALIDATOR))) {
                     try {
                         updateEmailClaim(tenantDomain);
                     } catch (ClaimMetadataException e) {

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
@@ -21,8 +21,6 @@ package org.wso2.carbon.identity.input.validation.mgt.model.handlers;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.openjdk.nashorn.JsOpenJdkNashornGraphBuilderFactory;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.core.util.IdentityUtil;

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
@@ -220,6 +220,4 @@ public class UsernameValidationConfigurationHandler extends AbstractFieldValidat
             }
         }
     }
-
-
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
@@ -79,7 +79,7 @@ public class UsernameValidationConfigurationHandler extends AbstractFieldValidat
             String usernameRegEx = getUsernameRegEx(realmConfiguration);
 
             // Return the Default JsRegex -> AlphaNumeric Validator
-            // if the default regex has been updated by the user.
+            // TODO: Need to add a config to provide legacy behaviour using JSRegex validator.
             if (!usernameRegEx.isEmpty() &&
                     !DEFAULT_EMAIL_JS_REGEX_PATTERN.equals(usernameRegEx)) {
                 rules.add(getRuleConfig(AlphanumericValidator.class.getSimpleName(),

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
@@ -43,7 +43,8 @@ import java.util.List;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.DEFAULT_EMAIL_JS_REGEX_PATTERN;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.EMAIL_FORMAT_VALIDATOR;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.ENABLE_VALIDATOR;
-import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.JS_REGEX;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.MAX_LENGTH;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.MIN_LENGTH;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.USERNAME;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.EMAIL_CLAIM_URI;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_GETTING_EXISTING_CONFIGURATIONS;
@@ -77,11 +78,15 @@ public class UsernameValidationConfigurationHandler extends AbstractFieldValidat
             RealmConfiguration realmConfiguration = getRealmConfiguration(tenantDomain);
             String usernameRegEx = getUsernameRegEx(realmConfiguration);
 
-            // Return the JsRegex if the default regex has been updated by the user.
+            // Return the Default JsRegex -> AlphaNumeric Validator
+            // if the default regex has been updated by the user.
             if (!usernameRegEx.isEmpty() &&
                     !DEFAULT_EMAIL_JS_REGEX_PATTERN.equals(usernameRegEx)) {
-                rules.add(getRuleConfig("JsRegExValidator", JS_REGEX, usernameRegEx));
-                configuration.setRegEx(rules);
+                rules.add(getRuleConfig(AlphanumericValidator.class.getSimpleName(),
+                        ENABLE_VALIDATOR, Boolean.TRUE.toString()));
+                rules.add(getRuleConfig(LengthValidator.class.getSimpleName(), MIN_LENGTH, "5"));
+                rules.add(getRuleConfig(LengthValidator.class.getSimpleName(), MAX_LENGTH, "30"));
+                configuration.setRules(rules);
             } else {
                 rules.add(getRuleConfig(EmailFormatValidator.class.getSimpleName(),
                         ENABLE_VALIDATOR, Boolean.TRUE.toString()));

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -83,7 +83,7 @@ public class Constants {
             "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![.+\\-_]{2})[\\u00C0-\\u00FF\\w.+\\-]){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0" +
             "-9]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";
 
-        public static final String INPUT_VALIDATION_DEFAULT_VALIDATOR = "InputValidation.DefaultValidator";
+        public static final String INPUT_VALIDATION_DEFAULT_VALIDATOR = "InputValidation.DefaultUserNameValidator";
 
         public static final String ALPHA_NUMERIC = "alphaNumeric";
     }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -86,7 +86,6 @@ public class Constants {
         public static final String INPUT_VALIDATION_DEFAULT_VALIDATOR = "InputValidation.DefaultValidator";
 
         public static final String ALPHA_NUMERIC = "alphaNumeric";
-
     }
 
     /**

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -82,6 +82,11 @@ public class Constants {
         public static final String DEFAULT_EMAIL_JS_REGEX_PATTERN =
             "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![.+\\-_]{2})[\\u00C0-\\u00FF\\w.+\\-]){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0" +
             "-9]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";
+
+        public static final String INPUT_VALIDATION_DEFAULT_VALIDATOR = "InputValidation.DefaultValidator";
+
+        public static final String ALPHA_NUMERIC = "alphaNumeric";
+
     }
 
     /**

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -153,6 +153,14 @@
 		<OpenIDAssociationCleanupPeriod>15</OpenIDAssociationCleanupPeriod>
 	-->
     </OpenID>
+    <!--
+    Configuration to select default validation.
+    Currently we are supporting two username validation "alphaNumeric" and "email".
+    This should be secondary configuration along with input validation event listener.
+    -->
+    <InputValidation>
+        <DefaultUserNameValidator>alphaNumeric</DefaultUserNameValidator>
+    </InputValidation>
 
     <OAuth>
         <!-- Token cleanup feature config to clean IDN_OAUTH2_ACCESS_TOKEN table-->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -187,6 +187,15 @@
         <WorkingDirectory>{{remote_fetch.working_directory}}</WorkingDirectory>
     </RemoteFetch>
 
+    <!--
+    Configuration to select default validation.
+    Currently we are supporting two username validation "alphaNumeric" and "email".
+    This should be secondary configuration along with input validation event listener.
+    -->
+    <InputValidation>
+        <DefaultUserNameValidator>{{input_validation.default_validator}}</DefaultUserNameValidator>
+    </InputValidation>
+
     <OAuth>
         <!-- Token cleanup feature config to clean IDN_OAUTH2_ACCESS_TOKEN table-->
         <TokenCleanup>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1117,5 +1117,6 @@
   "organization.user.invitation.default.accept_url": "/accountrecoveryendpoint/acceptinvitation.do",
   "extension_mgt.extension_types": "applications,identity-providers,connections,identity-verification-providers",
 
-  "identity_datastore.datastore_type": "org.wso2.carbon.identity.governance.store.JDBCIdentityDataStore"
+  "identity_datastore.datastore_type": "org.wso2.carbon.identity.governance.store.JDBCIdentityDataStore",
+  "input_validation.default_validator": "alphaNumeric"
 }


### PR DESCRIPTION
### Proposed changes in this pull request
Issue: https://github.com/wso2/product-is/issues/16631

Previously we provide JSRegex validator as default but with new changes on board we will provide alphanumeric validator as default validator with default values.


