### PR TITLE
Fix the issue of returning invalid policy order in HybridPolicyPersistenceManager

### DIFF
--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/HybridPolicyPersistenceManager.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/HybridPolicyPersistenceManager.java
@@ -173,11 +173,11 @@ public class HybridPolicyPersistenceManager extends AbstractPolicyFinderModule i
     @Override
     public int getPolicyOrder(String policyId) {
 
-        int policyOrder = jdbcPolicyPersistenceManager.getPolicyOrder(policyId);
-        if (policyOrder == -1) {
-            policyOrder = registryPolicyPersistenceManager.getPolicyOrder(policyId);
+        if (jdbcPolicyPersistenceManager.isPolicyExist(policyId)) {
+            return jdbcPolicyPersistenceManager.getPolicyOrder(policyId);
+        } else {
+            return registryPolicyPersistenceManager.getPolicyOrder(policyId);
         }
-        return policyOrder;
     }
 
     /**


### PR DESCRIPTION
### Issue Description

- Even though the published policy has a policy order, the `getPolicyOrder `method in HybridPolicyPersistenceManager always returns 0 as the policy order." This issue arises only when the PDP Policy stored in the registry.
- As per the logic in `getPolicyOrder` method in the HybridPolicyPersistenceManager class we first get the policy order by calling the JDBC Persistence Manager. However even though there are no policy in the database, we always return and empty object and there the default order of the policy object has 0.
- But according to our code we expect the -1 as the value of the policy order when there are no such policies in the DB.



### Proposed Solution

Improve the logic inside the HybridPolicyPersistenceManager to correctly identify the scenarios where the policy not exists in the database.
