### PR TITLE
Introduce a config to only disable periodic temp-session data cleanup

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -147,7 +147,7 @@ public class SessionDataStore {
     private boolean sessionDataCleanupEnabled = true;
     private boolean operationDataCleanupEnabled = false;
     private static boolean tempDataCleanupEnabled = false;
-    private static boolean periodicTempDataCleanupEnabled = false;
+    private static boolean periodicTempDataCleanupEnabled = true;
     private static boolean sessionAndTempDataSeparationEnabled = false;
 
     static {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -147,6 +147,7 @@ public class SessionDataStore {
     private boolean sessionDataCleanupEnabled = true;
     private boolean operationDataCleanupEnabled = false;
     private static boolean tempDataCleanupEnabled = false;
+    private static boolean periodicTempDataCleanupEnabled = false;
     private static boolean sessionAndTempDataSeparationEnabled = false;
 
     static {
@@ -163,6 +164,12 @@ public class SessionDataStore {
                     = IdentityUtil.getProperty("JDBCPersistenceManager.SessionDataPersist.TempDataCleanup.Enable");
             if (StringUtils.isNotBlank(isTempDataCleanupEnabledVal)) {
                 tempDataCleanupEnabled = Boolean.parseBoolean(isTempDataCleanupEnabledVal);
+            }
+
+            String isPeriodicTempDataCleanupEnabledVal = IdentityUtil.getProperty
+                    ("JDBCPersistenceManager.SessionDataPersist.TempDataCleanup.EnablePeriodicCleanup");
+            if (StringUtils.isNotBlank(isTempDataCleanupEnabledVal)) {
+                periodicTempDataCleanupEnabled = Boolean.parseBoolean(isPeriodicTempDataCleanupEnabledVal);
             }
 
             sessionAndTempDataSeparationEnabled = Boolean.parseBoolean(IdentityUtil
@@ -273,7 +280,8 @@ public class SessionDataStore {
             operationDataCleanupEnabled = Boolean.parseBoolean(isOperationCleanUpEnabledVal);
         }
 
-        if (sessionDataCleanupEnabled || operationDataCleanupEnabled || tempDataCleanupEnabled) {
+        if (sessionDataCleanupEnabled || operationDataCleanupEnabled ||
+                (tempDataCleanupEnabled && periodicTempDataCleanupEnabled)) {
             long sessionCleanupPeriod = IdentityUtil.getCleanUpPeriod(
                     CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
             if (log.isDebugEnabled()) {
@@ -491,7 +499,7 @@ public class SessionDataStore {
         if (sessionDataCleanupEnabled) {
             removeExpiredSessionData(sqlDeleteExpiredDataTask);
         }
-        if (tempDataCleanupEnabled) {
+        if (tempDataCleanupEnabled && periodicTempDataCleanupEnabled) {
             removeExpiredSessionData(replaceTableName(sqlDeleteExpiredDataTask));
         }
         if (operationDataCleanupEnabled) {

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -53,7 +53,7 @@
                 <!-- All temporary authentication context data older than CleanUpTimeout value are considered as expired
                 and would be deleted during cleanup task -->
                 <CleanUpTimeout>40</CleanUpTimeout>
-                <EnablePeriodicCleanup>false</EnablePeriodicCleanup>
+                <EnablePeriodicCleanup>true</EnablePeriodicCleanup>
             </TempDataCleanup>
             <UserSessionMapping>
                 <Enable>true</Enable>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -53,6 +53,7 @@
                 <!-- All temporary authentication context data older than CleanUpTimeout value are considered as expired
                 and would be deleted during cleanup task -->
                 <CleanUpTimeout>40</CleanUpTimeout>
+                <EnablePeriodicCleanup>false</EnablePeriodicCleanup>
             </TempDataCleanup>
             <UserSessionMapping>
                 <Enable>true</Enable>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -58,6 +58,7 @@
                 <!-- All temporary authentication context data older than CleanUpTimeout value are considered as expired
                 and would be deleted during cleanup task -->
                 <CleanUpTimeout>{{session_data.cleanup.expire_pre_session_data_after}}</CleanUpTimeout>
+                <EnablePeriodicCleanup>{{session_data.cleanup.enable_periodic_pre_session_data_cleanup}}</EnablePeriodicCleanup>
             </TempDataCleanup>
             <SessionAndTempDataSeparation>
                 <Enable>{{session_data.session_data_persist.session_and_temp_data_separation_enabled.enable}}</Enable>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -27,7 +27,7 @@
   "session_data.cleanup.clean_expired_session_data_in_chunks_of": "8192",
   "session_data.cleanup.clean_logged_out_sessions_at_immediate_cycle": true,
   "session_data.cleanup.enable_pre_session_data_cleanup": true,
-  "session_data.cleanup.enable_periodic_pre_session_data_cleanup": false,
+  "session_data.cleanup.enable_periodic_pre_session_data_cleanup": true,
   "session_data.session_data_persist.session_and_temp_data_separation_enabled.enable": true,
   "session_data.cleanup.pre_session_data_cleanup_thread_pool_size": "20",
   "session.nonce.cookie.enabled": true,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -27,6 +27,7 @@
   "session_data.cleanup.clean_expired_session_data_in_chunks_of": "8192",
   "session_data.cleanup.clean_logged_out_sessions_at_immediate_cycle": true,
   "session_data.cleanup.enable_pre_session_data_cleanup": true,
+  "session_data.cleanup.enable_periodic_pre_session_data_cleanup": false,
   "session_data.session_data_persist.session_and_temp_data_separation_enabled.enable": true,
   "session_data.cleanup.pre_session_data_cleanup_thread_pool_size": "20",
   "session.nonce.cookie.enabled": true,


### PR DESCRIPTION
### Proposed changes in this pull request

Introduce a config to only disable periodic temp-session data cleanup

```
[session_data.cleanup]
enable_periodic_pre_session_data_cleanup = true
```

- Default value of this config is **true** to preserve previous behaviour


### Implementation Details

Before introduce the above config following temp session data cleanup processes were depends only a one config(`enable_pre_session_data_cleanup`).

- If `enable_pre_session_data_cleanup = true`:
   - Immediate Temp Data cleanup is enabled 
   - Periodic Temp Data cleanup is enabled 

After introducing the `enable_periodic_pre_session_data_cleanup` config

- If `enable_pre_session_data_cleanup = true` & `enable_periodic_pre_session_data_cleanup=true`:
   - Immediate Temp Data cleanup is enabled 
   - Periodic Temp Data cleanup is enabled 

- If `enable_pre_session_data_cleanup = true` & `enable_periodic_pre_session_data_cleanup=false`:
   - Immediate Temp Data cleanup is enabled 
   - Periodic Temp Data cleanup is disabled 

- If `enable_pre_session_data_cleanup = false` & `enable_periodic_pre_session_data_cleanup=true`:
   - Immediate Temp Data cleanup is disabled 
   - Periodic Temp Data cleanup is disabled 

- If `enable_pre_session_data_cleanup = false` & `enable_periodic_pre_session_data_cleanup=false`:
   - Immediate Temp Data cleanup is disabled 
   - Periodic Temp Data cleanup is disabled 
