### PR TITLE
Introduce authorize_all_scopes configuration 

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1203,6 +1203,8 @@
                 <Parameter>{{parameter}}</Parameter>
             {% endfor %}
         </RestrictedQueryParameters>
+
+        <AuthorizeAllScopes>{{oauth.authorize_all_scopes}}</AuthorizeAllScopes>
     </OAuth>
 
     <RestApiAuthentication>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1566,6 +1566,8 @@
 
   "on_demand_config.on_initial_use.enable_sms_otp_password_recovery_if_connector_enabled": false,
 
-  "actions.maximum_actions_per_action_type": 1
+  "actions.maximum_actions_per_action_type": 1,
+
+  "oauth.authorize_all_scopes": false
 }
 


### PR DESCRIPTION
For IS 7.x compatibility with APIM 4.x, it is required to make all api resources in that organisation available for any application. This is achieved by allowing all scopes to be authorised for all applications upon server-wide configuration authorize_all_scopes. This will not make any impact on the default behaviour.

This pr introduces the new configuration `authorize_all_scopes`

Related PR : https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2525