### PR TITLE
Add validation to catch constraint violation and ignore gracefully

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthHistory;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.DuplicatedAuthUserException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.PostAuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
@@ -898,7 +899,17 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                                         user.getUserStoreDomain(), user.getUserName());
                         if (StringUtils.isNotEmpty(localUserId) &&
                                 !UserSessionStore.getInstance().isExistingMapping(localUserId, sessionContextKey)) {
-                            UserSessionStore.getInstance().storeUserSessionData(localUserId, sessionContextKey);
+                            try {
+                                UserSessionStore.getInstance().storeUserSessionData(localUserId, sessionContextKey);
+                            } catch (DuplicatedAuthUserException e) {
+                                // If isExistingMapping return false due to a database write latency issue,
+                                // the same user to session mapping will be persisted from the same node handling the
+                                // request. Thus, persisting the user to session mapping can be gracefully ignored here.
+                                if (log.isDebugEnabled()) {
+                                    log.debug("Mapping between session Id: " + sessionContextKey + " and user Id: "
+                                            + userId + " is already persisted.");
+                                }
+                            }
                         }
                     }
                 } catch (UserSessionException e) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStore.java
@@ -343,6 +343,15 @@ public class UserSessionStore {
                 if (log.isDebugEnabled()) {
                     log.debug("Stored user session data for user " + userId + " with session id: " + sessionId);
                 }
+            } catch (SQLIntegrityConstraintViolationException e1) {
+                IdentityDatabaseUtil.rollbackTransaction(connection);
+                if (isExistingMapping(userId, sessionId)) {
+                    throw new DuplicatedAuthUserException("Mapping between user Id: " + userId + " and session Id: "
+                            + sessionId + " already exists in the database.", e1);
+                } else {
+                    throw new UserSessionException("Error while storing mapping between user Id: " + userId +
+                            " and session Id: " + sessionId, e1);
+                }
             } catch (SQLException e1) {
                 IdentityDatabaseUtil.rollbackTransaction(connection);
                 throw new UserSessionException("Error while storing mapping between user Id: " + userId +

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStoreTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStoreTest.java
@@ -235,10 +235,8 @@ public class UserSessionStoreTest extends DataStoreBaseTest {
             Exception {
 
         try (Connection connection = getConnection(DB_NAME);
-             Connection connection1 = getConnection(DB_NAME);
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             mockIdentityDataBaseUtilConnection(connection, true, identityDatabaseUtil);
-            mockIdentityDataBaseUtilConnection(connection1, false, identityDatabaseUtil);
             UserSessionStore.getInstance().storeUserSessionData(userId, sessionId);
         }
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStoreTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStoreTest.java
@@ -230,13 +230,15 @@ public class UserSessionStoreTest extends DataStoreBaseTest {
     }
 
     @Test(dataProvider = "getDuplicatedSessionsForUsers", dependsOnMethods = {"testStoreUserSessionData"},
-            expectedExceptions = UserSessionException.class)
+            expectedExceptions = {UserSessionException.class, DuplicatedAuthUserException.class})
     public void testExceptionAtStoreUserSessionDataForDuplicatedSession(String userId, String sessionId) throws
             Exception {
 
         try (Connection connection = getConnection(DB_NAME);
+             Connection connection1 = getConnection(DB_NAME);
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             mockIdentityDataBaseUtilConnection(connection, true, identityDatabaseUtil);
+            mockIdentityDataBaseUtilConnection(connection1, false, identityDatabaseUtil);
             UserSessionStore.getInstance().storeUserSessionData(userId, sessionId);
         }
     }


### PR DESCRIPTION
Related issue:
- https://github.com/wso2/product-is/issues/20468

It was suspected that the constraint key violation might occur since, when checking the mapping for the second time, the method might return false due to any latency in previous database write action. With this PR, the relevant exception will be caught and validated again whether the mapping is already available or not. If available, the flow will be gracefully ignored.