### PR TITLE
Add config for using old scopes as alias for new scopes

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1151,6 +1151,15 @@
                 <Enable>{{oauth.global_scope_validators.role_based_scope_issuer.enable}}</Enable>
             </RoleBasedScopeIssuer>
         </GlobalScopeValidators>
+        {% if oauth.use_legacy_scopes_as_alias_for_new_scopes is defined %}
+        <!--
+        Configuration to maintain backward compatibility for the internal scopes used for the system API access control.
+        Prior to IS 7.0.0, some of the internal scopes were used as shared scopes for multiple APIs for the access control.
+        With the introduction of new authorization runtime with IS 7.0.0, new internal scopes were introduced for some of the APIs
+        which previously used shared scopes. This configuration will allow to use the legacy scopes as alias for the new scopes.
+        -->
+        <UseLegacyScopesAsAliasForNewScopes>{{oauth.use_legacy_scopes_as_alias_for_new_scopes}}</UseLegacyScopesAsAliasForNewScopes>
+        {% endif %}
     </OAuth>
 
     <RestApiAuthentication>


### PR DESCRIPTION
### Proposed changes in this pull request
Prior to IS 7.0.0, some of the internal scopes were used as shared scopes for multiple APIs for the access control. With the introduction of new authorization runtime with IS 7.0.0, new internal scopes were introduced for some of the APIs which previously used shared scopes. This configuration will allow to use the old scopes as alias for the new scopes to preserve the backward compatibility.

Related Issues - https://github.com/wso2/product-is/issues/18826