### PR TITLE
Upgrade Jackson Dependencies version range to [2.13.0, 2.16.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2006,11 +2006,11 @@
         <kaptcha.wso2.version>2.3.0.wso2v1</kaptcha.wso2.version>
         <json.wso2.version>3.0.0.wso2v1</json.wso2.version>
         <json.wso2.version.range>[3.0.0.wso2v1, 4.0.0)</json.wso2.version.range>
-        <com.fasterxml.jackson.version>2.13.0</com.fasterxml.jackson.version>
-        <com.fasterxml.jackson.annotation.version>2.13.0</com.fasterxml.jackson.annotation.version>
-        <com.fasterxml.jackson.databind.version>2.14.0-rc2</com.fasterxml.jackson.databind.version>
-        <com.fasterxml.jackson.jaxrs-json-provider-version>2.13.0</com.fasterxml.jackson.jaxrs-json-provider-version>
-        <com.fasterxml.jackson.annotation.version.range>[2.13.0, 2.14.0)</com.fasterxml.jackson.annotation.version.range>
+        <com.fasterxml.jackson.version>2.15.2</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.annotation.version>2.15.2</com.fasterxml.jackson.annotation.version>
+        <com.fasterxml.jackson.databind.version>2.15.2</com.fasterxml.jackson.databind.version>
+        <com.fasterxml.jackson.jaxrs-json-provider-version>2.15.2</com.fasterxml.jackson.jaxrs-json-provider-version>
+        <com.fasterxml.jackson.annotation.version.range>[2.13.0, 2.16.0)</com.fasterxml.jackson.annotation.version.range>
 
         <apache.wink.version>1.1.3-incubating</apache.wink.version>
         <msf4j.version>2.7.0</msf4j.version>


### PR DESCRIPTION
### Purpose
Upgrading Jackson dependencies to 2.15.2 requires updating this version range.