### PR TITLE
Align SCIM schemas according the spec definitions

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -1806,26 +1806,6 @@
 				<SupportedByDefault />
 				<MappedLocalClaim>http://wso2.org/claims/metadata.version</MappedLocalClaim>
 			</Claim>
-			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.fax</ClaimURI>
-				<DisplayName>Phone Numbers - Fax Phone Number</DisplayName>
-				<AttributeID>faxPhoneNumber</AttributeID>
-				<Description>Fax Phone Number</Description>
-				<DisplayOrder>5</DisplayOrder>
-				<SupportedByDefault />
-				<RegEx>^\s*(?:\+?(\d{1,3}))?[-. (]*(\d{2,3})[-. )]*(\d{3})[-. ]*(\d{4,6})(?: *x(\d+))?\s*$</RegEx>
-				<MappedLocalClaim>http://wso2.org/claims/phoneNumbers.fax</MappedLocalClaim>
-			</Claim>
-			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.pager</ClaimURI>
-				<DisplayName>Phone Numbers - Pager Phone Number</DisplayName>
-				<AttributeID>pagerPhoneNumber</AttributeID>
-				<Description>Pager Phone Number</Description>
-				<DisplayOrder>5</DisplayOrder>
-				<SupportedByDefault />
-				<RegEx>^\s*(?:\+?(\d{1,3}))?[-. (]*(\d{2,3})[-. )]*(\d{3})[-. ]*(\d{4,6})(?: *x(\d+))?\s*$</RegEx>
-				<MappedLocalClaim>http://wso2.org/claims/phoneNumbers.pager</MappedLocalClaim>
-			</Claim>
 		</Dialect>
 		<Dialect dialectURI="urn:ietf:params:scim:schemas:core:2.0:User"
 				 claimURIRegex="urn:ietf:params:scim:schemas:core:2.0:User:[a-zA-Z0-9$\-_\.]*$">
@@ -2070,6 +2050,26 @@
 				<MappedLocalClaim>http://wso2.org/claims/phoneNumbers.work</MappedLocalClaim>
 			</Claim>
 			<Claim>
+				<ClaimURI>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.fax</ClaimURI>
+				<DisplayName>Phone Numbers - Fax Phone Number</DisplayName>
+				<AttributeID>faxPhoneNumber</AttributeID>
+				<Description>Fax Phone Number</Description>
+				<DisplayOrder>5</DisplayOrder>
+				<SupportedByDefault />
+				<RegEx>^\s*(?:\+?(\d{1,3}))?[-. (]*(\d{2,3})[-. )]*(\d{3})[-. ]*(\d{4,6})(?: *x(\d+))?\s*$</RegEx>
+				<MappedLocalClaim>http://wso2.org/claims/phoneNumbers.fax</MappedLocalClaim>
+			</Claim>
+			<Claim>
+				<ClaimURI>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.pager</ClaimURI>
+				<DisplayName>Phone Numbers - Pager Phone Number</DisplayName>
+				<AttributeID>pagerPhoneNumber</AttributeID>
+				<Description>Pager Phone Number</Description>
+				<DisplayOrder>5</DisplayOrder>
+				<SupportedByDefault />
+				<RegEx>^\s*(?:\+?(\d{1,3}))?[-. (]*(\d{2,3})[-. )]*(\d{3})[-. ]*(\d{4,6})(?: *x(\d+))?\s*$</RegEx>
+				<MappedLocalClaim>http://wso2.org/claims/phoneNumbers.pager</MappedLocalClaim>
+			</Claim>
+			<Claim>
 				<ClaimURI>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.other</ClaimURI>
 				<DisplayName>Phone Numbers - Other</DisplayName>
 				<AttributeID>otherPhoneNumber</AttributeID>
@@ -2270,8 +2270,10 @@
 				<SupportedByDefault />
 				<MappedLocalClaim>http://wso2.org/claims/extendedDisplayName</MappedLocalClaim>
 			</Claim>
+		</Dialect>
+		<Dialect dialectURI="urn:scim:wso2:schema" claimURIRegex="urn:scim:wso2:schema:[a-zA-Z0-9$\-_]*$">
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:askPassword</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:askPassword</ClaimURI>
 				<DisplayName>Ask Password</DisplayName>
 				<AttributeID>askPassword</AttributeID>
 				<Description>Temporary claim to invoke email ask Password feature</Description>
@@ -2281,7 +2283,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/askPassword</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyEmail</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:verifyEmail</ClaimURI>
 				<DisplayName>Verify Email</DisplayName>
 				<AttributeID>verifyEmail</AttributeID>
 				<Description>Temporary claim to invoke email verified feature</Description>
@@ -2290,18 +2292,18 @@
 				<SupportedByDefault />
 				<MappedLocalClaim>http://wso2.org/claims/identity/verifyEmail</MappedLocalClaim>
 			</Claim>
-            <Claim>
-                <ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingEmails.value</ClaimURI>
-                <DisplayName>Verification Pending Email</DisplayName>
-                <AttributeID>pendingEmailAddress</AttributeID>
-                <Description>Claim to store newly updated email address until the new email address is verified</Description>
-                <Required />
-                <DisplayOrder>1</DisplayOrder>
-                <SupportedByDefault />
-                <MappedLocalClaim>http://wso2.org/claims/identity/emailaddress.pendingValue</MappedLocalClaim>
-            </Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:accountLocked</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:pendingEmails.value</ClaimURI>
+				<DisplayName>Verification Pending Email</DisplayName>
+				<AttributeID>pendingEmailAddress</AttributeID>
+				<Description>Claim to store newly updated email address until the new email address is verified</Description>
+				<Required />
+				<DisplayOrder>1</DisplayOrder>
+				<SupportedByDefault />
+				<MappedLocalClaim>http://wso2.org/claims/identity/emailaddress.pendingValue</MappedLocalClaim>
+			</Claim>
+			<Claim>
+				<ClaimURI>urn:scim:wso2:schema:accountLocked</ClaimURI>
 				<DisplayName>Account Locked</DisplayName>
 				<AttributeID>accountLocked</AttributeID>
 				<Description>Account locked</Description>
@@ -2311,7 +2313,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/accountLocked</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:accountState</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:accountState</ClaimURI>
 				<DisplayName>Account State</DisplayName>
 				<AttributeID>accountState</AttributeID>
 				<Description>Account state</Description>
@@ -2321,7 +2323,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/accountState</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:emailOTPDisabled</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:emailOTPDisabled</ClaimURI>
 				<DisplayName>Disable email OTP</DisplayName>
 				<AttributeID>emailOTPDisabled</AttributeID>
 				<Description>Store whether email OTP is enabled or disabled</Description>
@@ -2331,7 +2333,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/emailotp_disabled</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:emailVerified</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:emailVerified</ClaimURI>
 				<DisplayName>Email Verified</DisplayName>
 				<AttributeID>emailVerified</AttributeID>
 				<Description>True if the End-User's e-mail address has been verified; otherwise false</Description>
@@ -2341,7 +2343,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/emailVerified</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedEmailOTPAttempts</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:failedEmailOTPAttempts</ClaimURI>
 				<DisplayName>Account State</DisplayName>
 				<AttributeID>failedEmailOTPAttempts</AttributeID>
 				<Description>Number of failed email OTP attempts</Description>
@@ -2351,7 +2353,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/failedEmailOtpAttempts</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedLoginAttempts</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:failedLoginAttempts</ClaimURI>
 				<DisplayName>Faliled Login Attempts</DisplayName>
 				<AttributeID>failedLoginAttempts</AttributeID>
 				<Description>Number of failed login attempts</Description>
@@ -2361,7 +2363,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/failedLoginAttempts</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedLoginAttemptsBeforeSuccess</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:failedLoginAttemptsBeforeSuccess</ClaimURI>
 				<DisplayName>Faliled Login Attempts Before Success</DisplayName>
 				<AttributeID>failedLoginAttemptsBeforeSuccess</AttributeID>
 				<Description>Number of failed attempts before a success login</Description>
@@ -2371,7 +2373,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/failedLoginAttemptsBeforeSuccess</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedLoginLockoutCount</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:failedLoginLockoutCount</ClaimURI>
 				<DisplayName>Failed Lockout Count</DisplayName>
 				<AttributeID>failedLoginLockoutCount</AttributeID>
 				<Description>Failed lockout count</Description>
@@ -2381,7 +2383,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/failedLoginLockoutCount</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedPasswordRecoveryAttempts</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:failedPasswordRecoveryAttempts</ClaimURI>
 				<DisplayName>Failed Password Recovery Attempts</DisplayName>
 				<AttributeID>failedPasswordRecoveryAttempts</AttributeID>
 				<Description>Number of consecutive failed attempts done for password recovery</Description>
@@ -2391,7 +2393,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/failedPasswordRecoveryAttempts</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedSMSOTPAttempts</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:failedSMSOTPAttempts</ClaimURI>
 				<DisplayName>Failed SMS OTP attempts</DisplayName>
 				<AttributeID>failedSMSOTPAttempts</AttributeID>
 				<Description>Number of failed SMS OTP attempts</Description>
@@ -2401,7 +2403,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/failedSmsOtpAttempts</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedTOTPAttempts</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:failedTOTPAttempts</ClaimURI>
 				<DisplayName>Failed TOTP Attempts</DisplayName>
 				<AttributeID>failedTOTPAttempts</AttributeID>
 				<Description>Number of failed TOTP attempts</Description>
@@ -2411,7 +2413,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/failedTotpAttempts</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:isLiteUser</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:isLiteUser</ClaimURI>
 				<DisplayName>Lite User</DisplayName>
 				<AttributeID>isLiteUser</AttributeID>
 				<Description>Store whether the account is a lite user account</Description>
@@ -2421,7 +2423,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/isLiteUser</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:lastLoginTime</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:lastLoginTime</ClaimURI>
 				<DisplayName>Last Login Time</DisplayName>
 				<AttributeID>lastLoginTime</AttributeID>
 				<Description>Last login time</Description>
@@ -2431,7 +2433,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/lastLoginTime</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:lastLogonTime</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:lastLogonTime</ClaimURI>
 				<DisplayName>Last Logon Time</DisplayName>
 				<AttributeID>lastLogonTime</AttributeID>
 				<Description>Last logon time</Description>
@@ -2441,7 +2443,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/lastLogonTime</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:lastPasswordUpdateTime</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:lastPasswordUpdateTime</ClaimURI>
 				<DisplayName>Last Password Update Time</DisplayName>
 				<AttributeID>lastPasswordUpdateTime</AttributeID>
 				<Description>Last password update time</Description>
@@ -2451,7 +2453,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/lastPasswordUpdateTime</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:lockedReason</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:lockedReason</ClaimURI>
 				<DisplayName>Locked Reason</DisplayName>
 				<AttributeID>lockedReason</AttributeID>
 				<Description>The reason why the user account is locked</Description>
@@ -2461,7 +2463,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/lockedReason</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:phoneVerified</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:phoneVerified</ClaimURI>
 				<DisplayName>Phone Verified</DisplayName>
 				<AttributeID>phoneVerified</AttributeID>
 				<Description>True if the End-User's phone number has been verified; otherwise false</Description>
@@ -2471,7 +2473,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/phoneVerified</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:preferredChannel</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:preferredChannel</ClaimURI>
 				<DisplayName>Preferred Channel</DisplayName>
 				<AttributeID>preferredChannel</AttributeID>
 				<Description>Preferred Notification Channel</Description>
@@ -2481,7 +2483,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/preferredChannel</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:smsOTPDisabled</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:smsOTPDisabled</ClaimURI>
 				<DisplayName>Disable SMS OTP</DisplayName>
 				<AttributeID>smsOTPDisabled</AttributeID>
 				<Description>Store whether SMS OTP is enabled or disabled</Description>
@@ -2491,7 +2493,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/smsotp_disabled</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:tenantAdminAskPassword</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:tenantAdminAskPassword</ClaimURI>
 				<DisplayName>Tenant Admin Ask Password</DisplayName>
 				<AttributeID>tenantAdminAskPassword</AttributeID>
 				<Description>Temporary claim to invoke email tenant admin ask Password feature</Description>
@@ -2501,7 +2503,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/tenantAdminAskPassword</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:unlockTime</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:unlockTime</ClaimURI>
 				<DisplayName>Unlock Time</DisplayName>
 				<AttributeID>unlockTime</AttributeID>
 				<Description>Unlock time</Description>
@@ -2511,7 +2513,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/unlockTime</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:accountDisabled</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:accountDisabled</ClaimURI>
 				<DisplayName>Account Disabled</DisplayName>
 				<AttributeID>accountDisabled</AttributeID>
 				<Description>Store whether the user account is disabled or not</Description>
@@ -2521,7 +2523,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/accountDisabled</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:dateOfBirth</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:dateOfBirth</ClaimURI>
 				<DisplayName>Date Of Birth</DisplayName>
 				<AttributeID>dateOfBirth</AttributeID>
 				<Description>Date of birth</Description>
@@ -2531,7 +2533,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/dob</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:isReadOnlyUser</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:isReadOnlyUser</ClaimURI>
 				<DisplayName>Read Only User</DisplayName>
 				<AttributeID>isReadOnlyUser</AttributeID>
 				<Description>Claim to store if the user is read only</Description>
@@ -2541,7 +2543,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/isReadOnlyUser</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingMobileNumber</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:pendingMobileNumber</ClaimURI>
 				<DisplayName>Verification Pending Mobile</DisplayName>
 				<AttributeID>pendingMobileNumber</AttributeID>
 				<Description>To store newly updated mobile number until it is verified</Description>
@@ -2551,7 +2553,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/mobileNumber.pendingValue</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:forcePasswordReset</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:forcePasswordReset</ClaimURI>
 				<DisplayName>Force Password Reset</DisplayName>
 				<AttributeID>forcePasswordReset</AttributeID>
 				<Description>Temporary claim to invoke forced password reset feature</Description>
@@ -2561,7 +2563,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/adminForcedPasswordReset</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:oneTimePassword</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:oneTimePassword</ClaimURI>
 				<DisplayName>One Time Password</DisplayName>
 				<AttributeID>oneTimePassword</AttributeID>
 				<Description>One Time Password</Description>
@@ -2571,7 +2573,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/oneTimePassword</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyMobile</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:verifyMobile</ClaimURI>
 				<DisplayName>Verify Mobile</DisplayName>
 				<AttributeID>verifyMobile</AttributeID>
 				<Description>Temporary claim to invoke mobile verification feature</Description>
@@ -2581,7 +2583,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/verifyMobile</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:country</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:country</ClaimURI>
 				<DisplayName>Country</DisplayName>
 				<AttributeID>country</AttributeID>
 				<Description>Country</Description>
@@ -2591,7 +2593,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/country</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:userSourceId</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:userSourceId</ClaimURI>
 				<DisplayName>User Source ID</DisplayName>
 				<AttributeID>userSourceId</AttributeID>
 				<Description>User Provisioned IDP ID</Description>
@@ -2601,7 +2603,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/userSourceId</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:totpEnabled</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:totpEnabled</ClaimURI>
 				<DisplayName>TOTP Enabled</DisplayName>
 				<AttributeID>totpEnabled</AttributeID>
 				<Description>TOTP Authenticator Enabled</Description>
@@ -2611,7 +2613,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/totpEnabled</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:backupCodeEnabled</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:backupCodeEnabled</ClaimURI>
 				<DisplayName>Backup Code Enabled</DisplayName>
 				<AttributeID>backupCodeEnable</AttributeID>
 				<Description>Whether user has configured backup code authenticator or not.</Description>
@@ -2621,7 +2623,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/backupCodeEnabled</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedBackupCodeAttempts</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:failedBackupCodeAttempts</ClaimURI>
 				<DisplayName>Failed Backup Code Attempts</DisplayName>
 				<AttributeID>failedBackupCodeAttempts</AttributeID>
 				<Description>Number of failed backup code attempts</Description>
@@ -2631,7 +2633,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/failedBackupCodeAttempts</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:managedOrg</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:managedOrg</ClaimURI>
 				<DisplayName>Managed Organization</DisplayName>
 				<AttributeID>managedOrg</AttributeID>
 				<Description>Organization where the user is managed</Description>
@@ -2640,7 +2642,7 @@
 				<MappedLocalClaim>http://wso2.org/claims/identity/managedOrg</MappedLocalClaim>
 			</Claim>
 			<Claim>
-				<ClaimURI>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:preferredMFAOption</ClaimURI>
+				<ClaimURI>urn:scim:wso2:schema:preferredMFAOption</ClaimURI>
 				<DisplayName>PreferredMFAOption</DisplayName>
 				<AttributeID>preferredMFAOption</AttributeID>
 				<Description>Preferred MFA option</Description>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -211,6 +211,61 @@
           ]
         }
       ]
+    },
+    "legacy": {
+      "schemas.remove_from_default_schema" : [
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0:User",
+          "attributes": [
+            "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.fax",
+            "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.pager"
+          ]
+        }
+      ],
+      "schemas.add_to_default_schema": [
+        {
+          "id": "urn:ietf:params:scim:schemas:core:2.0",
+          "attributes": [
+            "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.fax",
+            "urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.pager"
+          ]
+        },
+        {
+          "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+          "attributes": [
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:accountDisabled",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:accountLocked",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:accountState",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:askPassword",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:country",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:dateOfBirth",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:emailOTPDisabled",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedEmailOTPAttempts",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedLoginAttempts",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedLoginAttemptsBeforeSuccess",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedLoginLockoutCount",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedPasswordRecoveryAttempts",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedSMSOTPAttempts",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedTOTPAttempts",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:forcePasswordReset",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:isLiteUser",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:lastLogonTime",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:lastPasswordUpdateTime",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:lockedReason",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:oneTimePassword",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingMobileNumber",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:phoneVerified",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:preferredChannel",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:smsOTPDisabled",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:tenantAdminAskPassword",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:unlockTime",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:userSourceId",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyEmail",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyMobile",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingEmails.value"
+          ]
+        }
+      ]
     }
   },
   "server.legacy_mode": {

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/schemas.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/schemas.xml.j2
@@ -38,8 +38,6 @@
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:meta.resourceType</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:meta.version</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:externalId</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.fax</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.pager</Attribute>
             </Schema>
             <Schema id="urn:ietf:params:scim:schemas:core:2.0:User">
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:userName</Attribute>
@@ -63,6 +61,8 @@
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.home</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.work</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.mobile</Attribute>
+                <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.fax</Attribute>
+                <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.pager</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.other</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:ims.aim</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:core:2.0:User:ims.gtalk</Attribute>
@@ -95,36 +95,6 @@
                 <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.value</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.$ref</Attribute>
                 <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.displayName</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:accountDisabled</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:accountLocked</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:accountState</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:askPassword</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:country</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:dateOfBirth</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:emailOTPDisabled</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedEmailOTPAttempts</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedLoginAttempts</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedLoginAttemptsBeforeSuccess</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedLoginLockoutCount</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedPasswordRecoveryAttempts</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedSMSOTPAttempts</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:failedTOTPAttempts</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:forcePasswordReset</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:isLiteUser</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:lastLogonTime</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:lastPasswordUpdateTime</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:lockedReason</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:oneTimePassword</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingMobileNumber</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:phoneVerified</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:preferredChannel</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:smsOTPDisabled</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:tenantAdminAskPassword</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:unlockTime</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:userSourceId</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyEmail</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:verifyMobile</Attribute>
-                <Attribute>urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:pendingEmails.value</Attribute>
             </Schema>
         </Schemas>
     </DefaultSchema>


### PR DESCRIPTION
### Proposed changes in this pull request

This PR modifies the SCIM schemas to align with the schema definitions in the specification RFC 7643. 

In `schemas.xml.j2` file,
- `phoneNumbers.fax` and `phoneNumbers.pager` are removed from the score schema and added to the user schema. 
- WSO2 defined SCIM attributes (which are mapped to identity claims and other local claims) are removed from the Enterprise schema and added to the WSO2 schema (URI: urn:scim:wso2:schema).

In `claim-config.xml` file,
- Claims mappings for `phoneNumbers.fax` and `phoneNumbers.pager` are shifted to User schema from Core schema.
- Mapping of WSO2 defined SCIM attributes are shifted to the dialect `urn:scim:wso2:schema`.

To preserve backward compatibility,
- A new `schemas.profile` called `legacy` is introduced. When this profile is enabled, the default schema will be modified to the existing state. 

### Related Issues
- https://github.com/wso2/product-is/issues/20850

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
