### PR TITLE
Upgrade xmlsec dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1810,7 +1810,7 @@
         <derby.version>10.4.2.0</derby.version>
         <activation.version>1.1</activation.version>
         <javamail.version>1.4</javamail.version>
-        <xmlsec.version>2.3.0</xmlsec.version>
+        <xmlsec.version>2.3.4</xmlsec.version>
         <jsr105.version>1.0.1.wso2v1</jsr105.version>
         <xmlsec.version.imp.pkg.version.range>[2.1.7,2.4.0)</xmlsec.version.imp.pkg.version.range>
         <wsdl4j.wso2.version>1.6.2.wso2v4</wsdl4j.wso2.version>


### PR DESCRIPTION
### Purpose
Upgrade the xmlsec dependency version to the latest non-vulnerable version in 2.3 versions: 2.3.4