### PR TITLE
Fix the issue with the encodeURL method when a # symbol is present in the query params of given URL

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
@@ -91,6 +91,7 @@ public class IdentityManagementEndpointUtil {
     public static final String PADDING_CHAR = "=";
     public static final String UNDERSCORE = "_";
     public static final String SPLITTING_CHAR = "&";
+    public static final String FRAGMENT_CHAR = "#";
     public static final String PII_CATEGORIES = "piiCategories";
     public static final String PII_CATEGORY = "piiCategory";
     public static final String PURPOSES = "purposes";
@@ -558,6 +559,7 @@ public class IdentityManagementEndpointUtil {
     /**
      * Encode query params of the call back url. Method supports all URL formats supported in
      * {@link #getURLEncodedCallback(String)} and URLs containing spaces
+     * NOTE: This method will not support URLs that contain a fragment part.
      *
      * @param callbackUrl callback url from the request.
      * @return encoded callback url.
@@ -568,6 +570,23 @@ public class IdentityManagementEndpointUtil {
         URL url = new URL(callbackUrl);
         StringBuilder encodedCallbackUrl = new StringBuilder(
                 new URL(url.getProtocol(), url.getHost(), url.getPort(), url.getPath(), null).toString());
+
+        /*
+         * If the given URL contains query parameters that include a `#` symbol,
+         * the URL class will store the content after the `#` in the `ref` field.
+         * This logic checks if both query parameters and the `ref` field exist,
+         * and if so, appends the `ref` part, prefixed with a `#`, to the query
+         * parameters.
+         */
+        StringBuilder queryParams = new StringBuilder();
+        if (StringUtils.isNotBlank(url.getQuery())) {
+            queryParams.append(url.getQuery());
+            if (StringUtils.isNotBlank(url.getRef())) {
+                queryParams.append(FRAGMENT_CHAR);
+                queryParams.append(url.getRef());
+            }
+        }
+
         Map<String, String> encodedQueryMap = getEncodedQueryParamMap(url.getQuery());
 
         if (MapUtils.isNotEmpty(encodedQueryMap)) {

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
@@ -587,7 +587,7 @@ public class IdentityManagementEndpointUtil {
             }
         }
 
-        Map<String, String> encodedQueryMap = getEncodedQueryParamMap(url.getQuery());
+        Map<String, String> encodedQueryMap = getEncodedQueryParamMap(queryParams.toString());
 
         if (MapUtils.isNotEmpty(encodedQueryMap)) {
             encodedCallbackUrl.append("?");


### PR DESCRIPTION
## Purpose

### Previous Behaviour
This `encodeURL` utility function is designed to encode the query parameters of a given URL. However, when the URL contains a `#` symbol in its query parameters, the function fails to generate the correct encoded URL. For instance, consider the following URL:

```bash
https://example.com/path/to/the/resources?query1=test 1&query2=test 2#test&query3=test3&query4=test4
```

If we pass the above URL to the `encodeURL` method, it will return the following URL as the result: 

```bash
https://example.com/path/to/the/resources?query1=test%201&query2=test%202
```
You'll notice that in the above URL, all query strings after the `#` symbol are missing. The main reason for this is that the `encodeURL` method uses `java.net.URL` to separate the URL components. Since `#` is considered a special character, everything after it is treated as the fragment of the URL. As a result, the `encodeURL` method returns a URL that omits everything following the `#` symbol.

### New Behaviour
In the previous behavior, `encodeURL` didn't support URLs with fragment parts or `#` symbols. Since there's no straightforward way to differentiate between fragments and the `#` character in query parameters, we'll need to make improvements without accounting for fragmented URLs. This will be a limitation of the `encodeURL` method.

`Assumption: The callback url doesn't contain fragment part`

This PR introduces changes to address the issue described above by treating the `#` symbol as part of the query string if query parameters are present in the URL. With this implementation, the above URL can be correctly encoded as follows.

Example 1:
```bash
https://example.com/path/to/the/resources?query1=test%201&query2=test%202%23test&query3=test3&query4=test4
```

### Related Issue
- https://github.com/wso2/product-is/issues/20914