### PR TITLE
Make the xacml policy metadata saving configurable

### DIFF
--- a/components/entitlement/org.wso2.carbon.identity.entitlement/pom.xml
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/pom.xml
@@ -136,6 +136,10 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/EntitlementUtil.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/EntitlementUtil.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.identity.entitlement;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.Document;
@@ -653,5 +654,19 @@ public class EntitlementUtil {
         DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
         return documentBuilder;
 
+    }
+
+    /**
+     * Read PAP.Policy.Store.MetaData property from entitlement.properties file.
+     *
+     * @return true if policy meta data storing is enabled, false otherwise.
+     */
+    public static boolean isPolicyMetadataStoringEnabled() {
+
+        String propertyValue = EntitlementServiceComponent.getEntitlementConfig().
+                getEngineProperties().getProperty(PDPConstants.STORE_POLICY_META_DATA);
+
+        // The default behavior is to store policy meta data.
+        return StringUtils.isEmpty(propertyValue) || Boolean.parseBoolean(propertyValue);
     }
 }

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/PDPConstants.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/PDPConstants.java
@@ -288,4 +288,7 @@ public class PDPConstants {
     public static final String USER_CATEGORY = "http://wso2.org/identity/user";
 
     public static final String USER_TYPE_ID = USER_CATEGORY + "/user-type";
+
+    public static final String STORE_POLICY_META_DATA = "PAP.Policy.Store.MetaData";
+
 }

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/internal/EntitlementExtensionBuilder.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/internal/EntitlementExtensionBuilder.java
@@ -216,6 +216,7 @@ public class EntitlementExtensionBuilder {
         setProperty(properties, pdpProperties, PDPConstants.PDP_REGISTRY_LEVEL_POLICY_CACHE_CLEAR);
         setProperty(properties, pdpProperties, PDPConstants.POLICY_CACHING_INTERVAL);
         setProperty(properties, pdpProperties, PDPConstants.XACML_JSON_SHORT_FORM_ENABLED);
+        setProperty(properties, pdpProperties, PDPConstants.STORE_POLICY_META_DATA);
 
         holder.setEngineProperties(pdpProperties);
     }

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/pap/store/PAPPolicyStore.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/pap/store/PAPPolicyStore.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.identity.entitlement.EntitlementException;
+import org.wso2.carbon.identity.entitlement.EntitlementUtil;
 import org.wso2.carbon.identity.entitlement.PDPConstants;
 import org.wso2.carbon.identity.entitlement.dto.PolicyDTO;
 import org.wso2.carbon.identity.entitlement.internal.EntitlementServiceComponent;
@@ -38,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 public class PAPPolicyStore {
@@ -218,7 +220,11 @@ public class PAPPolicyStore {
                     String key = o.toString();
                     resourceProperties.put(key, Collections.singletonList(properties.get(key)));
                 }
-                resource.setProperties(resourceProperties);
+
+                // Store policy metadata based on the configured property.
+                if (EntitlementUtil.isPolicyMetadataStoringEnabled()) {
+                    resource.setProperties(resourceProperties);
+                }
             }
 
             resource.setProperty(PDPConstants.ACTIVE_POLICY, Boolean.toString(policy.isActive()));
@@ -312,6 +318,15 @@ public class PAPPolicyStore {
                 }
                 resource.setProperty(PDPConstants.BASIC_POLICY_EDITOR_META_DATA_AMOUNT,
                                      Integer.toString(i));
+            }
+
+            // Store policy metadata based on the configured property.
+            if (!EntitlementUtil.isPolicyMetadataStoringEnabled()) {
+                for (Map.Entry<Object, Object> entry : resource.getProperties().entrySet()) {
+                    if (entry.getKey().toString().startsWith(PDPConstants.POLICY_META_DATA)) {
+                        resource.getProperties().remove(entry.getKey());
+                    }
+                }
             }
 
             registry.put(path, resource);

--- a/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/entitlement.properties
+++ b/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/entitlement.properties
@@ -32,6 +32,7 @@ PDP.Global.Policy.Combining.Algorithm=urn:oasis:names:tc:xacml:3.0:policy-combin
 PAP.Policy.Add.Start.Enable=true
 #PAP.Policy.Add.Start.Policy.File.Path=
 PAP.Items.Per.Page=10
+PAP.Policy.Store.MetaData=true
 PDP.Registry.Level.Policy.Cache.Clear=false
 PDP.PolicyCaching.CachingInterval=100
 Entitlement.Engine.CachingInterval=100000

--- a/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/entitlement.properties.j2
+++ b/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/entitlement.properties.j2
@@ -32,6 +32,7 @@ PDP.Global.Policy.Combining.Algorithm={{identity.entitlement.policy_point.pdp.gl
 PAP.Policy.Add.Start.Enable={{identity.entitlement.policy_point.pap.policy_add_start_enable}}
 #PAP.Policy.Add.Start.Policy.File.Path=
 PAP.Items.Per.Page={{identity.entitlement.policy_point.pap.items_per_page}}
+PAP.Policy.Store.MetaData={{identity.entitlement.policy_point.pap.store_metadata}}
 PDP.Registry.Level.Policy.Cache.Clear={{identity.entitlement.policy_point.pdp.registry_level_policy_cache_clear}}
 PDP.PolicyCaching.CachingInterval={{identity.entitlement.policy_point.pdp.caching.policy_caching.caching_interval}}
 Entitlement.Engine.CachingInterval={{identity.entitlement.entitlement_engine_caching_interval}}

--- a/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/org.wso2.carbon.identity.xacml.server.feature.default.json
+++ b/features/xacml/org.wso2.carbon.identity.xacml.server.feature/resources/org.wso2.carbon.identity.xacml.server.feature.default.json
@@ -22,6 +22,7 @@
   "identity.entitlement.policy_point.pap.enabled": true,
   "identity.entitlement.policy_point.pap.policy_add_start_enable": true,
   "identity.entitlement.policy_point.pap.items_per_page": "10",
+  "identity.entitlement.policy_point.pap.store_metadata": true,
   "identity.entitlement.policy_point.pap.entitlement_data_finders": [
     "org.wso2.carbon.identity.entitlement.pap.CarbonEntitlementDataFinder"
   ],


### PR DESCRIPTION
Implement the improvements suggested in https://github.com/wso2/product-is/issues/20029

This will introduce a new config to the `entitlement.properties` file. The default value of this is set to true to preserve the existing behavior
```
PAP.Policy.Store.MetaData=true
```
The value can be set from the `deployment.toml` file as 
```
[identity.entitlement.policy_point.pap]
store_metadata=true
```

With the change done in https://github.com/wso2/carbon-identity-framework/pull/5311, the customers have lost the ability to audit policy administration operations. Therefore an audit log is printed for each status update if  config is enabled from the deployment.toml

```
[identity.entitlement.xacml_policy_status]
use_last_status_only=true
```

```
TID: [-1234] [2024-04-16 14:50:25,834] [96b872bf-5289-4dfa-86c0-3c662a0c6567]  INFO {AUDIT_LOG} - Initiator : a***n | Action : GET_POLICY | Target : PAP POLICY STORE | Data : { "Key" : "authn_time_based_policy_template" , "Target Action" : "LOAD" } | Result : SUCCESS 
TID: [-1234] [2024-04-16 14:50:34,435] [f1f34862-89bd-498e-84c4-ed970173f345]  INFO {AUDIT_LOG} - Initiator : a***n | Action : UPDATE_POLICY | Target : PAP POLICY STORE | Data : { "Key" : "authn_time_based_policy_template" , "Target Action" : "PERSIST" } | Result : SUCCESS 
TID: [-1234] [2024-04-16 14:50:54,036] [c7f77add-0245-454b-b638-e7142c125828]  INFO {AUDIT_LOG} - Initiator : a***n | Action : PUBLISH_POLICY | Target : PDP Subscriber | Data : { "Key" : "scope_based_token_issuance_policy_template" , "Target Action" : "CREATE" } | Result : SUCCESS 
```
