### PR TITLE
Added null check for updatedClaimValue in UserClaimsAuditLogger

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserClaimsAuditLogger.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserClaimsAuditLogger.java
@@ -191,7 +191,8 @@ public class UserClaimsAuditLogger extends AbstractIdentityUserOperationEventLis
                     updatedClaims.put(claimURI, updatedClaimValue);
                 }
                 // Get claims when the claim value is removed.
-                if (StringUtils.isEmpty(updatedClaimValue) && StringUtils.isNotEmpty(claimValue)) {
+                if (updatedClaimValue != null &&
+                        StringUtils.isEmpty(updatedClaimValue) && StringUtils.isNotEmpty(claimValue)) {
                     removedClaims.put(claimURI, claimValue);
                 }
             }


### PR DESCRIPTION
### Purpose
If some external class calls the logger with a list of claims that are not configured as loggable claims, it will incorrectly add the missing loggable claim as a removed claim. Adding a null check will fix this issue. 

### Related issues
- https://github.com/wso2/product-is/issues/19196