### PR TITLE
Remove the SecretManagement apis from the access control

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -404,25 +404,6 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="secretsManagement" displayName="Secrets Management" type="tenant">
-        <Scopes>
-            <Feature>
-                <Scope name="console:secretsManagement"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_secret_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_secret_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_secret_mgt_add"/>
-            </Create>
-            <Read>
-                <Scope name="internal_secret_mgt_view"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
     <APIResourceCollection name="roles" displayName="Roles" type="tenant">
         <Scopes>
             <Feature>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -438,25 +438,6 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="secretsManagement" displayName="Secrets Management" type="tenant">
-        <Scopes>
-            <Feature>
-                <Scope name="console:secretsManagement"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_secret_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_secret_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_secret_mgt_add"/>
-            </Create>
-            <Read>
-                <Scope name="internal_secret_mgt_view"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
     <APIResourceCollection name="roles" displayName="Roles" type="tenant">
         <Scopes>
             <Feature>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -425,33 +425,6 @@
                     description="Delete script libraries"/>
         </Scopes>
     </APIResource>
-    <APIResource name="Secret Type Management API" identifier="/api/server/v1/secret-type"
-                 requiresAuthorization="true"
-                 description="API representation of the Secret Type Management API" type="TENANT">
-        <Scopes>
-            <Scope displayName="Add Secret Type" name="internal_secret_type_mgt_add" 
-                    description="Create new secret types in secret management service"/>
-            <Scope displayName="Update Secret Type" name="internal_secret_type_mgt_update" 
-                    description="Update secret types in secret management service"/>
-            <Scope displayName="View Secret Type" name="internal_secret_type_mgt_view" 
-                    description="View secret types in secret management service"/>
-            <Scope displayName="Delete Secret Type" name="internal_secret_type_mgt_delete" 
-                    description="Delete secret types in secret management service"/>
-        </Scopes>
-    </APIResource>
-    <APIResource name="Secret Management API" identifier="/api/server/v1/secrets"
-                 requiresAuthorization="true" description="API representation of the Secret Management API" type="TENANT">
-        <Scopes>
-            <Scope displayName="Add Secret" name="internal_secret_mgt_add" 
-                    description="Create new secrets in secret management service"/>
-            <Scope displayName="Update Secret" name="internal_secret_mgt_update" 
-                    description="Update secrets in secret management service"/>
-            <Scope displayName="View Secret" name="internal_secret_mgt_view" 
-                    description="View secrets in secret management service"/>
-            <Scope displayName="Delete Secret" name="internal_secret_mgt_delete" 
-                    description="Delete secrets in secret management service"/>
-        </Scopes>
-    </APIResource>
     <APIResource name="Userstore Management API" identifier="/api/server/v1/userstore"
                  requiresAuthorization="true"
                  description="API representation of the Userstore Management API" type="TENANT">
@@ -1066,15 +1039,6 @@
         <Scopes>
             <Scope displayName="Getting Started Feature" name="console:org:home"
                    description="Manage home settings in the organization from the Console"/>
-        </Scopes>
-    </APIResource>
-    <APIResource name="Secret Management Feature" identifier="console:secretsManagement"
-                 requiresAuthorization="true"
-                 description="Resource representation of the Secret Management Feature"
-                 type="CONSOLE_FEATURE">
-        <Scopes>
-            <Scope displayName="Secret Management Feature" name="console:secretsManagement" 
-                    description="Manage secrets from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Certificate Management Feature" identifier="console:certificates"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -434,33 +434,6 @@
                     description="Delete script libraries"/>
         </Scopes>
     </APIResource>
-    <APIResource name="Secret Type Management API" identifier="/api/server/v1/secret-type"
-                 requiresAuthorization="true"
-                 description="API representation of the Secret Type Management API" type="TENANT">
-        <Scopes>
-            <Scope displayName="Add Secret Type" name="internal_secret_type_mgt_add" 
-                    description="Create new secret types in secret management service"/>
-            <Scope displayName="Update Secret Type" name="internal_secret_type_mgt_update" 
-                    description="Update secret types in secret management service"/>
-            <Scope displayName="View Secret Type" name="internal_secret_type_mgt_view" 
-                    description="View secret types in secret management service"/>
-            <Scope displayName="Delete Secret Type" name="internal_secret_type_mgt_delete" 
-                    description="Delete secret types in secret management service"/>
-        </Scopes>
-    </APIResource>
-    <APIResource name="Secret Management API" identifier="/api/server/v1/secrets"
-                 requiresAuthorization="true" description="API representation of the Secret Management API" type="TENANT">
-        <Scopes>
-            <Scope displayName="Add Secret" name="internal_secret_mgt_add" 
-                    description="Create new secrets in secret management service"/>
-            <Scope displayName="Update Secret" name="internal_secret_mgt_update" 
-                    description="Update secrets in secret management service"/>
-            <Scope displayName="View Secret" name="internal_secret_mgt_view" 
-                    description="View secrets in secret management service"/>
-            <Scope displayName="Delete Secret" name="internal_secret_mgt_delete" 
-                    description="Delete secrets in secret management service"/>
-        </Scopes>
-    </APIResource>
     <APIResource name="Userstore Management API" identifier="/api/server/v1/userstore"
                  requiresAuthorization="true"
                  description="API representation of the Userstore Management API" type="TENANT">
@@ -1075,15 +1048,6 @@
         <Scopes>
             <Scope displayName="Getting Started Feature" name="console:org:home"
                    description="Manage home settings in the organization from the Console"/>
-        </Scopes>
-    </APIResource>
-    <APIResource name="Secret Management Feature" identifier="console:secretsManagement"
-                 requiresAuthorization="true"
-                 description="Resource representation of the Secret Management Feature"
-                 type="CONSOLE_FEATURE">
-        <Scopes>
-            <Scope displayName="Secret Management Feature" name="console:secretsManagement" 
-                    description="Manage secrets from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Certificate Management Feature" identifier="console:certificates"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1455,40 +1455,6 @@
             <Scopes>internal_config_mgt_delete</Scopes>
         </Resource>
 
-        <Resource context="(.*)/api/server/v1/secret-type(.*)" secured="true" http-method="POST">
-            <Permissions>/permission/admin/manage/identity/secretmgt/add</Permissions>
-            <Scopes>internal_secret_mgt_add</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secret-type/(.*)" secured="true" http-method="PUT">
-            <Permissions>/permission/admin/manage/identity/secretmgt/update</Permissions>
-            <Scopes>internal_secret_mgt_update</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secret-type/(.*)" secured="true" http-method="GET">
-            <Permissions>/permission/admin/manage/identity/secretmgt/view</Permissions>
-            <Scopes>internal_secret_mgt_view</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secret-type/(.*)" secured="true" http-method="DELETE">
-            <Permissions>/permission/admin/manage/identity/secretmgt/delete</Permissions>
-            <Scopes>internal_secret_mgt_delete</Scopes>
-        </Resource>
-
-        <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="POST">
-            <Permissions>/permission/admin/manage/identity/secretmgt/add</Permissions>
-            <Scopes>internal_secret_mgt_add</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="PATCH, PUT">
-            <Permissions>/permission/admin/manage/identity/secretmgt/update</Permissions>
-            <Scopes>internal_secret_mgt_update</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="GET">
-            <Permissions>/permission/admin/manage/identity/secretmgt/view</Permissions>
-            <Scopes>internal_secret_mgt_view</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="DELETE">
-            <Permissions>/permission/admin/manage/identity/secretmgt/delete</Permissions>
-            <Scopes>internal_secret_mgt_delete</Scopes>
-        </Resource>
-
         <Resource context="(.*)/api/server/v1/branding-preference(.*)" secured="false" http-method="GET"/>
         <Resource context="(.*)/api/server/v1/branding-preference(.*)" secured="true" http-method="POST">
             <Permissions>/permission/admin/manage/identity/applicationmgt/update</Permissions>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2412,40 +2412,6 @@
             <Scopes>internal_config_mgt_delete</Scopes>
         </Resource>
 
-        <Resource context="(.*)/api/server/v1/secret-type(.*)" secured="true" http-method="POST">
-            <Permissions>/permission/admin/manage/identity/secretmgt/add</Permissions>
-            <Scopes>internal_secret_mgt_add</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secret-type/(.*)" secured="true" http-method="PUT">
-            <Permissions>/permission/admin/manage/identity/secretmgt/update</Permissions>
-            <Scopes>internal_secret_mgt_update</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secret-type/(.*)" secured="true" http-method="GET">
-            <Permissions>/permission/admin/manage/identity/secretmgt/view</Permissions>
-            <Scopes>internal_secret_mgt_view</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secret-type/(.*)" secured="true" http-method="DELETE">
-            <Permissions>/permission/admin/manage/identity/secretmgt/delete</Permissions>
-            <Scopes>internal_secret_mgt_delete</Scopes>
-        </Resource>
-
-        <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="POST">
-            <Permissions>/permission/admin/manage/identity/secretmgt/add</Permissions>
-            <Scopes>internal_secret_mgt_add</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="PATCH, PUT">
-            <Permissions>/permission/admin/manage/identity/secretmgt/update</Permissions>
-            <Scopes>internal_secret_mgt_update</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="GET">
-            <Permissions>/permission/admin/manage/identity/secretmgt/view</Permissions>
-            <Scopes>internal_secret_mgt_view</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="DELETE">
-            <Permissions>/permission/admin/manage/identity/secretmgt/delete</Permissions>
-            <Scopes>internal_secret_mgt_delete</Scopes>
-        </Resource>
-
         <Resource context="(.*)/api/server/v1/branding-preference(.*)" secured="false" http-method="GET"/>
         <Resource context="(.*)/api/server/v1/branding-preference(.*)" secured="true" http-method="POST">
             <Permissions>/permission/admin/manage/identity/applicationmgt/update</Permissions>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -125,34 +125,6 @@
         <Scopes>internal_notification_senders_delete</Scopes>
     </Resource>
 
-    <!-- Secret Type Management API -->
-    <Resource context="(.*)/api/server/v1/secret-type(.*)" secured="true" http-method="POST">
-        <Scopes>internal_secret_type_mgt_add</Scopes>
-    </Resource>
-    <Resource context="(.*)/api/server/v1/secret-type/(.*)" secured="true" http-method="PUT">
-        <Scopes>internal_secret_type_mgt_update</Scopes>
-    </Resource>
-    <Resource context="(.*)/api/server/v1/secret-type/(.*)" secured="true" http-method="GET">
-        <Scopes>internal_secret_type_mgt_view</Scopes>
-    </Resource>
-    <Resource context="(.*)/api/server/v1/secret-type/(.*)" secured="true" http-method="DELETE">
-        <Scopes>internal_secret_type_mgt_delete</Scopes>
-    </Resource>
-
-    <!-- Secret Management API -->
-    <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="POST">
-        <Scopes>internal_secret_mgt_add</Scopes>
-    </Resource>
-    <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="PATCH, PUT">
-        <Scopes>internal_secret_mgt_update</Scopes>
-    </Resource>
-    <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="GET">
-        <Scopes>internal_secret_mgt_view</Scopes>
-    </Resource>
-    <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="DELETE">
-        <Scopes>internal_secret_mgt_delete</Scopes>
-    </Resource>
-
     <!-- [Organization] Branding Preference Management API -->
     <Resource context="(.*)/o/api/server/v1/branding-preference(.*)" secured="false" http-method="GET"/>
     <Resource context="(.*)/o/api/server/v1/branding-preference(.*)" secured="true" http-method="POST">

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -147,34 +147,6 @@
             <Scopes>internal_notification_senders_delete</Scopes>
         </Resource>
 
-        <!-- Secret Type Management API -->
-        <Resource context="(.*)/api/server/v1/secret-type(.*)" secured="true" http-method="POST">
-            <Scopes>internal_secret_type_mgt_add</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secret-type/(.*)" secured="true" http-method="PUT">
-            <Scopes>internal_secret_type_mgt_update</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secret-type/(.*)" secured="true" http-method="GET">
-            <Scopes>internal_secret_type_mgt_view</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secret-type/(.*)" secured="true" http-method="DELETE">
-            <Scopes>internal_secret_type_mgt_delete</Scopes>
-        </Resource>
-
-        <!-- Secret Management API -->
-        <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="POST">
-            <Scopes>internal_secret_mgt_add</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="PATCH, PUT">
-            <Scopes>internal_secret_mgt_update</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="GET">
-            <Scopes>internal_secret_mgt_view</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v1/secrets/(.*)" secured="true" http-method="DELETE">
-            <Scopes>internal_secret_mgt_delete</Scopes>
-        </Resource>
-
         <!-- [Organization] Branding Preference Management API -->
         <Resource context="(.*)/o/api/server/v1/branding-preference(.*)" secured="false" http-method="GET"/>
         <Resource context="(.*)/o/api/server/v1/branding-preference(.*)" secured="true" http-method="POST">


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/19514

This PR removes access to the secret management related apis as the feature is not being used in Identity Server (with the removal from access control the api is no longer exposed from the server). If these api access is required it can be added to the server via a deployment.toml config (refer to the templating in each of the .j2 files on how to add each of the resources).

