### PR TITLE
Add UseLastStatusOnly option to SimplePAPStatusDataHandler

### DIFF
--- a/components/entitlement/org.wso2.carbon.identity.entitlement.common/src/main/java/org/wso2/carbon/identity/entitlement/common/EntitlementConstants.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.common/src/main/java/org/wso2/carbon/identity/entitlement/common/EntitlementConstants.java
@@ -37,6 +37,8 @@ public class EntitlementConstants {
 
     public static final String PDP_SUBSCRIBER_ID = "PDP Subscriber";
 
+    public static final String PROP_USE_LAST_STATUS_ONLY = "EntitlementSettings.XacmlPolicyStatus.UseLastStatusOnly";
+
     public static final class PolicyPublish {
 
         public static final String ACTION_CREATE = "CREATE";

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/SimplePAPStatusDataHandler.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/SimplePAPStatusDataHandler.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.entitlement;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.entitlement.common.EntitlementConstants;
 import org.wso2.carbon.identity.entitlement.dto.PublisherPropertyDTO;
 import org.wso2.carbon.identity.entitlement.dto.StatusHolder;
@@ -173,7 +174,9 @@ public class SimplePAPStatusDataHandler implements PAPStatusDataHandler {
         try {
             registry = EntitlementServiceComponent.getRegistryService().
                     getGovernanceSystemRegistry(tenantId);
-            if (registry.resourceExists(path) && !isNew) {
+            boolean useLastStatusOnly = Boolean.parseBoolean(
+                    IdentityUtil.getProperty(EntitlementConstants.PROP_USE_LAST_STATUS_ONLY));
+            if (registry.resourceExists(path) && !isNew && !useLastStatusOnly) {
                 resource = registry.get(path);
                 String[] versions = registry.getVersions(path);
                 // remove all versions.  As we have no way to disable versioning for specific resource

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1276,6 +1276,9 @@
             <!-- Enable this element to mention the host-name of your IS machine -->
             <ThriftHostName>{{entitlement.thrift.hostname}}</ThriftHostName>
         </ThirftBasedEntitlementConfig>
+        <XacmlPolicyStatus>
+            <UseLastStatusOnly>{{identity.entitlement.xacml_policy_status.use_last_status_only}}</UseLastStatusOnly>
+        </XacmlPolicyStatus>
     </EntitlementSettings>
 
     <SCIM>

--- a/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/org.wso2.carbon.identity.xacml.server.feature.default.json
+++ b/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/org.wso2.carbon.identity.xacml.server.feature.default.json
@@ -41,5 +41,6 @@
   ],
   "identity.entitlement.entitlement_engine_caching_interval": "1d",
   "identity.entitlement.JSON_shorten_form_enabled": false,
-  "identity.entitlement.default_attribute_finder.properties.MapFederatedUsersToLocal": true
+  "identity.entitlement.default_attribute_finder.properties.MapFederatedUsersToLocal": true,
+  "identity.entitlement.xacml_policy_status.use_last_status_only":false
 }


### PR DESCRIPTION
## Purpose 
Add and use UseLastStatusOnly configuration in SimplePAPStatusDataHandler to limit the XACML policy status history to just one entry. 