### PR TITLE
Template OIDCSessionStateManager config

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -854,6 +854,11 @@
             {% endif %}
         </OpenIDConnect>
 
+        <!-- OIDCSessionStateManager configuration -->
+        {% if oauth.oidc.session_state_manager is defined %}
+        <OIDCSessionStateManager>{{oauth.oidc.session_state_manager}}</OIDCSessionStateManager>
+        {% endif %}
+
         <!--
             Configs related to OAuth2 Device Code Grant.
             Supported versions: IS 5.12.0 onwards


### PR DESCRIPTION
### Proposed changes in this pull request
$subject 

With this config, we can define the OIDCSessionStateManager class in the deployment.toml as follows,
```
[oauth.oidc]
session_state_manager="OIDCSessionStateManager"
```

### Related Issue(s)
- https://github.com/wso2/product-is/issues/16678