### PR TITLE
Add appleAppID to client Attestation meta data

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ClientAttestationMetaData.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ClientAttestationMetaData.java
@@ -42,6 +42,7 @@ public class ClientAttestationMetaData implements Serializable {
     private static final String IS_ATTESTATION_ENABLED = "IsAttestationEnabled";
     private static final String ANDROID_PACKAGE_NAME = "AndroidPackageName";
     private static final String ANDROID_ATTESTATION_SERVICE_CREDENTIALS = "AndroidAttestationServiceCredentials";
+    private static final String APPLE_APP_ID = "AppleAppId";
 
     // Field to store whether attestation is enabled.
     @IgnoreNullElement
@@ -57,6 +58,11 @@ public class ClientAttestationMetaData implements Serializable {
     @IgnoreNullElement
     @XmlElement(name = ANDROID_ATTESTATION_SERVICE_CREDENTIALS)
     private String androidAttestationServiceCredentials;
+
+    // Field to store Apple app ID.
+    @IgnoreNullElement
+    @XmlElement(name = APPLE_APP_ID)
+    private String appleAppId;
 
     /**
      * Creates an instance of the ClientAttestationMetaData class by parsing an OMElement.
@@ -82,6 +88,9 @@ public class ClientAttestationMetaData implements Serializable {
             }
             if (ANDROID_ATTESTATION_SERVICE_CREDENTIALS.equals(elementName)) {
                 metaData.setAndroidAttestationServiceCredentials(element.getText());
+            }
+            if (APPLE_APP_ID.equals(elementName)) {
+                metaData.setAppleAppId(element.getText());
             }
         }
         return metaData;
@@ -146,5 +155,25 @@ public class ClientAttestationMetaData implements Serializable {
     public void setAndroidAttestationServiceCredentials(String androidAttestationServiceCredentials) {
 
         this.androidAttestationServiceCredentials = androidAttestationServiceCredentials;
+    }
+
+    /**
+     * Gets the Apple App ID.
+     *
+     * @return The Apple App ID.
+     */
+    public String getAppleAppId() {
+
+        return appleAppId;
+    }
+
+    /**
+     * Sets the Apple App ID.
+     *
+     * @param appleAppId The Apple App ID to set.
+     */
+    public void setAppleAppId(String appleAppId) {
+
+        this.appleAppId = appleAppId;
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
@@ -124,6 +124,8 @@ public class IdentityApplicationConstants {
     public static final String IS_ATTESTATION_ENABLED_DISPLAY_NAME = "Is Client Attestation Enabled";
     public static final String ANDROID_PACKAGE_NAME_PROPERTY_NAME = "androidPackageName";
     public static final String ANDROID_PACKAGE_NAME_DISPLAY_NAME = "Android mobile application package name";
+    public static final String APPLE_APP_ID_PROPERTY_NAME = "appleAppId";
+    public static final String APPLE_APP_ID_DISPLAY_NAME = "Apple application id";
     public static final String APPLICATION_SECRET_TYPE_ANDROID_ATTESTATION_CREDENTIALS
                 = "ANDROID_ATTESTATION_CREDENTIALS";
     public static final String CLIENT_ATTESTATION = "CLIENT_ATTESTATION";

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -133,6 +133,8 @@ import static org.wso2.carbon.identity.application.common.util.IdentityApplicati
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.ANDROID;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.ANDROID_PACKAGE_NAME_DISPLAY_NAME;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.ANDROID_PACKAGE_NAME_PROPERTY_NAME;
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.APPLE_APP_ID_DISPLAY_NAME;
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.APPLE_APP_ID_PROPERTY_NAME;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.APPLICATION_SECRET_TYPE_ANDROID_ATTESTATION_CREDENTIALS;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.CLIENT_ATTESTATION;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.CLIENT_ID_SP_PROPERTY_NAME;
@@ -449,6 +451,10 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                 ServiceProviderProperty androidPackageName =
                         buildAndroidPackageNameProperty(application.getClientAttestationMetaData());
                 serviceProviderProperties.add(androidPackageName);
+
+                ServiceProviderProperty appleAppId =
+                        buildAppleAppIdProperty(application.getClientAttestationMetaData());
+                serviceProviderProperties.add(appleAppId);
 
                 storeAndroidAttestationServiceCredentialAsSecret(application);
             }
@@ -2118,6 +2124,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
             ClientAttestationMetaData clientAttestationMetaData = new ClientAttestationMetaData();
             clientAttestationMetaData.setAttestationEnabled(getIsAttestationEnabled(propertyList));
             clientAttestationMetaData.setAndroidPackageName(getAndroidPackageName(propertyList));
+            clientAttestationMetaData.setAppleAppId(getAppleAppId(propertyList));
             if (StringUtils.isNotEmpty(clientAttestationMetaData.getAndroidPackageName())
                     && clientAttestationMetaData.isAttestationEnabled()) {
                 clientAttestationMetaData.setAndroidAttestationServiceCredentials
@@ -2353,6 +2360,15 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
 
         return propertyList.stream()
                 .filter(property -> ANDROID_PACKAGE_NAME_PROPERTY_NAME.equals(property.getName()))
+                .findFirst()
+                .map(ServiceProviderProperty::getValue)
+                .orElse(StringUtils.EMPTY);
+    }
+
+    private String getAppleAppId(List<ServiceProviderProperty> propertyList) {
+
+        return propertyList.stream()
+                .filter(property -> APPLE_APP_ID_PROPERTY_NAME.equals(property.getName()))
                 .findFirst()
                 .map(ServiceProviderProperty::getValue)
                 .orElse(StringUtils.EMPTY);
@@ -4973,6 +4989,10 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                     buildAndroidPackageNameProperty(sp.getClientAttestationMetaData());
             spPropertyMap.put(androidPackageName.getName(), androidPackageName);
 
+            ServiceProviderProperty appleAppId =
+                    buildAppleAppIdProperty(sp.getClientAttestationMetaData());
+            spPropertyMap.put(appleAppId.getName(), appleAppId);
+
             storeAndroidAttestationServiceCredentialAsSecret(sp);
         }
 
@@ -5006,6 +5026,16 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         androidPackageName.setDisplayName(ANDROID_PACKAGE_NAME_DISPLAY_NAME);
         androidPackageName.setValue(String.valueOf(clientAttestationMetaData.getAndroidPackageName()));
         return androidPackageName;
+    }
+
+    private ServiceProviderProperty buildAppleAppIdProperty
+            (ClientAttestationMetaData clientAttestationMetaData) {
+
+        ServiceProviderProperty appleAppId = new ServiceProviderProperty();
+        appleAppId.setName(APPLE_APP_ID_PROPERTY_NAME);
+        appleAppId.setDisplayName(APPLE_APP_ID_DISPLAY_NAME);
+        appleAppId.setValue(String.valueOf(clientAttestationMetaData.getAppleAppId()));
+        return appleAppId;
     }
 
     private void storeAndroidAttestationServiceCredentialAsSecret(ServiceProvider sp)

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
@@ -828,14 +828,15 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
 
 
         return new Object[][]{
-                {true, "com.wso2.sample.mobile.application", "sampleCredentials"}
+                {true, "com.wso2.sample.mobile.application", "sampleCredentials", "APPLETEAMID.com.wso2.mobile.sample"}
         };
     }
 
     @Test(dataProvider = "testAddApplicationWithAttestationData")
     public void testAddApplicationWithAttestationData(boolean isAttestationEnabled,
                                                       String androidPackageName,
-                                                      String androidCredentials) throws Exception {
+                                                      String androidCredentials,
+                                                      String appleAppId) throws Exception {
 
         ResolvedSecret resolvedSecret = new ResolvedSecret();
         resolvedSecret.setResolvedSecretValue(androidCredentials);
@@ -850,6 +851,7 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
         ClientAttestationMetaData clientAttestationMetaData = new ClientAttestationMetaData();
         clientAttestationMetaData.setAttestationEnabled(isAttestationEnabled);
         clientAttestationMetaData.setAndroidPackageName(androidPackageName);
+        clientAttestationMetaData.setAppleAppId(appleAppId);
         clientAttestationMetaData.setAndroidAttestationServiceCredentials(androidCredentials);
         inputSP.setClientAttestationMetaData(clientAttestationMetaData);
 
@@ -860,6 +862,8 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
         Assert.assertEquals(addedSP.getClientAttestationMetaData().getAndroidPackageName(), androidPackageName);
         Assert.assertEquals(addedSP.getClientAttestationMetaData().getAndroidAttestationServiceCredentials(),
                 androidCredentials);
+        Assert.assertEquals(addedSP.getClientAttestationMetaData().getAppleAppId(),
+                appleAppId);
 
         SecretManager secretManager = mock(SecretManagerImpl.class);
         when(secretManager.isSecretExist(anyString(), anyString())).thenReturn(true);
@@ -870,12 +874,14 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
                 (inputSP.getApplicationName(), SUPER_TENANT_DOMAIN_NAME);
         Assert.assertEquals(retrievedSP.getClientAttestationMetaData().isAttestationEnabled(), isAttestationEnabled);
         Assert.assertEquals(retrievedSP.getClientAttestationMetaData().getAndroidPackageName(), androidPackageName);
+        Assert.assertEquals(retrievedSP.getClientAttestationMetaData().getAppleAppId(), appleAppId);
         Assert.assertEquals(retrievedSP.getClientAttestationMetaData().getAndroidAttestationServiceCredentials(),
                 androidCredentials);
         // Updating the application by changing the isManagementApplication flag. It should be changed.
         ClientAttestationMetaData clientAttestationMetaData2 = new ClientAttestationMetaData();
         clientAttestationMetaData2.setAttestationEnabled(!isAttestationEnabled);
         clientAttestationMetaData2.setAndroidPackageName(null);
+        clientAttestationMetaData2.setAppleAppId(null);
         clientAttestationMetaData2.setAndroidAttestationServiceCredentials(null);
         inputSP.setClientAttestationMetaData(clientAttestationMetaData2);
         applicationManagementService.updateApplication(inputSP, SUPER_TENANT_DOMAIN_NAME, REGISTRY_SYSTEM_USERNAME);

--- a/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
@@ -427,6 +427,7 @@
                 <xs:sequence>
                     <xs:element minOccurs="0" name="androidAttestationServiceCredentials" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="androidPackageName" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="appleAppId" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="attestationEnabled" type="xs:boolean"/>
                 </xs:sequence>
             </xs:complexType>


### PR DESCRIPTION
### Proposed changes in this pull request
Issue: https://github.com/wso2/product-is/issues/16836

### Implementation
Add Apple App Id . The app ID will look like {apple-teamId}.{bundleId} to ClientAttestationMetaData. 
Improve WSDL and Unit tests too.