### PR TITLE
Pass empty list when updating added permissions

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
@@ -277,8 +277,8 @@ public class AuthorizedAPIManagementServiceImpl implements AuthorizedAPIManageme
                 tenantDomain);
         try {
             for (RoleV2 role : roles) {
-                getRoleManagementServiceV2().updatePermissionListOfRole(role.getId(), null, removedPermissions,
-                        tenantDomain);
+                getRoleManagementServiceV2().updatePermissionListOfRole(role.getId(), new ArrayList<>(),
+                        removedPermissions, tenantDomain);
             }
         } catch (IdentityRoleManagementException e) {
             throw new IdentityApplicationManagementException("Error while updating permission list of roles " +


### PR DESCRIPTION
### Proposed changes in this pull request
When updating the permissions when removing authorizes scopes, it is better to pass an empty list instead of null since this values can be used in event handlers.