### PR TITLE
Fix pre process username method when input validation enabled

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -193,7 +193,9 @@ import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.ORG_WISE_
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.ORG_WISE_MULTI_ATTRIBUTE_SEPARATOR_ENABLED;
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.ORG_WISE_MULTI_ATTRIBUTE_SEPARATOR_RESOURCE_NAME;
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.ORG_WISE_MULTI_ATTRIBUTE_SEPARATOR_RESOURCE_TYPE;
+import static org.wso2.carbon.identity.core.util.IdentityTenantUtil.isAppendTenantDomainWithUserName;
 import static org.wso2.carbon.identity.core.util.IdentityTenantUtil.isLegacySaaSAuthenticationEnabled;
+import static org.wso2.carbon.identity.core.util.IdentityTenantUtil.isTenantQualifiedUrlsEnabled;
 import static org.wso2.carbon.identity.core.util.IdentityUtil.getLocalGroupsClaimURI;
 
 /**
@@ -3068,6 +3070,9 @@ public class FrameworkUtils {
                 return username;
             }
             return username + "@" + context.getUserTenantDomain();
+        } else if (isTenantQualifiedUrlsEnabled() && isAppendTenantDomainWithUserName()) {
+            // This will be a user with tenant domain as email domain.
+            return username + "@" + context.getUserTenantDomain();
         }
         return username;
     }
@@ -3099,6 +3104,9 @@ public class FrameworkUtils {
             if (isSaaSApp && StringUtils.countMatches(username, "@") >= 1) {
                 return username;
             }
+            return username + "@" + appTenantDomain;
+        } else if (isTenantQualifiedUrlsEnabled() && isAppendTenantDomainWithUserName()) {
+            // This will be a user with tenant domain as email domain.
             return username + "@" + appTenantDomain;
         }
         return username;

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -36,6 +36,9 @@ public class IdentityCoreConstants {
 
     public static final String TENANT_NAME_FROM_CONTEXT = "TenantNameFromContext";
     public static final String ENABLE_TENANT_QUALIFIED_URLS = "EnableTenantQualifiedUrls";
+    public static final String APPEND_TENANT_DOMAIN_IN_USERNAME_PREPROCESSING
+            = "AppendTenantDomainInUserNamePreprocessing";
+
     public static final String ENABLE_TENANTED_SESSIONS = "EnableTenantedSessions";
     public static final String PROXY_CONTEXT_PATH = "ProxyContextPath";
     public static final int DEFAULT_HTTPS_PORT = 443;

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
@@ -412,6 +412,17 @@ public class IdentityTenantUtil {
         return Boolean.parseBoolean(IdentityUtil.getProperty(IdentityCoreConstants.ENABLE_TENANT_QUALIFIED_URLS));
     }
 
+    /**
+     * Checks whether to add tenant domain when preprocessing UserNames.
+     *
+     * @return true if the config is set to true, false otherwise.
+     */
+    public static boolean isAppendTenantDomainWithUserName() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty
+                (IdentityCoreConstants.APPEND_TENANT_DOMAIN_IN_USERNAME_PREPROCESSING));
+    }
+
 
     /**
      * Checks if the tenanted session support is enabled.

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/PasswordValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/PasswordValidationConfigurationHandler.java
@@ -32,12 +32,15 @@ import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.UserCoreConstants;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.ALPHA_NUMERIC;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.INPUT_VALIDATION_DEFAULT_VALIDATOR;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.JAVA_REGEX_PATTERN;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.JS_REGEX;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.MAX_LENGTH;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.MIN_LENGTH;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.PASSWORD;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_GETTING_EXISTING_CONFIGURATIONS;
@@ -71,11 +74,7 @@ public class PasswordValidationConfigurationHandler extends AbstractFieldValidat
             if (!javaRegex.isEmpty() && !jsRegex.isEmpty() && !JAVA_REGEX_PATTERN.equals(javaRegex)) {
 
                 if (isRuleBasedValidationByDefault()) {
-                    rules.add(getRuleConfig(LengthValidator.class.getSimpleName(), MIN_LENGTH, "8"));
-                    rules.add(getRuleConfig(NumeralValidator.class.getSimpleName(), MIN_LENGTH, "1"));
-                    rules.add(getRuleConfig(UpperCaseValidator.class.getSimpleName(), MIN_LENGTH, "1"));
-                    rules.add(getRuleConfig(LowerCaseValidator.class.getSimpleName(), MIN_LENGTH, "1"));
-                    rules.add(getRuleConfig(SpecialCharacterValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                    rules.add(getDefaultLengthValidatorRuleConfig());
                     configuration.setRules(rules);
                 } else {
                     rules.add(getRuleConfig("JsRegExValidator", JS_REGEX, jsRegex));
@@ -99,5 +98,21 @@ public class PasswordValidationConfigurationHandler extends AbstractFieldValidat
 
         String defaultValidator = IdentityUtil.getProperty(INPUT_VALIDATION_DEFAULT_VALIDATOR);
         return defaultValidator != null && StringUtils.equalsIgnoreCase(ALPHA_NUMERIC, defaultValidator);
+    }
+
+    /**
+     * Method to retrieve to default length validation for password.
+     *
+     * @return RulesConfiguration.
+     */
+    private RulesConfiguration getDefaultLengthValidatorRuleConfig() {
+
+        RulesConfiguration rule = new RulesConfiguration();
+        rule.setValidatorName(LengthValidator.class.getSimpleName());
+        Map<String, String> properties = new HashMap<>();
+        properties.put(MIN_LENGTH, "5");
+        properties.put(MAX_LENGTH, "30");
+        rule.setProperties(properties);
+        return rule;
     }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/PasswordValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/PasswordValidationConfigurationHandler.java
@@ -75,7 +75,8 @@ public class PasswordValidationConfigurationHandler extends AbstractFieldValidat
                     rules.add(getRuleConfig(NumeralValidator.class.getSimpleName(), MIN_LENGTH, "1"));
                     rules.add(getRuleConfig(UpperCaseValidator.class.getSimpleName(), MIN_LENGTH, "1"));
                     rules.add(getRuleConfig(LowerCaseValidator.class.getSimpleName(), MIN_LENGTH, "1"));
-                    rules.add(getRuleConfig(SpecialCharacterValidator.class.getSimpleName(), MIN_LENGTH, "1"));                    configuration.setRules(rules);
+                    rules.add(getRuleConfig(SpecialCharacterValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                    configuration.setRules(rules);
                 } else {
                     rules.add(getRuleConfig("JsRegExValidator", JS_REGEX, jsRegex));
                     configuration.setRegEx(rules);

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/PasswordValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/PasswordValidationConfigurationHandler.java
@@ -32,15 +32,12 @@ import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.UserCoreConstants;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.ALPHA_NUMERIC;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.INPUT_VALIDATION_DEFAULT_VALIDATOR;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.JAVA_REGEX_PATTERN;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.JS_REGEX;
-import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.MAX_LENGTH;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.MIN_LENGTH;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.PASSWORD;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_GETTING_EXISTING_CONFIGURATIONS;
@@ -74,8 +71,11 @@ public class PasswordValidationConfigurationHandler extends AbstractFieldValidat
             if (!javaRegex.isEmpty() && !jsRegex.isEmpty() && !JAVA_REGEX_PATTERN.equals(javaRegex)) {
 
                 if (isRuleBasedValidationByDefault()) {
-                    rules.add(getDefaultLengthValidatorRuleConfig());
-                    configuration.setRules(rules);
+                    rules.add(getRuleConfig(LengthValidator.class.getSimpleName(), MIN_LENGTH, "8"));
+                    rules.add(getRuleConfig(NumeralValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                    rules.add(getRuleConfig(UpperCaseValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                    rules.add(getRuleConfig(LowerCaseValidator.class.getSimpleName(), MIN_LENGTH, "1"));
+                    rules.add(getRuleConfig(SpecialCharacterValidator.class.getSimpleName(), MIN_LENGTH, "1"));                    configuration.setRules(rules);
                 } else {
                     rules.add(getRuleConfig("JsRegExValidator", JS_REGEX, jsRegex));
                     configuration.setRegEx(rules);
@@ -98,21 +98,5 @@ public class PasswordValidationConfigurationHandler extends AbstractFieldValidat
 
         String defaultValidator = IdentityUtil.getProperty(INPUT_VALIDATION_DEFAULT_VALIDATOR);
         return defaultValidator != null && StringUtils.equalsIgnoreCase(ALPHA_NUMERIC, defaultValidator);
-    }
-
-    /**
-     * Method to retrieve to default length validation for password.
-     *
-     * @return RulesConfiguration.
-     */
-    private RulesConfiguration getDefaultLengthValidatorRuleConfig() {
-
-        RulesConfiguration rule = new RulesConfiguration();
-        rule.setValidatorName(LengthValidator.class.getSimpleName());
-        Map<String, String> properties = new HashMap<>();
-        properties.put(MIN_LENGTH, "5");
-        properties.put(MAX_LENGTH, "30");
-        rule.setProperties(properties);
-        return rule;
     }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/userinfo/UserInfoHandlerImpl.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/userinfo/UserInfoHandlerImpl.java
@@ -62,13 +62,8 @@ public class UserInfoHandlerImpl implements UserInfoHandler {
 
         // Check if the tenant domain matches the email domain
         if (tenantDomain.equalsIgnoreCase(emailDomain)) {
-            boolean isEmailTypeUserName = isEmailAsUserName(tenantDomain);
             int lastAtSymbolIndex = username.lastIndexOf('@');
-
-            // If it's not an email type username or there are multiple '@' symbols, return the modified username
-            if (!isEmailTypeUserName || username.indexOf('@') != lastAtSymbolIndex) {
-                return username.substring(0, lastAtSymbolIndex);
-            }
+            return username.substring(0, lastAtSymbolIndex);
         }
         // Return the username as is
         return username;

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3234,6 +3234,12 @@
     -->
     <EnableLegacySaaSAuthentication>{{authentication.enable_legacy_saas_mode | default(false)}}</EnableLegacySaaSAuthentication>
 
+    <!--
+        When this property is set to 'true', in user name preprocessing method tenant domain will be added for the email
+        type user names which have tenant domain as email domain.
+    -->
+    <AppendTenantDomainInUserNamePreprocessing>{{authentication.append_tenant_domain_with_user_name | default(false)}}</AppendTenantDomainInUserNamePreprocessing>
+
     <EnablePerUserFunctionalityLocking>{{user.enable_per_user_functionality_locking}}</EnablePerUserFunctionalityLocking>
 
     <TenantContextsToRewrite>


### PR DESCRIPTION
### Proposed changes in this pull request
Issue: https://github.com/wso2/product-is/issues/16930

Added tenant domain for users with email domain as tenant domain with a config.
Modify getTenantAwareUsername name to remove the tenant domain appended in Username