### PR TITLE
Add validation for superAdmin in UserIdentityManagementAdminService SOAP service

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementAdminService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementAdminService.java
@@ -85,8 +85,7 @@ public class UserIdentityManagementAdminService {
         try {
             UserStoreManager userStoreManager = IdentityMgtServiceComponent.getRealmService().
                     getTenantUserRealm(CarbonContext.getThreadLocalCarbonContext().getTenantId()).getUserStoreManager();
-            if (isAttemptToUpdateSuperAdmin(userName)) {
-                log.warn("An attempt to delete admin user.");
+            if (isSuperAdmin(userName)) {
                 throw new org.wso2.carbon.user.core.UserStoreException("You do not have the required privilege to " +
                         "delete superAdmin user");
             }
@@ -110,8 +109,7 @@ public class UserIdentityManagementAdminService {
 
         try {
 
-            if (isAttemptToUpdateSuperAdmin(userName)) {
-                log.warn("An attempt to lock admin user.");
+            if (isSuperAdmin(userName)) {
                 throw new org.wso2.carbon.user.core.UserStoreException("You do not have the required privilege to " +
                         "lock superAdmin user");
             }
@@ -171,8 +169,7 @@ public class UserIdentityManagementAdminService {
     public void disableUserAccount(String userName, String notificationType) throws IdentityMgtServiceException {
 
         try {
-            if (isAttemptToUpdateSuperAdmin(userName)) {
-                log.warn("An attempt to disable admin user.");
+            if (isSuperAdmin(userName)) {
                 throw new org.wso2.carbon.user.core.UserStoreException("You do not have the required privilege to " +
                         "disable superAdmin user");
             }
@@ -272,8 +269,7 @@ public class UserIdentityManagementAdminService {
     public void resetUserPassword(String userName, String newPassword)
             throws IdentityMgtServiceException {
         try {
-            if (isAttemptToUpdateSuperAdmin(userName)) {
-                log.warn("An attempt to update admin user.");
+            if (isSuperAdmin(userName)) {
                 throw new org.wso2.carbon.user.core.UserStoreException("You do not have the required privilege to " +
                         "update superAdmin user");
             }
@@ -658,7 +654,7 @@ public class UserIdentityManagementAdminService {
      * @param userName Username
      * @return boolean
      */
-    private boolean isAttemptToUpdateSuperAdmin(String userName) throws org.wso2.carbon.user.core.UserStoreException {
+    private boolean isSuperAdmin(String userName) throws org.wso2.carbon.user.core.UserStoreException {
 
         String loggedInUserName = CarbonContext.getThreadLocalCarbonContext().getUsername();
         if (loggedInUserName != null) {

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementAdminService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementAdminService.java
@@ -38,9 +38,11 @@ import org.wso2.carbon.identity.mgt.internal.IdentityMgtServiceComponent;
 import org.wso2.carbon.identity.mgt.util.UserIdentityManagementUtil;
 import org.wso2.carbon.identity.mgt.util.Utils;
 import org.wso2.carbon.user.api.AuthorizationManager;
+import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
@@ -83,6 +85,11 @@ public class UserIdentityManagementAdminService {
         try {
             UserStoreManager userStoreManager = IdentityMgtServiceComponent.getRealmService().
                     getTenantUserRealm(CarbonContext.getThreadLocalCarbonContext().getTenantId()).getUserStoreManager();
+            if (isAttemptToUpdateSuperAdmin(userName)) {
+                log.warn("An attempt to delete admin user.");
+                throw new org.wso2.carbon.user.core.UserStoreException("You do not have the required privilege to " +
+                        "delete superAdmin user");
+            }
             userStoreManager.deleteUser(userName);
             log.info("Deleted user: " + userName);
         } catch (UserStoreException e) {
@@ -102,11 +109,18 @@ public class UserIdentityManagementAdminService {
     public void lockUserAccount(String userName) throws IdentityMgtServiceException {
 
         try {
+
+            if (isAttemptToUpdateSuperAdmin(userName)) {
+                log.warn("An attempt to lock admin user.");
+                throw new org.wso2.carbon.user.core.UserStoreException("You do not have the required privilege to " +
+                        "lock superAdmin user");
+            }
+
             UserStoreManager userStoreManager = getUserStore(userName);
             String userNameWithoutDomain = UserCoreUtil.removeDomainFromName(userName);
             UserIdentityManagementUtil.lockUserAccount(userNameWithoutDomain, userStoreManager);
             log.info("User account locked: " + userName);
-        } catch (UserStoreException|IdentityException e) {
+        } catch (UserStoreException | IdentityException e) {
             log.error("Error occurred while trying to lock the account " + userName, e);
             throw new IdentityMgtServiceException("Error occurred while trying to lock the account " + userName, e);
         }
@@ -140,7 +154,7 @@ public class UserIdentityManagementAdminService {
                 IdentityMgtServiceComponent.getRecoveryProcessor().recoverWithNotification(dto);
             }
             log.info("Account unlocked for: " + userName);
-        } catch (UserStoreException|IdentityException e) {
+        } catch (UserStoreException | IdentityException e) {
             String message = "Error occurred while unlocking account for: " + userName;
             log.error(message, e);
             throw new IdentityMgtServiceException(message, e);
@@ -157,6 +171,11 @@ public class UserIdentityManagementAdminService {
     public void disableUserAccount(String userName, String notificationType) throws IdentityMgtServiceException {
 
         try {
+            if (isAttemptToUpdateSuperAdmin(userName)) {
+                log.warn("An attempt to disable admin user.");
+                throw new org.wso2.carbon.user.core.UserStoreException("You do not have the required privilege to " +
+                        "disable superAdmin user");
+            }
             UserStoreManager userStoreManager = getUserStore(userName);
             String userNameWithoutDomain = UserCoreUtil.removeDomainFromName(userName);
             UserIdentityManagementUtil.disableUserAccount(userNameWithoutDomain, userStoreManager);
@@ -180,7 +199,7 @@ public class UserIdentityManagementAdminService {
                 dto.setNotificationType(notificationType);
                 IdentityMgtServiceComponent.getRecoveryProcessor().recoverWithNotification(dto);
 
-                if(log.isDebugEnabled()){
+                if (log.isDebugEnabled()) {
                     log.debug("Account enabled notification is sent in " + notificationType);
                 }
             }
@@ -231,7 +250,7 @@ public class UserIdentityManagementAdminService {
                 dto.setNotificationType(notificationType);
                 IdentityMgtServiceComponent.getRecoveryProcessor().recoverWithNotification(dto);
 
-                if(log.isDebugEnabled()){
+                if (log.isDebugEnabled()) {
                     log.debug("Account enabled notification is sent in " + notificationType);
                 }
             }
@@ -253,6 +272,11 @@ public class UserIdentityManagementAdminService {
     public void resetUserPassword(String userName, String newPassword)
             throws IdentityMgtServiceException {
         try {
+            if (isAttemptToUpdateSuperAdmin(userName)) {
+                log.warn("An attempt to update admin user.");
+                throw new org.wso2.carbon.user.core.UserStoreException("You do not have the required privilege to " +
+                        "update superAdmin user");
+            }
             UserStoreManager userStoreManager = getUserStore(userName);
             String userNameWithoutDomain = UserCoreUtil.removeDomainFromName(userName);
             userStoreManager.updateCredentialByAdmin(userNameWithoutDomain, newPassword);
@@ -265,7 +289,7 @@ public class UserIdentityManagementAdminService {
     }
 
     /**
-     * get challenges of user
+     * get challenges of user.
      *
      * @param userName bean class that contains user and tenant Information
      * @return array of challenges  if null, return empty array
@@ -278,28 +302,28 @@ public class UserIdentityManagementAdminService {
         String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         String loggedInName = CarbonContext.getThreadLocalCarbonContext().getUsername();
 
-        if(userName != null && !userName.equals(loggedInName)){
+        if (userName != null && !userName.equals(loggedInName)) {
             AuthorizationManager authzManager = null;
             try {
                 authzManager = IdentityMgtServiceComponent.getRealmService().getTenantUserRealm(tenantId).
                         getAuthorizationManager();
             } catch (UserStoreException e) {
-                throw new IdentityMgtServiceException("Error occurred while retrieving AuthorizationManager for tenant " +
-                        tenantDomain, e);
+                throw new IdentityMgtServiceException(
+                        "Error occurred while retrieving AuthorizationManager for tenant " + tenantDomain, e);
             }
             boolean isAuthorized = false;
             try {
-                isAuthorized = authzManager.isUserAuthorized(loggedInName, "/permission/admin/manage/identity/identitymgt/view",
-                        CarbonConstants.UI_PERMISSION_ACTION);
+                isAuthorized = authzManager.isUserAuthorized(loggedInName,
+                        "/permission/admin/manage/identity/identitymgt/view", CarbonConstants.UI_PERMISSION_ACTION);
             } catch (UserStoreException e) {
                     throw new IdentityMgtServiceException("Error occurred while checking access level for " +
                             "user " + userName + " in tenant " + tenantDomain, e);
             }
-            if(!isAuthorized){
+            if (!isAuthorized) {
                 throw new IdentityMgtServiceException("Unauthorized access!! Possible violation of confidentiality. " +
                         "User " + loggedInName + " trying to get challenge questions for user " + userName);
             }
-        } else if (userName == null){
+        } else if (userName == null) {
             userName = loggedInName;
         }
 
@@ -310,7 +334,7 @@ public class UserIdentityManagementAdminService {
     }
 
     /**
-     * get all promoted user challenges
+     * get all promoted user challenges.
      *
      * @return array of user challenges
      * @throws IdentityMgtServiceException if fails
@@ -356,7 +380,7 @@ public class UserIdentityManagementAdminService {
     }
 
     /**
-     * get all challenge questions
+     * get all challenge questions.
      *
      * @return array of questions
      * @throws IdentityMgtServiceException if fails
@@ -378,7 +402,7 @@ public class UserIdentityManagementAdminService {
     }
 
     /**
-     * set all challenge questions
+     * set all challenge questions.
      *
      * @param challengeQuestionDTOs array of questions
      * @throws IdentityMgtServiceException if fails
@@ -397,12 +421,13 @@ public class UserIdentityManagementAdminService {
     }
 
     /**
-     * set challenges of user
+     * set challenges of user.
      *
      * @param userName bean class that contains user and tenant Information
      * @throws IdentityMgtServiceException if fails
      */
-    public void setChallengeQuestionsOfUser(String userName, UserChallengesDTO[] challengesDTOs) throws IdentityMgtServiceException {
+    public void setChallengeQuestionsOfUser(String userName, UserChallengesDTO[] challengesDTOs) throws
+            IdentityMgtServiceException {
 
         if (challengesDTOs == null || challengesDTOs.length < 1) {
             log.error("no challenges provided by user");
@@ -413,28 +438,28 @@ public class UserIdentityManagementAdminService {
         String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         String loggedInName = CarbonContext.getThreadLocalCarbonContext().getUsername();
 
-        if(userName != null && !userName.equals(loggedInName)){
+        if (userName != null && !userName.equals(loggedInName)) {
             AuthorizationManager authzManager = null;
             try {
                 authzManager = IdentityMgtServiceComponent.getRealmService().getTenantUserRealm(tenantId).
                         getAuthorizationManager();
             } catch (UserStoreException e) {
-                throw new IdentityMgtServiceException("Error occurred while retrieving AuthorizationManager for tenant " +
-                        tenantDomain, e);
+                throw new IdentityMgtServiceException(
+                        "Error occurred while retrieving AuthorizationManager for tenant " + tenantDomain, e);
             }
             boolean isAuthorized = false;
             try {
-                isAuthorized = authzManager.isUserAuthorized(loggedInName, "/permission/admin/manage/identity/identitymgt/update",
-                        CarbonConstants.UI_PERMISSION_ACTION);
+                isAuthorized = authzManager.isUserAuthorized(loggedInName,
+                        "/permission/admin/manage/identity/identitymgt/update", CarbonConstants.UI_PERMISSION_ACTION);
             } catch (UserStoreException e) {
                 throw new IdentityMgtServiceException("Error occurred while checking access level for " +
                         "user " + userName + " in tenant " + tenantDomain, e);
             }
-            if(!isAuthorized){
+            if (!isAuthorized) {
                 throw new IdentityMgtServiceException("Unauthorized access!! Possible elevation of privilege attack. " +
                         "User " + loggedInName + " trying to change challenge questions for user " + userName);
             }
-        } else if (userName == null){
+        } else if (userName == null) {
             userName = loggedInName;
         }
 
@@ -445,17 +470,18 @@ public class UserIdentityManagementAdminService {
 
         try {
             List<ChallengeQuestionDTO> challengeQuestionDTOs = processor.getAllChallengeQuestions();
-            for (UserChallengesDTO userChallengesDTO : challengesDTOs){
-                boolean found = false ;
-                for (ChallengeQuestionDTO challengeQuestionDTO :challengeQuestionDTOs ){
-                    if(challengeQuestionDTO.getQuestion().equals(userChallengesDTO.getQuestion()) &&
-                            challengeQuestionDTO.getQuestionSetId().equals(userChallengesDTO.getId())){
-                        found = true ;
-                        break ;
+            for (UserChallengesDTO userChallengesDTO : challengesDTOs) {
+                boolean found = false;
+                for (ChallengeQuestionDTO challengeQuestionDTO :challengeQuestionDTOs) {
+                    if (challengeQuestionDTO.getQuestion().equals(userChallengesDTO.getQuestion()) &&
+                            challengeQuestionDTO.getQuestionSetId().equals(userChallengesDTO.getId())) {
+                        found = true;
+                        break;
                     }
                 }
-                if(!found){
-                    String errMsg = "Error while persisting user challenges for user : " + userName + ", because these user challengers are not registered with the tenant" ;
+                if (!found) {
+                    String errMsg = "Error while persisting user challenges for user : " + userName +
+                            ", because these user challengers are not registered with the tenant";
                     log.error(errMsg);
                     throw new IdentityMgtServiceException(errMsg);
                 }
@@ -496,7 +522,7 @@ public class UserIdentityManagementAdminService {
             }
             userStoreManager.setUserClaimValues(userName, claims, null);
 
-        } catch (UserStoreException|IdentityException e) {
+        } catch (UserStoreException | IdentityException e) {
             String errorMessage = "Error while updating identity recovery data for : " + userName;
             log.error(errorMessage, e);
             throw new IdentityMgtServiceException(errorMessage, e);
@@ -504,7 +530,7 @@ public class UserIdentityManagementAdminService {
     }
 
     /**
-     * Returns all user claims which can be used in the identity recovery
+     * Returns all user claims which can be used in the identity recovery.
      * process
      * such as the email address, telephone number etc
      *
@@ -576,9 +602,9 @@ public class UserIdentityManagementAdminService {
         try {
             if (userStoreManager != null && userStoreManager.isReadOnly()) {
                 isReadOnly = true;
-            } else
+            } else {
                 isReadOnly = false;
-
+            }
         } catch (org.wso2.carbon.user.core.UserStoreException e) {
             String errorMessage = "Error while retrieving user store manager";
             log.error(errorMessage, e);
@@ -610,18 +636,59 @@ public class UserIdentityManagementAdminService {
         return userNameWithoutDomain;
     }
 
-    private void validateSecurityQuestionDuplicate(UserChallengesDTO[] challengesDTOs) throws IdentityMgtServiceException {
+    private void validateSecurityQuestionDuplicate(UserChallengesDTO[] challengesDTOs)
+            throws IdentityMgtServiceException {
 
         Set<String> tmpMap = new HashSet<String>();
-        for(int i = 0; i < challengesDTOs.length ; i++) {
+        for (int i = 0; i < challengesDTOs.length; i++) {
             UserChallengesDTO userChallengesDTO = challengesDTOs[i];
-            if(tmpMap.contains(userChallengesDTO.getId())){
-                String errMsg = "Error while validating user challenges, because these can't be more than one security challenges for one claim uri" ;
+            if (tmpMap.contains(userChallengesDTO.getId())) {
+                String errMsg = "Error while validating user challenges, because these can't be " +
+                        "more than one security challenges for one claim uri";
                 log.error(errMsg);
                 throw new IdentityMgtServiceException(errMsg);
             }
             tmpMap.add(userChallengesDTO.getId());
         }
+    }
+
+    /**
+     * Check if the request updates super admin properties.
+     *
+     * @param userName Username
+     * @return boolean
+     */
+    private boolean isAttemptToUpdateSuperAdmin(String userName) throws org.wso2.carbon.user.core.UserStoreException {
+
+        String loggedInUserName = CarbonContext.getThreadLocalCarbonContext().getUsername();
+        if (loggedInUserName != null) {
+            loggedInUserName = addPrimaryDomainIfNotExists(loggedInUserName);
+        }
+        UserRealm realm = (UserRealm) CarbonContext.getThreadLocalCarbonContext().getUserRealm();
+        RealmConfiguration realmConfig = realm.getRealmConfiguration();
+        String adminUser = addPrimaryDomainIfNotExists(realmConfig.getAdminUserName());
+        if (realmConfig.getAdminUserName().equalsIgnoreCase(userName) &&
+                !adminUser.equalsIgnoreCase(loggedInUserName)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Add the primary domain to the username if username does not contain a domain.
+     *
+     * @param userName Username
+     * @return Primary domain added username
+     */
+    private final String addPrimaryDomainIfNotExists(String userName) {
+
+        if (StringUtils.isNotEmpty(userName) && (!userName.contains(UserCoreConstants.DOMAIN_SEPARATOR))) {
+            StringBuilder builder = new StringBuilder();
+            builder.append(UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME).append(CarbonConstants.DOMAIN_SEPARATOR)
+                    .append(userName);
+            userName = builder.toString();
+        }
+        return userName;
     }
 
 }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementAdminService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementAdminService.java
@@ -86,7 +86,7 @@ public class UserIdentityManagementAdminService {
             UserStoreManager userStoreManager = IdentityMgtServiceComponent.getRealmService().
                     getTenantUserRealm(CarbonContext.getThreadLocalCarbonContext().getTenantId()).getUserStoreManager();
             if (isSuperAdmin(userName)) {
-                throw new org.wso2.carbon.user.core.UserStoreException("You do not have the required privilege to " +
+                throw new IdentityMgtServiceException("You do not have the required privilege to " +
                         "delete superAdmin user");
             }
             userStoreManager.deleteUser(userName);
@@ -110,7 +110,7 @@ public class UserIdentityManagementAdminService {
         try {
 
             if (isSuperAdmin(userName)) {
-                throw new org.wso2.carbon.user.core.UserStoreException("You do not have the required privilege to " +
+                throw new IdentityMgtServiceException("You do not have the required privilege to " +
                         "lock superAdmin user");
             }
 
@@ -170,7 +170,7 @@ public class UserIdentityManagementAdminService {
 
         try {
             if (isSuperAdmin(userName)) {
-                throw new org.wso2.carbon.user.core.UserStoreException("You do not have the required privilege to " +
+                throw new IdentityMgtServiceException("You do not have the required privilege to " +
                         "disable superAdmin user");
             }
             UserStoreManager userStoreManager = getUserStore(userName);
@@ -270,7 +270,7 @@ public class UserIdentityManagementAdminService {
             throws IdentityMgtServiceException {
         try {
             if (isSuperAdmin(userName)) {
-                throw new org.wso2.carbon.user.core.UserStoreException("You do not have the required privilege to " +
+                throw new IdentityMgtServiceException("You do not have the required privilege to " +
                         "update superAdmin user");
             }
             UserStoreManager userStoreManager = getUserStore(userName);


### PR DESCRIPTION
Implementing validations for password reset, account lock and account delete for superAdmin in UserIdentityManagementAdminService SOAP service.

Fix derived from : https://github.com/wso2/carbon-identity-framework/blob/2a18bd31140957aeec25aeedae0dcfefec8a8c6b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserRealmProxy.java#L836