### PR TITLE
Overload getResourcesByType method with tenantId

### DIFF
--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManager.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManager.java
@@ -108,10 +108,11 @@ public interface ConfigurationManager {
      * @return {@link Resources} object with all the resources of the given resource type name.
      * @throws ConfigurationManagementException Configuration Management Exception.
      */
-   default Resources getResourcesByType(int tenantId, String resourceTypeName) throws ConfigurationManagementException {
+    default Resources getResourcesByType(int tenantId, String resourceTypeName)
+            throws ConfigurationManagementException {
 
-            throw new NotImplementedException("This functionality is not implemented.");
-   }
+        throw new NotImplementedException("This functionality is not implemented.");
+    }
 
     /**
      * Get all the resources belonging to the given {@link ResourceType}.

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManager.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManager.java
@@ -118,7 +118,7 @@ public interface ConfigurationManager {
      * Get all the resources belonging to the given {@link ResourceType}.
      *
      * @param resourceTypeName {@link ResourceType} object name.
-     * @return 200 ok. {@link Resources} object with all the resources of the given resource type name.
+     * @return {@link Resources} object with all the resources of the given resource type name.
      * @throws ConfigurationManagementException Configuration Management Exception.
      */
     Resources getResourcesByType(String resourceTypeName) throws ConfigurationManagementException;

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManager.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManager.java
@@ -101,11 +101,11 @@ public interface ConfigurationManager {
     Resources getResources() throws ConfigurationManagementException;
 
     /**
-     * Get all the resources belongs to the given {@link ResourceType} for a given tenant ID.
+     * Get all the resources belonging to the given {@link ResourceType} for a given tenant ID.
 
      * @param tenantId         The ID of the tenant.
      * @param resourceTypeName {@link ResourceType} object name.
-     * @return 200 ok. @link Resources} object with all the resources of the given resource type name.
+     * @return {@link Resources} object with all the resources of the given resource type name.
      * @throws ConfigurationManagementException Configuration Management Exception.
      */
    default Resources getResourcesByType(int tenantId, String resourceTypeName) throws ConfigurationManagementException {
@@ -114,10 +114,10 @@ public interface ConfigurationManager {
    }
 
     /**
-     * Get all the resources belongs to the given {@link ResourceType}.
+     * Get all the resources belonging to the given {@link ResourceType}.
      *
      * @param resourceTypeName {@link ResourceType} object name.
-     * @return 200 ok. @link Resources} object with all the resources of the given resource type name.
+     * @return 200 ok. {@link Resources} object with all the resources of the given resource type name.
      * @throws ConfigurationManagementException Configuration Management Exception.
      */
     Resources getResourcesByType(String resourceTypeName) throws ConfigurationManagementException;

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManager.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManager.java
@@ -101,6 +101,19 @@ public interface ConfigurationManager {
     Resources getResources() throws ConfigurationManagementException;
 
     /**
+     * Get all the resources belongs to the given {@link ResourceType} for a given tenant ID.
+
+     * @param tenantId         The ID of the tenant.
+     * @param resourceTypeName {@link ResourceType} object name.
+     * @return 200 ok. @link Resources} object with all the resources of the given resource type name.
+     * @throws ConfigurationManagementException Configuration Management Exception.
+     */
+   default Resources getResourcesByType(int tenantId, String resourceTypeName) throws ConfigurationManagementException {
+
+            throw new NotImplementedException("This functionality is not implemented.");
+   }
+
+    /**
      * Get all the resources belongs to the given {@link ResourceType}.
      *
      * @param resourceTypeName {@link ResourceType} object name.

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManagerImpl.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManagerImpl.java
@@ -161,12 +161,24 @@ public class ConfigurationManagerImpl implements ConfigurationManager {
     /**
      * {@inheritDoc}
      */
+    public Resources getResourcesByType(int tenantId, String resourceTypeName) throws ConfigurationManagementException {
+
+        return retrieveResourcesByType(tenantId, resourceTypeName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public Resources getResourcesByType(String resourceTypeName) throws ConfigurationManagementException {
+
+        return retrieveResourcesByType(getTenantId(), resourceTypeName);
+    }
+
+    private Resources retrieveResourcesByType(int tenantId, String resourceTypeName) throws ConfigurationManagementException {
 
         validateResourcesRetrieveRequest(resourceTypeName);
         ResourceType resourceType = getResourceType(resourceTypeName);
-        List<Resource> resourceList = this.getConfigurationDAO()
-                .getResourcesByType(getTenantId(), resourceType.getId());
+        List<Resource> resourceList = this.getConfigurationDAO().getResourcesByType(tenantId, resourceType.getId());
         if (resourceList == null) {
             if (log.isDebugEnabled()) {
                 log.debug("No resource found for the resourceTypeName: " + resourceTypeName);


### PR DESCRIPTION
### Proposed changes in this pull request
$subject
 The `getResourcesByType` method has been overloaded to facilitate the retrieval of resources based on the provided tenantId.

### Related Issues
- https://github.com/wso2/product-is/issues/18247

