### PR TITLE
Update tenant management scopes

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -358,8 +358,10 @@
     <APIResource name="Tenant Management API" identifier="/api/server/v1/tenants"
                  requiresAuthorization="true" description="API representation of the Tenant Management API" type="SYSTEM">
         <Scopes>
-            <Scope displayName="List Tenants" name="internal_list_tenants" 
-                    description="Create/retrieve the organizations (root) and check domain availability"/>
+            <Scope displayName="Create Tenants" name="internal_create_tenants"
+                   description="Create the organizations (root)"/>
+            <Scope displayName="List Tenants" name="internal_list_tenants"
+                   description="Retrieve the organizations (root) and check domain availability"/>
             <Scope displayName="Modify Tenants" name="internal_modify_tenants" 
                     description="Activate/deactivate the organization (root) and delete its meta data"/>
         </Scopes>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -367,8 +367,10 @@
     <APIResource name="Tenant Management API" identifier="/api/server/v1/tenants"
                  requiresAuthorization="true" description="API representation of the Tenant Management API" type="SYSTEM">
         <Scopes>
+            <Scope displayName="Create Tenants" name="internal_create_tenants"
+                    description="Create the organizations (root)"/>
             <Scope displayName="List Tenants" name="internal_list_tenants" 
-                    description="Create/retrieve the organizations (root) and check domain availability"/>
+                    description="Retrieve the organizations (root) and check domain availability"/>
             <Scope displayName="Modify Tenants" name="internal_modify_tenants" 
                     description="Activate/deactivate the organization (root) and delete its meta data"/>
         </Scopes>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -899,11 +899,14 @@
     </Resource>
 
     <!-- Tenant Management API -->
-    <Resource context="/api/server/v1/tenants(.*)" secured="true" http-method="GET, POST, HEAD">
+    <Resource context="/api/server/v1/tenants(.*)" secured="true" http-method="GET, HEAD">
         <Scopes>internal_list_tenants</Scopes>
     </Resource>
+    <Resource context="/api/server/v1/tenants(.*)" secured="true" http-method="POST">
+        <Scopes>internal_create_tenants</Scopes>
+    </Resource>
     <Resource context="/api/server/v1/channel-verified-tenants(.*)" secured="true" http-method="POST">
-        <Scopes>internal_list_tenants</Scopes>
+        <Scopes>internal_create_tenants</Scopes>
     </Resource>
     <Resource context="/api/server/v1/tenants(.*)" secured="true" http-method="PUT">
         <Scopes>internal_modify_tenants</Scopes>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -948,11 +948,14 @@
         </Resource>
 
         <!-- Tenant Management API -->
-        <Resource context="/api/server/v1/tenants(.*)" secured="true" http-method="GET, POST, HEAD">
+        <Resource context="/api/server/v1/tenants(.*)" secured="true" http-method="GET, HEAD">
             <Scopes>internal_list_tenants</Scopes>
         </Resource>
+        <Resource context="/api/server/v1/tenants(.*)" secured="true" http-method="POST">
+            <Scopes>internal_create_tenants</Scopes>
+        </Resource>
         <Resource context="/api/server/v1/channel-verified-tenants(.*)" secured="true" http-method="POST">
-            <Scopes>internal_list_tenants</Scopes>
+            <Scopes>internal_create_tenants</Scopes>
         </Resource>
         <Resource context="/api/server/v1/tenants(.*)" secured="true" http-method="PUT">
             <Scopes>internal_modify_tenants</Scopes>


### PR DESCRIPTION
### Proposed changes in this pull request

Currently, listing, creating and domain existence operations of the tenant management API are being protected by `internal_list_tenants` scopes. This updates the tenant management scopes to have a `internal_create_tenants` scope.

Issue https://github.com/wso2/product-is/issues/19177