### PR TITLE
Allow list access to GraalJS

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/graaljs/JsGraalGraphBuilderFactory.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/graaljs/JsGraalGraphBuilderFactory.java
@@ -131,6 +131,7 @@ public class JsGraalGraphBuilderFactory implements JsGenericGraphBuilderFactory<
          * functional interfaces we have for existing conditional authentication functions.
          */
         return HostAccess.newBuilder(HostAccess.EXPLICIT)
+                .allowListAccess(true)
                 .targetTypeMapping(Value.class, JsAuthenticationContext.class,
                         (v) -> v.asProxyObject() instanceof JsAuthenticationContext,
                         (v) -> (JsAuthenticationContext) v.asProxyObject())


### PR DESCRIPTION
### Proposed changes in this pull request
- Allow Java List access to GraalJS
- This eliminates the need to explicitly convert Java Lists as Proxy Arrays when returning conditional authentication function results to javascript runtime.