### PR TITLE
Revert "Disable `applications.loginFlow.legacyEditor` in Console"

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -973,7 +973,6 @@
   ],
   "console.applications.scopes.update": ["internal_application_mgt_update"],
   "console.applications.scopes.delete": ["internal_application_mgt_delete"],
-  "console.applications.disabled_features": ["applications.loginFlow.legacyEditor"],
   "console.applications.ui.certificate_alias_enabled": false,
   "console.application_roles.enabled": true,
   "console.approvals.enabled": true,


### PR DESCRIPTION
Reverts wso2/carbon-identity-framework#5061

Issue: https://github.com/wso2/product-is/issues/17219