### PR TITLE
Add support for retrieving scope metadata

### DIFF
--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/APIResourceManager.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/APIResourceManager.java
@@ -156,4 +156,15 @@ public interface APIResourceManager {
      * @throws APIResourceMgtException If an error occurs while retrieving scope.
      */
     Scope getScopeByName(String scopeName, String tenantDomain) throws APIResourceMgtException;
+
+    /**
+     * Get scope metadata by scope names and tenant domain.
+     *
+     * @param scopeNames   List of scope names.
+     * @param tenantDomain Tenant domain.
+     * @return Scope metadata grouped by API Resource.
+     * @throws APIResourceMgtException If an error occurs while retrieving scope metadata.
+     */
+    List<APIResource> getScopeMetadata(List<String> scopeNames, String tenantDomain)
+            throws APIResourceMgtException;
 }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/APIResourceManagerImpl.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/APIResourceManagerImpl.java
@@ -148,6 +148,13 @@ public class APIResourceManagerImpl implements APIResourceManager {
         return CACHE_BACKED_DAO.getScopeByNameAndTenantId(scopeName, IdentityTenantUtil.getTenantId(tenantDomain));
     }
 
+    @Override
+    public List<APIResource> getScopeMetadata(List<String> scopeNames, String tenantDomain)
+            throws APIResourceMgtException {
+
+        return CACHE_BACKED_DAO.getScopeMetadata(scopeNames, IdentityTenantUtil.getTenantId(tenantDomain));
+    }
+
     /**
      * Get the filter node as a list.
      *

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/constant/APIResourceManagementConstants.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/constant/APIResourceManagementConstants.java
@@ -98,6 +98,8 @@ public class APIResourceManagementConstants {
                 " scope.", "Error while checking existence of scope in the database."),
         ERROR_CODE_ERROR_WHILE_CHECKING_API_RESOURCE_EXISTENCE("65011", "Error while checking existence " +
                 "of API resource.", "Error while checking existence of API resource in the database."),
+        ERROR_CODE_ERROR_WHILE_RETRIEVING_SCOPE_METADATA("65012", "Error while retrieving scope metadata.",
+                "Error while retrieving scope metadata from the database."),
         ;
 
         private final String code;

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/constant/SQLConstants.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/constant/SQLConstants.java
@@ -53,6 +53,9 @@ public class SQLConstants {
     public static final String SCOPE_UNIQUE_CONSTRAINT = "scope_unique";
     public static final String DB2_SQL_ERROR_CODE_UNIQUE_CONSTRAINT = "-803";
 
+    // Placeholders.
+    public static final String SCOPE_LIST_PLACEHOLDER = "_SCOPE_LIST_";
+
     // SQL queries.
     public static final String GET_API_RESOURCES = "SELECT ID, CURSOR_KEY, NAME, IDENTIFIER, DESCRIPTION, TENANT_ID," +
             " TYPE, REQUIRES_AUTHORIZATION FROM API_RESOURCE WHERE ";
@@ -111,4 +114,12 @@ public class SQLConstants {
             "TENANT_ID FROM SCOPE WHERE ";
     public static final String GET_SCOPES_BY_TENANT_ID_TAIL = " TENANT_ID = ?";
     public static final String DELETE_SCOPE_BY_NAME = "DELETE FROM SCOPE WHERE NAME = ? AND TENANT_ID = ?";
+    public static final String GET_SCOPE_METADATA = "SELECT" +
+            " AR.ID AS API_RESOURCE_ID," +
+            " AR.NAME AS API_RESOURCE_NAME," +
+            " S.NAME AS SCOPE_QUALIFIED_NAME," +
+            " S.DISPLAY_NAME AS SCOPE_DISPLAY_NAME," +
+            " S.DESCRIPTION AS SCOPE_DESCRIPTION" +
+            " FROM API_RESOURCE AR LEFT JOIN SCOPE S ON AR.ID = S.API_ID WHERE S.TENANT_ID = ?" +
+            " AND S.NAME IN (" + SCOPE_LIST_PLACEHOLDER + ")";
 }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/dao/APIResourceManagementDAO.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/dao/APIResourceManagementDAO.java
@@ -231,4 +231,14 @@ public interface APIResourceManagementDAO {
      * @throws APIResourceMgtException If an error occurs while retrieving the subscribed applications.
      */
     List<ApplicationBasicInfo> getSubscribedApplications(String apiId) throws APIResourceMgtException;
+
+    /**
+     * Retrieve scope metadata for given scopes.
+     *
+     * @param scopeNames List of scopes.
+     * @param tenantId   Tenant Id.
+     * @return List of API Resources with scope metadata.
+     * @throws APIResourceMgtException If an error occurs while retrieving the scope metadata.
+     */
+    List<APIResource> getScopeMetadata(List<String> scopeNames, Integer tenantId) throws APIResourceMgtException;
 }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/dao/impl/APIResourceManagementDAOImpl.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/dao/impl/APIResourceManagementDAOImpl.java
@@ -39,6 +39,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -486,6 +488,49 @@ public class APIResourceManagementDAOImpl implements APIResourceManagementDAO {
     @Override
     public List<ApplicationBasicInfo> getSubscribedApplications(String apiId) {
         return null;
+    }
+
+    @Override
+    public List<APIResource> getScopeMetadata(List<String> scopeNames, Integer tenantId)
+            throws APIResourceMgtException {
+
+        String query = SQLConstants.GET_SCOPE_METADATA;
+        String placeholders = String.join(",", Collections.nCopies(scopeNames.size(), "?"));
+        query = query.replace(SQLConstants.SCOPE_LIST_PLACEHOLDER, placeholders);
+        try (Connection dbConnection = IdentityDatabaseUtil.getDBConnection(false);
+             PreparedStatement prepStmt = dbConnection.prepareStatement(query)) {
+            prepStmt.setInt(1, tenantId);
+            int scopeIndex = 2;
+            for (String scopeName : scopeNames) {
+                prepStmt.setString(scopeIndex, scopeName);
+                scopeIndex++;
+            }
+            try (ResultSet resultSet = prepStmt.executeQuery()) {
+                Map<String, APIResource> apiResources = new HashMap<>();
+                while (resultSet.next()) {
+                    String apiId = resultSet.getString(SQLConstants.API_RESOURCE_ID_COLUMN_NAME);
+                    Scope scope = new Scope.ScopeBuilder()
+                            .name(resultSet.getString(SQLConstants.SCOPE_QUALIFIED_NAME_COLUMN_NAME))
+                            .displayName(resultSet.getString(SQLConstants.SCOPE_DISPLAY_NAME_COLUMN_NAME))
+                            .description(resultSet.getString(SQLConstants.SCOPE_DESCRIPTION_COLUMN_NAME))
+                            .build();
+                    if (apiResources.containsKey(apiId)) {
+                        apiResources.get(apiId).getScopes().add(scope);
+                    } else {
+                        APIResource apiResource = new APIResource.APIResourceBuilder()
+                                .id(apiId)
+                                .name(resultSet.getString(SQLConstants.API_RESOURCE_NAME_COLUMN_NAME))
+                                .scopes(Collections.singletonList(scope))
+                                .build();
+                        apiResources.put(apiId, apiResource);
+                    }
+                }
+                return new ArrayList<>(apiResources.values());
+            }
+        } catch (SQLException e) {
+            throw APIResourceManagementUtil.handleServerException(
+                    APIResourceManagementConstants.ErrorMessages.ERROR_CODE_ERROR_WHILE_RETRIEVING_SCOPE_METADATA, e);
+        }
     }
 
     /**

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/dao/impl/CacheBackedAPIResourceMgtDAO.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/dao/impl/CacheBackedAPIResourceMgtDAO.java
@@ -285,6 +285,13 @@ public class CacheBackedAPIResourceMgtDAO implements APIResourceManagementDAO {
         return apiResourceManagementDAO.getSubscribedApplications(apiId);
     }
 
+    @Override
+    public List<APIResource> getScopeMetadata(List<String> scopeNames, Integer tenantId)
+            throws APIResourceMgtException {
+
+            return apiResourceManagementDAO.getScopeMetadata(scopeNames, tenantId);
+    }
+
     private void clearAPIResourceCache(String identifier, String resourceId, int tenantId) throws
             APIResourceMgtException {
 


### PR DESCRIPTION
### Proposed changes in this pull request

Add support to get the scope metadata including scope name, scope display name and scope description grouped by the API resource in order to display user friendly scope names in consent page.

Related Issues - https://github.com/wso2/product-is/issues/16973
