### PR TITLE
Add organization email template scopes for SYSTEM

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -720,6 +720,12 @@
         <Scopes>
             <Scope displayName="View Email Template" name="internal_org_email_mgt_view" 
                     description="View email templates and types in the organization"/>
+            <Scope displayName="Create Email Template" name="internal_org_email_mgt_create"
+                   description="Create new email template and types in the organization"/>
+            <Scope displayName="Update Email Template" name="internal_org_email_mgt_update"
+                   description="Update email templates and types in the organization"/>
+            <Scope displayName="Delete Email Template" name="internal_org_email_mgt_delete"
+                   description="Delete email templates and types in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Entitlement Management API" identifier="/api/identity/entitlement/"


### PR DESCRIPTION
### Description
Sub organization email branding feature requires the following scopes to work in console which are introduced in this PR.
- internal_org_email_mgt_create
- internal_org_email_mgt_update
- internal_org_email_mgt_delete
