### PR TITLE
Change user_self_registration.lock_on_creation config

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -445,7 +445,7 @@
   "identity_mgt.user_self_registration.otp.otp_length": "6",
   "identity_mgt.user_self_registration.enable_account_lock_for_verified_preferred_channel": true,
   "identity_mgt.user_self_registration.enable_detailed_api_response": false,
-  "identity_mgt.user_self_registration.lock_on_creation": true,
+  "identity_mgt.user_self_registration.lock_on_creation": false,
   "identity_mgt.user_self_registration.send_confirmation_on_creation": false,
   "identity_mgt.user_self_registration.notify_account_confirmation": false,
   "identity_mgt.user_self_registration.enable_recaptcha": true,


### PR DESCRIPTION
Issue: 
- https://github.com/wso2/product-is/issues/18321

Change default config as follows as the by default server do not have a email notification mechanism.
```
"identity_mgt.user_self_registration.lock_on_creation": false,
```