### PR TITLE
Close BufferedReader reader

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/bulkimport/CSVUserBulkImport.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/bulkimport/CSVUserBulkImport.java
@@ -130,8 +130,11 @@ public class CSVUserBulkImport extends UserBulkImport {
                 if (csvReader != null) {
                     csvReader.close();
                 }
+                if (reader != null) {
+                    reader.close();
+                }
             } catch (IOException e) {
-                log.error("Error occurred while closing CSV Reader", e);
+                log.error("Error occurred while closing Reader", e);
             }
         }
     }


### PR DESCRIPTION
### Purpose
A BufferedReader object is initiated in the constructor of the method. However, this reader object is not explicitly closed in the code. Hence, fixed.