### PR TITLE
Remove domain from application roles

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
@@ -298,9 +298,12 @@ public class DefaultClaimHandler implements ClaimHandler {
                                 serviceProviderMappedUserRoles : StringUtils.EMPTY);
             }
             if (CollectionUtils.isNotEmpty(federatedUserRolesUnmappedExclusive)) {
+                Set<String> federatedUserRolesUnmappedInclusiveSetWithoutDomain =
+                        federatedUserRolesUnmappedExclusive.stream().map(UserCoreUtil::removeDomainFromName)
+                                .collect(Collectors.toSet());
                 localUnfilteredClaims.put(FrameworkConstants.APP_ROLES_CLAIM,
                         String.join(FrameworkUtils.getMultiAttributeSeparator(),
-                                federatedUserRolesUnmappedExclusive));
+                                federatedUserRolesUnmappedInclusiveSetWithoutDomain));
             }
         }
 
@@ -780,11 +783,11 @@ public class DefaultClaimHandler implements ClaimHandler {
                             appAssociatedRoles));
                 }
                 if (isAppRoleClaimRequested) {
-                    appAssociatedRoles = appAssociatedRoles.stream()
+                    List<String> appAssociatedRolesWithoutDomain = appAssociatedRoles.stream()
                             .map(UserCoreUtil::removeDomainFromName)
                             .collect(Collectors.toList());;
                     allLocalClaims.put(FrameworkConstants.APP_ROLES_CLAIM, String.join(FrameworkUtils
-                            .getMultiAttributeSeparator(), appAssociatedRoles));
+                            .getMultiAttributeSeparator(), appAssociatedRolesWithoutDomain));
                 }
             } else {
                 if (isRoleClaimRequested && !Boolean.parseBoolean(IdentityUtil.getProperty(

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
@@ -61,6 +61,7 @@ import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.util.ArrayList;
@@ -779,6 +780,9 @@ public class DefaultClaimHandler implements ClaimHandler {
                             appAssociatedRoles));
                 }
                 if (isAppRoleClaimRequested) {
+                    appAssociatedRoles = appAssociatedRoles.stream()
+                            .map(UserCoreUtil::removeDomainFromName)
+                            .collect(Collectors.toList());;
                     allLocalClaims.put(FrameworkConstants.APP_ROLES_CLAIM, String.join(FrameworkUtils
                             .getMultiAttributeSeparator(), appAssociatedRoles));
                 }


### PR DESCRIPTION
### Description
Fix getting the application roles claim in ID token, "Internal/" is removed from the role name.