### PR TITLE
 Fix potential npe in session store

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -47,6 +47,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.LOCAL_IDP_NAME;
+
 /**
  * Class to store and retrieve user related data.
  */
@@ -298,7 +300,10 @@ public class UserSessionStore {
     public int getIdPId(String idpName, int tenantId) throws UserSessionException {
 
         int idPId = -1;
-        if (idpName.equals("LOCAL")) {
+        if (StringUtils.isBlank(idpName)) {
+            throw new UserSessionException("Blank IDP Name is provided to retrieve IdP id of tenant ID: " + tenantId);
+        }
+        if (StringUtils.equals(LOCAL_IDP_NAME, idpName)) {
             return idPId;
         }
         try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {


### PR DESCRIPTION
### Proposed changes in this pull request
When running integration tests for device flow following issue occured.
```
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - [2024-03-01 10:47:33,226] [a8a5a21f-cdc8-4bb3-8c68-b135da8e29ac] ERROR {org.wso2.carbon.identity.oauth2.OAuth2Service} - Error occurred while issuing the access token for Client ID : t5QNvkGgJlYYp1K4zVoao4WTwP0a, User ID null, Scope : [] and Grant Type : urn:ietf:params:oauth:grant-type:device_code java.lang.NullPointerException
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] -   at org.wso2.carbon.identity.application.authentication.framework.store.UserSessionStore.getIdPId(UserSessionStore.java:301)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] -   at org.wso2.carbon.identity.oauth2.device.dao.DeviceFlowDAOImpl.getAuthenticationDetails(DeviceFlowDAOImpl.java:203)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] -   at org.wso2.carbon.identity.oauth2.device.grant.DeviceFlowGrant.validateGrant(DeviceFlowGrant.java:68)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] -   at org.wso2.carbon.identity.oauth2.token.AccessTokenIssuer.issue(AccessTokenIssuer.java:358)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] -   at org.wso2.carbon.identity.oauth2.OAuth2Service.issueAccessToken(OAuth2Service.java:434)
INFO  [org.wso2.carbon.automation.extensions.se...........
```
This PR will fix the NPE and throw sessionException if the input is empty.