### PR TITLE
Include "View" API Resources in Write Scopes

### DIFF
--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionManagerImpl.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionManagerImpl.java
@@ -130,7 +130,7 @@ public class APIResourceCollectionManagerImpl implements APIResourceCollectionMa
             List<APIResource> readAPIResources =
                     filterAPIResources(allAPIResources, clonedCollection.getReadScopes());
             List<APIResource> writeAPIResources =
-                    filterAPIResources(allAPIResources, clonedCollection.getWriteScopes());
+                    filterAPIResources(allAPIResources, new ArrayList<>(combinedScopes));
 
             Map<String, List<APIResource>> apiResourcesMap = new HashMap<>();
             apiResourcesMap.put(APIResourceCollectionManagementConstants.READ, readAPIResources);


### PR DESCRIPTION
### Proposed changes in this pull request
In the current implementation, "Read" api resource, includes resources necessary for viewing specific features. Similarly, under "Write," the API resources required for create, update, and delete operations are included. With this proposed update, read API resources will also be sent under "Write".

### Related Issues
- https://github.com/wso2/product-is/issues/18070