### PR TITLE
Fix keystore issue.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/TenantMgtAdminServiceClient.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/TenantMgtAdminServiceClient.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonException;
+import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import javax.net.ssl.HostnameVerifier;
@@ -65,7 +66,9 @@ public class TenantMgtAdminServiceClient {
     /**
      * Default keystore type of the client
      */
-    private static String keyStoreType = KeystoreUtils.StoreFileType.defaultFileType();
+    @Deprecated
+    private static String keyStoreType = KeystoreUtils.getKeyStoreFileExtension(
+            MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
     /**
      * Default truststore type of the client
      */
@@ -291,10 +294,12 @@ public class TenantMgtAdminServiceClient {
         return response;
     }
 
+    @Deprecated
     public static String getKeyStoreType() {
         return keyStoreType;
     }
 
+    @Deprecated
     public static void setKeyStoreType(String keyStoreType) {
         TenantMgtAdminServiceClient.keyStoreType = keyStoreType;
     }


### PR DESCRIPTION
Previously we kept the KEYSTORE_FILE_EXTENSION as follows. With the https://github.com/wso2/product-is/issues/18466 effort, we need to pass the tenant domain to get the relevent file extension to support backward compatibility. 
`public static final String KEYSTORE_FILE_EXTENSION = ".jks";`

Hence, make `KEYSTORE_FILE_EXTENSION` deprecated and keep the same value