### PR TITLE
Authorise all scopes for all application upon server-wide configuration

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
@@ -125,6 +125,7 @@ public class ApplicationConstants {
     public static final String CONSOLE_PORTAL_PATH = "Console.AppBaseName";
     public static final String MYACCOUNT_PORTAL_PATH = "MyAccount.AppBaseName";
     public static final String AUTHORIZE_ALL_SCOPES = "OAuth.AuthorizeAllScopes";
+    public static final String RBAC = "RBAC";
 
     /**
      * Group the constants related to logs.

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
@@ -124,6 +124,7 @@ public class ApplicationConstants {
     public static final String MYACCOUNT_ACCESS_ORIGIN = "MyAccount.Origin";
     public static final String CONSOLE_PORTAL_PATH = "Console.AppBaseName";
     public static final String MYACCOUNT_PORTAL_PATH = "MyAccount.AppBaseName";
+    public static final String AUTHORIZE_ALL_SCOPES = "OAuth.AuthorizeAllScopes";
 
     /**
      * Group the constants related to logs.

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
@@ -45,8 +45,9 @@ import org.wso2.carbon.identity.role.v2.mgt.core.model.Permission;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.Error.INVALID_REQUEST;
@@ -211,10 +212,15 @@ public class AuthorizedAPIManagementServiceImpl implements AuthorizedAPIManageme
             if (Boolean.parseBoolean(IdentityUtil.getProperty(AUTHORIZE_ALL_SCOPES))) {
                 List<Scope> scopes = ApplicationManagementServiceComponentHolder.getInstance().getAPIResourceManager()
                         .getScopesByTenantDomain(tenantDomain, null);
-                authorizedScopes = Collections.singletonList(
-                        new AuthorizedScopes(RBAC, scopes.stream()
-                                .map(Scope::getName)
-                                .collect(Collectors.toCollection(ArrayList::new))));
+                Map<String, AuthorizedScopes> authorizedScopesMap = new HashMap<>();
+                AuthorizedScopes.AuthorizedScopesBuilder authorizedScopesBuilder =
+                        new AuthorizedScopes.AuthorizedScopesBuilder()
+                                .policyId(RBAC)
+                                .scopes(scopes.stream()
+                                        .map(Scope::getName)
+                                        .collect(Collectors.toCollection(ArrayList::new)));
+                authorizedScopesMap.put(RBAC, authorizedScopesBuilder.build());
+                authorizedScopes = new ArrayList<>(authorizedScopesMap.values());
             } else {
                 authorizedScopes = authorizedAPIDAO.getAuthorizedScopes(appId,
                         IdentityTenantUtil.getTenantId(tenantDomain));

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.Error.INVALID_REQUEST;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.Error.UNEXPECTED_SERVER_ERROR;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.AUTHORIZE_ALL_SCOPES;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.RBAC;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.APPLICATION;
 
 /**
@@ -211,7 +212,7 @@ public class AuthorizedAPIManagementServiceImpl implements AuthorizedAPIManageme
                 List<Scope> scopes = ApplicationManagementServiceComponentHolder.getInstance().getAPIResourceManager()
                         .getScopesByTenantDomain(tenantDomain, null);
                 authorizedScopes = Collections.singletonList(
-                        new AuthorizedScopes("RBAC", scopes.stream()
+                        new AuthorizedScopes(RBAC, scopes.stream()
                                 .map(Scope::getName)
                                 .collect(Collectors.toCollection(ArrayList::new))));
             } else {


### PR DESCRIPTION
For IS 7.x compatibility with APIM 4.x, it is required to make all api resources in that organisation available for any application. This is achieved by allowing all scopes to be authorised for all applications upon server-wide configuration `authorize_all_scopes`. This will not make any impact on the default behaviour.

Since we are considering all scopes as authorized for all applications, internal and console scopes will be made available as well. With the 'SYSTEM' scope/scope requesting method, we will be issuing all internal and console scopes. UI support is not required and the console will not reflect this.