### PR TITLE
[5.25.x] Add encoding to avoid XSS vulnerability in JSP

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/role/rename-role.jsp
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/role/rename-role.jsp
@@ -153,8 +153,8 @@
             <form action="rename-role-finish-ajaxprocessor.jsp" method="post" id="renameRoleForm">
 
                 <input type="hidden" id="role_regex" name="role_regex" value=<%=Encode.forHtmlAttribute(regEx)%>>
-                <input type="hidden" id="oldRoleName" name="oldRoleName" value=<%=Encode.forHtmlAttribute(roleName)%>>
-
+                <input type="hidden" id="oldRoleName" name="oldRoleName" value=<%=Encode.forJavaScript(Encode
+                .forUriComponent(roleName))%>>
                 <table class="styledLeft">
                     <thead>
                     <tr>


### PR DESCRIPTION
To avoid the XSS vulnerability found here the value of the roleName parameter used in the hidden input field is properly encoded.

- Security Internal :  https://github.com/wso2-enterprise/security-internals/issues/818