### PR TITLE
Enable custom claim mappings config

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -4,6 +4,7 @@
   "authentication.map_federated_users_to_local": false,
   "authentication.enable_scope_based_claim_filtering": true,
   "authentication.allow_sp_requested_fed_claims_only": true,
+  "authentication.endpoint.enable_custom_claim_mappings": true,
 
   "identity.data_source": "jdbc/WSO2IdentityDB",
   "identity_data_source.skip_db_schema_creation": false,


### PR DESCRIPTION
### Proposed changes in this pull request
Currently custom claim mappings are not honored for OIDC connections as the default behavior. We are enabling the config to honor the custom claim mappings as default behavior

Related Issue - https://github.com/wso2/product-is/issues/19415