### PR TITLE
Add a flag to ignore custom domain configurations when building service urls

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
@@ -115,6 +115,7 @@ public class ApplicationConstants {
     public static final String MY_ACCOUNT_ACCESS_URL_FROM_SERVER_CONFIGS = "MyAccount.AccessURL";
     public static final String CONSOLE_APPLICATION_CLIENT_ID = "CONSOLE";
     public static final String CONSOLE_APPLICATION_INBOUND_TYPE = "oauth2";
+    public static final String MY_ACCOUNT_APPLICATION_CLIENT_ID = "MY_ACCOUNT";
     public static final String TENANT_DOMAIN_PLACEHOLDER = "{TENANT_DOMAIN}";
     public static final String CONSOLE_ACCESS_ORIGIN = "Console.Origin";
     public static final String MYACCOUNT_ACCESS_ORIGIN = "MyAccount.Origin";

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
@@ -58,6 +58,7 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
     protected boolean mandateTenantedPath = false;
     protected Map<String, String> parameters = new HashMap<>();
     protected Map<String, String> fragmentParams = new HashMap<>();
+    protected boolean skipCustomDomain = false;
 
     /**
      * Returns {@link ServiceURLBuilder} appended the URL path.
@@ -209,6 +210,12 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
     public ServiceURLBuilder addFragmentParameter(String key, String value) {
 
         fragmentParams.put(key, value);
+        return this;
+    }
+
+    @Override
+    public ServiceURLBuilder setSkipCustomDomain(boolean skipCustomDomain) {
+        this.skipCustomDomain = skipCustomDomain;
         return this;
     }
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
@@ -58,7 +58,9 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
     protected boolean mandateTenantedPath = false;
     protected Map<String, String> parameters = new HashMap<>();
     protected Map<String, String> fragmentParams = new HashMap<>();
-    protected boolean skipCustomDomain = false;
+    // This flag is added to skip custom domain configurations.
+    // When set to true, custom domain configurations for the tenant will be ignored when building service urls.
+    protected boolean skipDomainBranding = false;
 
     /**
      * Returns {@link ServiceURLBuilder} appended the URL path.
@@ -214,8 +216,9 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
     }
 
     @Override
-    public ServiceURLBuilder setSkipCustomDomain(boolean skipCustomDomain) {
-        this.skipCustomDomain = skipCustomDomain;
+    public ServiceURLBuilder setSkipDomainBranding(boolean skipDomainBranding) {
+
+        this.skipDomainBranding = skipDomainBranding;
         return this;
     }
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURLBuilder.java
@@ -70,6 +70,16 @@ public interface ServiceURLBuilder {
      */
     ServiceURLBuilder addFragmentParameter(String key, String value);
 
+    /**
+     * Returns {@link ServiceURLBuilder} after setting skipCustomDomain flag
+     *
+     * @param skipCustomDomain          Tenant domain.
+     * @return  {@link ServiceURLBuilder}
+     */
+    default ServiceURLBuilder setSkipCustomDomain(boolean skipCustomDomain) {
+
+        return this;
+    }
 
     /**
      * Returns {@link ServiceURLBuilder} with tenant domain set for the context.

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/ServiceURLBuilder.java
@@ -73,10 +73,10 @@ public interface ServiceURLBuilder {
     /**
      * Returns {@link ServiceURLBuilder} after setting skipCustomDomain flag
      *
-     * @param skipCustomDomain          Tenant domain.
+     * @param skipDomainBranding          Tenant domain.
      * @return  {@link ServiceURLBuilder}
      */
-    default ServiceURLBuilder setSkipCustomDomain(boolean skipCustomDomain) {
+    default ServiceURLBuilder setSkipDomainBranding(boolean skipDomainBranding) {
 
         return this;
     }


### PR DESCRIPTION
### Proposed changes in this pull request
Added a flag that can be used to skip custom domains when building service urls. When this is set to true, custom domain configurations for the tenant will be ignored and the service urls will be built using the default builder