### PR TITLE
Introduce SERVICE_PROVIDER_UUID EventProperty

### DIFF
--- a/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
@@ -321,6 +321,7 @@ public class IdentityEventConstants {
         public static final String CORRELATION_ID = "correlation-id";
         public static final String APPLICATION_NAME = "application-name";
         public static final String APPLICATION_ID = "application-id";
+        public static final String SERVICE_PROVIDER_UUID = "serviceProviderUUID";
         public static final String USER_AGENT = "user-agent";
         public static final String RESEND_CODE = "resend-code";
         public static final String GENERATED_OTP = "generated-otp";


### PR DESCRIPTION
### Description
Introduce SERVICE_PROVIDER_UUID EventProperty to store SP-UUID in the carbon context.

### Related issue
- https://github.com/wso2/product-is/issues/20543