### PR TITLE
Revert "Remove features from management console"

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.ui.feature/pom.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.ui.feature/pom.xml
@@ -63,6 +63,7 @@
                                 </properties>
                             </adviceFile>
                             <bundles>
+                                <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.claim.mgt.ui</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.claim.mgt.stub</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.claim.metadata.mgt.stub</bundleDef>
                             </bundles>

--- a/features/user-mgt/org.wso2.carbon.user.mgt.ui.feature/pom.xml
+++ b/features/user-mgt/org.wso2.carbon.user.mgt.ui.feature/pom.xml
@@ -47,6 +47,10 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.user.store.configuration.ui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.user.store.configuration</artifactId>
         </dependency>
         <dependency>
@@ -87,6 +91,9 @@
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.user.mgt.ui</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.user.mgt.stub</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.user.mgt.common
+                                </bundleDef>
+                                <bundleDef>
+                                    org.wso2.carbon.identity.framework:org.wso2.carbon.identity.user.store.configuration.ui
                                 </bundleDef>
                                 <bundleDef>
                                     org.wso2.carbon.identity.framework:org.wso2.carbon.identity.user.store.configuration.stub


### PR DESCRIPTION
Reverts wso2/carbon-identity-framework#5382

Remove the UI features from configuration, instead of removing the UI component