### PR TITLE
Disable workflow approvals feature by default in the Console

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1120,7 +1120,7 @@
   "console.applications.scopes.delete": ["internal_application_mgt_delete"],
   "console.applications.ui.certificate_alias_enabled": false,
   "console.application_roles.enabled": true,
-  "console.approvals.enabled": true,
+  "console.approvals.enabled": false,
   "console.approvals.scopes.feature": ["console:workflowApprovals"],
   "console.approvals.scopes.create": ["internal_humantask_view"],
   "console.approvals.scopes.read": ["internal_humantask_view"],


### PR DESCRIPTION
### Proposed changes in this pull request

This PR disables workflow approvals feature by default in the Console.