### PR TITLE
Fix shared shared v2 role display name update issue

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleConstants.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleConstants.java
@@ -98,6 +98,7 @@ public class RoleConstants {
         public static final String UM_MAIN_ROLE_TENANT_ID = "UM_MAIN_ROLE_TENANT_ID";
         public static final String UM_GROUP_ID = "UM_GROUP_ID";
         public static final String GROUP_NAME = "GROUP_NAME";
+        public static final String ID = "ID";
 
         public static final String NEW_ROLE_NAME = "NEW_ROLE_NAME";
         public static final String USER_NOT_FOUND_ERROR_MESSAGE = "A user doesn't exist with name: %s " +

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -1191,7 +1191,7 @@ public class RoleDAOImpl implements RoleDAO {
 
         for (RoleDTO roleDTO : sharedRoles) {
             try (NamedPreparedStatement statement = new NamedPreparedStatement(connection, UPDATE_SCIM_ROLE_NAME_SQL,
-                    RoleConstants.RoleTableColumns.UM_ID)) {
+                    RoleConstants.RoleTableColumns.ID)) {
                 statement.setString(RoleConstants.RoleTableColumns.NEW_ROLE_NAME, newRoleName);
                 statement.setInt(RoleConstants.RoleTableColumns.TENANT_ID, roleDTO.getTenantId());
                 statement.setString(ROLE_NAME, roleDTO.getName());


### PR DESCRIPTION
### Issue:
In the current implementation of the API, there's an issue when attempting to update the display name of a shared v2 role. When following the steps outlined below, the API returns a 500 Internal Server Error:

### Steps to Reproduce:
- Create an application with the allowed audience type set as "Application."
- Create a role with the audience set as "Application."
- Share the application.
- Attempt to update the display name of the shared v2 role.

This PR fixes above mentioned issue.

### Related Issue
- https://github.com/wso2/product-is/issues/16363


