### PR TITLE
Introduce config to send unsplitted SAML multi valued attributes

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1270,6 +1270,9 @@
         {% if saml.metadata.define_name_id_policy_if_unspecified is defined %}
             <SAML2AuthnRequestNameIdPolicyDefinedIfUnspecified>{{saml.metadata.define_name_id_policy_if_unspecified}}</SAML2AuthnRequestNameIdPolicyDefinedIfUnspecified>
         {% endif %}
+        {% if saml.separate_multi_attributes_from_idp is defined %}
+            <SeparateMultiAttributesFromIdP>{{saml.separate_multi_attributes_from_idp}}</SeparateMultiAttributesFromIdP>
+        {% endif %}
     </SSOService>
 
     <Consent>


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves https://github.com/wso2/product-is/issues/20484

We will preserve the new behaviour(splitting the multi valued SAML attributes), and introduce a config to switch to the old behaviour(unsplitted saml multi valued attributes)


```
[saml]
separate_multi_attributes_from_idp = false.
```

If the app wants to get  the unsplitted SAML multi valued attributes, then can enable above config

Refer https://github.com/wso2/product-is/issues/19745 to check the old behaviour
