### PR TITLE
Improve the service URL build for retrieval clients

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2013, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2013-2023, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.AuthenticationStep;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
@@ -38,6 +39,8 @@ import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 
@@ -355,13 +358,22 @@ public class ConfigurationFacade {
                 path = urlFromFileBasedConfig;
             }
         }
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
+        ServiceURLBuilder serviceURLBuilder = ServiceURLBuilder.create().addPath(path);
         try {
-            String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
-            return ServiceURLBuilder.create().addPath(path).setOrganization(organizationId).build()
-                    .getAbsolutePublicURL();
+            // If the organization ID is not set in the context for a tenant which is associated to an organization.
+            if (StringUtils.isEmpty(organizationId) && OrganizationManagementUtil.isOrganization(tenantDomain)) {
+                organizationId = FrameworkServiceDataHolder.getInstance().getOrganizationManager()
+                        .resolveOrganizationId(tenantDomain);
+            }
+            return serviceURLBuilder.setOrganization(organizationId).build().getAbsolutePublicURL();
         } catch (URLBuilderException e) {
             throw new IdentityRuntimeException(
                     "Error while building tenant qualified url for context: " + defaultContext, e);
+        } catch (OrganizationManagementException e) {
+            throw new IdentityRuntimeException(
+                    "Error while resolving organization by tenant domain: " + tenantDomain, e);
         }
     }
 }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
@@ -36,6 +36,7 @@ import org.json.JSONObject;
 import org.owasp.encoder.Encode;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.core.SameSiteCookie;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
@@ -778,6 +779,12 @@ public class IdentityManagementEndpointUtil {
                 if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
                     basePath = ServiceURLBuilder.create().addPath(context).setTenant(tenantDomain).build()
                             .getAbsoluteInternalURL();
+                    if (basePath != null && basePath.contains(FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX)) {
+                    /* Resolving tenant domain from organization ID is not provided by an API. Hence, the retrieval
+                       client will have to assume organization ID is same as tenant domain. */
+                    basePath = basePath.replace(FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX,
+                                FrameworkConstants.TENANT_CONTEXT_PREFIX);
+                    }
                 } else {
                     serverUrl = ServiceURLBuilder.create().build().getAbsoluteInternalURL();
                     if (StringUtils.isNotBlank(tenantDomain) && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/IdentityProviderDataRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/IdentityProviderDataRetrievalClient.java
@@ -260,14 +260,7 @@ public class IdentityProviderDataRetrievalClient {
             throws IdentityProviderDataRetrievalClientException {
 
         try {
-            String endpoint = IdentityManagementEndpointUtil.getBasePath(tenantDomain, context);
-            if (endpoint != null && endpoint.contains(FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX)) {
-                /* Resolving tenant domain from organization ID is not provided by an API. Hence, the retrieval client
-                will have to assume organization ID is same as tenant domain. */
-                endpoint = endpoint.replace(FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX,
-                        FrameworkConstants.TENANT_CONTEXT_PREFIX);
-            }
-            return endpoint;
+            return IdentityManagementEndpointUtil.getBasePath(tenantDomain, context);
         } catch (ApiException e) {
             throw new IdentityProviderDataRetrievalClientException("Error while building url for context: " + context);
         }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2344,9 +2344,6 @@
                     <Path>/api/server/v1/branding-preference/resolve</Path>
                     <Path>/api/server/v1/branding-preference/text</Path>
                     <Path>/api/server/v1/branding-preference/text/resolve</Path>
-                    <Path>/api/identity/recovery/v0.9</Path>
-                    <Path>/api/server/v1/identity-governance/preferences</Path>
-                    <Path>/api/server/v1/identity-governance</Path>
                     <Path>/api/identity/auth/v1.1/data</Path>
                 </SubPaths>
             </Context>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3438,9 +3438,6 @@
                     <Path>/api/server/v1/branding-preference/resolve</Path>
                     <Path>/api/server/v1/branding-preference/text</Path>
                     <Path>/api/server/v1/branding-preference/text/resolve</Path>
-                    <Path>/api/identity/recovery/v0.9</Path>
-                    <Path>/api/server/v1/identity-governance/preferences</Path>
-                    <Path>/api/server/v1/identity-governance</Path>
                     <Path>/api/identity/auth/v1.1/data</Path>
                 </SubPaths>
             </Context>


### PR DESCRIPTION
### Proposed changes in this pull request

There were set of APIs exposed for organization qualified paths due to the retrieval clients invoke those APIs with organization qualified paths. 

```
<Path>/api/identity/recovery/v0.9</Path>
<Path>/api/server/v1/identity-governance/preferences</Path>
<Path>/api/server/v1/identity-governance</Path>
```

In this PR, all the organization resource related retrieval related API calls are executed in tenanted path with the base assumption of tenant domain and organization ID are equal for the organizations.

$subject

#### Related Issues
- https://github.com/wso2/product-is/issues/18155