### PR TITLE
Include a white logo to ensure compatibility with the dark theme in My Account app

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1090,6 +1090,7 @@
   "myaccount.ui.app_title": "My Account | WSO2 Identity Server",
   "myaccount.ui.app_name": "My Account",
   "myaccount.ui.app_logo_path": "/assets/images/branding/logo.svg",
+  "myaccount.ui.app_white_logo_path": "/assets/images/branding/logo-white.svg",
   "myaccount.ui.is_header_avatar_label_allowed": true,
   "myaccount.ui.product_name": "WSO2 Identity Server",
   "myaccount.theme": "default",


### PR DESCRIPTION
### Proposed changes in this pull request

Include a white logo to ensure compatibility with the dark theme in My Account app

### Related issues
- https://github.com/wso2/product-is/issues/16786
