### PR TITLE
Disable autocommit in DB Connection when Retrieving Active Session Count

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -1272,7 +1272,7 @@ public class UserSessionStore {
         long currentTime = System.currentTimeMillis();
         long minTimestamp = currentTime - idleSessionTimeOut;
 
-        try (Connection connection = IdentityDatabaseUtil.getSessionDBConnection(false)) {
+        try (Connection connection = IdentityDatabaseUtil.getSessionDBConnection(true)) {
             String sqlStmt = JdbcUtils.isH2DB(JdbcUtils.Database.SESSION)
                     ? SQLQueries.SQL_GET_ACTIVE_SESSION_COUNT_BY_TENANT_H2
                     : SQLQueries.SQL_GET_ACTIVE_SESSION_COUNT_BY_TENANT;


### PR DESCRIPTION
Related issue: https://github.com/wso2-enterprise/wso2-iam-internal/issues/1290

This PR sets the autocommit option to false in the db connection inside `getActiveSessionCount` method to fix the SQL exception when `pool_options.defaultAutoCommit` config is set to true at deployment.toml for that db. When `defaultAutoCommit` is set to true, we cannot use commitTransaction and therefore with this fix, we will be setting autocommit to false for this db connection.

Similar to: https://github.com/wso2/carbon-identity-framework/pull/3191