### PR TITLE
Fix shared role retrieval query for mysql

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -1068,6 +1068,9 @@ public class RoleDAOImpl implements RoleDAO {
             throws IdentityRoleManagementException {
 
         Map<String, String> rolesMap = new HashMap<>();
+        if (CollectionUtils.isEmpty(roleIds)) {
+            return rolesMap;
+        }
         String query = GET_MAIN_ROLE_TO_SHARED_ROLE_MAPPINGS_BY_SUBORG_SQL +
                 String.join(", ", Collections.nCopies(roleIds.size(), "?")) + ")";
         try (Connection connection = IdentityDatabaseUtil.getUserDBConnection(false);


### PR DESCRIPTION
### Proposed changes in this pull request
Fix issue on suborg creation in IS pack connected to MySQL
```
Caused by: org.wso2.carbon.identity.application.common.IdentityApplicationManagementException: Error while retrieving the fragment application details.

	at org.wso2.carbon.identity.organization.management.application.listener.FragmentApplicationMgtListener.doPostGetServiceProvider(FragmentApplicationMgtListener.java:280)

	at org.wso2.carbon.identity.application.mgt.listener.DefaultApplicationResourceMgtListener.doPostGetApplicationByResourceId(DefaultApplicationResourceMgtListener.java:189)

	at org.wso2.carbon.identity.application.mgt.ApplicationManagementServiceImpl.getApplicationByResourceId(ApplicationManagementServiceImpl.java:2559)

	at org.wso2.carbon.identity.organization.management.application.listener.ApplicationSharingManagerListenerImpl.getSharedUserAttributes(ApplicationSharingManagerListenerImpl.java:190)

	... 66 more

Caused by: org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementServerException: Error while retrieving main role to shared role mappings by sub org tenant : 853853f8-b690-4dfc-ae02-2248978db592

	at org.wso2.carbon.identity.role.v2.mgt.core.dao.RoleDAOImpl.getMainRoleToSharedRoleMappingsBySubOrg(RoleDAOImpl.java:1090)

	at org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementServiceImpl.getMainRoleToSharedRoleMappingsBySubOrg(RoleManagementServiceImpl.java:578)

	at org.wso2.carbon.identity.organization.management.application.listener.FragmentApplicationMgtListener.getAssociatedRolesConfigForSharedApp(FragmentApplicationMgtListener.java:332)

	at org.wso2.carbon.identity.organization.management.application.listener.FragmentApplicationMgtListener.doPostGetServiceProvider(FragmentApplicationMgtListener.java:275)

	... 69 more

Caused by: java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1

	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:120)

	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)

	at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:916)

	at com.mysql.cj.jdbc.ClientPreparedStatement.executeQuery(ClientPreparedStatement.java:972)

	at jdk.internal.reflect.GeneratedMethodAccessor40.invoke(Unknown Source)

	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)

	at java.base/java.lang.reflect.Method.invoke(Method.java:566)

	at org.apache.tomcat.jdbc.pool.StatementFacade$StatementProxy.invoke(StatementFacade.java:118)

	at com.sun.proxy.$Proxy50.executeQuery(Unknown Source)

	at org.wso2.carbon.database.utils.jdbc.NamedPreparedStatement.executeQuery(NamedPreparedStatement.java:246)

	at org.wso2.carbon.identity.role.v2.mgt.core.dao.RoleDAOImpl.getMainRoleToSharedRoleMappingsBySubOrg(RoleDAOImpl.java:1080)

	... 72 more
```
