### PR TITLE
Add safety null check for when setting String fields in SPs

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -5060,7 +5060,9 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         ServiceProviderProperty androidPackageName = new ServiceProviderProperty();
         androidPackageName.setName(ANDROID_PACKAGE_NAME_PROPERTY_NAME);
         androidPackageName.setDisplayName(ANDROID_PACKAGE_NAME_DISPLAY_NAME);
-        androidPackageName.setValue(String.valueOf(clientAttestationMetaData.getAndroidPackageName()));
+        if (StringUtils.isNotBlank(clientAttestationMetaData.getAndroidPackageName())) {
+            androidPackageName.setValue(String.valueOf(clientAttestationMetaData.getAndroidPackageName()));
+        }
         return androidPackageName;
     }
 
@@ -5070,7 +5072,9 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         ServiceProviderProperty appleAppId = new ServiceProviderProperty();
         appleAppId.setName(APPLE_APP_ID_PROPERTY_NAME);
         appleAppId.setDisplayName(APPLE_APP_ID_DISPLAY_NAME);
-        appleAppId.setValue(String.valueOf(clientAttestationMetaData.getAppleAppId()));
+        if (StringUtils.isNotBlank(clientAttestationMetaData.getAppleAppId())) {
+            appleAppId.setValue(String.valueOf(clientAttestationMetaData.getAppleAppId()));
+        }
         return appleAppId;
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request
> $subject

When updating an SP if the value returned from the db is null, the value returned to the FE will be String "null". This effort adds a safety check and only updates the field if the value is not null. If the value is null, FE will receive the value as a null.

Resolves https://github.com/wso2/product-is/issues/18019