### PR TITLE
Handle role extraction for a shared user in organization switching

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -66,6 +66,8 @@ public class AuthenticatedUser extends User {
     private String accessingOrganization;
     private String userResidentOrganization;
     private Map<ClaimMapping, String> userAttributes = new HashMap<>();
+    private String sharedUserId;
+    private String userSharedOrganizationId;
 
     /**
      * Instantiates an AuthenticatedUser
@@ -580,5 +582,25 @@ public class AuthenticatedUser extends User {
             return authenticatedSubjectIdentifier;
         }
         return super.toString();
+    }
+
+    public String getSharedUserId() {
+
+        return sharedUserId;
+    }
+
+    public void setSharedUserId(String sharedUserId) {
+
+        this.sharedUserId = sharedUserId;
+    }
+
+    public String getUserSharedOrganizationId() {
+
+        return userSharedOrganizationId;
+    }
+
+    public void setUserSharedOrganizationId(String sharedUserOrganizationId) {
+
+        this.userSharedOrganizationId = sharedUserOrganizationId;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

- Part of the fix for https://github.com/wso2/product-is/issues/20122
- Handle role extraction for a shared user when that user is switching to the shared organization.
- Introduce `sharedUserId` and `userSharedOrganizationId` params to the `AuthenticatedUser`.

### When should this PR be merged

- This PR needs to be merged before https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2433