### PR TITLE
Revert "Get tenantDomain from CarbonContext instead of getting from the username"

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -22,7 +22,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.DuplicatedAuthUserException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
@@ -165,8 +164,7 @@ public class AuthenticatedUser extends User {
             authenticatedUser.setUserName(MultitenantUtils.getTenantAwareUsername(authenticatedSubjectIdentifier));
         }
 
-        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        authenticatedUser.setTenantDomain(tenantDomain);
+        authenticatedUser.setTenantDomain(MultitenantUtils.getTenantDomain(authenticatedSubjectIdentifier));
         authenticatedUser.setAuthenticatedSubjectIdentifier(authenticatedSubjectIdentifier);
         authenticatedUser.setUserId(authenticatedUser.getLocalUserIdInternal());
 


### PR DESCRIPTION
### Proposed changes in this pull request
Reverting https://github.com/wso2/carbon-identity-framework/pull/5374 since the fix https://github.com/wso2/identity-apps/pull/5706 addresses the related issues.

### Related PRs
- https://github.com/wso2/identity-apps/pull/5706

### Related Issues
- https://github.com/wso2/product-is/issues/18795
- https://github.com/wso2-enterprise/asgardeo-product/issues/21612
