### PR TITLE
Add new config to specify to append super tenant in URL

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.StringJoiner;
 
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.PROXY_CONTEXT_PATH;
+import static org.wso2.carbon.identity.core.util.IdentityTenantUtil.isSuperTenantMandatoryInUrl;
 
 /**
  * Implementation for {@link ServiceURLBuilder}.
@@ -124,7 +125,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
 
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && !resolvedUrlContext.startsWith("t/") &&
                 !resolvedUrlContext.startsWith("o/")) {
-            if (mandateTenantedPath || isNotSuperTenant(tenantDomain)) {
+            if (mandateTenantedPath || isSuperTenantMandatoryInUrl() || isNotSuperTenant(tenantDomain)) {
                 String organizationId = StringUtils.isNotBlank(orgId) ? orgId :
                         PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
                 if (organizationId != null) {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import java.util.StringJoiner;
 
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.PROXY_CONTEXT_PATH;
-import static org.wso2.carbon.identity.core.util.IdentityTenantUtil.isSuperTenantMandatoryInUrl;
+import static org.wso2.carbon.identity.core.util.IdentityTenantUtil.isSuperTenantRequiredInUrl;
 
 /**
  * Implementation for {@link ServiceURLBuilder}.
@@ -125,7 +125,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
 
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && !resolvedUrlContext.startsWith("t/") &&
                 !resolvedUrlContext.startsWith("o/")) {
-            if (mandateTenantedPath || isSuperTenantMandatoryInUrl() || isNotSuperTenant(tenantDomain)) {
+            if (mandateTenantedPath || isSuperTenantRequiredInUrl() || isNotSuperTenant(tenantDomain)) {
                 String organizationId = StringUtils.isNotBlank(orgId) ? orgId :
                         PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
                 if (organizationId != null) {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -35,9 +35,10 @@ public class IdentityCoreConstants {
     public static final String PORTS_OFFSET = "Ports.Offset";
 
     public static final String TENANT_NAME_FROM_CONTEXT = "TenantNameFromContext";
-    public static final String ENABLE_TENANT_QUALIFIED_URLS = "EnableTenantQualifiedUrls";
-    public static final String ENABLE_TENANTED_SESSIONS = "EnableTenantedSessions";
-    public static final String APPEND_SUPER_TENANT_IN_URL = "AppendSuperTenantInUrl";
+    public static final String ENABLE_TENANT_QUALIFIED_URLS = "TenantContext.TenantQualifiedUrls.Enable";
+    public static final String REQUIRED_SUPER_TENANT_IN_URLS =
+            "TenantContext.TenantQualifiedUrls.RequireSuperTenantInUrls";
+    public static final String ENABLE_TENANTED_SESSIONS = "TenantContext.TenantQualifiedUrls.EnableTenantedSessions";
     public static final String PROXY_CONTEXT_PATH = "ProxyContextPath";
     public static final int DEFAULT_HTTPS_PORT = 443;
     public static final String UTF_8 = "UTF-8";

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -37,6 +37,7 @@ public class IdentityCoreConstants {
     public static final String TENANT_NAME_FROM_CONTEXT = "TenantNameFromContext";
     public static final String ENABLE_TENANT_QUALIFIED_URLS = "EnableTenantQualifiedUrls";
     public static final String ENABLE_TENANTED_SESSIONS = "EnableTenantedSessions";
+    public static final String APPEND_SUPER_TENANT_IN_URL = "AppendSuperTenantInUrl";
     public static final String PROXY_CONTEXT_PATH = "ProxyContextPath";
     public static final int DEFAULT_HTTPS_PORT = 443;
     public static final String UTF_8 = "UTF-8";

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
@@ -429,7 +429,7 @@ public class IdentityTenantUtil {
      */
     public static boolean isSuperTenantRequiredInUrl() {
 
-        return Boolean.parseBoolean(IdentityUtil.getProperty(IdentityCoreConstants.APPEND_SUPER_TENANT_IN_URL));
+        return Boolean.parseBoolean(IdentityUtil.getProperty(IdentityCoreConstants.REQUIRED_SUPER_TENANT_IN_URLS));
     }
 
     /**

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
@@ -423,6 +423,16 @@ public class IdentityTenantUtil {
     }
 
     /**
+     * Checks if it is required to specify carbon.super in tenant qualified URLs.
+     *
+     * @return true if it is mandatory, false otherwise.
+     */
+    public static boolean isSuperTenantRequiredInUrl() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(IdentityCoreConstants.APPEND_SUPER_TENANT_IN_URL));
+    }
+
+    /**
      *
      * Checks whether legacy SaaS authentication is enabled.
      *

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2252,6 +2252,14 @@
     -->
     <EnableFederatedUserAssociation>false</EnableFederatedUserAssociation>
 
+    <TenantContext>
+        <TenantQualifiedUrls>
+            <Enable>false</Enable>
+            <RequireSuperTenantInUrls>false</RequireSuperTenantInUrls>
+            <EnableTenantedSessions>false</EnableTenantedSessions>
+        </TenantQualifiedUrls>
+    </TenantContext>
+
     <TenantContextsToRewrite>
         <WebApp>
             <Context>/api/identity/user/v1.0/</Context>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3214,9 +3214,14 @@
     -->
     <EnableFederatedUserAssociation>{{user.association.enable_for_federated_users}}</EnableFederatedUserAssociation>
 
-    <EnableTenantQualifiedUrls>{{tenant_context.enable_tenant_qualified_urls}}</EnableTenantQualifiedUrls>
-    <EnableTenantedSessions>{{tenant_context.enable_tenanted_sessions | default(false)}}</EnableTenantedSessions>
-    <AppendSuperTenantInUrl>{{tenant_context.append_super_tenant_in_url | default(false)}}</AppendSuperTenantInUrl>
+    <TenantContext>
+        <TenantQualifiedUrls>
+            <Enable>{{tenant_context.enable_tenant_qualified_urls}}</Enable>
+            <RequireSuperTenantInUrls>{{tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls}}</RequireSuperTenantInUrls>
+            <EnableTenantedSessions>{{tenant_context.enable_tenant_qualified_urls && tenant_context.enable_tenanted_sessions}}</EnableTenantedSessions>
+       </TenantQualifiedUrls>
+    </TenantContext>
+
 
     <!--
         When this property is set to 'true', if the username provided during the SaaS application authentication does

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3216,6 +3216,7 @@
 
     <EnableTenantQualifiedUrls>{{tenant_context.enable_tenant_qualified_urls}}</EnableTenantQualifiedUrls>
     <EnableTenantedSessions>{{tenant_context.enable_tenanted_sessions | default(false)}}</EnableTenantedSessions>
+    <AppendSuperTenantInUrl>{{tenant_context.append_super_tenant_in_url | default(false)}}</AppendSuperTenantInUrl>
 
     <!--
         When this property is set to 'true', if the username provided during the SaaS application authentication does

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -639,6 +639,7 @@
   "user.association.enable_for_federated_users": false,
   "user.enable_per_user_functionality_locking": false,
   "tenant_context.enable_tenant_qualified_urls": false,
+  "tenant_context.require_super_tenant_in_urls": false,
   "tenant_context.rewrite.webapps": [
     "/oauth2/",
     "/scim2/",


### PR DESCRIPTION
Related issue:
- https://github.com/wso2/product-is/issues/16906

Add new configurations to specify where `carbon.super` is needed to append to the URL when tenant qualified URL feature is enabled.