### PR TITLE
Fix user ID resolving issue

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -109,6 +109,7 @@ import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.functions.library.mgt.FunctionLibraryManagementService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
@@ -1008,6 +1009,21 @@ public class FrameworkServiceComponent {
     public void unsetApplicationManagement(ApplicationManagementService applicationManagementService) {
 
         FrameworkServiceDataHolder.getInstance().setApplicationManagementService(null);
+    }
+
+    @Reference(name = "identity.organization.management.component",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager")
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        FrameworkServiceDataHolder.getInstance().setOrganizationManager(organizationManager);
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        FrameworkServiceDataHolder.getInstance().setOrganizationManager(null);
     }
 
     @Reference(

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
@@ -52,6 +52,7 @@ import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.functions.library.mgt.FunctionLibraryManagementService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -110,6 +111,7 @@ public class FrameworkServiceDataHolder {
 
     private boolean isAdaptiveAuthenticationAvailable = false;
     private boolean isOrganizationManagementEnable = false;
+    private OrganizationManager organizationManager;
 
     private FrameworkServiceDataHolder() {
 
@@ -668,6 +670,26 @@ public class FrameworkServiceDataHolder {
         if (organizationManagementInitializeService != null) {
             isOrganizationManagementEnable = organizationManagementInitializeService.isOrganizationManagementEnabled();
         }
+    }
+
+    /**
+     * Get {@link OrganizationManager}.
+     *
+     * @return organization manager instance {@link OrganizationManager}.
+     */
+    public OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    /**
+     * Set {@link OrganizationManager}.
+     *
+     * @param organizationManager Instance of {@link OrganizationManager}.
+     */
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+
+        this.organizationManager = organizationManager;
     }
 
     public IdpManager getIdentityProviderManager() {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -181,6 +181,8 @@ public class AuthenticatedUser extends User {
         if (userName != null && userStoreDomain != null && tenantDomain != null) {
             try {
                 String tenantDomain = this.getTenantDomain();
+                /* When the user resident organization is set in the authenticated user, use that to resolve the user's
+                tenant domain. The below check should be removed once console app is registered per each tenant. */
                 if (StringUtils.isNotEmpty(this.userResidentOrganization)) {
                     tenantDomain = FrameworkServiceDataHolder.getInstance().getOrganizationManager()
                             .resolveTenantDomain(this.userResidentOrganization);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -180,7 +180,7 @@ public class AuthenticatedUser extends User {
         String userId = null;
         if (userName != null && userStoreDomain != null && tenantDomain != null) {
             try {
-                String tenantDomain= this.getTenantDomain();
+                String tenantDomain = this.getTenantDomain();
                 if (StringUtils.isNotEmpty(this.userResidentOrganization)) {
                     tenantDomain = FrameworkServiceDataHolder.getInstance().getOrganizationManager()
                             .resolveTenantDomain(this.userResidentOrganization);


### PR DESCRIPTION
### Proposed changes in this pull request

The user ID resolving fail for IDaaS deployments of the WSO2 IS when switching to console of different organizations. This PR is initiated as a temporary fix until the console app is registered on each tenants. After that, this PR can be reverted.

In IDaaS deployments, the app reside in the carbon.super tenant but the authenticated user resides in a different tenant which is below the super tenant. When switching to organizations (sub-orgs), the user resolving flows break due to the recent improvements done for organization switch grant to not to change tenant domain.