### PR TITLE
Introduce a new step config to skip prompting for user input during an authentication step

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
@@ -202,6 +202,12 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
         }
     }
 
+    /**
+     * Checks whether the skipPrompt step config is set to true for the current step.
+     *
+     * @param context Authentication context.
+     * @return True if the skipPrompt step config is set to true for the current step.
+     */
     private boolean isSkipPrompt(AuthenticationContext context) {
 
         return context.getSequenceConfig().getStepMap().get(context.getCurrentStep()).isSkipPrompt();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
@@ -210,6 +210,9 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
      */
     private boolean isSkipPrompt(AuthenticationContext context) {
 
+        if (context.getCurrentStep() == 0) {
+            return false;
+        }
         return context.getSequenceConfig().getStepMap().get(context.getCurrentStep()).isSkipPrompt();
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/StepConfig.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/StepConfig.java
@@ -47,6 +47,7 @@ public class StepConfig implements Serializable {
     private boolean multiOption;
     private boolean retrying;
     private boolean forced;
+    private boolean skipPrompt;
 
     public StepConfig() {
     }
@@ -236,6 +237,16 @@ public class StepConfig implements Serializable {
     public void setForced(boolean forced) {
 
         this.forced = forced;
+    }
+
+    public boolean isSkipPrompt() {
+
+        return skipPrompt;
+    }
+
+    public void setSkipPrompt(boolean skipPrompt) {
+
+        this.skipPrompt = skipPrompt;
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/StepConfig.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/StepConfig.java
@@ -239,11 +239,21 @@ public class StepConfig implements Serializable {
         this.forced = forced;
     }
 
+    /**
+     * This method is used to check whether the prompt should be skipped or not.
+     *
+     * @return True if the prompt should be skipped.
+     */
     public boolean isSkipPrompt() {
 
         return skipPrompt;
     }
 
+    /**
+     * This method is used to set whether the prompt should be skipped or not.
+     *
+     * @param skipPrompt True if the prompt should be skipped.
+     */
     public void setSkipPrompt(boolean skipPrompt) {
 
         this.skipPrompt = skipPrompt;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraphBuilder.java
@@ -257,6 +257,8 @@ public abstract class JsGraphBuilder implements JsBaseGraphBuilder {
         if (Boolean.parseBoolean(stepOptions.get(FrameworkConstants.JSAttributes.SUBJECT_ATTRIBUTE_PARAM))) {
             setCurrentStepAsSubjectAttribute(stepConfig, stepConfigMap);
         }
+        stepConfig.setSkipPrompt(Boolean.parseBoolean(stepOptions.get(
+                FrameworkConstants.JSAttributes.SKIP_PROMPT)));
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/openjdk/nashorn/JsOpenJdkNashornGraphBuilder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/openjdk/nashorn/JsOpenJdkNashornGraphBuilder.java
@@ -435,6 +435,8 @@ public class JsOpenJdkNashornGraphBuilder extends JsGraphBuilder {
         if (Boolean.parseBoolean(stepOptions.get(FrameworkConstants.JSAttributes.SUBJECT_ATTRIBUTE_PARAM))) {
             setCurrentStepAsSubjectAttribute(stepConfig, stepConfigMap);
         }
+        stepConfig.setSkipPrompt(Boolean.parseBoolean(stepOptions.get(
+                FrameworkConstants.JSAttributes.SKIP_PROMPT)));
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -588,6 +588,7 @@ public abstract class FrameworkConstants {
         public static final String FORCE_AUTH_PARAM = "forceAuth";
         public static final String SUBJECT_IDENTIFIER_PARAM = "markAsSubjectIdentifierStep";
         public static final String SUBJECT_ATTRIBUTE_PARAM = "markAsSubjectAttributeStep";
+        public static final String SKIP_PROMPT = "skipPrompt";
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

- We are introducing a new step config named as 'skipPrompt' which can be used to skip prompting the user for an input during an authentication step. 
- The default value will remain as false and this config can be set to true through the adaptive script.