### PR TITLE
Introduce additional scopes for identityProviders view/edit role

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -359,6 +359,7 @@
             </Feature>
             <Update>
                 <Scope name="internal_idp_update"/>
+                <Scope name="internal_governance_update"/>
             </Update>
             <Delete>
                 <Scope name="internal_idp_delete"/>
@@ -371,6 +372,9 @@
                 <Scope name="internal_idp_view"/>
                 <Scope name="internal_role_mgt_view"/>
                 <Scope name="internal_claim_meta_view"/>
+                <Scope name="internal_authenticator_view"/>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_extensions_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -393,6 +393,7 @@
             </Feature>
             <Update>
                 <Scope name="internal_idp_update"/>
+                <Scope name="internal_governance_update"/>
             </Update>
             <Delete>
                 <Scope name="internal_idp_delete"/>
@@ -405,6 +406,9 @@
                 <Scope name="internal_idp_view"/>
                 <Scope name="internal_role_mgt_view"/>
                 <Scope name="internal_claim_meta_view"/>
+                <Scope name="internal_authenticator_view"/>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_extensions_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>


### PR DESCRIPTION
### Purpose 

$subject. The additional scopes was introduced to fix the issues in the RBAC console for connections edit/view role.

### Related Issue
- https://github.com/wso2/product-is/issues/18632