### PR TITLE
Provide support to configure additional cookie properties

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2511,7 +2511,11 @@
     {% if identity.cookies is defined %}
     <Cookies>
     {% for cookie in identity.cookies %}
-        <Cookie name="{{cookie.name}}" domain="{{cookie.domain}}" httpOnly="{{cookie.httpOnly}}" secure="{{cookie.secure}}" sameSite="{{cookie.sameSite}}" />
+        <Cookie
+        {% for key,value in cookie.items() %}
+            {{key}}="{{value}}"
+        {% endfor %}
+        />
     {% endfor %}
     </Cookies>
     {% endif %}


### PR DESCRIPTION
### Purpose
Only these cookie properties are supported to be configured via deployment.toml as of now: `domain, httpOnly, secure, sameSite`

This pr adds support to configure `path, maxAge, comment, version` and any other additional properties added in the future

Following properties can be configured from deployment.toml
```
[[identity.cookies]]
name = "commonAuthId"
domain = "test.com"
httpOnly = true
secure = false
sameSite="NONE"
path="/home"
maxAge="1"
comment="test"
version="2"
```

### Related issue
- https://github.com/wso2/product-is/issues/20943