### PR TITLE
Add user id attribute to oidc dialect

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -1610,6 +1610,13 @@
 				<MappedLocalClaim>http://wso2.org/claims/emailaddress</MappedLocalClaim>
 			</Claim>
 			<Claim>
+				<ClaimURI>userid</ClaimURI>
+				<DisplayName>user Id</DisplayName>
+				<AttributeID>uid</AttributeID>
+				<Description>User Id</Description>
+				<MappedLocalClaim>http://wso2.org/claims/userid</MappedLocalClaim>
+			</Claim>
+			<Claim>
 				<ClaimURI>email_verified</ClaimURI>
 				<DisplayName>Email Verified</DisplayName>
 				<AttributeID>emailVerified</AttributeID>


### PR DESCRIPTION
Fix for the https://github.com/wso2/product-is/issues/17969

- Added the user ID as a default OIDC claim. 
- Even though the specification does not discuss about it, from the identity server this should be available as a default OIDC claim to make the userid as the default subject identifier of the OIDC apps.