### PR TITLE
Add configurations for organization user invitation

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2930,13 +2930,10 @@
             <Permissions>/permission/admin/manage/identity/organizationmgt/update</Permissions>
             <Scopes>internal_organization_update</Scopes>
         </Resource>
+        <Resource context="(.*)/api/server/v1/guests/invitation/accept" secured="false" http-method="POST"/>
         <Resource context="(.*)/api/server/v1/guests/invite" secured="true" http-method="POST">
             <Permissions>/permission/admin/manage/identity/guestmgt/user/invite/add</Permissions>
             <Scopes>internal_guest_mgt_invite_add</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/guests/invitation/accept" secured="true" http-method="POST">
-            <Permissions>none</Permissions>
-            <Scopes>internal_login</Scopes>
         </Resource>
         <Resource context="(.*)/api/server/v1/guests/invitation/introspect" secured="true" http-method="POST">
             <Permissions>none</Permissions>
@@ -3637,6 +3634,12 @@
 
     <!-- Configuration to enable the generation of random numbers using HMACSHA256 in IdentityUtil-->
     <EnableSHA256RandomNumberGenerator>{{identity_util.enable_sha256_random_numbers}}</EnableSHA256RandomNumberGenerator>
+
+    <OrganizationUserInvitation>
+        <DefaultExpiryTime>{{organization.user.invitation.default.expiry_time}}</DefaultExpiryTime>
+        <PrimaryUserDomain>{{organization.user.invitation.primary.user_domain}}</PrimaryUserDomain>
+        <DefaultAcceptURL>{{organization.user.invitation.default.accept_url}}</DefaultAcceptURL>
+    </OrganizationUserInvitation>
 
     <!-- Extension management service configurations -->
     <ExtensionManagementService>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1110,6 +1110,9 @@
 
   "show_pending_user_information.enable": true,
   "identity_util.enable_sha256_random_numbers": true,
+  "organization.user.invitation.default.expiry_time": "4320",
+  "organization.user.invitation.primary.user_domain": "PRIMARY",
+  "organization.user.invitation.default.accept_url": "/accountrecoveryendpoint/acceptinvitation.do",
   "extension_mgt.extension_types": "applications,identity-providers,connections,identity-verification-providers",
 
   "identity_datastore.datastore_type": "org.wso2.carbon.identity.governance.store.JDBCIdentityDataStore"


### PR DESCRIPTION
### Proposed changes in this pull request
* $subject
* Change permission on `invitation/accept` API.
* Added default expiry time, default user store domain for user invitation and default user invitation accept URL.