### PR TITLE
Remove backtick from username

### DIFF
--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -79,7 +79,7 @@ public class Constants {
         public static final String JAVA_REGEX_PATTERN = "^((?=.*\\d)(?=.*[a-z])(?=.*[A-Z])).{8,100}$";
         public static final String DEFAULT_ALPHANUMERIC_REGEX_PATTERN = "^(?=.*[a-zA-Z])[a-zA-Z0-9]+$";
         public static final String ALPHANUMERIC_REGEX_PATTERN_WITH_SPECIAL_CHARACTERS =
-                "^(?=.*[a-zA-Z])[a-zA-Z0-9!@#$%&'*+\\\\=?^_.{|}~-]+$";
+                "^(?=.*[a-zA-Z])[a-zA-Z0-9!@#$&'+\\\\=^_.{|}~-]+$";
         public static final String DEFAULT_EMAIL_JAVA_REGEX_PATTERN =
             "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![.+\\-_]{2})[\\u00C0-\\u00FF\\w.+\\-]){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0" +
             "-9]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -79,7 +79,7 @@ public class Constants {
         public static final String JAVA_REGEX_PATTERN = "^((?=.*\\d)(?=.*[a-z])(?=.*[A-Z])).{8,100}$";
         public static final String DEFAULT_ALPHANUMERIC_REGEX_PATTERN = "^(?=.*[a-zA-Z])[a-zA-Z0-9]+$";
         public static final String ALPHANUMERIC_REGEX_PATTERN_WITH_SPECIAL_CHARACTERS =
-                "^(?=.*[a-zA-Z])[a-zA-Z0-9!@#$%&'*+\\\\=?^_`.{|}~-]+$";
+                "^(?=.*[a-zA-Z])[a-zA-Z0-9!@#$%&'*+\\\\=?^_.{|}~-]+$";
         public static final String DEFAULT_EMAIL_JAVA_REGEX_PATTERN =
             "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![.+\\-_]{2})[\\u00C0-\\u00FF\\w.+\\-]){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0" +
             "-9]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";


### PR DESCRIPTION
### Description
Remove backtick from the username regex as a security measure.