### PR TITLE
Improve the role user remove from role validation

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleConstants.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleConstants.java
@@ -64,6 +64,7 @@ public class RoleConstants {
 
     // Role audiences
     public static final String APPLICATION = "application";
+    public static final String CONSOLE_APP_AUDIENCE_NAME = "Console";
     public static final String ORGANIZATION = "organization";
     public static final String SYSTEM = "system";
 

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
@@ -1124,8 +1124,8 @@ public class RoleManagementServiceImpl implements RoleManagementService {
      * Validate user removal from role.
      *
      * @param deletedUserIDList Deleted user ID list.
-     * @param roleId             Role ID.
-     * @param tenantDomain         Tenant domain.
+     * @param roleId            Role ID.
+     * @param tenantDomain      Tenant domain.
      * @throws IdentityRoleManagementException Error occurred while validating user removal from role.
      */
     private void validateUserRemovalFromRole(List<String> deletedUserIDList, String roleId, String tenantDomain)

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
@@ -1159,10 +1159,10 @@ public class RoleManagementServiceImpl implements RoleManagementService {
 
             Role role = getRole(roleId, tenantDomain);
             // Only the tenant owner can remove users from Administrator role.
-            if (StringUtils.equals(adminRoleName, role.getName())
-                    && RoleConstants.ORGANIZATION.equals(role.getAudience()) ||
-                    RoleConstants.ADMINISTRATOR.equals(role.getName()) &&
-                            RoleConstants.CONSOLE_APP_AUDIENCE_NAME.equals(role.getAudienceName())) {
+            if ((StringUtils.equals(adminRoleName, role.getName())
+                    && RoleConstants.ORGANIZATION.equals(role.getAudience()))
+                    || (RoleConstants.ADMINISTRATOR.equals(role.getName()) &&
+                            RoleConstants.CONSOLE_APP_AUDIENCE_NAME.equals(role.getAudienceName()))) {
                 if ((isUseCaseSensitiveUsernameForCacheKeys && !StringUtils.equals(username, adminUserName)) || (
                         !isUseCaseSensitiveUsernameForCacheKeys && !StringUtils
                                 .equalsIgnoreCase(username, adminUserName))) {

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -2976,7 +2976,6 @@ public class RoleDAOImpl implements RoleDAO {
                     "Role id: " + roleId + " does not exist in the system.");
         }
         String roleName = getRoleNameByID(roleId, tenantDomain);
-        RoleAudience roleAudience = getAudienceByRoleID(roleId, tenantDomain);
         if (CollectionUtils.isEmpty(newUserIDList) && CollectionUtils.isEmpty(deletedUserIDList)) {
             LOG.debug("User lists are empty.");
             return;
@@ -2991,8 +2990,6 @@ public class RoleDAOImpl implements RoleDAO {
         List<String> deletedUserNamesList = getUserNamesByIDs(deletedUserIDList, tenantDomain);
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
 
-        // Validate the user removal operation based on the default system roles.
-        validateUserRemovalFromRole(deletedUserNamesList, roleName, tenantDomain, roleAudience);
         int audienceRefId = getAudienceRefByID(roleId, tenantDomain);
         try (Connection connection = IdentityDatabaseUtil.getUserDBConnection(true)) {
 
@@ -3125,70 +3122,6 @@ public class RoleDAOImpl implements RoleDAO {
             }
         } catch (UserStoreException e) {
             String errorMessage = "Error while validating group removal from the role: %s in the tenantDomain: %s";
-            throw new IdentityRoleManagementServerException(RoleConstants.Error.UNEXPECTED_SERVER_ERROR.getCode(),
-                    String.format(errorMessage, roleName, tenantDomain), e);
-        }
-    }
-
-    /**
-     * Validate user removal from role.
-     *
-     * @param deletedUserNamesList Deleted user name list.
-     * @param roleName             Role name.
-     * @param tenantDomain         Tenant domain.
-     * @param roleAudience         The role Audience.
-     * @throws IdentityRoleManagementException Error occurred while validating user removal from role.
-     */
-    private void validateUserRemovalFromRole(List<String> deletedUserNamesList, String roleName, String tenantDomain,
-                                             RoleAudience roleAudience)
-            throws IdentityRoleManagementException {
-
-        if (!IdentityUtil.isSystemRolesEnabled() || deletedUserNamesList.isEmpty()) {
-            return;
-        }
-        try {
-            boolean isOrganization = OrganizationManagementUtil.isOrganization(tenantDomain);
-            // No restriction when removing access from an organization user.
-            if (isOrganization) {
-                return;
-            }
-        } catch (OrganizationManagementException e) {
-            throw new IdentityRoleManagementServerException(RoleConstants.Error.UNEXPECTED_SERVER_ERROR.getCode(),
-                    String.format("Error while checking the tenant domain: %s is an organization.", tenantDomain), e);
-        }
-
-        try {
-            String username = CarbonContext.getThreadLocalCarbonContext().getUsername();
-            UserRealm userRealm = CarbonContext.getThreadLocalCarbonContext().getUserRealm();
-            String adminUserName = userRealm.getRealmConfiguration().getAdminUserName();
-            String adminRoleName = userRealm.getRealmConfiguration().getAdminRoleName();
-
-            org.wso2.carbon.user.core.UserStoreManager userStoreManager =
-                    (org.wso2.carbon.user.core.UserStoreManager) userRealm
-                            .getUserStoreManager();
-            boolean isUseCaseSensitiveUsernameForCacheKeys = IdentityUtil
-                    .isUseCaseSensitiveUsernameForCacheKeys(userStoreManager);
-            // Only the tenant owner can remove users from Administrator role.
-            if (StringUtils.equals(adminRoleName, roleName)
-                    && RoleConstants.ORGANIZATION.equals(roleAudience.getAudience())) {
-                if ((isUseCaseSensitiveUsernameForCacheKeys && !StringUtils.equals(username, adminUserName)) || (
-                        !isUseCaseSensitiveUsernameForCacheKeys && !StringUtils
-                                .equalsIgnoreCase(username, adminUserName))) {
-                    String errorMessage = "Invalid operation. Only the tenant owner can remove users from the role: %s";
-                    throw new IdentityRoleManagementClientException(RoleConstants.Error.OPERATION_FORBIDDEN.getCode(),
-                            String.format(errorMessage, RoleConstants.ADMINISTRATOR));
-                } else {
-                    // Tenant owner cannot be removed from Administrator role.
-                    if (deletedUserNamesList.contains(adminUserName)) {
-                        String errorMessage = "Invalid operation. Tenant owner cannot be removed from the role: %s";
-                        throw new IdentityRoleManagementClientException(RoleConstants.Error.OPERATION_FORBIDDEN
-                                .getCode(),
-                                String.format(errorMessage, RoleConstants.ADMINISTRATOR));
-                    }
-                }
-            }
-        } catch (UserStoreException e) {
-            String errorMessage = "Error while validating user removal from the role: %s in the tenantDomain: %s";
             throw new IdentityRoleManagementServerException(RoleConstants.Error.UNEXPECTED_SERVER_ERROR.getCode(),
                     String.format(errorMessage, roleName, tenantDomain), e);
         }


### PR DESCRIPTION
### Proposed changes in this pull request

When the default tenant admin role is removed from a user, a validation logic is executed to check whether it is performed by the tenant owner as it is only allowed for the tenant owner.

The role name can be either organization audience or application audience, hence the logic should be improved to verify whether the role is default tenant admin role which is an organization audience role or the console Administrator role.

This validation is not required to be applied for the suborganizations.