### PR TITLE
Add support for alphanumeric username with special characters

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/ValidationConfigurationRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/ValidationConfigurationRetrievalClient.java
@@ -61,8 +61,10 @@ public class ValidationConfigurationRetrievalClient {
     private static final String MAX_REPEATED_KEY = "maxConsecutiveChr";
     private static final String PROPERTIES = "properties";
     private static final String VALIDATOR = "enable.validator";
+    private static final String ENABLE_SPECIAL_CHARACTERS = "enable.special.characters";
     private static final String EMAIL_VALIDATOR_KEY = "emailFormatValidator";
     private static final String ALPHANUMERIC_VALIDATOR_KEY = "alphanumericFormatValidator";
+    private static final String ENABLE_SPECIAL_CHARACTERS_KEY = "enableSpecialCharacters";
     private static final String JS_REG_EX_VALIDATOR_KEY = "JsRegExValidator";
 
     /**
@@ -272,6 +274,8 @@ public class ValidationConfigurationRetrievalClient {
         } else if (name.equalsIgnoreCase("AlphanumericValidator")) {
             addBooleanValue(VALIDATOR, (JSONArray) rule.get(PROPERTIES), config,
                     ALPHANUMERIC_VALIDATOR_KEY);
+            addBooleanValue(ENABLE_SPECIAL_CHARACTERS, (JSONArray) rule.get(PROPERTIES), config,
+                    ENABLE_SPECIAL_CHARACTERS_KEY);
         } else if (name.equalsIgnoreCase("EmailFormatValidator")) {
             addBooleanValue(VALIDATOR, (JSONArray) rule.get(PROPERTIES), config,
                     EMAIL_VALIDATOR_KEY);

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/validators/AlphanumericValidator.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/validators/AlphanumericValidator.java
@@ -27,7 +27,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.ALPHANUMERIC_REGEX_PATTERN_WITH_SPECIAL_CHARACTERS;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.DEFAULT_ALPHANUMERIC_REGEX_PATTERN;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.ENABLE_SPECIAL_CHARACTERS;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.ENABLE_VALIDATOR;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.USERNAME;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_INPUT_VALUE_NULL;
@@ -63,6 +65,10 @@ public class AlphanumericValidator extends AbstractRulesValidator {
         String field = context.getField();
         Map<String, String> attributesMap = context.getProperties();
         String alphanumericRegEx = DEFAULT_ALPHANUMERIC_REGEX_PATTERN;
+        // Check whether special characters are allowed.
+        if (attributesMap.containsKey(ENABLE_SPECIAL_CHARACTERS)) {
+            alphanumericRegEx = ALPHANUMERIC_REGEX_PATTERN_WITH_SPECIAL_CHARACTERS;
+        }
 
         // Check whether value satisfies the alphanumeric criteria.
         if (attributesMap.containsKey(ENABLE_VALIDATOR)) {
@@ -98,6 +104,14 @@ public class AlphanumericValidator extends AbstractRulesValidator {
         enableValidator.setType("boolean");
         enableValidator.setDisplayOrder(++parameterCount);
         configProperties.add(enableValidator);
+
+        Property allowSpecialChars = new Property();
+        allowSpecialChars.setName(ENABLE_SPECIAL_CHARACTERS);
+        allowSpecialChars.setDisplayName("Alphanumeric field value with special characters");
+        allowSpecialChars.setDescription("Validate whether the field value is alphanumeric.");
+        allowSpecialChars.setType("boolean");
+        allowSpecialChars.setDisplayOrder(++parameterCount);
+        configProperties.add(allowSpecialChars);
 
         return configProperties;
     }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/validators/AlphanumericValidator.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/validators/AlphanumericValidator.java
@@ -108,7 +108,8 @@ public class AlphanumericValidator extends AbstractRulesValidator {
         Property allowSpecialChars = new Property();
         allowSpecialChars.setName(ENABLE_SPECIAL_CHARACTERS);
         allowSpecialChars.setDisplayName("Alphanumeric field value with special characters");
-        allowSpecialChars.setDescription("Validate whether the field value is alphanumeric.");
+        allowSpecialChars.setDescription("Validate for allowed set of special characters along with alphanumeric" +
+                " in the field value.");
         allowSpecialChars.setType("boolean");
         allowSpecialChars.setDisplayOrder(++parameterCount);
         configProperties.add(allowSpecialChars);

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -67,6 +67,7 @@ public class Constants {
         public static final String MIN_UNIQUE_CHR = "min.unique.character";
         public static final String MAX_CONSECUTIVE_CHR = "max.consecutive.character";
         public static final String ENABLE_VALIDATOR = "enable.validator";
+        public static final String ENABLE_SPECIAL_CHARACTERS = "enable.special.characters";
 
         // Keys for password regEx validation.
         public static final String JS_REGEX = "regex";
@@ -77,6 +78,8 @@ public class Constants {
         public static final String PERIOD = ".";
         public static final String JAVA_REGEX_PATTERN = "^((?=.*\\d)(?=.*[a-z])(?=.*[A-Z])).{8,100}$";
         public static final String DEFAULT_ALPHANUMERIC_REGEX_PATTERN = "^(?=.*[a-zA-Z])[a-zA-Z0-9]+$";
+        public static final String ALPHANUMERIC_REGEX_PATTERN_WITH_SPECIAL_CHARACTERS =
+                "^(?=.*[a-zA-Z])[a-zA-Z0-9!@#$%&'*+\\=?^_`.{|}~-]+$";
         public static final String DEFAULT_EMAIL_JAVA_REGEX_PATTERN =
             "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![.+\\-_]{2})[\\u00C0-\\u00FF\\w.+\\-]){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0" +
             "-9]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";


### PR DESCRIPTION
### Description
Support for alphanumeric usernames with the following special characters in the regex,
```
^(?=.*[a-zA-Z])[a-zA-Z0-9!@#$%&'*+/=?^_`.{|}~-]+$
```

Sample payload for validation config is as follows,
```
[
    {
        "field": "username",
        "rules": [
            {
                "properties": [
                    {
                        "key": "enable.validator",
                        "value": "true"
                    },
                    {
                        "key": "enable.special.characters",
                        "value": "true"
                    }
                ],
                "validator": "AlphanumericValidator"
            },
            {
                "properties": [
                    {
                        "key": "min.length",
                        "value": "3"
                    },
                    {
                        "key": "max.length",
                        "value": "50"
                    }
                ],
                "validator": "LengthValidator"
            }
        ]
    }
]
```