### PR TITLE
Deprecating role v1 related methods in JIT provisioning flow

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/ProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/ProvisioningHandler.java
@@ -29,27 +29,34 @@ import java.util.Map;
 public interface ProvisioningHandler {
 
     /**
-     * @param roles
-     * @param subject
-     * @param attributes
-     * @param provisioningUserStoreId
-     * @param tenantDomain
-     * @throws FrameworkException
+     * Handle provisioning with v1 roles.
+     *
+     * @param roles                   List of role names.
+     * @param subject                 Subject identifier.
+     * @param attributes              Attributes.
+     * @param provisioningUserStoreId Provisioning user store Id.
+     * @param tenantDomain            Tenant domain.
+     * @throws FrameworkException If an error occurred while handling provisioning.
+     * @deprecated This method is deprecated and use {@link #handleWithV2Roles(List, String, Map, String, String)}.
      */
+    @Deprecated
     public void handle(List<String> roles, String subject, Map<String, String> attributes,
                        String provisioningUserStoreId, String tenantDomain) throws FrameworkException;
 
     /**
-     * Default implementation to validate idp role mappings by keeping backward compatibility.
+     * Default implementation to handle provisioning with v1 roles by validating idp role mappings by keeping backward
+     * compatibility.
      *
-     * @param roles
-     * @param subject
-     * @param attributes
-     * @param provisioningUserStoreId
-     * @param tenantDomain
-     * @param idpToLocalRoleMapping
-     * @throws FrameworkException
+     * @param roles List of role names.
+     * @param subject Subject identifier.
+     * @param attributes Attributes.
+     * @param provisioningUserStoreId Provisioning user store Id.
+     * @param tenantDomain Tenant domain.
+     * @param idpToLocalRoleMapping IdP to local role mapping.
+     * @throws FrameworkException If an error occurred while handling provisioning.
+     * @deprecated This method is deprecated and use {@link #handleWithV2Roles(List, String, Map, String, String)}.
      */
+    @Deprecated
     default void handle(List<String> roles, String subject, Map<String, String> attributes,
             String provisioningUserStoreId, String tenantDomain, List<String> idpToLocalRoleMapping)
             throws FrameworkException {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -99,6 +99,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
         return instance;
     }
 
+    @Deprecated
     @Override
     public void handle(List<String> roles, String subject, Map<String, String> attributes,
             String provisioningUserStoreId, String tenantDomain) throws FrameworkException {
@@ -110,6 +111,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
 
     }
 
+    @Deprecated
     @Override
     public void handle(List<String> roles, String subject, Map<String, String> attributes,
             String provisioningUserStoreId, String tenantDomain, List<String> idpToLocalRoleMapping)

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/StepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/StepBasedSequenceHandler.java
@@ -37,7 +37,10 @@ public interface StepBasedSequenceHandler extends SequenceHandler {
      * @param mappedRoles           Mapped Roles
      * @param extAttributesValueMap Attributes Value Map.
      * @throws FrameworkException Framework Exception.
+     * @deprecated This method is deprecated and use
+     * {@link #callJitProvisioningWithV2Roles(String, AuthenticationContext, List, Map)}.
      */
+    @Deprecated
     default void callJitProvisioning(String subjectIdentifier, AuthenticationContext context, List<String> mappedRoles,
             Map<String, String> extAttributesValueMap) throws FrameworkException { }
 
@@ -52,8 +55,5 @@ public interface StepBasedSequenceHandler extends SequenceHandler {
      */
     default void callJitProvisioningWithV2Roles(String subjectIdentifier, AuthenticationContext context,
                                                 List<String> assignedRoleIdList,
-                                                Map<String, String> extAttributesValueMap) throws FrameworkException {
-
-        throw new FrameworkException("Operation is not supported.");
-    }
+                                                Map<String, String> extAttributesValueMap) throws FrameworkException { }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -495,6 +495,7 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
         return Collections.emptyMap();
     }
 
+    @Deprecated
     @Override
     public void callJitProvisioning(String subjectIdentifier, AuthenticationContext context,
                                     List<String> mappedRoles, Map<String, String> extAttributesValueMap)


### PR DESCRIPTION
### Proposed changes in this pull request
We have introduced new default methods in ProvisioningHandler and StepBasedSequenceHandler interfaces for handling v2 roles in JIT provisioning flow. Deprecating the methods related to V1 roles.
