### PR TITLE
Subscribe identityOauthEventHandler for new events related to Role v2

### DIFF
--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -173,7 +173,10 @@
     "POST_SET_USER_CLAIM",
     "POST_UPDATE_USER_LIST_OF_ROLE_EVENT",
     "PRE_DELETE_ROLE_EVENT",
-    "POST_SET_PERMISSIONS_FOR_ROLE_EVENT"
+    "POST_SET_PERMISSIONS_FOR_ROLE_EVENT",
+    "POST_UPDATE_USER_LIST_OF_ROLE_V2_EVENT",
+    "PRE_DELETE_ROLE_V2_EVENT",
+    "POST_UPDATE_PERMISSIONS_FOR_ROLE_V2_EVENT"
   ],
   "identity_mgt.events.schemes.userOperationDataDASPublisher.module_index": "29",
   "identity_mgt.events.schemes.userOperationDataDASPublisher.properties.enable": false,


### PR DESCRIPTION
New events are introduced for the purpose of session termination for the role v2 implementation. Those events were not subscribed to the relevant event handlers. This PR will subscribe the event handlers to such events.

Related issue
- https://github.com/wso2/product-is/issues/18813