### PR TITLE
Enhance RecoveryApiV2 Client to add missing functions from the RecoveryAPI V2

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointConstants.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointConstants.java
@@ -51,6 +51,7 @@ public class IdentityManagementEndpointConstants {
 
     public static final class PasswordRecoveryOptions {
         public static final String EMAIL = "EMAIL";
+        public static final String SMSOTP = "SMSOTP";
         public static final String SECURITY_QUESTIONS = "SECURITY_QUESTIONS";
     }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
@@ -60,7 +60,8 @@ public class PreferenceRetrievalClient {
     private static final String USERNAME_RECOVERY_PROPERTY = "Recovery.Notification.Username.Enable";
     private static final String NOTIFICATION_PASSWORD_RECOVERY_PROPERTY = "Recovery.Notification.Password.Enable";
     private static final String SMS_OTP_PASSWORD_RECOVERY_PROPERTY = "Recovery.Notification.Password.smsOtp.Enable";
-    private static final String EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY = "Recovery.Notification.Password.emailLink.Enable";
+    private static final String EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY
+            = "Recovery.Notification.Password.emailLink.Enable";
     private static final String QUESTION_PASSWORD_RECOVERY_PROPERTY = "Recovery.Question.Password.Enable";
     private static final String SELF_SIGN_UP_LOCK_ON_CREATION_PROPERTY = "SelfRegistration.LockOnCreation";
     private static final String MULTI_ATTRIBUTE_LOGIN_PROPERTY = "account.multiattributelogin.handler.enable";
@@ -150,9 +151,9 @@ public class PreferenceRetrievalClient {
     /**
      * Check email link based password recovery is enabled or not.
      *
-     * @param tenant tenant domain name.
-     * @return returns true if  email link based password recovery enabled.
-     * @throws PreferenceRetrievalClientException
+     * @param tenant Tenant domain name.
+     * @return Returns true if email link based password recovery enabled.
+     * @throws PreferenceRetrievalClientException PreferenceRetrievalClientException.
      */
     public boolean checkEmailLinkBasedPasswordRecovery(String tenant) throws PreferenceRetrievalClientException {
 
@@ -162,9 +163,9 @@ public class PreferenceRetrievalClient {
     /**
      * Check notification based password recovery is enabled or not.
      *
-     * @param tenant tenant domain name.
-     * @return returns true if  notification based password recovery enabled.
-     * @throws PreferenceRetrievalClientException
+     * @param tenant Tenant domain name.
+     * @return Returns true if notification based password recovery enabled.
+     * @throws PreferenceRetrievalClientException PreferenceRetrievalClientException.
      */
     public boolean checkSMSOTPBasedPasswordRecovery(String tenant) throws PreferenceRetrievalClientException {
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
@@ -60,6 +60,7 @@ public class PreferenceRetrievalClient {
     private static final String USERNAME_RECOVERY_PROPERTY = "Recovery.Notification.Username.Enable";
     private static final String NOTIFICATION_PASSWORD_RECOVERY_PROPERTY = "Recovery.Notification.Password.Enable";
     private static final String SMS_OTP_PASSWORD_RECOVERY_PROPERTY = "Recovery.Notification.Password.smsOtp.Enable";
+    private static final String EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY = "Recovery.Notification.Password.emailLink.Enable";
     private static final String QUESTION_PASSWORD_RECOVERY_PROPERTY = "Recovery.Question.Password.Enable";
     private static final String SELF_SIGN_UP_LOCK_ON_CREATION_PROPERTY = "SelfRegistration.LockOnCreation";
     private static final String MULTI_ATTRIBUTE_LOGIN_PROPERTY = "account.multiattributelogin.handler.enable";
@@ -140,9 +141,22 @@ public class PreferenceRetrievalClient {
      * @return returns true if  notification based password recovery enabled.
      * @throws PreferenceRetrievalClientException
      */
+    @Deprecated
     public boolean checkNotificationBasedPasswordRecovery(String tenant) throws PreferenceRetrievalClientException {
 
         return checkPreference(tenant, RECOVERY_CONNECTOR, NOTIFICATION_PASSWORD_RECOVERY_PROPERTY);
+    }
+
+    /**
+     * Check email link based password recovery is enabled or not.
+     *
+     * @param tenant tenant domain name.
+     * @return returns true if  email link based password recovery enabled.
+     * @throws PreferenceRetrievalClientException
+     */
+    public boolean checkEmailLinkBasedPasswordRecovery(String tenant) throws PreferenceRetrievalClientException {
+
+        return checkPreference(tenant, RECOVERY_CONNECTOR, EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY);
     }
 
     /**
@@ -179,8 +193,8 @@ public class PreferenceRetrievalClient {
     public boolean checkPasswordRecovery(String tenant) throws PreferenceRetrievalClientException {
 
         List<String> propertyNameList = new ArrayList<String>();
-        propertyNameList.add(NOTIFICATION_PASSWORD_RECOVERY_PROPERTY);
         propertyNameList.add(QUESTION_PASSWORD_RECOVERY_PROPERTY);
+        propertyNameList.add(SMS_OTP_PASSWORD_RECOVERY_PROPERTY);
         return checkMultiplePreference(tenant, RECOVERY_CONNECTOR, propertyNameList);
     }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
@@ -195,6 +195,7 @@ public class PreferenceRetrievalClient {
         List<String> propertyNameList = new ArrayList<String>();
         propertyNameList.add(QUESTION_PASSWORD_RECOVERY_PROPERTY);
         propertyNameList.add(SMS_OTP_PASSWORD_RECOVERY_PROPERTY);
+        propertyNameList.add(EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY);
         return checkMultiplePreference(tenant, RECOVERY_CONNECTOR, propertyNameList);
     }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
@@ -59,6 +59,7 @@ public class PreferenceRetrievalClient {
     private static final String SELF_REGISTRATION_PROPERTY = "SelfRegistration.Enable";
     private static final String USERNAME_RECOVERY_PROPERTY = "Recovery.Notification.Username.Enable";
     private static final String NOTIFICATION_PASSWORD_RECOVERY_PROPERTY = "Recovery.Notification.Password.Enable";
+    private static final String SMS_OTP_PASSWORD_RECOVERY_PROPERTY = "Recovery.Notification.Password.smsOtp.Enable";
     private static final String QUESTION_PASSWORD_RECOVERY_PROPERTY = "Recovery.Question.Password.Enable";
     private static final String SELF_SIGN_UP_LOCK_ON_CREATION_PROPERTY = "SelfRegistration.LockOnCreation";
     private static final String MULTI_ATTRIBUTE_LOGIN_PROPERTY = "account.multiattributelogin.handler.enable";
@@ -142,6 +143,18 @@ public class PreferenceRetrievalClient {
     public boolean checkNotificationBasedPasswordRecovery(String tenant) throws PreferenceRetrievalClientException {
 
         return checkPreference(tenant, RECOVERY_CONNECTOR, NOTIFICATION_PASSWORD_RECOVERY_PROPERTY);
+    }
+
+    /**
+     * Check notification based password recovery is enabled or not.
+     *
+     * @param tenant tenant domain name.
+     * @return returns true if  notification based password recovery enabled.
+     * @throws PreferenceRetrievalClientException
+     */
+    public boolean checkSMSOTPBasedPasswordRecovery(String tenant) throws PreferenceRetrievalClientException {
+
+        return checkPreference(tenant, RECOVERY_CONNECTOR, SMS_OTP_PASSWORD_RECOVERY_PROPERTY);
     }
 
     /**

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/api/RecoveryApiV2.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/api/RecoveryApiV2.java
@@ -22,6 +22,7 @@ import com.sun.jersey.api.client.GenericType;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants;
 import org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil;
 import org.wso2.carbon.identity.mgt.endpoint.util.client.ApiClient;
@@ -86,7 +87,7 @@ public class RecoveryApiV2 {
                                                               String tenantDomain, Map<String, String> headers)
             throws ApiException {
 
-        String localVarPath = "/password/init";
+        final String localVarPath = "/password/init";
         return initiateRecovery(recoveryInitRequest, tenantDomain, headers, localVarPath);
     }
 
@@ -102,7 +103,7 @@ public class RecoveryApiV2 {
     public RecoveryResponse recoverPassword(RecoveryRequest recoveryRequest, String tenantDomain,
                                             Map<String, String> headers) throws ApiException {
 
-        String localVarPath = "/password/recover";
+        final String localVarPath = "/password/recover";
         return recover(recoveryRequest, tenantDomain, headers, localVarPath);
     }
 
@@ -118,7 +119,7 @@ public class RecoveryApiV2 {
     public ResendResponse resendPasswordNotification(ResendRequest resendRequest, String tenantDomain,
                                                      Map<String, String> headers) throws ApiException {
 
-        String localVarPath = "/password/resend";
+        final String localVarPath = "/password/resend";
         return resend(resendRequest, tenantDomain, headers, localVarPath);
     }
 
@@ -134,7 +135,7 @@ public class RecoveryApiV2 {
     public ConfirmResponse confirmPasswordRecovery(ConfirmRequest confirmRequest, String tenantDomain,
                                                    Map<String, String> headers) throws ApiException {
 
-        String localVarPath = "/password/confirm";
+        final String localVarPath = "/password/confirm";
         return confirm(confirmRequest, tenantDomain, headers, localVarPath);
     }
 
@@ -150,7 +151,7 @@ public class RecoveryApiV2 {
     public ResetResponse resetUserPassword(ResetRequest resetRequest, String tenantDomain,
                                            Map<String, String> headers) throws ApiException {
 
-        String localVarPath = "/password/reset";
+        final String localVarPath = "/password/reset";
         return reset(resetRequest, tenantDomain, headers, localVarPath);
     }
 
@@ -187,11 +188,11 @@ public class RecoveryApiV2 {
         }
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
         final String[] localVarAccepts = {
-                "application/json"
+                FrameworkConstants.ContentTypes.TYPE_APPLICATION_JSON
         };
         final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = {
-                "application/json"
+                FrameworkConstants.ContentTypes.TYPE_APPLICATION_JSON
         };
         final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
         String[] localVarAuthNames = new String[]{};
@@ -233,11 +234,11 @@ public class RecoveryApiV2 {
         }
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
         final String[] localVarAccepts = {
-                "application/json"
+                FrameworkConstants.ContentTypes.TYPE_APPLICATION_JSON
         };
         final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = {
-                "application/json"
+                FrameworkConstants.ContentTypes.TYPE_APPLICATION_JSON
         };
         final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
         String[] localVarAuthNames = new String[]{};
@@ -265,8 +266,10 @@ public class RecoveryApiV2 {
         if (MapUtils.isNotEmpty(headers)) {
             localVarHeaderParams.putAll(headers);
         }
-        final String localVarAccept = apiClient.selectHeaderAccept(new String[]{"application/json"});
-        final String localVarContentType = apiClient.selectHeaderContentType(new String[]{"application/json"});
+        final String localVarAccept = apiClient.selectHeaderAccept(
+                new String[]{FrameworkConstants.ContentTypes.TYPE_APPLICATION_JSON});
+        final String localVarContentType = apiClient.selectHeaderContentType(
+                new String[]{FrameworkConstants.ContentTypes.TYPE_APPLICATION_JSON});
         return apiClient.invokeAPI(localVarPath, "POST", new ArrayList<>(), resendRequest,
                 localVarHeaderParams, new HashMap<>(), localVarAccept, localVarContentType, new String[]{},
                 new GenericType<ResendResponse>(){});
@@ -289,8 +292,10 @@ public class RecoveryApiV2 {
         if (MapUtils.isNotEmpty(headers)) {
             localVarHeaderParams.putAll(headers);
         }
-        final String localVarAccept = apiClient.selectHeaderAccept(new String[]{"application/json"});
-        final String localVarContentType = apiClient.selectHeaderContentType(new String[]{"application/json"});
+        final String localVarAccept = apiClient.selectHeaderAccept(
+                new String[]{FrameworkConstants.ContentTypes.TYPE_APPLICATION_JSON});
+        final String localVarContentType = apiClient.selectHeaderContentType(
+                new String[]{FrameworkConstants.ContentTypes.TYPE_APPLICATION_JSON});
         return apiClient.invokeAPI(localVarPath, "POST", new ArrayList<>(), confirmRequest,
                 localVarHeaderParams, new HashMap<>(), localVarAccept, localVarContentType, new String[]{},
                 new GenericType<ConfirmResponse>(){});
@@ -313,8 +318,10 @@ public class RecoveryApiV2 {
         if (MapUtils.isNotEmpty(headers)) {
             localVarHeaderParams.putAll(headers);
         }
-        final String localVarAccept = apiClient.selectHeaderAccept(new String[]{"application/json"});
-        final String localVarContentType = apiClient.selectHeaderContentType(new String[]{"application/json"});
+        final String localVarAccept = apiClient.selectHeaderAccept(
+                new String[]{FrameworkConstants.ContentTypes.TYPE_APPLICATION_JSON});
+        final String localVarContentType = apiClient.selectHeaderContentType(
+                new String[]{FrameworkConstants.ContentTypes.TYPE_APPLICATION_JSON});
         return apiClient.invokeAPI(localVarPath, "POST", new ArrayList<>(), resetRequest,
                 localVarHeaderParams, new HashMap<>(), localVarAccept, localVarContentType, new String[]{},
                 new GenericType<ResetResponse>(){});

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/api/RecoveryApiV2.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/api/RecoveryApiV2.java
@@ -29,9 +29,13 @@ import org.wso2.carbon.identity.mgt.endpoint.util.client.ApiException;
 import org.wso2.carbon.identity.mgt.endpoint.util.client.Configuration;
 import org.wso2.carbon.identity.mgt.endpoint.util.client.Pair;
 import org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.AccountRecoveryType;
+import org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.ConfirmRequest;
+import org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.ConfirmResponse;
 import org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.RecoveryInitRequest;
 import org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.RecoveryRequest;
 import org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.RecoveryResponse;
+import org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.ResendRequest;
+import org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.ResendResponse;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -98,6 +102,38 @@ public class RecoveryApiV2 {
 
         String localVarPath = "/password/recover".replaceAll("\\{format\\}", "json");
         return recover(recoveryRequest, tenantDomain, headers, localVarPath);
+    }
+
+    /**
+     * Resend password recovery confirmation details.
+     *
+     * @param resendRequest   Resend request. (required)
+     * @param tenantDomain      Tenant Domain which user belongs. Default "carbon.super" (optional)
+     * @param headers           Any additional headers to be embedded. (optional)
+     * @return Resend response.
+     * @throws ApiException If fails to make API call.
+     */
+    public ResendResponse resendPasswordNotification(ResendRequest resendRequest, String tenantDomain,
+                                                     Map<String, String> headers) throws ApiException {
+
+        String localVarPath = "/password/resend".replaceAll("\\{format\\}", "json");
+        return resend(resendRequest, tenantDomain, headers, localVarPath);
+    }
+
+    /**
+     * Confirm password recovery.
+     *
+     * @param confirmRequest   Password recovery confirm request. (required)
+     * @param tenantDomain      Tenant Domain which user belongs. Default "carbon.super" (optional)
+     * @param headers           Any additional headers to be embedded. (optional)
+     * @return Confirm response.
+     * @throws ApiException If fails to make API call.
+     */
+    public ConfirmResponse confirmPasswordRecovery(ConfirmRequest confirmRequest, String tenantDomain,
+                                                     Map<String, String> headers) throws ApiException {
+
+        String localVarPath = "/password/confirm".replaceAll("\\{format\\}", "json");
+        return confirm(confirmRequest, tenantDomain, headers, localVarPath);
     }
 
     /**
@@ -190,6 +226,76 @@ public class RecoveryApiV2 {
         GenericType<RecoveryResponse> localVarReturnType = new GenericType<RecoveryResponse>() {
         };
         return apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, localVarPostBody,
+                localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames,
+                localVarReturnType);
+    }
+
+    private ResendResponse resend(ResendRequest resendRequest, String tenantDomain, Map<String, String> headers,
+                                  String localVarPath) throws ApiException {
+
+        // Verify if the required parameter 'recoveryRequest' is set.
+        if (resendRequest == null) {
+            throw new ApiException(400, "Missing the required parameter 'resendRequest' when requesting recovery");
+        }
+        if (StringUtils.isBlank(tenantDomain)) {
+            tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        }
+        basePath = IdentityManagementEndpointUtil.getBasePath(tenantDomain,
+                IdentityManagementEndpointConstants.UserInfoRecovery.RECOVERY_API_V2_RELATIVE_PATH);
+        apiClient.setBasePath(basePath);
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        if (MapUtils.isNotEmpty(headers)) {
+            localVarHeaderParams.putAll(headers);
+        }
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+        final String[] localVarAccepts = {
+                "application/json"
+        };
+        final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+        final String[] localVarContentTypes = {
+                "application/json"
+        };
+        final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+        String[] localVarAuthNames = new String[]{};
+        GenericType<ResendResponse> localVarReturnType = new GenericType<ResendResponse>() {
+        };
+        return apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, resendRequest,
+                localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames,
+                localVarReturnType);
+    }
+
+    private ConfirmResponse confirm(ConfirmRequest confirmRequest, String tenantDomain, Map<String, String> headers,
+                                   String localVarPath) throws ApiException {
+
+        // Verify if the required parameter 'recoveryRequest' is set.
+        if (confirmRequest == null) {
+            throw new ApiException(400, "Missing the required parameter 'confirmRequest' when requesting recovery");
+        }
+        if (StringUtils.isBlank(tenantDomain)) {
+            tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        }
+        basePath = IdentityManagementEndpointUtil.getBasePath(tenantDomain,
+                IdentityManagementEndpointConstants.UserInfoRecovery.RECOVERY_API_V2_RELATIVE_PATH);
+        apiClient.setBasePath(basePath);
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        if (MapUtils.isNotEmpty(headers)) {
+            localVarHeaderParams.putAll(headers);
+        }
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+        final String[] localVarAccepts = {
+                "application/json"
+        };
+        final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+        final String[] localVarContentTypes = {
+                "application/json"
+        };
+        final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+        String[] localVarAuthNames = new String[]{};
+        GenericType<ConfirmResponse> localVarReturnType = new GenericType<ConfirmResponse>() {
+        };
+        return apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, confirmRequest,
                 localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames,
                 localVarReturnType);
     }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/api/RecoveryApiV2.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/api/RecoveryApiV2.java
@@ -86,7 +86,7 @@ public class RecoveryApiV2 {
                                                               String tenantDomain, Map<String, String> headers)
             throws ApiException {
 
-        String localVarPath = "/password/init".replaceAll("\\{format\\}", "json");
+        String localVarPath = "/password/init";
         return initiateRecovery(recoveryInitRequest, tenantDomain, headers, localVarPath);
     }
 
@@ -102,7 +102,7 @@ public class RecoveryApiV2 {
     public RecoveryResponse recoverPassword(RecoveryRequest recoveryRequest, String tenantDomain,
                                             Map<String, String> headers) throws ApiException {
 
-        String localVarPath = "/password/recover".replaceAll("\\{format\\}", "json");
+        String localVarPath = "/password/recover";
         return recover(recoveryRequest, tenantDomain, headers, localVarPath);
     }
 
@@ -110,15 +110,15 @@ public class RecoveryApiV2 {
      * Resend password recovery confirmation details.
      *
      * @param resendRequest   Resend request. (required)
-     * @param tenantDomain      Tenant Domain which user belongs. Default "carbon.super" (optional)
-     * @param headers           Any additional headers to be embedded. (optional)
+     * @param tenantDomain    Tenant Domain which user belongs. Default "carbon.super". (optional)
+     * @param headers         Any additional headers to be embedded. (optional)
      * @return Resend response.
      * @throws ApiException If fails to make API call.
      */
     public ResendResponse resendPasswordNotification(ResendRequest resendRequest, String tenantDomain,
                                                      Map<String, String> headers) throws ApiException {
 
-        String localVarPath = "/password/resend".replaceAll("\\{format\\}", "json");
+        String localVarPath = "/password/resend";
         return resend(resendRequest, tenantDomain, headers, localVarPath);
     }
 
@@ -126,15 +126,15 @@ public class RecoveryApiV2 {
      * Confirm password recovery.
      *
      * @param confirmRequest   Password recovery confirm request. (required)
-     * @param tenantDomain      Tenant Domain which user belongs. Default "carbon.super" (optional)
-     * @param headers           Any additional headers to be embedded. (optional)
+     * @param tenantDomain     Tenant Domain which user belongs. Default "carbon.super". (optional)
+     * @param headers          Any additional headers to be embedded. (optional)
      * @return Confirm response.
      * @throws ApiException If fails to make API call.
      */
     public ConfirmResponse confirmPasswordRecovery(ConfirmRequest confirmRequest, String tenantDomain,
                                                    Map<String, String> headers) throws ApiException {
 
-        String localVarPath = "/password/confirm".replaceAll("\\{format\\}", "json");
+        String localVarPath = "/password/confirm";
         return confirm(confirmRequest, tenantDomain, headers, localVarPath);
     }
 
@@ -142,15 +142,15 @@ public class RecoveryApiV2 {
      * Reset user password.
      *
      * @param resetRequest   Password reset request. (required)
-     * @param tenantDomain      Tenant Domain which user belongs. Default "carbon.super" (optional)
-     * @param headers           Any additional headers to be embedded. (optional)
+     * @param tenantDomain   Tenant Domain which user belongs. Default "carbon.super". (optional)
+     * @param headers        Any additional headers to be embedded. (optional)
      * @return reset response.
      * @throws ApiException If fails to make API call.
      */
     public ResetResponse resetUserPassword(ResetRequest resetRequest, String tenantDomain,
                                            Map<String, String> headers) throws ApiException {
 
-        String localVarPath = "/password/reset".replaceAll("\\{format\\}", "json");
+        String localVarPath = "/password/reset";
         return reset(resetRequest, tenantDomain, headers, localVarPath);
     }
 
@@ -261,12 +261,12 @@ public class RecoveryApiV2 {
         basePath = IdentityManagementEndpointUtil.getBasePath(tenantDomain,
                 IdentityManagementEndpointConstants.UserInfoRecovery.RECOVERY_API_V2_RELATIVE_PATH);
         apiClient.setBasePath(basePath);
-        List<Pair> localVarQueryParams = new ArrayList<Pair>();
-        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        List<Pair> localVarQueryParams = new ArrayList<>();
+        Map<String, String> localVarHeaderParams = new HashMap<>();
         if (MapUtils.isNotEmpty(headers)) {
             localVarHeaderParams.putAll(headers);
         }
-        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+        Map<String, Object> localVarFormParams = new HashMap<>();
         final String[] localVarAccepts = {
                 "application/json"
         };
@@ -296,12 +296,12 @@ public class RecoveryApiV2 {
         basePath = IdentityManagementEndpointUtil.getBasePath(tenantDomain,
                 IdentityManagementEndpointConstants.UserInfoRecovery.RECOVERY_API_V2_RELATIVE_PATH);
         apiClient.setBasePath(basePath);
-        List<Pair> localVarQueryParams = new ArrayList<Pair>();
-        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        List<Pair> localVarQueryParams = new ArrayList<>();
+        Map<String, String> localVarHeaderParams = new HashMap<>();
         if (MapUtils.isNotEmpty(headers)) {
             localVarHeaderParams.putAll(headers);
         }
-        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+        Map<String, Object> localVarFormParams = new HashMap<>();
         final String[] localVarAccepts = {
                 "application/json"
         };
@@ -331,12 +331,12 @@ public class RecoveryApiV2 {
         basePath = IdentityManagementEndpointUtil.getBasePath(tenantDomain,
                 IdentityManagementEndpointConstants.UserInfoRecovery.RECOVERY_API_V2_RELATIVE_PATH);
         apiClient.setBasePath(basePath);
-        List<Pair> localVarQueryParams = new ArrayList<Pair>();
-        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        List<Pair> localVarQueryParams = new ArrayList<>();
+        Map<String, String> localVarHeaderParams = new HashMap<>();
         if (MapUtils.isNotEmpty(headers)) {
             localVarHeaderParams.putAll(headers);
         }
-        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+        Map<String, Object> localVarFormParams = new HashMap<>();
         final String[] localVarAccepts = {
                 "application/json"
         };

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/api/RecoveryApiV2.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/api/RecoveryApiV2.java
@@ -261,26 +261,15 @@ public class RecoveryApiV2 {
         basePath = IdentityManagementEndpointUtil.getBasePath(tenantDomain,
                 IdentityManagementEndpointConstants.UserInfoRecovery.RECOVERY_API_V2_RELATIVE_PATH);
         apiClient.setBasePath(basePath);
-        List<Pair> localVarQueryParams = new ArrayList<>();
         Map<String, String> localVarHeaderParams = new HashMap<>();
         if (MapUtils.isNotEmpty(headers)) {
             localVarHeaderParams.putAll(headers);
         }
-        Map<String, Object> localVarFormParams = new HashMap<>();
-        final String[] localVarAccepts = {
-                "application/json"
-        };
-        final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-        final String[] localVarContentTypes = {
-                "application/json"
-        };
-        final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-        String[] localVarAuthNames = new String[]{};
-        GenericType<ResendResponse> localVarReturnType = new GenericType<ResendResponse>() {
-        };
-        return apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, resendRequest,
-                localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames,
-                localVarReturnType);
+        final String localVarAccept = apiClient.selectHeaderAccept(new String[]{"application/json"});
+        final String localVarContentType = apiClient.selectHeaderContentType(new String[]{"application/json"});
+        return apiClient.invokeAPI(localVarPath, "POST", new ArrayList<>(), resendRequest,
+                localVarHeaderParams, new HashMap<>(), localVarAccept, localVarContentType, new String[]{},
+                new GenericType<ResendResponse>(){});
     }
 
     private ConfirmResponse confirm(ConfirmRequest confirmRequest, String tenantDomain, Map<String, String> headers,
@@ -296,26 +285,15 @@ public class RecoveryApiV2 {
         basePath = IdentityManagementEndpointUtil.getBasePath(tenantDomain,
                 IdentityManagementEndpointConstants.UserInfoRecovery.RECOVERY_API_V2_RELATIVE_PATH);
         apiClient.setBasePath(basePath);
-        List<Pair> localVarQueryParams = new ArrayList<>();
         Map<String, String> localVarHeaderParams = new HashMap<>();
         if (MapUtils.isNotEmpty(headers)) {
             localVarHeaderParams.putAll(headers);
         }
-        Map<String, Object> localVarFormParams = new HashMap<>();
-        final String[] localVarAccepts = {
-                "application/json"
-        };
-        final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-        final String[] localVarContentTypes = {
-                "application/json"
-        };
-        final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-        String[] localVarAuthNames = new String[]{};
-        GenericType<ConfirmResponse> localVarReturnType = new GenericType<ConfirmResponse>() {
-        };
-        return apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, confirmRequest,
-                localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames,
-                localVarReturnType);
+        final String localVarAccept = apiClient.selectHeaderAccept(new String[]{"application/json"});
+        final String localVarContentType = apiClient.selectHeaderContentType(new String[]{"application/json"});
+        return apiClient.invokeAPI(localVarPath, "POST", new ArrayList<>(), confirmRequest,
+                localVarHeaderParams, new HashMap<>(), localVarAccept, localVarContentType, new String[]{},
+                new GenericType<ConfirmResponse>(){});
     }
 
     private ResetResponse reset(ResetRequest resetRequest, String tenantDomain, Map<String, String> headers,
@@ -331,25 +309,14 @@ public class RecoveryApiV2 {
         basePath = IdentityManagementEndpointUtil.getBasePath(tenantDomain,
                 IdentityManagementEndpointConstants.UserInfoRecovery.RECOVERY_API_V2_RELATIVE_PATH);
         apiClient.setBasePath(basePath);
-        List<Pair> localVarQueryParams = new ArrayList<>();
         Map<String, String> localVarHeaderParams = new HashMap<>();
         if (MapUtils.isNotEmpty(headers)) {
             localVarHeaderParams.putAll(headers);
         }
-        Map<String, Object> localVarFormParams = new HashMap<>();
-        final String[] localVarAccepts = {
-                "application/json"
-        };
-        final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-        final String[] localVarContentTypes = {
-                "application/json"
-        };
-        final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-        String[] localVarAuthNames = new String[]{};
-        GenericType<ResetResponse> localVarReturnType = new GenericType<ResetResponse>() {
-        };
-        return apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, resetRequest,
-                localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames,
-                localVarReturnType);
+        final String localVarAccept = apiClient.selectHeaderAccept(new String[]{"application/json"});
+        final String localVarContentType = apiClient.selectHeaderContentType(new String[]{"application/json"});
+        return apiClient.invokeAPI(localVarPath, "POST", new ArrayList<>(), resetRequest,
+                localVarHeaderParams, new HashMap<>(), localVarAccept, localVarContentType, new String[]{},
+                new GenericType<ResetResponse>(){});
     }
 }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/api/RecoveryApiV2.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/api/RecoveryApiV2.java
@@ -50,6 +50,11 @@ import java.util.Map;
  */
 public class RecoveryApiV2 {
 
+    private static final String PATH_PASSWORD_RECOVERY_INIT = "/password/init";
+    private static final String PATH_PASSWORD_RECOVERY_RECOVER = "/password/recover";
+    private static final String PATH_PASSWORD_RECOVERY_RESEND = "/password/resend";
+    private static final String PATH_PASSWORD_RECOVERY_CONFIRM = "/password/confirm";
+    private static final String PATH_PASSWORD_RECOVERY_RESET = "/password/reset";
     String basePath = IdentityManagementEndpointUtil.buildEndpointUrl(IdentityManagementEndpointConstants
             .UserInfoRecovery.RECOVERY_API_V2_RELATIVE_PATH);
     private ApiClient apiClient;
@@ -87,8 +92,7 @@ public class RecoveryApiV2 {
                                                               String tenantDomain, Map<String, String> headers)
             throws ApiException {
 
-        final String localVarPath = "/password/init";
-        return initiateRecovery(recoveryInitRequest, tenantDomain, headers, localVarPath);
+        return initiateRecovery(recoveryInitRequest, tenantDomain, headers, PATH_PASSWORD_RECOVERY_INIT);
     }
 
     /**
@@ -103,8 +107,7 @@ public class RecoveryApiV2 {
     public RecoveryResponse recoverPassword(RecoveryRequest recoveryRequest, String tenantDomain,
                                             Map<String, String> headers) throws ApiException {
 
-        final String localVarPath = "/password/recover";
-        return recover(recoveryRequest, tenantDomain, headers, localVarPath);
+        return recover(recoveryRequest, tenantDomain, headers, PATH_PASSWORD_RECOVERY_RECOVER);
     }
 
     /**
@@ -118,9 +121,8 @@ public class RecoveryApiV2 {
      */
     public ResendResponse resendPasswordNotification(ResendRequest resendRequest, String tenantDomain,
                                                      Map<String, String> headers) throws ApiException {
-
-        final String localVarPath = "/password/resend";
-        return resend(resendRequest, tenantDomain, headers, localVarPath);
+        
+        return resend(resendRequest, tenantDomain, headers, PATH_PASSWORD_RECOVERY_RESEND);
     }
 
     /**
@@ -134,9 +136,8 @@ public class RecoveryApiV2 {
      */
     public ConfirmResponse confirmPasswordRecovery(ConfirmRequest confirmRequest, String tenantDomain,
                                                    Map<String, String> headers) throws ApiException {
-
-        final String localVarPath = "/password/confirm";
-        return confirm(confirmRequest, tenantDomain, headers, localVarPath);
+        
+        return confirm(confirmRequest, tenantDomain, headers, PATH_PASSWORD_RECOVERY_CONFIRM);
     }
 
     /**
@@ -151,8 +152,7 @@ public class RecoveryApiV2 {
     public ResetResponse resetUserPassword(ResetRequest resetRequest, String tenantDomain,
                                            Map<String, String> headers) throws ApiException {
 
-        final String localVarPath = "/password/reset";
-        return reset(resetRequest, tenantDomain, headers, localVarPath);
+        return reset(resetRequest, tenantDomain, headers, PATH_PASSWORD_RECOVERY_RESET);
     }
 
     /**

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/api/RecoveryApiV2.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/api/RecoveryApiV2.java
@@ -36,6 +36,8 @@ import org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.Recov
 import org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.RecoveryResponse;
 import org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.ResendRequest;
 import org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.ResendResponse;
+import org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.ResetRequest;
+import org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.ResetResponse;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -130,10 +132,26 @@ public class RecoveryApiV2 {
      * @throws ApiException If fails to make API call.
      */
     public ConfirmResponse confirmPasswordRecovery(ConfirmRequest confirmRequest, String tenantDomain,
-                                                     Map<String, String> headers) throws ApiException {
+                                                   Map<String, String> headers) throws ApiException {
 
         String localVarPath = "/password/confirm".replaceAll("\\{format\\}", "json");
         return confirm(confirmRequest, tenantDomain, headers, localVarPath);
+    }
+
+    /**
+     * Reset user password.
+     *
+     * @param resetRequest   Password reset request. (required)
+     * @param tenantDomain      Tenant Domain which user belongs. Default "carbon.super" (optional)
+     * @param headers           Any additional headers to be embedded. (optional)
+     * @return reset response.
+     * @throws ApiException If fails to make API call.
+     */
+    public ResetResponse resetUserPassword(ResetRequest resetRequest, String tenantDomain,
+                                           Map<String, String> headers) throws ApiException {
+
+        String localVarPath = "/password/reset".replaceAll("\\{format\\}", "json");
+        return reset(resetRequest, tenantDomain, headers, localVarPath);
     }
 
     /**
@@ -266,7 +284,7 @@ public class RecoveryApiV2 {
     }
 
     private ConfirmResponse confirm(ConfirmRequest confirmRequest, String tenantDomain, Map<String, String> headers,
-                                   String localVarPath) throws ApiException {
+                                    String localVarPath) throws ApiException {
 
         // Verify if the required parameter 'recoveryRequest' is set.
         if (confirmRequest == null) {
@@ -296,6 +314,41 @@ public class RecoveryApiV2 {
         GenericType<ConfirmResponse> localVarReturnType = new GenericType<ConfirmResponse>() {
         };
         return apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, confirmRequest,
+                localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames,
+                localVarReturnType);
+    }
+
+    private ResetResponse reset(ResetRequest resetRequest, String tenantDomain, Map<String, String> headers,
+                                    String localVarPath) throws ApiException {
+
+        // Verify if the required parameter 'recoveryRequest' is set.
+        if (resetRequest == null) {
+            throw new ApiException(400, "Missing the required parameter 'resetRequest' when requesting recovery");
+        }
+        if (StringUtils.isBlank(tenantDomain)) {
+            tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        }
+        basePath = IdentityManagementEndpointUtil.getBasePath(tenantDomain,
+                IdentityManagementEndpointConstants.UserInfoRecovery.RECOVERY_API_V2_RELATIVE_PATH);
+        apiClient.setBasePath(basePath);
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        if (MapUtils.isNotEmpty(headers)) {
+            localVarHeaderParams.putAll(headers);
+        }
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+        final String[] localVarAccepts = {
+                "application/json"
+        };
+        final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+        final String[] localVarContentTypes = {
+                "application/json"
+        };
+        final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+        String[] localVarAuthNames = new String[]{};
+        GenericType<ResetResponse> localVarReturnType = new GenericType<ResetResponse>() {
+        };
+        return apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, resetRequest,
                 localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames,
                 localVarReturnType);
     }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ConfirmRequest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ConfirmRequest.java
@@ -55,7 +55,7 @@ public class ConfirmRequest {
     }
 
     /**
-     * otp sent to the user.
+     * OTP sent to the user.
      **/
     public ConfirmRequest otp(String otp) {
 
@@ -94,6 +94,11 @@ public class ConfirmRequest {
         this.properties = properties;
     }
 
+    /**
+     * Adds property to the request properties.
+     * @param propertiesItem propertiesItem.
+     * @return ConfirmRequest.
+     */
     public ConfirmRequest addPropertiesItem(Property propertiesItem) {
 
         if (this.properties == null) {

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ConfirmRequest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ConfirmRequest.java
@@ -96,6 +96,7 @@ public class ConfirmRequest {
 
     /**
      * Adds property to the request properties.
+     *
      * @param propertiesItem propertiesItem.
      * @return ConfirmRequest.
      */

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ConfirmRequest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ConfirmRequest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wso2.carbon.identity.mgt.endpoint.util.client.model.Property;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Request to confirm recovery attempt.
+ */
+public class ConfirmRequest {
+
+    private String confirmationCode;
+    private String otp;
+    private List<Property> properties = null;
+
+    /**
+     * Confirmation code for the request.
+     **/
+    public ConfirmRequest confirmationCode(String confirmationCode) {
+
+        this.confirmationCode = confirmationCode;
+        return this;
+    }
+
+    @JsonProperty("confirmationCode")
+    public String getConfirmationCode() {
+
+        return confirmationCode;
+    }
+
+    public void setConfirmationCode(String confirmationCode) {
+
+        this.confirmationCode = confirmationCode;
+    }
+
+    /**
+     * otp sent to the user.
+     **/
+    public ConfirmRequest otp(String otp) {
+
+        this.otp = otp;
+        return this;
+    }
+
+    @JsonProperty("otp")
+    public String getOtp() {
+
+        return otp;
+    }
+
+    public void setOtp(String otp) {
+
+        this.otp = otp;
+    }
+
+    /**
+     * (OPTIONAL) Additional META properties.
+     **/
+    public ConfirmRequest properties(List<Property> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+
+    @JsonProperty("properties")
+    public List<Property> getProperties() {
+
+        return properties;
+    }
+
+    public void setProperties(List<Property> properties) {
+
+        this.properties = properties;
+    }
+
+    public ConfirmRequest addPropertiesItem(Property propertiesItem) {
+
+        if (this.properties == null) {
+            this.properties = new ArrayList<>();
+        }
+        this.properties.add(propertiesItem);
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConfirmRequest recoveryRequest = (ConfirmRequest) o;
+        return Objects.equals(this.confirmationCode, recoveryRequest.confirmationCode) &&
+                Objects.equals(this.otp, recoveryRequest.otp) &&
+                Objects.equals(this.properties, recoveryRequest.properties);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(confirmationCode, otp, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        return "class ConfirmRequest {" +
+                "    confirmationCode: " + confirmationCode + "\n" +
+                "    otp: " + otp + "\n" +
+                "    properties: " + properties + "\n" +
+                "}";
+    }
+}

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ConfirmResponse.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ConfirmResponse.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Response to confirm recovery attempt.
+ */
+public class ConfirmResponse {
+
+    private String resetCode;
+    private List<APICall> links = null;
+
+
+    /**
+     * ResetCode for recovery.
+     **/
+    public ConfirmResponse resetCode(String resetCode) {
+
+        this.resetCode = resetCode;
+        return this;
+    }
+
+    @JsonProperty("resetCode")
+    public String getResetCode() {
+
+        return resetCode;
+    }
+    public void setResetCode(String resetCode) {
+
+        this.resetCode = resetCode;
+    }
+
+    /**
+     * Contains available api calls.
+     **/
+    public ConfirmResponse links(List<APICall> links) {
+
+        this.links = links;
+        return this;
+    }
+
+    @JsonProperty("links")
+    public List<APICall> getLinks() {
+
+        return links;
+    }
+    public void setLinks(List<APICall> links) {
+
+        this.links = links;
+    }
+
+    public ConfirmResponse addLinksItem(APICall linksItem) {
+        if (this.links == null) {
+            this.links = new ArrayList<>();
+        }
+        this.links.add(linksItem);
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConfirmResponse passwordRecoveryInternalNotifyResponse = (ConfirmResponse) o;
+        return Objects.equals(this.resetCode, passwordRecoveryInternalNotifyResponse.resetCode) &&
+                Objects.equals(this.links, passwordRecoveryInternalNotifyResponse.links);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(resetCode, links);
+    }
+
+    @Override
+    public String toString() {
+
+        String sb = "class RecoveryResponse {\n" +
+                "    resetCode: " + resetCode + "\n" +
+                "    links: " + links + "\n" +
+                "}";
+        return sb;
+    }
+}

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ConfirmResponse.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ConfirmResponse.java
@@ -73,6 +73,7 @@ public class ConfirmResponse {
 
     /**
      * Add linksItem.
+     *
      * @param linksItem linksItem.
      * @return ResendResponse.
      */

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ConfirmResponse.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ConfirmResponse.java
@@ -53,7 +53,7 @@ public class ConfirmResponse {
     }
 
     /**
-     * Contains available api calls.
+     * Contains available API links for next recovery steps.
      **/
     public ConfirmResponse links(List<APICall> links) {
 
@@ -71,6 +71,11 @@ public class ConfirmResponse {
         this.links = links;
     }
 
+    /**
+     * Add linksItem.
+     * @param linksItem linksItem.
+     * @return ResendResponse.
+     */
     public ConfirmResponse addLinksItem(APICall linksItem) {
         if (this.links == null) {
             this.links = new ArrayList<>();
@@ -102,10 +107,9 @@ public class ConfirmResponse {
     @Override
     public String toString() {
 
-        String sb = "class RecoveryResponse {\n" +
+        return "class RecoveryResponse {\n" +
                 "    resetCode: " + resetCode + "\n" +
                 "    links: " + links + "\n" +
                 "}";
-        return sb;
     }
 }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResendRequest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResendRequest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2;
+
+import org.wso2.carbon.identity.mgt.endpoint.util.client.model.Property;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Request to resend the recovery code.
+ **/
+public class ResendRequest {
+
+    private String resendCode;
+    private List<Property> properties = null;
+
+    /**
+     * Resend code for the user.
+     **/
+    public ResendRequest resendCode(String resendCode) {
+
+        this.resendCode = resendCode;
+        return this;
+    }
+
+    /**
+     * Get resendCode
+     *
+     * @return resendCode
+     **/
+    @JsonProperty("resendCode")
+    public String getResendCode() {
+
+        return resendCode;
+    }
+
+    /**
+     * Set resendCode
+     *
+     * @param resendCode
+     **/
+    public void setResendCode(String resendCode) {
+
+        this.resendCode = resendCode;
+    }
+
+    /**
+     * (OPTIONAL) Additional META properties.
+     **/
+    public ResendRequest properties(List<Property> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+
+    /**
+     * Get meta properties
+     *
+     * @return List<Property>
+     **/
+    @JsonProperty("properties")
+    public List<Property> getProperties() {
+
+        return properties;
+    }
+
+    /**
+     * Set meta properties
+     *
+     * @param properties
+     **/
+    public void setProperties(List<Property> properties) {
+
+        this.properties = properties;
+    }
+
+    /**
+     * Add meta properties
+     *
+     * @param propertiesItem
+     * @return ResendRequest
+     **/
+    public ResendRequest addPropertiesItem(Property propertiesItem) {
+
+        if (this.properties == null) {
+            this.properties = new ArrayList<>();
+        }
+        this.properties.add(propertiesItem);
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResendRequest resendRequest = (ResendRequest) o;
+        return Objects.equals(this.resendCode, resendRequest.resendCode) &&
+                Objects.equals(this.properties, resendRequest.properties);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(resendCode, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ResendRequest {\n");
+
+        sb.append("    resendCode: ").append(toIndentedString(resendCode)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResendRequest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResendRequest.java
@@ -43,22 +43,12 @@ public class ResendRequest {
         return this;
     }
 
-    /**
-     * Get resendCode
-     *
-     * @return resendCode
-     **/
     @JsonProperty("resendCode")
     public String getResendCode() {
 
         return resendCode;
     }
 
-    /**
-     * Set resendCode
-     *
-     * @param resendCode
-     **/
     public void setResendCode(String resendCode) {
 
         this.resendCode = resendCode;
@@ -73,32 +63,22 @@ public class ResendRequest {
         return this;
     }
 
-    /**
-     * Get meta properties
-     *
-     * @return List<Property>
-     **/
     @JsonProperty("properties")
     public List<Property> getProperties() {
 
         return properties;
     }
 
-    /**
-     * Set meta properties
-     *
-     * @param properties
-     **/
     public void setProperties(List<Property> properties) {
 
         this.properties = properties;
     }
 
     /**
-     * Add meta properties
+     * Add meta properties.
      *
-     * @param propertiesItem
-     * @return ResendRequest
+     * @param propertiesItem propertiesItem.
+     * @return ResendRequest.
      **/
     public ResendRequest addPropertiesItem(Property propertiesItem) {
 
@@ -132,13 +112,10 @@ public class ResendRequest {
     @Override
     public String toString() {
 
-        StringBuilder sb = new StringBuilder();
-        sb.append("class ResendRequest {\n");
-
-        sb.append("    resendCode: ").append(toIndentedString(resendCode)).append("\n");
-        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
-        sb.append("}");
-        return sb.toString();
+        return "class ResendRequest {\n" +
+                "    resendCode: " + toIndentedString(resendCode) + "\n" +
+                "    properties: " + toIndentedString(properties) + "\n" +
+                "}";
     }
 
     /**

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResendResponse.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResendResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,9 +25,9 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Response to username/password recovery request.
- */
-public class RecoveryResponse {
+ * Response to resend recovery code request.
+ **/
+public class ResendResponse {
 
 
     private String code;
@@ -41,17 +41,22 @@ public class RecoveryResponse {
     /**
      * Success status code.
      **/
-    public RecoveryResponse code(String code) {
+    public ResendResponse code(String code) {
 
         this.code = code;
         return this;
     }
+
 
     @JsonProperty("code")
     public String getCode() {
 
         return code;
     }
+
+    /**
+     * Set code
+     **/
     public void setCode(String code) {
 
         this.code = code;
@@ -59,100 +64,160 @@ public class RecoveryResponse {
 
     /**
      * Success status message.
-     **/
-    public RecoveryResponse message(String message) {
+     * @param message message
+     * @return ResendResponse
+     */
+    public ResendResponse message(String message) {
 
         this.message = message;
         return this;
     }
 
+    /**
+     * Get message
+     * @return message
+     */
     @JsonProperty("message")
     public String getMessage() {
 
         return message;
     }
+
+    /**
+     * Set message
+     * @param message message
+     */
     public void setMessage(String message) {
 
         this.message = message;
     }
 
     /**
-     * Recovery flow confirmation code.
-     **/
-    public RecoveryResponse flowConfirmationCode(String flowConfirmationCode) {
+     * Confirmation code of the recovery flow.
+     * @param flowConfirmationCode flowConfirmationCode
+     * @return ResendResponse
+     */
+    public ResendResponse flowConfirmationCode(String flowConfirmationCode) {
 
         this.flowConfirmationCode = flowConfirmationCode;
         return this;
     }
 
+    /**
+     * Get flowConfirmationCode
+     * @return flowConfirmationCode
+     */
     @JsonProperty("flowConfirmationCode")
     public String getFlowConfirmationCode() {
 
         return flowConfirmationCode;
     }
+
+    /**
+     * Set flowConfirmationCode
+     * @param flowConfirmationCode flowConfirmationCode
+     */
     public void setFlowConfirmationCode(String flowConfirmationCode) {
 
-        this.flowConfirmationCode = flowConfirmationCode;
+        this.message = flowConfirmationCode;
     }
 
     /**
-     * Channel that is used to send recovery information.
-     **/
-    public RecoveryResponse notificationChannel(String notificationChannel) {
+     * Set the notification channel that user prefers to get recovery notifications.
+     * @param notificationChannel notificationChannel
+     * @return ResendResponse
+     */
+    public ResendResponse notificationChannel(String notificationChannel) {
 
         this.notificationChannel = notificationChannel;
         return this;
     }
 
+    /**
+     * Get notificationChannel
+     * @return notificationChannel
+     */
     @JsonProperty("notificationChannel")
     public String getNotificationChannel() {
 
         return notificationChannel;
     }
+
+    /**
+     * Set notificationChannel
+     * @param notificationChannel notificationChannel
+     */
     public void setNotificationChannel(String notificationChannel) {
 
         this.notificationChannel = notificationChannel;
     }
 
     /**
-     * Code to resend the confirmation code to the user via user selected channel.
-     **/
-    public RecoveryResponse resendCode(String resendCode) {
+     * Code to resend the notification to the user via user selected channel.
+     * @param resendCode resendCode
+     * @return ResendResponse
+     */
+    public ResendResponse resendCode(String resendCode) {
 
         this.resendCode = resendCode;
         return this;
     }
 
+    /**
+     * Get resendCode
+     * @return resendCode
+     */
     @JsonProperty("resendCode")
     public String getResendCode() {
 
         return resendCode;
     }
+
+    /**
+     * Set resendCode
+     * @param resendCode resendCode
+     */
     public void setResendCode(String resendCode) {
 
         this.resendCode = resendCode;
     }
 
     /**
-     * Contains available api calls.
-     **/
-    public RecoveryResponse links(List<APICall> links) {
+     * Links for next requests.
+     * @param links links
+     * @return ResendResponse
+     */
+    public ResendResponse links(List<APICall> links) {
 
         this.links = links;
         return this;
     }
 
+    /**
+     * Get links
+     * @return links
+     */
     @JsonProperty("links")
     public List<APICall> getLinks() {
 
         return links;
     }
+
+    /**
+     * Set links
+     * @param links links
+     */
     public void setLinks(List<APICall> links) {
 
         this.links = links;
     }
 
-    public RecoveryResponse addLinksItem(APICall linksItem) {
+    /**
+     * Add linksItem
+     * @param linksItem linksItem
+     * @return ResendResponse
+     */
+    public ResendResponse addLinksItem(APICall linksItem) {
         if (this.links == null) {
             this.links = new ArrayList<>();
         }
@@ -169,10 +234,9 @@ public class RecoveryResponse {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        RecoveryResponse passwordRecoveryInternalNotifyResponse = (RecoveryResponse) o;
+        ResendResponse passwordRecoveryInternalNotifyResponse = (ResendResponse) o;
         return Objects.equals(this.code, passwordRecoveryInternalNotifyResponse.code) &&
                 Objects.equals(this.message, passwordRecoveryInternalNotifyResponse.message) &&
-                Objects.equals(this.flowConfirmationCode, passwordRecoveryInternalNotifyResponse.flowConfirmationCode) &&
                 Objects.equals(this.notificationChannel, passwordRecoveryInternalNotifyResponse.notificationChannel) &&
                 Objects.equals(this.resendCode, passwordRecoveryInternalNotifyResponse.resendCode) &&
                 Objects.equals(this.links, passwordRecoveryInternalNotifyResponse.links);
@@ -181,23 +245,19 @@ public class RecoveryResponse {
     @Override
     public int hashCode() {
 
-        return Objects.hash(code, message, flowConfirmationCode, notificationChannel, resendCode, links);
+        return Objects.hash(code, message, notificationChannel, resendCode, links);
     }
 
     @Override
     public String toString() {
 
-        StringBuilder sb = new StringBuilder();
-        sb.append("class RecoveryResponse {\n");
-
-        sb.append("    code: ").append(toIndentedString(code)).append("\n");
-        sb.append("    message: ").append(toIndentedString(message)).append("\n");
-        sb.append("    flowConfirmationCode: ").append(toIndentedString(flowConfirmationCode)).append("\n");
-        sb.append("    notificationChannel: ").append(toIndentedString(notificationChannel)).append("\n");
-        sb.append("    resendCode: ").append(toIndentedString(resendCode)).append("\n");
-        sb.append("    links: ").append(toIndentedString(links)).append("\n");
-        sb.append("}");
-        return sb.toString();
+        return "class ResendResponse {\n" +
+                "    code: " + toIndentedString(code) + "\n" +
+                "    message: " + toIndentedString(message) + "\n" +
+                "    notificationChannel: " + toIndentedString(notificationChannel) + "\n" +
+                "    resendCode: " + toIndentedString(resendCode) + "\n" +
+                "    links: " + toIndentedString(links) + "\n" +
+                "}";
     }
 
     /**
@@ -209,6 +269,8 @@ public class RecoveryResponse {
         if (o == null) {
             return "null";
         }
-        return o.toString().replace("\n", "\n");
+        return o.toString().replace("\n", "\n    ");
     }
+
+
 }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResendResponse.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResendResponse.java
@@ -61,6 +61,7 @@ public class ResendResponse {
 
     /**
      * Success status message.
+     *
      * @param message message
      * @return ResendResponse
      */
@@ -83,6 +84,7 @@ public class ResendResponse {
 
     /**
      * Confirmation code of the recovery flow.
+     *
      * @param flowConfirmationCode flowConfirmationCode
      * @return ResendResponse
      */
@@ -105,6 +107,7 @@ public class ResendResponse {
 
     /**
      * Set the notification channel that user prefers to get recovery notifications.
+     *
      * @param notificationChannel notificationChannel
      * @return ResendResponse
      */
@@ -127,6 +130,7 @@ public class ResendResponse {
 
     /**
      * Code to resend the notification to the user via user selected channel.
+     *
      * @param resendCode resendCode
      * @return ResendResponse
      */
@@ -149,6 +153,7 @@ public class ResendResponse {
 
     /**
      * Links for next requests.
+     *
      * @param links links
      * @return ResendResponse
      */
@@ -171,6 +176,7 @@ public class ResendResponse {
 
     /**
      * Add linksItem.
+     *
      * @param linksItem linksItem.
      * @return ResendResponse.
      */

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResendResponse.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResendResponse.java
@@ -119,7 +119,7 @@ public class ResendResponse {
      */
     public void setFlowConfirmationCode(String flowConfirmationCode) {
 
-        this.message = flowConfirmationCode;
+        this.flowConfirmationCode = flowConfirmationCode;
     }
 
     /**

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResendResponse.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResendResponse.java
@@ -54,9 +54,6 @@ public class ResendResponse {
         return code;
     }
 
-    /**
-     * Set code
-     **/
     public void setCode(String code) {
 
         this.code = code;
@@ -73,20 +70,12 @@ public class ResendResponse {
         return this;
     }
 
-    /**
-     * Get message
-     * @return message
-     */
     @JsonProperty("message")
     public String getMessage() {
 
         return message;
     }
 
-    /**
-     * Set message
-     * @param message message
-     */
     public void setMessage(String message) {
 
         this.message = message;
@@ -103,20 +92,12 @@ public class ResendResponse {
         return this;
     }
 
-    /**
-     * Get flowConfirmationCode
-     * @return flowConfirmationCode
-     */
     @JsonProperty("flowConfirmationCode")
     public String getFlowConfirmationCode() {
 
         return flowConfirmationCode;
     }
 
-    /**
-     * Set flowConfirmationCode
-     * @param flowConfirmationCode flowConfirmationCode
-     */
     public void setFlowConfirmationCode(String flowConfirmationCode) {
 
         this.flowConfirmationCode = flowConfirmationCode;
@@ -133,20 +114,12 @@ public class ResendResponse {
         return this;
     }
 
-    /**
-     * Get notificationChannel
-     * @return notificationChannel
-     */
     @JsonProperty("notificationChannel")
     public String getNotificationChannel() {
 
         return notificationChannel;
     }
 
-    /**
-     * Set notificationChannel
-     * @param notificationChannel notificationChannel
-     */
     public void setNotificationChannel(String notificationChannel) {
 
         this.notificationChannel = notificationChannel;
@@ -163,20 +136,12 @@ public class ResendResponse {
         return this;
     }
 
-    /**
-     * Get resendCode
-     * @return resendCode
-     */
     @JsonProperty("resendCode")
     public String getResendCode() {
 
         return resendCode;
     }
 
-    /**
-     * Set resendCode
-     * @param resendCode resendCode
-     */
     public void setResendCode(String resendCode) {
 
         this.resendCode = resendCode;
@@ -193,29 +158,21 @@ public class ResendResponse {
         return this;
     }
 
-    /**
-     * Get links
-     * @return links
-     */
     @JsonProperty("links")
     public List<APICall> getLinks() {
 
         return links;
     }
 
-    /**
-     * Set links
-     * @param links links
-     */
     public void setLinks(List<APICall> links) {
 
         this.links = links;
     }
 
     /**
-     * Add linksItem
-     * @param linksItem linksItem
-     * @return ResendResponse
+     * Add linksItem.
+     * @param linksItem linksItem.
+     * @return ResendResponse.
      */
     public ResendResponse addLinksItem(APICall linksItem) {
         if (this.links == null) {

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResetRequest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResetRequest.java
@@ -115,6 +115,11 @@ public class ResetRequest {
         this.properties = properties;
     }
 
+    /**
+     * Adds property to the request properties.
+     * @param propertiesItem propertiesItem.
+     * @return ConfirmRequest.
+     */
     public ResetRequest addPropertiesItem(Property propertiesItem) {
 
         if (this.properties == null) {

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResetRequest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResetRequest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wso2.carbon.identity.mgt.endpoint.util.client.model.Property;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Reset request to reset user password.
+ */
+public class ResetRequest {
+
+    private String resetCode;
+    private String flowConfirmationCode;
+    private String password;
+    private List<Property> properties = null;
+
+    /**
+     * Reset code sent at confirm step.
+     **/
+    public ResetRequest resetCode(String resetCode) {
+
+        this.resetCode = resetCode;
+        return this;
+    }
+
+    @JsonProperty("resetCode")
+    public String getResetCode() {
+
+        return resetCode;
+    }
+
+    public void setResetCode(String resetCode) {
+
+        this.resetCode = resetCode;
+    }
+
+    /**
+     * flowConfirmationCode for the recovery flow.
+     **/
+    public ResetRequest flowConfirmationCode(String flowConfirmationCode) {
+
+        this.flowConfirmationCode = flowConfirmationCode;
+        return this;
+    }
+
+    @JsonProperty("flowConfirmationCode")
+    public String getFlowConfirmationCode() {
+
+        return flowConfirmationCode;
+    }
+
+    public void setFlowConfirmationCode(String flowConfirmationCode) {
+
+        this.flowConfirmationCode = flowConfirmationCode;
+    }
+
+    /**
+     * Reset code sent at confirm step.
+     **/
+    public ResetRequest password(String password) {
+
+        this.password = password;
+        return this;
+    }
+
+    @JsonProperty("password")
+    public String getPassword() {
+
+        return password;
+    }
+
+    public void setPassword(String password) {
+
+        this.password = password;
+    }
+
+    /**
+     * (OPTIONAL) Additional META properties.
+     **/
+    public ResetRequest properties(List<Property> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+
+    @JsonProperty("properties")
+    public List<Property> getProperties() {
+
+        return properties;
+    }
+
+    public void setProperties(List<Property> properties) {
+
+        this.properties = properties;
+    }
+
+    public ResetRequest addPropertiesItem(Property propertiesItem) {
+
+        if (this.properties == null) {
+            this.properties = new ArrayList<>();
+        }
+        this.properties.add(propertiesItem);
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResetRequest recoveryRequest = (ResetRequest) o;
+        return Objects.equals(this.resetCode, recoveryRequest.resetCode) &&
+                Objects.equals(this.flowConfirmationCode, recoveryRequest.flowConfirmationCode) &&
+                Objects.equals(this.properties, recoveryRequest.properties);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(resetCode, flowConfirmationCode, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        return "class ConfirmRequest {" +
+                "    confirmationCode: " + resetCode + "\n" +
+                "    otp: " + flowConfirmationCode + "\n" +
+                "    properties: " + properties + "\n" +
+                "}";
+    }
+}

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResetRequest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResetRequest.java
@@ -117,6 +117,7 @@ public class ResetRequest {
 
     /**
      * Adds property to the request properties.
+     *
      * @param propertiesItem propertiesItem.
      * @return ConfirmRequest.
      */

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResetResponse.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResetResponse.java
@@ -20,8 +20,6 @@ package org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -51,7 +49,7 @@ public class ResetResponse {
     }
 
     /**
-     * Set code
+     * Set status code.
      **/
     public void setCode(String code) {
 
@@ -60,8 +58,8 @@ public class ResetResponse {
 
     /**
      * Success status message.
-     * @param message message
-     * @return ResendResponse
+     * @param message message.
+     * @return ResendResponse.
      */
     public ResetResponse message(String message) {
 
@@ -70,8 +68,8 @@ public class ResetResponse {
     }
 
     /**
-     * Get message
-     * @return message
+     * Get message.
+     * @return message.
      */
     @JsonProperty("message")
     public String getMessage() {
@@ -80,8 +78,8 @@ public class ResetResponse {
     }
 
     /**
-     * Set message
-     * @param message message
+     * Set message.
+     * @param message message.
      */
     public void setMessage(String message) {
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResetResponse.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResetResponse.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Response to password reset request.
+ **/
+public class ResetResponse {
+
+
+    private String code;
+    private String message;
+
+
+    /**
+     * Success status code.
+     **/
+    public ResetResponse code(String code) {
+
+        this.code = code;
+        return this;
+    }
+
+
+    @JsonProperty("code")
+    public String getCode() {
+
+        return code;
+    }
+
+    /**
+     * Set code
+     **/
+    public void setCode(String code) {
+
+        this.code = code;
+    }
+
+    /**
+     * Success status message.
+     * @param message message
+     * @return ResendResponse
+     */
+    public ResetResponse message(String message) {
+
+        this.message = message;
+        return this;
+    }
+
+    /**
+     * Get message
+     * @return message
+     */
+    @JsonProperty("message")
+    public String getMessage() {
+
+        return message;
+    }
+
+    /**
+     * Set message
+     * @param message message
+     */
+    public void setMessage(String message) {
+
+        this.message = message;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResetResponse passwordRecoveryInternalNotifyResponse = (ResetResponse) o;
+        return Objects.equals(this.code, passwordRecoveryInternalNotifyResponse.code) &&
+                Objects.equals(this.message, passwordRecoveryInternalNotifyResponse.message);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(code, message);
+    }
+
+    @Override
+    public String toString() {
+
+        return "class ResendResponse {\n" +
+                "    code: " + toIndentedString(code) + "\n" +
+                "    message: " + toIndentedString(message) + "\n" +
+                "}";
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+
+}

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResetResponse.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/model/recovery/v2/ResetResponse.java
@@ -58,6 +58,7 @@ public class ResetResponse {
 
     /**
      * Success status message.
+     *
      * @param message message.
      * @return ResendResponse.
      */
@@ -69,6 +70,7 @@ public class ResetResponse {
 
     /**
      * Get message.
+     *
      * @return message.
      */
     @JsonProperty("message")
@@ -79,6 +81,7 @@ public class ResetResponse {
 
     /**
      * Set message.
+     *
      * @param message message.
      */
     public void setMessage(String message) {

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -121,6 +121,10 @@ public class IdPManagementDAO {
     private static final Log log = LogFactory.getLog(IdPManagementDAO.class);
 
     private static final String OPENID_IDP_ENTITY_ID = "IdPEntityId";
+    private static final String DEPRECATED_RECOVERY_NOTIFICATION_PASSWORD_CONFIG
+            = "Recovery.Notification.Password.Enable";
+    private static final String EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY
+            = "Recovery.Notification.Password.emailLink.Enable";
 
     /**
      * @param dbConnection
@@ -984,7 +988,6 @@ public class IdPManagementDAO {
                                                                         int idpId, int tenantId)
             throws SQLException {
 
-        final String DEPRECATED_RECOVERY_NOTIFICATION_PASSWORD_CONFIG = "Recovery.Notification.Password.Enable";
         String recoveryNotificationPasswordValue = "";
         PreparedStatement prepStmt = null;
         ResultSet rs = null;
@@ -5952,10 +5955,10 @@ public class IdPManagementDAO {
         // Set value of Recovery.Notification.Password.Enable to Recovery.Notification.Password.emailLink.Enable
         // property to keep backward compatibility. This is only run once per tenant.
         IdentityProviderProperty property = new IdentityProviderProperty();
-        property.setName("Recovery.Notification.Password.emailLink.Enable");
+        property.setName(EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY);
         property.setValue(recoveryNotificationPasswordValue);
         idpProperties.add(property);
-        idpProperties.stream().filter(idpProperty -> "Recovery.Notification.Password.Enable".equals(idpProperty.getName()))
+        idpProperties.stream().filter(idpProperty -> DEPRECATED_RECOVERY_NOTIFICATION_PASSWORD_CONFIG.equals(idpProperty.getName()))
                 .findFirst().ifPresent(idpProperties::remove);
         updateIdentityProviderProperties(dbConnection, idpId, idpProperties, tenantId);
     }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -5949,8 +5949,8 @@ public class IdPManagementDAO {
                                        String recoveryNotificationPasswordValue)
         throws SQLException {
 
-        // Set value of Recovery.Notification.Password.Enable to Recovery.Notification.Password.emailLink.
-        // Enable property to keep backward compatibility. This is only run once per tenant.
+        // Set value of Recovery.Notification.Password.Enable to Recovery.Notification.Password.emailLink.Enable
+        // property to keep backward compatibility. This is only run once per tenant.
         IdentityProviderProperty property = new IdentityProviderProperty();
         property.setName("Recovery.Notification.Password.emailLink.Enable");
         property.setValue(recoveryNotificationPasswordValue);

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -241,7 +241,7 @@
   "account_recovery.endpoint.auth.hash":"66cd9688a2ae068244ea01e70f0e230f5623b7fa4cdecb65070a09ec06452262",
 
   "authorization_control.skip_authorization.client_authentication.name":"ClientAuthentication",
-  "authorization_control.skip_authorization.client_authentication.allowedEndpoints": "(.*)/accountrecoveryendpoint(.*),(.*)/api/identity/recovery/(.*),(.*)/data/AuthRequestKey/(.*),(.*)/applications(.*),(.*)/identity-governance(.*),(.*)/user/(.*)/validate-username(.*),(.*)/consent-mgt/v(.*)/consents/(.*),(.*)/user/v(.*)/me(.*),(.*)/identity/auth/v(.*)/data/(.*),(.*)/identity/user/v(.*)/validate-code,(.*)/api/server/v(.*)/identity-providers(.*),(.*)/api/identity/auth/(.*)/context(.*),(.*)/api/identity/user/v(.*)/resend-code(.*)",
+  "authorization_control.skip_authorization.client_authentication.allowedEndpoints": "(.*)/accountrecoveryendpoint(.*),(.*)/api/identity/recovery/(.*),(.*)/data/AuthRequestKey/(.*),(.*)/applications(.*),(.*)/identity-governance(.*),(.*)/user/(.*)/validate-username(.*),(.*)/consent-mgt/v(.*)/consents/(.*),(.*)/user/v(.*)/me(.*),(.*)/identity/auth/v(.*)/data/(.*),(.*)/identity/user/v(.*)/validate-code,(.*)/api/server/v(.*)/identity-providers(.*),(.*)/api/identity/auth/(.*)/context(.*),(.*)/api/identity/user/v(.*)/resend-code(.*),(.*)/api/users/v2/recovery/password/(.*)",
 
   "jit_provisioning.indelible_claims.claim_uris": [
     "http://wso2.org/claims/userid",


### PR DESCRIPTION
### Propose 

1. Currently the RecoveryApiV2 client implementation contains only the initialise password recovery and get recovery information functionality. This PR adds the following missing functions which the `Account Recovery V2 API` supports.

    - Resend password recovery confirmation details
    - Confirm password recovery
    - Reset password

2. Add PasswordRecoveryOptions.SMSOTP constant which is needed in the recovery portal implementation to support SMS OTP for password recovery. 

### Related Issues
- https://github.com/wso2-enterprise/iam-product-management/issues/51
- https://github.com/wso2-enterprise/iam-engineering/issues/534