### PR TITLE
Fix user being provisioned as username@tenantdomain when associate to local user is enabled

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -404,14 +404,6 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                                 + " coming from " + externalIdPConfig.getIdPName()
                                 + " do have a local account, with the username " + username);
                     }
-                    //When the local user association is enabled, user email id will be used to create the association.
-                    //Since the default provisioning handler removes the email domain, in case the username equals to
-                    //the email address, tenant domain is appended to the username.
-                    if (externalIdPConfig.isAssociateLocalUserEnabled() &&
-                            StringUtils.equals(UserCoreUtil.removeDomainFromName(username),
-                                    localClaimValues.get(EMAIL_ADDRESS_CLAIM))) {
-                        username = UserCoreUtil.addTenantDomainToEntry(username, context.getTenantDomain());
-                    }
                     callDefaultProvisioningHandler(username, context, externalIdPConfig, localClaimValues,
                             stepConfig);
                 }


### PR DESCRIPTION
### Proposed changes in this pull request

With [this change](https://github.com/wso2/carbon-identity-framework/pull/5237) the tenant aware username resolution is removed from the `DefaultProvisioningHandler`. Therefore in the `JITProvisioningPostAuthenticationHandler` tenant domain shouldn't be added to the username.

### Issue