### PR TITLE
Fix my account MFA backup codes bug

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1293,6 +1293,8 @@
   "myaccount.client_id": "MY_ACCOUNT",
   "myaccount.login_callback_path": "",
   "myaccount.logout_callback_path": "",
+  "myaccount.enable_mfa_user_wise": true,
+  "myaccount.force_backup_code": true,
   "myaccount.route_paths.home": "/overview",
   "myaccount.route_paths.login": "",
   "myaccount.route_paths.logout": "/logout",


### PR DESCRIPTION
### Purpose

This will introduce some missing configs which caused a bug in the MFA backup codes section in the My Account

### Related Issues
- https://github.com/wso2/product-is/issues/18006
- https://github.com/wso2/product-is/issues/18008