### PR TITLE
Check the existence of everyone and admin roles before retrieving role IDs

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -571,6 +571,10 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                     realm.getRealmConfiguration().getAdminRoleName());
             String superAdminRoleId;
             try {
+                if (!roleManagementService.isExistingRoleName(superAdminRoleName, ORGANIZATION, organizationId,
+                        tenantDomain)) {
+                    return;
+                }
                 superAdminRoleId = roleManagementService.getRoleIdByName(superAdminRoleName, ORGANIZATION,
                         organizationId, tenantDomain);
             } catch (IdentityRoleManagementException e) {
@@ -595,6 +599,10 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
         try {
             String everyoneRoleName = UserCoreUtil.removeDomainFromName(
                     realm.getRealmConfiguration().getEveryOneRoleName());
+            if (!roleManagementService.isExistingRoleName(everyoneRoleName, ORGANIZATION, organizationId,
+                    tenantDomain)) {
+                return null;
+            }
             return roleManagementService.getRoleIdByName(everyoneRoleName, ORGANIZATION, organizationId, tenantDomain);
         } catch (IdentityRoleManagementException | UserStoreException e) {
             throw new FrameworkException("Error while retrieving role id for everyone role", e);


### PR DESCRIPTION
### Proposed changes in this pull request
This PR fixes the issue of user provisioning failing when trying to get the role IDs of the everyone role when user log into a sub org through organization sso with federated login. Additionally this PR handles the places where the super admin role id is retrieved.

Issue - https://github.com/wso2/product-is/issues/18453