### PR TITLE
Tenant Qualify Default IDP Alias URL

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit.jsp
@@ -34,7 +34,9 @@
 <%@ page import="org.wso2.carbon.identity.application.common.model.idp.xsd.RoleMapping" %>
 <%@ page import="org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants" %>
 <%@ page import="org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil" %>
-<%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
+<%@ page import="org.wso2.carbon.identity.base.IdentityConstants" %>
+<%@ page import="org.wso2.carbon.identity.core.ServiceURLBuilder" %>
+<%@ page import="org.wso2.carbon.identity.core.URLBuilderException" %>
 <%@ page import="org.wso2.carbon.idp.mgt.ui.client.IdentityProviderMgtServiceClient" %>
 <%@ page import="org.wso2.carbon.idp.mgt.ui.util.IdPManagementUIUtil" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
@@ -790,7 +792,11 @@
     }
 
     if (StringUtils.isBlank(idPAlias)) {
-        idPAlias = IdentityUtil.getServerURL("/oauth2/token", true, false);
+        try {
+            idPAlias = ServiceURLBuilder.create().addPath(IdentityConstants.OAuth.TOKEN).build().getAbsolutePublicURL();
+        } catch(URLBuilderException e) {
+            throw new RuntimeException("Error occurred while building URL in tenant qualified mode.", e);
+        }
     }
     String provisionStaticDropdownDisabled = "";
     String provisionDynamicDropdownDisabled = "";


### PR DESCRIPTION
The default idp alias is set to `https://localhost:9443/oauth2/token` for tenants. This PR will use the ServiceURLBuilder to build the tenant qualified url instead.

Related issue: https://github.com/wso2/product-is/issues/9051