### PR TITLE
Revert "Move HYPR connector resource files to the store"

### DIFF
--- a/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/hypr/info.json
+++ b/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/hypr/info.json
@@ -1,0 +1,10 @@
+{
+    "id": "hypr-idp",
+    "name": "HYPR",
+    "description": "Enable login for users with existing HYPR accounts.",
+    "image": "assets/images/logos/hypr.svg",
+    "category": "DEFAULT",
+    "displayOrder": 6,
+    "tags": [ "Social-Login" ],
+    "type": "identity-provider"
+}

--- a/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/hypr/metadata.json
+++ b/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/hypr/metadata.json
@@ -1,0 +1,218 @@
+{
+    "create": {
+        "image": "assets/images/logos/hypr.svg",
+        "header": "HYPR",
+        "Subheading": "Enable login for users with existing HYPR accounts.",
+        "documentation": "{ENV}/asgardeo/docs/guides/authentication/#manage-connections",
+        "modal": {
+            "form": {
+                "fields": [
+                    {
+                        "index": 0,
+                        "ariaLabel": "HYPR IDP Name",
+                        "name": "name",
+                        "label": "Name",
+                        "type": "text",
+                        "required": true,
+                        "placeholder": "Enter a name for the connection.",
+                        "initialValue": "HYPR",
+                        "data-testid": "hypr-idp-create-wizard-page-idp-name",
+                        "maxLength": "50",
+                        "minLength": "3",
+                        "width": "13"
+                    },
+                    {
+                        "index": 1,
+                        "ariaLabel": "HYPR App ID", 
+                        "type": "text", 
+                        "name": "appId", 
+                        "label": "Relying Party App ID",
+                        "placeholder": "Enter App ID from HYPR application.",
+                        "required": true, 
+                        "autoComplete": false,
+                        "data-testid": "hypr-idp-create-wizard-page-idp-app-id",
+                        "maxLength": "100",
+                        "minLength": "3",
+                        "width": "13"
+                    },
+                    {
+                        "index": 2,
+                        "ariaLabel": "HYPR Base URL", 
+                        "type": "text", 
+                        "name": "baseUrl", 
+                        "label": "Base URL",
+                        "placeholder": "Enter HYPR server base URL",
+                        "required": true, 
+                        "autoComplete": false,
+                        "data-testid": "hypr-idp-create-wizard-page-idp-base-url",
+                        "maxLength": "100",
+                        "minLength": "3",
+                        "width": "13"
+                    },
+                    {
+                        "index": 3,
+                        "className": "addon-field-wrapper",
+                        "ariaLabel": "HYPR API Token", 
+                        "type": "password", 
+                        "name": "apiToken", 
+                        "label": "API Token",
+                        "placeholder": "Enter API token from HYPR",
+                        "required": true, 
+                        "autoComplete": false,
+                        "testId": "hypr-idp-create-wizard-page-idp-api-token",
+                        "maxLength": "100",
+                        "minLength": "3",
+                        "width": "13"
+                    }
+                ]
+                
+            },
+            "wizardHelp": {
+                "message": {
+                    "header": "Prerequites",
+                    "paragraphs": [
+                        "Before you begin, create a RP application in <a href={ hyprControlCentreDocUrl } target=\"_blank\" rel=\"noopener noreferrer\">HYPR control centre</a>, and obtain the application ID.",                    
+                        "You also have to obtain an <a href={ hyprTokenDocUrl } target=\"_blank\" rel=\"noopener noreferrer\">API Token</a> for the application you have created."
+                    ]
+                },
+                "fields": [
+                    {
+                        "fieldName": "Name",
+                        "hint": "Provide a unique name for the connection."
+                    },
+                    {
+                        "fieldName": "App ID",
+                        "hint": "Provide the <Code class=\"inline-code\">Application ID</Code> of the application registered in the HYPR control center."
+                    },
+                    {
+                        "fieldName": "Base URL",
+                        "hint": "Provide the <Code class=\"inline-code\">Base URL</Code> of your HYPR server deployment."
+                    },
+                    {
+                        "fieldName": "API Token",
+                        "hint": "Provide the <Code class=\"inline-code\">API Token</Code> obtained from HYPR. This will be used to access HYPR's APIs."
+                    }
+                ]
+            }
+        },
+        "properties": [
+            {
+                "key": "appId",
+                "value": ""
+            },
+            {
+                "key": "apiToken",
+                "value": ""
+            },
+            {
+                "key": "baseUrl",
+                "value": ""
+            }
+        ]
+    },
+    "edit" : {
+        "tabs": {
+            "general" : [
+                {
+                    "index": 0,
+                    "displayOrder" : 1,
+                    "ariaLabel": "name", 
+                    "inputType": "resource_name",
+                    "type": "text",
+                    "name": "name",
+                    "label": "Name",
+                    "required": true ,
+                    "message": "Identity Provider name is required",
+                    "placeholder": "HYPR",
+                    "validation": true,
+                    "value": "",
+                    "maxLength": "50",
+                    "minLength": "3",
+                    "data-testid": "idp-edit-page-general-settings-form-idp-name",
+                    "hint": "Enter a unique name for this connection.",
+                    "readOnly": false
+                },
+                {
+                    "index": 1,
+                    "displayOrder" : 2,
+                    "type": "textarea", 
+                    "name" : "description",
+                    "ariaLabel" : "description",
+                    "label" : "Description",
+                    "required": false,
+                    "placeholder": "Enter a description of the identity provider.",
+                    "value": "",
+                    "data-testid": "idp-edit-page-general-settings-form-idp-description",
+                    "maxLength": "300",
+                    "minLength": "3",
+                    "hint": "A text description of the identity provider.",
+                    "readOnly": false
+                },
+                {
+                    "index": 2,
+                    "displayOrder" : 3,
+                    "name": "jwks_endpoint",
+                    "ariaLabel": "JWKS Endpoint URL",
+                    "inputType": "url",
+                    "type": "text",
+                    "label": "JWKS Endpoint URL",
+                    "required": true,
+                    "placeholder": "https://{ oauth-provider-url }/oauth/jwks",
+                    "value": "",
+                    "data-testid": "",
+                    "maxLength": "2048",
+                    "minLength": "10",
+                    "hint": "A JSON Web Key (JWK) Set is a JSON object that represents a set of JWKs. The JSON object MUST have a keys member, with its value being an array of JWKs.",
+                    "readOnly": false
+                },
+                {
+                    "index": 3,
+                    "displayOrder" : 4,
+                    "type": "certbox",
+                    "isJWKSEnabled": "",
+                    "isReadOnly": "",
+                    "editingIDP": "",
+                    "onUpdate": "",
+                    "isPEMEnabled": ""
+                }
+            ],
+            "settings" : [
+                {
+                    "index": 0,
+                    "displayOrder" : 5,
+                    "label": "Base URL",
+                    "data-testid": "idp-edit-page-authenticator-settings-HYPRAuthenticator-content-form-baseUrl",
+                    "name": "baseUrl",
+                    "required": true,
+                    "type": "text",
+                    "hint": "Enter the base URL of your HYPR server deployment.",
+                    "validation": true
+                },
+                {
+                    "index": 1,
+                    "displayOrder" : 6,
+                    "label": "Relying Party App ID",
+                    "data-testid": "idp-edit-page-authenticator-settings-HYPRAuthenticator-content-form-appId",
+                    "name": "appId",
+                    "required": true,
+                    "type": "text",
+                    "hint": "Enter the relying party app ID in HYPR control center.",
+                    "validation": false
+                },
+                {
+                    "index": 2,
+                    "displayOrder" : 7,
+                    "label": "API Token",
+                    "data-testid": "idp-edit-page-authenticator-settings-HYPRAuthenticator-content-form-apiToken",
+                    "name": "apiToken",
+                    "required": true,
+                    "type": "password",
+                    "hint": "Enter the relying party app access token generated in the control center.",
+                    "validation": false
+                }
+            ],
+            "quickStart": "hypr"
+        }
+        
+    }
+}

--- a/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/hypr/template.json
+++ b/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/hypr/template.json
@@ -1,0 +1,89 @@
+{
+    "id": "hypr-idp",
+    "name": "HYPR",
+    "description": "Enable login for users with existing HYPR accounts.",
+    "docLink": "/guides/authentication/#manage-connections",
+    "image": "assets/images/logos/hypr.svg",
+    "category": "DEFAULT",
+    "displayOrder": 6,
+    "services": [],
+    "tags": [ "Social-Login" ],
+    "idp": {
+        "name": "HYPR",
+        "description": "",
+        "image": "",
+        "isPrimary": false,
+        "isFederationHub": false,
+        "homeRealmIdentifier": "",
+        "certificate": {
+            "certificates": []
+        },
+        "alias": "https://localhost:9444/oauth2/token",
+        "idpIssuerName": "",
+        "claims": {
+            "userIdClaim": {
+                "uri": "http://wso2.org/claims/username"
+            },
+            "roleClaim": {
+                "uri": "http://wso2.org/claims/role"
+            },
+            "provisioningClaims": []
+        },
+        "roles": {
+            "mappings": [],
+            "outboundProvisioningRoles": []
+        },
+        "federatedAuthenticators": {
+            "defaultAuthenticatorId": "SFlQUkF1dGhlbnRpY2F0b3I",
+            "authenticators": [
+                {
+                    "authenticatorId": "SFlQUkF1dGhlbnRpY2F0b3I",
+                    "isEnabled": true,
+                    "properties": [
+                        {
+                            "key": "appId",
+                            "displayName": "Relying Party App ID",
+                            "description": "Enter application ID of the application registered in HYPR",
+                            "type": "STRING",
+                            "displayOrder": 1,
+                            "regex": ".*",
+                            "isMandatory": true,
+                            "isConfidential": false,
+                            "options": [],
+                            "defaultValue": "",
+                            "subProperties": []
+                        },
+                        {
+                            "key": "apiToken",
+                            "displayName": "API Token",
+                            "description": "Enter API token from HYPR",
+                            "type": "STRING",
+                            "displayOrder": 3,
+                            "regex": ".*",
+                            "isMandatory": true,
+                            "isConfidential": true,
+                            "options": [],
+                            "defaultValue": "",
+                            "subProperties": []
+                        },
+                        {
+                            "key": "baseUrl",
+                            "displayName": "Base URL",
+                            "description": "Enter base URL",
+                            "type": "STRING",
+                            "displayOrder": 2,
+                            "regex": ".*",
+                            "isMandatory": true,
+                            "isConfidential": false,
+                            "options": [],
+                            "defaultValue": "",
+                            "subProperties": []
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "type": "SOCIAL",
+    "templateId": "hypr-idp"
+}

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1046,7 +1046,7 @@
   "console.ui.i18n_configs.langAutoDetectEnabled": false,
   "console.ui.product_name": "WSO2 Identity Server",
   "console.ui.hiddenAuthenticators": [],
-  "console.ui.hiddenConnectionTemplates": [ "swe-idp" ],
+  "console.ui.hiddenConnectionTemplates": [ "hypr-idp", "swe-idp" ],
   "console.ui.google_one_tap_enabled_tenants": [],
   "console.ui.show_app_switch_button": true,
   "console.ui.legacy_mode.apiResources": true,


### PR DESCRIPTION
Reverts wso2/carbon-identity-framework#5272

This will be temporarily reverted due to an error logged by moving the templates to the connector store.