### PR TITLE
Provide SCIM2 roles based outbound provisioning

### DIFF
--- a/components/provisioning/org.wso2.carbon.identity.provisioning/pom.xml
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/pom.xml
@@ -89,6 +89,10 @@
             <artifactId>org.wso2.carbon.identity.role.v2.mgt.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.balana</groupId>
             <artifactId>org.wso2.balana.utils</artifactId>
         </dependency>
@@ -167,7 +171,8 @@
                             org.wso2.carbon.user.mgt.*;
                             version="${carbon.identity.package.import.version.range}",
                             org.json;version="${json.wso2.version.range}",
-                            org.wso2.carbon.identity.role.v2.mgt.core.*; version="${carbon.identity.package.import.version.range}"
+                            org.wso2.carbon.identity.role.v2.mgt.core.*; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.util; version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.provisioning.internal,

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/pom.xml
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/pom.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- ~
- ~ WSO2 Inc. licenses this file to you under the Apache License,
- ~ Version 2.0 (the "License"); you may not use this file except
- ~ in compliance with the License.
- ~ You may obtain a copy of the License at
- ~
- ~    http://www.apache.org/licenses/LICENSE-2.0
- ~
- ~ Unless required by applicable law or agreed to in writing,
- ~ software distributed under the License is distributed on an
- ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- ~ KIND, either express or implied.  See the License for the
- ~ specific language governing permissions and limitations
- ~ under the License.
- -->
+  ~ Copyright (c) 2010-2024, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
@@ -83,6 +83,10 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.role.v2.mgt.core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.balana</groupId>
@@ -163,6 +167,7 @@
                             org.wso2.carbon.user.mgt.*;
                             version="${carbon.identity.package.import.version.range}",
                             org.json;version="${json.wso2.version.range}",
+                            org.wso2.carbon.identity.role.v2.mgt.core.*; version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.provisioning.internal,

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/OutboundProvisioningManager.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/OutboundProvisioningManager.java
@@ -888,7 +888,6 @@ public class OutboundProvisioningManager {
         if (provisioningEntity.getAttributes() != null &&
                 StringUtils.isNotBlank(provisioningEntity.getEntityName())) {
             String userName = provisioningEntity.getEntityName();
-            isInternalRole(provisioningEntity.getEntityName(), tenantDomain);
             List<String> provisioningRoleList = Arrays.asList(provisionByRoleList);
             if (provisioningEntity.getInboundAttributes() == null ||
                     provisioningEntity.getInboundAttributes().get(USER_ID_CLAIM) == null) {

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/OutboundProvisioningManager.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/OutboundProvisioningManager.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -493,9 +493,14 @@ public class OutboundProvisioningManager {
                     Map<ClaimMapping, List<String>> attributes = provisioningEntity.getAttributes();
                     List<String> newUsersList = attributes.get(ClaimMapping.build(
                             IdentityProvisioningConstants.NEW_USER_CLAIM_URI, null, null, false));
-
+                    if (newUsersList == null) {
+                        newUsersList = new ArrayList<>();
+                    }
                     List<String> deletedUsersList = attributes.get(ClaimMapping.build(
                             IdentityProvisioningConstants.DELETED_USER_CLAIM_URI, null, null, false));
+                    if (deletedUsersList == null) {
+                        deletedUsersList = new ArrayList<>();
+                    }
 
                     Map<ClaimMapping, List<String>> mappedUserClaims;
                     ProvisionedIdentifier provisionedUserIdentifier;

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/OutboundProvisioningManager.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/OutboundProvisioningManager.java
@@ -65,6 +65,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.CONSOLE_APPLICATION_NAME;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.LOCAL_SP;
@@ -73,6 +74,7 @@ import static org.wso2.carbon.identity.provisioning.IdentityProvisioningConstant
 import static org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants.SELF_SIGNUP_ROLE;
 import static org.wso2.carbon.identity.provisioning.ProvisioningUtil.isApplicationBasedOutboundProvisioningEnabled;
 import static org.wso2.carbon.identity.provisioning.ProvisioningUtil.isUserTenantBasedOutboundProvisioningEnabled;
+import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.INTERNAL_DOMAIN;
 
 /**
  *
@@ -877,7 +879,9 @@ public class OutboundProvisioningManager {
                 StringUtils.isNotBlank(provisioningEntity.getEntityName())) {
             String userName = provisioningEntity.getEntityName();
             List<String> provisioningRoleList = Arrays.asList(provisionByRoleList);
-
+            provisioningRoleList = provisioningRoleList.stream()
+                    .map(role -> INTERNAL_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + role)
+                    .collect(Collectors.toList());
             List<String> roleListOfUser = getUserRoles(userName, tenantDomain);
             if (userHasProvisioningRoles(roleListOfUser, provisioningRoleList, userName)) {
                 return true;

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisioningUtil.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisioningUtil.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.OutboundProvisioningConfig;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -560,12 +561,18 @@ public class ProvisioningUtil {
     public static boolean isOutboundProvisioningEnabled(String serviceProviderIdentifier,
                                                         String tenantDomainName) throws IdentityApplicationManagementException {
 
+        if (!isApplicationBasedOutboundProvisioningEnabled()) {
+            return true;
+        }
+
         ServiceProvider serviceProvider = ApplicationManagementService.getInstance()
                 .getServiceProvider(serviceProviderIdentifier, tenantDomainName);
-
         if (serviceProvider == null) {
             throw new IdentityApplicationManagementException("Cannot find the service provider " +
                     serviceProviderIdentifier);
+        }
+        if (ApplicationConstants.CONSOLE_APPLICATION_NAME.equals(serviceProvider.getApplicationName())) {
+            return true;
         }
 
         OutboundProvisioningConfig outboundProvisioningConfiguration = serviceProvider

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -36,6 +36,9 @@ import org.wso2.carbon.identity.provisioning.listener.DefaultInboundUserProvisio
 import org.wso2.carbon.identity.provisioning.listener.ProvisioningApplicationMgtListener;
 import org.wso2.carbon.identity.provisioning.listener.ProvisioningErrorListener;
 import org.wso2.carbon.identity.provisioning.listener.ProvisioningIdentityProviderMgtListener;
+import org.wso2.carbon.identity.provisioning.listener.ProvisioningRoleMgtListener;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
+import org.wso2.carbon.identity.role.v2.mgt.core.listener.RoleManagementListener;
 import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
 import org.wso2.carbon.user.core.listener.UserManagementErrorEventListener;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
@@ -88,7 +91,9 @@ public class IdentityProvisionServiceComponent {
     protected void activate(ComponentContext context) {
         try {
             ProvisioningServiceDataHolder.getInstance().setBundleContext(context.getBundleContext());
-            ProvisioningServiceDataHolder.getInstance().getBundleContext().registerService(UserOperationEventListener.class.getName(), new DefaultInboundUserProvisioningListener(), null);
+            DefaultInboundUserProvisioningListener provisioningListener = new DefaultInboundUserProvisioningListener();
+            ProvisioningServiceDataHolder.getInstance().setDefaultInboundUserProvisioningListener(provisioningListener);
+            ProvisioningServiceDataHolder.getInstance().getBundleContext().registerService(UserOperationEventListener.class.getName(), provisioningListener, null);
             if (log.isDebugEnabled()) {
                 log.debug("Identity Provision Event listener registered successfully");
             }
@@ -103,6 +108,9 @@ public class IdentityProvisionServiceComponent {
             ProvisioningServiceDataHolder.getInstance().getBundleContext()
                     .registerService(UserManagementErrorEventListener.class.getName(), new ProvisioningErrorListener(),
                             null);
+            ProvisioningServiceDataHolder.getInstance().getBundleContext()
+                    .registerService(RoleManagementListener.class, new ProvisioningRoleMgtListener(), null);
+            log.debug("Provisioning role management listener registered successfully");
             if (log.isDebugEnabled()) {
                 log.debug("Identity provisioning error event listener registered successfully");
             }
@@ -206,6 +214,24 @@ public class IdentityProvisionServiceComponent {
             log.debug("Role Permission Management Service is unset to Identity Provisioning bundle.");
         }
         ProvisioningServiceDataHolder.getInstance().setRolePermissionManagementService(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService",
+            service = org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRoleManagementServiceV2")
+    protected void setRoleManagementServiceV2(RoleManagementService roleManagementService) {
+
+        ProvisioningServiceDataHolder.getInstance().setRoleManagementService(roleManagementService);
+        log.debug("RoleManagementService set in ProvisioningServiceDataHolder bundle.");
+    }
+
+    protected void unsetRoleManagementServiceV2(RoleManagementService roleManagementService) {
+
+        ProvisioningServiceDataHolder.getInstance().setRoleManagementService(null);
+        log.debug("RoleManagementService unset in ProvisioningServiceDataHolder bundle.");
     }
 }
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
@@ -93,7 +93,8 @@ public class IdentityProvisionServiceComponent {
             ProvisioningServiceDataHolder.getInstance().setBundleContext(context.getBundleContext());
             DefaultInboundUserProvisioningListener provisioningListener = new DefaultInboundUserProvisioningListener();
             ProvisioningServiceDataHolder.getInstance().setDefaultInboundUserProvisioningListener(provisioningListener);
-            ProvisioningServiceDataHolder.getInstance().getBundleContext().registerService(UserOperationEventListener.class.getName(), provisioningListener, null);
+            ProvisioningServiceDataHolder.getInstance().getBundleContext()
+                    .registerService(UserOperationEventListener.class.getName(), provisioningListener, null);
             if (log.isDebugEnabled()) {
                 log.debug("Identity Provision Event listener registered successfully");
             }

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
@@ -37,7 +37,6 @@ import org.wso2.carbon.identity.provisioning.listener.ProvisioningApplicationMgt
 import org.wso2.carbon.identity.provisioning.listener.ProvisioningErrorListener;
 import org.wso2.carbon.identity.provisioning.listener.ProvisioningIdentityProviderMgtListener;
 import org.wso2.carbon.identity.provisioning.listener.ProvisioningRoleMgtListener;
-import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.listener.RoleManagementListener;
 import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
 import org.wso2.carbon.user.core.listener.UserManagementErrorEventListener;
@@ -214,24 +213,6 @@ public class IdentityProvisionServiceComponent {
             log.debug("Role Permission Management Service is unset to Identity Provisioning bundle.");
         }
         ProvisioningServiceDataHolder.getInstance().setRolePermissionManagementService(null);
-    }
-
-    @Reference(
-            name = "org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService",
-            service = org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService.class,
-            cardinality = ReferenceCardinality.MANDATORY,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetRoleManagementServiceV2")
-    protected void setRoleManagementServiceV2(RoleManagementService roleManagementService) {
-
-        ProvisioningServiceDataHolder.getInstance().setRoleManagementService(roleManagementService);
-        log.debug("RoleManagementService set in ProvisioningServiceDataHolder bundle.");
-    }
-
-    protected void unsetRoleManagementServiceV2(RoleManagementService roleManagementService) {
-
-        ProvisioningServiceDataHolder.getInstance().setRoleManagementService(null);
-        log.debug("RoleManagementService unset in ProvisioningServiceDataHolder bundle.");
     }
 }
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/IdentityProvisionServiceComponent.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.provisioning.listener.ProvisioningApplicationMgt
 import org.wso2.carbon.identity.provisioning.listener.ProvisioningErrorListener;
 import org.wso2.carbon.identity.provisioning.listener.ProvisioningIdentityProviderMgtListener;
 import org.wso2.carbon.identity.provisioning.listener.ProvisioningRoleMgtListener;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.listener.RoleManagementListener;
 import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
 import org.wso2.carbon.user.core.listener.UserManagementErrorEventListener;
@@ -213,6 +214,24 @@ public class IdentityProvisionServiceComponent {
             log.debug("Role Permission Management Service is unset to Identity Provisioning bundle.");
         }
         ProvisioningServiceDataHolder.getInstance().setRolePermissionManagementService(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService",
+            service = org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRoleManagementServiceV2")
+    protected void setRoleManagementServiceV2(RoleManagementService roleManagementService) {
+
+        ProvisioningServiceDataHolder.getInstance().setRoleManagementService(roleManagementService);
+        log.debug("RoleManagementService set in ProvisioningServiceDataHolder bundle.");
+    }
+
+    protected void unsetRoleManagementServiceV2(RoleManagementService roleManagementService) {
+
+        ProvisioningServiceDataHolder.getInstance().setRoleManagementService(null);
+        log.debug("RoleManagementService unset in ProvisioningServiceDataHolder bundle.");
     }
 }
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/ProvisioningServiceDataHolder.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/ProvisioningServiceDataHolder.java
@@ -22,7 +22,6 @@ import org.osgi.framework.BundleContext;
 import org.wso2.carbon.identity.entitlement.EntitlementService;
 import org.wso2.carbon.identity.provisioning.AbstractProvisioningConnectorFactory;
 import org.wso2.carbon.identity.provisioning.listener.DefaultInboundUserProvisioningListener;
-import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.mgt.RolePermissionManagementService;
 
@@ -38,7 +37,6 @@ public class ProvisioningServiceDataHolder {
     private RolePermissionManagementService rolePermissionManagementService;
     private Map<String, AbstractProvisioningConnectorFactory> connectorFactories = new HashMap<String, AbstractProvisioningConnectorFactory>();
     private DefaultInboundUserProvisioningListener defaultInboundUserProvisioningListener;
-    private RoleManagementService roleManagementService;
 
     private ProvisioningServiceDataHolder() {
     }
@@ -108,16 +106,6 @@ public class ProvisioningServiceDataHolder {
             DefaultInboundUserProvisioningListener defaultInboundUserProvisioningListener) {
 
         this.defaultInboundUserProvisioningListener = defaultInboundUserProvisioningListener;
-    }
-
-    public RoleManagementService getRoleManagementService() {
-
-        return roleManagementService;
-    }
-
-    public void setRoleManagementService(RoleManagementService roleManagementService) {
-
-        this.roleManagementService = roleManagementService;
     }
 }
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/ProvisioningServiceDataHolder.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/ProvisioningServiceDataHolder.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2015-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -21,6 +21,8 @@ package org.wso2.carbon.identity.provisioning.internal;
 import org.osgi.framework.BundleContext;
 import org.wso2.carbon.identity.entitlement.EntitlementService;
 import org.wso2.carbon.identity.provisioning.AbstractProvisioningConnectorFactory;
+import org.wso2.carbon.identity.provisioning.listener.DefaultInboundUserProvisioningListener;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.mgt.RolePermissionManagementService;
 
@@ -35,6 +37,8 @@ public class ProvisioningServiceDataHolder {
     private EntitlementService entitlementService;
     private RolePermissionManagementService rolePermissionManagementService;
     private Map<String, AbstractProvisioningConnectorFactory> connectorFactories = new HashMap<String, AbstractProvisioningConnectorFactory>();
+    private DefaultInboundUserProvisioningListener defaultInboundUserProvisioningListener;
+    private RoleManagementService roleManagementService;
 
     private ProvisioningServiceDataHolder() {
     }
@@ -93,6 +97,27 @@ public class ProvisioningServiceDataHolder {
             throw new RuntimeException("Role permission management service cannot be found.");
         }
         return rolePermissionManagementService;
+    }
+
+    public DefaultInboundUserProvisioningListener getDefaultInboundUserProvisioningListener() {
+
+        return defaultInboundUserProvisioningListener;
+    }
+
+    public void setDefaultInboundUserProvisioningListener(
+            DefaultInboundUserProvisioningListener defaultInboundUserProvisioningListener) {
+
+        this.defaultInboundUserProvisioningListener = defaultInboundUserProvisioningListener;
+    }
+
+    public RoleManagementService getRoleManagementService() {
+
+        return roleManagementService;
+    }
+
+    public void setRoleManagementService(RoleManagementService roleManagementService) {
+
+        this.roleManagementService = roleManagementService;
     }
 }
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/ProvisioningServiceDataHolder.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/internal/ProvisioningServiceDataHolder.java
@@ -22,6 +22,7 @@ import org.osgi.framework.BundleContext;
 import org.wso2.carbon.identity.entitlement.EntitlementService;
 import org.wso2.carbon.identity.provisioning.AbstractProvisioningConnectorFactory;
 import org.wso2.carbon.identity.provisioning.listener.DefaultInboundUserProvisioningListener;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.mgt.RolePermissionManagementService;
 
@@ -37,6 +38,7 @@ public class ProvisioningServiceDataHolder {
     private RolePermissionManagementService rolePermissionManagementService;
     private Map<String, AbstractProvisioningConnectorFactory> connectorFactories = new HashMap<String, AbstractProvisioningConnectorFactory>();
     private DefaultInboundUserProvisioningListener defaultInboundUserProvisioningListener;
+    private RoleManagementService roleManagementService;
 
     private ProvisioningServiceDataHolder() {
     }
@@ -106,6 +108,16 @@ public class ProvisioningServiceDataHolder {
             DefaultInboundUserProvisioningListener defaultInboundUserProvisioningListener) {
 
         this.defaultInboundUserProvisioningListener = defaultInboundUserProvisioningListener;
+    }
+
+    public RoleManagementService getRoleManagementService() {
+
+        return roleManagementService;
+    }
+
+    public void setRoleManagementService(RoleManagementService roleManagementService) {
+
+        this.roleManagementService = roleManagementService;
     }
 }
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/DefaultInboundUserProvisioningListener.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/DefaultInboundUserProvisioningListener.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants;
 import org.wso2.carbon.identity.provisioning.IdentityProvisioningException;
 import org.wso2.carbon.identity.provisioning.OutboundProvisioningManager;
@@ -174,7 +175,16 @@ public class DefaultInboundUserProvisioningListener extends AbstractIdentityUser
                 outboundAttributes);
 
         // set the in-bound attribute list.
-        provisioningEntity.setInboundAttributes(inboundAttributes);
+        Map<String, String> provisioningAttributes = new HashMap<>(inboundAttributes);
+        if (IdentityUtil.threadLocalProperties.get().get("newClaimList") instanceof HashMap<?,?>) {
+            Map<?, ?> newClaimList = (HashMap<?, ?>) IdentityUtil.threadLocalProperties.get().get("newClaimList");
+            for (Map.Entry<?, ?> entry : newClaimList.entrySet()) {
+                if (entry.getKey() instanceof String && entry.getValue() instanceof String) {
+                    provisioningAttributes.computeIfAbsent((String) entry.getKey(), k -> (String) entry.getValue());
+                }
+            }
+        }
+        provisioningEntity.setInboundAttributes(provisioningAttributes);
 
         String tenantDomainName = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/DefaultInboundUserProvisioningListener.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/DefaultInboundUserProvisioningListener.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/ProvisioningRoleMgtListener.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/ProvisioningRoleMgtListener.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.provisioning.listener;
+
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.provisioning.internal.ProvisioningServiceDataHolder;
+import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
+import org.wso2.carbon.identity.role.v2.mgt.core.listener.AbstractRoleManagementListener;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+
+import java.util.List;
+
+public class ProvisioningRoleMgtListener extends AbstractRoleManagementListener {
+
+    @Override
+    public int getDefaultOrderId() {
+
+        return 999;
+    }
+
+    @Override
+    public boolean isEnable() {
+
+        return true;
+    }
+
+    @Override
+    public void postUpdateUserListOfRole(String roleId, List<String> newUserIDList, List<String> deletedUserIDList,
+                                         String tenantDomain) throws IdentityRoleManagementException {
+
+        try {
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) ProvisioningServiceDataHolder
+                    .getInstance().getRealmService().getTenantUserRealm(IdentityTenantUtil.getTenantId(tenantDomain))
+                    .getUserStoreManager();
+
+            String[] deletedUserNames = deletedUserIDList.stream().map(userId -> {
+                try {
+                    return userStoreManager.getUserNameFromUserID(userId);
+                } catch (org.wso2.carbon.user.core.UserStoreException e) {
+                    return userId;
+                }
+            }).toArray(String[]::new);
+
+            String[] newUserNames = newUserIDList.stream().map(userId -> {
+                try {
+                    return userStoreManager.getUserNameFromUserID(userId);
+                } catch (org.wso2.carbon.user.core.UserStoreException e) {
+                    return userId;
+                }
+            }).toArray(String[]::new);
+
+            String roleName = ProvisioningServiceDataHolder.getInstance().getRoleManagementService().getRoleNameByRoleId(roleId, tenantDomain);
+            ProvisioningServiceDataHolder.getInstance().getDefaultInboundUserProvisioningListener()
+                    .doPostUpdateUserListOfRole(roleName, deletedUserNames, newUserNames, userStoreManager);
+        } catch (UserStoreException e) {
+            throw new IdentityRoleManagementException(e.getMessage(), e);
+        }
+    }
+}

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/ProvisioningRoleMgtListener.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/ProvisioningRoleMgtListener.java
@@ -31,6 +31,9 @@ import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 
 import java.util.List;
 
+/**
+ * The implementation for outbound user provisioning based on role.
+ */
 public class ProvisioningRoleMgtListener extends AbstractRoleManagementListener {
 
     @Override

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1372,6 +1372,12 @@
                        name="org.wso2.carbon.identity.organization.management.organization.user.sharing.listener.SharedUserOperationEventListener"
                        orderId="128" enable="true"/>
 
+        <!-- Role management Event Listeners -->
+        <EventListener id="provisioning_role_mgt_listener"
+                       type="org.wso2.carbon.identity.role.v2.mgt.core.listener.RoleManagementListener"
+                       name="org.wso2.carbon.identity.provisioning.listener.ProvisioningRoleMgtListener"
+                       orderId="999" enable="true"/>
+
     </EventListeners>
 
     <!-- These recorders are used to write user delete information to specific sources. Default event recorder is CSV

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2253,6 +2253,13 @@
                        orderId="{{event.default_listener.organization_user_association_listener.priority}}"
                        enable="{{event.default_listener.organization_user_association_listener.enable}}"/>
 
+        <!-- Role management Event Listeners -->
+        <EventListener id="provisioning_role_mgt_listener"
+                               type="org.wso2.carbon.identity.role.v2.mgt.core.listener.RoleManagementListener"
+                               name="org.wso2.carbon.identity.provisioning.listener.ProvisioningRoleMgtListener"
+                               orderId="{{event.default_listener.provisioning_role_mgt_listener.priority}}"
+                               enable="{{event.default_listener.provisioning_role_mgt_listener.enable}}"/>
+
         <!-- Introspection Data Providers -->
         <EventListener id="is_introspection_data_provider" type="org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
                 name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.mutualtls.introspection.ISIntrospectionDataProvider"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -597,6 +597,9 @@
   "event.default_listener.organization_user_association_listener.priority": "128",
   "event.default_listener.organization_user_association_listener.enable": true,
 
+  "event.default_listener.provisioning_role_mgt_listener.enable": true,
+  "event.default_listener.provisioning_role_mgt_listener.priority": "999",
+
   "event.default_listener.unique_claim_user_operation_event_listener.priority": "101",
   "event.default_listener.unique_claim_user_operation_event_listener.enable": false,
 


### PR DESCRIPTION
### Proposed changes in this pull request

The SCIM2 role based outbound provisioning is provide by this PR. 
When role updates, a listener is introduced to be executed to provision the users to the outbound connectors.

### Related Issues
- https://github.com/wso2/product-is/issues/11394

The role based outbound provisioning worked for both groups and roles previously. A coma separated role name list is passed in the API payload.

But with IS 7.0, role name is not unique in a given tenant. Hence role uuid is used when referring roles.
The group based outbound provisioning can be separately handled (Adding another column or IDP property to keep the groups for outbound provisioning) instead of having under the list of outbound roles, but in this PR the roles& groups still kept in same list and process.

```
curl --location --request PUT 'https://localhost:9443/t/<tenant-domain>/api/server/v1/identity-providers/<idp-id>/roles' \
--header 'Accept: application/json' \
--header 'Referer;' \
--header 'Authorization: Basic YWRtaW46YWRtaW4=' \
--header 'Content-Type: application/json' \
--data '{
    "mappings": [],
    "outboundProvisioningRoles": [
        "<role-uuid>, <group-name>"
    ]
}'
```