### PR TITLE
Add feature configurations for RBAC and default.json

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -67,6 +67,7 @@
                 <Scope name="internal_governance_view"/>
                 <Scope name="internal_userstore_view"/>
                 <Scope name="internal_shared_application_view"/>
+                <Scope name="internal_extensions_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>
@@ -700,6 +701,7 @@
                 <Scope name="internal_org_role_mgt_view"/>
                 <Scope name="internal_org_userstore_view"/>
                 <Scope name="internal_org_idp_view"/>
+                <Scope name="internal_org_extensions_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1087,6 +1087,7 @@
     "OAuthRequestPathAuthenticator"
   ],
   "console.ui.hiddenConnectionTemplates": [ "swe-idp" ],
+  "console.ui.hiddenApplicationTemplates": [],
   "console.ui.google_one_tap_enabled_tenants": [],
   "console.ui.show_app_switch_button": true,
   "console.ui.administrator_role_display_name": "Administrator",


### PR DESCRIPTION
### Proposed changes in this pull request

- After introducing the SSO integration templates to the application section, similar to the connections, the application section uses the extension management endpoint to render its views. Therefore, we need to add the extension management endpoint scope to the API resource collection (This is needed for RBAC).
- Additionally, I have added a configuration to hide application templates at the deployment level. If anything goes wrong, we can hide these templates without requiring a new deployment.

### Related Issues

- https://github.com/wso2/product-is/issues/20026
