### PR TITLE
Fix Github Template Scopes

### DIFF
--- a/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/github/metadata.json
+++ b/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/github/metadata.json
@@ -105,7 +105,7 @@
             },
             {
                 "key": "scope",
-                "value": "user:email,read:user"
+                "value": "user:email read:user"
             },
             {
                 "key": "UsePrimaryEmail",


### PR DESCRIPTION
### Purpose

- According to Github docs [1], the scopes should be space separated and with this PR, it corrects the default scopes in the Github connector template.

[1] - https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps