### PR TITLE
Add OAuth related configuration

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -765,6 +765,13 @@
         Default value : true
         -->
         <RemoveUsernameFromIntrospectionResponseForAppTokens>true</RemoveUsernameFromIntrospectionResponseForAppTokens>
+
+        <!-- Configuration to pass a list of keys which are restricted to be sent as query parameters. -->
+        <RestrictedQueryParameters>
+            <Parameter>username</Parameter>
+            <Parameter>password</Parameter>
+            <Parameter>client_secret</Parameter>
+        </RestrictedQueryParameters>
     </OAuth>
 
     <RestApiAuthentication>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1195,6 +1195,13 @@
         {% if oauth.extensions.scope_metadata_service is defined %}
         <ScopeMetadataService>{{oauth.extensions.scope_metadata_service}}</ScopeMetadataService>
         {% endif %}
+
+        <!-- Configuration to pass a list of keys which are restricted to be sent as query parameters. -->
+        <RestrictedQueryParameters>
+            {%for parameter in oauth.restricted_query_parameters%}
+                <Parameter>{{parameter}}</Parameter>
+            {% endfor %}
+        </RestrictedQueryParameters>
     </OAuth>
 
     <RestApiAuthentication>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -274,6 +274,8 @@
   "oauth.drop_unregistered_scopes": true,
   "oauth.allowed_scopes": ["^device_.*"],
 
+  "oauth.restricted_query_parameters": ["username", "password", "client_secret"],
+
   "rest_api_authentication.add_realm_user_to_error": false,
 
   "saml.entity_id": "${carbon.host}",


### PR DESCRIPTION
### Proposed changes in this pull request

Adds the configuration `oauth.restricted_query_parameters` which contains the list of query parameters that are not accepted to be sent as query parameters in oauth token requests.

### Related PRs
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2510