### PR TITLE
Support MTLS Aliases for well known endpoint

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
@@ -78,7 +78,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
      *
      * @return {@link ServiceURL}.
      * @throws URLBuilderException If error occurred while constructing the URL.
-     * @deprecated Use {@link #buildURL(String)} instead.
+     * @deprecated Use {@link #build(String)} (String)} instead.
      */
     @Override
     @Deprecated

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
@@ -96,7 +96,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
      * @throws URLBuilderException If error occurred while constructing the URL.
      */
     @Override
-    public ServiceURL buildURL(String hostname) throws URLBuilderException {
+    public ServiceURL build(String hostname) throws URLBuilderException {
 
         return buildServiceURL(hostname);
     }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
@@ -78,12 +78,32 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
      *
      * @return {@link ServiceURL}.
      * @throws URLBuilderException If error occurred while constructing the URL.
+     * @deprecated Use {@link #buildURL(String)} instead.
      */
     @Override
+    @Deprecated
     public ServiceURL build() throws URLBuilderException {
 
+        return buildServiceURL(fetchProxyHostName());
+    }
+
+    /**
+     * Returns a ServiceURL with the protocol, hostname, port, proxy context path, a web context
+     * root and the tenant domain (appended if required).
+     *
+     * @param hostname Hostname.
+     * @return {@link ServiceURL}.
+     * @throws URLBuilderException If error occurred while constructing the URL.
+     */
+    @Override
+    public ServiceURL buildURL(String hostname) throws URLBuilderException {
+
+        return buildServiceURL(hostname);
+    }
+
+    private ServiceURL buildServiceURL(String proxyHostName) throws URLBuilderException {
+
         String protocol = fetchProtocol();
-        String proxyHostName = fetchProxyHostName();
         String internalHostName = fetchInternalHostName();
         String authenticationEndpointHostName = fetchAuthenticationEndpointHostName();
         String authenticationEndpointPath = fetchAuthenticationEndpointPath();

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURLBuilder.java
@@ -125,5 +125,5 @@ public interface ServiceURLBuilder {
      * @return {@link ServiceURL}.
      * @throws URLBuilderException If error occurred while constructing the URL.
      */
-    ServiceURL buildURL(String hostname) throws URLBuilderException;
+    ServiceURL build(String hostname) throws URLBuilderException;
 }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURLBuilder.java
@@ -112,6 +112,18 @@ public interface ServiceURLBuilder {
      *
      * @return {@link ServiceURL}.
      * @throws URLBuilderException If error occurred while constructing the URL.
+     * @deprecated Use {@link #buildURL(String)} instead.
      */
+    @Deprecated
     ServiceURL build() throws URLBuilderException;
+
+    /**
+     * Returns a ServiceURL with the protocol, hostname, port, proxy context path, a web context
+     * root and the tenant domain (appended if required).
+     *
+     * @param hostname Hostname.
+     * @return {@link ServiceURL}.
+     * @throws URLBuilderException If error occurred while constructing the URL.
+     */
+    ServiceURL buildURL(String hostname) throws URLBuilderException;
 }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURLBuilder.java
@@ -112,7 +112,7 @@ public interface ServiceURLBuilder {
      *
      * @return {@link ServiceURL}.
      * @throws URLBuilderException If error occurred while constructing the URL.
-     * @deprecated Use {@link #buildURL(String)} instead.
+     * @deprecated Use {@link #build(String)} instead.
      */
     @Deprecated
     ServiceURL build() throws URLBuilderException;
@@ -125,5 +125,8 @@ public interface ServiceURLBuilder {
      * @return {@link ServiceURL}.
      * @throws URLBuilderException If error occurred while constructing the URL.
      */
-    ServiceURL build(String hostname) throws URLBuilderException;
+    default ServiceURL build(String hostname) throws URLBuilderException {
+
+        return build();
+    }
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -301,6 +301,11 @@
         <OIDCDiscoveryEPUrl>{{oauth.endpoints.oidc_discovery_url}}</OIDCDiscoveryEPUrl>
         <OAuth2DeviceAuthzEPUrl>{{oauth.endpoints.oauth2_device_authz_url}}</OAuth2DeviceAuthzEPUrl>
 
+        <MutualTLSAliases>
+            <Enabled>{{oauth.mtls_aliases.enabled}}</Enabled>
+            <Hostname>{{oauth.mtls_aliases.hostname}}</Hostname>
+        </MutualTLSAliases>
+
         <EnableSHA256OAuth2JWKThumbprint>{{oauth.jwk_thumbprint_enable_sha256}}</EnableSHA256OAuth2JWKThumbprint>
 
         <!-- If enabled, resident Idp entity id will be honoured as the issuer location in OpenId Connect Discovery -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -109,6 +109,8 @@
   "oauth.endpoints.oidc_discovery_url": "$ref{server.base_path}/oauth2/oidcdiscovery",
   "oauth.endpoints.oauth2_device_authz_url": "$ref{server.base_path}/oauth2/device_authorize",
   "oauth.jwk_thumbprint_enable_sha256": true,
+  "oauth.mtls_aliases.enabled": false,
+  "oauth.mtls_aliases.hostname": "$ref{server.base_path}",
 
   "oauth.response_type.token.enable": true,
   "oauth.response_type.token.class": "org.wso2.carbon.identity.oauth2.authz.handlers.AccessTokenResponseTypeHandler",


### PR DESCRIPTION
## Purpose
This pr adds configurations

-  to enable MTLS aliases in the discovery endpoint
- to configure MTLS domain name

example depployment.toml configuration
```
[oauth.mtls_aliases]
enabled = true
hostname= "dev.mtls.asgardeo.io
```

Add support to build service URL with a given hostname 

## Related PRs
> List any other related PRs
