### PR TITLE
Add missing permissions for Connections in org

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -238,7 +238,7 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="identityProviders" displayName="Identity Providers" type="tenant">
+    <APIResourceCollection name="connections" displayName="Connections" type="tenant">
         <Scopes>
             <Feature>
                 <Scope name="console:idps"/>
@@ -534,7 +534,7 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="org_identityProviders" displayName="Identity Providers" type="organization">
+    <APIResourceCollection name="org_connections" displayName="Connections" type="organization">
         <Scopes>
             <Feature>
                 <Scope name="console:org:idps"/>
@@ -553,6 +553,9 @@
                 <Scope name="internal_org_idp_view"/>
                 <Scope name="internal_org_role_mgt_view"/>
                 <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_authenticator_view"/>
+                <Scope name="internal_org_governance_view"/>
+                <Scope name="internal_org_extensions_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -272,7 +272,7 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="identityProviders" displayName="Identity Providers" type="tenant">
+    <APIResourceCollection name="connections" displayName="Connections" type="tenant">
         <Scopes>
             <Feature>
                 <Scope name="console:idps"/>
@@ -568,7 +568,7 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="org_identityProviders" displayName="Identity Providers" type="organization">
+    <APIResourceCollection name="org_connections" displayName="Connections" type="organization">
         <Scopes>
             <Feature>
                 <Scope name="console:org:idps"/>
@@ -587,6 +587,9 @@
                 <Scope name="internal_org_idp_view"/>
                 <Scope name="internal_org_role_mgt_view"/>
                 <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_authenticator_view"/>
+                <Scope name="internal_org_governance_view"/>
+                <Scope name="internal_org_extensions_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>


### PR DESCRIPTION
### Proposed changes in this pull request
- Add missing permissions for Connections section in sub org.
- Rename Identity Providers to Connections

https://github.com/wso2/carbon-identity-framework/assets/61885844/4490211c-1de1-4777-a385-5720548c37ca

### Related Issues 
- https://github.com/wso2/product-is/issues/19832
- https://github.com/wso2/product-is/issues/19834

