### PR TITLE
Fix jdbc scope validator invalid scope issue

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -476,6 +476,7 @@
         Supported versions: IS 5.8.1  onwards
         -->
         <ScopeValidationEnabledForAuthzCodeAndImplicitGrant>true</ScopeValidationEnabledForAuthzCodeAndImplicitGrant>
+        <ScopeValidationPreserveCaseSensitivity>false</ScopeValidationPreserveCaseSensitivity>
 
         <!-- Scope handlers list. The handlers registered here will be executed at the scope validation phase while
              issuing access tokens. -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -684,6 +684,7 @@
         Supported versions: IS 5.8.1  onwards
         -->
         <ScopeValidationEnabledForAuthzCodeAndImplicitGrant>{{oauth.scope_validator.authz_implicit.enable}}</ScopeValidationEnabledForAuthzCodeAndImplicitGrant>
+        <ScopeValidationPreserveCaseSensitivity>{{oauth.scope_validator.preserve_case_sensitivity}}</ScopeValidationPreserveCaseSensitivity>
 
 
         <!-- Scope handlers list. The handlers registered here will be executed at the scope validation phase while

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -211,6 +211,7 @@
   "oauth.scope_validator.xacml.enable": true,
   "oauth.scope_validator.xacml.class": "org.wso2.carbon.identity.oauth2.validators.xacml.XACMLScopeValidator",
   "oauth.scope_validator.authz_implicit.enable": true,
+  "oauth.scope_validator.preserve_case_sensitivity": false,
   "oauth.grant_type.saml_bearer.user_type": "FEDERATED",
 
   "oauth.prompt_consent": "$ref{authentication.consent.prompt}",


### PR DESCRIPTION
When jdbc scope validator is enabled, the scopes are not properly validated due to a fix added with PR[1]. The PR[1] was added with the intention of supporting scopes with case sensitivity. The PR[1] uses environmental variable `preservedCaseSensitive` to determine if case sensitivity is enabled or not. This PR will add a separate config to configure this behavior via deployment.toml file. 

With this PR, we will not change the default behavior which is preserve case sensitivity false. 

Add following config to deployment.toml file to enable/disable case sensitivity for jdbc scope validator

```
[oauth.scope_validator]
preserve_case_sensitivity=true
```

## Related Issues
- https://github.com/wso2/product-is/issues/20573
- https://github.com/wso2/product-apim/issues/12584

## Related PRs
- [1] https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1812
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2505