### PR TITLE
Improve setting cookie path for super tenant

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -1015,7 +1015,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             if (FrameworkUtils.isOrganizationQualifiedRequest()) {
                 path = FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX + context.getLoginTenantDomain() + "/";
             } else {
-                if (!IdentityTenantUtil.isSuperTenantRequiredInUrl() &&
+                if (!IdentityTenantUtil.isSuperTenantAppendInCookiePath() &&
                         MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(context.getLoginTenantDomain())) {
                     path = "/";
                 } else {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -38,6 +38,8 @@ public class IdentityCoreConstants {
     public static final String ENABLE_TENANT_QUALIFIED_URLS = "TenantContext.TenantQualifiedUrls.Enable";
     public static final String REQUIRED_SUPER_TENANT_IN_URLS =
             "TenantContext.TenantQualifiedUrls.RequireSuperTenantInUrls";
+    public static final String APPEND_SUPER_TENANT_IN_COOKIE_PATH =
+            "TenantContext.TenantQualifiedUrls.AppendSuperTenantInCookiePath";
     public static final String ENABLE_TENANTED_SESSIONS = "TenantContext.TenantQualifiedUrls.EnableTenantedSessions";
     public static final String PROXY_CONTEXT_PATH = "ProxyContextPath";
     public static final int DEFAULT_HTTPS_PORT = 443;

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
@@ -436,6 +436,16 @@ public class IdentityTenantUtil {
     }
 
     /**
+     * Checks if it is required to append the carbon.super in cookie path.
+     *
+     * @return true if it is mandatory, false otherwise.
+     */
+    public static boolean isSuperTenantAppendInCookiePath() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(IdentityCoreConstants.APPEND_SUPER_TENANT_IN_COOKIE_PATH));
+    }
+
+    /**
      *
      * Checks whether legacy SaaS authentication is enabled.
      *

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2297,6 +2297,7 @@
         <TenantQualifiedUrls>
             <Enable>false</Enable>
             <RequireSuperTenantInUrls>false</RequireSuperTenantInUrls>
+            <AppendSuperTenantInCookiePath>false</AppendSuperTenantInCookiePath>
             <EnableTenantedSessions>false</EnableTenantedSessions>
         </TenantQualifiedUrls>
     </TenantContext>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3338,6 +3338,7 @@
         <TenantQualifiedUrls>
             <Enable>{{tenant_context.enable_tenant_qualified_urls}}</Enable>
             <RequireSuperTenantInUrls>{{tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls}}</RequireSuperTenantInUrls>
+            <AppendSuperTenantInCookiePath>{{tenant_context.enable_tenant_qualified_urls && tenant_context.append_super_tenant_in_cookie_path}}</AppendSuperTenantInCookiePath>
             <EnableTenantedSessions>{{tenant_context.enable_tenant_qualified_urls && tenant_context.enable_tenanted_sessions}}</EnableTenantedSessions>
        </TenantQualifiedUrls>
     </TenantContext>


### PR DESCRIPTION
Add a new config "TenantContext.TenantQualifiedUrls.AppendSuperTenantInCookiePath" to specify whether to append the `carbon.super` in the cookie paths and if enabled append the `carbon.super` to the cookie path.