### PR TITLE
Remove un-needed # from link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains the core components and features required by the [WSO2 
 If you want to build **carbon-identity-framework** from the source code:
 
 1. Install Java 11
-2. Install Apache Maven 3.x.x (https://maven.apache.org/download.cgi#)
+2. Install Apache Maven 3.x.x (https://maven.apache.org/download.cgi)
 3. Get a clone or download the source from this repository (https://github.com/wso2/carbon-identity-framework.git)
 4. Run the Maven command ``mvn clean install`` from the ``carbon-identity-framework`` directory.
 


### PR DESCRIPTION
### Proposed changes in this pull request

This is a very minor change that just removes the `#` character in the link.
It is not needed and the link looks better without it.