### PR TITLE
Fix issue with user store client exceptions getting logged as errors

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornClaims.java
@@ -43,6 +43,7 @@ import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.claim.Claim;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -245,6 +246,11 @@ public class JsNashornClaims extends AbstractJSContextMemberObject implements Ab
             claimUriMap.put(claimUri, String.valueOf(claimValue));
             ((AbstractUserStoreManager) userRealm.getUserStoreManager())
                     .setUserClaimValuesWithID(authenticatedUser.getUserId(), claimUriMap, null);
+        } catch (UserStoreClientException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Error when setting claim : %s of user: %s to value: %s", claimUri,
+                        authenticatedUser, String.valueOf(claimValue)), e);
+            }
         } catch (UserStoreException e) {
             LOG.error(String.format("Error when setting claim : %s of user: %s to value: %s", claimUri,
                     authenticatedUser, String.valueOf(claimValue)), e);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornClaims.java
@@ -248,8 +248,8 @@ public class JsNashornClaims extends AbstractJSContextMemberObject implements Ab
                     .setUserClaimValuesWithID(authenticatedUser.getUserId(), claimUriMap, null);
         } catch (UserStoreClientException e) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug(String.format("Error when setting claim : %s of user: %s to value: %s", claimUri,
-                        authenticatedUser, String.valueOf(claimValue)), e);
+                LOG.debug(String.format("Error when setting claim : %s of user: %s to value: %s. Error Message: %s",
+                        claimUri, authenticatedUser, String.valueOf(claimValue), e.getMessage()));
             }
         } catch (UserStoreException e) {
             LOG.error(String.format("Error when setting claim : %s of user: %s to value: %s", claimUri,

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornClaims.java
@@ -43,6 +43,7 @@ import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.claim.Claim;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -246,6 +247,11 @@ public class JsOpenJdkNashornClaims extends AbstractJSContextMemberObject implem
             claimUriMap.put(claimUri, String.valueOf(claimValue));
             ((AbstractUserStoreManager) userRealm.getUserStoreManager())
                     .setUserClaimValuesWithID(authenticatedUser.getUserId(), claimUriMap, null);
+        } catch (UserStoreClientException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Error when setting claim : %s of user: %s to value: %s", claimUri,
+                        authenticatedUser, String.valueOf(claimValue)), e);
+            }
         } catch (UserStoreException e) {
             LOG.error(String.format("Error when setting claim : %s of user: %s to value: %s", claimUri,
                     authenticatedUser, String.valueOf(claimValue)), e);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornClaims.java
@@ -249,8 +249,8 @@ public class JsOpenJdkNashornClaims extends AbstractJSContextMemberObject implem
                     .setUserClaimValuesWithID(authenticatedUser.getUserId(), claimUriMap, null);
         } catch (UserStoreClientException e) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug(String.format("Error when setting claim : %s of user: %s to value: %s", claimUri,
-                        authenticatedUser, String.valueOf(claimValue)), e);
+                LOG.debug(String.format("Error when setting claim : %s of user: %s to value: %s. Error Message: %s",
+                        claimUri, authenticatedUser, String.valueOf(claimValue), e.getMessage()));
             }
         } catch (UserStoreException e) {
             LOG.error(String.format("Error when setting claim : %s of user: %s to value: %s", claimUri,


### PR DESCRIPTION
This PR fixes an issue with user store client exceptions getting logged as errors. Client errors should not be logged as server errors and hence this fix was implemented.

### Related Issues

- https://github.com/wso2-enterprise/asgardeo-product/issues/20339

### When should this PR be merged

This can be merged now.

