### PR TITLE
Fix JARMResponseJwtValidityPeriod not effected issue

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -288,8 +288,6 @@
                 <ResponseModeName>form_post</ResponseModeName>
                 <ResponseModeProviderClass>org.wso2.carbon.identity.oauth2.responsemode.provider.impl.FormPostResponseModeProvider</ResponseModeProviderClass>
             </SupportedResponseMode>
-            <!-- Validity period for jarm response jwt in seconds -->
-            <JARMResponseJwtValidityPeriodInSeconds>7200</JARMResponseJwtValidityPeriodInSeconds>
             <SupportedResponseMode>
                 <ResponseModeName>jwt</ResponseModeName>
                 <ResponseModeProviderClass>org.wso2.carbon.identity.oauth2.responsemode.provider.jarm.impl.JwtResponseModeProvider</ResponseModeProviderClass>
@@ -309,6 +307,9 @@
         </SupportedResponseModes>
 
         <DefaultResponseModeProviderClass>org.wso2.carbon.identity.oauth2.responsemode.provider.impl.DefaultResponseModeProvider</DefaultResponseModeProviderClass>
+        
+        <!-- Validity period for jarm response jwt in seconds -->
+        <JARMResponseJwtValidityPeriodInSeconds>7200</JARMResponseJwtValidityPeriodInSeconds>
 
         <!-- Supported Response Types -->
         <SupportedResponseTypes>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -309,7 +309,7 @@
         <DefaultResponseModeProviderClass>org.wso2.carbon.identity.oauth2.responsemode.provider.impl.DefaultResponseModeProvider</DefaultResponseModeProviderClass>
         
         <!-- Validity period for jarm response jwt in seconds -->
-        <JARMResponseJwtValidityPeriodInSeconds>7200</JARMResponseJwtValidityPeriodInSeconds>
+        <JARMResponseJwtValidityPeriodInSeconds>600</JARMResponseJwtValidityPeriodInSeconds>
 
         <!-- Supported Response Types -->
         <SupportedResponseTypes>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -340,8 +340,6 @@
                 <ResponseModeProviderClass>org.wso2.carbon.identity.oauth2.responsemode.provider.impl.FormPostResponseModeProvider</ResponseModeProviderClass>
             </SupportedResponseMode>
             {% if oauth.jarm.enable is sameas true %}
-             <!-- Validity period for jarm response jwt in seconds -->
-            <JARMResponseJwtValidityPeriodInSeconds>{{oauth.jarm.jarm_response_jwt_validity}}</JARMResponseJwtValidityPeriodInSeconds>
                 {% if oauth.jarm.jwt.enable is sameas true %}
                 <SupportedResponseMode>
                     <ResponseModeName>jwt</ResponseModeName>
@@ -376,6 +374,11 @@
         </SupportedResponseModes>
 
         <DefaultResponseModeProviderClass>org.wso2.carbon.identity.oauth2.responsemode.provider.impl.DefaultResponseModeProvider</DefaultResponseModeProviderClass>
+
+        {% if oauth.jarm.enable is sameas true %}
+        <!-- Validity period for jarm response jwt in seconds -->
+        <JARMResponseJwtValidityPeriodInSeconds>{{oauth.jarm.jarm_response_jwt_validity}}</JARMResponseJwtValidityPeriodInSeconds>
+        {% endif %}
 
         <!-- Supported Response Types -->
         <SupportedResponseTypes>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -265,7 +265,7 @@
   "oauth.jarm.query_jwt.enable": true,
   "oauth.jarm.fragment_jwt.enable": true,
   "oauth.jarm.form_post_jwt.enable": true,
-  "oauth.jarm.jarm_response_jwt_validity": "7200",
+  "oauth.jarm.jarm_response_jwt_validity": "600",
   "oauth.jarm.response_mode.jwt.class": "org.wso2.carbon.identity.oauth2.responsemode.provider.jarm.impl.JwtResponseModeProvider",
   "oauth.jarm.response_mode.query_jwt.class": "org.wso2.carbon.identity.oauth2.responsemode.provider.jarm.impl.QueryJwtResponseModeProvider",
   "oauth.jarm.response_mode.fragment_jwt.class": "org.wso2.carbon.identity.oauth2.responsemode.provider.jarm.impl.FragmentJwtResponseModeProvider",


### PR DESCRIPTION
JARMResponseJwtValidityPeriod config was not properly set. This PR fixes it. And the default value is set to `600` (10mins) as recommended by FAPI-JARM compliance.