### PR TITLE
Add application properties for impersonation

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ClientImpersonation.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ClientImpersonation.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.application.common.model;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axis2.databinding.annotation.IgnoreNullElement;
+
+import java.io.Serializable;
+import java.util.Iterator;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * This class represents the metadata related to client impersonation. It is used for
+ * serializing and deserializing data to/from XML format.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "ClientImpersonationMetaData")
+public class ClientImpersonation implements Serializable {
+
+    private static final long serialVersionUID = 1995041000019950518L;
+    private static final String IS_IMPERSONATION_EMAIL_NOTIFICATION_ENABLED = "IsImpersonationEmailNotificationEnabled";
+    private static final String IS_IMPERSONATION_ENABLED = "IsImpersonationEnabled";
+
+    @IgnoreNullElement
+    @XmlElement(name = IS_IMPERSONATION_ENABLED)
+    private boolean isImpersonationEnabled;
+
+    // Field to store whether email notification for impersonation is enabled.
+    @IgnoreNullElement
+    @XmlElement(name = IS_IMPERSONATION_EMAIL_NOTIFICATION_ENABLED)
+    private boolean isImpersonationEmailNotificationEnabled;
+
+    /**
+     * Creates an instance of the ClientImpersonationMetaData class by parsing an OMElement.
+     *
+     * @param metaDataOM The OMElement to parse and build the ClientImpersonationMetaData object from.
+     * @return A new ClientImpersonationMetaData object populated with data from the OMElement.
+     */
+    public static ClientImpersonation build(OMElement metaDataOM) {
+        ClientImpersonation metaData = new ClientImpersonation();
+
+        Iterator<?> iter = metaDataOM.getChildElements();
+
+        while (iter.hasNext()) {
+            OMElement element = (OMElement) (iter.next());
+            String elementName = element.getLocalName();
+
+            if (IS_IMPERSONATION_ENABLED.equals(elementName)) {
+                boolean isImpersonationEnabled = element.getText() != null && Boolean.parseBoolean(element.getText());
+                metaData.setImpersonationEnabled(isImpersonationEnabled);
+            } else if (IS_IMPERSONATION_EMAIL_NOTIFICATION_ENABLED.equals(elementName)) {
+                boolean isImpersonationEmailNotificationEnabled = element.getText() != null
+                        && Boolean.parseBoolean(element.getText());
+                metaData.setImpersonationEmailNotificationEnabled(isImpersonationEmailNotificationEnabled);
+            }
+        }
+        return metaData;
+    }
+
+
+    /**
+     * Get the value indicating whether email notification for impersonation is enabled.
+     *
+     * @return True if attestation is enabled, otherwise false.
+     */
+    public boolean isImpersonationEmailNotificationEnabled() {
+
+        return isImpersonationEmailNotificationEnabled;
+    }
+
+    /**
+     * Set the value indicating whether email notification for impersonation is enabled.
+     *
+     * @param impersonationEmailNotificationEnabled True to enable attestation, false to disable it.
+     */
+    public void setImpersonationEmailNotificationEnabled(boolean impersonationEmailNotificationEnabled) {
+
+        isImpersonationEmailNotificationEnabled = impersonationEmailNotificationEnabled;
+    }
+
+
+    public boolean isImpersonationEnabled() {
+
+        return isImpersonationEnabled;
+    }
+
+    public void setImpersonationEnabled(boolean impersonationEnabled) {
+
+        isImpersonationEnabled = impersonationEnabled;
+    }
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ServiceProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ServiceProvider.java
@@ -149,6 +149,10 @@ public class ServiceProvider implements Serializable {
     @XmlElement(name = "ClientAttestationMetaData")
     private ClientAttestationMetaData clientAttestationMetaData;
 
+    @IgnoreNullElement
+    @XmlElement(name = "ClientImpersonation")
+    private ClientImpersonation clientImpersonation;
+
     /*
      * <ServiceProvider> <ApplicationID></ApplicationID> <Description></Description>
      * <Owner>....</Owner>
@@ -206,6 +210,9 @@ public class ServiceProvider implements Serializable {
                 serviceProvider
                         .setClientAttestationMetaData(ClientAttestationMetaData
                                 .build(element));
+            } else if ("ClientImpersonation".equals(elementName)) {
+                // build client impersonation meta data configuration.
+                serviceProvider.setClientImpersonation(ClientImpersonation.build(element));
             } else if ("IsSaaSApp".equals(elementName)) {
                 if (element.getText() != null && "true".equals(element.getText())) {
                     serviceProvider.setSaasApp(true);
@@ -601,6 +608,16 @@ public class ServiceProvider implements Serializable {
     public void setClientAttestationMetaData(ClientAttestationMetaData clientAttestationMetaData) {
 
         this.clientAttestationMetaData = clientAttestationMetaData;
+    }
+
+    public ClientImpersonation getClientImpersonation() {
+
+        return clientImpersonation;
+    }
+
+    public void setClientImpersonation(ClientImpersonation clientImpersonation) {
+
+        this.clientImpersonation = clientImpersonation;
     }
 }
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
@@ -130,6 +130,12 @@ public class IdentityApplicationConstants {
                 = "ANDROID_ATTESTATION_CREDENTIALS";
     public static final String CLIENT_ATTESTATION = "CLIENT_ATTESTATION";
     public static final String ANDROID = "ANDROID";
+    public static final String IS_IMPERSONATION_ENABLED_PROPERTY_NAME = "IsImpersonationEnabled";
+    public static final String IS_IMPERSONATION_ENABLED_DISPLAY_NAME = "Is Client Impersonation Enabled";
+    public static final String IS_IMPERSONATION_EMAIL_NOTIFICATION_ENABLED_PROPERTY_NAME =
+            "IsImpersonationEmailNotificationEnabled";
+    public static final String IS_IMPERSONATION_EMAIL_NOTIFICATION_ENABLED_DISPLAY_NAME =
+            "Is Impersonation Email Notification Enabled";
 
     /**
      * Config elements.


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/20066

## Purpose
Each application should have 2 properties to store following configurations
- Impersonation enabled or not.
- Email Notification is enabled or not for impersonation.

## Approach
Here we are using application sp properties to store these properties, note that Impersonation should be enabled to store email notification configuration.


- [x] Unit Tests Covered [Link](https://github.com/wso2/carbon-identity-framework/pull/5670/files#diff-2e328fa4268cc62493fff766ff7c1c9359d0fd49e2a3b895fdf7c5d1935e3a43R1003)