### PR TITLE
[5.25.x] Bump pax-logging version to 2.2.1-wso2v2

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt.ui/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>org.wso2.carbon.ui</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>commons-collections</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
@@ -91,7 +91,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/carbon-authenticators/thrift-authenticator/org.wso2.carbon.identity.authenticator.thrift/pom.xml
+++ b/components/carbon-authenticators/thrift-authenticator/org.wso2.carbon.identity.authenticator.thrift/pom.xml
@@ -62,7 +62,7 @@
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/components/claim-mgt/org.wso2.carbon.claim.mgt.ui/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.claim.mgt.ui/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>org.wso2.carbon.ui</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/claim-mgt/org.wso2.carbon.claim.mgt/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.claim.mgt/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt.ui/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt.ui/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>org.wso2.carbon.ui</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/pom.xml
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>org.eclipse.osgi.services</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/pom.xml
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/pom.xml
@@ -68,7 +68,7 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/directory-server-manager/org.wso2.carbon.directory.server.manager.ui/pom.xml
+++ b/components/directory-server-manager/org.wso2.carbon.directory.server.manager.ui/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>org.wso2.carbon.directory.server.manager.common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.common/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.common/pom.xml
@@ -64,7 +64,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/entitlement/org.wso2.carbon.identity.entitlement.ui/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement.ui/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/pom.xml
@@ -89,7 +89,7 @@
             <artifactId>javax.cache.wso2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/pom.xml
+++ b/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt.ui/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>org.wso2.carbon.user.mgt.stub</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt/pom.xml
+++ b/components/functions-library-mgt/org.wso2.carbon.identity.functions.library.mgt/pom.xml
@@ -163,7 +163,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/identity-core/org.wso2.carbon.identity.base/pom.xml
+++ b/components/identity-core/org.wso2.carbon.identity.base/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/identity-core/org.wso2.carbon.identity.core/pom.xml
+++ b/components/identity-core/org.wso2.carbon.identity.core/pom.xml
@@ -91,7 +91,7 @@
             <artifactId>commons-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/identity-event/org.wso2.carbon.identity.event/pom.xml
+++ b/components/identity-event/org.wso2.carbon.identity.event/pom.xml
@@ -89,7 +89,7 @@
             <artifactId>javax.cache.wso2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.ui/pom.xml
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.ui/pom.xml
@@ -53,7 +53,7 @@
             <artifactId>axiom</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/pom.xml
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/pom.xml
@@ -58,7 +58,7 @@
             <artifactId>axiom</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/notification-mgt/org.wso2.carbon.identity.notification.mgt/pom.xml
+++ b/components/notification-mgt/org.wso2.carbon.identity.notification.mgt/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/pom.xml
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/pom.xml
@@ -57,7 +57,7 @@
             <artifactId>axiom</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/secret-mgt/org.wso2.carbon.identity.secret.mgt.core/pom.xml
+++ b/components/secret-mgt/org.wso2.carbon.identity.secret.mgt.core/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>org.eclipse.osgi.services</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/template-mgt/org.wso2.carbon.identity.template.mgt/pom.xml
+++ b/components/template-mgt/org.wso2.carbon.identity.template.mgt/pom.xml
@@ -166,7 +166,7 @@
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/user-functionality-mgt/org.wso2.carbon.identity.user.functionality.mgt/pom.xml
+++ b/components/user-functionality-mgt/org.wso2.carbon.identity.user.functionality.mgt/pom.xml
@@ -218,7 +218,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/components/user-mgt/org.wso2.carbon.identity.user.profile.ui/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.identity.user.profile.ui/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>org.wso2.carbon.ui</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/user-mgt/org.wso2.carbon.identity.user.profile/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.identity.user.profile/pom.xml
@@ -55,7 +55,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/user-mgt/org.wso2.carbon.identity.user.registration/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.identity.user.registration/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>org.wso2.carbon.identity.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/components/user-mgt/org.wso2.carbon.user.mgt.common/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.common/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>org.wso2.carbon.user.mgt.common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/user-mgt/org.wso2.carbon.user.mgt/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/pom.xml
@@ -89,11 +89,11 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-log4j2</artifactId>
         </dependency>
         <dependency>

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration.ui/pom.xml
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration.ui/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>org.wso2.carbon.user.mgt.ui</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/pom.xml
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/user-store/org.wso2.carbon.identity.user.store.count/pom.xml
+++ b/components/user-store/org.wso2.carbon.identity.user.store.count/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>org.wso2.carbon.user.api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/pom.xml
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt.ui/pom.xml
@@ -36,7 +36,7 @@
             <artifactId>org.wso2.carbon.ui</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -490,12 +490,12 @@
                 <version>${wsdl4j.wso2.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.ops4j.pax.logging</groupId>
+                <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-api</artifactId>
                 <version>${pax.logging.api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.ops4j.pax.logging</groupId>
+                <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-log4j2</artifactId>
                 <version>${pax.logging.log4j2.version}</version>
             </dependency>
@@ -2010,8 +2010,8 @@
         <jersey-version>1.19.1</jersey-version>
 
         <!-- Pax Logging Version -->
-        <pax.logging.api.version>1.10.1</pax.logging.api.version>
-        <pax.logging.log4j2.version>1.10.1</pax.logging.log4j2.version>
+        <pax.logging.api.version>2.2.1-wso2v2</pax.logging.api.version>
+        <pax.logging.log4j2.version>2.2.1-wso2v2</pax.logging.log4j2.version>
 
         <!-- Log4j -->
         <log4j.api.version>2.17.1</log4j.api.version>

--- a/service-stubs/identity/org.wso2.carbon.security.mgt.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.security.mgt.stub/pom.xml
@@ -127,7 +127,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Proposed changes in this pull request

This PR bumps the pax-logging version to 2.2.1-wso2v2.