### PR TITLE
Add authenticator to the params map

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
@@ -273,11 +273,11 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
             boolean isFederated = this instanceof FederatedApplicationAuthenticator;
             Map<String, Object> paramMap = new HashMap<>();
             paramMap.put(FrameworkConstants.AnalyticsAttributes.USER, user);
+            paramMap.put(FrameworkConstants.AUTHENTICATOR, getName());
             if (isFederated) {
                 // Setting this value to authentication context in order to use in AuthenticationSuccess Event
                 context.setProperty(FrameworkConstants.AnalyticsAttributes.HAS_FEDERATED_STEP, true);
                 paramMap.put(FrameworkConstants.AnalyticsAttributes.IS_FEDERATED, true);
-                paramMap.put(FrameworkConstants.AUTHENTICATOR, getName());
                 if (user != null) {
                     user.setTenantDomain(context.getTenantDomain());
                 }


### PR DESCRIPTION
## Purpose
- Previously, the `authenticator` is set to the params map when the authenticator is fedearted only.
- To handle the failure event for the local authenticator of the multi option scenarios, we need the used authenticator in that step.
- To get the authentictaor that is used in the failed step, we are adding the name of the authenticator for the params maps.

### Related issue
https://github.com/wso2/product-is/issues/16917