### PR TITLE
Fix Duplicated IDP properties issue

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -3021,11 +3021,13 @@ public class IdPManagementDAO {
             List<IdentityProviderProperty> identityProviderProperties = getCombinedProperties(identityProvider
                     .getJustInTimeProvisioningConfig(), idpProperties);
 
-            IdentityProviderProperty trustedIdpProperty = new IdentityProviderProperty();
-            trustedIdpProperty.setName(IS_TRUSTED_TOKEN_ISSUER);
-            trustedIdpProperty.setValue(String.valueOf(identityProvider.isTrustedTokenIssuer()));
-            identityProviderProperties.add(trustedIdpProperty);
-
+            if (!identityProviderProperties.stream().anyMatch(identityProviderProperty ->
+                    IS_TRUSTED_TOKEN_ISSUER.equals(identityProviderProperty.getName()))) {
+                IdentityProviderProperty trustedIdpProperty = new IdentityProviderProperty();
+                trustedIdpProperty.setName(IS_TRUSTED_TOKEN_ISSUER);
+                trustedIdpProperty.setValue(String.valueOf(identityProvider.isTrustedTokenIssuer()));
+                identityProviderProperties.add(trustedIdpProperty);
+            }
             addTemplateIdProperty(identityProviderProperties, identityProvider);
             addIdentityProviderProperties(dbConnection, idPId, identityProviderProperties, tenantId);
             IdentityDatabaseUtil.commitTransaction(dbConnection);


### PR DESCRIPTION
With the change https://github.com/wso2/carbon-identity-framework/commit/8487ab55f7f896797714873c75ba8323d4998891#diff-6af8c5bc4fe450a0e7aaa28ea162b84d3e862c57f60cfe438e8fd0030539ce72R3009, the `isTrustedTokenIssuer` property is added to IDP properties when adding a new IDP. 

But if the identity provider object already has that property in the IDP properties, this will cause this property to be available twice in IDP properties and therefore will cause SQL constraint violation issues since we are attempting to add the same property twice to the DB.

This property can be already available in IDP properties of the IDP object when trying to create or import an IDP using the REST APIs.

Related issue: https://github.com/wso2/product-is/issues/16679