### PR TITLE
Remove \ from default email regex

### DIFF
--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -82,11 +82,11 @@ public class Constants {
         public static final String ALPHANUMERIC_REGEX_PATTERN_WITH_SPECIAL_CHARACTERS =
                 "^(?=.*[a-zA-Z])[a-zA-Z0-9!@#$&'+\\\\=^_.{|}~-]+$";
         public static final String DEFAULT_EMAIL_JAVA_REGEX_PATTERN =
-            "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![!#$'+\\\\=^_.{|}~\\-&]{2})[\\u00C0-\\u00FF\\w!#$'+\\\\=^_.{|}~\\-&]" +
+            "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![!#$'+=^_.{|}~\\-&]{2})[\\u00C0-\\u00FF\\w!#$'+=^_.{|}~\\-&]" +
                     "){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0-9_]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}" +
                     "(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";
         public static final String DEFAULT_EMAIL_JS_REGEX_PATTERN =
-            "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![!#$'+\\\\=^_.{|}~\\-&]{2})[\\u00C0-\\u00FF\\w!#$'+\\\\=^_.{|}~\\-&]" +
+            "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![!#$'+=^_.{|}~\\-&]{2})[\\u00C0-\\u00FF\\w!#$'+=^_.{|}~\\-&]" +
                     "){0,63}(?=[\\u00C0-\\u00FFa-zA-Z0-9_]).\\@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}" +
                     "(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";
 

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -68,7 +68,7 @@
 				<Required />
 				<DisplayOrder>6</DisplayOrder>
 				<SupportedByDefault />
-                <RegEx>^([a-zA-Z0-9!#$'\+\\=^_\.{|}~\-&amp;])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,10})+$</RegEx>
+                <RegEx>^([a-zA-Z0-9!#$'\+=^_\.{|}~\-&amp;])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,10})+$</RegEx>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/telephone</ClaimURI>


### PR DESCRIPTION
### Proposed changes in this pull request
By this PR https://github.com/wso2/carbon-identity-framework/pull/5568, the default email regex has been updated to provide the support to special characters in the email username.
Even the `\` character is also allowed by the PR the RFC spec[1] is not allowing that character. 
Hence removing it from this PR.

[1] - https://datatracker.ietf.org/doc/html/rfc3696#page-5:~:text=!%20%23%20%24%20%25%20%26%20%27%20*%20%2B%20%2D%20/%20%3D%20%3F%20%20%5E%20_%20%60%20.%20%7B%20%7C%20%7D%20

