### PR TITLE
Improve admin role resolving

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -2216,8 +2216,10 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
             serviceProvider.setCertificateContent(getCertificateContent(propertyList, connection));
 
             // Set role associations.
-            serviceProvider.setAssociatedRolesConfig(
-                    getAssociatedRoles(serviceProvider.getApplicationResourceId(), connection, tenantID));
+            if (!CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME) {
+                serviceProvider.setAssociatedRolesConfig(
+                        getAssociatedRoles(serviceProvider.getApplicationResourceId(), connection, tenantID));
+            }
             // Will be supported with 'Advance Consent Management Feature'.
             /*
             ConsentConfig consentConfig = serviceProvider.getConsentConfig();

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/AdminRoleListener.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/AdminRoleListener.java
@@ -140,10 +140,13 @@ public class AdminRoleListener extends AbstractRoleManagementListener {
         RoleManagementService roleManagementService = ApplicationManagementServiceComponentHolder.getInstance()
                 .getRoleManagementServiceV2();
         RoleBasicInfo role = roleManagementService.getRoleBasicInfoById(roleId, tenantDomain);
-        if (StringUtils.equals(getOrgAdminRoleName(), (role.getName()))) {
-            return role.getAudience().equals(RoleConstants.ORGANIZATION);
-        } else if (RoleConstants.ADMINISTRATOR.equals(role.getName())) {
-            return role.getAudienceName().equals(ApplicationConstants.CONSOLE_APPLICATION_NAME);
+        if (StringUtils.equals(getOrgAdminRoleName(), (role.getName())) &&
+                role.getAudience().equals(RoleConstants.ORGANIZATION)) {
+            return true;
+        }
+        if (RoleConstants.ADMINISTRATOR.equals(role.getName()) &&
+                role.getAudienceName().equals(ApplicationConstants.CONSOLE_APPLICATION_NAME)) {
+            return true;
         }
         return false;
     }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
@@ -24,6 +24,7 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -166,6 +167,7 @@ public class ApplicationManagementServiceImplTest extends PowerMockTestCase {
         SecretManagerComponentDataHolder.getInstance().setSecretManagementEnabled(true);
         SecretDAO secretDAO = new SecretDAOImpl();
         SecretManagerComponentDataHolder.getInstance().setSecretDAOS(Collections.singletonList(secretDAO));
+        CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = false;
     }
 
     @DataProvider(name = "addApplicationDataProvider")


### PR DESCRIPTION
### Proposed changes in this pull request
 
$subject

The two conditions are simplified as below.
- If default tenant admin role is same as the given role, and the given role's audience is organization audience, it is an admin role.

- If the given role name is Administrator and its audience value is console, then it is console administrator role.

<img width="959" alt="Screenshot 2024-04-08 at 18 11 09" src="https://github.com/wso2/carbon-identity-framework/assets/35717390/04b3a688-876f-49a0-8830-bb6ced7b24df">

The above image shows how the current logic identify the Administrator role. For the same flow, previous logic failed to identify the administrator role.