### PR TITLE
Bump opensaml version to 3.3.1.wso2v11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1970,7 +1970,7 @@
         <orbit.version.commons.fileuploader>1.2.0.wso2v1</orbit.version.commons.fileuploader>
         <opensaml.version>3.3.1</opensaml.version>
         <shibboleth.version>7.3.0</shibboleth.version>
-        <opensaml2.wso2.version>3.3.1.wso2v7</opensaml2.wso2.version>
+        <opensaml2.wso2.version>3.3.1.wso2v11</opensaml2.wso2.version>
         <opensaml2.wso2.osgi.version.range>[3.3.1,3.4.0)</opensaml2.wso2.osgi.version.range>
         <joda.version>2.9.4</joda.version>
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>


### PR DESCRIPTION
### Proposed changes in this pull request
- $suject
- From this PR the below dependencies are upgraded in the opensaml orbit jar
   - apache commons codec version from 1.10 to 1.16
   - esapi.version  from 2.4.0.0 to 2.5.3.1
   - org.apache.xml.security.version range