### PR TITLE
Fix spelling mistake in FB userinfo field

### DIFF
--- a/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/facebook/metadata.json
+++ b/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/facebook/metadata.json
@@ -110,7 +110,7 @@
             },
             {
                 "key": "UserInfoFields",
-                "value": "id,name,gender,emai,first_name,last_name,age_range,link"
+                "value": "id,name,gender,email,first_name,last_name,age_range,link"
             }
         ]
     },


### PR DESCRIPTION
The placeholder value of `user information fields` config for Facebook authenticator contains a spelling mistake leading to authentication failure. This PR fixes this mistake.

Related issue: https://github.com/wso2/product-is/issues/17059