### PR TITLE
Skip custom domain for my account & console

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
@@ -326,8 +326,7 @@ public class ConfigurationFacade {
 
     private String buildUrl(String defaultContext, Supplier<String> getValueFromFileBasedConfig) {
 
-        String applicationName = null;
-        applicationName = PrivilegedCarbonContext.getThreadLocalCarbonContext().getApplicationName();
+        String applicationName = PrivilegedCarbonContext.getThreadLocalCarbonContext().getApplicationName();
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
             try {
                 String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
@@ -337,7 +336,6 @@ public class ConfigurationFacade {
                         FrameworkConstants.Application.CONSOLE_APP.equals(applicationName)) {
                     serviceURLBuilder.setSkipDomainBranding(true);
                 }
-
                 return serviceURLBuilder.build().getAbsolutePublicURL();
             } catch (URLBuilderException e) {
                 throw new IdentityRuntimeException(

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.AuthenticationStep;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
@@ -325,11 +326,19 @@ public class ConfigurationFacade {
 
     private String buildUrl(String defaultContext, Supplier<String> getValueFromFileBasedConfig) {
 
+        String applicationName = null;
+        applicationName = PrivilegedCarbonContext.getThreadLocalCarbonContext().getApplicationName();
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
             try {
                 String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
-                return ServiceURLBuilder.create().addPath(defaultContext).setOrganization(organizationId).build()
-                        .getAbsolutePublicURL();
+                ServiceURLBuilder serviceURLBuilder =
+                        ServiceURLBuilder.create().addPath(defaultContext).setOrganization(organizationId);
+                if (FrameworkConstants.Application.MY_ACCOUNT_APP.equals(applicationName) ||
+                        FrameworkConstants.Application.CONSOLE_APP.equals(applicationName)) {
+                    serviceURLBuilder.setSkipDomainBranding(true);
+                }
+
+                return serviceURLBuilder.build().getAbsolutePublicURL();
             } catch (URLBuilderException e) {
                 throw new IdentityRuntimeException(
                         "Error while building tenant qualified url for context: " + defaultContext, e);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -133,10 +133,8 @@ public class DefaultStepHandler implements StepHandler {
                 .get(context.getCurrentStep());
 
         Optional<String> appName = FrameworkUtils.getApplicationName(context);
-
         appName.ifPresent(name ->
                 PrivilegedCarbonContext.getThreadLocalCarbonContext().setApplicationName(name));
-
         List<AuthenticatorConfig> authConfigList = stepConfig.getAuthenticatorList();
 
         String authenticatorNames = FrameworkUtils.getAuthenticatorIdPMappingString(authConfigList);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticationFlowHandler;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
@@ -130,6 +131,11 @@ public class DefaultStepHandler implements StepHandler {
 
         StepConfig stepConfig = context.getSequenceConfig().getStepMap()
                 .get(context.getCurrentStep());
+
+        Optional<String> appName = FrameworkUtils.getApplicationName(context);
+
+        appName.ifPresent(name ->
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setApplicationName(name));
 
         List<AuthenticatorConfig> authConfigList = stepConfig.getAuthenticatorList();
 


### PR DESCRIPTION
### Proposed changes in this pull request
We need to skip custom domain configurations when building the authentication endpoint url for console and my account applications