### PR TITLE
Disable application based outbound provisioning by default

### DIFF
--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/IdentityProvisioningConstants.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/IdentityProvisioningConstants.java
@@ -48,6 +48,7 @@ public class IdentityProvisioningConstants {
 
     // Outbound provisioning constants.
     public static final String USE_USER_TENANT_DOMAIN_FOR_OUTBOUND_PROVISIONING_IN_SAAS_APPS = "OutboundProvisioning.useUserTenantDomainInSaasApps";
+    public static final String APPLICATION_BASED_OUTBOUND_PROVISIONING_ENABLED = "OutboundProvisioning.enableApplicationBasedOutboundProvisioning";
 
     public static class SQLQueries {
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/OutboundProvisioningManager.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/OutboundProvisioningManager.java
@@ -71,6 +71,7 @@ import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.LOCA
 import static org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants.ASK_PASSWORD_CLAIM;
 import static org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants.GROUP_CLAIM_URI;
 import static org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants.SELF_SIGNUP_ROLE;
+import static org.wso2.carbon.identity.provisioning.ProvisioningUtil.isApplicationBasedOutboundProvisioningEnabled;
 import static org.wso2.carbon.identity.provisioning.ProvisioningUtil.isUserTenantBasedOutboundProvisioningEnabled;
 
 /**
@@ -347,7 +348,9 @@ public class OutboundProvisioningManager {
             }
 
             // Any provisioning request coming via Console, considered as coming from the resident SP.
-            if (StringUtils.equals(CONSOLE_APPLICATION_NAME, serviceProviderIdentifier)) {
+            // If the application based outbound provisioning is disabled, resident SP configuration will be used.
+            if (StringUtils.equals(CONSOLE_APPLICATION_NAME, serviceProviderIdentifier) ||
+                    !isApplicationBasedOutboundProvisioningEnabled()) {
                 serviceProviderIdentifier = LOCAL_SP;
                 inboundClaimDialect = IdentityProvisioningConstants.WSO2_CARBON_DIALECT;
             }

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisioningUtil.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisioningUtil.java
@@ -39,6 +39,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants.APPLICATION_BASED_OUTBOUND_PROVISIONING_ENABLED;
 import static org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants.USE_USER_TENANT_DOMAIN_FOR_OUTBOUND_PROVISIONING_IN_SAAS_APPS;
 
 public class ProvisioningUtil {
@@ -585,5 +586,22 @@ public class ProvisioningUtil {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Check whether the application based outbound provisioning is enabled.
+     *
+     * @return true if applicationBasedOutboundProvisioningEnabled config is enabled.
+     */
+    public static boolean isApplicationBasedOutboundProvisioningEnabled() {
+
+        boolean applicationBasedOutboundProvisioningEnabled = false;
+
+        if (StringUtils.isNotEmpty(
+                IdentityUtil.getProperty(APPLICATION_BASED_OUTBOUND_PROVISIONING_ENABLED))) {
+            applicationBasedOutboundProvisioningEnabled = Boolean
+                    .parseBoolean(IdentityUtil.getProperty(APPLICATION_BASED_OUTBOUND_PROVISIONING_ENABLED));
+        }
+        return applicationBasedOutboundProvisioningEnabled;
     }
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1177,6 +1177,7 @@
 
     <OutboundProvisioning>
         <ResetProvisioningEntitiesOnConfigUpdate>true</ResetProvisioningEntitiesOnConfigUpdate>
+        <enableApplicationBasedOutboundProvisioning>false</enableApplicationBasedOutboundProvisioning>
     </OutboundProvisioning>
 
     <EventListeners>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1841,6 +1841,7 @@
             -->
             <useUserTenantDomainInSaasApps>{{outbound_provisioning_management.use_user_tenant_domain_in_saas_apps}}</useUserTenantDomainInSaasApps>
         {% endif %}
+        <enableApplicationBasedOutboundProvisioning>{{outbound_provisioning_management.enable_application_based_outbound_provisioning}}</enableApplicationBasedOutboundProvisioning>
     </OutboundProvisioning>
 
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -493,6 +493,7 @@
   "idp_role_management.return_only_mapped_local_roles": true,
   "idp_role_management.return_manually_added_local_roles": true,
   "outbound_provisioning_management.reset_provisioning_entities_on_config_update": true,
+  "outbound_provisioning_management.enable_application_based_outbound_provisioning": false,
 
   "authentication_policy.check_account_exist": true,
   "authentication.jit_provisioning.username_provisioning_url": "/accountrecoveryendpoint/register.do",


### PR DESCRIPTION
### Proposed changes in this pull request

- Disable application-based outbound provisioning by default.
- To enable application-based outbound provisioning, set the following configuration to true in the deployment.toml file.


```
[outbound_provisioning_management]
enable_application_based_outbound_provisioning=false

```

### Related Issue
- https://github.com/wso2/product-is/issues/19326

