### PR TITLE
Add legacy mode config for SaaS applications

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1062,6 +1062,7 @@
   "console.ui.legacy_mode.rolesV1": false,
   "console.ui.legacy_mode.roleMapping": false,
   "console.ui.legacy_mode.secretsManagement": false,
+  "console.ui.legacy_mode.saasApplications": false,
   "console.ui.isXacmlConnectorEnabled": false,
   "console.theme": "wso2is",
   "console.session.params.userIdleTimeOut": 600,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -252,7 +252,8 @@
       "console.ui.legacy_mode.approvals": true,
       "console.ui.legacy_mode.certificates": true,
       "console.ui.legacy_mode.loginAndRegistrationEmailDomainDiscovery": true,
-      "console.ui.legacy_mode.organizations": false
+      "console.ui.legacy_mode.organizations": false,
+      "console.ui.legacy_mode.saasApplications": true
     }
   }
 }


### PR DESCRIPTION
### Purpose

This will add a configuration to show/hide SaaS application configuration based on the legacy mode in the console

### Related Issues

- https://github.com/wso2/product-is/issues/18611

### Related PRs

- https://github.com/wso2/identity-apps/pull/5091