### PR TITLE
Add service provider UUID to outbound query string.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/loader/UIBasedConfigurationLoader.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/loader/UIBasedConfigurationLoader.java
@@ -92,6 +92,7 @@ public class UIBasedConfigurationLoader implements SequenceLoader {
                     .getJsGraphBuilderFactory();
             JsBaseGraphBuilder jsGraphBuilder = jsGraphBuilderFactory.createBuilder(context, stepConfigMapCopy);
             context.setServiceProviderName(serviceProvider.getApplicationName());
+            context.setServiceProviderResourceId(serviceProvider.getApplicationResourceId());
 
             AuthenticationGraph graph = jsGraphBuilder
                     .createWith(localAndOutboundAuthenticationConfig.getAuthenticationScriptConfig().getContent())

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
@@ -65,6 +65,7 @@ public class AuthenticationContext extends MessageContext implements Serializabl
     private int currentPostAuthHandlerIndex = 0;
     private Map<String, String> authenticatorProperties = new HashMap<>();
     private String serviceProviderName;
+    private String serviceProviderResourceId;
     private String contextIdIncludedQueryParams;
     private String currentAuthenticator;
     private String redirectURL;
@@ -294,6 +295,16 @@ public class AuthenticationContext extends MessageContext implements Serializabl
 
     public void setServiceProviderName(String serviceProviderName) {
         this.serviceProviderName = serviceProviderName;
+    }
+
+    public String getServiceProviderResourceId() {
+
+        return serviceProviderResourceId;
+    }
+
+    public void setServiceProviderResourceId(String serviceProviderResourceId) {
+
+        this.serviceProviderResourceId = serviceProviderResourceId;
     }
 
     public boolean isForceAuthenticate() {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -1006,7 +1006,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     .append(FrameworkConstants.REQUEST_PARAM_SP).append("=")
                     .append(URLEncoder.encode(context.getServiceProviderName(), "UTF-8")).append("&")
                     .append(FrameworkConstants.REQUEST_PARAM_SP_UUID).append("=")
-                    .append(context.getServiceProviderResourceId()).append("&")
+                    .append(URLEncoder.encode(context.getServiceProviderResourceId())).append("&")
                     .append("&isSaaSApp=")
                     .append(context.getSequenceConfig().getApplicationConfig().isSaaSApp());
         } catch (UnsupportedEncodingException e) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -1004,7 +1004,10 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     .append("&relyingParty=").append(URLEncoder.encode(context.getRelyingParty(), "UTF-8"))
                     .append("&type=").append(context.getRequestType()).append("&")
                     .append(FrameworkConstants.REQUEST_PARAM_SP).append("=")
-                    .append(URLEncoder.encode(context.getServiceProviderName(), "UTF-8")).append("&isSaaSApp=")
+                    .append(URLEncoder.encode(context.getServiceProviderName(), "UTF-8")).append("&")
+                    .append(FrameworkConstants.REQUEST_PARAM_SP_UUID).append("=")
+                    .append(context.getServiceProviderResourceId()).append("&")
+                    .append("&isSaaSApp=")
                     .append(context.getSequenceConfig().getApplicationConfig().isSaaSApp());
         } catch (UnsupportedEncodingException e) {
             throw new FrameworkException("Error while URL Encoding", e);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -126,6 +126,7 @@ public abstract class FrameworkConstants {
     public static final String POST_AUTH_MISSING_CLAIMS_ERROR_CODE = "postAuthMissingClaimsErrorCode";
 
     public static final String REQUEST_PARAM_SP = "sp";
+    public static final String REQUEST_PARAM_SP_UUID = "spId";
     public static final String REQUEST_PARAM_ERROR_KEY = "errorKey";
     public static final String REQUEST_PARAM_AUTH_FLOW_ID = "authFlowId";
     public static final String MAPPED_ATTRIBUTES = "MappedAttributes";


### PR DESCRIPTION
### Description
Introduce `spId` query param to resolve branding preference using application UUID to avoid conflicts and to handle application name changes. 