### PR TITLE
Add sha256 configs

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationManagementUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationManagementUtil.java
@@ -417,7 +417,13 @@ public class IdentityApplicationManagementUtil {
 
         if (encodedCert != null) {
             MessageDigest digestValue = null;
-            digestValue = MessageDigest.getInstance("SHA-256");
+            String algorithm;
+            if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.CERT_THUMBPRINT_ENABLE_SHA256))) {
+                algorithm = "SHA-256";
+            } else {
+                algorithm = "SHA-1";
+            }
+            digestValue = MessageDigest.getInstance(algorithm);
             byte[] der = Base64.decode(encodedCert);
             digestValue.update(der);
             byte[] digestInBytes = digestValue.digest();

--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -164,7 +164,8 @@ public class IdentityConstants {
     // User account association constants
     public static final String USER_ACCOUNT_ASSOCIATION_ENABLE_SHA256_KEY = "UserAccountAssociation.EnableSHA256Key";
 
-    public static final String IDENTITY_UTIL_ENABLE_SHA256_RANDOM_NUMBERS = "EnableSHA256RandomNumberGenerator";
+    public static final String IDENTITY_UTIL_ENABLE_SHA256 = "IdentityUtil.EnableSHA256";
+    public static final String CERT_THUMBPRINT_ENABLE_SHA256 = "CertThumbprint.EnableSHA256";
 
     private IdentityConstants() {
     }
@@ -415,14 +416,6 @@ public class IdentityConstants {
     }
 
     /**
-     * Common constants related to Mex endpoint
-     */
-    public static class MEX {
-
-        public static final String ENABLE_SHA256_SIGNATURE_ALG = "Mex.EnableSHA256Alg";
-    }
-
-    /**
      * Common constants realted to SCIM
      */
     public static class SCIM {
@@ -498,7 +491,6 @@ public class IdentityConstants {
         public static final String SIMPLE_REGISTRATION = "sreg";
         public static final String ATTRIBUTE_EXCHANGE = "ax";
         public static final String PAPE = "pape";
-        public static final String ENABLE_SHA256_PPID_DISPLAY_VALUE = "OpenID.EnableSHA256PPIDDisplayValue";
 
         public static class PapeAttributes {
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -332,7 +332,7 @@ public class IdentityUtil {
         byte[] rawPpid = Base64.getDecoder().decode(value);
 
         String algorithm;
-        if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.OpenId.ENABLE_SHA256_PPID_DISPLAY_VALUE))) {
+        if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.IDENTITY_UTIL_ENABLE_SHA256))) {
             algorithm = SHA256_ALGORITHM;
         } else {
             algorithm = SHA1_ALGORITHM;
@@ -367,8 +367,14 @@ public class IdentityUtil {
 
     public static String getHMAC(String secretKey, String baseString) throws SignatureException {
         try {
-            SecretKeySpec key = new SecretKeySpec(secretKey.getBytes(), HMAC_SHA256_ALGORITHM);
-            Mac mac = Mac.getInstance(HMAC_SHA256_ALGORITHM);
+            String algorithm;
+            if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.IDENTITY_UTIL_ENABLE_SHA256))) {
+                algorithm = HMAC_SHA256_ALGORITHM;
+            } else {
+                algorithm = HMAC_SHA1_ALGORITHM;
+            }
+            SecretKeySpec key = new SecretKeySpec(secretKey.getBytes(), algorithm);
+            Mac mac = Mac.getInstance(algorithm);
             mac.init(key);
             byte[] rawHmac = mac.doFinal(baseString.getBytes());
             return Base64.getEncoder().encodeToString(rawHmac);
@@ -414,7 +420,7 @@ public class IdentityUtil {
             String baseString = UUIDGenerator.generateUUID();
 
             String algorithm;
-            if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.IDENTITY_UTIL_ENABLE_SHA256_RANDOM_NUMBERS))) {
+            if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.IDENTITY_UTIL_ENABLE_SHA256))) {
                 algorithm = HMAC_SHA256_ALGORITHM;
             } else {
                 algorithm = HMAC_SHA1_ALGORITHM;

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/util/IdentityUtilTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/util/IdentityUtilTest.java
@@ -366,9 +366,9 @@ public class IdentityUtilTest {
     @DataProvider
     public Object[][] getHmacTestData() {
         return new Object[][]{
-                {"Secret", "text2hmac", "z0XIaT8rj/RWZlR+w0OD0TX51g+hEfTnzucHGSbS0f8="},
-                {"Secret", "", "DmWwlxMYdf692IJa9TD+5PHo/4tUn6xTxfme8G0yXPM="},
-                {" ", "", "f/LRRYVdcBczSZySEtT6ENcODf1MJMO6aPLnwDElPkQ="},
+                {"Secret", "text2hmac", "YXtiz29YSC7+tSC/MoSLUp/Bpaw="},
+                {"Secret", "", "C+IW8zY183KCv2ykZKQV1rLVuAY="},
+                {" ", "", "SRJSdgtKDFBrWRewM1+u6JJU3PI="},
         };
     }
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/resources/identity.xml
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/resources/identity.xml
@@ -70,6 +70,10 @@
         <DisableOpenIDDumbMode>false</DisableOpenIDDumbMode>
     </OpenID>
 
+    <IdentityUtil>
+        <EnableSHA256>true</EnableSHA256>
+    </IdentityUtil>
+
     <OAuth>
         <OAuth1RequestTokenUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth/request-token</OAuth1RequestTokenUrl>
         <OAuth1AuthorizeUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth/authorize-url</OAuth1AuthorizeUrl>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -119,8 +119,6 @@
         <OpenIDRememberMeExpiry>7200</OpenIDRememberMeExpiry>
         <!-- To enable or disable openid dumb mode -->
         <DisableOpenIDDumbMode>false</DisableOpenIDDumbMode>
-        <!-- To enable or disable sha256 ppid display value -->
-        <EnableSHA256PPIDDisplayValue>true</EnableSHA256PPIDDisplayValue>
         <!--
                OpenID private association store is configurable from following configs.
                It includes two new replication stores,
@@ -838,10 +836,6 @@
         <EnableDefaultSignatureAndDigestAlgorithm>true</EnableDefaultSignatureAndDigestAlgorithm>
         <EnableLogoutWreplyValidation>true</EnableLogoutWreplyValidation>
     </PassiveSTS>
-
-    <Mex>
-        <EnableSHA256Alg>true</EnableSHA256Alg>
-    </Mex>
 
     <UserAccountAssociation>
         <EnableSHA256Key>true</EnableSHA256Key>
@@ -2529,8 +2523,14 @@
     <!-- Configuration to enable the organization level branding of email templates. -->
     <EnableOrganizationLevelEmailBranding>false</EnableOrganizationLevelEmailBranding>
 
-    <!-- Configuration to enable the generation of random numbers using HMACSHA256 in IdentityUtil-->
-    <EnableSHA256RandomNumberGenerator>true</EnableSHA256RandomNumberGenerator>
+    <!-- Configuration to enable SHA256 in IdentityUtil-->
+    <IdentityUtil>
+        <EnableSHA256>true</EnableSHA256>
+    </IdentityUtil>
+
+    <CertThumbprint>
+        <EnableSHA256>true</EnableSHA256>
+    </CertThumbprint>
 
     <!-- Extension management service configurations -->
     <ExtensionManagementService>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -146,8 +146,6 @@
         <OpenIDRememberMeExpiry>7200</OpenIDRememberMeExpiry>
         <!-- To enable or disable openid dumb mode -->
         <DisableOpenIDDumbMode>false</DisableOpenIDDumbMode>
-        <!-- To enable or disable sha256 ppid display value -->
-        <EnableSHA256PPIDDisplayValue>{{openid.enable_sha256_ppid_value}}</EnableSHA256PPIDDisplayValue>
         <!--
                OpenID private association store is configurable from following configs.
                It includes two new replication stores,
@@ -249,7 +247,7 @@
         {% endif %}
 
         <!-- This configuration is used to enable or disable generation of random numbers using HMAC-SHA256 algorithm.-->
-        <EnableSHA256Params>{{oauth.enable_sha256_params}}</EnableSHA256Params>
+        <EnableSHA256Params>{{oauth.enable_sha256}}</EnableSHA256Params>
 
         <!--
             Default values for OAuth1RequestTokenUrl, OAuth1AccessTokenUrl, OAuth1AuthorizeUrl
@@ -282,7 +280,7 @@
         <OIDCDiscoveryEPUrl>{{oauth.endpoints.oidc_discovery_url}}</OIDCDiscoveryEPUrl>
         <OAuth2DeviceAuthzEPUrl>{{oauth.endpoints.oauth2_device_authz_url}}</OAuth2DeviceAuthzEPUrl>
 
-        <EnableSHA256OAuth2JWKThumbprint>{{oauth.enable_sha256_jwk_thumbprint}}</EnableSHA256OAuth2JWKThumbprint>
+        <EnableSHA256OAuth2JWKThumbprint>{{oauth.jwk_thumbprint_enable_sha256}}</EnableSHA256OAuth2JWKThumbprint>
 
         <!-- If enabled, resident Idp entity id will be honoured as the issuer location in OpenId Connect Discovery -->
         <UseEntityIdAsIssuerInOidcDiscovery>{{oauth.use_entityid_as_issuer_in_oidc_discovery}}</UseEntityIdAsIssuerInOidcDiscovery>
@@ -1203,8 +1201,8 @@
         <SAMLECPEndpoint>{{saml.endpoints.ecp}}</SAMLECPEndpoint>
         <SAMLMetadataValidityPeriod>{{saml.metadata.validity_period}}</SAMLMetadataValidityPeriod>
         <SAMLMetadataSigningEnabled>{{saml.metadata.enable_signing}}</SAMLMetadataSigningEnabled>
-        <SAMLIDPMetadataEnableSHA256Alg>{{saml.metadata.idp_enable_sha256_alg}}</SAMLIDPMetadataEnableSHA256Alg>
-        <SAMLSPMetadataParsingEnableSHA256Alg>{{saml.metadata.sp_enable_sha256_alg}}</SAMLSPMetadataParsingEnableSHA256Alg>
+        <SAMLIDPMetadataEnableSHA256Alg>{{saml.metadata.idp_enable_sha256}}</SAMLIDPMetadataEnableSHA256Alg>
+        <SAMLSPMetadataParsingEnableSHA256Alg>{{saml.metadata.sp_enable_sha256}}</SAMLSPMetadataParsingEnableSHA256Alg>
         <SAML2AuthenticationRequestValidityPeriodEnabled>{{saml.enable_request_validity_period}}</SAML2AuthenticationRequestValidityPeriodEnabled>
         <!-- Request validity period in minutes-->
         <SAML2AuthenticationRequestValidityPeriod>{{saml.request_validity_period}}</SAML2AuthenticationRequestValidityPeriod>
@@ -1252,13 +1250,9 @@
         <EnableLogoutWreplyValidation>{{passive_sts.enable_logout_wreply_validation}}</EnableLogoutWreplyValidation>
     </PassiveSTS>
 
-    <Mex>
-        <EnableSHA256Alg>{{mex.enable_sha256_alg}}</EnableSHA256Alg>
-    </Mex>
-
     <UserAccountAssociation>
-            <EnableSHA256Key>{{user_account_association.enable_sha256_key}}</EnableSHA256Key>
-        </UserAccountAssociation>
+            <EnableSHA256Key>{{user_account_association.enable_sha256}}</EnableSHA256Key>
+    </UserAccountAssociation>
 
     <EntitlementSettings>
         <ThirftBasedEntitlementConfig>
@@ -3879,8 +3873,14 @@
         {% endfor %}
     </OrganizationLevelEmailBrandingFallbacks>
 
-    <!-- Configuration to enable the generation of random numbers using HMACSHA256 in IdentityUtil-->
-    <EnableSHA256RandomNumberGenerator>{{identity_util.enable_sha256_random_numbers}}</EnableSHA256RandomNumberGenerator>
+    <!-- Configuration to enable SHA256 in IdentityUtil-->
+    <IdentityUtil>
+        <EnableSHA256>{{identity_util.enable_sha256}}</EnableSHA256>
+    </IdentityUtil>
+
+    <CertThumbprint>
+        <EnableSHA256>{{cert_thumbprint.enable_sha256}}</EnableSHA256>
+    </CertThumbprint>
 
     <OrganizationUserInvitation>
         <DefaultExpiryTime>{{organization.user.invitation.default.expiry_time}}</DefaultExpiryTime>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -52,7 +52,6 @@
   "remote_fetch.enable": false,
   "remote_fetch.working_directory": "${carbon.home}/tmp/",
 
-  "openid.enable_sha256_ppid_value": true,
   "oauth.token_cleanup.enable": true,
   "oauth.token_cleanup.retain_access_tokens_for_auditing": false,
 
@@ -82,7 +81,7 @@
   "oauth.token_persistence.enable": true,
 
   "oauth.access_token.generate_with_sp_tenant_domain": true,
-  "oauth.enable_sha256_params": true,
+  "oauth.enable_sha256": true,
 
   "oauth.endpoints.oauth1_request_token_url": "$ref{server.base_path}/oauth/request-token",
   "oauth.endpoints.oauth1_authorize_url": "$ref{server.base_path}/oauth/authorize-url",
@@ -105,7 +104,7 @@
   "oauth.endpoints.oidc_web_finger_url": "$ref{server.base_path}/.well-known/webfinger",
   "oauth.endpoints.oidc_discovery_url": "$ref{server.base_path}/oauth2/oidcdiscovery",
   "oauth.endpoints.oauth2_device_authz_url": "$ref{server.base_path}/oauth2/device_authorize",
-  "oauth.enable_sha256_jwk_thumbprint": true,
+  "oauth.jwk_thumbprint_enable_sha256": true,
 
   "oauth.response_type.token.enable": true,
   "oauth.response_type.token.class": "org.wso2.carbon.identity.oauth2.authz.handlers.AccessTokenResponseTypeHandler",
@@ -307,8 +306,8 @@
   "saml.metadata.validity_period": "1h",
   "saml.metadata.enable_signing": false,
   "saml.metadata.enable_authentication_requests_signing": false,
-  "saml.metadata.idp_enable_sha256_alg": true,
-  "saml.metadata.sp_enable_sha256_alg": true,
+  "saml.metadata.idp_enable_sha256": true,
+  "saml.metadata.sp_enable_sha256": true,
 
   "sts.endpoint.idp": "$ref{server.base_path}/services/wso2carbon-sts",
   "sts.local_subject_identifier.include_user_store_domain": true,
@@ -323,8 +322,7 @@
   "passive_sts.endpoints.idp": "$ref{server.base_path}/passivests",
   "passive_sts.endpoints.retry": "$ref{server.base_path}/authenticationendpoint/retry.do",
 
-  "mex.enable_sha256_alg": true,
-  "user_account_association.enable_sha256_key": true,
+  "user_account_association.enable_sha256": true,
 
   "entitlement.thrift.enable": false,
   "entitlement.thrift.receiver_port": "${Ports.ThriftEntitlementReceivePort}",
@@ -1353,7 +1351,8 @@
 
   "show_pending_user_information.enable": true,
   "replace_amr_value_with_idp_sent_values.enable": false,
-  "identity_util.enable_sha256_random_numbers": true,
+  "identity_util.enable_sha256": true,
+  "cert_thumbprint.enable_sha256": true,
   "organization.user.invitation.default.expiry_time": "4320",
   "organization.user.invitation.primary.user_domain": "PRIMARY",
   "organization.user.invitation.default.accept_url": "/accountrecoveryendpoint/acceptinvitation.do",


### PR DESCRIPTION
### Proposed changes in this pull request


This PR adds more configs to revert SHA256 algorithm usages

### Migration impact
The new user account association key length will be longer (44) than the previous (28). To revert the above behavior, use the following deployment.toml config.

1. IdentityUtil - usages in deprecated OpenId 2.0 implementations: getPPIDDisplayValue() method used for getting the PPID display value, getHMAC() for generating tokens, generateUUID() for generating cookies.
To revert this behavior, use the following deployment.toml config.
```
[identity_util]
enable_sha256= false
```
2. Certificate thumbprint generation with generateThumbPrint() method in `IdentityApplicationManagementUtil.java` 
```
[cert_thumbprint]
enable_sha256=false
```

### Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/4567



