### PR TITLE
Add trusted app metadata to V1 audit logs

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/ApplicationMgtAuditLogger.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/ApplicationMgtAuditLogger.java
@@ -41,6 +41,8 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.CarbonUtils;
 
+import java.util.Arrays;
+
 import static org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil.getUsernameWithUserTenantDomain;
 
 /**
@@ -299,6 +301,21 @@ public class ApplicationMgtAuditLogger extends AbstractApplicationMgtListener {
                 }
                 data.append("]");
             }
+            data.append("}");
+        }
+
+        if (serviceProvider.getTrustedAppMetadata() != null) {
+            data.append(", Trusted App Metadata:{");
+            data.append("isConsentGranted:").append(serviceProvider.getTrustedAppMetadata()
+                    .getIsConsentGranted()).append(", ");
+            data.append("isFidoTrusted:").append(serviceProvider.getTrustedAppMetadata()
+                    .getIsFidoTrusted()).append(", ");
+            data.append("androidPackageName:").append(serviceProvider.getTrustedAppMetadata()
+                    .getAndroidPackageName()).append(", ");
+            data.append("androidThumbprints:").append(Arrays.toString(serviceProvider.getTrustedAppMetadata()
+                    .getAndroidThumbprints())).append(", ");
+            data.append("appleAppId:").append(serviceProvider.getTrustedAppMetadata()
+                    .getAppleAppId()).append(", ");
             data.append("}");
         }
 


### PR DESCRIPTION
$subject

Related issue: https://github.com/wso2/product-is/issues/20487

An example audit log after adding the trusted app metadaata:
```
TID: [-1234] [2024-07-16 14:57:11,110] [d24ddfd2-1788-4278-ba5a-8a6650f8d5ad]  INFO {AUDIT_LOG} - Initiator : 6f000c30-5b02-4772-babe-0c287532d324 | Action : Update-Application | Target : dce45e89-007e-441b-a0ac-03633a07ff5c | Data : { Changed-State : { Name:Asgardeo Support Center, Description:This is the Asgardeo Help Center Application., Resource ID:dce45e89-007e-441b-a0ac-03633a07ff5c, Access URL:null, Is Discoverable:false, Is SaaS:false, Inbound Authentication Configs:[{Auth Key:D**********r, Auth Type:samlsso, Config Type:standardAPP, Inbound configuration:null}], Local and Outbound Configuration:{Auth Type:default}, Claim Configuration:{User Claim URI:null, Role Claim URI:null}, Inbound Provisioning Configuration:{Provisioning Userstore:null, Is Dumb Mode:false}, Outbound Provisioning Configuration:{}, Trusted App Metadata:{isConsentGranted:true, isFidoTrusted:true, androidPackageName:com.wso2.mobile.sample1, androidThumbprints:[18:94:0A:DE:63:77:B6:84:43:1E:85:8F:03:CF:8A:14:87:9C:DE:DF:EA:7A:25:53:CD:53:5A:AF:C3:54:A5:56], appleAppId:APPLETEAMID.com.org.mobile.sample, }, Service Provider Properties:[{isAPIBasedAuthenticationEnabled:false}, {isManagementApp:false}, {USE_DOMAIN_IN_ROLES:true}, {skipLogoutConsent:false}, {skipConsent:true}, {jwksURI:}, {appleAppId:null}, {templateId:}, {IsApplicationEnabled:true}, {useUserIdForDefaultSubject:true}, {isB2BSelfServiceApp:false}, {androidPackageName:null}, {useExternalConsentPage:false}, {allowedAudienceForAssociatedRoles:application}, {IsAttestationEnabled:false}] } } | Result : Success 
```