### PR TITLE
Add SCIM2 user endpoint pagination enabled config

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -105,7 +105,7 @@ public class IdentityCoreConstants {
     public static final String S_MICROSOFT = "microsoft";
 
     // SCIM2 constants.
-    public static final String SCIM2_USER_ENDPOINT_MAXIMUM_ITEMS_PER_PAGE_ENABLED = "SCIM2.UserEndpointMaximumItemsPerPageEnabled";
+    public static final String SCIM2_USER_MAX_ITEMS_PER_PAGE_ENABLED = "SCIM2.UserEndpointMaxItemsPerPageEnabled";
 
     public static class Filter {
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -104,6 +104,9 @@ public class IdentityCoreConstants {
     public static final String MICROSOFT = "Microsoft";
     public static final String S_MICROSOFT = "microsoft";
 
+    // SCIM2 constants.
+    public static final String SCIM2_USER_ENDPOINT_MAXIMUM_ITEMS_PER_PAGE_ENABLED = "SCIM2.UserEndpointMaximumItemsPerPageEnabled";
+
     public static class Filter {
 
         public static final String AND = "and";

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -1799,4 +1799,20 @@ public class IdentityUtil {
         }
         return userId;
     }
+
+    /**
+     * Read the SCIM User Endpoint Maximum Items Per Page is enabled config and returns it.
+     *
+     * @return If SCIM User Endpoint Maximum Items Per Page is enabled.
+     */
+    public static boolean isSCIM2UserEndpointMaximumItemsPerPageEnabled() {
+
+        String scim2UserEndpointMaximumItemsPerPageEnabledProperty =
+                IdentityUtil.getProperty(IdentityCoreConstants.SCIM2_USER_ENDPOINT_MAXIMUM_ITEMS_PER_PAGE_ENABLED);
+
+        if (StringUtils.isBlank(scim2UserEndpointMaximumItemsPerPageEnabledProperty)) {
+            return true;
+        }
+        return Boolean.parseBoolean(scim2UserEndpointMaximumItemsPerPageEnabledProperty);
+    }
 }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -1805,14 +1805,14 @@ public class IdentityUtil {
      *
      * @return If SCIM User Endpoint Maximum Items Per Page is enabled.
      */
-    public static boolean isSCIM2UserEndpointMaximumItemsPerPageEnabled() {
+    public static boolean isSCIM2UserMaxItemsPerPageEnabled() {
 
-        String scim2UserEndpointMaximumItemsPerPageEnabledProperty =
-                IdentityUtil.getProperty(IdentityCoreConstants.SCIM2_USER_ENDPOINT_MAXIMUM_ITEMS_PER_PAGE_ENABLED);
+        String scim2UserMaxItemsPerPageEnabledProperty =
+                IdentityUtil.getProperty(IdentityCoreConstants.SCIM2_USER_MAX_ITEMS_PER_PAGE_ENABLED);
 
-        if (StringUtils.isBlank(scim2UserEndpointMaximumItemsPerPageEnabledProperty)) {
+        if (StringUtils.isBlank(scim2UserMaxItemsPerPageEnabledProperty)) {
             return true;
         }
-        return Boolean.parseBoolean(scim2UserEndpointMaximumItemsPerPageEnabledProperty);
+        return Boolean.parseBoolean(scim2UserMaxItemsPerPageEnabledProperty);
     }
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -968,7 +968,7 @@
           Supported versions : IS 5.10.0 onwards
         -->
         <!--<ConsiderTotalRecordsForTotalResultOfLDAP>false</ConsiderTotalRecordsForTotalResultOfLDAP>-->
-
+        <UserEndpointMaximumItemsPerPageEnabled>true</UserEndpointMaximumItemsPerPageEnabled>
     </SCIM2>
 
     <!--Recovery>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -975,7 +975,7 @@
              Default value : true
              Supported versions : IS 7.0.0 onwards
         -->
-        <UserEndpointMaximumItemsPerPageEnabled>true</UserEndpointMaximumItemsPerPageEnabled>
+        <UserEndpointMaxItemsPerPageEnabled>true</UserEndpointMaxItemsPerPageEnabled>
     </SCIM2>
 
     <!--Recovery>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -968,6 +968,13 @@
           Supported versions : IS 5.10.0 onwards
         -->
         <!--<ConsiderTotalRecordsForTotalResultOfLDAP>false</ConsiderTotalRecordsForTotalResultOfLDAP>-->
+        <!--
+             If you want to remove the limit set for the count query parameter of SCIM2 Users Endpoint then disable this
+             property value.
+
+             Default value : true
+             Supported versions : IS 7.0.0 onwards
+        -->
         <UserEndpointMaximumItemsPerPageEnabled>true</UserEndpointMaximumItemsPerPageEnabled>
     </SCIM2>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1424,7 +1424,7 @@
              Default value : true
              Supported versions : IS 7.0.0 onwards
         -->
-        <UserEndpointMaximumItemsPerPageEnabled>{{scim2.user_endpoint_maximum_items_per_page.enable}}</UserEndpointMaximumItemsPerPageEnabled>
+        <UserEndpointMaxItemsPerPageEnabled>{{scim2.user_endpoint_max_items_per_page.enable}}</UserEndpointMaxItemsPerPageEnabled>
     </SCIM2>
 
       <PasswordPolicy>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1417,6 +1417,7 @@
         -->
         <ConsiderTotalRecordsForTotalResultOfLDAP>{{scim2.consider_total_records_for_total_results_of_ldap}}</ConsiderTotalRecordsForTotalResultOfLDAP>
 
+        <UserEndpointMaximumItemsPerPageEnabled>{{scim2.user_endpoint_maximum_items_per_page.enable}}</UserEndpointMaximumItemsPerPageEnabled>
     </SCIM2>
 
       <PasswordPolicy>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1417,6 +1417,13 @@
         -->
         <ConsiderTotalRecordsForTotalResultOfLDAP>{{scim2.consider_total_records_for_total_results_of_ldap}}</ConsiderTotalRecordsForTotalResultOfLDAP>
 
+        <!--
+             If you want to remove the limit set for the count query parameter of SCIM2 Users Endpoint then disable this
+             property value.
+
+             Default value : true
+             Supported versions : IS 7.0.0 onwards
+        -->
         <UserEndpointMaximumItemsPerPageEnabled>{{scim2.user_endpoint_maximum_items_per_page.enable}}</UserEndpointMaximumItemsPerPageEnabled>
     </SCIM2>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -351,6 +351,7 @@
   "scim2.remove_duplicate_users_in_users_response": false,
   "scim2.consider_max_limit_for_total_results": false,
   "scim2.consider_total_records_for_total_results_of_ldap": false,
+  "scim2.user_endpoint_maximum_items_per_page.enable": true,
 
   "identity_mgt.password_policy.password_policy_validation_handler.enable": true,
   "identity_mgt.recovery.enable_v1_api": false,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -351,7 +351,7 @@
   "scim2.remove_duplicate_users_in_users_response": false,
   "scim2.consider_max_limit_for_total_results": false,
   "scim2.consider_total_records_for_total_results_of_ldap": false,
-  "scim2.user_endpoint_maximum_items_per_page.enable": true,
+  "scim2.user_endpoint_max_items_per_page.enable": true,
 
   "identity_mgt.password_policy.password_policy_validation_handler.enable": true,
   "identity_mgt.recovery.enable_v1_api": false,


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

The config is enabled by default for the master fix. To disable the config, add the below config to the `deployment.toml`.

```
[scim2.user_endpoint_maximum_items_per_page]
enable=false

```

### Related Issue:
- https://github.com/wso2/product-is/issues/20030