### PR TITLE
Fix for building identity-event properties related to sms publisher

### DIFF
--- a/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConfigBuilder.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConfigBuilder.java
@@ -143,7 +143,7 @@ public class IdentityEventConfigBuilder {
      * Build and store per module configuration objects
      */
     private void build() {
-        Properties moduleNames = IdentityEventUtils.getSubProperties("module.name", notificationMgtConfigProperties);
+        Properties moduleNames = IdentityEventUtils.getModuleNames("module.name", notificationMgtConfigProperties);
         Enumeration propertyNames = moduleNames.propertyNames();
         // Iterate through events and build event objects
         while (propertyNames.hasMoreElements()) {

--- a/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventUtils.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventUtils.java
@@ -68,7 +68,7 @@ public class IdentityEventUtils {
     }
 
     /**
-     * Returns a sub set of properties which has the given prefix key. ie properties which has numbers at the end
+     * Returns a sub set of properties which has the given prefix key.
      *
      * @param prefix     Prefix of the key
      * @param properties Set of properties which needs be filtered for the given prefix
@@ -81,9 +81,33 @@ public class IdentityEventUtils {
             throw new IllegalArgumentException("Prefix and Properties should not be null to get sub properties");
         }
 
+        int i = 1;
+        Properties subProperties = new Properties();
+        while (properties.getProperty(prefix + "." + i) != null) {
+            // Remove from original properties to hold property schema. ie need to get the set of properties which
+            // remains after consuming all required specific properties.
+            subProperties.put(prefix + "." + i, properties.remove(prefix + "." + i++));
+        }
+        return subProperties;
+    }
+
+    /**
+     * Returns the module names using a given prefix key. ie properties which has numbers at the end.
+     *
+     * @param prefix     Prefix of the properties used to define module names.
+     * @param properties Set of properties which needs be filtered for the given prefix.
+     * @return Map of module names.
+     */
+    public static Properties getModuleNames(String prefix, Properties properties) {
+
+        // Stop proceeding if required arguments are not present.
+        if (StringUtils.isEmpty(prefix) || properties == null) {
+            throw new IllegalArgumentException("Prefix and Properties should not be null to get sub properties");
+        }
+
         Properties subProperties = new Properties();
         // Remove from original properties to hold property schema. ie need to get the set of properties which
-        // remains after consuming all required specific properties
+        // remains after consuming all required specific properties.
         subProperties.putAll(getPropertiesWithPrefix(prefix, properties));
         return subProperties;
     }


### PR DESCRIPTION
### Proposed changes in this pull request
A separate method is introduced to get the module names. 
Previously, the same method was used to get module names and sub properties. This was causing errors when reading the sub properties of the sms publisher.

### Related Issue

- https://github.com/wso2/product-is/issues/19413

