### PR TITLE
Fix the issue of sending duplicate user provisioning requests

### DIFF
--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/IdentityProvisioningConstants.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/IdentityProvisioningConstants.java
@@ -40,6 +40,8 @@ public class IdentityProvisioningConstants {
     public static final String LOCAL_SP = ApplicationConstants.LOCAL_SP;
     public static final String JIT_PROVISIONING_ENABLED = "jitProvisioningEnabled";
     public static final String LAST_MODIFIED_CLAIM = "http://wso2.org/claims/modified";
+    public static final String ASK_PASSWORD_CLAIM = "http://wso2.org/claims/identity/askPassword";
+    public static final String SELF_SIGNUP_ROLE = "Internal/selfsignup";
 
     public static final String IS_TRUE_VALUE = "1";
     public static final String IS_FALSE_VALUE = "0";


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves https://github.com/wso2/product-is/issues/19055

### Describe the issue
- During the self registration flow and ask password flow, when we have enabled outbound provisioning(google/scim2) woith non-blocking we can see duplicate outbound user creation requests and due to duplicate user creation requests second user provisioning request was failing with 409(conflicts) error.
- The reason for this is that when the non-blocking outbound provisioning was enabled we don't wait till the outbound user provisioning getting completed since we are using a thread pool. 
- But the the User provisioning identifier receives only after the successful completion of the user provisioning and after receiving it we store it in our database.
- But in the self registration and ask password flow, with our implementations, we do user claim update for account locking after the user creation in the same thread.
- Due to this user claim update `OutboundProvisioningManager` receives a user update request and but at the moment we don't have a provisioning identifier for that user, since the first user outbound provisioning was not completed yet. Since the user doesn't have a provisioning identifier, `OutboundProvisioningManager` tries to creates the user again in Outbound IDP.

### Proposed Solution
- With this fix we are implement a waiting(blocking) mechanism until the outbound provisioning user creation get completes in self registration and ask password flows.