### PR TITLE
Remove unused http methods in resource access control and unused scopes

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -739,10 +739,6 @@
                     description="View recovery in the organization (root)"/>
             <Scope displayName="Create Recovery" name="internal_recovery_create" 
                     description="Create new recovery in the organization (root)"/>
-            <Scope displayName="Update Recovery" name="internal_recovery_update" 
-                    description="Update recovery in the organization (root)"/>
-            <Scope displayName="Delete Recovery" name="internal_recovery_delete" 
-                    description="Delete recovery in the organization (root)"/>
         </Scopes>
     </APIResource>
     <APIResource name="Identity Recovery API" identifier="/o/api/identity/recovery"
@@ -754,10 +750,6 @@
                     description="View recovery in the organization"/>
             <Scope displayName="Create Recovery" name="internal_org_recovery_create" 
                     description="Create new recovery in the organization"/>
-            <Scope displayName="Update Recovery" name="internal_org_recovery_update" 
-                    description="Update recovery in the organization"/>
-            <Scope displayName="Delete Recovery" name="internal_org_recovery_delete" 
-                    description="Delete recovery in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="OAuth DCR API" identifier="/api/identity/oauth2/dcr/v1.1/register"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -748,10 +748,6 @@
                     description="View recovery in the organization (root)"/>
             <Scope displayName="Create Recovery" name="internal_recovery_create" 
                     description="Create new recovery in the organization (root)"/>
-            <Scope displayName="Update Recovery" name="internal_recovery_update" 
-                    description="Update recovery in the organization (root)"/>
-            <Scope displayName="Delete Recovery" name="internal_recovery_delete" 
-                    description="Delete recovery in the organization (root)"/>
         </Scopes>
     </APIResource>
     <APIResource name="Identity Recovery API" identifier="/o/api/identity/recovery"
@@ -763,10 +759,6 @@
                     description="View recovery in the organization"/>
             <Scope displayName="Create Recovery" name="internal_org_recovery_create" 
                     description="Create new recovery in the organization"/>
-            <Scope displayName="Update Recovery" name="internal_org_recovery_update" 
-                    description="Update recovery in the organization"/>
-            <Scope displayName="Delete Recovery" name="internal_org_recovery_delete" 
-                    description="Delete recovery in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="OAuth DCR API" identifier="/api/identity/oauth2/dcr/v1.1/register"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1550,20 +1550,6 @@
             <Scopes>internal_identity_mgt_create</Scopes>
             <Scopes>internal_identity_mgt_delete</Scopes>
         </Resource>
-        <Resource context="(.*)/api/identity/recovery/(.*)" secured="true" http-method="PATCH, PUT">
-            <Permissions>/permission/admin/manage/identity/identitymgt</Permissions>
-            <Scopes>internal_identity_mgt_view</Scopes>
-            <Scopes>internal_identity_mgt_update</Scopes>
-            <Scopes>internal_identity_mgt_create</Scopes>
-            <Scopes>internal_identity_mgt_delete</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/identity/recovery/(.*)" secured="true" http-method="DELETE">
-            <Permissions>/permission/admin/manage/identity/identitymgt</Permissions>
-            <Scopes>internal_identity_mgt_view</Scopes>
-            <Scopes>internal_identity_mgt_update</Scopes>
-            <Scopes>internal_identity_mgt_create</Scopes>
-            <Scopes>internal_identity_mgt_delete</Scopes>
-        </Resource>
         <Resource context="(.*)/.well-known/openid-configuration(.*)" secured="false" http-method="all"/>
         <Resource context="/.well-known/webfinger(.*)" secured="false" http-method="all"/>
         <Resource context="(.*)/api/identity/oauth2/dcr/(.*)" secured="true" http-method="POST">

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2528,20 +2528,6 @@
             <Scopes>internal_identity_mgt_create</Scopes>
             <Scopes>internal_identity_mgt_delete</Scopes>
         </Resource>
-        <Resource context="(.*)/api/identity/recovery/(.*)" secured="true" http-method="PATCH, PUT">
-            <Permissions>/permission/admin/manage/identity/identitymgt</Permissions>
-            <Scopes>internal_identity_mgt_view</Scopes>
-            <Scopes>internal_identity_mgt_update</Scopes>
-            <Scopes>internal_identity_mgt_create</Scopes>
-            <Scopes>internal_identity_mgt_delete</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/identity/recovery/(.*)" secured="true" http-method="DELETE">
-            <Permissions>/permission/admin/manage/identity/identitymgt</Permissions>
-            <Scopes>internal_identity_mgt_view</Scopes>
-            <Scopes>internal_identity_mgt_update</Scopes>
-            <Scopes>internal_identity_mgt_create</Scopes>
-            <Scopes>internal_identity_mgt_delete</Scopes>
-        </Resource>
         <Resource context="(.*)/.well-known/openid-configuration(.*)" secured="false" http-method="all"/>
         <Resource context="/.well-known/webfinger(.*)" secured="false" http-method="all"/>
         <Resource context="(.*)/api/identity/oauth2/dcr/(.*)" secured="true" http-method="POST">

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -240,12 +240,6 @@
     <Resource context="(.*)/o/api/identity/recovery/(.*)" secured="true" http-method="POST">
         <Scopes>internal_org_recovery_create</Scopes>
     </Resource>
-    <Resource context="(.*)/o/api/identity/recovery/(.*)" secured="true" http-method="PATCH, PUT">
-        <Scopes>internal_org_recovery_update</Scopes>
-    </Resource>
-    <Resource context="(.*)/o/api/identity/recovery/(.*)" secured="true" http-method="DELETE">
-        <Scopes>internal_org_recovery_delete</Scopes>
-    </Resource>
 
     <!-- Identity Recovery API -->
     <Resource context="(.*)/api/identity/recovery/(.*)" secured="true" http-method="GET">
@@ -253,12 +247,6 @@
     </Resource>
     <Resource context="(.*)/api/identity/recovery/(.*)" secured="true" http-method="POST">
         <Scopes>internal_recovery_create</Scopes>
-    </Resource>
-    <Resource context="(.*)/api/identity/recovery/(.*)" secured="true" http-method="PATCH, PUT">
-        <Scopes>internal_recovery_update</Scopes>
-    </Resource>
-    <Resource context="(.*)/api/identity/recovery/(.*)" secured="true" http-method="DELETE">
-        <Scopes>internal_recovery_delete</Scopes>
     </Resource>
 
     <Resource context="(.*)/.well-known/openid-configuration(.*)" secured="false" http-method="all"/>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -262,12 +262,6 @@
         <Resource context="(.*)/o/api/identity/recovery/(.*)" secured="true" http-method="POST">
             <Scopes>internal_org_recovery_create</Scopes>
         </Resource>
-        <Resource context="(.*)/o/api/identity/recovery/(.*)" secured="true" http-method="PATCH, PUT">
-            <Scopes>internal_org_recovery_update</Scopes>
-        </Resource>
-        <Resource context="(.*)/o/api/identity/recovery/(.*)" secured="true" http-method="DELETE">
-            <Scopes>internal_org_recovery_delete</Scopes>
-        </Resource>
 
         <!-- Identity Recovery API -->
         <Resource context="(.*)/api/identity/recovery/(.*)" secured="true" http-method="GET">
@@ -275,12 +269,6 @@
         </Resource>
         <Resource context="(.*)/api/identity/recovery/(.*)" secured="true" http-method="POST">
             <Scopes>internal_recovery_create</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/identity/recovery/(.*)" secured="true" http-method="PATCH, PUT">
-            <Scopes>internal_recovery_update</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/identity/recovery/(.*)" secured="true" http-method="DELETE">
-            <Scopes>internal_recovery_delete</Scopes>
         </Resource>
 
         <Resource context="(.*)/.well-known/openid-configuration(.*)" secured="false" http-method="all"/>


### PR DESCRIPTION
### Proposed changes in this pull request
Only POST and GET calls are available in `/api/identity/recovery/` endpoint. This PR removes,
- Not available http methods in `/api/identity/recovery/` endpoint from resource access control files.
- Remove the scopes from system api resources
