### PR TITLE
Add audit logs to record consent granting status for a trusted app in a SP

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -152,13 +152,15 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 
-import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.*;
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.ANDROID_PACKAGE_NAME_PROPERTY_NAME;
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.APPLE_APP_ID_PROPERTY_NAME;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.Error.APPLICATION_ALREADY_EXISTS;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.Error.APPLICATION_NOT_FOUND;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.Error.INVALID_REQUEST;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.Error.INVALID_TENANT_DOMAIN;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.Error.OPERATION_FORBIDDEN;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.Error.UNEXPECTED_SERVER_ERROR;
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.TRUSTED_APP_CONSENT_GRANTED_SP_PROPERTY_NAME;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.APPLICATION_NAME_CONFIG_ELEMENT;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.DEFAULT_APPLICATIONS_CONFIG_ELEMENT;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.SYSTEM_APPLICATIONS_CONFIG_ELEMENT;
@@ -3409,7 +3411,8 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
 
         if (serviceProvider != null) {
             String trustedAppConsent = Arrays.stream(serviceProvider.getSpProperties())
-                    .filter(spProp -> StringUtils.equals(spProp.getName(), TRUSTED_APP_CONSENT_GRANTED_SP_PROPERTY_NAME))
+                    .filter(spProp -> StringUtils.equals(spProp.getName(),
+                            TRUSTED_APP_CONSENT_GRANTED_SP_PROPERTY_NAME))
                     .map(ServiceProviderProperty::getValue)
                     .findFirst()
                     .orElse(null);
@@ -3426,7 +3429,8 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
      * @param tenantDomain  Tenant domain.
      * @param serviceProvider Service provider.
      */
-    private void publishTrustedAppConsentAuditLog(String username, String tenantDomain, ServiceProvider serviceProvider) {
+    private void publishTrustedAppConsentAuditLog(String username, String tenantDomain,
+                                                  ServiceProvider serviceProvider) {
 
         JSONObject dataObject = new JSONObject();
         dataObject.put("TrustedAppConsent", "Trusted app consent granted for the application: " + serviceProvider

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -78,6 +78,7 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.TRUSTED_APP_CONSENT_GRANTED_SP_PROPERTY_NAME;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.CONSOLE_ACCESS_ORIGIN;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.CONSOLE_ACCESS_URL_FROM_SERVER_CONFIGS;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.ENABLE_APPLICATION_ROLE_VALIDATION_PROPERTY;
@@ -1224,5 +1225,51 @@ public class ApplicationMgtUtil {
     public static boolean isTrustedAppConsentRequired() {
 
         return Boolean.parseBoolean(IdentityUtil.getProperty(TRUSTED_APP_CONSENT_REQUIRED_PROPERTY));
+    }
+
+    /**
+     * Check whether the trusted app consent is granted for the application.
+     *
+     * @param serviceProvider Service provider.
+     * @return True if 'trustedAppConsentGranted' spProperty of the application is true.
+     */
+    public static boolean isTrustedAppConsentGranted(ServiceProvider serviceProvider) {
+
+        if (serviceProvider != null && serviceProvider.getTrustedAppMetadata() != null) {
+            return serviceProvider.getTrustedAppMetadata().getIsConsentGranted();
+        }
+        return false;
+    }
+
+    /**
+     * Check whether consent is newly granted for trusted app.
+     *
+     * @param updatedApp   Updated service provider.
+     * @param tenantDomain Tenant domain.
+     * @return True if the consent for trusted apps is updated from false to true.
+     */
+    public static boolean isTrustedAppConsentUpdatedToGranted(ServiceProvider updatedApp, String tenantDomain)
+            throws IdentityApplicationManagementException {
+
+        boolean updatedSpConsent = isTrustedAppConsentGranted(updatedApp);
+        if (updatedSpConsent && StringUtils.isNotEmpty(getAppId(updatedApp))) {
+            String storedSpConsent = ApplicationMgtSystemConfig.getInstance().getApplicationDAO()
+                    .getSPPropertyValueByPropertyKey(getAppId(updatedApp), TRUSTED_APP_CONSENT_GRANTED_SP_PROPERTY_NAME,
+                            tenantDomain);
+            return !Boolean.parseBoolean(storedSpConsent);
+        }
+        return false;
+    }
+
+    /**
+     * Check whether consent is newly granted for trusted app.
+     *
+     * @param storedApp    Stored service provider.
+     * @param updatedApp   Updated service provider.
+     * @return True if the consent for trusted apps is updated from false to true.
+     */
+    public static boolean isTrustedAppConsentUpdatedToGranted(ServiceProvider storedApp, ServiceProvider updatedApp) {
+
+        return isTrustedAppConsentGranted(updatedApp) && !isTrustedAppConsentGranted(storedApp);
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/ApplicationMgtAuditLogger.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/ApplicationMgtAuditLogger.java
@@ -36,12 +36,18 @@ import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
+import org.wso2.carbon.identity.application.common.model.SpTrustedAppMetadata;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.CarbonUtils;
 
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.ANDROID_PACKAGE_NAME_PROPERTY_NAME;
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.APPLE_APP_ID_PROPERTY_NAME;
 import static org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil.getUsernameWithUserTenantDomain;
+import static org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil.isTrustedAppConsentGranted;
+import static org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil.isTrustedAppConsentRequired;
+import static org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil.isTrustedAppConsentUpdatedToGranted;
 
 /**
  * Audit log implementation for Application (Service Provider) changes.
@@ -76,6 +82,10 @@ public class ApplicationMgtAuditLogger extends AbstractApplicationMgtListener {
         String initiator = getInitiatorForLog(userName, tenantDomain);
         String data = buildData(serviceProvider);
         audit.info(String.format(AUDIT_MESSAGE, initiator, "Add-Application", appId, data, SUCCESS));
+        if (isTrustedAppConsentRequired() && isTrustedAppConsentGranted(serviceProvider)) {
+            audit.info(String.format(AUDIT_MESSAGE, initiator, "Add-Application", appId,
+                    buildTrustedAppData(serviceProvider), SUCCESS));
+        }
         return true;
     }
 
@@ -88,6 +98,10 @@ public class ApplicationMgtAuditLogger extends AbstractApplicationMgtListener {
         String data = buildData(serviceProvider);
 
         audit.info(String.format(AUDIT_MESSAGE, initiator, "Update-Application", appId, data, SUCCESS));
+        if (isTrustedAppConsentRequired() && isTrustedAppConsentUpdatedToGranted(serviceProvider, tenantDomain)) {
+            audit.info(String.format(AUDIT_MESSAGE, initiator, "Update-Application", appId,
+                    buildTrustedAppData(serviceProvider), SUCCESS));
+        }
         return true;
     }
 
@@ -365,5 +379,21 @@ public class ApplicationMgtAuditLogger extends AbstractApplicationMgtListener {
             }
         }
         return LoggerUtils.getMaskedContent(username);
+    }
+
+    private String buildTrustedAppData(ServiceProvider serviceProvider) {
+
+        StringBuilder data = new StringBuilder();
+        data.append("TrustedAppConsent: Trusted app consent granted for the application: ").append(
+                serviceProvider.getApplicationName()).append(", ");
+        SpTrustedAppMetadata trustedAppMetadata = serviceProvider.getTrustedAppMetadata();
+        if (trustedAppMetadata != null) {
+            data.append("IsFidoTrusted").append(trustedAppMetadata.getIsFidoTrusted()).append(", ");
+            data.append(ANDROID_PACKAGE_NAME_PROPERTY_NAME).append(trustedAppMetadata.getAndroidPackageName())
+                    .append(", ");
+            data.append("androidThumbprints").append(trustedAppMetadata.getAndroidThumbprints()).append(", ");
+            data.append(APPLE_APP_ID_PROPERTY_NAME).append(trustedAppMetadata.getAppleAppId());
+        }
+        return data.toString();
     }
 }


### PR DESCRIPTION
This PR adds the changes needed to publish V1 and V2 audit logs in the application management service component when consent is granted or updated from not granted to granted for a trusted app.

Related issue:  https://github.com/wso2/product-is/issues/20487