### PR TITLE
Prioritize input parameters before cookie config values when updating cookie

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2222,20 +2222,20 @@ public class FrameworkUtils {
             cookieBuilder.setDomain(cookieConfig.getDomain());
         }
 
-        if (cookieConfig.getPath() != null) {
-            cookieBuilder.setPath(cookieConfig.getPath());
-        } else if (StringUtils.isNotBlank(path)) {
+        if (StringUtils.isNotBlank(path)) {
             cookieBuilder.setPath(path);
+        } else if (cookieConfig.getPath() != null) {
+            cookieBuilder.setPath(cookieConfig.getPath());
         }
 
         if (cookieConfig.getComment() != null) {
             cookieBuilder.setComment(cookieConfig.getComment());
         }
 
-        if (cookieConfig.getMaxAge() > 0) {
-            cookieBuilder.setMaxAge(cookieConfig.getMaxAge());
-        } else if (age != null) {
+        if (age != null) {
             cookieBuilder.setMaxAge(age);
+        } else if (cookieConfig.getMaxAge() > 0) {
+            cookieBuilder.setMaxAge(cookieConfig.getMaxAge());
         }
 
         if (cookieConfig.getVersion() > 0) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -664,6 +664,27 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
     }
 
     @Test
+    public void testSetCookieExistCookieConfigWithMaxAgeAndPath() {
+
+        IdentityCookieConfig cookieConfig = new IdentityCookieConfig(FrameworkConstants.COMMONAUTH_COOKIE);
+        cookieConfig.setPath("Dummy-Path");
+        cookieConfig.setMaxAge(3600);
+        IdentityUtil.getIdentityCookiesConfigurationHolder().put(FrameworkConstants.COMMONAUTH_COOKIE, cookieConfig);
+        int age = 7200;
+
+        FrameworkUtils.setCookie(request, response, FrameworkConstants.COMMONAUTH_COOKIE, "commonAuthIdValue", age);
+
+        verify(response, times(1)).addCookie(cookieCaptor.capture());
+        List<Cookie> capturedCookies = cookieCaptor.getAllValues();
+        Cookie storedCookie = capturedCookies.get(0);
+        assertEquals(storedCookie.getName(), FrameworkConstants.COMMONAUTH_COOKIE);
+        assertEquals(storedCookie.getPath(), "Dummy-Path");
+        assertEquals(storedCookie.getMaxAge(), age);
+
+        IdentityUtil.getIdentityCookiesConfigurationHolder().put(FrameworkConstants.COMMONAUTH_COOKIE, null);
+    }
+
+    @Test
     public void testGetCookieExistingCookie() {
 
         Cookie[] cookies = getAuthenticationCookies();


### PR DESCRIPTION
### Proposed changes in this pull request
- When cookies are updated with values given for `age` and `path`, given values should be prioritized over the cookie config values configured in deployment.toml 