### PR TITLE
Enable SCIM2 Group based User Filtering Improvements by Default

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1011,9 +1011,9 @@
             It determines the totalResults based on the total user count corresponding to the given group-based filter.
             Additionally, when invoking the user endpoint with a groups filter by passing a role (hybrid or system roles),
             it returns an empty list when role group separation is enabled, instead of returning users linked to the passed role.
-            Default value : false
+            Default value : true
         -->
-        <!--<EnableGroupBasedUserFilteringImprovements>false</EnableGroupBasedUserFilteringImprovements>-->
+        <!--<EnableGroupBasedUserFilteringImprovements>true</EnableGroupBasedUserFilteringImprovements>-->
 
     </SCIM2>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1478,7 +1478,7 @@
              It determines the totalResults based on the total user count corresponding to the given group-based filter.
              Additionally, when invoking the user endpoint with a groups filter by passing a role (hybrid or system roles),
              it returns an empty list when role group separation is enabled, instead of returning users linked to the passed role.
-             Default value : false
+             Default value : true
         -->
         <EnableGroupBasedUserFilteringImprovements>{{scim2.enable_group_based_user_filter_improvements}}</EnableGroupBasedUserFilteringImprovements>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -356,7 +356,7 @@
   "scim2.endpoints.groups_endpoint": "$ref{server.base_path}/scim2/Groups",
   "scim2.enable_complex_multivalued_attribute_support": false,
   "scim2.enable_filtering_enhancements": false,
-  "scim2.enable_group_based_user_filter_improvements": false,
+  "scim2.enable_group_based_user_filter_improvements": true,
   "scim2.notify_userstore_status": false,
   "scim2.filter_users_and_groups_from_primary_domain": false,
   "scim2.mandate_domain_for_uesrnames_and_group_names_in_response": false,


### PR DESCRIPTION
### Proposed changes in this pull request

- Enabled SCIM2 group based user filtering improvements in order to enforce the correct filtering techniques in the future release of product-is.
- In order to disable these improvements, the following config can be added to the `deployment.toml`.

```
[scim2]
enable_group_based_user_filter_improvements = false
```

### Related Issues
- https://github.com/wso2/product-is/issues/12813

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/5533
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/547
- https://github.com/wso2/carbon-kernel/pull/3906
- https://github.com/wso2/carbon-kernel/pull/3951