### PR TITLE
Return user sessions belongs to the requested tenant

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/UserSessionManagementServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/UserSessionManagementServiceImpl.java
@@ -1,19 +1,19 @@
 /*
- *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018-2024, WSO2 LLC. (http://www.wso2.com).
  *
- *   WSO2 Inc. licenses this file to you under the Apache License,
- *   Version 2.0 (the "License"); you may not use this file except
- *   in compliance with the License.
- *   You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.wso2.carbon.identity.application.authentication.framework.internal.impl;
 
@@ -583,6 +583,13 @@ public class UserSessionManagementServiceImpl implements UserSessionManagementSe
                 SessionContext sessionContext = FrameworkUtils.getSessionContextFromCache(sessionId,
                         FrameworkUtils.getLoginTenantDomainFromContext());
                 if (sessionContext != null) {
+                    if (sessionContext.getProperties().get(FrameworkUtils.TENANT_DOMAIN) instanceof String) {
+                        String tenantDomain = (String) sessionContext.getProperties().get(FrameworkUtils.TENANT_DOMAIN);
+                        // User's sessions belongs to the requested tenant is returned.
+                        if (!StringUtils.equals(FrameworkUtils.getLoginTenantDomainFromContext(), tenantDomain)) {
+                            continue;
+                        }
+                    }
                     UserSessionDAO userSessionDAO = new UserSessionDAOImpl();
                     UserSession userSession = userSessionDAO.getSession(sessionId);
                     if (userSession != null) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/UserSessionManagementServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/UserSessionManagementServiceImpl.java
@@ -583,7 +583,8 @@ public class UserSessionManagementServiceImpl implements UserSessionManagementSe
                 SessionContext sessionContext = FrameworkUtils.getSessionContextFromCache(sessionId,
                         FrameworkUtils.getLoginTenantDomainFromContext());
                 if (sessionContext != null) {
-                    if (sessionContext.getProperties().get(FrameworkUtils.TENANT_DOMAIN) instanceof String) {
+                    if (sessionContext.getProperties() != null &&
+                            sessionContext.getProperties().get(FrameworkUtils.TENANT_DOMAIN) instanceof String) {
                         String tenantDomain = (String) sessionContext.getProperties().get(FrameworkUtils.TENANT_DOMAIN);
                         // User's sessions belongs to the requested tenant is returned.
                         if (!StringUtils.equals(FrameworkUtils.getLoginTenantDomainFromContext(), tenantDomain)) {


### PR DESCRIPTION
### Proposed changes in this pull request

The user sessions are stored in the "IDN_AUTH_USER_SESSION_MAPPING" table. There is no tenant domain mapping, but sessions are stored against the user-ids.

<img width="800" alt="Screenshot 2024-05-14 at 14 58 01" src="https://github.com/wso2/carbon-identity-framework/assets/35717390/bbf3caef-7c69-497a-bd02-85eb002c71e9">



There can be situations, the same user store is plugged in multiple tenants. In such cases, the user IDs will be same when the same user accessing apps in each tenants. But when viewing the active sessions from each tenant, all the tenanted sessions will be retrieved.

This PR is initiated to return only the sessions belongs to the requested tenant.