### PR TITLE
Add default `hiddenAuthenticators` for Console

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1047,7 +1047,10 @@
   "console.ui.i18n_configs.showLanguageSwitcher": false,
   "console.ui.i18n_configs.langAutoDetectEnabled": false,
   "console.ui.product_name": "WSO2 Identity Server",
-  "console.ui.hiddenAuthenticators": [],
+  "console.ui.hiddenAuthenticators": [
+    "BasicAuthRequestPathAuthenticator",
+    "OAuthRequestPathAuthenticator"
+  ],
   "console.ui.hiddenConnectionTemplates": [ "swe-idp" ],
   "console.ui.google_one_tap_enabled_tenants": [],
   "console.ui.show_app_switch_button": true,


### PR DESCRIPTION
### Proposed changes in this pull request

Add default `hiddenAuthenticators` for Console in the TOML level since the code level restrictions were causing issues when custom local authenticators are being added.

### When should this PR be merged

Before:
   - https://github.com/wso2/identity-apps/pull/5410

