### PR TITLE
[🧹 UNIFICATION CLEANUP] Remove redundant `applications.myaccount.saasMyaccountSettings`

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1154,8 +1154,7 @@
   "console.applications.scopes.delete": ["internal_application_mgt_delete"],
   "console.applications.disabled_features": [
     "applications.loginFlow.ai",
-    "applications.loginFlow.legacyEditor",
-    "applications.myaccount.saasMyaccountSettings"
+    "applications.loginFlow.legacyEditor"
   ],
   "console.applications.ui.certificate_alias_enabled": false,
   "console.application_roles.enabled": false,


### PR DESCRIPTION
### Purpose

`applications.myaccount.saasMyaccountSettings` is no longer needed with the refactor done in the following PR:
- https://github.com/wso2/identity-apps/pull/6838

### Related Issues
- https://github.com/wso2/product-is/issues/20802