### PR TITLE
Add impersonation email template configs for display purposes in console

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1047,6 +1047,11 @@
       "id": "T3JnYW5pemF0aW9uVXNlckludml0YXRpb24",
       "displayName": "Organization User Invitation",
       "description": "This email is sent when the organization admin invites a user to the organization"
+    },
+    {
+      "id": "SW1wZXJzb25hdGlvbkVtYWlsTm90aWZpY2F0aW9u",
+      "displayName": "Impersonation Email Notification",
+      "description": "This email is sent to the impersonated user when the impersonation session is started"
     }
   ],
   "console.ui.app_copyright": "WSO2 Identity Server",


### PR DESCRIPTION
This PR will add the display name and the description for the impersonation email notification template for the purpose of showing it in the console UI.

After adding this config:
<img width="566" alt="Screenshot 2024-06-24 at 19 53 25" src="https://github.com/wso2/carbon-identity-framework/assets/50801227/15ec0b06-5531-4e11-b73d-2528bdb18791">

Related issue:
- https://github.com/wso2/product-is/issues/20066