### PR TITLE
Improve attestation meta data deletion

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -5423,9 +5423,9 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
             throws IdentityApplicationManagementException {
 
         try {
-            if (ApplicationManagementServiceComponentHolder.getInstance()
-                    .getSecretManager().isSecretExist(APPLICATION_SECRET_TYPE_ANDROID_ATTESTATION_CREDENTIALS,
-                            getAndroidAttestationSecretName(application.getApplicationResourceId()))) {
+            if (application.getClientAttestationMetaData() != null
+                    && StringUtils.isNotEmpty(application.getClientAttestationMetaData()
+                    .getAndroidAttestationServiceCredentials())) {
                 ApplicationManagementServiceComponentHolder.getInstance()
                         .getSecretManager().deleteSecret(APPLICATION_SECRET_TYPE_ANDROID_ATTESTATION_CREDENTIALS,
                                 getAndroidAttestationSecretName(application.getApplicationResourceId()));


### PR DESCRIPTION
### Proposed changes in this pull request
Issue: https://github.com/wso2/product-is/issues/16836, https://github.com/wso2/product-is/issues/17774
**Improvement**
Before deleting an application we are already retrieve the application from the db. Rather than checking whether the secret exists in the db, we can check the application object.

This will remove 1 db call and will not affect any application which doesn't have android attestation credentials.