### PR TITLE
Re-add runtime exception when validating for actions to be handled at the upper layer .

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutorServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutorServiceImpl.java
@@ -112,10 +112,7 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
     private void validateActions(List<Action> actions, ActionType actionType) throws ActionExecutionException {
 
         if (CollectionUtils.isEmpty(actions)) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("No actions found for action type: " + actionType);
-            }
-            return;
+            throw new ActionExecutionRuntimeException("No actions found for action type: " + actionType);
         }
 
         if (actions.size() > 1) {

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutorServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutorServiceImpl.java
@@ -92,7 +92,7 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
                     .orElse(new ActionExecutionStatus(ActionExecutionStatus.Status.FAILED, eventContext));
         } catch (ActionExecutionRuntimeException e) {
             // todo: add to diagnostics
-            LOG.error("Skip executing actions for action type: " + actionType.name() + ". Error: " + e.getMessage(), e);
+            LOG.debug("Skip executing actions for action type: " + actionType.name(), e);
             return new ActionExecutionStatus(ActionExecutionStatus.Status.FAILED, eventContext);
 
         }


### PR DESCRIPTION
### Proposed changes in this pull request

This adds back the runtime exception removed as per a review comment due to following.
This method is intended to handle the validation and to break the flow based on the validation given the different types of validations it needs to cater for.

Related to https://github.com/wso2/product-is/issues/20739 and resolves a bug that let the actions to be invoked even when there are no actions available as the flow doesn't break properly.

### When should this PR be merged
Soon