### PR TITLE
Add APIAuth tag to supported connection templates

### DIFF
--- a/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/facebook/template.json
+++ b/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/facebook/template.json
@@ -7,7 +7,7 @@
     "category": "DEFAULT",
     "displayOrder": 3,
     "services": [],
-    "tags": [ "Social-Login" ],
+    "tags": [ "Social-Login", "APIAuth" ],
     "idp": {
         "name": "Facebook",
         "description": "",

--- a/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/github/template.json
+++ b/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/github/template.json
@@ -7,7 +7,7 @@
     "displayOrder": 4,
     "docLink": "/guides/authentication/social-login/add-github-login/",
     "services": [],
-    "tags": [ "Social-Login" ],
+    "tags": [ "Social-Login", "APIAuth" ],
     "idp": {
         "name": "GitHub",
         "description": "",

--- a/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/google/template.json
+++ b/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/google/template.json
@@ -7,7 +7,7 @@
     "category": "DEFAULT",
     "displayOrder": 1,
     "services": [],
-    "tags": [ "Social-Login" ],
+    "tags": [ "Social-Login", "APIAuth" ],
     "idp": {
         "name": "Google",
         "description": "",

--- a/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/microsoft/template.json
+++ b/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/microsoft/template.json
@@ -7,7 +7,7 @@
     "category": "DEFAULT",
     "displayOrder": 2,
     "services": [],
-    "tags": [ "Social-Login" ],
+    "tags": [ "Social-Login", "APIAuth" ],
     "idp": {
         "name": "Microsoft",
         "description": "",

--- a/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/oidc-identity-provider/template.json
+++ b/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/oidc-identity-provider/template.json
@@ -5,7 +5,7 @@
     "templateGroup": "enterprise-protocols",
     "displayOrder": 5,
     "id": "enterprise-oidc-idp",
-    "tags": [ "OIDC" ],
+    "tags": [ "OIDC", "APIAuth" ],
     "idp": {
         "alias": "",
         "idpIssuerName": "",

--- a/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/swe/template.json
+++ b/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/swe/template.json
@@ -7,7 +7,7 @@
     "category": "DEFAULT",
     "displayOrder": 9,
     "services": [],
-    "tags": [ "OIDC" ],
+    "tags": [ "OIDC", "APIAuth" ],
     "disabled": false,
     "templateId": "swe-idp",
     "idp": {


### PR DESCRIPTION
Add the` APIAuth` tag to template.json for connections supporting app-native authentication feature. 

Part of: https://github.com/wso2/carbon-identity-framework/pull/5633