### PR TITLE
Set retrying attribute as false when navigating back from an authenticator to multi options page

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/LoginContextManagementUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/LoginContextManagementUtil.java
@@ -96,6 +96,7 @@ public class LoginContextManagementUtil {
             // If the context is valid and at the first step.
             if (isStepHasMultiOption(context) && !FrameworkUtils.isIdfInitiatedFromAuthenticator(context)) {
                 context.setCurrentAuthenticator(null);
+                context.setRetrying(false);
             }
             result.addProperty("status", "success");
             response.getWriter().write(result.toString());


### PR DESCRIPTION
Whenever `choose a different option` button is pressed and navigated to the multi Options page, the `doGet()` method of `LoginContextServlet` will be triggered. Here, the current authenticator will be set to null. Along, with that, by setting the value of `Retrying` parameter to false, the issue of displaying authentication error message without doing an authentication and not sending emailOTP and SMSOTP will be sorted.

Related issue:
- https://github.com/wso2/product-is/issues/19025