### PR TITLE
Improve ConfigPersistenceManager contract

### DIFF
--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/ConfigPersistenceManager.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/ConfigPersistenceManager.java
@@ -52,5 +52,5 @@ public interface ConfigPersistenceManager {
      * @return true if the policy combining algorithm is updated, false if the policy combining algorithm is added.
      * @throws EntitlementException If an error occurs.
      */
-    boolean addOrUpdateGlobalPolicyAlgorithm(String policyCombiningAlgorithm) throws EntitlementException;
+    void addOrUpdateGlobalPolicyAlgorithm(String policyCombiningAlgorithm) throws EntitlementException;
 }

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/HybridConfigPersistenceManager.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/HybridConfigPersistenceManager.java
@@ -56,16 +56,15 @@ public class HybridConfigPersistenceManager implements ConfigPersistenceManager 
     }
 
     @Override
-    public boolean addOrUpdateGlobalPolicyAlgorithm(String policyCombiningAlgorithm) throws EntitlementException {
+    public void addOrUpdateGlobalPolicyAlgorithm(String policyCombiningAlgorithm) throws EntitlementException {
 
-        boolean isUpdate = jdbcConfigPersistenceManager.addOrUpdateGlobalPolicyAlgorithm(policyCombiningAlgorithm);
-        if (!isUpdate) {
+        jdbcConfigPersistenceManager.addOrUpdateGlobalPolicyAlgorithm(policyCombiningAlgorithm);
+        if (registryConfigPersistenceManager.isGlobalPolicyAlgorithmExist()) {
             try {
                 registryConfigPersistenceManager.deleteGlobalPolicyAlgorithm();
             } catch (EntitlementException e) {
                 LOG.debug("Error while deleting global policy combining algorithm from registry", e);
             }
         }
-        return isUpdate;
     }
 }

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/JDBCConfigPersistenceManager.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/JDBCConfigPersistenceManager.java
@@ -65,7 +65,7 @@ public class JDBCConfigPersistenceManager implements ConfigPersistenceManager {
      * @throws EntitlementException throws if fails.
      */
     @Override
-    public boolean addOrUpdateGlobalPolicyAlgorithm(String policyCombiningAlgorithm) throws EntitlementException {
+    public void addOrUpdateGlobalPolicyAlgorithm(String policyCombiningAlgorithm) throws EntitlementException {
 
         int tenantId = CarbonContext.getThreadLocalCarbonContext().getTenantId();
 
@@ -79,10 +79,8 @@ public class JDBCConfigPersistenceManager implements ConfigPersistenceManager {
         }
         if (StringUtils.isBlank(algorithm)) {
             configDAO.insertPolicyCombiningAlgorithm(policyCombiningAlgorithm, tenantId);
-            return false;
         } else {
             configDAO.updatePolicyCombiningAlgorithm(policyCombiningAlgorithm, tenantId);
-            return true;
         }
     }
 }

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/RegistryConfigPersistenceManager.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/RegistryConfigPersistenceManager.java
@@ -55,9 +55,8 @@ public class RegistryConfigPersistenceManager implements ConfigPersistenceManage
      * @throws EntitlementException If an error occurs.
      */
     @Override
-    public boolean addOrUpdateGlobalPolicyAlgorithm(String policyCombiningAlgorithm) throws EntitlementException {
+    public void addOrUpdateGlobalPolicyAlgorithm(String policyCombiningAlgorithm) throws EntitlementException {
 
-        boolean isUpdate = false;
         try {
             Collection policyCollection;
             if (registry.resourceExists(POLICY_DATA_COLLECTION)) {
@@ -65,16 +64,11 @@ public class RegistryConfigPersistenceManager implements ConfigPersistenceManage
             } else {
                 policyCollection = registry.newCollection();
             }
-            if (StringUtils.isNotBlank(policyCollection.getProperty(GLOBAL_POLICY_COMBINING_ALGORITHM))) {
-                isUpdate = true;
-            }
             policyCollection.setProperty(GLOBAL_POLICY_COMBINING_ALGORITHM, policyCombiningAlgorithm);
             registry.put(POLICY_DATA_COLLECTION, policyCollection);
-
         } catch (RegistryException e) {
             throw new EntitlementException("Error while updating global policy combining algorithm in policy store", e);
         }
-        return isUpdate;
     }
 
     /**
@@ -84,6 +78,18 @@ public class RegistryConfigPersistenceManager implements ConfigPersistenceManage
      */
     @Override
     public String getGlobalPolicyAlgorithmName() {
+
+        String algorithm = getGlobalPolicyAlgorithmValue();
+
+        // set default
+        if (algorithm == null) {
+            algorithm = PDPConstants.Algorithms.DENY_OVERRIDES;
+        }
+
+        return algorithm;
+    }
+
+    private String getGlobalPolicyAlgorithmValue() {
 
         String algorithm = null;
         try {
@@ -96,12 +102,6 @@ public class RegistryConfigPersistenceManager implements ConfigPersistenceManage
                 LOG.debug(e);
             }
         }
-
-        // set default
-        if (algorithm == null) {
-            algorithm = PDPConstants.Algorithms.DENY_OVERRIDES;
-        }
-
         return algorithm;
     }
 
@@ -119,5 +119,11 @@ public class RegistryConfigPersistenceManager implements ConfigPersistenceManage
         } catch (RegistryException e) {
             throw new EntitlementException("Error while deleting global policy combining algorithm in policy store", e);
         }
+    }
+
+    boolean isGlobalPolicyAlgorithmExist() {
+
+        return getGlobalPolicyAlgorithmValue() != null;
+
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

$subject to avoid returning any status for `addOrUpdateGlobalPolicyAlgorithm()`. This was introduced, not due to an external requirement, rather for a need of the `HybridPolicyPersistenceManager`. In `HybridPolicyPersistenceManager` it was needed to check whether there is an existing record in registry.

With this PR it is improved to handle this requirement by introducing `isGlobalPolicyAlgorithmExist()` to registry impl and using that in method in `HybridPolicyPersistenceManager` without compromising `ConfigPersistenceManager` contract.

### When should this PR be merged

Immediate

### Follow up actions

N/A