### PR TITLE
Fix IDP metadata retrieval issue and recovery endpoint service URL builder issue

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
@@ -356,7 +356,8 @@ public class ConfigurationFacade {
             }
         }
         try {
-            return ServiceURLBuilder.create().addPath(path).build().getAbsolutePublicURL();
+            String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
+            return ServiceURLBuilder.create().addPath(path).setOrganization(organizationId).build().getAbsolutePublicURL();
         } catch (URLBuilderException e) {
             throw new IdentityRuntimeException(
                     "Error while building tenant qualified url for context: " + defaultContext, e);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
@@ -357,7 +357,8 @@ public class ConfigurationFacade {
         }
         try {
             String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
-            return ServiceURLBuilder.create().addPath(path).setOrganization(organizationId).build().getAbsolutePublicURL();
+            return ServiceURLBuilder.create().addPath(path).setOrganization(organizationId).build()
+                    .getAbsolutePublicURL();
         } catch (URLBuilderException e) {
             throw new IdentityRuntimeException(
                     "Error while building tenant qualified url for context: " + defaultContext, e);

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/pom.xml
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/pom.xml
@@ -328,6 +328,8 @@
                             org.wso2.carbon.identity.base; version="${carbon.identity.package.import.version.range}",
 
                             org.wso2.carbon.idp.mgt; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.util;
+                            version="${carbon.identity.package.import.version.range}",
 
                             org.wso2.securevault.*; version="${org.wso2.securevault.import.version.range}",
                         </Import-Package>

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
@@ -35,6 +35,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.owasp.encoder.Encode;
 import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.core.SameSiteCookie;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
@@ -776,6 +777,11 @@ public class IdentityManagementEndpointUtil {
         try {
             if (StringUtils.isBlank(serverUrl)) {
                 if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+                    if (StringUtils.isNotEmpty(PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                            .getOrganizationId())) {
+                        serverUrl = ServiceURLBuilder.create().build().getAbsolutePublicUrlWithoutPath();
+                        return serverUrl + "/t/" + tenantDomain + "/o/" + context;
+                    }
                     basePath = ServiceURLBuilder.create().addPath(context).setTenant(tenantDomain).build()
                             .getAbsoluteInternalURL();
                 } else {

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
@@ -35,7 +35,6 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.owasp.encoder.Encode;
 import org.wso2.carbon.base.MultitenantConstants;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.core.SameSiteCookie;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
@@ -777,11 +776,6 @@ public class IdentityManagementEndpointUtil {
         try {
             if (StringUtils.isBlank(serverUrl)) {
                 if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-                    if (StringUtils.isNotEmpty(PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                            .getOrganizationId())) {
-                        serverUrl = ServiceURLBuilder.create().build().getAbsolutePublicUrlWithoutPath();
-                        return serverUrl + "/t/" + tenantDomain + "/o/" + context;
-                    }
                     basePath = ServiceURLBuilder.create().addPath(context).setTenant(tenantDomain).build()
                             .getAbsoluteInternalURL();
                 } else {

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/IdentityProviderDataRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/IdentityProviderDataRetrievalClient.java
@@ -35,6 +35,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.owasp.encoder.Encode;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil;
 import org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementServiceUtil;
 
@@ -259,7 +260,12 @@ public class IdentityProviderDataRetrievalClient {
             throws IdentityProviderDataRetrievalClientException {
 
         try {
-            return IdentityManagementEndpointUtil.getBasePath(tenantDomain, context);
+            String endpoint = IdentityManagementEndpointUtil.getBasePath(tenantDomain, context);
+            if (endpoint != null && endpoint.contains(FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX)) {
+                endpoint = endpoint.replace(FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX,
+                        FrameworkConstants.TENANT_CONTEXT_PREFIX);
+            }
+            return endpoint;
         } catch (ApiException e) {
             throw new IdentityProviderDataRetrievalClientException("Error while building url for context: " + context);
         }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/IdentityProviderDataRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/IdentityProviderDataRetrievalClient.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022-2023, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/IdentityProviderDataRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/IdentityProviderDataRetrievalClient.java
@@ -262,6 +262,8 @@ public class IdentityProviderDataRetrievalClient {
         try {
             String endpoint = IdentityManagementEndpointUtil.getBasePath(tenantDomain, context);
             if (endpoint != null && endpoint.contains(FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX)) {
+                /* Resolving tenant domain from organization ID is not provided by an API. Hence, the retrieval client
+                will have to assume organization ID is same as tenant domain. */
                 endpoint = endpoint.replace(FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX,
                         FrameworkConstants.TENANT_CONTEXT_PREFIX);
             }


### PR DESCRIPTION
### Proposed changes in this pull request

There are two fixes sent with this PR
1 - There are internal API calls which are invoked from the preference client to retrieve metadata information. When accessing organization resources, the service URLs should be in the format of `/t/<tenant-domain>/o/`. But the retrieval clients used the product is not following client-credentials grant type based token used approach, instead a basic auth based approach. Hence the mentioned `/t/<tenant-domain>/o/` can't be followed. Hence for this case only, call the organization resource APIs with `/t/<tenant-domain>` path, where the tenant domain is the corresponding tenant of the organization. Here the organization-id & tenant-domain are assumed to be equal when considering organizations.

The above discussed API calls are invoked internally, until properly fix the retrieval clients with proper authentication mechanisms, this fix has to be applied.

2 - There was an issue in service URL building for the recovery endpoint in the ask password feature of the organization level.

### Related Issues
1 
- https://github.com/wso2/product-is/issues/17591

2 
- https://github.com/wso2/product-is/issues/18057