### PR TITLE
Disable `applications.loginFlow.legacyEditor` in Console

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1119,6 +1119,7 @@
   ],
   "console.applications.scopes.update": ["internal_application_mgt_update"],
   "console.applications.scopes.delete": ["internal_application_mgt_delete"],
+  "console.applications.disabled_features": ["applications.loginFlow.legacyEditor"],
   "console.applications.ui.certificate_alias_enabled": false,
   "console.application_roles.enabled": true,
   "console.approvals.enabled": false,


### PR DESCRIPTION
Reverts wso2/carbon-identity-framework#5105

### Proposed changes in this pull request

Going forward we are only enabling the visual editor by default.

### Related Issues

- https://github.com/wso2/product-is/issues/17219
