### PR TITLE
Change unit test usages of getIDP function

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStoreTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/store/UserSessionStoreTest.java
@@ -215,7 +215,7 @@ public class UserSessionStoreTest extends DataStoreBaseTest {
     @Test
     public void testGetIdPIdForLocalIdP() throws Exception {
 
-        Assert.assertEquals(-1, UserSessionStore.getInstance().getIdPId("LOCAL"), "Expected -1 as the IdP " +
+        Assert.assertEquals(-1, UserSessionStore.getInstance().getIdPId("LOCAL", -1234), "Expected -1 as the IdP " +
                 "Id for LOCAL IdP.");
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

$subject as the  getIdPId(String idpName) function is deprecated.

Resolves:
- https://github.com/wso2/product-is/issues/20475