### PR TITLE
Add backward compatibility for password and username validation 

### DIFF
--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/PasswordValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/PasswordValidationConfigurationHandler.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.input.validation.mgt.model.handlers;
 
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtException;
 import org.wso2.carbon.identity.input.validation.mgt.model.RulesConfiguration;
 import org.wso2.carbon.identity.input.validation.mgt.model.ValidationConfiguration;
@@ -26,12 +28,19 @@ import org.wso2.carbon.identity.input.validation.mgt.model.validators.LowerCaseV
 import org.wso2.carbon.identity.input.validation.mgt.model.validators.NumeralValidator;
 import org.wso2.carbon.identity.input.validation.mgt.model.validators.SpecialCharacterValidator;
 import org.wso2.carbon.identity.input.validation.mgt.model.validators.UpperCaseValidator;
+import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.UserCoreConstants;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.ALPHA_NUMERIC;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.INPUT_VALIDATION_DEFAULT_VALIDATOR;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.JAVA_REGEX_PATTERN;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.JS_REGEX;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.MIN_LENGTH;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.PASSWORD;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_GETTING_EXISTING_CONFIGURATIONS;
 
 /**
  * Password Validation Configuration Handler.
@@ -51,12 +60,44 @@ public class PasswordValidationConfigurationHandler extends AbstractFieldValidat
         ValidationConfiguration configuration = new ValidationConfiguration();
         configuration.setField(PASSWORD);
         List<RulesConfiguration> rules = new ArrayList<>();
-        rules.add(getRuleConfig(LengthValidator.class.getSimpleName(), MIN_LENGTH, "8"));
-        rules.add(getRuleConfig(NumeralValidator.class.getSimpleName(), MIN_LENGTH, "1"));
-        rules.add(getRuleConfig(UpperCaseValidator.class.getSimpleName(), MIN_LENGTH, "1"));
-        rules.add(getRuleConfig(LowerCaseValidator.class.getSimpleName(), MIN_LENGTH, "1"));
-        rules.add(getRuleConfig(SpecialCharacterValidator.class.getSimpleName(), MIN_LENGTH, "1"));
-        configuration.setRules(rules);
-        return configuration;
+        try {
+            RealmConfiguration realmConfiguration = getRealmConfiguration(tenantDomain);
+            String javaRegex = realmConfiguration.getUserStoreProperty(UserCoreConstants
+                    .RealmConfig.PROPERTY_JAVA_REG_EX);
+            String jsRegex = realmConfiguration.
+                    getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_JS_REG_EX);
+
+            // Return the JsRegex if the default regex has been updated by the user.
+            if (!javaRegex.isEmpty() && !jsRegex.isEmpty() && !JAVA_REGEX_PATTERN.equals(javaRegex)) {
+
+                if (isRuleBasedValidationByDefault()) {
+                    rules.add(getRuleConfig(LengthValidator.class.getSimpleName(), MIN_LENGTH, "8"));
+                    rules.add(getRuleConfig(NumeralValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                    rules.add(getRuleConfig(UpperCaseValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                    rules.add(getRuleConfig(LowerCaseValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                    rules.add(getRuleConfig(SpecialCharacterValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                    configuration.setRules(rules);
+                } else {
+                    rules.add(getRuleConfig("JsRegExValidator", JS_REGEX, jsRegex));
+                    configuration.setRegEx(rules);
+                }
+            } else {
+                rules.add(getRuleConfig(LengthValidator.class.getSimpleName(), MIN_LENGTH, "8"));
+                rules.add(getRuleConfig(NumeralValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                rules.add(getRuleConfig(UpperCaseValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                rules.add(getRuleConfig(LowerCaseValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                rules.add(getRuleConfig(SpecialCharacterValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                configuration.setRules(rules);
+            }
+            return configuration;
+        } catch (InputValidationMgtException e) {
+            throw new InputValidationMgtException(ERROR_GETTING_EXISTING_CONFIGURATIONS.getCode(), e.getMessage());
+        }
+    }
+
+    private boolean isRuleBasedValidationByDefault() {
+
+        String defaultValidator = IdentityUtil.getProperty(INPUT_VALIDATION_DEFAULT_VALIDATOR);
+        return defaultValidator != null && StringUtils.equalsIgnoreCase(ALPHA_NUMERIC, defaultValidator);
     }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
@@ -39,16 +39,21 @@ import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.ALPHA_NUMERIC;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.DEFAULT_EMAIL_JS_REGEX_PATTERN;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.EMAIL_FORMAT_VALIDATOR;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.ENABLE_VALIDATOR;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.INPUT_VALIDATION_DEFAULT_VALIDATOR;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.JS_REGEX;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.MAX_LENGTH;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.MIN_LENGTH;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.USERNAME;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.EMAIL_CLAIM_URI;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_GETTING_EXISTING_CONFIGURATIONS;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_INVALID_VALIDATORS_COMBINATION;
 import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.PROPERTY_USER_NAME_JS_REG;
 import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.PROPERTY_USER_NAME_JS_REG_EX;
@@ -75,18 +80,32 @@ public class UsernameValidationConfigurationHandler extends AbstractFieldValidat
         configuration.setField(USERNAME);
         List<RulesConfiguration> rules = new ArrayList<>();
 
-        if (isAlphaNumericValidationByDefault()) {
-            rules.add(getRuleConfig(AlphanumericValidator.class.getSimpleName(),
-                    ENABLE_VALIDATOR, Boolean.TRUE.toString()));
-            rules.add(getRuleConfig(LengthValidator.class.getSimpleName(), MIN_LENGTH, "5"));
-            rules.add(getRuleConfig(LengthValidator.class.getSimpleName(), MAX_LENGTH, "30"));
-            configuration.setRules(rules);
-        } else {
-            rules.add(getRuleConfig(EmailFormatValidator.class.getSimpleName(),
-                    ENABLE_VALIDATOR, Boolean.TRUE.toString()));
-            configuration.setRules(rules);
+        try {
+            RealmConfiguration realmConfiguration = getRealmConfiguration(tenantDomain);
+            String usernameRegEx = getUsernameRegEx(realmConfiguration);
+
+            // Return the JsRegex if the default regex has been updated by the user.
+            if (!usernameRegEx.isEmpty() &&
+                    !DEFAULT_EMAIL_JS_REGEX_PATTERN.equals(usernameRegEx)) {
+                if (isAlphaNumericValidationByDefault()) {
+                    rules.add(getDefaultLengthValidatorRuleConfig());
+                    rules.add(getRuleConfig(AlphanumericValidator.class.getSimpleName(),
+                            ENABLE_VALIDATOR, Boolean.TRUE.toString()));
+                    configuration.setRules(rules);
+                } else {
+                    rules.add(getRuleConfig("JsRegExValidator", JS_REGEX, usernameRegEx));
+                    configuration.setRegEx(rules);
+                }
+            } else {
+                rules.add(getRuleConfig(EmailFormatValidator.class.getSimpleName(),
+                        ENABLE_VALIDATOR, Boolean.TRUE.toString()));
+                configuration.setRules(rules);
+            }
+            return configuration;
+        } catch (InputValidationMgtException e) {
+            throw new InputValidationMgtException(ERROR_GETTING_EXISTING_CONFIGURATIONS.getCode(), e.getMessage(),
+                    e.getDescription());
         }
-        return configuration;
     }
 
     private boolean isAlphaNumericValidationByDefault() {
@@ -214,5 +233,21 @@ public class UsernameValidationConfigurationHandler extends AbstractFieldValidat
                 break;
             }
         }
+    }
+
+    /**
+     * Method to retrieve to default length validation for alpha numeric rule configuration.
+     *
+     * @return RulesConfiguration.
+     */
+    private RulesConfiguration getDefaultLengthValidatorRuleConfig() {
+
+        RulesConfiguration rule = new RulesConfiguration();
+        rule.setValidatorName(LengthValidator.class.getSimpleName());
+        Map<String, String> properties = new HashMap<>();
+        properties.put(MIN_LENGTH, "5");
+        properties.put(MAX_LENGTH, "30");
+        rule.setProperties(properties);
+        return rule;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
With 
https://github.com/wso2/carbon-identity-framework/pull/4839 and 
https://github.com/wso2/carbon-identity-framework/pull/4910

We change alpha numeric validation by default. But this may cause backward compatibility issue, hence here we are providing backward compatibility