### PR TITLE
Upgrade xmlsec dependency version and downgrade poi version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1831,7 +1831,7 @@
         <derby.version>10.4.2.0</derby.version>
         <activation.version>1.1</activation.version>
         <javamail.version>1.4</javamail.version>
-        <xmlsec.version>2.3.0</xmlsec.version>
+        <xmlsec.version>2.3.4</xmlsec.version>
         <jsr105.version>1.0.1.wso2v1</jsr105.version>
         <xmlsec.version.imp.pkg.version.range>[2.1.7,2.4.0)</xmlsec.version.imp.pkg.version.range>
         <wsdl4j.wso2.version>1.6.2.wso2v4</wsdl4j.wso2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1982,7 +1982,7 @@
         <cxf-bundle.wso2.version>2.7.16.wso2v1</cxf-bundle.wso2.version>
         <org.apache.cxf.version>3.6.2</org.apache.cxf.version>
         <opencsv.wso2.version>1.8.wso2v1</opencsv.wso2.version>
-        <orbit.version.poi>5.2.3.wso2v1</orbit.version.poi>
+        <orbit.version.poi>4.1.2.wso2v1</orbit.version.poi>
         <javax.activation.import.pkg.version>[0.0.0, 1.0.0)</javax.activation.import.pkg.version>
         <com.yubico.version>0.14.0</com.yubico.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>


### PR DESCRIPTION
### Purpose
- Upgrade the xmlsec dependency version to the latest non-vulnerable version in 2.3 versions: 2.3.4
- Resolve APIM repository build issues by downgrading poi version from poi-4.1.2.