### PR TITLE
Improve session termination logic to limit the process only for applicable role audience

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/UserSessionManagementService.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/UserSessionManagementService.java
@@ -78,6 +78,19 @@ public interface UserSessionManagementService {
     }
 
     /**
+     * Terminate active sessions of the given user ID mapped to the application associated to the given roleId.
+     *
+     * @param userId Unique ID of the user.
+     * @param roleId Unique ID of the role.
+     * @return Whether the sessions termination is success or not. In default method, false is returned.
+     * @throws SessionManagementException if the session termination fails.
+     */
+    default boolean terminateSessionsByUserId(String userId, String roleId) throws SessionManagementException {
+
+        return false;
+    }
+
+    /**
      * Get a specific session of the given user ID.
      *
      * @param userId    Unique ID of the user.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/UserSessionManagementServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/UserSessionManagementServiceImpl.java
@@ -344,8 +344,7 @@ public class UserSessionManagementServiceImpl implements UserSessionManagementSe
         try {
             RoleManagementService roleManagementServiceV2 = FrameworkServiceDataHolder.getInstance()
                     .getRoleManagementServiceV2();
-            Role role = roleManagementServiceV2.getRole(roleId,
-                    CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+            Role role = roleManagementServiceV2.getRole(roleId);
             String associatedApplication = role.getAudienceName();
             Iterator<String> iterator = sessionIdList.iterator();
             while (iterator.hasNext()) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionMgtConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/SessionMgtConstants.java
@@ -148,7 +148,10 @@ public class SessionMgtConstants {
                 "Data validation has failed, %s."),
         ERROR_CODE_INVALID_SESSION_ID("USM-10011",
                 "Invalid Session",
-                "Session cannot be found for the given session ID.");
+                "Session cannot be found for the given session ID."),
+        ERROR_CODE_UNABLE_TO_GET_ROLE("USM-10012",
+                "Unable to retrieve role information",
+                "Server encountered an error while retrieving role information of roleId, %s.");
 
         private final String code;
         private final String message;


### PR DESCRIPTION
Session termination by userId terminates all session which is irrelevant to the role audience. Hence, the logic has been improved according to the requirement.

Related issue:
- https://github.com/wso2/product-is/issues/18815