### PR TITLE
[JIT] Fix unwanted username conversions

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -82,7 +82,6 @@ import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
-import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -1290,8 +1289,7 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
             UserRealm realm = getUserRealm(context.getTenantDomain());
             UserStoreManager userStoreManager = getUserStoreManager(context.getExternalIdP()
                     .getProvisioningUserStoreId(), realm, username);
-            String sanitizedUserName = UserCoreUtil.removeDomainFromName(
-                    MultitenantUtils.getTenantAwareUsername(username));
+            String sanitizedUserName = UserCoreUtil.removeDomainFromName(username);
             if (userStoreManager.isExistingUser(sanitizedUserName)) {
                 // Logging the error because the thrown exception is handled in the UI.
                 log.error(ErrorMessages.USER_ALREADY_EXISTS_ERROR.getCode() + " - "


### PR DESCRIPTION
### Proposed changes in this pull request
related issue: https://github.com/wso2/product-is/issues/19265


### Root cause

Framework cross checks whether username already exists in the system [here](https://github.com/wso2/carbon-identity-framework/blob/bbefd009d39a8a9500f5ffd1e27803053f39a823/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java#L1294). 

But before checking in userstore, we are sanitising the username by removing tenant domain and user store domain.

Since the deployment is not configured email as username type, so `abc@gmail.com `-becomes ` abc` after sanitization. If there is a user named `abc` exists, the flow will fail.

Tested with Google JIT provisioning

https://github.com/wso2/carbon-identity-framework/assets/25488962/7036f967-ea4b-47ab-82a2-b2891e60a8ba


