### PR TITLE
Improving the method used to obtain the tenant domain

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
@@ -376,10 +376,13 @@ public class IdentityTenantUtil {
                 log.debug("The tenant domain is not set to the thread local. Hence using the tenant domain from the " +
                         "privileged carbon context.");
             }
-            return PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+            tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         }
 
-        return tenantDomain;
+        if (StringUtils.isNotBlank(tenantDomain)) {
+            return tenantDomain;
+        }
+        return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
     }
 
     /**


### PR DESCRIPTION
## Purpose
> This PR will improve the resolveTenantDomain() method in order to return the super tenant domain in an instance when the tenant domain could not be obtained in any other way.

## Related Issues
https://github.com/wso2/product-is/issues/16906