### PR TITLE
Control JIT provisioning users associating to local users through associating_to_existing_user configuration

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -121,6 +121,7 @@ public abstract class FrameworkConstants {
     public static final String SECRET_KEY_CLAIM_URL = "http://wso2.org/claims/identity/secretkey";
     public static final String IDP_RESOURCE_ID = "IDPResourceID";
     public static final String ENABLE_JIT_PROVISION_ENHANCE_FEATURE = "JITProvisioning.EnableEnhancedFeature";
+    public static final String ALLOW_ASSOCIATING_TO_EXISTING_USER = "JITProvisioning.AllowAssociatingToExistingUser";
     public static final String ERROR_CODE_INVALID_ATTRIBUTE_UPDATE = "SUO-10000";
 
     // Error details sent from authenticators

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1464,7 +1464,9 @@
                 <ClaimURI>{{claimuri}}</ClaimURI>
             {% endfor %}
         </IndelibleClaims>
-
+        <AllowAssociatingToExistingUser>
+            {{authentication.jit_provisioning.associating_to_existing_user | default(true)}}
+        </AllowAssociatingToExistingUser>
     </JITProvisioning>
 
     <!--Application management service configurations-->


### PR DESCRIPTION
## Purpose
Adding the `associating_to_existing_user`  configuration.

This configuration allows the configuration of whether to allow JIT provisioning users to be associated to an already existing local account or not. The default value of this configuration is set to true to retain the previous behaviour on default configuration. If a local account is already existing for the federated user's username, and local user association is not allowed through the configuration, an error is thrown blocking the JIT provisioning. However the federated authentication flow will continue.

