### PR TITLE
Enable My Account app switch in Console header dropdown

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -903,6 +903,7 @@
   "console.ui.hiddenAuthenticators": [],
   "console.ui.hiddenConnectionTemplates": [],
   "console.ui.google_one_tap_enabled_tenants": [],
+  "console.ui.show_app_switch_button": true,
   "console.theme": "wso2is",
   "console.session.params.userIdleTimeOut": 600,
   "console.session.params.userIdleWarningTimeOut": 580,


### PR DESCRIPTION
### Proposed changes in this pull request

This PR enables the My Account app switch in the Console header dropdown by default.