### PR TITLE
Fix reading header when only one header is configured.

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/util/ActionExecutorConfig.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/util/ActionExecutorConfig.java
@@ -154,6 +154,10 @@ public class ActionExecutorConfig {
             return Collections.emptyList();
         }
 
+        if (propertyValue instanceof String) {
+            return Collections.singletonList(propertyValue.toString());
+        }
+
         if (propertyValue instanceof List) {
             return (List<String>) propertyValue;
         } else {

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/ActionExecutorConfigTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/ActionExecutorConfigTest.java
@@ -138,6 +138,19 @@ public class ActionExecutorConfigTest {
     }
 
     @Test
+    public void testGetExcludedHeadersInActionRequestForValidConfigWithOneValueForDefinedTypeOnly() {
+
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("Actions.Types.PreIssueAccessToken.ActionRequest.ExcludedHeaders.Header", "header1");
+
+        when(mockIdentityConfigParser.getConfiguration()).thenReturn(configMap);
+
+        Set<String> excludedHeaders =
+                actionExecutorConfig.getExcludedHeadersInActionRequestForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN);
+        assertEquals(excludedHeaders, new HashSet<>(Collections.singletonList("header1")));
+    }
+
+    @Test
     public void testGetExcludedHeadersInActionRequestForValidConfigForAllAndDefinedType() {
 
         Map<String, Object> configMap = new HashMap<>();
@@ -156,7 +169,7 @@ public class ActionExecutorConfigTest {
     public void testGetExcludedHeadersInActionRequestForInvalidConfigForAllTypes() {
 
         Map<String, Object> configMap = new HashMap<>();
-        configMap.put("Actions.ActionRequest.ExcludedHeaders.Header", "invalid");
+        configMap.put("Actions.ActionRequest.ExcludedHeaders.Header", 12);
 
         when(mockIdentityConfigParser.getConfiguration()).thenReturn(configMap);
 
@@ -169,7 +182,7 @@ public class ActionExecutorConfigTest {
     public void testGetExcludedHeadersInActionRequestForInvalidConfigForDefinedType() {
 
         Map<String, Object> configMap = new HashMap<>();
-        configMap.put("Actions.Types.PreIssueAccessToken.ActionRequest.ExcludedHeaders.Header", "invalid");
+        configMap.put("Actions.Types.PreIssueAccessToken.ActionRequest.ExcludedHeaders.Header", 12);
 
         when(mockIdentityConfigParser.getConfiguration()).thenReturn(configMap);
 
@@ -253,7 +266,7 @@ public class ActionExecutorConfigTest {
     public void testGetExcludedParamsInActionRequestForInvalidConfigForAllTypes() {
 
         Map<String, Object> configMap = new HashMap<>();
-        configMap.put("Actions.ActionRequest.ExcludedParameters.Parameter", "invalid");
+        configMap.put("Actions.ActionRequest.ExcludedParameters.Parameter", 12);
 
         when(mockIdentityConfigParser.getConfiguration()).thenReturn(configMap);
 
@@ -266,7 +279,7 @@ public class ActionExecutorConfigTest {
     public void testGetExcludedParamsInActionRequestForInvalidConfigForDefinedType() {
 
         Map<String, Object> configMap = new HashMap<>();
-        configMap.put("Actions.Types.PreIssueAccessToken.ActionRequest.ExcludedParameters.Parameter", "invalid");
+        configMap.put("Actions.Types.PreIssueAccessToken.ActionRequest.ExcludedParameters.Parameter", 12);
 
         when(mockIdentityConfigParser.getConfiguration()).thenReturn(configMap);
 


### PR DESCRIPTION
### Proposed changes in this pull request

When only one header or parameter is configured in the server level configuration to be excluded in actions request it gets rather skipped as per the current implementation.
This PR fixes that issue.

Relates to https://github.com/wso2/product-is/issues/20926 which incorporated this behaviour

### When should this PR be merged

soon
