### PR TITLE
Fix email otp and sms otp is not receiving issue

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
@@ -435,6 +435,12 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
     protected org.wso2.carbon.user.core.common.User getUser(AuthenticatedUser authenticatedUser)
             throws AuthenticationFailedException {
 
+        return getUser(authenticatedUser, null);
+    }
+    protected org.wso2.carbon.user.core.common.User getUser(AuthenticatedUser authenticatedUser,
+                                                            AuthenticationContext context)
+            throws AuthenticationFailedException {
+
         org.wso2.carbon.user.core.common.User user = null;
         String tenantDomain = authenticatedUser.getTenantDomain();
         if (tenantDomain == null) {
@@ -443,9 +449,13 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
         try {
             if (FrameworkServiceDataHolder.getInstance().getMultiAttributeLoginService().isEnabled(tenantDomain)) {
+                String username = authenticatedUser.getUserName();
+                if (context != null) {
+                    username = FrameworkUtils.preprocessUsername(username, context);
+                }
                 ResolvedUserResult resolvedUserResult = FrameworkServiceDataHolder.getInstance()
                         .getMultiAttributeLoginService().resolveUser(MultitenantUtils.getTenantAwareUsername(
-                                authenticatedUser.getUserName()), tenantDomain);
+                                username), tenantDomain);
                 if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS.
                         equals(resolvedUserResult.getResolvedStatus())) {
                     user = resolvedUserResult.getUser();


### PR DESCRIPTION
### Proposed changes in this pull request
- Fixing the issue when multi attribute login is enabled, the email otp and sms otp first factor is not working with the username attribute.
- The issue is due to `email domain` is removed from the username when getting the tenant aware username
- Fix the issue by preprocess the username before getting the tenant aware username

