### PR TITLE
Update default email regex to allow special characters in the email username

### DIFF
--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/model/handlers/UsernameValidationConfigurationHandler.java
@@ -56,6 +56,7 @@ import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Conf
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.EMAIL_CLAIM_URI;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_GETTING_EXISTING_CONFIGURATIONS;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_INVALID_VALIDATORS_COMBINATION;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.SUPER_TENANT_DOMAIN;
 import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.PROPERTY_USER_NAME_JS_REG;
 import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.PROPERTY_USER_NAME_JS_REG_EX;
 import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.PROPERTY_USER_NAME_WITH_EMAIL_JS_REG_EX;
@@ -91,7 +92,8 @@ public class UsernameValidationConfigurationHandler extends AbstractFieldValidat
                 rules.add(getRuleConfig(AlphanumericValidator.class.getSimpleName(),
                         ENABLE_VALIDATOR, Boolean.TRUE.toString()));
                 configuration.setRules(rules);
-            } else if (PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain().equals("carbon.super")) {
+            } else if (PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()
+                    .equals(SUPER_TENANT_DOMAIN)) {
                 // Return the JSRegex if the tenant domain is carbon.super
                 rules.add(getRuleConfig("JsRegExValidator", JS_REGEX, usernameRegEx));
                 configuration.setRegEx(rules);

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -50,6 +50,7 @@ public class Constants {
                 put(PASSWORD, PasswordValidationConfigurationHandler.class.getSimpleName());
             }});
     public static final String EMAIL_CLAIM_URI = "http://wso2.org/claims/emailaddress";
+    public static final String SUPER_TENANT_DOMAIN = "carbon.super";
 
     /**
      * Class contains the configuration related constants.

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -81,11 +81,13 @@ public class Constants {
         public static final String ALPHANUMERIC_REGEX_PATTERN_WITH_SPECIAL_CHARACTERS =
                 "^(?=.*[a-zA-Z])[a-zA-Z0-9!@#$&'+\\\\=^_.{|}~-]+$";
         public static final String DEFAULT_EMAIL_JAVA_REGEX_PATTERN =
-            "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![.+\\-_]{2})[\\u00C0-\\u00FF\\w.+\\-]){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0" +
-            "-9]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";
+            "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![!#$'+\\\\=^_.{|}~\\-&]{2})[\\u00C0-\\u00FF\\w!@#$'+\\\\=^_.{|}~\\-&]" +
+                    "){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0-9_]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}" +
+                    "(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";
         public static final String DEFAULT_EMAIL_JS_REGEX_PATTERN =
-            "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![.+\\-_]{2})[\\u00C0-\\u00FF\\w.+\\-]){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0" +
-            "-9]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";
+            "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![!#$'+\\\\=^_.{|}~\\-&]{2})[\\u00C0-\\u00FF\\w!@#$'+\\\\=^_.{|}~\\-&]" +
+                    "){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0-9_]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}" +
+                    "(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";
 
         public static final String INPUT_VALIDATION_DEFAULT_VALIDATOR = "InputValidation.DefaultUserNameValidator";
 

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -81,11 +81,11 @@ public class Constants {
         public static final String ALPHANUMERIC_REGEX_PATTERN_WITH_SPECIAL_CHARACTERS =
                 "^(?=.*[a-zA-Z])[a-zA-Z0-9!@#$&'+\\\\=^_.{|}~-]+$";
         public static final String DEFAULT_EMAIL_JAVA_REGEX_PATTERN =
-            "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![!#$'+\\\\=^_.{|}~\\-&]{2})[\\u00C0-\\u00FF\\w!@#$'+\\\\=^_.{|}~\\-&]" +
+            "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![!#$'+\\\\=^_.{|}~\\-&]{2})[\\u00C0-\\u00FF\\w!#$'+\\\\=^_.{|}~\\-&]" +
                     "){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0-9_]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}" +
                     "(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";
         public static final String DEFAULT_EMAIL_JS_REGEX_PATTERN =
-            "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![!#$'+\\\\=^_.{|}~\\-&]{2})[\\u00C0-\\u00FF\\w!@#$'+\\\\=^_.{|}~\\-&]" +
+            "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![!#$'+\\\\=^_.{|}~\\-&]{2})[\\u00C0-\\u00FF\\w!#$'+\\\\=^_.{|}~\\-&]" +
                     "){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0-9_]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}" +
                     "(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";
 

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -67,7 +67,7 @@
 				<Required />
 				<DisplayOrder>6</DisplayOrder>
 				<SupportedByDefault />
-                <RegEx>^([a-zA-Z0-9_\+\.\-])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,10})+$</RegEx>
+                <RegEx>^([a-zA-Z0-9!#$'+\\=^_.{|}~\-&amp;])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,10})+$</RegEx>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/telephone</ClaimURI>

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -67,7 +67,7 @@
 				<Required />
 				<DisplayOrder>6</DisplayOrder>
 				<SupportedByDefault />
-                <RegEx>^([a-zA-Z0-9!#$'+\\=^_.{|}~\-&amp;])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,10})+$</RegEx>
+                <RegEx>^([a-zA-Z0-9!#$'\+\\=^_\.{|}~\-&amp;])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,10})+$</RegEx>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/telephone</ClaimURI>


### PR DESCRIPTION
### Proposed changes in this pull request
This PR will improve the BE regex validation logic for email usernames to allow special characters in the email.
`! # $ ' + \ = ^ _ . { | } ~ - &`
