### PR TITLE
Make AuthenticatorMessage object to implement Serializable

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatorMessage.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatorMessage.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.application.authentication.framework.model;
 
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,7 +28,7 @@ import java.util.Map;
  * Holds the messages related to an authenticator which requires to populate {@Code AuthenticatorData}
  * during an authentication flow. This contains messages related details specific to authentication flow.
  */
-public class AuthenticatorMessage {
+public class AuthenticatorMessage implements Serializable {
 
     private FrameworkConstants.AuthenticatorMessageType type;
     private String code;


### PR DESCRIPTION
A NonSerializable exception is thrown when AuthenticationContext is cloned. This occurs because the AuthenticatorMessage object does not implement Serializable. This PR will fix this issue.

Related issue:
- https://github.com/wso2/product-is/issues/19003