### PR TITLE
Add a separate config for federated IDP group claim value separator

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -179,6 +179,8 @@ public abstract class FrameworkConstants {
 
     public static final String FEDERATED_IDP_ROLE_CLAIM_VALUE_SEPARATOR =
             "FederatedIDPRoleClaimValueAttributeSeparator";
+    public static final String FEDERATED_IDP_GROUP_CLAIM_VALUE_SEPARATOR =
+            "FederatedIDPGroupClaimValueAttributeSeparator";
 
     // Current session thread local identifier.
     public static final String CURRENT_SESSION_IDENTIFIER = "currentSessionIdentifier";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2378,20 +2378,20 @@ public class FrameworkUtils {
             idpGroupAttrValue = extAttributesValueMap.get(idpGroupClaimUri);
         }
         List<String> idpGroupValues;
-        String federatedIDPRoleClaimAttributeSeparator;
+        String federatedIDPGroupClaimAttributeSeparator;
         if (idpGroupAttrValue != null) {
-            if (IdentityUtil.getProperty(FrameworkConstants.FEDERATED_IDP_ROLE_CLAIM_VALUE_SEPARATOR) != null) {
-                federatedIDPRoleClaimAttributeSeparator = IdentityUtil.getProperty(FrameworkConstants
-                        .FEDERATED_IDP_ROLE_CLAIM_VALUE_SEPARATOR);
+            if (IdentityUtil.getProperty(FrameworkConstants.FEDERATED_IDP_GROUP_CLAIM_VALUE_SEPARATOR) != null) {
+                federatedIDPGroupClaimAttributeSeparator = IdentityUtil.getProperty(FrameworkConstants
+                        .FEDERATED_IDP_GROUP_CLAIM_VALUE_SEPARATOR);
                 if (log.isDebugEnabled()) {
-                    log.debug("The IDP side role claim value separator is configured as : "
-                            + federatedIDPRoleClaimAttributeSeparator);
+                    log.debug("The IDP side group claim value separator is configured as : "
+                            + federatedIDPGroupClaimAttributeSeparator);
                 }
             } else {
-                federatedIDPRoleClaimAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
+                federatedIDPGroupClaimAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
             }
 
-            idpGroupValues = Arrays.asList(idpGroupAttrValue.split(federatedIDPRoleClaimAttributeSeparator));
+            idpGroupValues = Arrays.asList(idpGroupAttrValue.split(federatedIDPGroupClaimAttributeSeparator));
         } else {
             // No identity provider group values found.
             if (log.isDebugEnabled()) {

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3586,6 +3586,11 @@
     <!--This is the separator that use to separate multiple roles in the role claim value coming from IDP side-->
     <FederatedIDPRoleClaimValueAttributeSeparator>{{federated.idp.role_claim_value_attribute_separator}}</FederatedIDPRoleClaimValueAttributeSeparator>
 
+    {% if federated.idp.group_claim_value_attribute_separator is defined %}
+    <!--This is the separator that use to separate multiple groups in the group claim value coming from IDP side-->
+    <FederatedIDPGroupClaimValueAttributeSeparator>{{federated.idp.group_claim_value_attribute_separator}}</FederatedIDPGroupClaimValueAttributeSeparator>
+    {% endif %}
+
      {% if system_applications.fidp_role_based_authz_enabled_apps is defined %}
      <!-- Following applications can use federated user role based authorization -->
      <FIdPRoleBasedAuthzApplications>


### PR DESCRIPTION
### Proposed changes in this pull request
- In the implementation of https://github.com/wso2/product-is/issues/18283, federated IDP role claim value separator is used as the separator for federated IDP group claim value. With this, new config is introduced if a separate group claim value separator is needed.
