### PR TITLE
Add method to get configuration resource from tenant ID

### DIFF
--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManager.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManager.java
@@ -167,6 +167,18 @@ public interface ConfigurationManager {
     Resource getResource(String resourceTypeName, String resourceName) throws ConfigurationManagementException;
 
     /**
+     * This API is used to retrieve the given resource by the tenant ID.
+     *
+     * @param tenantId         The ID of the tenant.
+     * @param resourceTypeName The name of the {@link ResourceType}.
+     * @param resourceName     The name of the {@link ResourceType}.
+     * @return {@link Resource}
+     * @throws ConfigurationManagementException Configuration management exception.
+     */
+    Resource getResourceByTenantId(int tenantId, String resourceTypeName, String resourceName) throws
+            ConfigurationManagementException;
+
+    /**
      * This API is used to delete the given resource.
      *
      * @param resourceTypeName Name of the {@link ResourceType}.

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManagerImpl.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManagerImpl.java
@@ -26,7 +26,6 @@ import org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationCon
 import org.wso2.carbon.identity.configuration.mgt.core.dao.ConfigurationDAO;
 import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementClientException;
 import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
-import org.wso2.carbon.identity.configuration.mgt.core.internal.ConfigurationManagerComponentDataHolder;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ConfigurationManagerConfigurationHolder;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
@@ -39,7 +38,6 @@ import org.wso2.carbon.identity.configuration.mgt.core.search.ComplexCondition;
 import org.wso2.carbon.identity.configuration.mgt.core.search.Condition;
 import org.wso2.carbon.identity.configuration.mgt.core.search.PrimitiveCondition;
 import org.wso2.carbon.identity.configuration.mgt.core.search.constant.ConditionType;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -185,16 +183,28 @@ public class ConfigurationManagerImpl implements ConfigurationManager {
     public Resource getResource(String resourceTypeName, String resourceName)
             throws ConfigurationManagementException {
 
+        return getResource(getTenantId(), resourceTypeName, resourceName);
+    }
+
+    @Override
+    public Resource getResourceByTenantId(int tenantId, String resourceTypeName, String resourceName)
+            throws ConfigurationManagementException {
+
+        return getResource(tenantId, resourceTypeName, resourceName);
+    }
+
+    private Resource getResource(int tenantId, String resourceTypeName, String resourceName)
+            throws ConfigurationManagementException {
+
         validateResourceRetrieveRequest(resourceTypeName, resourceName);
         ResourceType resourceType = getResourceType(resourceTypeName);
-        Resource resource = this.getConfigurationDAO()
-                .getResourceByName(getTenantId(), resourceType.getId(), resourceName);
+        Resource resource = this.getConfigurationDAO().getResourceByName(tenantId, resourceType.getId(), resourceName);
         if (resource == null) {
             if (log.isDebugEnabled()) {
-                log.debug("No resource found for the resourceName: " + resourceName);
+                log.debug(String.format("No resource found for the resource with name: %s in tenant with ID: %s",
+                        resourceName, tenantId));
             }
-            throw handleClientException(
-                    ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS, resourceName, null);
+            throw handleClientException(ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS, resourceName, null);
         }
         return resource;
     }


### PR DESCRIPTION
When getting the resource from ConfigurationManager currently the tenant id is fetched from the context. However, there are cases such as in organization discovery where we need to fetch the resource by passing the tenant id (instead of getting it directly from the context). Hence introducing a new method to achieve this.