### PR TITLE
Skip set commonauth cookie

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -623,7 +623,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                         authenticationResult.getSubject().getUserName(), sessionContextKey,
                         authenticationResult.getSubject().getTenantDomain(), FrameworkUtils.getCorrelation(),
                         createdTimeMillis, sessionContext.isRememberMe());
-                if(request.getAttribute(SKIP_SET_COMMONAUTH_COOKIE)==null
+                if (request.getAttribute(SKIP_SET_COMMONAUTH_COOKIE) == null
                         || !Boolean.parseBoolean(request.getAttribute(SKIP_SET_COMMONAUTH_COOKIE).toString())) {
                     setAuthCookie(request, response, context, sessionKey, applicationTenantDomain);
                 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -86,6 +86,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import static java.util.Objects.nonNull;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ORGANIZATION_USER_PROPERTIES;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.SKIP_SET_COMMONAUTH_COOKIE;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_CONCLUDING_AUTHENTICATION_SUBJECT_ID_NULL;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_CONCLUDING_AUTHENTICATION_USER_ID_NULL;
 import static org.wso2.carbon.identity.application.authentication.framework.util.SessionNonceCookieUtil.NONCE_ERROR_CODE;
@@ -622,7 +623,13 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                         authenticationResult.getSubject().getUserName(), sessionContextKey,
                         authenticationResult.getSubject().getTenantDomain(), FrameworkUtils.getCorrelation(),
                         createdTimeMillis, sessionContext.isRememberMe());
-                setAuthCookie(request, response, context, sessionKey, applicationTenantDomain);
+                if(StringUtils.isNotBlank(request.getAttribute(SKIP_SET_COMMONAUTH_COOKIE).toString())
+                        && Boolean.parseBoolean(request.getAttribute(SKIP_SET_COMMONAUTH_COOKIE).toString())) {
+                    log.info("Skipped setting commonAuth cookie for the request with sessionDataKey: " +
+                            request.getParameter("sessionDataKey"));
+                } else {
+                    setAuthCookie(request, response, context, sessionKey, applicationTenantDomain);
+                }
                 if (FrameworkServiceDataHolder.getInstance().isUserSessionMappingEnabled()) {
                     try {
                         storeSessionMetaData(sessionContextKey, request);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -85,8 +85,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static java.util.Objects.nonNull;
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ORGANIZATION_USER_PROPERTIES;
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.SKIP_SET_COMMONAUTH_COOKIE;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.*;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_CONCLUDING_AUTHENTICATION_SUBJECT_ID_NULL;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_CONCLUDING_AUTHENTICATION_USER_ID_NULL;
 import static org.wso2.carbon.identity.application.authentication.framework.util.SessionNonceCookieUtil.NONCE_ERROR_CODE;
@@ -623,8 +622,8 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                         authenticationResult.getSubject().getUserName(), sessionContextKey,
                         authenticationResult.getSubject().getTenantDomain(), FrameworkUtils.getCorrelation(),
                         createdTimeMillis, sessionContext.isRememberMe());
-                if (request.getAttribute(SKIP_SET_COMMONAUTH_COOKIE) == null
-                        || !Boolean.parseBoolean(request.getAttribute(SKIP_SET_COMMONAUTH_COOKIE).toString())) {
+                if (request.getAttribute(ALLOW_SESSION_CREATION) == null
+                        || Boolean.parseBoolean(request.getAttribute(ALLOW_SESSION_CREATION).toString())) {
                     setAuthCookie(request, response, context, sessionKey, applicationTenantDomain);
                 }
                 if (FrameworkServiceDataHolder.getInstance().isUserSessionMappingEnabled()) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -623,11 +623,8 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                         authenticationResult.getSubject().getUserName(), sessionContextKey,
                         authenticationResult.getSubject().getTenantDomain(), FrameworkUtils.getCorrelation(),
                         createdTimeMillis, sessionContext.isRememberMe());
-                if(StringUtils.isNotBlank(request.getAttribute(SKIP_SET_COMMONAUTH_COOKIE).toString())
-                        && Boolean.parseBoolean(request.getAttribute(SKIP_SET_COMMONAUTH_COOKIE).toString())) {
-                    log.info("Skipped setting commonAuth cookie for the request with sessionDataKey: " +
-                            request.getParameter("sessionDataKey"));
-                } else {
+                if(request.getAttribute(SKIP_SET_COMMONAUTH_COOKIE)==null
+                        || !Boolean.parseBoolean(request.getAttribute(SKIP_SET_COMMONAUTH_COOKIE).toString())) {
                     setAuthCookie(request, response, context, sessionKey, applicationTenantDomain);
                 }
                 if (FrameworkServiceDataHolder.getInstance().isUserSessionMappingEnabled()) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -85,7 +85,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static java.util.Objects.nonNull;
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.*;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ALLOW_SESSION_CREATION;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ORGANIZATION_USER_PROPERTIES;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_CONCLUDING_AUTHENTICATION_SUBJECT_ID_NULL;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_CONCLUDING_AUTHENTICATION_USER_ID_NULL;
 import static org.wso2.carbon.identity.application.authentication.framework.util.SessionNonceCookieUtil.NONCE_ERROR_CODE;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -29,6 +29,7 @@ public abstract class FrameworkConstants {
     public static final String DEFAULT_SEQUENCE = "default";
     public static final String AUTHENTICATED_AUTHENTICATORS = "authenticatedAuthenticators";
     public static final String COMMONAUTH_COOKIE = "commonAuthId";
+    public static final String SKIP_SET_COMMONAUTH_COOKIE = "skipSetCommonAuthCookie";
     public static final String CONTEXT_PROP_INVALID_EMAIL_USERNAME = "InvalidEmailUsername";
     // Cookie used for post authenticaion sequence tracking
     public static final String PASTR_COOKIE = "pastr";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -29,7 +29,7 @@ public abstract class FrameworkConstants {
     public static final String DEFAULT_SEQUENCE = "default";
     public static final String AUTHENTICATED_AUTHENTICATORS = "authenticatedAuthenticators";
     public static final String COMMONAUTH_COOKIE = "commonAuthId";
-    public static final String SKIP_SET_COMMONAUTH_COOKIE = "skipSetCommonAuthCookie";
+    public static final String ALLOW_SESSION_CREATION = "allowSessionCreation";
     public static final String CONTEXT_PROP_INVALID_EMAIL_USERNAME = "InvalidEmailUsername";
     // Cookie used for post authenticaion sequence tracking
     public static final String PASTR_COOKIE = "pastr";


### PR DESCRIPTION
### Proposed changes in this pull request
- Partly supports: https://github.com/wso2/product-is/issues/16855
-  In this PR, we provide a way to skip setting commonauth cookie to the response.
- Since we are extending password grant to utilize authentication framework, while it creates a session , it sets a common-auth cookie back in the response. But for password grant there is no necessity for session. Though we force authentication again, it is advisable to not return commonauth cookie since the session can be manipulated from a different device. 

