### PR TITLE
Add event publishers to Application Authorized API Management Service

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.identity.application.mgt.dao.AuthorizedAPIDAO;
 import org.wso2.carbon.identity.application.mgt.dao.impl.AuthorizedAPIDAOImpl;
 import org.wso2.carbon.identity.application.mgt.dao.impl.CacheBackedAuthorizedAPIDAOImpl;
 import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponentHolder;
+import org.wso2.carbon.identity.application.mgt.publisher.ApplicationAuthorizedAPIManagementEventPublisherProxy;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
@@ -72,7 +73,11 @@ public class AuthorizedAPIManagementServiceImpl implements AuthorizedAPIManageme
     public void deleteAuthorizedAPI(String appId, String apiId, String tenantDomain)
             throws IdentityApplicationManagementException {
 
+        ApplicationAuthorizedAPIManagementEventPublisherProxy publisherProxy =
+                ApplicationAuthorizedAPIManagementEventPublisherProxy.getInstance();
+        publisherProxy.publishPreDeleteAuthorizedAPIForApplication(appId, apiId, tenantDomain);
         authorizedAPIDAO.deleteAuthorizedAPI(appId, apiId, IdentityTenantUtil.getTenantId(tenantDomain));
+        publisherProxy.publishPostDeleteAuthorizedAPIForApplication(appId, apiId, tenantDomain);
     }
 
     @Override
@@ -120,8 +125,14 @@ public class AuthorizedAPIManagementServiceImpl implements AuthorizedAPIManageme
                                    List<String> removedScopes, String tenantDomain)
             throws IdentityApplicationManagementException {
 
+        ApplicationAuthorizedAPIManagementEventPublisherProxy publisherProxy =
+                ApplicationAuthorizedAPIManagementEventPublisherProxy.getInstance();
+        publisherProxy.publishPreUpdateAuthorizedAPIForApplication(appId, apiId, addedScopes, removedScopes,
+                tenantDomain);
         authorizedAPIDAO.patchAuthorizedAPI(appId, apiId, addedScopes, removedScopes,
                 IdentityTenantUtil.getTenantId(tenantDomain));
+        publisherProxy.publishPostUpdateAuthorizedAPIForApplication(appId, apiId, addedScopes, removedScopes,
+                tenantDomain);
         updateRolesWithRemovedScopes(appId, removedScopes, tenantDomain);
     }
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/publisher/ApplicationAuthorizedAPIManagementEventPublisherProxy.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/publisher/ApplicationAuthorizedAPIManagementEventPublisherProxy.java
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.application.mgt.publisher;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponentHolder;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class handles creating event and publishing events related to application authorized api management.
+ */
+public class ApplicationAuthorizedAPIManagementEventPublisherProxy {
+
+    private static final Log log = LogFactory.getLog(ApplicationAuthorizedAPIManagementEventPublisherProxy.class);
+    private static final ApplicationAuthorizedAPIManagementEventPublisherProxy proxy =
+            new ApplicationAuthorizedAPIManagementEventPublisherProxy();
+
+    private ApplicationAuthorizedAPIManagementEventPublisherProxy() {
+
+    }
+
+    public static ApplicationAuthorizedAPIManagementEventPublisherProxy getInstance() {
+
+        return proxy;
+    }
+    public void publishPreUpdateAuthorizedAPIForApplication(String appId, String apiId, List<String> addedScopes,
+                                                            List<String> removedScopes, String tenantDomain)
+            throws IdentityApplicationManagementException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.APPLICATION_ID, appId);
+        eventProperties.put(IdentityEventConstants.EventProperty.API_ID, apiId);
+        eventProperties.put(IdentityEventConstants.EventProperty.ADDED_SCOPES, addedScopes);
+        eventProperties.put(IdentityEventConstants.EventProperty.DELETED_SCOPES, removedScopes);
+        eventProperties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
+        Event event = createEvent(eventProperties,
+                IdentityEventConstants.Event.PRE_UPDATE_AUTHORIZED_API_FOR_APPLICATION_EVENT);
+        doPublishEvent(event);
+    }
+
+    public void publishPostUpdateAuthorizedAPIForApplication(String appId, String apiId, List<String> addedScopes,
+                                                             List<String> removedScopes, String tenantDomain)
+            throws IdentityApplicationManagementException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.APPLICATION_ID, appId);
+        eventProperties.put(IdentityEventConstants.EventProperty.API_ID, apiId);
+        eventProperties.put(IdentityEventConstants.EventProperty.ADDED_SCOPES, addedScopes);
+        eventProperties.put(IdentityEventConstants.EventProperty.DELETED_SCOPES, removedScopes);
+        eventProperties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
+        Event event = createEvent(eventProperties,
+                IdentityEventConstants.Event.POST_UPDATE_AUTHORIZED_API_FOR_APPLICATION_EVENT);
+        doPublishEvent(event);
+
+    }
+
+    public void publishPreDeleteAuthorizedAPIForApplication(String appId, String apiId, String tenantDomain)
+            throws IdentityApplicationManagementException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.APPLICATION_ID, appId);
+        eventProperties.put(IdentityEventConstants.EventProperty.API_ID, apiId);
+        eventProperties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
+        Event event = createEvent(eventProperties,
+                IdentityEventConstants.Event.PRE_DELETE_AUTHORIZED_API_FOR_APPLICATION_EVENT);
+        doPublishEvent(event);
+    }
+
+    public void publishPostDeleteAuthorizedAPIForApplication(String appId, String apiId, String tenantDomain)
+            throws IdentityApplicationManagementException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.APPLICATION_ID, appId);
+        eventProperties.put(IdentityEventConstants.EventProperty.API_ID, apiId);
+        eventProperties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
+        Event event = createEvent(eventProperties,
+                IdentityEventConstants.Event.POST_DELETE_AUTHORIZED_API_FOR_APPLICATION_EVENT);
+        doPublishEvent(event);
+    }
+
+    private Event createEvent(Map<String, Object> eventProperties, String eventName) {
+
+        return new Event(eventName, eventProperties);
+    }
+
+    private void doPublishEvent(Event event) throws IdentityApplicationManagementException {
+
+        try {
+            if (log.isDebugEnabled()) {
+                log.debug("Event: " + event.getEventName() + " is published for the application management " +
+                        "operation in the tenant with the tenantId: "
+                        + event.getEventProperties().get(IdentityEventConstants.EventProperty.TENANT_ID));
+            }
+            IdentityEventService eventService =
+                    ApplicationManagementServiceComponentHolder.getInstance().getIdentityEventService();
+            eventService.handleEvent(event);
+        } catch (IdentityEventException e) {
+            throw new IdentityApplicationManagementException(e.getErrorCode(),
+                        "Error while publishing the event: " + event.getEventName() + ".", e);
+        }
+    }
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImplTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImplTest.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.mgt;
 
+import org.mockito.Mock;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -49,6 +50,7 @@ import org.wso2.carbon.identity.common.testng.realm.InMemoryRealmService;
 import org.wso2.carbon.identity.common.testng.realm.MockUserStoreManager;
 import org.wso2.carbon.identity.core.internal.IdentityCoreServiceDataHolder;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.organization.management.service.internal.OrganizationManagementDataHolder;
 import org.wso2.carbon.registry.core.Collection;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
@@ -66,8 +68,10 @@ import java.util.Collections;
 import java.util.List;
 
 import static java.lang.Boolean.FALSE;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
@@ -82,6 +86,8 @@ public class AuthorizedAPIManagementServiceImplTest extends PowerMockTestCase {
 
     private String tenantDomain;
     private APIResourceManager apiResourceManager;
+    @Mock
+    private IdentityEventService identityEventService;
     private ApplicationManagementService applicationManagementService;
     private AuthorizedAPIManagementService authorizedAPIManagementService;
 
@@ -93,6 +99,9 @@ public class AuthorizedAPIManagementServiceImplTest extends PowerMockTestCase {
         applicationManagementService = ApplicationManagementServiceImpl.getInstance();
         authorizedAPIManagementService = new AuthorizedAPIManagementServiceImpl();
         tenantDomain = "test_tenant_domain";
+        identityEventService = mock(IdentityEventService.class);
+        doNothing().when(identityEventService).handleEvent(any());
+        ApplicationManagementServiceComponentHolder.getInstance().setIdentityEventService(identityEventService);
     }
 
     @DataProvider

--- a/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
@@ -253,6 +253,12 @@ public class IdentityEventConstants {
         public static final String POST_UPDATE_PERMISSIONS_FOR_ROLE_V2_EVENT = "POST_UPDATE_PERMISSIONS_FOR_ROLE_V2_EVENT";
 
         public static final String POST_APP_USER_ATTRIBUTE_UPDATE = "POST_APP_USER_ATTRIBUTE_UPDATE";
+
+        // Application Authorized API
+        public static final String PRE_UPDATE_AUTHORIZED_API_FOR_APPLICATION_EVENT = "PRE_UPDATE_AUTHORIZED_API_FOR_APPLICATION_EVENT";
+        public static final String POST_UPDATE_AUTHORIZED_API_FOR_APPLICATION_EVENT = "POST_UPDATE_AUTHORIZED_API_FOR_APPLICATION_EVENT";
+        public static final String PRE_DELETE_AUTHORIZED_API_FOR_APPLICATION_EVENT = "PRE_DELETE_AUTHORIZED_API_FOR_APPLICATION_EVENT";
+        public static final String POST_DELETE_AUTHORIZED_API_FOR_APPLICATION_EVENT = "POST_DELETE_AUTHORIZED_API_FOR_APPLICATION_EVENT";
     }
 
     /**
@@ -378,6 +384,11 @@ public class IdentityEventConstants {
 
         public static final String UPDATED_CLAIM_MAPPINGS = "updatedClaimMappings";
         public static final String REQUIRED_ATTRIBUTES = "requiredAttributes";
+
+        // Application Authorized API
+        public static final String API_ID = "API_ID";
+        public static final String ADDED_SCOPES = "ADDED_SCOPES";
+        public static final String DELETED_SCOPES = "DELETED_SCOPES";
     }
 
     public class ErrorMessage {


### PR DESCRIPTION
### Proposed changes in this pull request

Add event publishers to Application Authorized API Management Service and use event publishers we patching authorized API and deleting authorized API.

Related Issue: https://github.com/wso2/product-is/issues/19330

