### PR TITLE
Set `apiResourcesV1` to false by default

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1066,7 +1066,7 @@
   "console.ui.google_one_tap_enabled_tenants": [],
   "console.ui.show_app_switch_button": true,
   "console.ui.administrator_role_display_name": "Administrator",
-  "console.ui.legacy_mode.apiResourcesV1": true,
+  "console.ui.legacy_mode.apiResourcesV1": false,
   "console.ui.legacy_mode.apiResourcesV2": true,
   "console.ui.legacy_mode.applicationListSystemApps": false,
   "console.ui.legacy_mode.applicationOIDCSubjectIdentifier": true,


### PR DESCRIPTION
### Proposed changes in this pull request

[List all changes you want to add here. If you fixed an issue, please
add a reference to that issue as well.]

-Set `apiResourcesV1` to false by default

Related PR: 
- https://github.com/wso2/carbon-identity-framework/pull/5625