### PR TITLE
Change the default value of the configuration `use_verify_claim` to `false`

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -469,7 +469,7 @@
   "identity_mgt.user_claim_update.otp.use_lowercase_in_otp": true,
   "identity_mgt.user_claim_update.otp.use_numeric_in_otp": true,
   "identity_mgt.user_claim_update.otp.otp_length": "6",
-  "identity_mgt.user_claim_update.use_verify_claim": true,
+  "identity_mgt.user_claim_update.use_verify_claim": false,
   "identity_mgt.user_claim_update.uniqueness.enable": false,
   "identity_mgt.user_claim_update.uniqueness.listener_priority": "2",
   "identity_mgt.user_claim_update.uniqueness.scope_within_userstore": false,


### PR DESCRIPTION
### Proposed changes in this pull request

- Previously the default value of the config `use_verify_claim` is **true**.
- Due to that even though email address verification on update/mobile number verification on update configs were enable, When updating the email/mobile value, we need to sending an additional temporary claim ('verifyEmail'/'verifyMobile') along with the update request to send the verification mail.
- According to https://github.com/wso2/product-is/issues/18414#issuecomment-1851962680, asking to send the `verifyEmail` or  `verifyMobile` attribute in the request is fundamentally wrong and defeats the purpose of this `email address verification on update` / `mobile number verification on update` features.
- So change the default value of this config to false.

### Related Issue
- https://github.com/wso2/product-is/issues/18414


### Follow up actions

- [ ] Updates Docs Related to `email address verification on update` / `mobile number verification on update` features.