### PR TITLE
Hide HYPR and Github connector templates

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -901,7 +901,7 @@
   "console.ui.idp_templates.github.enabled": false,
   "console.ui.product_name": "WSO2 Identity Server",
   "console.ui.hiddenAuthenticators": [],
-  "console.ui.hiddenConnectionTemplates": [],
+  "console.ui.hiddenConnectionTemplates": [ "hypr-idp", "github-idp" ],
   "console.ui.google_one_tap_enabled_tenants": [],
   "console.ui.show_app_switch_button": true,
   "console.theme": "wso2is",


### PR DESCRIPTION
### Proposed changes in this pull request

This PR hides the HYPR and Github connector templates in the default onprem Console.

### Related Issue

https://github.com/wso2/product-is/issues/17239