### PR TITLE
Avoid the double encoding by unescape an HTML string to a actual string

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
@@ -24,6 +24,7 @@ import org.apache.axiom.om.util.Base64;
 import org.apache.axis2.client.ServiceClient;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -454,14 +455,19 @@ public class IdentityManagementEndpointUtil {
      */
     public static String i18nBase64(ResourceBundle resourceBundle, String key) {
 
-        String base64Key = Base64.encode(key.getBytes(StandardCharsets.UTF_8)).replaceAll(PADDING_CHAR, UNDERSCORE);
+        /*
+        If the key is encoded already, before encoding (avoid double encoding) it within this method,
+        Unescapes an HTML string to a string containing the actual Unicode characters corresponding to the escapes.
+         */
+        String unescapedKey = StringEscapeUtils.unescapeHtml(key);
+        String base64Key = Base64.encode(unescapedKey.getBytes(StandardCharsets.UTF_8)).replaceAll(PADDING_CHAR, UNDERSCORE);
         try {
             return Encode.forHtml((StringUtils.isNotBlank(resourceBundle.getString(base64Key)) ?
-                    resourceBundle.getString(base64Key) : key));
+                    resourceBundle.getString(base64Key) : unescapedKey));
         } catch (Exception e) {
             // Intentionally catching Exception and if something goes wrong while finding the value for key, return
             // default, not to break the UI
-            return Encode.forHtml(key);
+            return Encode.forHtml(unescapedKey);
         }
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves https://github.com/wso2/product-is/issues/16658

 **Issue** 
The first place we are encoding is here.[1] Then after forwarding this to the the error jsp we are encoding it again in here[2].
The OWASP also mentioning that if we encode the same string twice the content will not display properly due to being double escaped.[3]


**Approach**
For encoding, we used` Encode.forHtml` which will encodes an input string for a safe HTML output. Hence with this PR, by using `StringEscapeUtils.unescapeHtml`, unescapes an HTML string to a string containing the actual Unicode characters corresponding to the escapes before encoding it again from the method [2].


[1] https://github.com/wso2/identity-apps/blob/c19fd4d0e1e9ad2161d569f612ddfcbd2f92c50f/java/apps/recovery-portal/src/main/webapp/recovery.jsp#L147-L149
[2] https://github.com/wso2/identity-apps/blame/5abc9ee64cb4e17b228e201cf8bf01a8ad2d63e6/java/apps/recovery-portal/src/main/webapp/error.jsp#L134
[3]https://owasp.org/www-project-proactive-controls/v3/en/c4-encode-escape-data#:~:text=Output%20encoding%20is,being%20double%20escaped.
### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
