### PR TITLE
Add default configs to remove unregistered scopes

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -271,6 +271,9 @@
   "oauth.jarm.response_mode.fragment_jwt.class": "org.wso2.carbon.identity.oauth2.responsemode.provider.jarm.impl.FragmentJwtResponseModeProvider",
   "oauth.jarm.response_mode.form_post_jwt.class": "org.wso2.carbon.identity.oauth2.responsemode.provider.jarm.impl.FormPostJwtResponseModeProvider",
 
+  "oauth.drop_unregistered_scopes": true,
+  "oauth.allowed_scopes": ["^device_.*"],
+
   "rest_api_authentication.add_realm_user_to_error": false,
 
   "saml.entity_id": "${carbon.host}",


### PR DESCRIPTION
### Proposed changes in this pull request
- $subject
- Once this PR is merged, all the unregistered scopes will get ignored from the consent page, if the user wants to add an unregistered scope, then he has to send a scope that matches the `^device_.*` regex pattern,
ex: device_1, device_2...
- If the user wants to disable this config, he can do it by simply adding the following configurations to the deployment.toml
```
[oauth]
drop_unregistered_scopes = "false"
allowed_scopes = []
```
- If the user wants to introduce their own customized pattern, then they have to add the configurations has follows in the `deployment.toml`
```
[oauth]
allowed_scopes = ["^device_.*", "any_custome_regex_pattern"]
```
The above config will consider both the default regex pattern (device_) and the customized regex pattern scopes as valid scopes and issue the scopes with the token. If the user wants to remove the default regex pattern, then they can just simply remove the `^device_.*"` regex pattern from the above config and just add their regex patterns and scopes (`allowed_scopes` config support both regex patterns and plain string text).

### Related PR(s)
https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2297

### Related Issue(s)
- https://github.com/wso2/product-is/issues/17551