### PR TITLE
Remove deriving tenantAwareUsername from federated IDP flows

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -54,7 +54,6 @@ import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.claim.Claim;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
-import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -118,7 +117,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
         try {
             int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
             UserRealm realm = (UserRealm) realmService.getTenantUserRealm(tenantId);
-            String username = MultitenantUtils.getTenantAwareUsername(subject);
+            String username = subject;
 
             String userStoreDomain;
             UserStoreManager userStoreManager;
@@ -167,7 +166,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
         try {
             int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
             UserRealm realm = (UserRealm) realmService.getTenantUserRealm(tenantId);
-            String username = MultitenantUtils.getTenantAwareUsername(subject);
+            String username = subject;
 
             String userStoreDomain;
             UserStoreManager userStoreManager;
@@ -467,6 +466,16 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
         }
     }
 
+    /**
+     * Creates federated user association.
+     *
+     * @param username        Username of the user.
+     * @param userStoreDomain User store domain of the user.
+     * @param tenantDomain    Tenant domain of the user.
+     * @param subject         Subject of the user.
+     * @param idp             Identity provider of the user.
+     * @throws FrameworkException If an error occurs while associating the user.
+     */
     protected void associateUser(String username, String userStoreDomain, String tenantDomain, String subject,
                                  String idp) throws FrameworkException {
 
@@ -509,7 +518,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
         User user = new User();
         user.setTenantDomain(tenantDomain);
         user.setUserStoreDomain(userStoreDomain);
-        user.setUserName(MultitenantUtils.getTenantAwareUsername(username));
+        user.setUserName(username);
         return user;
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request
> In this effort we remove retrieving tenant aware username from subject value sent by an external idp.

In user provisioning flow, the username is being extracted from the subject value sent by the federated idp. The subject value sent by the IDP is independent from the tenant domain of the configured application. Therefore, when username is being extracted, there is no need to get tenantAwareUsername from the given subject. 

This effort covers the scenario for the JIT silent provisioning. 

Resolves https://github.com/wso2/product-is/issues/18129

