### PR TITLE
Revert "Get tenantDomain from CarbonContext instead of getting from the username"

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -22,7 +22,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.DuplicatedAuthUserException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
@@ -165,8 +164,7 @@ public class AuthenticatedUser extends User {
             authenticatedUser.setUserName(MultitenantUtils.getTenantAwareUsername(authenticatedSubjectIdentifier));
         }
 
-        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        authenticatedUser.setTenantDomain(tenantDomain);
+        authenticatedUser.setTenantDomain(MultitenantUtils.getTenantDomain(authenticatedSubjectIdentifier));
         authenticatedUser.setAuthenticatedSubjectIdentifier(authenticatedSubjectIdentifier);
         authenticatedUser.setUserId(authenticatedUser.getLocalUserIdInternal());
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthAssociationHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthAssociationHandlerTest.java
@@ -26,7 +26,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.core.util.AdminServicesUtil;
 import org.wso2.carbon.identity.application.authentication.framework.AbstractFrameworkTest;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
@@ -73,15 +72,13 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
-import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_ID;
 import static org.wso2.carbon.identity.core.util.IdentityUtil.getLocalGroupsClaimURI;
 
 /**
  * This is a test class for {@link PostAuthAssociationHandler}.
  */
 @PrepareForTest({FrameworkUtils.class, ConfigurationFacade.class, ClaimMetadataHandler.class, AdminServicesUtil.class
-        , IdentityTenantUtil.class, PrivilegedCarbonContext.class})
+        , IdentityTenantUtil.class})
 @PowerMockIgnore({"javax.xml.*", "org.mockito.*"})
 public class PostAuthAssociationHandlerTest extends AbstractFrameworkTest {
 
@@ -145,7 +142,6 @@ public class PostAuthAssociationHandlerTest extends AbstractFrameworkTest {
     public void testHandleWithAuthenticatedUserWithFederatedIdpAssociatedToSecondaryUserStore(boolean hasSpRoleMapping)
             throws Exception {
 
-        mockCarbonContextForTenant();
         PowerMockito.spy(AdminServicesUtil.class);
         PowerMockito.doReturn(null).when(AdminServicesUtil.class, "getUserRealm");
         AuthenticationContext context = processAndGetAuthenticationContext(sp, true, true, hasSpRoleMapping);
@@ -242,15 +238,5 @@ public class PostAuthAssociationHandlerTest extends AbstractFrameworkTest {
 
         }
         return false;
-    }
-
-    private void mockCarbonContextForTenant() {
-
-        mockStatic(PrivilegedCarbonContext.class);
-        PrivilegedCarbonContext privilegedCarbonContext = mock(PrivilegedCarbonContext.class);
-        when(PrivilegedCarbonContext.getThreadLocalCarbonContext()).thenReturn(privilegedCarbonContext);
-        when(privilegedCarbonContext.getTenantDomain()).thenReturn(SUPER_TENANT_DOMAIN_NAME);
-        when(privilegedCarbonContext.getTenantId()).thenReturn(SUPER_TENANT_ID);
-        when(privilegedCarbonContext.getUsername()).thenReturn("admin");
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
Reverting https://github.com/wso2/carbon-identity-framework/pull/5374 since the fix https://github.com/wso2/identity-apps/pull/5706 addresses the related issues.

### Related PRs
- https://github.com/wso2/identity-apps/pull/5706

### Related Issues
- https://github.com/wso2/product-is/issues/18795
