### PR TITLE
Bug  fixing for IDF contained authenticators

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -334,7 +334,6 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     context.setCurrentAuthenticator(null);
                 }
 
-
                 /*
                 If
                  Request specify to restart the flow again from first step by passing `restart_flow`.


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/18655

### Root Cause

For IDF contained authenticators, we are setting current authenticators in the context [here](https://github.com/wso2/carbon-identity-framework/blob/205ef512c5c7a3a77f5ac3c2143194591598ac41/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java#L737) when prompting for identifier username input.
<img width="1274" alt="rc-3" src="https://github.com/wso2/carbon-identity-framework/assets/25488962/d71c793f-26a9-4cae-82f6-69eb02bb1a4a">


But we have an option to go back by choosing "choose different option". **Ideally when a user click this button current authenticators in the context should replaced to null which is not in this case**.

If the user choose different authenticator option like basic authentication, current authenticator in the context is already set to email otp, ( following image shows current authenticator in the context already set to email otp in [DefaultRequestCoordinator](https://github.com/wso2/carbon-identity-framework/blob/0b0011144455613a5f7792dfea6bb49c45b742d7/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java#L344).

<img width="1274" alt="rc-1" src="https://github.com/wso2/carbon-identity-framework/assets/25488962/d30c22d0-05dc-4f34-9a73-670c4fadb8fa">

framework aims to perform an email otp authentication also. ( following image shows [defaultStepHandler](https://github.com/wso2/carbon-identity-framework/blob/205ef512c5c7a3a77f5ac3c2143194591598ac41/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java#L660) chooses emailOTP Authenticator from current authenticator in the context). 

<img width="1274" alt="rc-2" src="https://github.com/wso2/carbon-identity-framework/assets/25488962/ab21b716-72e8-4c77-ad93-df431203dbb8">


### Proposed changes in this pull request

Check if the Identity Framework (IDF) is initiated from authenticators like SMS OTP or Email OTP, which have two procedures: 
1. Identify the User, and 
2. Perform authentication.

After the first procedure, the context's current authenticator is set to the corresponding authenticator.
Users have the option to restart the flow from the 1st step by choosing a different option.
 In such cases, if it's the first step in the authentication process, we need to remove the context's current authenticator to reset the flow.


### Tested Scenarios
1. Basic authenticators only
2. Email OTP (1F) + Basic (Multi Option - choosing Basic)
4. Email OTP (1F) + Basic (Multi Option - choosing Email, go back and choose basic)
5. Email OTP (1F) + Basic (Multi Option - choosing Email)
6. Email OTP (2nd F) with Basic
7. Email OTP (1F) without Basic
8. IDF alone

### Fix in action

https://github.com/wso2/carbon-identity-framework/assets/25488962/2998717f-97c3-42f7-b077-6acd61d83e9c



