### PR TITLE
[perf] Add role based scope validation config enabled check

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1145,6 +1145,12 @@
         <!-- Configuration to enable setting local IDP generated AMR values with the values sent by the used idp. -->
         <ReplaceDefaultAMRValuesWithIDPSentValues>{{replace_amr_value_with_idp_sent_values.enable}}</ReplaceDefaultAMRValuesWithIDPSentValues>
 
+        <!-- Configuration to enable global scope validators. -->
+        <GlobalScopeValidators>
+            <RoleBasedScopeIssuer>
+                <Enable>{{oauth.global_scope_validators.role_based_scope_issuer.enable}}</Enable>
+            </RoleBasedScopeIssuer>
+        </GlobalScopeValidators>
     </OAuth>
 
     <RestApiAuthentication>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -731,6 +731,7 @@
   "oauth.jwks_endpoint.read_timeout": "1s",
   "oauth.jwks_endpoint.size_limit_bytes": "51200",
   "oauth.jwks_endpoint.add_previous_version_kid" : false,
+  "oauth.global_scope_validators.role_based_scope_issuer.enable": false,
 
   "authentication.adaptive.event_publisher.authentication_type": "basic",
   "authentication.adaptive.async_executer_pool_size": "5",


### PR DESCRIPTION
### Proposed changes in this pull request
- By default the role based global scope validation is enable which result in unnecessary scope validation for each and every authorize. To enable the the validator, the below config should be added to `deployment.toml`.

```
[oauth.global_scope_validators.role_based_scope_issuer]
enable=true
```

Related Issues:
- https://github.com/wso2/product-is/issues/16517