### PR TITLE
Rename inappropriate scope names

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -470,7 +470,7 @@
             </Delete>
             <Create>
                 <Scope name="internal_user_mgt_create"/>
-                <Scope name="internal_bulk_mgt_create"/>
+                <Scope name="internal_bulk_resource_create"/>
                 <Scope name="internal_offline_invite"/>
             </Create>
             <Read>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -504,7 +504,7 @@
             </Delete>
             <Create>
                 <Scope name="internal_user_mgt_create"/>
-                <Scope name="internal_bulk_mgt_create"/>
+                <Scope name="internal_bulk_resource_create"/>
                 <Scope name="internal_offline_invite"/>
             </Create>
             <Read>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -684,13 +684,13 @@
     <APIResource name="SCIM2 Bulk API" identifier="/scim2/Bulk" requiresAuthorization="true"
                  description="API representation of the SCIM2 Bulk API" type="TENANT_ADMIN">
         <Scopes>
-            <Scope displayName="Create Bulk Resource" name="internal_bulk_mgt_create" 
+            <Scope displayName="Create Bulk Resource" name="internal_bulk_resource_create"
                     description="Create new SCIM resources in bulk in the organization (root)"/>
-            <Scope displayName="View Bulk Resource" name="internal_bulk_mgt_view" 
+            <Scope displayName="View Bulk Resource" name="internal_bulk_resource_view"
                     description="View SCIM resources in bulk in the organization (root)"/>
-            <Scope displayName="Update Bulk Resource" name="internal_bulk_mgt_update" 
+            <Scope displayName="Update Bulk Resource" name="internal_bulk_resource_update"
                     description="Update SCIM resources in bulk in the organization (root)"/>
-            <Scope displayName="Delete Bulk Resource" name="internal_bulk_mgt_delete" 
+            <Scope displayName="Delete Bulk Resource" name="internal_bulk_resource_delete"
                     description="Delete SCIM resources in bulk in the organization (root)"/>
         </Scopes>
     </APIResource>
@@ -698,27 +698,27 @@
                  requiresAuthorization="true"
                  description="API representation of the SCIM2 Bulk API" type="ORGANIZATION_ADMIN">
         <Scopes>
-            <Scope displayName="Create Bulk Resource" name="internal_org_bulk_mgt_create" 
+            <Scope displayName="Create Bulk Resource" name="internal_org_bulk_resource_create"
                         description="Create new SCIM resources in bulk in the organization"/>
-            <Scope displayName="View Bulk Resource" name="internal_org_bulk_mgt_view" 
+            <Scope displayName="View Bulk Resource" name="internal_org_bulk_resource_view"
                         description="View SCIM resources in bulk in the organization"/>
-            <Scope displayName="Update Bulk Resource" name="internal_org_bulk_mgt_update" 
+            <Scope displayName="Update Bulk Resource" name="internal_org_bulk_resource_update"
                         description="Update SCIM resources in bulk in the organization"/>
-            <Scope displayName="Delete Bulk Resource" name="internal_org_bulk_mgt_delete" 
+            <Scope displayName="Delete Bulk Resource" name="internal_org_bulk_resource_delete"
                         description="Delete SCIM resources in bulk in the organization"/>
         </Scopes>
     </APIResource>
-    <APIResource name="Code Management API" identifier="/api/identity/user/v1.0/(.*)-code"
-                 requiresAuthorization="true" description="API representation of the Code Management API" type="TENANT_USER">
+    <APIResource name="User Code Management API" identifier="/api/identity/user/v1.0/(.*)-code"
+                 requiresAuthorization="true" description="API representation of the User Related Code Management API" type="TENANT_USER">
         <Scopes>
-            <Scope displayName="View Code" name="internal_code_mgt_view" 
-                    description="View code in the organization (root)"/>
-            <Scope displayName="Create Code" name="internal_code_mgt_create" 
-                    description="Create new code in the organization (root)"/>
-            <Scope displayName="Update Code" name="internal_code_mgt_update" 
-                    description="Update code in the organization (root)"/>
-            <Scope displayName="Delete Code" name="internal_code_mgt_delete" 
-                    description="Delete code in the organization (root)"/>
+            <Scope displayName="View User Code" name="internal_user_code_mgt_view"
+                    description="View user related code in the organization (root)"/>
+            <Scope displayName="Create User Code" name="internal_user_code_mgt_create"
+                    description="Create user related new code in the organization (root)"/>
+            <Scope displayName="Update User Code" name="internal_user_code_mgt_update"
+                    description="Update user related code in the organization (root)"/>
+            <Scope displayName="Delete User Code" name="internal_user_code_mgt_delete"
+                    description="Delete user related code in the organization (root)"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Personal Identification API"
@@ -885,7 +885,7 @@
         <Scopes>
             <Scope displayName="Create Identity Register" name="internal_register_create" 
                     description="Create identity register"/>
-            <Scope displayName="Delete Identity Register" name="internal_register_delete" 
+            <Scope displayName="Delete Identity Register" name="internal_register_delete"
                     description="Delete identity register"/>
         </Scopes>
     </APIResource>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -686,12 +686,6 @@
         <Scopes>
             <Scope displayName="Create Bulk Resource" name="internal_bulk_resource_create"
                     description="Create new SCIM resources in bulk in the organization (root)"/>
-            <Scope displayName="View Bulk Resource" name="internal_bulk_resource_view"
-                    description="View SCIM resources in bulk in the organization (root)"/>
-            <Scope displayName="Update Bulk Resource" name="internal_bulk_resource_update"
-                    description="Update SCIM resources in bulk in the organization (root)"/>
-            <Scope displayName="Delete Bulk Resource" name="internal_bulk_resource_delete"
-                    description="Delete SCIM resources in bulk in the organization (root)"/>
         </Scopes>
     </APIResource>
     <APIResource name="SCIM2 Bulk API" identifier="/o/scim2/Bulk"
@@ -700,12 +694,6 @@
         <Scopes>
             <Scope displayName="Create Bulk Resource" name="internal_org_bulk_resource_create"
                         description="Create new SCIM resources in bulk in the organization"/>
-            <Scope displayName="View Bulk Resource" name="internal_org_bulk_resource_view"
-                        description="View SCIM resources in bulk in the organization"/>
-            <Scope displayName="Update Bulk Resource" name="internal_org_bulk_resource_update"
-                        description="Update SCIM resources in bulk in the organization"/>
-            <Scope displayName="Delete Bulk Resource" name="internal_org_bulk_resource_delete"
-                        description="Delete SCIM resources in bulk in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Code Management API" identifier="/api/identity/user/v1.0/(.*)-code"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -880,15 +880,6 @@
                     description="Introspect tokens"/>
         </Scopes>
     </APIResource>
-    <APIResource name="Identity Register API" identifier="/identity/register"
-                 requiresAuthorization="true" description="API representation of the Identity Register API" type="TENANT_ADMIN">
-        <Scopes>
-            <Scope displayName="Create Identity Register" name="internal_register_create" 
-                    description="Create identity register"/>
-            <Scope displayName="Delete Identity Register" name="internal_register_delete"
-                    description="Delete identity register"/>
-        </Scopes>
-    </APIResource>
     <APIResource name="Application Management Feature" identifier="console:applications"
                  requiresAuthorization="true"
                  description="Resource representation of the Application Management Feature"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -889,15 +889,6 @@
                     description="Introspect tokens"/>
         </Scopes>
     </APIResource>
-    <APIResource name="Identity Register API" identifier="/identity/register"
-                 requiresAuthorization="true" description="API representation of the Identity Register API" type="TENANT_ADMIN">
-        <Scopes>
-            <Scope displayName="Create Identity Register" name="internal_register_create" 
-                    description="Create identity register"/>
-            <Scope displayName="Delete Identity Register" name="internal_register_delete" 
-                    description="Delete identity register"/>
-        </Scopes>
-    </APIResource>
     <APIResource name="Application Management Feature" identifier="console:applications"
                  requiresAuthorization="true"
                  description="Resource representation of the Application Management Feature"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -693,13 +693,13 @@
     <APIResource name="SCIM2 Bulk API" identifier="/scim2/Bulk" requiresAuthorization="true"
                  description="API representation of the SCIM2 Bulk API" type="TENANT_ADMIN">
         <Scopes>
-            <Scope displayName="Create Bulk Resource" name="internal_bulk_mgt_create" 
+            <Scope displayName="Create Bulk Resource" name="internal_bulk_resource_create"
                     description="Create new SCIM resources in bulk in the organization (root)"/>
-            <Scope displayName="View Bulk Resource" name="internal_bulk_mgt_view" 
+            <Scope displayName="View Bulk Resource" name="internal_bulk_resource_view"
                     description="View SCIM resources in bulk in the organization (root)"/>
-            <Scope displayName="Update Bulk Resource" name="internal_bulk_mgt_update" 
+            <Scope displayName="Update Bulk Resource" name="internal_bulk_resource_update"
                     description="Update SCIM resources in bulk in the organization (root)"/>
-            <Scope displayName="Delete Bulk Resource" name="internal_bulk_mgt_delete" 
+            <Scope displayName="Delete Bulk Resource" name="internal_bulk_resource_delete"
                     description="Delete SCIM resources in bulk in the organization (root)"/>
         </Scopes>
     </APIResource>
@@ -707,27 +707,27 @@
                  requiresAuthorization="true"
                  description="API representation of the SCIM2 Bulk API" type="ORGANIZATION_ADMIN">
         <Scopes>
-            <Scope displayName="Create Bulk Resource" name="internal_org_bulk_mgt_create" 
+            <Scope displayName="Create Bulk Resource" name="internal_org_bulk_resource_create"
                         description="Create new SCIM resources in bulk in the organization"/>
-            <Scope displayName="View Bulk Resource" name="internal_org_bulk_mgt_view" 
+            <Scope displayName="View Bulk Resource" name="internal_org_bulk_resource_view"
                         description="View SCIM resources in bulk in the organization"/>
-            <Scope displayName="Update Bulk Resource" name="internal_org_bulk_mgt_update" 
+            <Scope displayName="Update Bulk Resource" name="internal_org_bulk_resource_update"
                         description="Update SCIM resources in bulk in the organization"/>
-            <Scope displayName="Delete Bulk Resource" name="internal_org_bulk_mgt_delete" 
+            <Scope displayName="Delete Bulk Resource" name="internal_org_bulk_resource_delete"
                         description="Delete SCIM resources in bulk in the organization"/>
         </Scopes>
     </APIResource>
-    <APIResource name="Code Management API" identifier="/api/identity/user/v1.0/(.*)-code"
-                 requiresAuthorization="true" description="API representation of the Code Management API" type="TENANT_USER">
+    <APIResource name="User Code Management API" identifier="/api/identity/user/v1.0/(.*)-code"
+                 requiresAuthorization="true" description="API representation of the User Related Code Management API" type="TENANT_USER">
         <Scopes>
-            <Scope displayName="View Code" name="internal_code_mgt_view" 
-                    description="View code in the organization (root)"/>
-            <Scope displayName="Create Code" name="internal_code_mgt_create" 
-                    description="Create new code in the organization (root)"/>
-            <Scope displayName="Update Code" name="internal_code_mgt_update" 
-                    description="Update code in the organization (root)"/>
-            <Scope displayName="Delete Code" name="internal_code_mgt_delete" 
-                    description="Delete code in the organization (root)"/>
+            <Scope displayName="View User Code" name="internal_user_code_mgt_view"
+                    description="View user related code in the organization (root)"/>
+            <Scope displayName="Create User Code" name="internal_user_code_mgt_create"
+                    description="Create user related new code in the organization (root)"/>
+            <Scope displayName="Update User Code" name="internal_user_code_mgt_update"
+                    description="Update user related code in the organization (root)"/>
+            <Scope displayName="Delete User Code" name="internal_user_code_mgt_delete"
+                    description="Delete user related code in the organization (root)"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Personal Identification API"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -695,12 +695,6 @@
         <Scopes>
             <Scope displayName="Create Bulk Resource" name="internal_bulk_resource_create"
                     description="Create new SCIM resources in bulk in the organization (root)"/>
-            <Scope displayName="View Bulk Resource" name="internal_bulk_resource_view"
-                    description="View SCIM resources in bulk in the organization (root)"/>
-            <Scope displayName="Update Bulk Resource" name="internal_bulk_resource_update"
-                    description="Update SCIM resources in bulk in the organization (root)"/>
-            <Scope displayName="Delete Bulk Resource" name="internal_bulk_resource_delete"
-                    description="Delete SCIM resources in bulk in the organization (root)"/>
         </Scopes>
     </APIResource>
     <APIResource name="SCIM2 Bulk API" identifier="/o/scim2/Bulk"
@@ -709,12 +703,6 @@
         <Scopes>
             <Scope displayName="Create Bulk Resource" name="internal_org_bulk_resource_create"
                         description="Create new SCIM resources in bulk in the organization"/>
-            <Scope displayName="View Bulk Resource" name="internal_org_bulk_resource_view"
-                        description="View SCIM resources in bulk in the organization"/>
-            <Scope displayName="Update Bulk Resource" name="internal_org_bulk_resource_update"
-                        description="Update SCIM resources in bulk in the organization"/>
-            <Scope displayName="Delete Bulk Resource" name="internal_org_bulk_resource_delete"
-                        description="Delete SCIM resources in bulk in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Code Management API" identifier="/api/identity/user/v1.0/(.*)-code"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -22,26 +22,26 @@
     <Resource context="(.*)" secured="false" http-method="OPTIONS"/>
     <Resource context="/" secured="false" http-method="GET"/>
 
-    <!-- Code Management API -->
+    <!-- User Code Management API -->
     <Resource context="(.*)/api/identity/user/v1.0/validate-code(.*)" secured="true" http-method="POST">
-        <Scopes>internal_code_mgt_create</Scopes>
+        <Scopes>internal_user_code_mgt_create</Scopes>
     </Resource>
 
     <Resource context="(.*)/api/identity/user/v1.0/introspect-code(.*)" secured="true" http-method="POST">
-        <Scopes>internal_code_mgt_view</Scopes>
+        <Scopes>internal_user_code_mgt_view</Scopes>
     </Resource>
 
     <Resource context="(.*)/api/identity/user/v1.0/resend-code(.*)" secured="true" http-method="GET">
-        <Scopes>internal_code_mgt_view</Scopes>
+        <Scopes>internal_user_code_mgt_view</Scopes>
     </Resource>
     <Resource context="(.*)/api/identity/user/v1.0/resend-code(.*)" secured="true" http-method="POST">
-        <Scopes>internal_code_mgt_create</Scopes>
+        <Scopes>internal_user_code_mgt_create</Scopes>
     </Resource>
     <Resource context="(.*)/api/identity/user/v1.0/resend-code(.*)" secured="true" http-method="PATCH, PUT">
-        <Scopes>internal_code_mgt_update</Scopes>
+        <Scopes>internal_user_code_mgt_update</Scopes>
     </Resource>
     <Resource context="(.*)/api/identity/user/v1.0/resend-code(.*)" secured="true" http-method="all">
-        <Scopes>internal_code_mgt_delete</Scopes>
+        <Scopes>internal_user_code_mgt_delete</Scopes>
     </Resource>
 
     <!-- User Personal Identification API -->
@@ -458,12 +458,12 @@
 
     <!-- [Organization] SCIM2 Bulk API -->
     <Resource context="(.*)/o/scim2/Bulk(.*)" secured="true" http-method="POST">
-        <Scopes>internal_org_bulk_mgt_create</Scopes>
+        <Scopes>internal_org_bulk_resource_create</Scopes>
     </Resource>
 
     <!-- SCIM2 Bulk API -->
     <Resource context="(.*)/scim2/Bulk(.*)" secured="true" http-method="POST">
-        <Scopes>internal_bulk_mgt_create</Scopes>
+        <Scopes>internal_bulk_resource_create</Scopes>
     </Resource>
 
     <!-- [Organization] Authentication Data APIs -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -280,7 +280,7 @@
 
     <!-- Identity Register API -->
     <Resource context="(.*)/identity/register(.*)" secured="true" http-method="all">
-        <Scopes>internal_dcr_delete</Scopes>
+        <Scopes>internal_dcr_create</Scopes>
     </Resource>
     <Resource context="(.*)/identity/connect/register(.*)" secured="true" http-method="all">
         <Scopes>internal_dcr_create</Scopes>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -44,26 +44,26 @@
         <Resource context="(.*)" secured="false" http-method="OPTIONS"/>
         <Resource context="/" secured="false" http-method="GET"/>
 
-        <!-- Code Management API -->
+        <!-- User Code Management API -->
         <Resource context="(.*)/api/identity/user/v1.0/validate-code(.*)" secured="true" http-method="POST">
-            <Scopes>internal_code_mgt_create</Scopes>
+            <Scopes>internal_user_code_mgt_create</Scopes>
         </Resource>
 
         <Resource context="(.*)/api/identity/user/v1.0/introspect-code(.*)" secured="true" http-method="POST">
-            <Scopes>internal_code_mgt_view</Scopes>
+            <Scopes>internal_user_code_mgt_view</Scopes>
         </Resource>
 
         <Resource context="(.*)/api/identity/user/v1.0/resend-code(.*)" secured="true" http-method="GET">
-            <Scopes>internal_code_mgt_view</Scopes>
+            <Scopes>internal_user_code_mgt_view</Scopes>
         </Resource>
         <Resource context="(.*)/api/identity/user/v1.0/resend-code(.*)" secured="true" http-method="POST">
-            <Scopes>internal_code_mgt_create</Scopes>
+            <Scopes>internal_user_code_mgt_create</Scopes>
         </Resource>
         <Resource context="(.*)/api/identity/user/v1.0/resend-code(.*)" secured="true" http-method="PATCH, PUT">
-            <Scopes>internal_code_mgt_update</Scopes>
+            <Scopes>internal_user_code_mgt_update</Scopes>
         </Resource>
         <Resource context="(.*)/api/identity/user/v1.0/resend-code(.*)" secured="true" http-method="all">
-            <Scopes>internal_code_mgt_delete</Scopes>
+            <Scopes>internal_user_code_mgt_delete</Scopes>
         </Resource>
 
         <!-- User Personal Identification API -->
@@ -480,12 +480,12 @@
 
         <!-- [Organization] SCIM2 Bulk API -->
         <Resource context="(.*)/o/scim2/Bulk(.*)" secured="true" http-method="POST">
-            <Scopes>internal_org_bulk_mgt_create</Scopes>
+            <Scopes>internal_org_bulk_resource_create</Scopes>
         </Resource>
 
         <!-- SCIM2 Bulk API -->
         <Resource context="(.*)/scim2/Bulk(.*)" secured="true" http-method="POST">
-            <Scopes>internal_bulk_mgt_create</Scopes>
+            <Scopes>internal_bulk_resource_create</Scopes>
         </Resource>
 
         <!-- [Organization] Authentication Data APIs -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -302,7 +302,7 @@
 
         <!-- Identity Register API -->
         <Resource context="(.*)/identity/register(.*)" secured="true" http-method="all">
-            <Scopes>internal_dcr_delete</Scopes>
+            <Scopes>internal_dcr_create</Scopes>
         </Resource>
         <Resource context="(.*)/identity/connect/register(.*)" secured="true" http-method="all">
             <Scopes>internal_dcr_create</Scopes>


### PR DESCRIPTION
Related to https://github.com/wso2/product-is/issues/18991

### Proposed changes in this pull request

Some of the API endpoints have inappropriate scope names when considered to actual behaviours. The following scope names are changed

- internal_org_bulk_mgt_create(view/update/delete) -> internal_org_bulk_resource_create(view/update/delete)
- internal_code_mgt_create(view/update/delete) -> internal_user_code_mgt_create(view/update/delete)


The following scope names are removed since they are not required
- internal_register_create
- internal_register_delete

Changed the scope name of `(.*)/identity/register(.*)` 
- internal_dcr_delete -> internal_dcr_create
