### PR TITLE
Introduce disabling management API resources

### DIFF
--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/constant/APIResourceManagementConstants.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/constant/APIResourceManagementConstants.java
@@ -85,7 +85,9 @@ public class APIResourceManagementConstants {
         public static final String DESCRIPTION = "description";
         public static final String REQUIRES_AUTHORIZATION = "requiresAuthorization";
         public static final String TYPE = "type";
+        public static final String DISABLED = "disabled";
         public static final String TENANT_ADMIN_TYPE = "TENANT_ADMIN";
+
     }
 
     /**

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/util/APIResourceManagementConfigBuilder.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/util/APIResourceManagementConfigBuilder.java
@@ -52,6 +52,7 @@ public class APIResourceManagementConfigBuilder {
     private static final Log LOG = LogFactory.getLog(APIResourceManagementConfigBuilder.class);
     private static final Map<String, APIResource> apiResourceMgtConfigurations = new HashMap<>();
     private static final Map<String, APIResource> duplicateAPIResourceConfigs = new HashMap<>();
+    private static final List<String> disabledAPIResourceIdentifiers = new ArrayList<>();
     private static final APIResourceManagementConfigBuilder apiResourceManagementConfigBuilder =
             new APIResourceManagementConfigBuilder();
 
@@ -162,6 +163,12 @@ public class APIResourceManagementConfigBuilder {
                 duplicateAPIResourceConfigs.put(apiResourceObj.getIdentifier(), apiResourceObj);
                 continue;
             }
+            if (disabledAPIResourceIdentifiers.contains(apiResourceObj.getIdentifier())) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("API resource with identifier: " + apiResourceObj.getIdentifier() + " is disabled.");
+                }
+                continue;
+            }
             apiResourceMgtConfigurations.put(apiResourceObj.getIdentifier(), apiResourceObj);
         }
     }
@@ -170,6 +177,8 @@ public class APIResourceManagementConfigBuilder {
 
         // If API resource is disabled skip adding to the list.
         if (Boolean.parseBoolean(element.getAttributeValue(new QName(APIResourceConfigBuilderConstants.DISABLED)))) {
+            disabledAPIResourceIdentifiers.add(element.getAttributeValue(
+                    new QName(APIResourceConfigBuilderConstants.IDENTIFIER)));
             return null;
         }
         String apiResourceIdentifier = element.getAttributeValue(

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/util/APIResourceManagementConfigBuilder.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/util/APIResourceManagementConfigBuilder.java
@@ -168,6 +168,10 @@ public class APIResourceManagementConfigBuilder {
 
     private APIResource buildAPIResource(OMElement element) {
 
+        // If API resource is disabled skip adding to the list.
+        if (Boolean.parseBoolean(element.getAttributeValue(new QName(APIResourceConfigBuilderConstants.DISABLED)))) {
+            return null;
+        }
         String apiResourceIdentifier = element.getAttributeValue(
                 new QName(APIResourceConfigBuilderConstants.IDENTIFIER));
         String type = APIResourceConfigBuilderConstants.TENANT_ADMIN_TYPE;

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/util/APIResourceManagementUtil.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/util/APIResourceManagementUtil.java
@@ -102,17 +102,10 @@ public class APIResourceManagementUtil {
                 HashMap<String, APIResource> tempConfigs = new HashMap<>(configs);
                 List<APIResource> systemAPIs = getSystemAPIs(tenantDomain);
                 for (APIResource systemAPI : systemAPIs) {
-                    if (tempConfigs.containsKey(systemAPI.getIdentifier())) {
-                        tempConfigs.remove(systemAPI.getIdentifier());
-                    } else {
-                        String apiId = APIResourceManagerImpl.getInstance().getAPIResourceByIdentifier(
-                                systemAPI.getIdentifier(), tenantDomain).getId();
-                        APIResourceManagerImpl.getInstance().deleteAPIResourceById(apiId, tenantDomain);
-                    }
+                    tempConfigs.remove(systemAPI.getIdentifier());
                 }
                 // Register the new system APIs.
                 registerAPIResources(new ArrayList<>(tempConfigs.values()), tenantDomain);
-
                 // Handle duplicate system APIs.
                 for (APIResource oldAPIResource : duplicateConfigs.values()) {
                     // Get the existing API resource from the DB.

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -19,7 +19,7 @@
 
 <APIResources>
     {% for api_resource in api_resources %}
-    <APIResource name="{{ api_resource.name }}" identifier="{{ api_resource.identifier }}" requiresAuthorization="{{ api_resource.requiresAuthorization }}" description="{{ api_resource.description }}" type="{{ api_resource.type }}">
+    <APIResource name="{{ api_resource.name }}" identifier="{{ api_resource.identifier }}" requiresAuthorization="{{ api_resource.requiresAuthorization }}" description="{{ api_resource.description }}" type="{{ api_resource.type }}" disabled="{{ api_resource.disabled }}">
         <Scopes>
             {% for scope in api_resource.scopes %}
             <Scope displayName="{{ scope.displayName }}" name="{{ scope.name }}" description = "{{ scope.description }}"/>


### PR DESCRIPTION
### Proposed changes in this pull request

Introduce a way to define a management API resource is disabled thus skipping registering it the first time.