### PR TITLE
Remove unnecessary removal of Internal domain from the filter

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserRealmProxy.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserRealmProxy.java
@@ -493,10 +493,6 @@ public class UserRealmProxy {
                 filteredDomain = filter.split(CarbonConstants.DOMAIN_SEPARATOR)[0];
             }
 
-            if (filter.startsWith(UserCoreConstants.INTERNAL_DOMAIN + CarbonConstants.DOMAIN_SEPARATOR)) {
-                filter = filter.substring(filter.indexOf(CarbonConstants.DOMAIN_SEPARATOR) + 1);
-            }
-
             String[] hybridRoles = ((AbstractUserStoreManager) userStoreMan).getHybridRoles(filter);
 
             // Filter the internal system roles created to maintain the backward compatibility.


### PR DESCRIPTION
### Purpose
- There's no need to remove the domain from the filter when searching for Internal roles as this is handled properly at the Hybrid role manager level.

### Related Issue
- https://github.com/wso2/product-is/issues/20264