### PR TITLE
Fix userClaim not getting set in for login onFail scenario

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsClaims.java
@@ -92,10 +92,12 @@ public abstract class JsClaims extends AbstractJSContextMemberObject implements 
     public void initializeContext(AuthenticationContext context) {
 
         super.initializeContext(context);
-        if (StringUtils.isNotBlank(idp) && getContext().getCurrentAuthenticatedIdPs().containsKey(idp)) {
-            this.authenticatedUser = getContext().getCurrentAuthenticatedIdPs().get(idp).getUser();
-        } else {
-            this.authenticatedUser = getAuthenticatedUserFromSubjectIdentifierStep();
+        if (this.authenticatedUser == null) {
+            if (StringUtils.isNotBlank(idp) && getContext().getCurrentAuthenticatedIdPs().containsKey(idp)) {
+                this.authenticatedUser = getContext().getCurrentAuthenticatedIdPs().get(idp).getUser();
+            } else {
+                this.authenticatedUser = getAuthenticatedUserFromSubjectIdentifierStep();
+            }
         }
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request
- Add a null check for `authentcatedUser` object before retrying to resolve the authenticated user

### Related issue
- https://github.com/wso2/product-is/issues/20446