### PR TITLE
Implement a client to interact with custom text API

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/BrandingPreferenceRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/BrandingPreferenceRetrievalClient.java
@@ -48,9 +48,11 @@ public class BrandingPreferenceRetrievalClient {
     private static final String CLIENT = "Client ";
     private static final Log log = LogFactory.getLog(PreferenceRetrievalClient.class);
     private static final String BRANDING_PREFERENCE_API_RELATIVE_PATH = "/api/server/v1/branding-preference/resolve";
+    private static final String CUSTOM_TEXT_API_RELATIVE_PATH = "/api/server/v1/branding-preference/text/resolve";
     private static final String RESOURCE_TYPE_URL_SEARCH_PARAM = "type";
     private static final String RESOURCE_NAME_URL_SEARCH_PARAM = "name";
     private static final String RESOURCE_LOCALE_URL_SEARCH_PARAM = "locale";
+    private static final String RESOURCE_SCREEN_URL_SEARCH_PARAM = "screen";
 
     /**
      * Check for branding preference in the given tenant.
@@ -125,6 +127,80 @@ public class BrandingPreferenceRetrievalClient {
     }
 
     /**
+     * Check for custom text preference in the given tenant.
+     *
+     * @param tenant Tenant Domain.
+     * @param type   Resource Type. ex: ORG, APP, etc.
+     * @param name   Resource Name. ex: Console, My Account, etc.
+     * @param screen Screen where the custom text needs to be applied. ex: Login, Recovery, etc.
+     * @param locale ISO language code of the resource. ex: en-US, pt-BR, etc.
+     * @return A JSON Object containing custom text preferences.
+     * @throws BrandingPreferenceRetrievalClientException If an error occurred while retrieving custom text preference.
+     */
+    public JSONObject getCustomTextPreference(String tenant, String type, String name, String screen, String locale)
+            throws BrandingPreferenceRetrievalClientException {
+
+        try (CloseableHttpClient httpclient = HttpClientBuilder.create().useSystemProperties().build()) {
+
+            String uri = getCustomTextPreferenceEndpoint(tenant);
+
+            try {
+                URIBuilder uriBuilder = new URIBuilder(uri);
+
+                if (StringUtils.isNotBlank(type)) {
+                    uriBuilder.addParameter(RESOURCE_TYPE_URL_SEARCH_PARAM, type);
+                }
+                if (StringUtils.isNotBlank(name)) {
+                    uriBuilder.addParameter(RESOURCE_NAME_URL_SEARCH_PARAM, name);
+                }
+                if (StringUtils.isNotBlank(screen)) {
+                    uriBuilder.addParameter(RESOURCE_SCREEN_URL_SEARCH_PARAM, screen);
+                }
+                if (StringUtils.isNotBlank(locale)) {
+                    uriBuilder.addParameter(RESOURCE_LOCALE_URL_SEARCH_PARAM, locale);
+                }
+                uri = uriBuilder.build().toString();
+
+                if (log.isDebugEnabled()) {
+                    log.debug("Custom Text Preferences endpoint URI for tenant " + tenant
+                            + " was constructed with params - type : "
+                            + type + ", name :" + name + ", locale :" + locale);
+                }
+            } catch (URISyntaxException e) {
+                if (log.isDebugEnabled()) {
+                    String msg = "Error while building the custom text preference endpoint URI with params for : "
+                            + tenant + ". Falling back to default endpoint URI: " + uri;
+                    log.debug(msg, e);
+                }
+            }
+
+            HttpGet request = new HttpGet(uri);
+            setAuthorizationHeader(request);
+
+            JSONObject jsonResponse = new JSONObject();
+
+            try (CloseableHttpResponse response = httpclient.execute(request)) {
+
+                if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+                    jsonResponse = new JSONObject(
+                            new JSONTokener(new InputStreamReader(response.getEntity().getContent())));
+                }
+
+                return jsonResponse;
+            } finally {
+                request.releaseConnection();
+            }
+        } catch (IOException e) {
+            String msg = "Error while getting custom text preference for tenant : " + tenant;
+
+            if (log.isDebugEnabled()) {
+                log.debug(msg, e);
+            }
+            throw new BrandingPreferenceRetrievalClientException(msg, e);
+        }
+    }
+
+    /**
      * Get the tenant branding preferences endpoint.
      *
      * @param tenantDomain Tenant Domain.
@@ -135,6 +211,19 @@ public class BrandingPreferenceRetrievalClient {
             throws BrandingPreferenceRetrievalClientException {
 
         return getEndpoint(tenantDomain, BRANDING_PREFERENCE_API_RELATIVE_PATH);
+    }
+
+    /**
+     * Get the tenant custom text preferences endpoint.
+     *
+     * @param tenantDomain Tenant Domain.
+     * @return A tenant qualified custom text endpoint.
+     * @throws BrandingPreferenceRetrievalClientException
+     */
+    private String getCustomTextPreferenceEndpoint(String tenantDomain)
+            throws BrandingPreferenceRetrievalClientException {
+
+        return getEndpoint(tenantDomain, CUSTOM_TEXT_API_RELATIVE_PATH);
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

- Added a new method to Client `BrandingPreferenceRetrievalClient` to interact with the `/api/server/v1/branding-preference/text` API.(https://github.com/wso2/identity-api-server/pull/495)
