### PR TITLE
Fix NPE when authenticated IDPs of the app is null

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/SessionContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/SessionContext.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2013, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2013-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -60,7 +60,10 @@ public class SessionContext implements Serializable {
 
     public Map<String, AuthenticatedIdPData> getAuthenticatedIdPsOfApp(String app) {
 
-        return authenticatedIdPsOfApp.get(app);
+        if (authenticatedIdPsOfApp != null) {
+            return authenticatedIdPsOfApp.get(app);
+        }
+        return null;
     }
 
     public void setAuthenticatedIdPsOfApp(String app, Map<String, AuthenticatedIdPData> authenticatedIdPsOfApp) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/SessionContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/SessionContext.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -63,7 +64,7 @@ public class SessionContext implements Serializable {
         if (authenticatedIdPsOfApp != null) {
             return authenticatedIdPsOfApp.get(app);
         }
-        return null;
+        return new HashMap<>();
     }
 
     public void setAuthenticatedIdPsOfApp(String app, Map<String, AuthenticatedIdPData> authenticatedIdPsOfApp) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/SessionContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/SessionContext.java
@@ -22,7 +22,6 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 


### PR DESCRIPTION
### Proposed changes in this pull request

$subject

Login to an application configured with IS 5.11.0. Then migrate it up to IS 7.0.0. Then try to login to the application again in a different tab of the browser. As the same session exist, it will try to use that and cause this NPE. After fixing this, user could seamlessly login to the app.

<img width="1423" alt="Screenshot 2024-02-08 at 05 28 54" src="https://github.com/wso2/carbon-identity-framework/assets/35717390/d23f066e-ca01-4a4f-bc87-e9f336ae99a6">
