### PR TITLE
Using try-with-resources for closing the Input Stream and Disable external entity processing to prevent XXE attacks

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -1933,10 +1933,16 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
         try {
             JAXBContext jaxbContext = JAXBContext.newInstance(ServiceProvider.class);
             Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+            // Disable external entity processing to prevent XXE attacks.
+            unmarshaller.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            unmarshaller.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
             return (ServiceProvider) unmarshaller.unmarshal(new ByteArrayInputStream(
                     spTemplateXml.getBytes(StandardCharsets.UTF_8)));
         } catch (JAXBException e) {
             throw new IdentityApplicationManagementException("Error in reading Service Provider template " +
+                    "configuration ", e);
+        } catch (Exception e) {
+            throw new IdentityApplicationManagementException("Unexpected error in reading Service Provider template " +
                     "configuration ", e);
         }
     }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.identity.application.mgt;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import javax.xml.XMLConstants;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -60,6 +59,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.application.mgt;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.xml.XMLConstants;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -575,11 +576,19 @@ public class ApplicationMgtUtil {
         try {
             JAXBContext jaxbContext = JAXBContext.newInstance(ServiceProvider.class);
             Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+            // Disable external entity processing to prevent XXE attacks.
+            unmarshaller.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            unmarshaller.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
             return (ServiceProvider) unmarshaller.unmarshal(spFileStream.getFileStream());
 
         } catch (JAXBException e) {
             throw new IdentityApplicationManagementException(String.format("Error in reading Service Provider " +
                     "configuration file %s uploaded by tenant: %s", spFileStream.getFileName(), tenantDomain), e);
+        } catch (Exception e) {
+            // Catch any other unexpected exceptions for proper error handling
+            throw new IdentityApplicationManagementException(String.format("Unexpected error in reading Service " +
+                    "Provider configuration file %s uploaded by tenant: %s", spFileStream.getFileName(), tenantDomain),
+                    e);
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -854,11 +854,12 @@ public class FrameworkServiceComponent {
 
         try {
             ClassLoader loader = FrameworkServiceComponent.class.getClassLoader();
-            InputStream resourceStream = loader.getResourceAsStream("js/require.js");
-            requireCode = IOUtils.toString(resourceStream);
-            FrameworkServiceDataHolder.getInstance().setCodeForRequireFunction(requireCode);
+            try (InputStream resourceStream = loader.getResourceAsStream("js/require.js")) {
+                requireCode = IOUtils.toString(resourceStream);
+                FrameworkServiceDataHolder.getInstance().setCodeForRequireFunction(requireCode);
+            }
         } catch (IOException e) {
-            log.error("Failed to read require.js file. Therefore, require() function doesn't support in" +
+            log.error("Failed to read require.js file. Therefore, require() function doesn't support in " +
                     "adaptive authentication scripts.", e);
         }
     }


### PR DESCRIPTION
### Proposed changes in this pull request

1st commit - Using try-with-resources for closing the Input Stream
2nd / 3rd commits - Porting https://github.com/wso2/carbon-identity-framework/pull/5226
4th commit - Exact similar fix as  porting https://github.com/wso2/carbon-identity-framework/pull/5226 in a different location