### PR TITLE
Create protocol details from the app-mgt component

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/IdentityApplicationManagementClientException.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/IdentityApplicationManagementClientException.java
@@ -89,6 +89,32 @@ public class IdentityApplicationManagementClientException extends IdentityApplic
 
         super(errorCode, message, cause);
     }
+    
+    /**
+     * Constructs a new exception with the specified error code, message and description.
+     *
+     * @param errorCode   Error code.
+     * @param message     Error message.
+     * @param description Error description.
+     */
+    public IdentityApplicationManagementClientException(String errorCode, String message, String description) {
+        
+        super(errorCode, message, description);
+    }
+    
+    /**
+     * Constructs a new exception with the specified error code, message, description and cause.
+     *
+     * @param errorCode   Error code
+     * @param message     Detailed message
+     * @param cause       Cause as {@link Throwable}
+     * @param description Error description.
+     */
+    public IdentityApplicationManagementClientException(String errorCode, String message, String description,
+                                                        Throwable cause) {
+        
+        super(errorCode, message, description, cause);
+    }
 
     public String[] getMessages() {
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/IdentityApplicationManagementException.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/IdentityApplicationManagementException.java
@@ -24,6 +24,7 @@ package org.wso2.carbon.identity.application.common;
 public class IdentityApplicationManagementException extends Exception {
 
     private String errorCode;
+    private String description;
 
     private static final long serialVersionUID = -1982152066401023165L;
 
@@ -59,6 +60,20 @@ public class IdentityApplicationManagementException extends Exception {
         super(message);
         this.errorCode = errorCode;
     }
+    
+    /**
+     * Constructs a new exception with the specified error code, message and description.
+     *
+     * @param errorCode   Error code.
+     * @param message     Error message.
+     * @param description Error description.
+     */
+    public IdentityApplicationManagementException(String errorCode, String message, String description) {
+
+        super(message);
+        this.errorCode = errorCode;
+        this.description = description;
+    }
 
     /**
      * Constructs a new exception with the specified error code, message and cause.
@@ -71,6 +86,22 @@ public class IdentityApplicationManagementException extends Exception {
 
         super(message, cause);
         this.errorCode = errorCode;
+    }
+
+    /**
+     * Constructs a new exception with the specified error code, message, description and cause.
+     *
+     * @param errorCode Error code
+     * @param message   Detailed message
+     * @param cause     Cause as {@link Throwable}
+     * @param description Error description.
+     */
+    public IdentityApplicationManagementException(String errorCode, String message, String description,
+                                                  Throwable cause) {
+
+        super(message, cause);
+        this.errorCode = errorCode;
+        this.description = description;
     }
 
     /**
@@ -93,5 +124,10 @@ public class IdentityApplicationManagementException extends Exception {
     public String getMessage() {
 
         return super.getMessage();
+    }
+
+    public String getDescription() {
+
+        return description;
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/IdentityApplicationManagementException.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/IdentityApplicationManagementException.java
@@ -91,9 +91,9 @@ public class IdentityApplicationManagementException extends Exception {
     /**
      * Constructs a new exception with the specified error code, message, description and cause.
      *
-     * @param errorCode Error code
-     * @param message   Detailed message
-     * @param cause     Cause as {@link Throwable}
+     * @param errorCode Error code.
+     * @param message   Detailed message.
+     * @param cause     Cause as {@link Throwable}.
      * @param description Error description.
      */
     public IdentityApplicationManagementException(String errorCode, String message, String description,

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/IdentityApplicationManagementServerException.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/IdentityApplicationManagementServerException.java
@@ -80,9 +80,9 @@ public class IdentityApplicationManagementServerException extends IdentityApplic
     /**
      * Constructs a new exception with the specified error code, message, description and cause.
      *
-     * @param errorCode Error code
-     * @param message   Detailed message
-     * @param cause     Cause as {@link Throwable}
+     * @param errorCode Error code.
+     * @param message   Detailed message.
+     * @param cause     Cause as {@link Throwable}.
      * @param description Error description.
      */
     public IdentityApplicationManagementServerException(String errorCode, String message, String description,

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/IdentityApplicationManagementServerException.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/IdentityApplicationManagementServerException.java
@@ -64,4 +64,30 @@ public class IdentityApplicationManagementServerException extends IdentityApplic
 
         super(errorCode, message, cause);
     }
+    
+    /**
+     * Constructs a new exception with the specified error code, message and description.
+     *
+     * @param errorCode   Error code.
+     * @param message     Error message.
+     * @param description Error description.
+     */
+    public IdentityApplicationManagementServerException(String errorCode, String message, String description) {
+
+        super(errorCode, message, description);
+    }
+
+    /**
+     * Constructs a new exception with the specified error code, message, description and cause.
+     *
+     * @param errorCode Error code
+     * @param message   Detailed message
+     * @param cause     Cause as {@link Throwable}
+     * @param description Error description.
+     */
+    public IdentityApplicationManagementServerException(String errorCode, String message, String description,
+                                                  Throwable cause) {
+
+        super(errorCode, message, description, cause);
+    }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundAuthenticationRequestConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundAuthenticationRequestConfig.java
@@ -19,9 +19,8 @@
 package org.wso2.carbon.identity.application.common.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.axiom.om.OMElement;
+import org.apache.axis2.databinding.annotation.IgnoreNullElement;
 import org.apache.commons.collections.CollectionUtils;
 
 import java.io.Serializable;
@@ -39,6 +38,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
 
 /**
  * Inbound authentication request configuration.
@@ -72,10 +72,11 @@ public class InboundAuthenticationRequestConfig implements Serializable {
     @XmlElement(name = "Property")
     private Property[] properties = new Property[0];
     
-    @JsonInclude(JsonInclude.Include.NON_EMPTY) // This will only include the map if it's not empty.
-    @JsonProperty("data")
     // This is used to store the data related to the inbound protocol. This is not persisted in the database.
     // We use this for auditing purposes.
+    @IgnoreNullElement
+    @XmlTransient
+    @JsonIgnore
     private Map<String, Object> data;
 
     /*

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundAuthenticationRequestConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundAuthenticationRequestConfig.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.identity.application.common.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
 
@@ -29,6 +31,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -68,6 +71,12 @@ public class InboundAuthenticationRequestConfig implements Serializable {
     @XmlElementWrapper(name = "Properties")
     @XmlElement(name = "Property")
     private Property[] properties = new Property[0];
+    
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) // This will only include the map if it's not empty.
+    @JsonProperty("data")
+    // This is used to store the data related to the inbound protocol. This is not persisted in the database.
+    // We use this for auditing purposes.
+    private Map<String, Object> data;
 
     /*
      * <InboundAuthenticationRequestConfig> <InboundAuthKey></InboundAuthKey>
@@ -222,5 +231,15 @@ public class InboundAuthenticationRequestConfig implements Serializable {
 
         this.inboundConfigurationProtocol = inboundConfigurationProtocol;
     }
-
+    
+    @JsonProperty("data")
+    public Map<String, Object> getData() {
+        
+        return data;
+    }
+    
+    public void setData(Map<String, Object> data) {
+        
+        this.data = data;
+    }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundAuthenticationRequestConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundAuthenticationRequestConfig.java
@@ -232,7 +232,6 @@ public class InboundAuthenticationRequestConfig implements Serializable {
         this.inboundConfigurationProtocol = inboundConfigurationProtocol;
     }
     
-    @JsonProperty("data")
     public Map<String, Object> getData() {
         
         return data;

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
@@ -115,6 +115,7 @@ public class ApplicationConstants {
         public static final String USER = "USER";
         public static final String INBOUND_AUTHENTICATION_CONFIG = "inboundAuthenticationConfig";
         public static final String APP_OWNER = "owner";
+        public static final String DISABLE_LEGACY_AUDIT_LOGS_IN_APP_MGT_CONFIG = "disableLegacyAuditLogsInAppMgt";
         public static final String ENABLE_V2_AUDIT_LOGS = "enableV2AuditLogs";
         public static final String CREATE_APPLICATION = "CREATE APPLICATION";
         public static final String UPDATE_APPLICATION = "UPDATE APPLICATION";

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
@@ -100,6 +100,8 @@ public class ApplicationConstants {
     // Application Management Service Configurations.
     public static final String ENABLE_APPLICATION_ROLE_VALIDATION_PROPERTY = "ApplicationMgt.EnableRoleValidation";
 
+    public static final String NON_EXISTING_USER_CODE = "30007 - ";
+
     // Console and My Account application names.
     public static final String CONSOLE_APPLICATION_NAME = "Console";
     public static final String MY_ACCOUNT_APPLICATION_NAME = "My Account";
@@ -113,7 +115,7 @@ public class ApplicationConstants {
         public static final String USER = "USER";
         public static final String INBOUND_AUTHENTICATION_CONFIG = "inboundAuthenticationConfig";
         public static final String APP_OWNER = "owner";
-        public static final String DISABLE_LEGACY_AUDIT_LOGS_IN_APP_MGT_CONFIG = "disableLegacyAuditLogsInAppMgt";
+        public static final String ENABLE_V2_AUDIT_LOGS = "enableV2AuditLogs";
         public static final String CREATE_APPLICATION = "CREATE APPLICATION";
         public static final String UPDATE_APPLICATION = "UPDATE APPLICATION";
         public static final String DELETE_APPLICATION = "DELETE APPLICATION";
@@ -161,6 +163,21 @@ public class ApplicationConstants {
 
         }
     }
+    
+    /**
+     * Standard inbound authentication protocols.
+     */
+    public static class StandardInboundProtocols {
+        
+        public static final String OAUTH2 = "oauth2";
+        public static final String WS_TRUST = "wstrust";
+        public static final String SAML2 = "samlsso";
+        public static final String PASSIVE_STS = "passivests";
+        
+        private StandardInboundProtocols() {
+        
+        }
+    }
 
     /**
      * Grouping of constants related to database SP_INBOUND_AUTH table.
@@ -172,6 +189,54 @@ public class ApplicationConstants {
 
         private ApplicationInboundTableColumns() {
 
+        }
+    }
+
+    /**
+     * Enums for error messages.
+     */
+    public enum ErrorMessage {
+
+        ERROR_RETRIEVING_USER_BY_ID("65503", "Error occurred while retrieving user",
+                "Error occurred while retrieving user by userid: %s."),
+        NON_EXISTING_USER_ID("60504", "User not found",
+                "No user found for the given user-id: %s."),
+        ERROR_RETRIEVING_USERSTORE_MANAGER("65504", "Error retrieving userstore manager.",
+                "Error occurred while retrieving userstore manager."),
+        UNEXPECTED_ERROR("65006", "Unexpected processing error.",
+                "Server encountered an unexpected error when creating the application.");
+
+        private final String code;
+
+        private final String message;
+        private final String description;
+
+        ErrorMessage(String code, String message, String description) {
+
+            this.code = code;
+            this.message = message;
+            this.description = description;
+        }
+
+        public String getCode() {
+
+            return code;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+
+        public String getDescription() {
+
+            return description;
+        }
+
+        @Override
+        public String toString() {
+
+            return code + " | " + message;
         }
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -2589,8 +2589,10 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
                 }
             }
         } catch (IdentityApplicationManagementClientException e) {
-           /*  If there is a client exception, we don't need to do rollback since it will not affect the already
-             existing app. */
+            /*
+             * If there is a client exception, we don't need to do rollback since it will not affect the already
+             * existing app.
+             */
             throw e;
         } catch (IdentityApplicationManagementException e) {
             if (log.isDebugEnabled()) {
@@ -2725,8 +2727,8 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
     }
     
     /**
-     * Update the application by resource id. This method allow to update the application with or without triggering
-     * audit logs.
+     * Update the application by resource id. This method update the inbound protocol configurations of the application
+     * by calling the relevant protocol handlers if available.
      *
      * @param resourceId        Unique resource identifier of the application.
      * @param serviceProvider   Service provider. This can contain updated application information.
@@ -2762,9 +2764,11 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
             updateOrInsertInbound(serviceProvider, addedInbound);
         }
         try {
-            /* At this point the serviceProvided object is updated with the inbound auth config details. So we can call
-             the updateApplicationByResourceId(String, ServiceProvider, String, String) method to update the
-             service provider details in the database. */
+            /*
+             * At this point the serviceProvided object is updated with the inbound auth config details. So we can call
+             * the updateApplicationByResourceId(String, ServiceProvider, String, String) method to update the
+             * service provider details in the database.
+             */
             updateApplicationByResourceId(resourceId, serviceProvider, tenantDomain, username);
         } catch (IdentityApplicationManagementException e) {
             if (addedInbound != null) {

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -18,14 +18,17 @@
 
 package org.wso2.carbon.identity.application.mgt;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.json.JSONArray;
 import org.json.JSONObject;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.base.MultitenantConstants;
@@ -60,11 +63,7 @@ import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -79,9 +78,10 @@ import javax.xml.bind.Unmarshaller;
 
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.ENABLE_APPLICATION_ROLE_VALIDATION_PROPERTY;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.LogConstants.APP_OWNER;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.LogConstants.DISABLE_LEGACY_AUDIT_LOGS_IN_APP_MGT_CONFIG;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.LogConstants.ENABLE_V2_AUDIT_LOGS;
-import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.LogConstants.INBOUND_AUTHENTICATION_CONFIG;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_ROLE_ALREADY_EXISTS;
+import static org.wso2.carbon.utils.CarbonUtils.isLegacyAuditLogsDisabled;
 
 /**
  * Few common utility functions related to Application (aka. Service Provider) Management.
@@ -952,10 +952,13 @@ public class ApplicationMgtUtil {
         if (serviceProvider == null) {
             return StringUtils.EMPTY;
         }
+        ObjectMapper mapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(InboundAuthenticationRequestConfig.class, new InboundAuthRequestConfigSerializer());
+        mapper.registerModule(module);
         try {
             JSONObject serviceProviderJSONObject =
-                    new JSONObject(new ObjectMapper().writeValueAsString(serviceProvider));
-            maskClientSecret(serviceProviderJSONObject.optJSONObject(INBOUND_AUTHENTICATION_CONFIG));
+                    new JSONObject(mapper.writeValueAsString(serviceProvider));
             maskAppOwnerUsername(serviceProviderJSONObject.optJSONObject(APP_OWNER));
             return serviceProviderJSONObject.toString();
         } catch (JsonProcessingException | IdentityException e) {
@@ -963,58 +966,10 @@ public class ApplicationMgtUtil {
         }
         return StringUtils.EMPTY;
     }
-
-    private static void maskClientSecret(JSONObject inboundAuthenticationConfig) {
-
-        if (inboundAuthenticationConfig == null) {
-            return;
-        }
-        JSONArray inboundAuthenticationRequestConfigsArray =
-                inboundAuthenticationConfig.optJSONArray("inboundAuthenticationRequestConfigs");
-        if (inboundAuthenticationRequestConfigsArray == null) {
-            return;
-        }
-
-        for (int i = 0; i < inboundAuthenticationRequestConfigsArray.length(); i++) {
-            JSONObject requestConfig = inboundAuthenticationRequestConfigsArray.getJSONObject(i);
-            JSONArray properties = requestConfig.optJSONArray("properties");
-            if (properties == null) {
-                return;
-            }
-            for (int j = 0; j < properties.length(); j++) {
-                JSONObject property = properties.optJSONObject(j);
-                if (property != null && StringUtils.equalsIgnoreCase("oauthConsumerSecret",
-                        (String) property.get("name"))) {
-                    String secret = property.get("value").toString();
-                    property.put("value", LoggerUtils.getMaskedContent(secret));
-                    break;
-                }
-            }
-        }
-    }
-
-    public static ServiceProvider deepCopyApplication(ServiceProvider application)
-            throws IdentityApplicationManagementServerException {
-
-        ObjectOutputStream objOutPutStream;
-        ObjectInputStream objInputStream;
-        ServiceProvider newObject;
-        try {
-            ByteArrayOutputStream byteArrayOutPutStream = new ByteArrayOutputStream();
-            objOutPutStream = new ObjectOutputStream(byteArrayOutPutStream);
-            objOutPutStream.writeObject(application);
-
-            ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArrayOutPutStream.toByteArray());
-            objInputStream = new ObjectInputStream(byteArrayInputStream);
-            newObject = (ServiceProvider) objInputStream.readObject();
-        } catch (ClassNotFoundException | IOException e) {
-            throw new IdentityApplicationManagementServerException("Error deep cloning application object.", e);
-        }
-        return newObject;
-    }
     
     /**
      * Check whether the v2 audit logs are enabled.
+     *
      * @return true if v2 audit logs are enabled.
      */
     public static boolean isEnableV2AuditLogs() {
@@ -1076,6 +1031,13 @@ public class ApplicationMgtUtil {
         return LoggerUtils.getMaskedContent(loggableUserId);
     }
 
+    @Deprecated
+    public static boolean isLegacyAuditLogsDisabledInAppMgt() {
+
+        return Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_AUDIT_LOGS_IN_APP_MGT_CONFIG))
+                || isLegacyAuditLogsDisabled();
+    }
+
     /**
      * This method use to replace the hostname and port with placeholders of URLs.
      *
@@ -1112,5 +1074,28 @@ public class ApplicationMgtUtil {
 
         return ApplicationConstants.CONSOLE_APPLICATION_NAME.equals(name) ||
                 ApplicationConstants.MY_ACCOUNT_APPLICATION_NAME.equals(name);
+    }
+    
+    private static class InboundAuthRequestConfigSerializer extends StdSerializer<InboundAuthenticationRequestConfig> {
+        
+        public InboundAuthRequestConfigSerializer() {
+            
+            super(InboundAuthenticationRequestConfig.class);
+        }
+        
+        @Override
+        public void serialize(InboundAuthenticationRequestConfig value, JsonGenerator gen, SerializerProvider provider)
+                throws IOException {
+            
+            gen.writeStartObject();
+            gen.writeStringField("inboundAuthKey", value.getInboundAuthKey());
+            gen.writeStringField("inboundAuthType", value.getInboundAuthType());
+            gen.writeStringField("friendlyName", value.getFriendlyName());
+            // Handle the data field.
+            if (value.getData() != null && !value.getData().isEmpty()) {
+                gen.writeObjectField("config", value.getData());
+            }
+            gen.writeEndObject();
+        }
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationResourceManager.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationResourceManager.java
@@ -36,17 +36,20 @@ public interface ApplicationResourceManager {
      */
     ApplicationBasicInfo getApplicationBasicInfoByResourceId(String resourceId, String tenantDomain)
             throws IdentityApplicationManagementException;
-
+    
     /**
      * Creates an application and returns the created application.
      *
-     * @param applicationModelDTO  ApplicationModelDTO containing the app information
-     * @return unique application resource id of the application
-     * @throws IdentityApplicationManagementException
+     * @param applicationModelDTO ApplicationModelDTO containing the app information.
+     * @return unique application resource id of the application.
+     * @throws IdentityApplicationManagementException IdentityApplicationManagementException.
      */
-    String createApplication(ApplicationDTO applicationModelDTO, String tenantDomain, String username)
-            throws IdentityApplicationManagementException;
-
+    default String createApplication(ApplicationDTO applicationModelDTO, String tenantDomain, String username)
+            throws IdentityApplicationManagementException {
+        
+        return createApplication(applicationModelDTO.getServiceProvider(), tenantDomain, username);
+    }
+    
     /**
      * Creates an application and returns the created application.
      *

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationResourceManager.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationResourceManager.java
@@ -86,6 +86,16 @@ public interface ApplicationResourceManager {
                                        String tenantDomain, String username)
             throws IdentityApplicationManagementException;
     
+    /**
+     * Update the application by resource id. This method will update the inbound protocol configurations of the
+     * application with the provided inbound protocol configurations object.
+     *
+     * @param resourceId        Unique resource identifier of the application.
+     * @param application   Service provider. This can contain updated application information.
+     * @param tenantDomain      Tenant domain of the application.
+     * @param username          Tenant aware username of the user performing the operation.
+     * @throws IdentityApplicationManagementException Identity Application Management Exception.
+     */
     default void updateApplicationByResourceId(String resourceId, ServiceProvider application,
                                                InboundProtocolConfigurationDTO inboundProtocolConfigurationDTO,
                                                String tenantDomain, String username)

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationResourceManager.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationResourceManager.java
@@ -18,6 +18,8 @@ package org.wso2.carbon.identity.application.mgt;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.mgt.inbound.dto.ApplicationDTO;
+import org.wso2.carbon.identity.application.mgt.inbound.dto.InboundProtocolConfigurationDTO;
 
 /**
  * Allows application CRUD operations using unique resourceId.
@@ -33,6 +35,16 @@ public interface ApplicationResourceManager {
      * @throws IdentityApplicationManagementException
      */
     ApplicationBasicInfo getApplicationBasicInfoByResourceId(String resourceId, String tenantDomain)
+            throws IdentityApplicationManagementException;
+
+    /**
+     * Creates an application and returns the created application.
+     *
+     * @param applicationModelDTO  ApplicationModelDTO containing the app information
+     * @return unique application resource id of the application
+     * @throws IdentityApplicationManagementException
+     */
+    String createApplication(ApplicationDTO applicationModelDTO, String tenantDomain, String username)
             throws IdentityApplicationManagementException;
 
     /**
@@ -70,6 +82,14 @@ public interface ApplicationResourceManager {
     void updateApplicationByResourceId(String resourceId, ServiceProvider updatedApplication,
                                        String tenantDomain, String username)
             throws IdentityApplicationManagementException;
+    
+    default void updateApplicationByResourceId(String resourceId, ServiceProvider application,
+                                               InboundProtocolConfigurationDTO inboundProtocolConfigurationDTO,
+                                               String tenantDomain, String username)
+            throws IdentityApplicationManagementException {
+
+        updateApplicationByResourceId(resourceId, application, tenantDomain, username);
+    }
 
     /**
      * Delete an application identified by the resourceId.

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -474,7 +474,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                 log.debug("Application Stored successfully with applicationId: " + applicationId +
                         " and applicationResourceId: " + resourceId);
             }
-
+            application.setApplicationResourceId(resourceId);
             return new ApplicationCreateResult(resourceId, applicationId);
         } catch (URLBuilderException e) {
             throw new IdentityApplicationManagementException(

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/InboundFunctions.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/InboundFunctions.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.mgt.inbound;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.InboundAuthenticationConfig;
+import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementServiceImpl;
+import org.wso2.carbon.identity.application.mgt.inbound.protocol.ApplicationInboundAuthConfigHandler;
+import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponentHolder;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Utility functions related to application inbound protocols.
+ */
+public class InboundFunctions {
+    
+    private static final Log log = LogFactory.getLog(InboundFunctions.class);
+    
+    private InboundFunctions() {
+    
+    }
+    
+    /**
+     * Get the inbound authentication key for the given inbound type.
+     *
+     * @param application Service provider.
+     * @param inboundType Inbound type.
+     * @return Inbound authentication key.
+     */
+    public static String getInboundAuthKey(ServiceProvider application,
+                                           String inboundType) {
+        
+        InboundAuthenticationConfig inboundAuthConfig = application.getInboundAuthenticationConfig();
+        if (inboundAuthConfig != null) {
+            InboundAuthenticationRequestConfig[] inbounds = inboundAuthConfig.getInboundAuthenticationRequestConfigs();
+            if (inbounds != null) {
+                return Arrays.stream(inbounds)
+                        .filter(inbound -> inboundType.equals(inbound.getInboundAuthType()))
+                        .findAny()
+                        .map(InboundAuthenticationRequestConfig::getInboundAuthKey)
+                        .orElse(null);
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * Rollback the inbounds.
+     *
+     * @param currentlyAddedInbounds Currently added inbounds list.
+     * @throws IdentityApplicationManagementException If an error occurred while rolling back the inbounds.
+     */
+    public static void rollbackInbounds(List<InboundAuthenticationRequestConfig> currentlyAddedInbounds)
+            throws IdentityApplicationManagementException {
+        
+        for (InboundAuthenticationRequestConfig inbound : currentlyAddedInbounds) {
+            rollbackInbound(inbound);
+        }
+    }
+    
+    /**
+     * Rollback the inbound authentication request config.
+     *
+     * @param inbound Inbound authentication request config.
+     * @throws IdentityApplicationManagementException If an error occurred while rolling back the inbound.
+     */
+    public static void rollbackInbound(InboundAuthenticationRequestConfig inbound)
+            throws IdentityApplicationManagementException {
+        
+        List<ApplicationInboundAuthConfigHandler> applicationInboundAuthConfigHandlerList =
+                ApplicationManagementServiceComponentHolder.getInstance().getApplicationInboundAuthConfigHandler();
+        for (ApplicationInboundAuthConfigHandler applicationInboundAuthConfigHandler :
+                applicationInboundAuthConfigHandlerList) {
+            if (applicationInboundAuthConfigHandler.canHandle(inbound.getInboundAuthType())) {
+                applicationInboundAuthConfigHandler.handleConfigDeletion(inbound.getInboundAuthKey());
+            }
+        }
+    }
+    
+    public static void doRollback(String applicationId, InboundAuthenticationRequestConfig updatedInbound,
+                            String tenantDomain) throws IdentityApplicationManagementException {
+        
+        ServiceProvider applicationByResourceId;
+        applicationByResourceId = ApplicationManagementServiceImpl.getInstance().getApplicationByResourceId(
+                applicationId, tenantDomain);
+        // Current inbound key. This will give us an idea whether updatedInbound was newly added or not.
+        String previousInboundKey = getInboundAuthKey(applicationByResourceId, updatedInbound.getInboundAuthType());
+        String attemptedInboundKeyForUpdate = updatedInbound.getInboundAuthKey();
+        if (!StringUtils.equals(previousInboundKey, attemptedInboundKeyForUpdate)) {
+            // This means the application was updated with a newly created inbound. So the updated inbound details
+            // could have been created before the update. Attempt to rollback by deleting any inbound configs created.
+            if (log.isDebugEnabled()) {
+                String inboundType = updatedInbound.getInboundAuthType();
+                log.debug("Removing inbound data related to inbound type: " + inboundType + " of application: "
+                        + applicationByResourceId + " as part of rollback.");
+            }
+            rollbackInbound(updatedInbound);
+        }
+    }
+    
+    /**
+     * Update or insert the inbound authentication request config to the service provider.
+     *
+     * @param application Service provider.
+     * @param newInbound  New inbound authentication request config.
+     */
+    public static void updateOrInsertInbound(ServiceProvider application,
+                                             InboundAuthenticationRequestConfig newInbound) {
+        
+        InboundAuthenticationConfig inboundAuthConfig = application.getInboundAuthenticationConfig();
+        if (inboundAuthConfig != null) {
+            
+            InboundAuthenticationRequestConfig[] inbounds = inboundAuthConfig.getInboundAuthenticationRequestConfigs();
+            if (inbounds != null) {
+                Map<String, InboundAuthenticationRequestConfig> inboundAuthConfigs =
+                        Arrays.stream(inbounds).collect(
+                                Collectors.toMap(InboundAuthenticationRequestConfig::getInboundAuthType,
+                                        Function.identity()));
+                
+                inboundAuthConfigs.put(newInbound.getInboundAuthType(), newInbound);
+                inboundAuthConfig.setInboundAuthenticationRequestConfigs(
+                        inboundAuthConfigs.values().toArray(new InboundAuthenticationRequestConfig[0]));
+            } else {
+                addNewInboundToSp(application, newInbound);
+            }
+        } else {
+            // Create new inbound auth config.
+            addNewInboundToSp(application, newInbound);
+        }
+    }
+    
+    private static void addNewInboundToSp(ServiceProvider application, InboundAuthenticationRequestConfig newInbound) {
+        
+        InboundAuthenticationConfig inboundAuth = new InboundAuthenticationConfig();
+        inboundAuth.setInboundAuthenticationRequestConfigs(new InboundAuthenticationRequestConfig[]{newInbound});
+        
+        application.setInboundAuthenticationConfig(inboundAuth);
+    }
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/InboundFunctions.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/InboundFunctions.java
@@ -128,8 +128,10 @@ public class InboundFunctions {
         String previousInboundKey = optionalInboundKey.get();
         String attemptedInboundKeyForUpdate = updatedInbound.getInboundAuthKey();
         if (!StringUtils.equals(previousInboundKey, attemptedInboundKeyForUpdate)) {
-            // This means the application was updated with a newly created inbound. So the updated inbound details
-            // could have been created before the update. Attempt to rollback by deleting any inbound configs created.
+             /*
+              * This means the application was updated with a newly created inbound. So the updated inbound details
+              * could have been created before the update. Attempt to rollback by deleting any inbound configs created.
+              */
             if (LOG.isDebugEnabled()) {
                 String inboundType = updatedInbound.getInboundAuthType();
                 LOG.debug("Removing inbound data related to inbound type: " + inboundType + " of application: "

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/dto/ApplicationDTO.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/dto/ApplicationDTO.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.mgt.inbound.dto;
+
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+
+/**
+ * DTO of the Application. This class hold the ServiceProvider and Inbound Protocol details.
+ */
+public class ApplicationDTO {
+
+    private final ServiceProvider serviceProvider;
+    private final InboundProtocolsDTO inboundProtocolConfigurationDto;
+
+    private ApplicationDTO(Builder builder) {
+
+        this.serviceProvider = builder.serviceProvider;
+        this.inboundProtocolConfigurationDto = builder.inboundProtocolConfigurationDto;
+    }
+    
+    /**
+     * Builder class for ApplicationDTO.
+     */
+    public static class Builder {
+
+        private ServiceProvider serviceProvider;
+        private InboundProtocolsDTO inboundProtocolConfigurationDto;
+
+        public Builder serviceProvider(ServiceProvider serviceProvider) {
+
+            this.serviceProvider = serviceProvider;
+            return this;
+        }
+
+        public Builder inboundProtocolConfigurationDto(InboundProtocolsDTO inboundProtocolConfigurationDto) {
+
+            this.inboundProtocolConfigurationDto = inboundProtocolConfigurationDto;
+            return this;
+        }
+
+        public ApplicationDTO build() {
+
+            if (serviceProvider == null) {
+                throw new IllegalArgumentException("serviceProvider and inboundProtocolConfigurationDto cannot" +
+                        " be null");
+            }
+            return new ApplicationDTO(this);
+        }
+
+    }
+
+    public ServiceProvider getServiceProvider() {
+
+        return serviceProvider;
+    }
+
+    public InboundProtocolsDTO getInboundProtocolConfigurationDto() {
+
+        return inboundProtocolConfigurationDto;
+    }
+
+
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/dto/ApplicationDTO.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/dto/ApplicationDTO.java
@@ -62,7 +62,6 @@ public class ApplicationDTO {
             }
             return new ApplicationDTO(this);
         }
-
     }
 
     public ServiceProvider getServiceProvider() {
@@ -74,6 +73,4 @@ public class ApplicationDTO {
 
         return inboundProtocolConfigurationDto;
     }
-
-
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/dto/InboundProtocolConfigurationDTO.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/dto/InboundProtocolConfigurationDTO.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.mgt.inbound.dto;
+
+/**
+ * Interface for the Inbound Protocol Configs. All inbound protocol configurations should implement this interface.
+ */
+public interface InboundProtocolConfigurationDTO {
+
+    String getProtocolName();
+
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/dto/InboundProtocolsDTO.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/dto/InboundProtocolsDTO.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.mgt.inbound.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * DTO of the InboundProtocols. This DTO will hold all the inbound configurations details of an application.
+ */
+public class InboundProtocolsDTO {
+    
+    private final Map<String, InboundProtocolConfigurationDTO> inboundProtocolConfigurationMap = new HashMap<>();
+    
+    /**
+     * Get the inbound protocol configuration map. This will be called from each inbound auth config handlers.
+     *
+     * @return Inbound protocol configuration map.
+     */
+    public Map<String, InboundProtocolConfigurationDTO> getInboundProtocolConfigurationMap() {
+        
+        return inboundProtocolConfigurationMap;
+    }
+    
+    /**
+     * Add a inbound auth config protocol to the map.
+     *
+     * @param inboundProtocolConfigurationDTO Inbound protocol configuration DTO.
+     */
+    public void addProtocolConfiguration(InboundProtocolConfigurationDTO inboundProtocolConfigurationDTO) {
+        
+        inboundProtocolConfigurationMap.put(inboundProtocolConfigurationDTO.getProtocolName(),
+                inboundProtocolConfigurationDTO);
+    }
+    
+    /**
+     * Remove an inbound auth config protocol from the map.
+     *
+     * @param inboundProtocolConfigurationDTO Inbound protocol configuration DTO.
+     * @return True if the protocol is removed successfully.
+     */
+    public boolean removeProtocolConfiguration(InboundProtocolConfigurationDTO inboundProtocolConfigurationDTO) {
+        
+        return inboundProtocolConfigurationMap.remove(inboundProtocolConfigurationDTO.getProtocolName()) != null;
+    }
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/protocol/ApplicationInboundAuthConfigHandler.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/protocol/ApplicationInboundAuthConfigHandler.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.mgt.inbound.protocol;
+
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.mgt.inbound.dto.InboundProtocolConfigurationDTO;
+import org.wso2.carbon.identity.application.mgt.inbound.dto.InboundProtocolsDTO;
+
+/**
+ * Interface for handling inbound authentication configuration.
+ */
+public interface ApplicationInboundAuthConfigHandler {
+    
+    /**
+     * Checks whether the handler can handle the given inbound protocol.
+     *
+     * @param inboundProtocolsDTO Inbound protocol DTO.
+     * @return True if the handler can handle the given protocol.
+     */
+    boolean canHandle(InboundProtocolsDTO inboundProtocolsDTO);
+    
+    
+    /**
+     * Checks whether the handler can handle the given inbound protocol name.
+     *
+     * @param inboundAuthConfigName Inbound auth config name.
+     * @return True if the handler can handle the given protocol.
+     */
+    boolean canHandle(String inboundAuthConfigName);
+    
+    
+    /**
+     * Handles the creation of inbound authentication configuration.
+     *
+     * @param application         Service provider.
+     * @param inboundProtocolsDTO Inbound protocol DTO.
+     * @return Inbound authentication request configuration.
+     * @throws IdentityApplicationManagementException If an error occurred while creating the configuration.
+     */
+    InboundAuthenticationRequestConfig handleConfigCreation(ServiceProvider application,
+                                                            InboundProtocolsDTO inboundProtocolsDTO)
+            throws IdentityApplicationManagementException;
+    
+    
+    /**
+     * Handles the update of inbound authentication configuration.
+     *
+     * @param application                     Service provider.
+     * @param inboundProtocolConfigurationDTO Inbound protocol configuration DTO.
+     * @return Inbound authentication request configuration.
+     * @throws IdentityApplicationManagementException If an error occurred while updating the configuration.
+     */
+    InboundAuthenticationRequestConfig handleConfigUpdate(
+            ServiceProvider application, InboundProtocolConfigurationDTO inboundProtocolConfigurationDTO)
+            throws IdentityApplicationManagementException;
+    
+    
+    /**
+     * Handles the deletion of inbound authentication configuration.
+     *
+     * @param inboundAuthKey Inbound auth key.
+     * @throws IdentityApplicationManagementException If an error occurred while deleting the configuration.
+     */
+    void handleConfigDeletion(String inboundAuthKey) throws IdentityApplicationManagementException;
+    
+    
+    /**
+     * Handles the retrieval of inbound authentication configuration.
+     *
+     * @param inboundAuthKey Inbound auth key.
+     * @return Inbound protocol configuration DTO.
+     * @throws IdentityApplicationManagementException If an error occurred while retrieving the configuration.
+     */
+    InboundProtocolConfigurationDTO handleConfigRetrieval(String inboundAuthKey)
+            throws IdentityApplicationManagementException;
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/protocol/ApplicationInboundAuthConfigHandler.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/inbound/protocol/ApplicationInboundAuthConfigHandler.java
@@ -37,7 +37,6 @@ public interface ApplicationInboundAuthConfigHandler {
      */
     boolean canHandle(InboundProtocolsDTO inboundProtocolsDTO);
     
-    
     /**
      * Checks whether the handler can handle the given inbound protocol name.
      *
@@ -45,7 +44,6 @@ public interface ApplicationInboundAuthConfigHandler {
      * @return True if the handler can handle the given protocol.
      */
     boolean canHandle(String inboundAuthConfigName);
-    
     
     /**
      * Handles the creation of inbound authentication configuration.
@@ -59,7 +57,6 @@ public interface ApplicationInboundAuthConfigHandler {
                                                             InboundProtocolsDTO inboundProtocolsDTO)
             throws IdentityApplicationManagementException;
     
-    
     /**
      * Handles the update of inbound authentication configuration.
      *
@@ -72,7 +69,6 @@ public interface ApplicationInboundAuthConfigHandler {
             ServiceProvider application, InboundProtocolConfigurationDTO inboundProtocolConfigurationDTO)
             throws IdentityApplicationManagementException;
     
-    
     /**
      * Handles the deletion of inbound authentication configuration.
      *
@@ -80,7 +76,6 @@ public interface ApplicationInboundAuthConfigHandler {
      * @throws IdentityApplicationManagementException If an error occurred while deleting the configuration.
      */
     void handleConfigDeletion(String inboundAuthKey) throws IdentityApplicationManagementException;
-    
     
     /**
      * Handles the retrieval of inbound authentication configuration.

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponent.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponent.java
@@ -48,6 +48,7 @@ import org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementServiceIm
 import org.wso2.carbon.identity.application.mgt.DiscoverableApplicationManager;
 import org.wso2.carbon.identity.application.mgt.defaultsequence.DefaultAuthSeqMgtService;
 import org.wso2.carbon.identity.application.mgt.defaultsequence.DefaultAuthSeqMgtServiceImpl;
+import org.wso2.carbon.identity.application.mgt.inbound.protocol.ApplicationInboundAuthConfigHandler;
 import org.wso2.carbon.identity.application.mgt.internal.impl.DiscoverableApplicationManagerImpl;
 import org.wso2.carbon.identity.application.mgt.listener.AdminRolePermissionsUpdateListener;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationClaimMgtListener;
@@ -482,6 +483,27 @@ public class ApplicationManagementServiceComponent {
         if (log.isDebugEnabled()) {
             log.debug("SAMLSSOServiceProviderManager unset in to bundle");
         }
+    }
+
+    @Reference(
+            name = "application.mgt.inbound.config.service",
+            service = ApplicationInboundAuthConfigHandler.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetApplicationInboundAuthConfigService"
+    )
+    protected void setApplicationInboundAuthConfigService(ApplicationInboundAuthConfigHandler
+                                                                  applicationInboundAuthConfigHandler) {
+
+        ApplicationManagementServiceComponentHolder.getInstance().addApplicationInboundAuthConfigHandler(
+                applicationInboundAuthConfigHandler);
+    }
+
+    protected void unsetApplicationInboundAuthConfigService(ApplicationInboundAuthConfigHandler
+                                                                    applicationInboundAuthConfigHandler) {
+
+        ApplicationManagementServiceComponentHolder.getInstance().removeApplicationInboundConfigHandler(
+                applicationInboundAuthConfigHandler);
     }
 
     @Reference(

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponentHolder.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponentHolder.java
@@ -389,6 +389,8 @@ public class ApplicationManagementServiceComponentHolder {
     
     /**
      * Add application inbound config service.
+     *
+     * @param applicationInboundAuthConfigHandler Protocol service.
      */
     public void addApplicationInboundAuthConfigHandler(ApplicationInboundAuthConfigHandler
                                                                applicationInboundAuthConfigHandler) {

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponentHolder.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/internal/ApplicationManagementServiceComponentHolder.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.application.mgt.internal;
 import org.wso2.carbon.consent.mgt.core.ConsentManager;
 import org.wso2.carbon.identity.api.resource.mgt.APIResourceManager;
 import org.wso2.carbon.identity.application.mgt.AbstractInboundAuthenticatorConfig;
+import org.wso2.carbon.identity.application.mgt.inbound.protocol.ApplicationInboundAuthConfigHandler;
 import org.wso2.carbon.identity.application.mgt.provider.ApplicationPermissionProvider;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.core.SAMLSSOServiceProviderManager;
@@ -33,7 +34,9 @@ import org.wso2.carbon.identity.secret.mgt.core.SecretResolveManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -68,6 +71,8 @@ public class ApplicationManagementServiceComponentHolder {
     private OrganizationManager organizationManager;
 
     private boolean isOrganizationManagementEnable = false;
+    private static final List<ApplicationInboundAuthConfigHandler> applicationInboundAuthConfigHandlers = new
+            ArrayList<>();
 
     private IdentityEventService identityEventService;
 
@@ -381,5 +386,34 @@ public class ApplicationManagementServiceComponentHolder {
 
         this.secretResolveManager = secretResolveManager;
     }
-
+    
+    /**
+     * Add application inbound config service.
+     */
+    public void addApplicationInboundAuthConfigHandler(ApplicationInboundAuthConfigHandler
+                                                               applicationInboundAuthConfigHandler) {
+        
+        applicationInboundAuthConfigHandlers.add(applicationInboundAuthConfigHandler);
+    }
+    
+    /**
+     * Remove application inbound config service.
+     *
+     * @param applicationInboundAuthConfigHandler Protocol service.
+     */
+    public void removeApplicationInboundConfigHandler(ApplicationInboundAuthConfigHandler
+                                                              applicationInboundAuthConfigHandler) {
+        
+        applicationInboundAuthConfigHandlers.remove(applicationInboundAuthConfigHandler);
+    }
+    
+    /**
+     * Get application inbound config service.
+     *
+     * @return List of application inbound config services.
+     */
+    public List<ApplicationInboundAuthConfigHandler> getApplicationInboundAuthConfigHandler() {
+        
+        return applicationInboundAuthConfigHandlers;
+    }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/ApplicationMgtAuditLogger.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/ApplicationMgtAuditLogger.java
@@ -39,9 +39,9 @@ import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.CarbonUtils;
 
 import static org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil.getUsernameWithUserTenantDomain;
-import static org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil.isLegacyAuditLogsDisabledInAppMgt;
 
 /**
  * Audit log implementation for Application (Service Provider) changes.
@@ -57,8 +57,8 @@ public class ApplicationMgtAuditLogger extends AbstractApplicationMgtListener {
     public boolean isEnable() {
 
         if (super.isEnable()) {
-            // Either legacy audit logs enabled in app mgt component or system wide, then enable audit logs.
-            return !isLegacyAuditLogsDisabledInAppMgt();
+            // Legacy audit logs should be enabled to log these audit logs.
+            return !CarbonUtils.isLegacyAuditLogsDisabled();
         }
         return false;
     }


### PR DESCRIPTION
### Proposed changes in this pull request
- $subject
- Creates the protocol details along with the service provider

With this PR, we will be able to handle the inbound protocol while handling (while doing CRUD operations) the application management. Earlier we had to separately call app-mgt services and protocol services to do this. With this improvement, the app-mgt service will be able to handle the protocol configurations as well.

![image](https://github.com/wso2/carbon-identity-framework/assets/32576163/dfe9651f-0ea5-46fb-b1e7-92416ab2f99b)

