### PR TITLE
Hide organization SSO for myaccount & console app when fidp=OrganizationSSO is not provided

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -851,7 +851,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
         if (FrameworkConstants.Application.CONSOLE_APP.equals(applicationName) ||
                 FrameworkConstants.Application.MY_ACCOUNT_APP.equals(applicationName)) {
             String[] fidpParam = request.getParameterMap().get(FrameworkConstants.RequestParams.FEDERATED_IDP);
-            if (fidpParam == null || !ORGANIZATION_LOGIN_HOME_REALM_IDENTIFIER.equals(fidpParam[0])) {
+            if (fidpParam == null || fidpParam.length > 0 &&
+                    !ORGANIZATION_LOGIN_HOME_REALM_IDENTIFIER.equals(fidpParam[0])) {
                 removeOrganizationSsoStepsForPortalApps(effectiveSequence);
             }
         }


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

We have decided to remove the SSO login option from console & myaccount. That decision should be propagated to the code base to remove the SSO IDP from console & myaccount.

But only if organization SSO IDP is requested via the fidp parameter, it allows to add the organization SSO login option.

Previously we have done an improvement to hide the organization SSO login option for console & myaccount, but looks incomplete. Hence raise this PR and it should be able to revert this PR - https://github.com/wso2/carbon-identity-framework/pull/5298

#### Related issues
- https://github.com/wso2/product-is/issues/20303