### PR TITLE
Remove features from management console

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.ui.feature/pom.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.ui.feature/pom.xml
@@ -68,7 +68,6 @@
                                 </properties>
                             </adviceFile>
                             <bundles>
-                                <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.claim.mgt.ui</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.claim.mgt.stub</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.claim.metadata.mgt.ui</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.claim.metadata.mgt.stub</bundleDef>

--- a/features/user-mgt/org.wso2.carbon.user.mgt.ui.feature/pom.xml
+++ b/features/user-mgt/org.wso2.carbon.user.mgt.ui.feature/pom.xml
@@ -47,10 +47,6 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.user.store.configuration.ui</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.user.store.configuration</artifactId>
         </dependency>
         <dependency>
@@ -91,9 +87,6 @@
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.user.mgt.ui</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.user.mgt.stub</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.user.mgt.common
-                                </bundleDef>
-                                <bundleDef>
-                                    org.wso2.carbon.identity.framework:org.wso2.carbon.identity.user.store.configuration.ui
                                 </bundleDef>
                                 <bundleDef>
                                     org.wso2.carbon.identity.framework:org.wso2.carbon.identity.user.store.configuration.stub


### PR DESCRIPTION
### Proposed changes in this pull request

Remove Userstores and Claim UI component from the aggregated pom. This hides both the Userstores and Claim menu item from the management console.

### Issue
https://github.com/wso2/product-is/issues/18950