### PR TITLE
Improve getSecuredTransformerFactory method to use JDK default factory instead of the xalan implementation

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -103,6 +103,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.TransformerFactoryConfigurationError;
 
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.ALPHABET;
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.ENCODED_ZERO;
@@ -150,6 +151,7 @@ public class IdentityUtil {
     private static final String APPLICATION_DOMAIN = "Application";
     private static final String WORKFLOW_DOMAIN = "Workflow";
     private static Boolean groupsVsRolesSeparationImprovementsEnabled;
+    private static String JAVAX_TRANSFORMER_PROP_VAL = "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl";
 
     // System Property for trust managers.
     public static final String PROP_TRUST_STORE_UPDATE_REQUIRED =
@@ -647,7 +649,17 @@ public class IdentityUtil {
      */
     public static TransformerFactory getSecuredTransformerFactory() {
 
-        TransformerFactory trfactory = TransformerFactory.newInstance();
+        TransformerFactory trfactory;
+        try {
+            // Prevent XXE Attack by ensure using the correct factory class to create TrasformerFactory instance.
+            // This will instruct Java to use to version which supports using ACCESS_EXTERNAL_DTD argument.
+            trfactory = TransformerFactory.newInstance(JAVAX_TRANSFORMER_PROP_VAL, null);
+        } catch (TransformerFactoryConfigurationError e) {
+            log.error("Failed to load default TransformerFactory", e);
+            // This part uses the default implementation of xalan.
+            trfactory = TransformerFactory.newInstance();
+        }
+
         try {
             trfactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         } catch (TransformerConfigurationException e) {


### PR DESCRIPTION
### Issue Description

- During the SAML artifact binding flow we are calling the [getSecuredTransformerFactory](https://github.com/wso2-extensions/identity-inbound-auth-saml/blob/013656ad651ccedff96854f77e6ba82924c5ee69/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/servlet/SAMLArtifactResolveServlet.java#L124) and we are getting the below exception from the `getSecuredTransformerFactory` method.

  ```
  ERROR {org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/].[bridgeservlet]} - Servlet.service() for servlet [bridgeservlet] in context with path [/] threw exception java.lang.IllegalArgumentException: Not supported: http://javax.xml.XMLConstants/property/accessExternalDTD
	  at org.apache.xalan.processor.TransformerFactoryImpl.setAttribute(TransformerFactoryImpl.java:571)
	  at org.wso2.carbon.identity.core.util.IdentityUtil.getSecuredTransformerFactory(IdentityUtil.java:657)
	  at org.wso2.carbon.identity.sso.saml.servlet.SAMLArtifactResolveServlet.handleRequest(SAMLArtifactResolveServlet.java:124)
  ```
- According to [this article](https://access.redhat.com/solutions/6136111), this happens because an outdated XML processor is present on the classpath (e.g. Xerces, Xalan) which is exactly in this case due to xalan. After removing xalan jar from the lib we didn't get this issue. 
-  This is because xalan's TransformerFactory does not support this attribute(http://javax.xml.XMLConstants/property/accessExternalDTD). Xalan's implementation gets picked up through ServiceLoader mechanism: it is specified in services/javax.xml.transform.TransfomerFactory in xalan jar. But we need to specify this attribute according to the [OWSP recommendations](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#transformerfactory)
- Since we need to keep xalan jar in lib and both OWASP recommendations we decided to Improve getSecuredTransformerFactory method to use JDK default factory instead of the xalan implementation


### Proposed changes in this pull request

- Improve `getSecuredTransformerFactory` method to use JDK default **TransformerFactory**(_com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl_) instead of the xalan TransformerFactory implementation(org.apache.xalan.processor.TransformerFactoryImpl).

### Related Issue 
- https://github.com/wso2/product-is/issues/18873

### References

1. https://stackoverflow.com/questions/75815506/java-lang-illegalargumentexception-not-supported-http-javax-xml-xmlconstants
2. https://stackoverflow.com/questions/50000756/is-it-possible-to-avoid-using-xalan-transformerfactory/50219550#50219550