### PR TITLE
[5.25.x] Exclude pax logging from classpath for utils

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/pom.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/pom.xml
@@ -228,6 +228,10 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Related PR: https://github.com/wso2/carbon-identity-framework/pull/5747