### PR TITLE
Invoke user core APIs when resolving groups

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/RoleConstants.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/RoleConstants.java
@@ -107,7 +107,8 @@ public class RoleConstants {
         ERROR_CODE_CUSTOM_EVENT_HANDLER_ERROR("55001"),
 
         UNEXPECTED_SERVER_ERROR("65001"),
-        SORTING_NOT_IMPLEMENTED("65002");
+        SORTING_NOT_IMPLEMENTED("65002"),
+        UNSUPPORTED_USER_STORE_MANAGER("65003");;
 
         private final String code;
         private static final String ROLE_MANAGEMENT_ERROR_CODE_PREFIX = "RMA-";

--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/dao/GroupDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/dao/GroupDAOImpl.java
@@ -18,188 +18,181 @@
 
 package org.wso2.carbon.identity.role.mgt.core.dao;
 
-import org.wso2.carbon.database.utils.jdbc.NamedPreparedStatement;
-import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.role.mgt.core.IdentityRoleManagementClientException;
 import org.wso2.carbon.identity.role.mgt.core.IdentityRoleManagementException;
 import org.wso2.carbon.identity.role.mgt.core.IdentityRoleManagementServerException;
-import org.wso2.carbon.identity.role.mgt.core.RoleConstants;
+import org.wso2.carbon.identity.role.mgt.core.internal.RoleManagementServiceComponentHolder;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.UserStoreClientException;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.wso2.carbon.identity.role.mgt.core.RoleConstants.Error.INVALID_REQUEST;
 import static org.wso2.carbon.identity.role.mgt.core.RoleConstants.Error.UNEXPECTED_SERVER_ERROR;
-import static org.wso2.carbon.identity.role.mgt.core.dao.SQLQueries.GET_GROUP_ID_BY_NAME_SQL;
-import static org.wso2.carbon.identity.role.mgt.core.dao.SQLQueries.GET_GROUP_NAME_BY_ID_SQL;
+import static org.wso2.carbon.identity.role.mgt.core.RoleConstants.Error.UNSUPPORTED_USER_STORE_MANAGER;
+import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_NO_GROUP_FOUND_WITH_ID;
+import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_NO_GROUP_FOUND_WITH_NAME;
 
 /**
  * RoleDAO Implementation.
  */
 public class GroupDAOImpl implements GroupDAO {
 
+    private static final Log LOG = LogFactory.getLog(GroupDAOImpl.class);
+
     @Override
     public String getGroupNameByID(String id, String tenantDomain) throws IdentityRoleManagementException {
 
-        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-        String groupName = null;
-        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
-            try (NamedPreparedStatement statement = new NamedPreparedStatement(connection, GET_GROUP_NAME_BY_ID_SQL)) {
-                statement.setInt(RoleConstants.RoleTableColumns.TENANT_ID, tenantId);
-                statement.setString(RoleConstants.RoleTableColumns.ATTR_NAME, RoleConstants.ID_URI);
-                statement.setString(RoleConstants.RoleTableColumns.ATTR_VALUE, id);
-                int count = 0;
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    while (resultSet.next()) {
-                        // Handle multiple matching groups.
-                        count++;
-                        if (count > 1) {
-                            String errorMessage =
-                                    "Invalid scenario. Multiple groups found for the given group ID: " + id + " and "
-                                            + "tenantDomain: " + tenantDomain;
-                            throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
-                        }
-                        groupName = resultSet.getString(1);
-                    }
+        try {
+            AbstractUserStoreManager userStoreManager = getUserStoreManager(tenantDomain);
+            return userStoreManager.getGroupNameByGroupId(id);
+        } catch (UserStoreException e) {
+            String errorMessage = String.format("Error while resolving the group name for the given " +
+                    "group ID: %s in tenantDomain: %s", id, tenantDomain);
+            if (e instanceof UserStoreClientException) {
+                // This is to ensure backward compatibility with the previous implementation.
+                if (StringUtils.isNotBlank(e.getErrorCode()) && ERROR_NO_GROUP_FOUND_WITH_ID.getCode()
+                        .equals(e.getErrorCode())) {
+                    LOG.debug(String.format("No group found for the given group ID: %s in the tenantDomain: %s. " +
+                            "Therefore, returning an empty String.", id, tenantDomain));
+                    return null;
                 }
+                throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage, e);
             }
-        } catch (SQLException e) {
-            String errorMessage =
-                    "Error while resolving the group name for the given group ID: " + id + " and tenantDomain: "
-                            + tenantDomain;
             throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(), errorMessage, e);
         }
-        return groupName;
     }
 
     @Override
     public Map<String, String> getGroupNamesByIDs(List<String> ids, String tenantDomain)
             throws IdentityRoleManagementException {
 
-        Map<String, String> groupIdsToNames;
-        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
-            groupIdsToNames = batchProcessGroupIDs(ids, tenantDomain, connection);
-        } catch (SQLException e) {
-            String errorMessage =
-                    "Error while resolving the group name for the given group Ids in the tenantDomain: " + tenantDomain;
-            throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(), errorMessage, e);
-        }
-        return groupIdsToNames;
-    }
-
-    private Map<String, String> batchProcessGroupIDs(List<String> ids, String tenantDomain, Connection connection)
-            throws SQLException, IdentityRoleManagementException {
-
-        Map<String, String> groupIdsToNames = new HashMap<>();
-        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-        String groupName;
-        for (String id : ids) {
-            try (NamedPreparedStatement statement = new NamedPreparedStatement(connection, GET_GROUP_NAME_BY_ID_SQL)) {
-                statement.setInt(RoleConstants.RoleTableColumns.TENANT_ID, tenantId);
-                statement.setString(RoleConstants.RoleTableColumns.ATTR_NAME, RoleConstants.ID_URI);
-                statement.setString(RoleConstants.RoleTableColumns.ATTR_VALUE, id);
-                int count = 0;
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    while (resultSet.next()) {
-                        // Handle multiple matching groups.
-                        count++;
-                        if (count > 1) {
-                            String errorMessage =
-                                    "Invalid scenario. Multiple groups found for the given group ID: " + id + " and "
-                                            + "tenantDomain: " + tenantDomain;
-                            throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
+        try {
+            Map<String, String> groupIdsToNames = new HashMap<>();
+            AbstractUserStoreManager userStoreManager = getUserStoreManager(tenantDomain);
+            for (String id : ids) {
+                try {
+                    groupIdsToNames.put(id, userStoreManager.getGroupNameByGroupId(id));
+                } catch (UserStoreClientException e) {
+                    // This is to ensure backward compatibility with the previous implementation.
+                    if (StringUtils.isNotBlank(e.getErrorCode()) && ERROR_NO_GROUP_FOUND_WITH_ID.getCode()
+                            .equals(e.getErrorCode())) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug(String.format("No group found for the given group ID: %s in the " +
+                                    "tenantDomain: %s. Therefore, skipping group id lookup.", id, tenantDomain));
                         }
-                        groupName = resultSet.getString(1);
-                        groupIdsToNames.put(id, groupName);
+                    } else {
+                        throw e;
                     }
                 }
             }
+            return groupIdsToNames;
+        } catch (UserStoreException e) {
+            String errorMessage = "Error while resolving the group name for the given group Ids in " +
+                    "the tenantDomain: " + tenantDomain;
+            if (e instanceof UserStoreClientException) {
+                throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage, e);
+            }
+            throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(), errorMessage, e);
         }
-        return groupIdsToNames;
     }
 
     @Override
     public String getGroupIDByName(String name, String tenantDomain) throws IdentityRoleManagementException {
 
-        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-        String groupID = null;
-        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
-            try (NamedPreparedStatement statement = new NamedPreparedStatement(connection, GET_GROUP_ID_BY_NAME_SQL)) {
-                statement.setInt(RoleConstants.RoleTableColumns.TENANT_ID, tenantId);
-                statement.setString(RoleConstants.RoleTableColumns.ROLE_NAME, name);
-                statement.setString(RoleConstants.RoleTableColumns.ATTR_NAME, RoleConstants.ID_URI);
-                int count = 0;
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    while (resultSet.next()) {
-                        // Handle multiple matching groups.
-                        count++;
-                        if (count > 1) {
-                            String errorMessage =
-                                    "Invalid scenario. Multiple groups found for the given group name: " + name + " "
-                                            + "and tenantDomain: " + tenantDomain;
-                            throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
-                        }
-                        groupID = resultSet.getString(1);
+        try {
+            AbstractUserStoreManager userStoreManager = getUserStoreManager(tenantDomain);
+            return userStoreManager.getGroupIdByGroupName(name);
+        } catch (UserStoreException e) {
+            String errorMessage = String.format("Error while resolving the group id for the given group: %s in " +
+                    "tenantDomain: %s", name, tenantDomain);
+            if (e instanceof UserStoreClientException) {
+                // This is to ensure backward compatibility with the previous implementation.
+                if (StringUtils.isNotBlank(e.getErrorCode()) && ERROR_NO_GROUP_FOUND_WITH_NAME.getCode()
+                        .equals(e.getErrorCode())) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(String.format("No group found for the given group: %s in the tenantDomain: %s. " +
+                                "Therefore, returning an Empty String.", name, tenantDomain));
                     }
+                    return null;
                 }
+                throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage, e);
             }
-        } catch (SQLException e) {
-            String errorMessage =
-                    "Error while resolving the group ID for the given group name: " + name + " and tenantDomain: "
-                            + tenantDomain;
             throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(), errorMessage, e);
         }
-        return groupID;
     }
 
     @Override
     public Map<String, String> getGroupIDsByNames(List<String> names, String tenantDomain)
             throws IdentityRoleManagementException {
 
-        Map<String, String> groupNamesToIDs;
-        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
-            groupNamesToIDs = batchProcessGroupNames(names, tenantDomain, connection);
-        } catch (SQLException e) {
-            String errorMessage =
-                    "Error while resolving the group ID for the given group names in the tenantDomain: " + tenantDomain;
-            throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(), errorMessage, e);
-        }
-        return groupNamesToIDs;
-    }
-
-    private Map<String, String> batchProcessGroupNames(List<String> names, String tenantDomain, Connection connection)
-            throws SQLException, IdentityRoleManagementException {
-
-        Map<String, String> groupNamesToIDs = new HashMap<>();
-        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-        String groupID;
-        for (String name : names) {
-            try (NamedPreparedStatement statement = new NamedPreparedStatement(connection, GET_GROUP_ID_BY_NAME_SQL)) {
-                statement.setInt(RoleConstants.RoleTableColumns.TENANT_ID, tenantId);
-                statement.setString(RoleConstants.RoleTableColumns.ROLE_NAME, name);
-                statement.setString(RoleConstants.RoleTableColumns.ATTR_NAME, RoleConstants.ID_URI);
-                int count = 0;
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    while (resultSet.next()) {
-                        // Handle multiple matching groups.
-                        count++;
-                        if (count > 1) {
-                            String errorMessage =
-                                    "Invalid scenario. Multiple groups found for the given group name: " + name + " "
-                                            + "and tenantDomain: " + tenantDomain;
-                            throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
+        try {
+            Map<String, String> groupNamesToIDs = new HashMap<>();
+            AbstractUserStoreManager userStoreManager = getUserStoreManager(tenantDomain);
+            for (String name : names) {
+                try {
+                    groupNamesToIDs.put(name, userStoreManager.getGroupIdByGroupName(name));
+                } catch (UserStoreClientException e) {
+                    // This is to ensure backward compatibility with the previous implementation.
+                    if (StringUtils.isNotBlank(e.getErrorCode()) && ERROR_NO_GROUP_FOUND_WITH_NAME.getCode()
+                            .equals(e.getErrorCode())) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug(String.format("No group id found for the given group: %s in the " +
+                                    "tenantDomain: %s. Therefore, skipping group name lookup.", name, tenantDomain));
                         }
-                        groupID = resultSet.getString(1);
-                        groupNamesToIDs.put(name, groupID);
+                    } else {
+                        throw e;
                     }
                 }
             }
+            return groupNamesToIDs;
+        } catch (UserStoreException e) {
+            String errorMessage = "Error while resolving the group ID for the given group names " +
+                    "in the tenantDomain: " + tenantDomain;
+            if (e instanceof UserStoreClientException) {
+                throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage, e);
+            }
+            throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(), errorMessage, e);
         }
-        return groupNamesToIDs;
+    }
+
+    /**
+     * Get the AbstractUserStoreManager for the given tenant domain.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return UserStoreManager.
+     * @throws IdentityRoleManagementServerException If an error occurred while getting the AbstractUserStoreManager
+     *                                               instance of the tenant.
+     */
+    private AbstractUserStoreManager getUserStoreManager(String tenantDomain)
+            throws IdentityRoleManagementServerException {
+
+        RealmService realmService = RoleManagementServiceComponentHolder.getInstance().getRealmService();
+        UserStoreManager userStoreManager;
+        try {
+            userStoreManager =
+                    realmService.getTenantUserRealm(realmService.getTenantManager().getTenantId(tenantDomain))
+                            .getUserStoreManager();
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(),
+                    "Error occurred while getting the userStoreManager for tenant: " + tenantDomain, e);
+        }
+        if (userStoreManager == null) {
+            throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(),
+                    "Error occurred while getting the userStoreManager for tenant: " + tenantDomain);
+        }
+        if (!(userStoreManager instanceof AbstractUserStoreManager)) {
+            throw new IdentityRoleManagementServerException(UNSUPPORTED_USER_STORE_MANAGER.getCode(),
+                    "Underlying userStoreManager does not support getGroupNameByID operation " + tenantDomain);
+        }
+        return (AbstractUserStoreManager) userStoreManager;
     }
 }

--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/dao/RoleDAOImpl.java
@@ -1705,30 +1705,26 @@ public class RoleDAOImpl implements RoleDAO {
 
         RealmService realmService = RoleManagementServiceComponentHolder.getInstance().getRealmService();
         String propValue = null;
-        if (realmService != null) {
-            try {
-                if (IdentityUtil.getPrimaryDomainName().equals(userStoreDomain)) {
-                    propValue = realmService.getTenantUserRealm(tenantId).getRealmConfiguration()
+        try {
+            if (IdentityUtil.getPrimaryDomainName().equals(userStoreDomain)) {
+                propValue = realmService.getTenantUserRealm(tenantId).getRealmConfiguration()
+                        .getUserStoreProperty(property);
+            } else {
+                UserStoreManager userStoreManager = realmService.getTenantUserRealm(tenantId).getUserStoreManager();
+                if (userStoreManager instanceof AbstractUserStoreManager) {
+                    propValue = ((AbstractUserStoreManager) userStoreManager)
+                            .getSecondaryUserStoreManager(userStoreDomain).getRealmConfiguration()
                             .getUserStoreProperty(property);
-                } else {
-                    UserStoreManager userStoreManager = realmService.getTenantUserRealm(tenantId).getUserStoreManager();
-                    if (userStoreManager instanceof AbstractUserStoreManager) {
-                        propValue = ((AbstractUserStoreManager) userStoreManager)
-                                .getSecondaryUserStoreManager(userStoreDomain).getRealmConfiguration()
-                                .getUserStoreProperty(property);
-                    }
                 }
-            } catch (UserStoreException e) {
-                log.error(String.format("Error while retrieving property %s for userstore %s in tenantId %s. " +
-                                "Returning null.", property, userStoreDomain, tenantId), e);
             }
+        } catch (UserStoreException e) {
+            log.error(String.format("Error while retrieving property %s for userstore %s in tenantId %s. " +
+                    "Returning null.", property, userStoreDomain, tenantId), e);
         }
-
         if (log.isDebugEnabled()) {
             log.debug(String.format("Userstore property %s is set to %s for userstore %s in tenantId %s",
                     property, propValue, userStoreDomain, tenantId));
         }
-
         return propValue;
     }
 }

--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/internal/RoleManagementServiceComponentHolder.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/internal/RoleManagementServiceComponentHolder.java
@@ -44,6 +44,9 @@ public class RoleManagementServiceComponentHolder {
 
     public RealmService getRealmService() {
 
+        if (realmService == null) {
+            throw new RuntimeException("RoleManagementServiceComponent is not initialized properly with RealmService");
+        }
         return realmService;
     }
 

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleConstants.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleConstants.java
@@ -139,7 +139,7 @@ public class RoleConstants {
 
         UNEXPECTED_SERVER_ERROR("65001"),
         SORTING_NOT_IMPLEMENTED("65002"),
-        UNSUPPORTED_USER_STORE_MANAGER("65003"),;
+        UNSUPPORTED_USER_STORE_MANAGER("65003");
 
         private final String code;
         public static final String ROLE_MANAGEMENT_ERROR_CODE_PREFIX = "RMA-";

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleConstants.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleConstants.java
@@ -138,7 +138,8 @@ public class RoleConstants {
         ERROR_CODE_CUSTOM_EVENT_HANDLER_ERROR("55001"),
 
         UNEXPECTED_SERVER_ERROR("65001"),
-        SORTING_NOT_IMPLEMENTED("65002");
+        SORTING_NOT_IMPLEMENTED("65002"),
+        UNSUPPORTED_USER_STORE_MANAGER("65003"),;
 
         private final String code;
         public static final String ROLE_MANAGEMENT_ERROR_CODE_PREFIX = "RMA-";

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/GroupDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/GroupDAOImpl.java
@@ -18,25 +18,24 @@
 
 package org.wso2.carbon.identity.role.v2.mgt.core.dao;
 
-import org.wso2.carbon.database.utils.jdbc.NamedPreparedStatement;
-import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementClientException;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementServerException;
+import org.wso2.carbon.identity.role.v2.mgt.core.internal.RoleManagementServiceComponentHolder;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.UserStoreClientException;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.Error.INVALID_REQUEST;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.Error.UNEXPECTED_SERVER_ERROR;
-import static org.wso2.carbon.identity.role.v2.mgt.core.dao.SQLQueries.GET_GROUP_ID_BY_NAME_SQL;
-import static org.wso2.carbon.identity.role.v2.mgt.core.dao.SQLQueries.GET_GROUP_NAME_BY_ID_SQL;
+import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.Error.UNSUPPORTED_USER_STORE_MANAGER;
 
 /**
  * RoleDAO Implementation.
@@ -46,160 +45,111 @@ public class GroupDAOImpl implements GroupDAO {
     @Override
     public String getGroupNameByID(String id, String tenantDomain) throws IdentityRoleManagementException {
 
-        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-        String groupName = null;
-        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
-            try (NamedPreparedStatement statement = new NamedPreparedStatement(connection, GET_GROUP_NAME_BY_ID_SQL)) {
-                statement.setInt(RoleConstants.RoleTableColumns.TENANT_ID, tenantId);
-                statement.setString(RoleConstants.RoleTableColumns.ATTR_NAME, RoleConstants.ID_URI);
-                statement.setString(RoleConstants.RoleTableColumns.ATTR_VALUE, id);
-                int count = 0;
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    while (resultSet.next()) {
-                        // Handle multiple matching groups.
-                        count++;
-                        if (count > 1) {
-                            String errorMessage =
-                                    "Invalid scenario. Multiple groups found for the given group ID: " + id + " and "
-                                            + "tenantDomain: " + tenantDomain;
-                            throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
-                        }
-                        groupName = resultSet.getString(1);
-                    }
-                }
+        try {
+            AbstractUserStoreManager userStoreManager = getUserStoreManager(tenantDomain);
+            return userStoreManager.getGroupNameByGroupId(id);
+        } catch (UserStoreException e) {
+            String errorMessage = String.format(
+                    "Error while resolving the group name for the given group ID: %s " + "and tenantDomain: %s", id,
+                    tenantDomain);
+            if (e instanceof UserStoreClientException) {
+                throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage, e);
             }
-        } catch (SQLException e) {
-            String errorMessage =
-                    "Error while resolving the group name for the given group ID: " + id + " and tenantDomain: "
-                            + tenantDomain;
             throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(), errorMessage, e);
         }
-        return groupName;
     }
 
     @Override
     public Map<String, String> getGroupNamesByIDs(List<String> ids, String tenantDomain)
             throws IdentityRoleManagementException {
 
-        Map<String, String> groupIdsToNames;
-        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
-            groupIdsToNames = batchProcessGroupIDs(ids, tenantDomain, connection);
-        } catch (SQLException e) {
+        try {
+            Map<String, String> groupIdsToNames = new HashMap<>();
+            AbstractUserStoreManager userStoreManager = getUserStoreManager(tenantDomain);
+            for (String id : ids) {
+                groupIdsToNames.put(id, userStoreManager.getGroupNameByGroupId(id));
+            }
+            return groupIdsToNames;
+        } catch (UserStoreException e) {
             String errorMessage =
                     "Error while resolving the group name for the given group Ids in the tenantDomain: " + tenantDomain;
+            if (e instanceof UserStoreClientException) {
+                throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage, e);
+            }
             throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(), errorMessage, e);
         }
-        return groupIdsToNames;
-    }
-
-    private Map<String, String> batchProcessGroupIDs(List<String> ids, String tenantDomain, Connection connection)
-            throws SQLException, IdentityRoleManagementException {
-
-        Map<String, String> groupIdsToNames = new HashMap<>();
-        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-        String groupName;
-        for (String id : ids) {
-            try (NamedPreparedStatement statement = new NamedPreparedStatement(connection, GET_GROUP_NAME_BY_ID_SQL)) {
-                statement.setInt(RoleConstants.RoleTableColumns.TENANT_ID, tenantId);
-                statement.setString(RoleConstants.RoleTableColumns.ATTR_NAME, RoleConstants.ID_URI);
-                statement.setString(RoleConstants.RoleTableColumns.ATTR_VALUE, id);
-                int count = 0;
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    while (resultSet.next()) {
-                        // Handle multiple matching groups.
-                        count++;
-                        if (count > 1) {
-                            String errorMessage =
-                                    "Invalid scenario. Multiple groups found for the given group ID: " + id + " and "
-                                            + "tenantDomain: " + tenantDomain;
-                            throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
-                        }
-                        groupName = resultSet.getString(1);
-                        groupIdsToNames.put(id, groupName);
-                    }
-                }
-            }
-        }
-        return groupIdsToNames;
     }
 
     @Override
     public String getGroupIDByName(String name, String tenantDomain) throws IdentityRoleManagementException {
 
-        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-        String groupID = null;
-        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
-            try (NamedPreparedStatement statement = new NamedPreparedStatement(connection, GET_GROUP_ID_BY_NAME_SQL)) {
-                statement.setInt(RoleConstants.RoleTableColumns.TENANT_ID, tenantId);
-                statement.setString(RoleConstants.RoleTableColumns.ROLE_NAME, name);
-                statement.setString(RoleConstants.RoleTableColumns.ATTR_NAME, RoleConstants.ID_URI);
-                int count = 0;
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    while (resultSet.next()) {
-                        // Handle multiple matching groups.
-                        count++;
-                        if (count > 1) {
-                            String errorMessage =
-                                    "Invalid scenario. Multiple groups found for the given group name: " + name + " "
-                                            + "and tenantDomain: " + tenantDomain;
-                            throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
-                        }
-                        groupID = resultSet.getString(1);
-                    }
-                }
+        String domainAwareName = UserCoreUtil.addDomainToName(name, tenantDomain);
+        try {
+            AbstractUserStoreManager userStoreManager = getUserStoreManager(tenantDomain);
+            return userStoreManager.getGroupIdByGroupName(UserCoreUtil.addDomainToName(name, domainAwareName));
+        } catch (UserStoreException e) {
+            String errorMessage = String.format(
+                    "Error while resolving the group id for the given group: %s " + "and tenantDomain: %s",
+                    domainAwareName, tenantDomain);
+            if (e instanceof UserStoreClientException) {
+                throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage, e);
             }
-        } catch (SQLException e) {
-            String errorMessage =
-                    "Error while resolving the group ID for the given group name: " + name + " and tenantDomain: "
-                            + tenantDomain;
             throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(), errorMessage, e);
         }
-        return groupID;
     }
 
     @Override
     public Map<String, String> getGroupIDsByNames(List<String> names, String tenantDomain)
             throws IdentityRoleManagementException {
 
-        Map<String, String> groupNamesToIDs;
-        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
-            groupNamesToIDs = batchProcessGroupNames(names, tenantDomain, connection);
-        } catch (SQLException e) {
+        try {
+            Map<String, String> groupNamesToIDs = new HashMap<>();
+            AbstractUserStoreManager userStoreManager = getUserStoreManager(tenantDomain);
+            for (String name : names) {
+                String domainAwareName = UserCoreUtil.addDomainToName(name, tenantDomain);
+                groupNamesToIDs.put(name,
+                        userStoreManager.getGroupIdByGroupName(UserCoreUtil.addDomainToName(name, domainAwareName)));
+            }
+            return groupNamesToIDs;
+        } catch (UserStoreException e) {
             String errorMessage =
                     "Error while resolving the group ID for the given group names in the tenantDomain: " + tenantDomain;
+            if (e instanceof UserStoreClientException) {
+                throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage, e);
+            }
             throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(), errorMessage, e);
         }
-        return groupNamesToIDs;
     }
 
-    private Map<String, String> batchProcessGroupNames(List<String> names, String tenantDomain, Connection connection)
-            throws SQLException, IdentityRoleManagementException {
+    /**
+     * Get the AbstractUserStoreManager for the given tenant domain.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return UserStoreManager.
+     * @throws IdentityRoleManagementServerException If an error occurred while getting the AbstractUserStoreManager
+     *                                               instance of the tenant.
+     */
+    private AbstractUserStoreManager getUserStoreManager(String tenantDomain)
+            throws IdentityRoleManagementServerException {
 
-        Map<String, String> groupNamesToIDs = new HashMap<>();
-        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-        String groupID;
-        for (String name : names) {
-            try (NamedPreparedStatement statement = new NamedPreparedStatement(connection, GET_GROUP_ID_BY_NAME_SQL)) {
-                statement.setInt(RoleConstants.RoleTableColumns.TENANT_ID, tenantId);
-                statement.setString(RoleConstants.RoleTableColumns.ROLE_NAME, name);
-                statement.setString(RoleConstants.RoleTableColumns.ATTR_NAME, RoleConstants.ID_URI);
-                int count = 0;
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    while (resultSet.next()) {
-                        // Handle multiple matching groups.
-                        count++;
-                        if (count > 1) {
-                            String errorMessage =
-                                    "Invalid scenario. Multiple groups found for the given group name: " + name + " "
-                                            + "and tenantDomain: " + tenantDomain;
-                            throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
-                        }
-                        groupID = resultSet.getString(1);
-                        groupNamesToIDs.put(name, groupID);
-                    }
-                }
-            }
+        RealmService realmService = RoleManagementServiceComponentHolder.getInstance().getRealmService();
+        UserStoreManager userStoreManager;
+        try {
+            userStoreManager =
+                    realmService.getTenantUserRealm(realmService.getTenantManager().getTenantId(tenantDomain))
+                            .getUserStoreManager();
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(),
+                    "Error occurred while getting the userStoreManager for tenant: " + tenantDomain, e);
         }
-        return groupNamesToIDs;
+        if (userStoreManager == null) {
+            throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(),
+                    "Error occurred while getting the userStoreManager for tenant: " + tenantDomain);
+        }
+        if (!(userStoreManager instanceof AbstractUserStoreManager)) {
+            throw new IdentityRoleManagementServerException(UNSUPPORTED_USER_STORE_MANAGER.getCode(),
+                    "Underlying userStoreManager does not support getGroupNameByID operation " + tenantDomain);
+        }
+        return (AbstractUserStoreManager) userStoreManager;
     }
 }

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -2243,23 +2243,21 @@ public class RoleDAOImpl implements RoleDAO {
 
         RealmService realmService = RoleManagementServiceComponentHolder.getInstance().getRealmService();
         String propValue = null;
-        if (realmService != null) {
-            try {
-                if (IdentityUtil.getPrimaryDomainName().equals(userStoreDomain)) {
-                    propValue = realmService.getTenantUserRealm(tenantId).getRealmConfiguration()
+        try {
+            if (IdentityUtil.getPrimaryDomainName().equals(userStoreDomain)) {
+                propValue = realmService.getTenantUserRealm(tenantId).getRealmConfiguration()
+                        .getUserStoreProperty(property);
+            } else {
+                UserStoreManager userStoreManager = realmService.getTenantUserRealm(tenantId).getUserStoreManager();
+                if (userStoreManager instanceof AbstractUserStoreManager) {
+                    propValue = ((AbstractUserStoreManager) userStoreManager)
+                            .getSecondaryUserStoreManager(userStoreDomain).getRealmConfiguration()
                             .getUserStoreProperty(property);
-                } else {
-                    UserStoreManager userStoreManager = realmService.getTenantUserRealm(tenantId).getUserStoreManager();
-                    if (userStoreManager instanceof AbstractUserStoreManager) {
-                        propValue = ((AbstractUserStoreManager) userStoreManager)
-                                .getSecondaryUserStoreManager(userStoreDomain).getRealmConfiguration()
-                                .getUserStoreProperty(property);
-                    }
                 }
-            } catch (UserStoreException e) {
-                log.error(String.format("Error while retrieving property %s for user store %s in tenantId %s. " +
-                        "Returning null.", property, userStoreDomain, tenantId), e);
             }
+        } catch (UserStoreException e) {
+            log.error(String.format("Error while retrieving property %s for user store %s in tenantId %s. " +
+                    "Returning null.", property, userStoreDomain, tenantId), e);
         }
         if (log.isDebugEnabled()) {
             log.debug(String.format("User store property %s is set to %s for user store %s in tenantId %s",

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/internal/RoleManagementServiceComponentHolder.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/internal/RoleManagementServiceComponentHolder.java
@@ -55,6 +55,10 @@ public class RoleManagementServiceComponentHolder {
 
     public RealmService getRealmService() {
 
+        if (realmService == null) {
+            throw new RuntimeException(
+                    "RoleManagementServiceComponent v2 is not initialized properly with RealmService");
+        }
         return realmService;
     }
 

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/util/UserIDResolver.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/util/UserIDResolver.java
@@ -149,7 +149,6 @@ public class UserIDResolver implements IDResolver {
 
         RealmService realmService = RoleManagementServiceComponentHolder.getInstance().getRealmService();
         UserRealm tenantUserRealm = realmService.getTenantUserRealm(tenantId);
-
         return (AbstractUserStoreManager) tenantUserRealm.getUserStoreManager();
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

Invoking the user core APIs to resolve the group names and attributes. The existing implementation uses SCIM tables. But the new improvements to user core do not store group attributes in the scim tables. Therefore, for group related operations user core APIs need to be invoked.

**This is related to following issues**
- Resolves 2nd Todo in https://github.com/wso2/product-is/issues/7913
- Part of https://github.com/wso2/product-is/issues/16368

### When should this PR be merged
After merging the following PRs.

- https://github.com/wso2/carbon-kernel/pull/3812
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/524


### Follow up actions

- Bump the framework version in the product-is