### PR TITLE
Add method to resolve the complete username instead of tenant-aware username

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementServiceUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementServiceUtil.java
@@ -273,6 +273,23 @@ public class IdentityManagementServiceUtil {
         return user;
     }
 
+    public User resolveUser(String username, String tenantDomain) {
+
+        if (username == null) {
+            return null;
+        }
+        String userStoreDomain = extractDomainFromName(username);
+        User user = new User();
+        if (MultitenantUtils.isEmailUserName() && username.indexOf('@') != username.lastIndexOf('@')) {
+            username = username.substring(0, username.lastIndexOf('@'));
+        }
+
+        user.setUsername(username);
+        user.setTenantDomain(tenantDomain);
+        user.setRealm(userStoreDomain);
+        return user;
+    }
+
     public String getAppName() {
         return appName;
     }


### PR DESCRIPTION
### Proposed changes in this pull request
This PR introduces an overloaded resolveUser method to resolve the user with the complete username required for the changes suggested in the following improvement

- https://github.com/wso2/product-is/issues/16500

