### PR TITLE
Adding default DCR server configurations

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -714,7 +714,7 @@
         <DCRM>
             <ApplicationRolePermissionRequiredToView>true</ApplicationRolePermissionRequiredToView>
             <ClientAuthenticationRequired>true</ClientAuthenticationRequired>
-            <MandatorySoftwareStatement>true</MandatorySoftwareStatement>
+            <MandatorySoftwareStatement>false</MandatorySoftwareStatement>
             <EnableFAPIEnforcement>false</EnableFAPIEnforcement>
             <EnableSectorIdentifierURIValidation>false</EnableSectorIdentifierURIValidation>
         </DCRM>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -713,6 +713,10 @@
         -->
         <DCRM>
             <ApplicationRolePermissionRequiredToView>true</ApplicationRolePermissionRequiredToView>
+            <ClientAuthenticationRequired>true</ClientAuthenticationRequired>
+            <MandatorySoftwareStatement>true</MandatorySoftwareStatement>
+            <EnableFAPIEnforcement>false</EnableFAPIEnforcement>
+            <EnableSectorIdentifierURIValidation>false</EnableSectorIdentifierURIValidation>
         </DCRM>
 
         <!--

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1055,6 +1055,8 @@
         -->
         <DCRM>
             <ApplicationRolePermissionRequiredToView>{{oauth.dcrm.application_role_permission_required_to_view}}</ApplicationRolePermissionRequiredToView>
+            <ClientAuthenticationRequired>{{oauth.dcr.authentication_required}}</ClientAuthenticationRequired>
+            <MandatorySoftwareStatement>{{oauth.dcr.mandate_ssa}}</MandatorySoftwareStatement>
             {% if oauth.dcr.ssa_jkws is defined %}
             <SoftwareStatementJWKS>{{oauth.dcr.ssa_jkws}}</SoftwareStatementJWKS>
             {% endif %}

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -111,7 +111,6 @@
   "oauth.jwk_thumbprint_enable_sha256": true,
   "oauth.mtls_aliases.enabled": false,
   "oauth.mtls_aliases.hostname": "$ref{server.hostname}",
-
   "oauth.response_type.token.enable": true,
   "oauth.response_type.token.class": "org.wso2.carbon.identity.oauth2.authz.handlers.AccessTokenResponseTypeHandler",
   "oauth.response_type.code.enable": true,
@@ -192,6 +191,8 @@
   "oauth.dcrm.application_role_permission_required_to_view": true,
   "oauth.dcr.enable_fapi_enforcement": false,
   "oauth.dcr.enable_sector_identifier_validation": false,
+  "oauth.dcr.authentication_required": true,
+  "oauth.dcr.mandate_ssa": false,
   "oauth.enable_jwt_token_validation_during_introspection": true,
   "oauth.use_client_id_as_sub_claim_for_app_tokens": true,
   "oauth.remove_username_from_introspection_response_for_app_tokens": true,


### PR DESCRIPTION
### Proposed changes in this pull request

> This PR adds default DCR server configurations to `default.json` and `identity.xml.j2`

Related Issue: https://github.com/wso2/product-is/issues/19274