### PR TITLE
Fix the issue sub org roles are not deleting when the app is deleting

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -346,6 +346,7 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
             throws IdentityApplicationManagementException {
 
         ApplicationDAO appDAO;
+        ApplicationBasicInfo[] applicationBasicInfos;
         // invoking the listeners
         Collection<ApplicationMgtListener> listeners = getApplicationMgtListeners();
         for (ApplicationMgtListener listener : listeners) {
@@ -358,16 +359,18 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
         try {
             startTenantFlow(tenantDomain, username);
             appDAO = ApplicationMgtSystemConfig.getInstance().getApplicationDAO();
+
+            if (!(appDAO instanceof AbstractApplicationDAOImpl)) {
+                log.error("Get application basic info service is not supported.");
+                throw new IdentityApplicationManagementException("This service is not supported.");
+            }
+
+            applicationBasicInfos = ((AbstractApplicationDAOImpl) appDAO).getApplicationBasicInfoBySPProperty(key, value);
         } finally {
             endTenantFlow();
         }
 
-        if (!(appDAO instanceof AbstractApplicationDAOImpl)) {
-            log.error("Get application basic info service is not supported.");
-            throw new IdentityApplicationManagementException("This service is not supported.");
-        }
-
-        return ((AbstractApplicationDAOImpl) appDAO).getApplicationBasicInfoBySPProperty(key, value);
+        return applicationBasicInfos;
     }
 
     /**

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -365,7 +365,8 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
                 throw new IdentityApplicationManagementException("This service is not supported.");
             }
 
-            applicationBasicInfos = ((AbstractApplicationDAOImpl) appDAO).getApplicationBasicInfoBySPProperty(key, value);
+            applicationBasicInfos = ((AbstractApplicationDAOImpl) appDAO)
+                    .getApplicationBasicInfoBySPProperty(key, value);
         } finally {
             endTenantFlow();
         }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/DefaultRoleManagementListener.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/DefaultRoleManagementListener.java
@@ -52,6 +52,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.ALLOWED_ROLE_AUDIENCE_PROPERTY_NAME;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.APPLICATION;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.Error.INVALID_AUDIENCE;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.Error.INVALID_PERMISSION;
@@ -497,13 +498,17 @@ public class DefaultRoleManagementListener extends AbstractApplicationMgtListene
             Role role = ApplicationManagementServiceComponentHolder.getInstance().getRoleManagementServiceV2()
                    .getRole(roleId, tenantDomain);
             if (ORGANIZATION.equalsIgnoreCase(role.getAudience())) {
-                ApplicationBasicInfo[] associatedApplications = ApplicationManagementService.getInstance().getApplicationBasicInfoBySPProperty(tenantDomain, PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername(),"allowedAudienceForAssociatedRoles",ORGANIZATION);
+                ApplicationBasicInfo[] associatedApplications = ApplicationManagementService.getInstance()
+                        .getApplicationBasicInfoBySPProperty(tenantDomain,
+                                PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername(),
+                                ALLOWED_ROLE_AUDIENCE_PROPERTY_NAME, ORGANIZATION);
                 associatedApplicationByRoleId.addAll(Arrays.stream(associatedApplications)
                         .map(ApplicationBasicInfo::getUuid).collect(Collectors.toList()));
             }
         } catch (IdentityRoleManagementException | IdentityApplicationManagementException e) {
             throw new IdentityRoleManagementException(
-                String.format("Error occurred while getting associated apps of role : %s in tenant domain : %s", tenantDomain), e);
+                String.format("Error occurred while getting associated apps of role : %s in tenant domain : %s",
+                        tenantDomain), e);
         }
     }
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/DefaultRoleManagementListener.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/DefaultRoleManagementListener.java
@@ -486,6 +486,11 @@ public class DefaultRoleManagementListener extends AbstractApplicationMgtListene
     }
 
     @Override
+    public void preGetAssociatedApplicationIdsByRoleId(String roleId, String tenantDomain)
+            throws IdentityRoleManagementException {
+    }
+
+    @Override
     public void postGetAssociatedApplicationIdsByRoleId(List<String> associatedApplicationByRoleId, String roleId,
                                                         String tenantDomain) throws IdentityRoleManagementException {
         try {

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/DefaultRoleManagementListener.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/DefaultRoleManagementListener.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.application.mgt.listener;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
 import org.wso2.carbon.identity.application.common.model.AuthorizedScopes;
@@ -46,13 +47,16 @@ import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.UserBasicInfo;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.APPLICATION;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.Error.INVALID_AUDIENCE;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.Error.INVALID_PERMISSION;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.Error.UNEXPECTED_SERVER_ERROR;
+import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.ORGANIZATION;
 
 /**
  * Default Role Management Listener implementation of Role Management V2 Listener,
@@ -479,6 +483,23 @@ public class DefaultRoleManagementListener extends AbstractApplicationMgtListene
     public void postDeleteRolesByApplication(String applicationId, String tenantDomain)
             throws IdentityRoleManagementException {
 
+    }
+
+    @Override
+    public void postGetAssociatedApplicationIdsByRoleId(List<String> associatedApplicationByRoleId, String roleId,
+                                                        String tenantDomain) throws IdentityRoleManagementException {
+        try {
+            Role role = ApplicationManagementServiceComponentHolder.getInstance().getRoleManagementServiceV2()
+                   .getRole(roleId, tenantDomain);
+            if (ORGANIZATION.equalsIgnoreCase(role.getAudience())) {
+                ApplicationBasicInfo[] associatedApplications = ApplicationManagementService.getInstance().getApplicationBasicInfoBySPProperty(tenantDomain, PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername(),"allowedAudienceForAssociatedRoles",ORGANIZATION);
+                associatedApplicationByRoleId.addAll(Arrays.stream(associatedApplications)
+                        .map(ApplicationBasicInfo::getUuid).collect(Collectors.toList()));
+            }
+        } catch (IdentityRoleManagementException | IdentityApplicationManagementException e) {
+            throw new IdentityRoleManagementException(
+                String.format("Error occurred while getting associated apps of role : %s in tenant domain : %s", tenantDomain), e);
+        }
     }
 
     /**

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.role.v2.mgt.core;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -880,7 +879,8 @@ public class RoleManagementServiceImpl implements RoleManagementService {
     public List<String> getAssociatedApplicationByRoleId(String roleId, String tenantDomain)
             throws IdentityRoleManagementException {
 
-        List<RoleManagementListener> roleManagementListenerList = RoleManagementServiceComponentHolder.getInstance().getRoleManagementListenerList();
+        List<RoleManagementListener> roleManagementListenerList =
+                RoleManagementServiceComponentHolder.getInstance().getRoleManagementListenerList();
         for (RoleManagementListener roleManagementListener : roleManagementListenerList) {
             if (roleManagementListener.isEnable()) {
                 roleManagementListener.preGetAssociatedApplicationIdsByRoleId(roleId, tenantDomain);
@@ -889,7 +889,8 @@ public class RoleManagementServiceImpl implements RoleManagementService {
         List<String> associatedApplicationIds = roleDAO.getAssociatedApplicationIdsByRoleId(roleId, tenantDomain);
         for (RoleManagementListener roleManagementListener : roleManagementListenerList) {
             if (roleManagementListener.isEnable()) {
-                roleManagementListener.postGetAssociatedApplicationIdsByRoleId(associatedApplicationIds, roleId, tenantDomain);
+                roleManagementListener.postGetAssociatedApplicationIdsByRoleId(associatedApplicationIds,
+                        roleId, tenantDomain);
             }
         }
         return associatedApplicationIds;

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
@@ -364,7 +364,6 @@ public class RoleManagementServiceImpl implements RoleManagementService {
         RoleManagementEventPublisherProxy roleManagementEventPublisherProxy = RoleManagementEventPublisherProxy
                 .getInstance();
         roleManagementEventPublisherProxy.publishPreDeleteRoleWithException(roleId, tenantDomain);
-        //doPreValidateRoleDeletion(roleId, tenantDomain);
         roleDAO.deleteRole(roleId, tenantDomain);
         roleManagementEventPublisherProxy.publishPostDeleteRole(roleId, tenantDomain);
         for (RoleManagementListener roleManagementListener : roleManagementListenerList) {
@@ -377,20 +376,6 @@ public class RoleManagementServiceImpl implements RoleManagementService {
                     getUser(tenantDomain), roleId));
         }
     }
-
-//    private void doPreValidateRoleDeletion(String roleId, String tenantDomain) throws IdentityRoleManagementException {
-
-//        RoleBasicInfo roleBasicInfo = getRoleBasicInfoById(roleId, tenantDomain);
-//        String roleAudience = roleBasicInfo.getAudience();
-//        if (APPLICATION.equalsIgnoreCase(roleAudience)) {
-//            return;
-//        }
-//        List<String> associatedApplicationByRoleId = getAssociatedApplicationByRoleId(roleId, tenantDomain);
-//        if (CollectionUtils.isNotEmpty(associatedApplicationByRoleId)) {
-//            throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(),
-//                    "Unable to delete the role since it is associated with applications.");
-//        }
-//    }
 
     @Override
     public List<UserBasicInfo> getUserListOfRole(String roleId, String tenantDomain)

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -653,7 +653,7 @@ public class RoleDAOImpl implements RoleDAO {
     public void deleteRole(String roleId, String tenantDomain) throws IdentityRoleManagementException {
 
         String roleName = getRoleNameByID(roleId, tenantDomain);
-        if (systemRoles.contains(roleName)) {
+        if (systemRoles.contains(roleName) && !isSubOrgByTenant(tenantDomain)) {
             throw new IdentityRoleManagementClientException(OPERATION_FORBIDDEN.getCode(),
                     "Invalid operation. Role: " + roleName + " Cannot be deleted since it's a read only system role.");
         }
@@ -661,8 +661,9 @@ public class RoleDAOImpl implements RoleDAO {
         UserRealm userRealm;
         try {
             userRealm = CarbonContext.getThreadLocalCarbonContext().getUserRealm();
-            if (UserCoreUtil.isEveryoneRole(roleName, userRealm.getRealmConfiguration())
-                    || isInternalAdminOrSystemRole(roleId, tenantDomain, userRealm)) {
+            if (!isSubOrgByTenant(tenantDomain) &&
+                    (UserCoreUtil.isEveryoneRole(roleName, userRealm.getRealmConfiguration())
+                    || isInternalAdminOrSystemRole(roleId, tenantDomain, userRealm))) {
                 throw new IdentityRoleManagementClientException(OPERATION_FORBIDDEN.getCode(),
                         "Invalid operation. Role: " + roleName + " Cannot be deleted.");
             }

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -661,9 +661,8 @@ public class RoleDAOImpl implements RoleDAO {
         UserRealm userRealm;
         try {
             userRealm = CarbonContext.getThreadLocalCarbonContext().getUserRealm();
-            if (!isSubOrgByTenant(tenantDomain) &&
-                    (UserCoreUtil.isEveryoneRole(roleName, userRealm.getRealmConfiguration())
-                    || isInternalAdminOrSystemRole(roleId, tenantDomain, userRealm))) {
+            if ((UserCoreUtil.isEveryoneRole(roleName, userRealm.getRealmConfiguration())
+                    || isInternalAdminOrSystemRole(roleId, tenantDomain, userRealm)) && !isSubOrgByTenant(tenantDomain)) {
                 throw new IdentityRoleManagementClientException(OPERATION_FORBIDDEN.getCode(),
                         "Invalid operation. Role: " + roleName + " Cannot be deleted.");
             }

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -662,7 +662,8 @@ public class RoleDAOImpl implements RoleDAO {
         try {
             userRealm = CarbonContext.getThreadLocalCarbonContext().getUserRealm();
             if ((UserCoreUtil.isEveryoneRole(roleName, userRealm.getRealmConfiguration())
-                    || isInternalAdminOrSystemRole(roleId, tenantDomain, userRealm)) && !isSubOrgByTenant(tenantDomain)) {
+                    || isInternalAdminOrSystemRole(roleId, tenantDomain, userRealm))
+                    && !isSubOrgByTenant(tenantDomain)) {
                 throw new IdentityRoleManagementClientException(OPERATION_FORBIDDEN.getCode(),
                         "Invalid operation. Role: " + roleName + " Cannot be deleted.");
             }

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -515,7 +515,7 @@ public class RoleDAOImpl implements RoleDAO {
     public List<Permission> getPermissionListOfRole(String roleId, String tenantDomain)
             throws IdentityRoleManagementException {
 
-        if (isSubOrgByTenant(tenantDomain)) {
+        if (isOrganization(tenantDomain)) {
             return getPermissionsOfSharedRole(roleId, tenantDomain);
         } else {
             return getPermissions(roleId, tenantDomain);
@@ -526,7 +526,7 @@ public class RoleDAOImpl implements RoleDAO {
     public List<String> getPermissionListOfRoles(List<String> roleIds, String tenantDomain)
             throws IdentityRoleManagementException {
 
-        if (isSubOrgByTenant(tenantDomain)) {
+        if (isOrganization(tenantDomain)) {
             return getPermissionsOfSharedRoles(roleIds, tenantDomain);
         } else {
             return getPermissionListOfRolesByIds(roleIds, tenantDomain);
@@ -653,7 +653,7 @@ public class RoleDAOImpl implements RoleDAO {
     public void deleteRole(String roleId, String tenantDomain) throws IdentityRoleManagementException {
 
         String roleName = getRoleNameByID(roleId, tenantDomain);
-        if (systemRoles.contains(roleName) && !isSubOrgByTenant(tenantDomain)) {
+        if (systemRoles.contains(roleName) && !isOrganization(tenantDomain)) {
             throw new IdentityRoleManagementClientException(OPERATION_FORBIDDEN.getCode(),
                     "Invalid operation. Role: " + roleName + " Cannot be deleted since it's a read only system role.");
         }
@@ -663,7 +663,7 @@ public class RoleDAOImpl implements RoleDAO {
             userRealm = CarbonContext.getThreadLocalCarbonContext().getUserRealm();
             if ((UserCoreUtil.isEveryoneRole(roleName, userRealm.getRealmConfiguration())
                     || isInternalAdminOrSystemRole(roleId, tenantDomain, userRealm))
-                    && !isSubOrgByTenant(tenantDomain)) {
+                    && !isOrganization(tenantDomain)) {
                 throw new IdentityRoleManagementClientException(OPERATION_FORBIDDEN.getCode(),
                         "Invalid operation. Role: " + roleName + " Cannot be deleted.");
             }
@@ -995,7 +995,7 @@ public class RoleDAOImpl implements RoleDAO {
                     roles.add(roleBasicInfo);
                 }
             }
-            if (!isSubOrgByTenant(tenantDomain)) {
+            if (!isOrganization(tenantDomain)) {
                 roles.add(getEveryOneRole(tenantDomain));
             }
         } catch (SQLException e) {
@@ -1185,7 +1185,7 @@ public class RoleDAOImpl implements RoleDAO {
                     roleIds.add(roleId);
                 }
             }
-            if (!isSubOrgByTenant(tenantDomain)) {
+            if (!isOrganization(tenantDomain)) {
                 roleIds.add(getEveryOneRoleId(tenantDomain));
             }
         } catch (SQLException e) {
@@ -1529,7 +1529,7 @@ public class RoleDAOImpl implements RoleDAO {
                 addRoleID(roleId, roleName, audienceRefId, tenantDomain, connection);
                 addPermissions(roleId, permissions, tenantDomain, connection);
 
-                if (APPLICATION.equals(audience) && !isSubOrgByTenant(tenantDomain)) {
+                if (APPLICATION.equals(audience) && !isOrganization(tenantDomain)) {
                     addAppRoleAssociation(roleId, audienceId, connection);
                 }
                 IdentityDatabaseUtil.commitTransaction(connection);
@@ -1586,7 +1586,7 @@ public class RoleDAOImpl implements RoleDAO {
      * @return is Shared Organization.
      * @throws IdentityRoleManagementException IdentityRoleManagementException.
      */
-    private boolean isSubOrgByTenant(String tenantDomain) throws IdentityRoleManagementException {
+    private boolean isOrganization(String tenantDomain) throws IdentityRoleManagementException {
 
         try {
             return OrganizationManagementUtil.isOrganization(tenantDomain);

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/listener/AbstractRoleManagementListener.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/listener/AbstractRoleManagementListener.java
@@ -334,13 +334,14 @@ public abstract class AbstractRoleManagementListener implements RoleManagementLi
     }
 
     @Override
-    public void preGetAssociatedApplicationIdsByRoleId(String roleId, String tenantDomain) throws IdentityRoleManagementException {
+    public void preGetAssociatedApplicationIdsByRoleId(String roleId, String tenantDomain)
+            throws IdentityRoleManagementException {
 
     }
 
     @Override
-    public void postGetAssociatedApplicationIdsByRoleId(List<String> associatedApplicationByRoleId, String roleId, String tenantDomain)
-            throws IdentityRoleManagementException {
+    public void postGetAssociatedApplicationIdsByRoleId(List<String> associatedApplicationByRoleId, String roleId,
+                                                        String tenantDomain) throws IdentityRoleManagementException {
 
     }
 

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/listener/AbstractRoleManagementListener.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/listener/AbstractRoleManagementListener.java
@@ -334,6 +334,17 @@ public abstract class AbstractRoleManagementListener implements RoleManagementLi
     }
 
     @Override
+    public void preGetAssociatedApplicationIdsByRoleId(String roleId, String tenantDomain) throws IdentityRoleManagementException {
+
+    }
+
+    @Override
+    public void postGetAssociatedApplicationIdsByRoleId(List<String> associatedApplicationByRoleId, String roleId, String tenantDomain)
+            throws IdentityRoleManagementException {
+
+    }
+
+    @Override
     public int getExecutionOrderId() {
 
         IdentityEventListenerConfig identityEventListenerConfig = IdentityUtil.readEventListenerProperty

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/listener/RoleManagementListener.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/listener/RoleManagementListener.java
@@ -664,8 +664,8 @@ public interface RoleManagementListener {
      * @param tenantDomain  The domain in which the operation was performed.
      * @throws IdentityRoleManagementException If an error occurs during the post-deletion phase.
      */
-    void postGetAssociatedApplicationIdsByRoleId(List<String> associatedApplicationByRoleId, String roleId, String tenantDomain)
-            throws IdentityRoleManagementException;
+    void postGetAssociatedApplicationIdsByRoleId(List<String> associatedApplicationByRoleId, String roleId,
+                                                 String tenantDomain) throws IdentityRoleManagementException;
 
     default void preGetPermissionListOfRoles(List<String> roleIds, String tenantDomain)
             throws IdentityRoleManagementException {}

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/listener/RoleManagementListener.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/listener/RoleManagementListener.java
@@ -651,10 +651,11 @@ public interface RoleManagementListener {
      *
      * @param roleId                        The unique identifier of the role.
      * @param tenantDomain  The domain in which the operation was performed.
-     * @throws IdentityRoleManagementException If an error occurs during the post-deletion phase.
+     * @throws IdentityRoleManagementException If an error occurs while executing pre-listeners of
+     * retrieving associated applications of a role.
      */
-    void preGetAssociatedApplicationIdsByRoleId(String roleId, String tenantDomain)
-            throws IdentityRoleManagementException;
+    default void preGetAssociatedApplicationIdsByRoleId(String roleId, String tenantDomain)
+            throws IdentityRoleManagementException {};
 
     /**
      * Invoked after getting the associate applications for a role in the given tenant domain.
@@ -662,10 +663,11 @@ public interface RoleManagementListener {
      * @param associatedApplicationByRoleId The list of associate app ids for a role id.
      * @param roleId                        The unique identifier of the role.
      * @param tenantDomain  The domain in which the operation was performed.
-     * @throws IdentityRoleManagementException If an error occurs during the post-deletion phase.
+     * @throws IdentityRoleManagementException If an error occurs while executing post-listeners of retrieving
+     * associated applications of a role.
      */
-    void postGetAssociatedApplicationIdsByRoleId(List<String> associatedApplicationByRoleId, String roleId,
-                                                 String tenantDomain) throws IdentityRoleManagementException;
+    default void postGetAssociatedApplicationIdsByRoleId(List<String> associatedApplicationByRoleId, String roleId,
+                                                 String tenantDomain) throws IdentityRoleManagementException {};
 
     default void preGetPermissionListOfRoles(List<String> roleIds, String tenantDomain)
             throws IdentityRoleManagementException {}

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/listener/RoleManagementListener.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/listener/RoleManagementListener.java
@@ -646,6 +646,27 @@ public interface RoleManagementListener {
     void postDeleteRolesByApplication(String applicationId, String tenantDomain)
             throws IdentityRoleManagementException;
 
+    /**
+     * Invoked before getting the associate applications for a role in the given tenant domain.
+     *
+     * @param roleId                        The unique identifier of the role.
+     * @param tenantDomain  The domain in which the operation was performed.
+     * @throws IdentityRoleManagementException If an error occurs during the post-deletion phase.
+     */
+    void preGetAssociatedApplicationIdsByRoleId(String roleId, String tenantDomain)
+            throws IdentityRoleManagementException;
+
+    /**
+     * Invoked after getting the associate applications for a role in the given tenant domain.
+     *
+     * @param associatedApplicationByRoleId The list of associate app ids for a role id.
+     * @param roleId                        The unique identifier of the role.
+     * @param tenantDomain  The domain in which the operation was performed.
+     * @throws IdentityRoleManagementException If an error occurs during the post-deletion phase.
+     */
+    void postGetAssociatedApplicationIdsByRoleId(List<String> associatedApplicationByRoleId, String roleId, String tenantDomain)
+            throws IdentityRoleManagementException;
+
     default void preGetPermissionListOfRoles(List<String> roleIds, String tenantDomain)
             throws IdentityRoleManagementException {}
 


### PR DESCRIPTION
### Purpose
- $subject

### Changes from this PR
- The roles admin and everyone in sub org is created when the application is shared with the sub orgs.
- Then if there only one app shared with the sub org, when we are deleting the app, the relevant roles also should be deleted.
- Add a pre-listner to get the associated app ids.


