### PR TITLE
Fix reverting properties to default values when disabling JIT Provisioning.

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -3152,7 +3152,7 @@ public class IdPManagementDAO {
             attributeSyncMethod.setValue(IdPManagementConstants.PRESERVE_LOCAL_ATTRIBUTE_SYNC);
         }
 
-        if (justInTimeProvisioningConfig != null && justInTimeProvisioningConfig.isProvisioningEnabled()) {
+        if (justInTimeProvisioningConfig != null) {
             passwordProvisioningProperty
                     .setValue(String.valueOf(justInTimeProvisioningConfig.isPasswordProvisioningEnabled()));
             modifyUserNameProperty.setValue(String.valueOf(justInTimeProvisioningConfig.isModifyUserNameAllowed()));


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/18649

When the Just-in-Time (JIT) User Provisioning checkbox in JIT settings is unchecked to disable JIT provisioning and the settings are updated, it unexpectedly reverts properties back to their default values in JIT settings. 