### PR TITLE
Add new DefinedBy property to authenticator config.

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/ApplicationAuthenticatorService.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/ApplicationAuthenticatorService.java
@@ -18,8 +18,6 @@
 
 package org.wso2.carbon.identity.application.common;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticatorConfig;
@@ -33,7 +31,6 @@ import java.util.List;
 public class ApplicationAuthenticatorService {
 
     private static volatile ApplicationAuthenticatorService instance;
-    private static final Log LOG = LogFactory.getLog(ApplicationAuthenticatorService.class);
 
     private List<LocalAuthenticatorConfig> localAuthenticators = new ArrayList<>();
     private List<FederatedAuthenticatorConfig> federatedAuthenticators = new ArrayList<>();
@@ -91,9 +88,6 @@ public class ApplicationAuthenticatorService {
 
     public void addLocalAuthenticator(LocalAuthenticatorConfig authenticator) {
         if (authenticator != null) {
-            if (authenticator.getDefinedByType() == null) {
-                LOG.debug("The defined by type is not set for the : " + authenticator.getName());
-            }
             localAuthenticators.add(authenticator);
         }
     }
@@ -106,9 +100,6 @@ public class ApplicationAuthenticatorService {
 
     public void addFederatedAuthenticator(FederatedAuthenticatorConfig authenticator) {
         if (authenticator != null) {
-            if (authenticator.getDefinedByType() == null) {
-                LOG.debug("The defined by type is not set for the : " + authenticator.getName());
-            }
             federatedAuthenticators.add(authenticator);
         }
     }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/ApplicationAuthenticatorService.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/ApplicationAuthenticatorService.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.application.common;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticatorConfig;
@@ -31,6 +33,7 @@ import java.util.List;
 public class ApplicationAuthenticatorService {
 
     private static volatile ApplicationAuthenticatorService instance;
+    private static final Log LOG = LogFactory.getLog(ApplicationAuthenticatorService.class);
 
     private List<LocalAuthenticatorConfig> localAuthenticators = new ArrayList<>();
     private List<FederatedAuthenticatorConfig> federatedAuthenticators = new ArrayList<>();
@@ -88,6 +91,10 @@ public class ApplicationAuthenticatorService {
 
     public void addLocalAuthenticator(LocalAuthenticatorConfig authenticator) {
         if (authenticator != null) {
+            //TODO: Remove warn log, once feature is ready.
+            if (authenticator.getDefinedByType() == null) {
+                LOG.warn("The defined by type is not set for the : " + authenticator.getName());
+            }
             localAuthenticators.add(authenticator);
         }
     }
@@ -100,6 +107,10 @@ public class ApplicationAuthenticatorService {
 
     public void addFederatedAuthenticator(FederatedAuthenticatorConfig authenticator) {
         if (authenticator != null) {
+            //TODO: Remove warn log, once feature is ready.
+            if (authenticator.getDefinedByType() == null) {
+                LOG.warn("The defined by type is not set for the : " + authenticator.getName());
+            }
             federatedAuthenticators.add(authenticator);
         }
     }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/ApplicationAuthenticatorService.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/ApplicationAuthenticatorService.java
@@ -91,9 +91,8 @@ public class ApplicationAuthenticatorService {
 
     public void addLocalAuthenticator(LocalAuthenticatorConfig authenticator) {
         if (authenticator != null) {
-            //TODO: Remove warn log, once feature is ready.
             if (authenticator.getDefinedByType() == null) {
-                LOG.warn("The defined by type is not set for the : " + authenticator.getName());
+                LOG.debug("The defined by type is not set for the : " + authenticator.getName());
             }
             localAuthenticators.add(authenticator);
         }
@@ -107,9 +106,8 @@ public class ApplicationAuthenticatorService {
 
     public void addFederatedAuthenticator(FederatedAuthenticatorConfig authenticator) {
         if (authenticator != null) {
-            //TODO: Remove warn log, once feature is ready.
             if (authenticator.getDefinedByType() == null) {
-                LOG.warn("The defined by type is not set for the : " + authenticator.getName());
+                LOG.debug("The defined by type is not set for the : " + authenticator.getName());
             }
             federatedAuthenticators.add(authenticator);
         }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
@@ -24,7 +24,8 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -68,10 +69,10 @@ public class FederatedAuthenticatorConfig implements Serializable {
     protected String[] tags;
 
     @XmlElement(name = "DefinedBy")
-    protected IdentityConstants.DefinedByType definedByType;
+    protected DefinedByType definedByType;
 
     @XmlElement(name = "AuthenticationType")
-    protected IdentityConstants.AuthenticationType authenticationType;
+    protected AuthenticationType authenticationType;
 
     public static FederatedAuthenticatorConfig build(OMElement federatedAuthenticatorConfigOM) {
 
@@ -113,15 +114,14 @@ public class FederatedAuthenticatorConfig implements Serializable {
                 }
             } else if ("DefinedBy".equals(elementName)) {
                 federatedAuthenticatorConfig.setDefinedByType(
-                        IdentityConstants.DefinedByType.valueOf(element.getText()));
+                        DefinedByType.valueOf(element.getText()));
             }
         }
 
         if (federatedAuthenticatorConfig.getDefinedByType() == null) {
-            federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            LOG.debug("The defined by type is not set for the : " + federatedAuthenticatorConfig.getName());
+            federatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
         }
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        federatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
 
         return federatedAuthenticatorConfig;
     }
@@ -253,9 +253,9 @@ public class FederatedAuthenticatorConfig implements Serializable {
     /**
      * Get the defined by type of the federated authenticator config.
      *
-     * @return IdentityConstants.DefinedByType
+     * @return DefinedByType
      */
-    public IdentityConstants.DefinedByType getDefinedByType() {
+    public DefinedByType getDefinedByType() {
 
         return definedByType;
     }
@@ -265,7 +265,7 @@ public class FederatedAuthenticatorConfig implements Serializable {
      *
      * @param type The defined by type of the authenticator config.
      */
-    public void setDefinedByType(IdentityConstants.DefinedByType type) {
+    public void setDefinedByType(DefinedByType type) {
 
         definedByType = type;
     }
@@ -273,9 +273,9 @@ public class FederatedAuthenticatorConfig implements Serializable {
     /**
      * Get the authentication type of the federated authenticator config.
      *
-     * @return IdentityConstants.AuthenticationType
+     * @return AuthenticationType
      */
-    public IdentityConstants.AuthenticationType getAuthenticationType() {
+    public AuthenticationType getAuthenticationType() {
 
         return authenticationType;
     }
@@ -285,7 +285,7 @@ public class FederatedAuthenticatorConfig implements Serializable {
      *
      * @param type  The authentication type.
      */
-    public void setAuthenticationType(IdentityConstants.AuthenticationType type) {
+    public void setAuthenticationType(AuthenticationType type) {
 
         authenticationType = type;
     }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
@@ -117,7 +117,7 @@ public class FederatedAuthenticatorConfig implements Serializable {
         // TODO: Remove warn log, once feature is ready.
         if (federatedAuthenticatorConfig.getDefinedByType() == null) {
             federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            LOG.warn("The defined by type is not set for the : " + federatedAuthenticatorConfig.getName());
+            LOG.debug("The defined by type is not set for the : " + federatedAuthenticatorConfig.getName());
         }
 
         return federatedAuthenticatorConfig;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
@@ -116,6 +116,7 @@ public class FederatedAuthenticatorConfig implements Serializable {
 
         // TODO: Remove warn log, once feature is ready.
         if (federatedAuthenticatorConfig.getDefinedByType() == null) {
+            federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
             LOG.warn("The defined by type is not set for the : " + federatedAuthenticatorConfig.getName());
         }
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
@@ -70,6 +70,9 @@ public class FederatedAuthenticatorConfig implements Serializable {
     @XmlElement(name = "DefinedBy")
     protected IdentityConstants.DefinedByType definedByType;
 
+    @XmlElement(name = "AuthenticationType")
+    protected IdentityConstants.AuthenticationType authenticationType;
+
     public static FederatedAuthenticatorConfig build(OMElement federatedAuthenticatorConfigOM) {
 
         if (federatedAuthenticatorConfigOM == null) {
@@ -114,11 +117,11 @@ public class FederatedAuthenticatorConfig implements Serializable {
             }
         }
 
-        // TODO: Remove warn log, once feature is ready.
         if (federatedAuthenticatorConfig.getDefinedByType() == null) {
             federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
             LOG.debug("The defined by type is not set for the : " + federatedAuthenticatorConfig.getName());
         }
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
 
         return federatedAuthenticatorConfig;
     }
@@ -248,9 +251,9 @@ public class FederatedAuthenticatorConfig implements Serializable {
     }
 
     /**
-     * Get the tag list of the Local authenticator.
+     * Get the defined by type of the federated authenticator config.
      *
-     * @return String[]
+     * @return IdentityConstants.DefinedByType
      */
     public IdentityConstants.DefinedByType getDefinedByType() {
 
@@ -258,12 +261,32 @@ public class FederatedAuthenticatorConfig implements Serializable {
     }
 
     /**
-     * Set the tag list for Local authenticator config.
+     * Set the defined by type of the federated authenticator config.
      *
-     * @param type  authenticator.
+     * @param type The defined by type of the authenticator config.
      */
     public void setDefinedByType(IdentityConstants.DefinedByType type) {
 
         definedByType = type;
+    }
+
+    /**
+     * Get the authentication type of the federated authenticator config.
+     *
+     * @return IdentityConstants.AuthenticationType
+     */
+    public IdentityConstants.AuthenticationType getAuthenticationType() {
+
+        return authenticationType;
+    }
+
+    /**
+     * Set the authentication type of the federated authenticator config.
+     *
+     * @param type  The authentication type.
+     */
+    public void setAuthenticationType(IdentityConstants.AuthenticationType type) {
+
+        authenticationType = type;
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
@@ -121,7 +121,7 @@ public class FederatedAuthenticatorConfig implements Serializable {
             federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
             LOG.debug("The defined by type is not set for the : " + federatedAuthenticatorConfig.getName());
         }
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
 
         return federatedAuthenticatorConfig;
     }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
@@ -22,6 +22,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.identity.base.IdentityConstants;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -46,6 +49,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 public class FederatedAuthenticatorConfig implements Serializable {
 
     private static final long serialVersionUID = -2361107623257323257L;
+    private static final Logger LOG = LoggerFactory.getLogger(LocalAuthenticatorConfig.class);
 
     @XmlElement(name = "Name")
     protected String name;
@@ -62,6 +66,9 @@ public class FederatedAuthenticatorConfig implements Serializable {
 
     @XmlElement(name = "Tags")
     protected String[] tags;
+
+    @XmlElement(name = "DefinedBy")
+    protected IdentityConstants.DefinedByType definedByType;
 
     public static FederatedAuthenticatorConfig build(OMElement federatedAuthenticatorConfigOM) {
 
@@ -101,7 +108,15 @@ public class FederatedAuthenticatorConfig implements Serializable {
                     Property[] propertiesArr = propertiesArrList.toArray(new Property[propertiesArrList.size()]);
                     federatedAuthenticatorConfig.setProperties(propertiesArr);
                 }
+            } else if ("DefinedBy".equals(elementName)) {
+                federatedAuthenticatorConfig.setDefinedByType(
+                        IdentityConstants.DefinedByType.valueOf(element.getText()));
             }
+        }
+
+        // TODO: Remove warn log, once feature is ready.
+        if (federatedAuthenticatorConfig.getDefinedByType() == null) {
+            LOG.warn("The defined by type is not set for the : " + federatedAuthenticatorConfig.getName());
         }
 
         return federatedAuthenticatorConfig;
@@ -229,5 +244,25 @@ public class FederatedAuthenticatorConfig implements Serializable {
     public void setTags(String[] tagList) {
 
         tags = tagList;
+    }
+
+    /**
+     * Get the tag list of the Local authenticator.
+     *
+     * @return String[]
+     */
+    public IdentityConstants.DefinedByType getDefinedByType() {
+
+        return definedByType;
+    }
+
+    /**
+     * Set the tag list for Local authenticator config.
+     *
+     * @param type  authenticator.
+     */
+    public void setDefinedByType(IdentityConstants.DefinedByType type) {
+
+        definedByType = type;
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
@@ -58,6 +58,7 @@ import javax.xml.bind.annotation.XmlTransient;
 public class IdentityProvider implements Serializable {
 
     private static final long serialVersionUID = 2199048941051702943L;
+    private static final Log LOG = LogFactory.getLog(IdentityProvider.class);
 
     private static final Log log = LogFactory.getLog(IdentityProvider.class);
     private static final String FILE_ELEMENT_IDENTITY_PROVIDER_NAME = "IdentityProviderName";
@@ -418,6 +419,13 @@ public class IdentityProvider implements Serializable {
 
         if (federatedAuthenticatorConfigs == null) {
             return;
+        }
+
+        // TODO: Remove warn log, once feature is ready.
+        for (FederatedAuthenticatorConfig config: federatedAuthenticatorConfigs) {
+            if (config.getDefinedByType() == null) {
+                LOG.warn("The defined by type is not set for the : " + config.getName());
+            }
         }
         Set<FederatedAuthenticatorConfig> propertySet =
                 new HashSet<FederatedAuthenticatorConfig>(Arrays.asList(federatedAuthenticatorConfigs));

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
@@ -58,7 +58,6 @@ import javax.xml.bind.annotation.XmlTransient;
 public class IdentityProvider implements Serializable {
 
     private static final long serialVersionUID = 2199048941051702943L;
-    private static final Log LOG = LogFactory.getLog(IdentityProvider.class);
 
     private static final Log log = LogFactory.getLog(IdentityProvider.class);
     private static final String FILE_ELEMENT_IDENTITY_PROVIDER_NAME = "IdentityProviderName";
@@ -419,13 +418,6 @@ public class IdentityProvider implements Serializable {
 
         if (federatedAuthenticatorConfigs == null) {
             return;
-        }
-
-        // TODO: Remove warn log, once feature is ready.
-        for (FederatedAuthenticatorConfig config: federatedAuthenticatorConfigs) {
-            if (config.getDefinedByType() == null) {
-                LOG.debug("The defined by type is not set for the : " + config.getName());
-            }
         }
         Set<FederatedAuthenticatorConfig> propertySet =
                 new HashSet<FederatedAuthenticatorConfig>(Arrays.asList(federatedAuthenticatorConfigs));

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
@@ -424,7 +424,7 @@ public class IdentityProvider implements Serializable {
         // TODO: Remove warn log, once feature is ready.
         for (FederatedAuthenticatorConfig config: federatedAuthenticatorConfigs) {
             if (config.getDefinedByType() == null) {
-                LOG.warn("The defined by type is not set for the : " + config.getName());
+                LOG.debug("The defined by type is not set for the : " + config.getName());
             }
         }
         Set<FederatedAuthenticatorConfig> propertySet =

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
@@ -123,6 +123,7 @@ public class LocalAuthenticatorConfig implements Serializable {
         }
 
         if (localAuthenticatorConfig.getDefinedByType() == null) {
+            localAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
             LOG.warn("The defined by type is not set for the : " + localAuthenticatorConfig.getName());
         }
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
@@ -24,6 +24,8 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 import org.wso2.carbon.identity.base.IdentityConstants;
 
 import java.io.Serializable;
@@ -69,10 +71,10 @@ public class LocalAuthenticatorConfig implements Serializable {
     protected String[] tags;
 
     @XmlElement(name = "DefinedBy")
-    protected IdentityConstants.DefinedByType definedByType;
+    protected DefinedByType definedByType;
 
     @XmlElement(name = "AuthenticationType")
-    protected IdentityConstants.AuthenticationType authenticationType;
+    protected AuthenticationType authenticationType;
 
     /*
      * <LocalAuthenticatorConfig> <Name></Name> <DisplayName></DisplayName> <IsEnabled></IsEnabled>
@@ -123,15 +125,15 @@ public class LocalAuthenticatorConfig implements Serializable {
                     localAuthenticatorConfig.setProperties(propertiesArr);
                 }
             } else if ("DefinedBy".equals(member.getLocalName())) {
-                localAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.valueOf(member.getText()));
+                localAuthenticatorConfig.setDefinedByType(DefinedByType.valueOf(member.getText()));
             } else if ("AuthenticationType".equals(member.getLocalName())) {
                 localAuthenticatorConfig.setAuthenticationType(
-                        IdentityConstants.AuthenticationType.valueOf(member.getText()));
+                        AuthenticationType.valueOf(member.getText()));
             }
         }
 
         if (localAuthenticatorConfig.getDefinedByType() == null) {
-            localAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+            localAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
             LOG.debug("The defined by type is not set for the {}. Hence setting default SYSTEM value.",
                     localAuthenticatorConfig.getName());
         }
@@ -139,9 +141,9 @@ public class LocalAuthenticatorConfig implements Serializable {
             if (localAuthenticatorConfig.getTags() != null &&
                     Arrays.stream(localAuthenticatorConfig.getTags()).anyMatch(s -> s.equalsIgnoreCase(TAG_2FA))) {
                 localAuthenticatorConfig.setAuthenticationType(
-                        IdentityConstants.AuthenticationType.VERIFICATION_ONLY);
+                        AuthenticationType.VERIFICATION_ONLY);
             } else {
-                localAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+                localAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
             }
             LOG.debug("The defined by type is not set for the: {}. Hence setting value based on the factor for the: {}",
                     localAuthenticatorConfig.getName(), localAuthenticatorConfig.getAuthenticationType().toString());
@@ -262,9 +264,9 @@ public class LocalAuthenticatorConfig implements Serializable {
     /**
      * Get the defined by type of the Local authenticator config.
      *
-     * @return IdentityConstants.DefinedByType
+     * @return DefinedByType
      */
-    public IdentityConstants.DefinedByType getDefinedByType() {
+    public DefinedByType getDefinedByType() {
 
         return definedByType;
     }
@@ -274,7 +276,7 @@ public class LocalAuthenticatorConfig implements Serializable {
      *
      * @param type The defined by type of the authenticator config.
      */
-    public void setDefinedByType(IdentityConstants.DefinedByType type) {
+    public void setDefinedByType(DefinedByType type) {
 
         definedByType = type;
     }
@@ -282,9 +284,9 @@ public class LocalAuthenticatorConfig implements Serializable {
     /**
      * Get the authentication type of the Local authenticator config .
      *
-     * @return IdentityConstants.AuthenticationType
+     * @return AuthenticationType
      */
-    public IdentityConstants.AuthenticationType getAuthenticationType() {
+    public AuthenticationType getAuthenticationType() {
 
         return authenticationType;
     }
@@ -294,7 +296,7 @@ public class LocalAuthenticatorConfig implements Serializable {
      *
      * @param type  The authentication type.
      */
-    public void setAuthenticationType(IdentityConstants.AuthenticationType type) {
+    public void setAuthenticationType(AuthenticationType type) {
 
         authenticationType = type;
     }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wso2.carbon.identity.base.IdentityConstants;
 
 import java.io.Serializable;
@@ -46,6 +48,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 public class LocalAuthenticatorConfig implements Serializable {
 
     private static final long serialVersionUID = 3363298518257599291L;
+    private static final Logger LOG = LoggerFactory.getLogger(LocalAuthenticatorConfig.class);
 
     @XmlElement(name = "Name")
     protected String name;
@@ -62,6 +65,9 @@ public class LocalAuthenticatorConfig implements Serializable {
 
     @XmlElement(name = "Tags")
     protected String[] tags;
+
+    @XmlElement(name = "DefinedBy")
+    protected IdentityConstants.DefinedByType definedByType;
 
     /*
      * <LocalAuthenticatorConfig> <Name></Name> <DisplayName></DisplayName> <IsEnabled></IsEnabled>
@@ -111,8 +117,15 @@ public class LocalAuthenticatorConfig implements Serializable {
                     Property[] propertiesArr = propertiesArrList.toArray(new Property[0]);
                     localAuthenticatorConfig.setProperties(propertiesArr);
                 }
+            } else if ("DefinedBy".equals(member.getLocalName())) {
+                localAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.valueOf(member.getText()));
             }
         }
+
+        if (localAuthenticatorConfig.getDefinedByType() == null) {
+            LOG.warn("The defined by type is not set for the : " + localAuthenticatorConfig.getName());
+        }
+
         return localAuthenticatorConfig;
     }
 
@@ -223,5 +236,25 @@ public class LocalAuthenticatorConfig implements Serializable {
     public void setTags(String[] tagList) {
 
         tags = tagList;
+    }
+
+    /**
+     * Get the tag list of the Local authenticator.
+     *
+     * @return String[]
+     */
+    public IdentityConstants.DefinedByType getDefinedByType() {
+
+        return definedByType;
+    }
+
+    /**
+     * Set the tag list for Local authenticator config.
+     *
+     * @param type  authenticator.
+     */
+    public void setDefinedByType(IdentityConstants.DefinedByType type) {
+
+        definedByType = type;
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
@@ -124,7 +124,7 @@ public class LocalAuthenticatorConfig implements Serializable {
 
         if (localAuthenticatorConfig.getDefinedByType() == null) {
             localAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            LOG.warn("The defined by type is not set for the : " + localAuthenticatorConfig.getName());
+            LOG.debug("The defined by type is not set for the : " + localAuthenticatorConfig.getName());
         }
 
         return localAuthenticatorConfig;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
@@ -139,9 +139,9 @@ public class LocalAuthenticatorConfig implements Serializable {
             if (localAuthenticatorConfig.getTags() != null &&
                     Arrays.stream(localAuthenticatorConfig.getTags()).anyMatch(s -> s.equalsIgnoreCase(TAG_2FA))) {
                 localAuthenticatorConfig.setAuthenticationType(
-                        IdentityConstants.AuthenticationType.FACTOR_VERIFICATION);
+                        IdentityConstants.AuthenticationType.VERIFICATION_ONLY);
             } else {
-                localAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.INTERNAL_ACCOUNT);
+                localAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
             }
             LOG.debug("The defined by type is not set for the: {}. Hence setting value based on the factor for the: {}",
                     localAuthenticatorConfig.getName(), localAuthenticatorConfig.getAuthenticationType().toString());

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
@@ -39,6 +39,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import static org.wso2.carbon.identity.base.IdentityConstants.TAG_2FA;
+
 /**
  * Local authenticator configuration of an application.
  */
@@ -68,6 +70,9 @@ public class LocalAuthenticatorConfig implements Serializable {
 
     @XmlElement(name = "DefinedBy")
     protected IdentityConstants.DefinedByType definedByType;
+
+    @XmlElement(name = "AuthenticationType")
+    protected IdentityConstants.AuthenticationType authenticationType;
 
     /*
      * <LocalAuthenticatorConfig> <Name></Name> <DisplayName></DisplayName> <IsEnabled></IsEnabled>
@@ -119,12 +124,27 @@ public class LocalAuthenticatorConfig implements Serializable {
                 }
             } else if ("DefinedBy".equals(member.getLocalName())) {
                 localAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.valueOf(member.getText()));
+            } else if ("AuthenticationType".equals(member.getLocalName())) {
+                localAuthenticatorConfig.setAuthenticationType(
+                        IdentityConstants.AuthenticationType.valueOf(member.getText()));
             }
         }
 
         if (localAuthenticatorConfig.getDefinedByType() == null) {
             localAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            LOG.debug("The defined by type is not set for the : " + localAuthenticatorConfig.getName());
+            LOG.debug("The defined by type is not set for the {}. Hence setting default SYSTEM value.",
+                    localAuthenticatorConfig.getName());
+        }
+        if (localAuthenticatorConfig.getAuthenticationType() == null && localAuthenticatorConfig.getTags() != null) {
+            if (localAuthenticatorConfig.getTags() != null &&
+                    Arrays.stream(localAuthenticatorConfig.getTags()).anyMatch(s -> s.equalsIgnoreCase(TAG_2FA))) {
+                localAuthenticatorConfig.setAuthenticationType(
+                        IdentityConstants.AuthenticationType.FACTOR_VERIFICATION);
+            } else {
+                localAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.INTERNAL_ACCOUNT);
+            }
+            LOG.debug("The defined by type is not set for the: {}. Hence setting value based on the factor for the: {}",
+                    localAuthenticatorConfig.getName(), localAuthenticatorConfig.getAuthenticationType().toString());
         }
 
         return localAuthenticatorConfig;
@@ -240,9 +260,9 @@ public class LocalAuthenticatorConfig implements Serializable {
     }
 
     /**
-     * Get the tag list of the Local authenticator.
+     * Get the defined by type of the Local authenticator config.
      *
-     * @return String[]
+     * @return IdentityConstants.DefinedByType
      */
     public IdentityConstants.DefinedByType getDefinedByType() {
 
@@ -250,12 +270,32 @@ public class LocalAuthenticatorConfig implements Serializable {
     }
 
     /**
-     * Set the tag list for Local authenticator config.
+     * Set the defined by type of the Local authenticator config.
      *
-     * @param type  authenticator.
+     * @param type The defined by type of the authenticator config.
      */
     public void setDefinedByType(IdentityConstants.DefinedByType type) {
 
         definedByType = type;
+    }
+
+    /**
+     * Get the authentication type of the Local authenticator config .
+     *
+     * @return IdentityConstants.AuthenticationType
+     */
+    public IdentityConstants.AuthenticationType getAuthenticationType() {
+
+        return authenticationType;
+    }
+
+    /**
+     * Set the authentication type of the Local authenticator config.
+     *
+     * @param type  The authentication type.
+     */
+    public void setAuthenticationType(IdentityConstants.AuthenticationType type) {
+
+        authenticationType = type;
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/RequestPathAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/RequestPathAuthenticatorConfig.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.identity.application.common.model;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -74,6 +76,10 @@ public class RequestPathAuthenticatorConfig extends LocalAuthenticatorConfig {
                 }
             }
         }
+
+        requestPathAuthenticatorConfig.setAuthenticationType(AuthenticationType.REQUEST_PATH);
+        requestPathAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+
         return requestPathAuthenticatorConfig;
     }
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
@@ -51,6 +51,7 @@ public class ApplicationConstants {
     public static final String IDP_AUTHENTICATOR_NAME = "authenticatorName";
     public static final String IDP_AUTHENTICATOR_DISPLAY_NAME = "authenticatorDisplayName";
     public static final String IDP_AUTHENTICATOR_DEFINED_BY_TYPE = "definedByType";
+    public static final String IDP_AUTHENTICATOR_AUTHENTICATION_TYPE = "authenticationType";
     public static final String APPLICATION_DOMAIN = "Application";
     // Regex for validating application name.
     public static final String APP_NAME_VALIDATING_REGEX = "^[a-zA-Z0-9 ._-]*$";

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
@@ -50,6 +50,7 @@ public class ApplicationConstants {
     public static final String IDP_NAME = "idpName";
     public static final String IDP_AUTHENTICATOR_NAME = "authenticatorName";
     public static final String IDP_AUTHENTICATOR_DISPLAY_NAME = "authenticatorDisplayName";
+    public static final String IDP_AUTHENTICATOR_DEFINED_BY_TYPE = "definedByType";
     public static final String APPLICATION_DOMAIN = "Application";
     // Regex for validating application name.
     public static final String APP_NAME_VALIDATING_REGEX = "^[a-zA-Z0-9 ._-]*$";

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -1569,7 +1569,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                                         lclAuthenticator.getDisplayName());
                             } else {
                                 if (lclAuthenticator.getDefinedByType() == null) {
-                                    log.warn("Authenticator already exists. Updating the authenticator, but the " +
+                                    log.debug("Authenticator already exists. Updating the authenticator, but the " +
                                             "defined by type is not set.");
                                 } else {
                                     log.debug("Authenticator already exists. Updating the authenticator.The defined "

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -3100,6 +3100,8 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                             .get(ApplicationConstants.IDP_AUTHENTICATOR_DISPLAY_NAME));
                     localAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
                             authenticatorInfo.get(ApplicationConstants.IDP_AUTHENTICATOR_DEFINED_BY_TYPE)));
+                    localAuthenticator.setAuthenticationType(IdentityConstants.AuthenticationType.valueOf(
+                            authenticatorInfo.get(ApplicationConstants.IDP_AUTHENTICATOR_AUTHENTICATION_TYPE)));
                     stepLocalAuth.get(step).add(localAuthenticator);
                 } else {
                     Map<String, List<FederatedAuthenticatorConfig>> stepFedIdps = stepFedIdPAuthenticators
@@ -3120,6 +3122,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                             .get(ApplicationConstants.IDP_AUTHENTICATOR_DISPLAY_NAME));
                     fedAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
                             authenticatorInfo.get(ApplicationConstants.IDP_AUTHENTICATOR_DEFINED_BY_TYPE)));
+                    fedAuthenticator.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
                     idpAuths.add(fedAuthenticator);
                 }
 
@@ -5031,7 +5034,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                 returnData
                         .put(ApplicationConstants.IDP_AUTHENTICATOR_DISPLAY_NAME, rs.getString(3));
             }
-            // TODO: Read from database and set the DefinedBy property to the authenticator.
+            // TODO: Read from database and set the DefinedBy and authenticationType properties to the authenticator.
             returnData.put(ApplicationConstants.IDP_AUTHENTICATOR_DEFINED_BY_TYPE,
                     IdentityConstants.DefinedByType.SYSTEM.toString());
         } finally {
@@ -5068,6 +5071,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
             prepStmt.setString(5, "1");
             prepStmt.setString(6, authenticatorDispalyName);
             //TODO: prepStmt.setString(7, IdentityConstants.DefinedByType.SYSTEM.toString());
+            //TODO: prepStmt.setString(8, IdentityConstants.AuthenticationType.<TYPE>.toString());
             prepStmt.execute();
             rs = prepStmt.getGeneratedKeys();
             if (rs.next()) {

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -3098,7 +3098,8 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                             .get(ApplicationConstants.IDP_AUTHENTICATOR_NAME));
                     localAuthenticator.setDisplayName(authenticatorInfo
                             .get(ApplicationConstants.IDP_AUTHENTICATOR_DISPLAY_NAME));
-                    localAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+                    localAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
+                            authenticatorInfo.get(ApplicationConstants.IDP_AUTHENTICATOR_DEFINED_BY_TYPE)));
                     stepLocalAuth.get(step).add(localAuthenticator);
                 } else {
                     Map<String, List<FederatedAuthenticatorConfig>> stepFedIdps = stepFedIdPAuthenticators
@@ -3117,7 +3118,8 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                             .get(ApplicationConstants.IDP_AUTHENTICATOR_NAME));
                     fedAuthenticator.setDisplayName(authenticatorInfo
                             .get(ApplicationConstants.IDP_AUTHENTICATOR_DISPLAY_NAME));
-                    fedAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+                    fedAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
+                            authenticatorInfo.get(ApplicationConstants.IDP_AUTHENTICATOR_DEFINED_BY_TYPE)));
                     idpAuths.add(fedAuthenticator);
                 }
 
@@ -5029,6 +5031,9 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                 returnData
                         .put(ApplicationConstants.IDP_AUTHENTICATOR_DISPLAY_NAME, rs.getString(3));
             }
+            // TODO: Read from database and set the DefinedBy property to the authenticator.
+            returnData.put(ApplicationConstants.IDP_AUTHENTICATOR_DEFINED_BY_TYPE,
+                    IdentityConstants.DefinedByType.SYSTEM.toString());
         } finally {
             IdentityApplicationManagementUtil.closeStatement(prepStmt);
         }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -77,7 +77,8 @@ import org.wso2.carbon.identity.application.mgt.dao.IdentityProviderDAO;
 import org.wso2.carbon.identity.application.mgt.dao.PaginatableFilterableApplicationDAO;
 import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponent;
 import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponentHolder;
-import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.CertificateRetrievingException;
@@ -1568,14 +1569,12 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                                         lclAuthenticator.getName(),
                                         lclAuthenticator.getDisplayName());
                             } else {
-                                if (lclAuthenticator.getDefinedByType() == null) {
-                                    log.debug("Authenticator already exists. Updating the authenticator, but the " +
-                                            "defined by type is not set.");
-                                } else {
-                                    log.debug("Authenticator already exists. Updating the authenticator.The defined "
+                                /* On demand migration for already saved local authenticators to save definedBy and
+                                 authenticationType properties to the database.
+                                 Remove this else block, once on-demand migration is done.*/
+                                log.debug("Authenticator already exists. Updating the authenticator.The defined "
                                             + "by type is set to: " + lclAuthenticator.getDefinedByType().toString());
-                                    //TODO: Update database with defined by properties for local authenticators.
-                                }
+                                //TODO: Update database with defined by properties for local authenticators.
                             }
                             if (authenticatorId > 0) {
                                 // ID, TENANT_ID, AUTHENTICATOR_ID
@@ -3098,9 +3097,9 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                             .get(ApplicationConstants.IDP_AUTHENTICATOR_NAME));
                     localAuthenticator.setDisplayName(authenticatorInfo
                             .get(ApplicationConstants.IDP_AUTHENTICATOR_DISPLAY_NAME));
-                    localAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
+                    localAuthenticator.setDefinedByType(DefinedByType.valueOf(
                             authenticatorInfo.get(ApplicationConstants.IDP_AUTHENTICATOR_DEFINED_BY_TYPE)));
-                    localAuthenticator.setAuthenticationType(IdentityConstants.AuthenticationType.valueOf(
+                    localAuthenticator.setAuthenticationType(AuthenticationType.valueOf(
                             authenticatorInfo.get(ApplicationConstants.IDP_AUTHENTICATOR_AUTHENTICATION_TYPE)));
                     stepLocalAuth.get(step).add(localAuthenticator);
                 } else {
@@ -3120,9 +3119,9 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                             .get(ApplicationConstants.IDP_AUTHENTICATOR_NAME));
                     fedAuthenticator.setDisplayName(authenticatorInfo
                             .get(ApplicationConstants.IDP_AUTHENTICATOR_DISPLAY_NAME));
-                    fedAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
+                    fedAuthenticator.setDefinedByType(DefinedByType.valueOf(
                             authenticatorInfo.get(ApplicationConstants.IDP_AUTHENTICATOR_DEFINED_BY_TYPE)));
-                    fedAuthenticator.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+                    fedAuthenticator.setAuthenticationType(AuthenticationType.IDENTIFICATION);
                     idpAuths.add(fedAuthenticator);
                 }
 
@@ -5036,7 +5035,9 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
             }
             // TODO: Read from database and set the DefinedBy and authenticationType properties to the authenticator.
             returnData.put(ApplicationConstants.IDP_AUTHENTICATOR_DEFINED_BY_TYPE,
-                    IdentityConstants.DefinedByType.SYSTEM.toString());
+                    DefinedByType.SYSTEM.toString());
+            returnData.put(ApplicationConstants.IDP_AUTHENTICATOR_AUTHENTICATION_TYPE,
+                    AuthenticationType.IDENTIFICATION.toString());
         } finally {
             IdentityApplicationManagementUtil.closeStatement(prepStmt);
         }
@@ -5070,8 +5071,8 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
             prepStmt.setString(4, authenticatorName);
             prepStmt.setString(5, "1");
             prepStmt.setString(6, authenticatorDispalyName);
-            //TODO: prepStmt.setString(7, IdentityConstants.DefinedByType.SYSTEM.toString());
-            //TODO: prepStmt.setString(8, IdentityConstants.AuthenticationType.<TYPE>.toString());
+            //TODO: prepStmt.setString(7, DefinedByType.SYSTEM.toString());
+            //TODO: prepStmt.setString(8, AuthenticationType.<TYPE>.toString());
             prepStmt.execute();
             rs = prepStmt.getGeneratedKeys();
             if (rs.next()) {

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -3122,7 +3122,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                             .get(ApplicationConstants.IDP_AUTHENTICATOR_DISPLAY_NAME));
                     fedAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
                             authenticatorInfo.get(ApplicationConstants.IDP_AUTHENTICATOR_DEFINED_BY_TYPE)));
-                    fedAuthenticator.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+                    fedAuthenticator.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
                     idpAuths.add(fedAuthenticator);
                 }
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
@@ -65,7 +65,8 @@ import org.wso2.carbon.identity.application.mgt.inbound.protocol.ApplicationInbo
 import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponentHolder;
 import org.wso2.carbon.identity.application.mgt.provider.ApplicationPermissionProvider;
 import org.wso2.carbon.identity.application.mgt.provider.RegistryBasedApplicationPermissionProvider;
-import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.common.testng.realm.InMemoryRealmService;
 import org.wso2.carbon.identity.common.testng.realm.MockUserStoreManager;
@@ -673,12 +674,14 @@ public class ApplicationManagementServiceImplTest {
             for (AuthenticationStep step : steps) {
                 LocalAuthenticatorConfig[] localAuthenticators = step.getLocalAuthenticatorConfigs();
                 for (LocalAuthenticatorConfig localConfig : localAuthenticators) {
-                    Assert.assertNotNull(localConfig.getDefinedByType());
+                    Assert.assertEquals(localConfig.getDefinedByType(), DefinedByType.SYSTEM);
+                    Assert.assertEquals(localConfig.getAuthenticationType(), AuthenticationType.IDENTIFICATION);
                 }
                 IdentityProvider[] identityProviders = step.getFederatedIdentityProviders();
                 for (IdentityProvider idp : identityProviders) {
                     for (FederatedAuthenticatorConfig fedConfig: idp.getFederatedAuthenticatorConfigs()) {
-                        Assert.assertNotNull(fedConfig.getDefinedByType());
+                        Assert.assertEquals(fedConfig.getDefinedByType(), DefinedByType.SYSTEM);
+                        Assert.assertEquals(fedConfig.getAuthenticationType(), AuthenticationType.IDENTIFICATION);
                     }
                 }
             }
@@ -1314,13 +1317,15 @@ public class ApplicationManagementServiceImplTest {
         identityProvider.setIdentityProviderName(IDP_NAME_1);
         FederatedAuthenticatorConfig federatedAuthenticatorConfig = new FederatedAuthenticatorConfig();
         federatedAuthenticatorConfig.setName("Federated authenticator");
-        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         identityProvider.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]
                 {federatedAuthenticatorConfig});
         authenticationStep.setFederatedIdentityProviders(new IdentityProvider[]{identityProvider});
         LocalAuthenticatorConfig localAuthenticatorConfig = new LocalAuthenticatorConfig();
         localAuthenticatorConfig.setName("Local authenticator");
-        localAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        localAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         authenticationStep.setLocalAuthenticatorConfigs(new LocalAuthenticatorConfig[]{localAuthenticatorConfig});
         authenticationConfig.setAuthenticationSteps(new AuthenticationStep[]{authenticationStep});
         serviceProvider.setLocalAndOutBoundAuthenticationConfig(authenticationConfig);

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
@@ -811,10 +811,6 @@ public class ApplicationManagementServiceImplTest {
         LocalAuthenticatorConfig[] localAuthenticatorConfigs = applicationManagementService.getAllLocalAuthenticators
                 (SUPER_TENANT_DOMAIN_NAME);
 
-        for (LocalAuthenticatorConfig config: localAuthenticatorConfigs) {
-            Assert.assertNotNull(config.getDefinedByType(), "");
-        }
-
         Assert.assertEquals(localAuthenticatorConfigs[0], localAuthenticatorConfig);
     }
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
@@ -107,7 +107,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.mockito.ArgumentMatchers.any;

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
@@ -63,6 +63,7 @@ import org.wso2.carbon.identity.application.mgt.inbound.protocol.ApplicationInbo
 import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponentHolder;
 import org.wso2.carbon.identity.application.mgt.provider.ApplicationPermissionProvider;
 import org.wso2.carbon.identity.application.mgt.provider.RegistryBasedApplicationPermissionProvider;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.common.testng.realm.InMemoryRealmService;
 import org.wso2.carbon.identity.common.testng.realm.MockUserStoreManager;
@@ -810,6 +811,10 @@ public class ApplicationManagementServiceImplTest {
         LocalAuthenticatorConfig[] localAuthenticatorConfigs = applicationManagementService.getAllLocalAuthenticators
                 (SUPER_TENANT_DOMAIN_NAME);
 
+        for (LocalAuthenticatorConfig config: localAuthenticatorConfigs) {
+            Assert.assertNotNull(config.getDefinedByType(), "");
+        }
+
         Assert.assertEquals(localAuthenticatorConfigs[0], localAuthenticatorConfig);
     }
 
@@ -1245,11 +1250,13 @@ public class ApplicationManagementServiceImplTest {
         identityProvider.setIdentityProviderName(IDP_NAME_1);
         FederatedAuthenticatorConfig federatedAuthenticatorConfig = new FederatedAuthenticatorConfig();
         federatedAuthenticatorConfig.setName("Federated authenticator");
+        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         identityProvider.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]
                 {federatedAuthenticatorConfig});
         authenticationStep.setFederatedIdentityProviders(new IdentityProvider[]{identityProvider});
         LocalAuthenticatorConfig localAuthenticatorConfig = new LocalAuthenticatorConfig();
         localAuthenticatorConfig.setName("Local authenticator");
+        localAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         authenticationStep.setLocalAuthenticatorConfigs(new LocalAuthenticatorConfig[]{localAuthenticatorConfig});
         authenticationConfig.setAuthenticationSteps(new AuthenticationStep[]{authenticationStep});
         serviceProvider.setLocalAndOutBoundAuthenticationConfig(authenticationConfig);

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
@@ -617,6 +617,19 @@ public class ApplicationManagementServiceImplTest {
         AuthenticationStep[] steps = applicationManagementService.getConfiguredAuthenticators(resourceID,
                 SUPER_TENANT_DOMAIN_NAME);
 
+        for (AuthenticationStep step : steps) {
+            LocalAuthenticatorConfig[] localAuthenticators = step.getLocalAuthenticatorConfigs();
+            for (LocalAuthenticatorConfig localConfig : localAuthenticators) {
+                Assert.assertNotNull(localConfig.getDefinedByType());
+            }
+            IdentityProvider[] identityProviders = step.getFederatedIdentityProviders();
+            for (IdentityProvider idp : identityProviders) {
+                for (FederatedAuthenticatorConfig fedConfig: idp.getFederatedAuthenticatorConfigs()) {
+                    Assert.assertNotNull(fedConfig.getDefinedByType());
+                }
+            }
+        }
+
         Assert.assertEquals(steps.length, 1);
         Assert.assertEquals(steps[0].getStepOrder(), 1);
         applicationManagementService.deleteApplication(APPLICATION_NAME_1, SUPER_TENANT_DOMAIN_NAME, USERNAME_1);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/ApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/ApplicationAuthenticator.java
@@ -181,4 +181,14 @@ public interface ApplicationAuthenticator extends Serializable {
 
         return IdentityConstants.DefinedByType.SYSTEM;
     }
+
+    /**
+     * Get the authenticator type. Default value will be SYSTEM.
+     *
+     * @return Authenticator Type.
+     */
+    default IdentityConstants.AuthenticationType getAuthenticationType() {
+
+        return null;
+    }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/ApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/ApplicationAuthenticator.java
@@ -24,7 +24,8 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.A
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorData;
 import org.wso2.carbon.identity.application.common.model.Property;
-import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 
 import java.io.Serializable;
 import java.util.List;
@@ -177,9 +178,9 @@ public interface ApplicationAuthenticator extends Serializable {
      *
      * @return Authenticator Type.
      */
-    default IdentityConstants.DefinedByType getDefinedByType() {
+    default DefinedByType getDefinedByType() {
 
-        return IdentityConstants.DefinedByType.SYSTEM;
+        return DefinedByType.SYSTEM;
     }
 
     /**
@@ -187,8 +188,8 @@ public interface ApplicationAuthenticator extends Serializable {
      *
      * @return Authenticator Type.
      */
-    default IdentityConstants.AuthenticationType getAuthenticationType() {
+    default AuthenticationType getAuthenticationType() {
 
-        return null;
+        return AuthenticationType.IDENTIFICATION;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/ApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/ApplicationAuthenticator.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.A
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorData;
 import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.base.IdentityConstants;
 
 import java.io.Serializable;
 import java.util.List;
@@ -171,4 +172,13 @@ public interface ApplicationAuthenticator extends Serializable {
         return StringUtils.EMPTY;
     }
 
+    /**
+     * Get the authenticator type. Default value will be SYSTEM.
+     *
+     * @return Authenticator Type.
+     */
+    default IdentityConstants.DefinedByType getDefinedByType() {
+
+        return IdentityConstants.DefinedByType.SYSTEM;
+    }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/FederatedApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/FederatedApplicationAuthenticator.java
@@ -18,9 +18,17 @@
 
 package org.wso2.carbon.identity.application.authentication.framework;
 
+import org.wso2.carbon.identity.base.IdentityConstants;
+
 /**
  * Federated application authenticator.
  */
 public interface FederatedApplicationAuthenticator extends ApplicationAuthenticator {
+
+    @Override
+    default IdentityConstants.AuthenticationType getAuthenticationType() {
+
+        return IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT;
+    }
 
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/FederatedApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/FederatedApplicationAuthenticator.java
@@ -28,7 +28,7 @@ public interface FederatedApplicationAuthenticator extends ApplicationAuthentica
     @Override
     default IdentityConstants.AuthenticationType getAuthenticationType() {
 
-        return IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT;
+        return IdentityConstants.AuthenticationType.IDENTIFICATION;
     }
 
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/FederatedApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/FederatedApplicationAuthenticator.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.identity.application.authentication.framework;
 
-import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
 
 /**
  * Federated application authenticator.
@@ -26,9 +26,9 @@ import org.wso2.carbon.identity.base.IdentityConstants;
 public interface FederatedApplicationAuthenticator extends ApplicationAuthenticator {
 
     @Override
-    default IdentityConstants.AuthenticationType getAuthenticationType() {
+    default AuthenticationType getAuthenticationType() {
 
-        return IdentityConstants.AuthenticationType.IDENTIFICATION;
+        return AuthenticationType.IDENTIFICATION;
     }
 
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/LocalApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/LocalApplicationAuthenticator.java
@@ -18,9 +18,24 @@
 
 package org.wso2.carbon.identity.application.authentication.framework;
 
+import org.wso2.carbon.identity.base.IdentityConstants;
+
+import java.util.Arrays;
+
+import static org.wso2.carbon.identity.base.IdentityConstants.TAG_2FA;
+
 /**
  * Local authenticator for applications.
  */
 public interface LocalApplicationAuthenticator extends ApplicationAuthenticator {
 
+    @Override
+    default IdentityConstants.AuthenticationType getAuthenticationType() {
+
+        if (getTags() != null && Arrays.stream(getTags()).anyMatch(s -> s.equalsIgnoreCase(TAG_2FA))) {
+            return IdentityConstants.AuthenticationType.FACTOR_VERIFICATION;
+        }
+
+        return IdentityConstants.AuthenticationType.INTERNAL_ACCOUNT;
+    }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/LocalApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/LocalApplicationAuthenticator.java
@@ -33,9 +33,9 @@ public interface LocalApplicationAuthenticator extends ApplicationAuthenticator 
     default IdentityConstants.AuthenticationType getAuthenticationType() {
 
         if (getTags() != null && Arrays.stream(getTags()).anyMatch(s -> s.equalsIgnoreCase(TAG_2FA))) {
-            return IdentityConstants.AuthenticationType.FACTOR_VERIFICATION;
+            return IdentityConstants.AuthenticationType.VERIFICATION_ONLY;
         }
 
-        return IdentityConstants.AuthenticationType.INTERNAL_ACCOUNT;
+        return IdentityConstants.AuthenticationType.IDENTIFICATION;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/LocalApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/LocalApplicationAuthenticator.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.identity.application.authentication.framework;
 
-import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
 
 import java.util.Arrays;
 
@@ -30,12 +30,12 @@ import static org.wso2.carbon.identity.base.IdentityConstants.TAG_2FA;
 public interface LocalApplicationAuthenticator extends ApplicationAuthenticator {
 
     @Override
-    default IdentityConstants.AuthenticationType getAuthenticationType() {
+    default AuthenticationType getAuthenticationType() {
 
         if (getTags() != null && Arrays.stream(getTags()).anyMatch(s -> s.equalsIgnoreCase(TAG_2FA))) {
-            return IdentityConstants.AuthenticationType.VERIFICATION_ONLY;
+            return AuthenticationType.VERIFICATION_ONLY;
         }
 
-        return IdentityConstants.AuthenticationType.IDENTIFICATION;
+        return AuthenticationType.IDENTIFICATION;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/RequestPathApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/RequestPathApplicationAuthenticator.java
@@ -18,9 +18,16 @@
 
 package org.wso2.carbon.identity.application.authentication.framework;
 
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+
 /**
  * Request path application authenticator.
  */
 public interface RequestPathApplicationAuthenticator extends ApplicationAuthenticator {
 
+    @Override
+    default AuthenticationType getAuthenticationType() {
+
+        return AuthenticationType.REQUEST_PATH;
+    }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -121,6 +121,7 @@ import org.wso2.carbon.user.core.service.RealmService;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -128,6 +129,8 @@ import java.util.List;
 import javax.servlet.Servlet;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.promptOnLongWait;
+import static org.wso2.carbon.identity.base.IdentityConstants.AuthenticationType;
+import static org.wso2.carbon.identity.base.IdentityConstants.TAG_2FA;
 import static org.wso2.carbon.identity.base.IdentityConstants.TRUE;
 
 /**
@@ -508,6 +511,12 @@ public class FrameworkServiceComponent {
             localAuthenticatorConfig.setDisplayName(authenticator.getFriendlyName());
             localAuthenticatorConfig.setTags(getTags(authenticator));
             localAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+            if (localAuthenticatorConfig.getTags() != null &&
+                    Arrays.stream(localAuthenticatorConfig.getTags()).anyMatch(s -> s.equalsIgnoreCase(TAG_2FA))) {
+                localAuthenticatorConfig.setAuthenticationType(AuthenticationType.FACTOR_VERIFICATION);
+            } else {
+                localAuthenticatorConfig.setAuthenticationType(AuthenticationType.INTERNAL_ACCOUNT);
+            }
             AuthenticatorConfig fileBasedConfig = getAuthenticatorConfig(authenticator.getName());
             localAuthenticatorConfig.setEnabled(fileBasedConfig.isEnabled());
             ApplicationAuthenticatorService.getInstance().addLocalAuthenticator(localAuthenticatorConfig);
@@ -518,6 +527,7 @@ public class FrameworkServiceComponent {
             federatedAuthenticatorConfig.setDisplayName(authenticator.getFriendlyName());
             federatedAuthenticatorConfig.setTags(getTags(authenticator));
             federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+            federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
             ApplicationAuthenticatorService.getInstance().addFederatedAuthenticator(federatedAuthenticatorConfig);
         } else if (authenticator instanceof RequestPathApplicationAuthenticator) {
             RequestPathAuthenticatorConfig reqPathAuthenticatorConfig = new RequestPathAuthenticatorConfig();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -99,6 +99,7 @@ import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfi
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticatorConfig;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.core.handler.HandlerComparator;
@@ -506,6 +507,7 @@ public class FrameworkServiceComponent {
             localAuthenticatorConfig.setProperties(configProperties);
             localAuthenticatorConfig.setDisplayName(authenticator.getFriendlyName());
             localAuthenticatorConfig.setTags(getTags(authenticator));
+            localAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
             AuthenticatorConfig fileBasedConfig = getAuthenticatorConfig(authenticator.getName());
             localAuthenticatorConfig.setEnabled(fileBasedConfig.isEnabled());
             ApplicationAuthenticatorService.getInstance().addLocalAuthenticator(localAuthenticatorConfig);
@@ -515,6 +517,7 @@ public class FrameworkServiceComponent {
             federatedAuthenticatorConfig.setProperties(configProperties);
             federatedAuthenticatorConfig.setDisplayName(authenticator.getFriendlyName());
             federatedAuthenticatorConfig.setTags(getTags(authenticator));
+            federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
             ApplicationAuthenticatorService.getInstance().addFederatedAuthenticator(federatedAuthenticatorConfig);
         } else if (authenticator instanceof RequestPathApplicationAuthenticator) {
             RequestPathAuthenticatorConfig reqPathAuthenticatorConfig = new RequestPathAuthenticatorConfig();
@@ -524,6 +527,7 @@ public class FrameworkServiceComponent {
             reqPathAuthenticatorConfig.setTags(getTags(authenticator));
             AuthenticatorConfig fileBasedConfig = getAuthenticatorConfig(authenticator.getName());
             reqPathAuthenticatorConfig.setEnabled(fileBasedConfig.isEnabled());
+            reqPathAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
             ApplicationAuthenticatorService.getInstance().addRequestPathAuthenticator(reqPathAuthenticatorConfig);
         }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -513,9 +513,9 @@ public class FrameworkServiceComponent {
             localAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
             if (localAuthenticatorConfig.getTags() != null &&
                     Arrays.stream(localAuthenticatorConfig.getTags()).anyMatch(s -> s.equalsIgnoreCase(TAG_2FA))) {
-                localAuthenticatorConfig.setAuthenticationType(AuthenticationType.FACTOR_VERIFICATION);
+                localAuthenticatorConfig.setAuthenticationType(AuthenticationType.VERIFICATION_ONLY);
             } else {
-                localAuthenticatorConfig.setAuthenticationType(AuthenticationType.INTERNAL_ACCOUNT);
+                localAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
             }
             AuthenticatorConfig fileBasedConfig = getAuthenticatorConfig(authenticator.getName());
             localAuthenticatorConfig.setEnabled(fileBasedConfig.isEnabled());
@@ -527,7 +527,7 @@ public class FrameworkServiceComponent {
             federatedAuthenticatorConfig.setDisplayName(authenticator.getFriendlyName());
             federatedAuthenticatorConfig.setTags(getTags(authenticator));
             federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+            federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
             ApplicationAuthenticatorService.getInstance().addFederatedAuthenticator(federatedAuthenticatorConfig);
         } else if (authenticator instanceof RequestPathApplicationAuthenticator) {
             RequestPathAuthenticatorConfig reqPathAuthenticatorConfig = new RequestPathAuthenticatorConfig();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -99,7 +99,8 @@ import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfi
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticatorConfig;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
-import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.core.handler.HandlerComparator;
@@ -129,7 +130,6 @@ import java.util.List;
 import javax.servlet.Servlet;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.promptOnLongWait;
-import static org.wso2.carbon.identity.base.IdentityConstants.AuthenticationType;
 import static org.wso2.carbon.identity.base.IdentityConstants.TAG_2FA;
 import static org.wso2.carbon.identity.base.IdentityConstants.TRUE;
 
@@ -510,7 +510,7 @@ public class FrameworkServiceComponent {
             localAuthenticatorConfig.setProperties(configProperties);
             localAuthenticatorConfig.setDisplayName(authenticator.getFriendlyName());
             localAuthenticatorConfig.setTags(getTags(authenticator));
-            localAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+            localAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
             if (localAuthenticatorConfig.getTags() != null &&
                     Arrays.stream(localAuthenticatorConfig.getTags()).anyMatch(s -> s.equalsIgnoreCase(TAG_2FA))) {
                 localAuthenticatorConfig.setAuthenticationType(AuthenticationType.VERIFICATION_ONLY);
@@ -526,8 +526,8 @@ public class FrameworkServiceComponent {
             federatedAuthenticatorConfig.setProperties(configProperties);
             federatedAuthenticatorConfig.setDisplayName(authenticator.getFriendlyName());
             federatedAuthenticatorConfig.setTags(getTags(authenticator));
-            federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+            federatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+            federatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
             ApplicationAuthenticatorService.getInstance().addFederatedAuthenticator(federatedAuthenticatorConfig);
         } else if (authenticator instanceof RequestPathApplicationAuthenticator) {
             RequestPathAuthenticatorConfig reqPathAuthenticatorConfig = new RequestPathAuthenticatorConfig();
@@ -537,7 +537,8 @@ public class FrameworkServiceComponent {
             reqPathAuthenticatorConfig.setTags(getTags(authenticator));
             AuthenticatorConfig fileBasedConfig = getAuthenticatorConfig(authenticator.getName());
             reqPathAuthenticatorConfig.setEnabled(fileBasedConfig.isEnabled());
-            reqPathAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+            reqPathAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+            reqPathAuthenticatorConfig.setAuthenticationType(AuthenticationType.REQUEST_PATH);
             ApplicationAuthenticatorService.getInstance().addRequestPathAuthenticator(reqPathAuthenticatorConfig);
         }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -115,6 +115,7 @@ import org.wso2.carbon.identity.application.common.model.IdentityProviderPropert
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
@@ -4189,5 +4190,24 @@ public class FrameworkUtils {
     public static boolean isURLRelative(String uriString) throws URISyntaxException {
 
         return !new URI(uriString).isAbsolute();
+    }
+
+    /**
+     * This method return defined by type for the given authenticator name.
+     *
+     * @param authenticatorName     Name of the authenticator.
+     * @return The defined by type.
+     * @throws FrameworkException If no authenticator found for the given authenticator name.
+     */
+    public static IdentityConstants.DefinedByType getAuthenticatorDefinedByType(String authenticatorName)
+            throws FrameworkException {
+
+        for (ApplicationAuthenticator authenticator: FrameworkServiceComponent.getAuthenticators()) {
+            if (authenticator.getName().equals(authenticatorName)) {
+                return authenticator.getDefinedByType();
+            }
+        }
+
+        throw new FrameworkException("No authenticator instance is found for " + authenticatorName);
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -4197,10 +4197,8 @@ public class FrameworkUtils {
      *
      * @param authenticatorName     Name of the authenticator.
      * @return The defined by type.
-     * @throws FrameworkException If no authenticator found for the given authenticator name.
      */
-    public static IdentityConstants.DefinedByType getAuthenticatorDefinedByType(String authenticatorName)
-            throws FrameworkException {
+    public static IdentityConstants.DefinedByType getAuthenticatorDefinedByType(String authenticatorName) {
 
         for (ApplicationAuthenticator authenticator: FrameworkServiceComponent.getAuthenticators()) {
             if (authenticator.getName().equals(authenticatorName)) {
@@ -4208,6 +4206,6 @@ public class FrameworkUtils {
             }
         }
 
-        throw new FrameworkException("No authenticator instance is found for " + authenticatorName);
+        return null;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -115,7 +115,7 @@ import org.wso2.carbon.identity.application.common.model.IdentityProviderPropert
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
-import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
@@ -4198,7 +4198,7 @@ public class FrameworkUtils {
      * @param authenticatorName     Name of the authenticator.
      * @return The defined by type.
      */
-    public static IdentityConstants.DefinedByType getAuthenticatorDefinedByType(String authenticatorName) {
+    public static DefinedByType getAuthenticatorDefinedByType(String authenticatorName) {
 
         for (ApplicationAuthenticator authenticator: FrameworkServiceComponent.getAuthenticators()) {
             if (authenticator.getName().equals(authenticatorName)) {

--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/AuthenticatorPropertiesConstant.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/AuthenticatorPropertiesConstant.java
@@ -1,0 +1,29 @@
+package org.wso2.carbon.identity.base;
+
+public class AuthenticatorPropertiesConstant {
+
+    /**
+     * The Defined by Types - SYSTEM: system define authenticator, USER: user defined authentication extension.
+     */
+    public static enum DefinedByType {
+
+        SYSTEM,
+        USER
+    }
+
+    /**
+     * The Authentication Types -
+     *      External User Account Authentication: This authenticator can authenticate federated users
+     *                                            and provision them.
+     *      Internal User Account Authentication: This authenticator collects the identifiers and authenticates user
+     *                                            accounts managed within the organization.
+     *      2FA Authentication: This authenticator can only verify users in the second or
+     *                          subsequent steps of the login process.
+     */
+    public static enum AuthenticationType {
+
+        IDENTIFICATION,
+        VERIFICATION_ONLY,
+        REQUEST_PATH
+    }
+ }

--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -619,4 +619,13 @@ public class IdentityConstants {
 
         public static final String SET_ACCOUNT_LOCK_AUTH_FAILURE_REASON = "APIResponse.SetAccountLockAuthFailureReason";
     }
+
+    /**
+     * The Authentication Type - SYSTEM: system define authenticator, CUSTOM: user defined authentication extension.
+     */
+    public enum DefinedByType {
+
+        SYSTEM,
+        USER
+    }
 }

--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -642,8 +642,7 @@ public class IdentityConstants {
      */
     public static enum AuthenticationType {
 
-        EXTERNAL_ACCOUNT,
-        INTERNAL_ACCOUNT,
-        FACTOR_VERIFICATION
+        IDENTIFICATION,
+        VERIFICATION_ONLY
     }
 }

--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -621,7 +621,7 @@ public class IdentityConstants {
     }
 
     /**
-     * The Authentication Type - SYSTEM: system define authenticator, CUSTOM: user defined authentication extension.
+     * The Authentication Type - SYSTEM: system define authenticator, USER: user defined authentication extension.
      */
     public static enum DefinedByType {
 

--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -623,7 +623,7 @@ public class IdentityConstants {
     /**
      * The Authentication Type - SYSTEM: system define authenticator, CUSTOM: user defined authentication extension.
      */
-    public enum DefinedByType {
+    public static enum DefinedByType {
 
         SYSTEM,
         USER

--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -160,6 +160,8 @@ public class IdentityConstants {
 
     // Configuration constants of authentication authenticator in identity.xml file.
     public static final String TAGS = "Tags";
+    public static final String TAG_2FA = "2FA";
+
 
     // User account association constants
     public static final String USER_ACCOUNT_ASSOCIATION_ENABLE_SHA256_KEY = "UserAccountAssociation.EnableSHA256Key";
@@ -621,11 +623,27 @@ public class IdentityConstants {
     }
 
     /**
-     * The Authentication Type - SYSTEM: system define authenticator, USER: user defined authentication extension.
+     * The Defined by Types - SYSTEM: system define authenticator, USER: user defined authentication extension.
      */
     public static enum DefinedByType {
 
         SYSTEM,
         USER
+    }
+
+    /**
+     * The Authentication Types -
+     *      External User Account Authentication: This authenticator can authenticate federated users
+     *                                            and provision them.
+     *      Internal User Account Authentication: This authenticator collects the identifiers and authenticates user
+     *                                            accounts managed within the organization.
+     *      2FA Authentication: This authenticator can only verify users in the second or
+     *                          subsequent steps of the login process.
+     */
+    public static enum AuthenticationType {
+
+        EXTERNAL_ACCOUNT,
+        INTERNAL_ACCOUNT,
+        FACTOR_VERIFICATION
     }
 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -43,6 +43,8 @@ import org.wso2.carbon.identity.application.common.model.RoleMapping;
 import org.wso2.carbon.identity.application.common.model.SubProperty;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
@@ -171,9 +173,9 @@ public class IdentityProviderManager implements IdpManager {
         if (saml2SSOResidentAuthenticatorConfig == null) {
             saml2SSOResidentAuthenticatorConfig = new FederatedAuthenticatorConfig();
             saml2SSOResidentAuthenticatorConfig.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.NAME);
-            saml2SSOResidentAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+            saml2SSOResidentAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
             saml2SSOResidentAuthenticatorConfig.setAuthenticationType(
-                    IdentityConstants.AuthenticationType.IDENTIFICATION);
+                    AuthenticationType.IDENTIFICATION);
         }
         if (saml2SSOResidentAuthenticatorConfig.getProperties() == null) {
             saml2SSOResidentAuthenticatorConfig.setProperties(new Property[0]);
@@ -258,8 +260,8 @@ public class IdentityProviderManager implements IdpManager {
         FederatedAuthenticatorConfig oidcAuthenticationConfig = new FederatedAuthenticatorConfig();
         oidcAuthenticationConfig.setProperties(new Property[]{oidcProperty});
         oidcAuthenticationConfig.setName(IdentityApplicationConstants.Authenticator.OIDC.NAME);
-        oidcAuthenticationConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        oidcAuthenticationConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        oidcAuthenticationConfig.setDefinedByType(DefinedByType.SYSTEM);
+        oidcAuthenticationConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
 
         Property passiveStsProperty = new Property();
         passiveStsProperty.setName(IdentityApplicationConstants.Authenticator.PassiveSTS.IDENTITY_PROVIDER_ENTITY_ID);
@@ -268,8 +270,8 @@ public class IdentityProviderManager implements IdpManager {
         FederatedAuthenticatorConfig passiveStsAuthenticationConfig = new FederatedAuthenticatorConfig();
         passiveStsAuthenticationConfig.setProperties(new Property[]{passiveStsProperty});
         passiveStsAuthenticationConfig.setName(IdentityApplicationConstants.Authenticator.PassiveSTS.NAME);
-        passiveStsAuthenticationConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        passiveStsAuthenticationConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        passiveStsAuthenticationConfig.setDefinedByType(DefinedByType.SYSTEM);
+        passiveStsAuthenticationConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
 
         FederatedAuthenticatorConfig[] federatedAuthenticatorConfigs = {saml2SSOResidentAuthenticatorConfig,
                 passiveStsAuthenticationConfig, oidcAuthenticationConfig};

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -171,6 +171,7 @@ public class IdentityProviderManager implements IdpManager {
         if (saml2SSOResidentAuthenticatorConfig == null) {
             saml2SSOResidentAuthenticatorConfig = new FederatedAuthenticatorConfig();
             saml2SSOResidentAuthenticatorConfig.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.NAME);
+            saml2SSOResidentAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         }
         if (saml2SSOResidentAuthenticatorConfig.getProperties() == null) {
             saml2SSOResidentAuthenticatorConfig.setProperties(new Property[0]);
@@ -255,6 +256,7 @@ public class IdentityProviderManager implements IdpManager {
         FederatedAuthenticatorConfig oidcAuthenticationConfig = new FederatedAuthenticatorConfig();
         oidcAuthenticationConfig.setProperties(new Property[]{oidcProperty});
         oidcAuthenticationConfig.setName(IdentityApplicationConstants.Authenticator.OIDC.NAME);
+        oidcAuthenticationConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
 
         Property passiveStsProperty = new Property();
         passiveStsProperty.setName(IdentityApplicationConstants.Authenticator.PassiveSTS.IDENTITY_PROVIDER_ENTITY_ID);
@@ -263,6 +265,7 @@ public class IdentityProviderManager implements IdpManager {
         FederatedAuthenticatorConfig passiveStsAuthenticationConfig = new FederatedAuthenticatorConfig();
         passiveStsAuthenticationConfig.setProperties(new Property[]{passiveStsProperty});
         passiveStsAuthenticationConfig.setName(IdentityApplicationConstants.Authenticator.PassiveSTS.NAME);
+        passiveStsAuthenticationConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
 
         FederatedAuthenticatorConfig[] federatedAuthenticatorConfigs = {saml2SSOResidentAuthenticatorConfig,
                 passiveStsAuthenticationConfig, oidcAuthenticationConfig};

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -172,6 +172,8 @@ public class IdentityProviderManager implements IdpManager {
             saml2SSOResidentAuthenticatorConfig = new FederatedAuthenticatorConfig();
             saml2SSOResidentAuthenticatorConfig.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.NAME);
             saml2SSOResidentAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+            saml2SSOResidentAuthenticatorConfig.setAuthenticationType(
+                    IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         }
         if (saml2SSOResidentAuthenticatorConfig.getProperties() == null) {
             saml2SSOResidentAuthenticatorConfig.setProperties(new Property[0]);
@@ -257,6 +259,7 @@ public class IdentityProviderManager implements IdpManager {
         oidcAuthenticationConfig.setProperties(new Property[]{oidcProperty});
         oidcAuthenticationConfig.setName(IdentityApplicationConstants.Authenticator.OIDC.NAME);
         oidcAuthenticationConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        oidcAuthenticationConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
 
         Property passiveStsProperty = new Property();
         passiveStsProperty.setName(IdentityApplicationConstants.Authenticator.PassiveSTS.IDENTITY_PROVIDER_ENTITY_ID);
@@ -266,6 +269,7 @@ public class IdentityProviderManager implements IdpManager {
         passiveStsAuthenticationConfig.setProperties(new Property[]{passiveStsProperty});
         passiveStsAuthenticationConfig.setName(IdentityApplicationConstants.Authenticator.PassiveSTS.NAME);
         passiveStsAuthenticationConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        passiveStsAuthenticationConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
 
         FederatedAuthenticatorConfig[] federatedAuthenticatorConfigs = {saml2SSOResidentAuthenticatorConfig,
                 passiveStsAuthenticationConfig, oidcAuthenticationConfig};

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -173,7 +173,7 @@ public class IdentityProviderManager implements IdpManager {
             saml2SSOResidentAuthenticatorConfig.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.NAME);
             saml2SSOResidentAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
             saml2SSOResidentAuthenticatorConfig.setAuthenticationType(
-                    IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+                    IdentityConstants.AuthenticationType.IDENTIFICATION);
         }
         if (saml2SSOResidentAuthenticatorConfig.getProperties() == null) {
             saml2SSOResidentAuthenticatorConfig.setProperties(new Property[0]);
@@ -259,7 +259,7 @@ public class IdentityProviderManager implements IdpManager {
         oidcAuthenticationConfig.setProperties(new Property[]{oidcProperty});
         oidcAuthenticationConfig.setName(IdentityApplicationConstants.Authenticator.OIDC.NAME);
         oidcAuthenticationConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        oidcAuthenticationConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        oidcAuthenticationConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
 
         Property passiveStsProperty = new Property();
         passiveStsProperty.setName(IdentityApplicationConstants.Authenticator.PassiveSTS.IDENTITY_PROVIDER_ENTITY_ID);
@@ -269,7 +269,7 @@ public class IdentityProviderManager implements IdpManager {
         passiveStsAuthenticationConfig.setProperties(new Property[]{passiveStsProperty});
         passiveStsAuthenticationConfig.setName(IdentityApplicationConstants.Authenticator.PassiveSTS.NAME);
         passiveStsAuthenticationConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        passiveStsAuthenticationConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        passiveStsAuthenticationConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
 
         FederatedAuthenticatorConfig[] federatedAuthenticatorConfigs = {saml2SSOResidentAuthenticatorConfig,
                 passiveStsAuthenticationConfig, oidcAuthenticationConfig};

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -1148,6 +1148,8 @@ public class IdPManagementDAO {
                 }
 
                 authnConfig.setDisplayName(rs.getString("DISPLAY_NAME"));
+                // TODO: Read from database and set the DefinedBy property to the authenticator.
+                authnConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
 
                 if (defaultAuthName != null && authnConfig.getName().equals(defaultAuthName)) {
                     federatedIdp.getDefaultAuthenticatorConfig().setDisplayName(authnConfig.getDisplayName());
@@ -1424,6 +1426,7 @@ public class IdPManagementDAO {
             }
             prepStmt1.setString(4, authnConfig.getName());
             prepStmt1.setString(5, authnConfig.getDisplayName());
+            //TODO: prepStmt1.setString(6, authnConfig.getDefinedByType().toString());
             prepStmt1.execute();
 
             int authnId = getAuthenticatorIdentifier(dbConnection, idpId, authnConfig.getName());
@@ -2330,6 +2333,7 @@ public class IdPManagementDAO {
         if (samlFederatedAuthConfig == null) {
             samlFederatedAuthConfig = new FederatedAuthenticatorConfig();
             samlFederatedAuthConfig.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.NAME);
+            samlFederatedAuthConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         }
 
         List<Property> propertiesList = new ArrayList<>();
@@ -2713,6 +2717,7 @@ public class IdPManagementDAO {
         if (openIdFedAuthn == null) {
             openIdFedAuthn = new FederatedAuthenticatorConfig();
             openIdFedAuthn.setName(IdentityApplicationConstants.Authenticator.OpenID.NAME);
+            openIdFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         }
         propertiesList = new ArrayList<>(Arrays.asList(openIdFedAuthn.getProperties()));
         if (IdentityApplicationManagementUtil.getProperty(openIdFedAuthn.getProperties(),
@@ -2735,6 +2740,7 @@ public class IdPManagementDAO {
         if (oauth1FedAuthn == null) {
             oauth1FedAuthn = new FederatedAuthenticatorConfig();
             oauth1FedAuthn.setName(IdentityApplicationConstants.OAuth10A.NAME);
+            oauth1FedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         }
         propertiesList = new ArrayList<>(Arrays.asList(oauth1FedAuthn.getProperties()));
         if (IdentityApplicationManagementUtil.getProperty(oauth1FedAuthn.getProperties(),
@@ -2770,6 +2776,7 @@ public class IdPManagementDAO {
         if (oidcFedAuthn == null) {
             oidcFedAuthn = new FederatedAuthenticatorConfig();
             oidcFedAuthn.setName(IdentityApplicationConstants.Authenticator.OIDC.NAME);
+            oidcFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         }
         propertiesList = new ArrayList<>();
 
@@ -2841,6 +2848,7 @@ public class IdPManagementDAO {
         if (passiveSTSFedAuthn == null) {
             passiveSTSFedAuthn = new FederatedAuthenticatorConfig();
             passiveSTSFedAuthn.setName(IdentityApplicationConstants.Authenticator.PassiveSTS.NAME);
+            passiveSTSFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         }
 
         propertiesList = new ArrayList<>();
@@ -2880,6 +2888,7 @@ public class IdPManagementDAO {
         if (stsFedAuthn == null) {
             stsFedAuthn = new FederatedAuthenticatorConfig();
             stsFedAuthn.setName(IdentityApplicationConstants.Authenticator.WSTrust.NAME);
+            stsFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         }
         propertiesList = new ArrayList<>(Arrays.asList(stsFedAuthn.getProperties()));
         if (IdentityApplicationManagementUtil.getProperty(stsFedAuthn.getProperties(),
@@ -2894,6 +2903,7 @@ public class IdPManagementDAO {
 
         FederatedAuthenticatorConfig sessionTimeoutConfig = new FederatedAuthenticatorConfig();
         sessionTimeoutConfig.setName(IdentityApplicationConstants.NAME);
+        sessionTimeoutConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
 
         propertiesList = new ArrayList<>(Arrays.asList(sessionTimeoutConfig.getProperties()));
 
@@ -3443,6 +3453,8 @@ public class IdPManagementDAO {
                 if (defaultAuthenticatorName != null) {
                     FederatedAuthenticatorConfig defaultAuthenticator = new FederatedAuthenticatorConfig();
                     defaultAuthenticator.setName(defaultAuthenticatorName);
+                    // TODO: Check the authenticator type and set the DefinedBy property accordingly.
+                    defaultAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
                     federatedIdp.setDefaultAuthenticatorConfig(defaultAuthenticator);
                 }
 
@@ -3606,6 +3618,8 @@ public class IdPManagementDAO {
                 if (defaultAuthenticatorName != null) {
                     FederatedAuthenticatorConfig defaultAuthenticator = new FederatedAuthenticatorConfig();
                     defaultAuthenticator.setName(defaultAuthenticatorName);
+                    // TODO: Check the authenticator type and set the DefinedBy property accordingly.
+                    defaultAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
                     federatedIdp.setDefaultAuthenticatorConfig(defaultAuthenticator);
                 }
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -3419,6 +3419,8 @@ public class IdPManagementDAO {
                 String roleClaimUri = rs.getString("ROLE_CLAIM_URI");
 
                 String defaultAuthenticatorName = rs.getString("DEFAULT_AUTHENTICATOR_NAME");
+                // TODO: Read from database and set the DefinedBy property to the authenticator.
+                String defaultAuthenticatorDefinedByType = IdentityConstants.DefinedByType.SYSTEM.toString();
                 String defaultProvisioningConnectorConfigName = rs.getString("DEFAULT_PRO_CONNECTOR_NAME");
                 federatedIdp.setIdentityProviderDescription(rs.getString("DESCRIPTION"));
 
@@ -3453,8 +3455,8 @@ public class IdPManagementDAO {
                 if (defaultAuthenticatorName != null) {
                     FederatedAuthenticatorConfig defaultAuthenticator = new FederatedAuthenticatorConfig();
                     defaultAuthenticator.setName(defaultAuthenticatorName);
-                    // TODO: Check the authenticator type and set the DefinedBy property accordingly.
-                    defaultAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+                    defaultAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
+                            defaultAuthenticatorDefinedByType));
                     federatedIdp.setDefaultAuthenticatorConfig(defaultAuthenticator);
                 }
 
@@ -3584,6 +3586,8 @@ public class IdPManagementDAO {
                 String roleClaimUri = rs.getString("ROLE_CLAIM_URI");
 
                 String defaultAuthenticatorName = rs.getString("DEFAULT_AUTHENTICATOR_NAME");
+                // TODO: Read from database and set the DefinedBy property to the authenticator.
+                String defaultAuthenticatorDefinedByType = IdentityConstants.DefinedByType.SYSTEM.toString();
                 String defaultProvisioningConnectorConfigName = rs.getString("DEFAULT_PRO_CONNECTOR_NAME");
                 federatedIdp.setIdentityProviderDescription(rs.getString("DESCRIPTION"));
 
@@ -3618,8 +3622,8 @@ public class IdPManagementDAO {
                 if (defaultAuthenticatorName != null) {
                     FederatedAuthenticatorConfig defaultAuthenticator = new FederatedAuthenticatorConfig();
                     defaultAuthenticator.setName(defaultAuthenticatorName);
-                    // TODO: Check the authenticator type and set the DefinedBy property accordingly.
-                    defaultAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+                    defaultAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
+                            defaultAuthenticatorDefinedByType));
                     federatedIdp.setDefaultAuthenticatorConfig(defaultAuthenticator);
                 }
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -1150,6 +1150,7 @@ public class IdPManagementDAO {
                 authnConfig.setDisplayName(rs.getString("DISPLAY_NAME"));
                 // TODO: Read from database and set the DefinedBy property to the authenticator.
                 authnConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+                authnConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
 
                 if (defaultAuthName != null && authnConfig.getName().equals(defaultAuthName)) {
                     federatedIdp.getDefaultAuthenticatorConfig().setDisplayName(authnConfig.getDisplayName());
@@ -1427,6 +1428,7 @@ public class IdPManagementDAO {
             prepStmt1.setString(4, authnConfig.getName());
             prepStmt1.setString(5, authnConfig.getDisplayName());
             //TODO: prepStmt1.setString(6, authnConfig.getDefinedByType().toString());
+            //TODO: prepStmt1.setString(7, IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
             prepStmt1.execute();
 
             int authnId = getAuthenticatorIdentifier(dbConnection, idpId, authnConfig.getName());
@@ -2334,6 +2336,7 @@ public class IdPManagementDAO {
             samlFederatedAuthConfig = new FederatedAuthenticatorConfig();
             samlFederatedAuthConfig.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.NAME);
             samlFederatedAuthConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+            samlFederatedAuthConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         }
 
         List<Property> propertiesList = new ArrayList<>();
@@ -2718,6 +2721,7 @@ public class IdPManagementDAO {
             openIdFedAuthn = new FederatedAuthenticatorConfig();
             openIdFedAuthn.setName(IdentityApplicationConstants.Authenticator.OpenID.NAME);
             openIdFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+            openIdFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         }
         propertiesList = new ArrayList<>(Arrays.asList(openIdFedAuthn.getProperties()));
         if (IdentityApplicationManagementUtil.getProperty(openIdFedAuthn.getProperties(),
@@ -2741,6 +2745,7 @@ public class IdPManagementDAO {
             oauth1FedAuthn = new FederatedAuthenticatorConfig();
             oauth1FedAuthn.setName(IdentityApplicationConstants.OAuth10A.NAME);
             oauth1FedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+            oauth1FedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         }
         propertiesList = new ArrayList<>(Arrays.asList(oauth1FedAuthn.getProperties()));
         if (IdentityApplicationManagementUtil.getProperty(oauth1FedAuthn.getProperties(),
@@ -2777,6 +2782,7 @@ public class IdPManagementDAO {
             oidcFedAuthn = new FederatedAuthenticatorConfig();
             oidcFedAuthn.setName(IdentityApplicationConstants.Authenticator.OIDC.NAME);
             oidcFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+            oidcFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         }
         propertiesList = new ArrayList<>();
 
@@ -2849,6 +2855,7 @@ public class IdPManagementDAO {
             passiveSTSFedAuthn = new FederatedAuthenticatorConfig();
             passiveSTSFedAuthn.setName(IdentityApplicationConstants.Authenticator.PassiveSTS.NAME);
             passiveSTSFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+            passiveSTSFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         }
 
         propertiesList = new ArrayList<>();
@@ -2889,6 +2896,7 @@ public class IdPManagementDAO {
             stsFedAuthn = new FederatedAuthenticatorConfig();
             stsFedAuthn.setName(IdentityApplicationConstants.Authenticator.WSTrust.NAME);
             stsFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+            stsFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         }
         propertiesList = new ArrayList<>(Arrays.asList(stsFedAuthn.getProperties()));
         if (IdentityApplicationManagementUtil.getProperty(stsFedAuthn.getProperties(),
@@ -2904,6 +2912,7 @@ public class IdPManagementDAO {
         FederatedAuthenticatorConfig sessionTimeoutConfig = new FederatedAuthenticatorConfig();
         sessionTimeoutConfig.setName(IdentityApplicationConstants.NAME);
         sessionTimeoutConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        sessionTimeoutConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
 
         propertiesList = new ArrayList<>(Arrays.asList(sessionTimeoutConfig.getProperties()));
 
@@ -3457,6 +3466,7 @@ public class IdPManagementDAO {
                     defaultAuthenticator.setName(defaultAuthenticatorName);
                     defaultAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
                             defaultAuthenticatorDefinedByType));
+                    defaultAuthenticator.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
                     federatedIdp.setDefaultAuthenticatorConfig(defaultAuthenticator);
                 }
 
@@ -3624,6 +3634,7 @@ public class IdPManagementDAO {
                     defaultAuthenticator.setName(defaultAuthenticatorName);
                     defaultAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
                             defaultAuthenticatorDefinedByType));
+                    defaultAuthenticator.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
                     federatedIdp.setDefaultAuthenticatorConfig(defaultAuthenticator);
                 }
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -44,6 +44,8 @@ import org.wso2.carbon.identity.application.common.model.ProvisioningConnectorCo
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.ConnectorConfig;
 import org.wso2.carbon.identity.core.ConnectorException;
@@ -1149,8 +1151,8 @@ public class IdPManagementDAO {
 
                 authnConfig.setDisplayName(rs.getString("DISPLAY_NAME"));
                 // TODO: Read from database and set the DefinedBy property to the authenticator.
-                authnConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-                authnConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+                authnConfig.setDefinedByType(DefinedByType.SYSTEM);
+                authnConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
 
                 if (defaultAuthName != null && authnConfig.getName().equals(defaultAuthName)) {
                     federatedIdp.getDefaultAuthenticatorConfig().setDisplayName(authnConfig.getDisplayName());
@@ -1428,7 +1430,7 @@ public class IdPManagementDAO {
             prepStmt1.setString(4, authnConfig.getName());
             prepStmt1.setString(5, authnConfig.getDisplayName());
             //TODO: prepStmt1.setString(6, authnConfig.getDefinedByType().toString());
-            //TODO: prepStmt1.setString(7, IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+            //TODO: prepStmt1.setString(7, AuthenticationType.EXTERNAL_ACCOUNT);
             prepStmt1.execute();
 
             int authnId = getAuthenticatorIdentifier(dbConnection, idpId, authnConfig.getName());
@@ -2335,8 +2337,8 @@ public class IdPManagementDAO {
         if (samlFederatedAuthConfig == null) {
             samlFederatedAuthConfig = new FederatedAuthenticatorConfig();
             samlFederatedAuthConfig.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.NAME);
-            samlFederatedAuthConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            samlFederatedAuthConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+            samlFederatedAuthConfig.setDefinedByType(DefinedByType.SYSTEM);
+            samlFederatedAuthConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         }
 
         List<Property> propertiesList = new ArrayList<>();
@@ -2720,8 +2722,8 @@ public class IdPManagementDAO {
         if (openIdFedAuthn == null) {
             openIdFedAuthn = new FederatedAuthenticatorConfig();
             openIdFedAuthn.setName(IdentityApplicationConstants.Authenticator.OpenID.NAME);
-            openIdFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            openIdFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+            openIdFedAuthn.setDefinedByType(DefinedByType.SYSTEM);
+            openIdFedAuthn.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         }
         propertiesList = new ArrayList<>(Arrays.asList(openIdFedAuthn.getProperties()));
         if (IdentityApplicationManagementUtil.getProperty(openIdFedAuthn.getProperties(),
@@ -2744,8 +2746,8 @@ public class IdPManagementDAO {
         if (oauth1FedAuthn == null) {
             oauth1FedAuthn = new FederatedAuthenticatorConfig();
             oauth1FedAuthn.setName(IdentityApplicationConstants.OAuth10A.NAME);
-            oauth1FedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            oauth1FedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+            oauth1FedAuthn.setDefinedByType(DefinedByType.SYSTEM);
+            oauth1FedAuthn.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         }
         propertiesList = new ArrayList<>(Arrays.asList(oauth1FedAuthn.getProperties()));
         if (IdentityApplicationManagementUtil.getProperty(oauth1FedAuthn.getProperties(),
@@ -2781,8 +2783,8 @@ public class IdPManagementDAO {
         if (oidcFedAuthn == null) {
             oidcFedAuthn = new FederatedAuthenticatorConfig();
             oidcFedAuthn.setName(IdentityApplicationConstants.Authenticator.OIDC.NAME);
-            oidcFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            oidcFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+            oidcFedAuthn.setDefinedByType(DefinedByType.SYSTEM);
+            oidcFedAuthn.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         }
         propertiesList = new ArrayList<>();
 
@@ -2854,8 +2856,8 @@ public class IdPManagementDAO {
         if (passiveSTSFedAuthn == null) {
             passiveSTSFedAuthn = new FederatedAuthenticatorConfig();
             passiveSTSFedAuthn.setName(IdentityApplicationConstants.Authenticator.PassiveSTS.NAME);
-            passiveSTSFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            passiveSTSFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+            passiveSTSFedAuthn.setDefinedByType(DefinedByType.SYSTEM);
+            passiveSTSFedAuthn.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         }
 
         propertiesList = new ArrayList<>();
@@ -2895,8 +2897,8 @@ public class IdPManagementDAO {
         if (stsFedAuthn == null) {
             stsFedAuthn = new FederatedAuthenticatorConfig();
             stsFedAuthn.setName(IdentityApplicationConstants.Authenticator.WSTrust.NAME);
-            stsFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            stsFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+            stsFedAuthn.setDefinedByType(DefinedByType.SYSTEM);
+            stsFedAuthn.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         }
         propertiesList = new ArrayList<>(Arrays.asList(stsFedAuthn.getProperties()));
         if (IdentityApplicationManagementUtil.getProperty(stsFedAuthn.getProperties(),
@@ -2911,8 +2913,8 @@ public class IdPManagementDAO {
 
         FederatedAuthenticatorConfig sessionTimeoutConfig = new FederatedAuthenticatorConfig();
         sessionTimeoutConfig.setName(IdentityApplicationConstants.NAME);
-        sessionTimeoutConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        sessionTimeoutConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        sessionTimeoutConfig.setDefinedByType(DefinedByType.SYSTEM);
+        sessionTimeoutConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
 
         propertiesList = new ArrayList<>(Arrays.asList(sessionTimeoutConfig.getProperties()));
 
@@ -3429,7 +3431,7 @@ public class IdPManagementDAO {
 
                 String defaultAuthenticatorName = rs.getString("DEFAULT_AUTHENTICATOR_NAME");
                 // TODO: Read from database and set the DefinedBy property to the authenticator.
-                String defaultAuthenticatorDefinedByType = IdentityConstants.DefinedByType.SYSTEM.toString();
+                String defaultAuthenticatorDefinedByType = DefinedByType.SYSTEM.toString();
                 String defaultProvisioningConnectorConfigName = rs.getString("DEFAULT_PRO_CONNECTOR_NAME");
                 federatedIdp.setIdentityProviderDescription(rs.getString("DESCRIPTION"));
 
@@ -3464,9 +3466,9 @@ public class IdPManagementDAO {
                 if (defaultAuthenticatorName != null) {
                     FederatedAuthenticatorConfig defaultAuthenticator = new FederatedAuthenticatorConfig();
                     defaultAuthenticator.setName(defaultAuthenticatorName);
-                    defaultAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
+                    defaultAuthenticator.setDefinedByType(DefinedByType.valueOf(
                             defaultAuthenticatorDefinedByType));
-                    defaultAuthenticator.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+                    defaultAuthenticator.setAuthenticationType(AuthenticationType.IDENTIFICATION);
                     federatedIdp.setDefaultAuthenticatorConfig(defaultAuthenticator);
                 }
 
@@ -3597,7 +3599,7 @@ public class IdPManagementDAO {
 
                 String defaultAuthenticatorName = rs.getString("DEFAULT_AUTHENTICATOR_NAME");
                 // TODO: Read from database and set the DefinedBy property to the authenticator.
-                String defaultAuthenticatorDefinedByType = IdentityConstants.DefinedByType.SYSTEM.toString();
+                String defaultAuthenticatorDefinedByType = DefinedByType.SYSTEM.toString();
                 String defaultProvisioningConnectorConfigName = rs.getString("DEFAULT_PRO_CONNECTOR_NAME");
                 federatedIdp.setIdentityProviderDescription(rs.getString("DESCRIPTION"));
 
@@ -3632,9 +3634,9 @@ public class IdPManagementDAO {
                 if (defaultAuthenticatorName != null) {
                     FederatedAuthenticatorConfig defaultAuthenticator = new FederatedAuthenticatorConfig();
                     defaultAuthenticator.setName(defaultAuthenticatorName);
-                    defaultAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
+                    defaultAuthenticator.setDefinedByType(DefinedByType.valueOf(
                             defaultAuthenticatorDefinedByType));
-                    defaultAuthenticator.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+                    defaultAuthenticator.setAuthenticationType(AuthenticationType.IDENTIFICATION);
                     federatedIdp.setDefaultAuthenticatorConfig(defaultAuthenticator);
                 }
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -1150,7 +1150,7 @@ public class IdPManagementDAO {
                 authnConfig.setDisplayName(rs.getString("DISPLAY_NAME"));
                 // TODO: Read from database and set the DefinedBy property to the authenticator.
                 authnConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-                authnConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+                authnConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
 
                 if (defaultAuthName != null && authnConfig.getName().equals(defaultAuthName)) {
                     federatedIdp.getDefaultAuthenticatorConfig().setDisplayName(authnConfig.getDisplayName());
@@ -2336,7 +2336,7 @@ public class IdPManagementDAO {
             samlFederatedAuthConfig = new FederatedAuthenticatorConfig();
             samlFederatedAuthConfig.setName(IdentityApplicationConstants.Authenticator.SAML2SSO.NAME);
             samlFederatedAuthConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            samlFederatedAuthConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+            samlFederatedAuthConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         }
 
         List<Property> propertiesList = new ArrayList<>();
@@ -2721,7 +2721,7 @@ public class IdPManagementDAO {
             openIdFedAuthn = new FederatedAuthenticatorConfig();
             openIdFedAuthn.setName(IdentityApplicationConstants.Authenticator.OpenID.NAME);
             openIdFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            openIdFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+            openIdFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         }
         propertiesList = new ArrayList<>(Arrays.asList(openIdFedAuthn.getProperties()));
         if (IdentityApplicationManagementUtil.getProperty(openIdFedAuthn.getProperties(),
@@ -2745,7 +2745,7 @@ public class IdPManagementDAO {
             oauth1FedAuthn = new FederatedAuthenticatorConfig();
             oauth1FedAuthn.setName(IdentityApplicationConstants.OAuth10A.NAME);
             oauth1FedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            oauth1FedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+            oauth1FedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         }
         propertiesList = new ArrayList<>(Arrays.asList(oauth1FedAuthn.getProperties()));
         if (IdentityApplicationManagementUtil.getProperty(oauth1FedAuthn.getProperties(),
@@ -2782,7 +2782,7 @@ public class IdPManagementDAO {
             oidcFedAuthn = new FederatedAuthenticatorConfig();
             oidcFedAuthn.setName(IdentityApplicationConstants.Authenticator.OIDC.NAME);
             oidcFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            oidcFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+            oidcFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         }
         propertiesList = new ArrayList<>();
 
@@ -2855,7 +2855,7 @@ public class IdPManagementDAO {
             passiveSTSFedAuthn = new FederatedAuthenticatorConfig();
             passiveSTSFedAuthn.setName(IdentityApplicationConstants.Authenticator.PassiveSTS.NAME);
             passiveSTSFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            passiveSTSFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+            passiveSTSFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         }
 
         propertiesList = new ArrayList<>();
@@ -2896,7 +2896,7 @@ public class IdPManagementDAO {
             stsFedAuthn = new FederatedAuthenticatorConfig();
             stsFedAuthn.setName(IdentityApplicationConstants.Authenticator.WSTrust.NAME);
             stsFedAuthn.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-            stsFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+            stsFedAuthn.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         }
         propertiesList = new ArrayList<>(Arrays.asList(stsFedAuthn.getProperties()));
         if (IdentityApplicationManagementUtil.getProperty(stsFedAuthn.getProperties(),
@@ -2912,7 +2912,7 @@ public class IdPManagementDAO {
         FederatedAuthenticatorConfig sessionTimeoutConfig = new FederatedAuthenticatorConfig();
         sessionTimeoutConfig.setName(IdentityApplicationConstants.NAME);
         sessionTimeoutConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        sessionTimeoutConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        sessionTimeoutConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
 
         propertiesList = new ArrayList<>(Arrays.asList(sessionTimeoutConfig.getProperties()));
 
@@ -3466,7 +3466,7 @@ public class IdPManagementDAO {
                     defaultAuthenticator.setName(defaultAuthenticatorName);
                     defaultAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
                             defaultAuthenticatorDefinedByType));
-                    defaultAuthenticator.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+                    defaultAuthenticator.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
                     federatedIdp.setDefaultAuthenticatorConfig(defaultAuthenticator);
                 }
 
@@ -3634,7 +3634,7 @@ public class IdPManagementDAO {
                     defaultAuthenticator.setName(defaultAuthenticatorName);
                     defaultAuthenticator.setDefinedByType(IdentityConstants.DefinedByType.valueOf(
                             defaultAuthenticatorDefinedByType));
-                    defaultAuthenticator.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+                    defaultAuthenticator.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
                     federatedIdp.setDefaultAuthenticatorConfig(defaultAuthenticator);
                 }
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
@@ -38,7 +38,8 @@ import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.ProvisioningConnectorConfig;
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
-import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementServiceImpl;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
@@ -134,8 +135,8 @@ public class IdentityProviderManagementServiceTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
-        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        federatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -561,8 +562,8 @@ public class IdentityProviderManagementServiceTest {
         newFederatedAuthenticatorConfig.setDisplayName("DisplayName1New");
         newFederatedAuthenticatorConfig.setName("Name");
         newFederatedAuthenticatorConfig.setEnabled(true);
-        newFederatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        newFederatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        newFederatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        newFederatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         Property newProperty1 = new Property();
         newProperty1.setName("Property1New");
         newProperty1.setValue("value1New");
@@ -802,8 +803,8 @@ public class IdentityProviderManagementServiceTest {
         facNew.setDisplayName("DisplayName1New");
         facNew.setName("Name");
         facNew.setEnabled(true);
-        facNew.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        facNew.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        facNew.setDefinedByType(DefinedByType.SYSTEM);
+        facNew.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         idp2New.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{facNew});
 
         // Initialize New Resident Identity Provider 3.
@@ -901,8 +902,8 @@ public class IdentityProviderManagementServiceTest {
         facNew.setDisplayName("SAML2SSO");
         facNew.setName("saml2sso");
         facNew.setEnabled(true);
-        facNew.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        facNew.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        facNew.setDefinedByType(DefinedByType.SYSTEM);
+        facNew.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         newIdp.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{facNew});
         identityProviderManagementService.updateResidentIdP((IdentityProvider) newIdp);
 
@@ -925,8 +926,8 @@ public class IdentityProviderManagementServiceTest {
         facNew.setDisplayName("SAML2SSO");
         facNew.setName("saml2sso");
         facNew.setEnabled(true);
-        facNew.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        facNew.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        facNew.setDefinedByType(DefinedByType.SYSTEM);
+        facNew.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         newIdp.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{facNew});
         identityProviderManagementService.updateResidentIdP((IdentityProvider) newIdp);
 
@@ -962,8 +963,8 @@ public class IdentityProviderManagementServiceTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
-        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        federatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1118,8 +1119,8 @@ public class IdentityProviderManagementServiceTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName");
         federatedAuthenticatorConfig.setName("SAMLSSOAuthenticator");
         federatedAuthenticatorConfig.setEnabled(true);
-        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        federatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("SPEntityId");
         property1.setValue("wso2-is");

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
@@ -135,7 +135,7 @@ public class IdentityProviderManagementServiceTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -562,7 +562,7 @@ public class IdentityProviderManagementServiceTest {
         newFederatedAuthenticatorConfig.setName("Name");
         newFederatedAuthenticatorConfig.setEnabled(true);
         newFederatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        newFederatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        newFederatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         Property newProperty1 = new Property();
         newProperty1.setName("Property1New");
         newProperty1.setValue("value1New");
@@ -803,7 +803,7 @@ public class IdentityProviderManagementServiceTest {
         facNew.setName("Name");
         facNew.setEnabled(true);
         facNew.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        facNew.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        facNew.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         idp2New.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{facNew});
 
         // Initialize New Resident Identity Provider 3.
@@ -902,7 +902,7 @@ public class IdentityProviderManagementServiceTest {
         facNew.setName("saml2sso");
         facNew.setEnabled(true);
         facNew.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        facNew.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        facNew.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         newIdp.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{facNew});
         identityProviderManagementService.updateResidentIdP((IdentityProvider) newIdp);
 
@@ -926,7 +926,7 @@ public class IdentityProviderManagementServiceTest {
         facNew.setName("saml2sso");
         facNew.setEnabled(true);
         facNew.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        facNew.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        facNew.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         newIdp.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{facNew});
         identityProviderManagementService.updateResidentIdP((IdentityProvider) newIdp);
 
@@ -963,7 +963,7 @@ public class IdentityProviderManagementServiceTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1119,7 +1119,7 @@ public class IdentityProviderManagementServiceTest {
         federatedAuthenticatorConfig.setName("SAMLSSOAuthenticator");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("SPEntityId");
         property1.setValue("wso2-is");

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.common.ApplicationAuthenticatorService;
 import org.wso2.carbon.identity.application.common.ProvisioningConnectorService;
 import org.wso2.carbon.identity.application.common.model.Claim;
@@ -1038,7 +1039,8 @@ public class IdentityProviderManagementServiceTest {
         idpProperty1.setValue("20");
         residentIdp.setIdpProperties(new IdentityProviderProperty[]{idpProperty1});
 
-        identityProviderManagementService.addIdP(residentIdp);
+        IdentityProviderManager.getInstance().addResidentIdP(residentIdp,
+                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
     }
 
     private void addSharedIdp() throws SQLException, IdentityProviderManagementException {

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
@@ -135,6 +135,7 @@ public class IdentityProviderManagementServiceTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -561,6 +562,7 @@ public class IdentityProviderManagementServiceTest {
         newFederatedAuthenticatorConfig.setName("Name");
         newFederatedAuthenticatorConfig.setEnabled(true);
         newFederatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        newFederatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         Property newProperty1 = new Property();
         newProperty1.setName("Property1New");
         newProperty1.setValue("value1New");
@@ -801,6 +803,7 @@ public class IdentityProviderManagementServiceTest {
         facNew.setName("Name");
         facNew.setEnabled(true);
         facNew.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        facNew.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         idp2New.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{facNew});
 
         // Initialize New Resident Identity Provider 3.
@@ -899,6 +902,7 @@ public class IdentityProviderManagementServiceTest {
         facNew.setName("saml2sso");
         facNew.setEnabled(true);
         facNew.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        facNew.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         newIdp.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{facNew});
         identityProviderManagementService.updateResidentIdP((IdentityProvider) newIdp);
 
@@ -922,6 +926,7 @@ public class IdentityProviderManagementServiceTest {
         facNew.setName("saml2sso");
         facNew.setEnabled(true);
         facNew.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        facNew.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         newIdp.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{facNew});
         identityProviderManagementService.updateResidentIdP((IdentityProvider) newIdp);
 
@@ -958,6 +963,7 @@ public class IdentityProviderManagementServiceTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1113,6 +1119,7 @@ public class IdentityProviderManagementServiceTest {
         federatedAuthenticatorConfig.setName("SAMLSSOAuthenticator");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         Property property1 = new Property();
         property1.setName("SPEntityId");
         property1.setValue("wso2-is");

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.ProvisioningConnectorConfig;
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementServiceImpl;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
@@ -132,6 +133,7 @@ public class IdentityProviderManagementServiceTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
+        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -557,6 +559,7 @@ public class IdentityProviderManagementServiceTest {
         newFederatedAuthenticatorConfig.setDisplayName("DisplayName1New");
         newFederatedAuthenticatorConfig.setName("Name");
         newFederatedAuthenticatorConfig.setEnabled(true);
+        newFederatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         Property newProperty1 = new Property();
         newProperty1.setName("Property1New");
         newProperty1.setValue("value1New");
@@ -796,6 +799,7 @@ public class IdentityProviderManagementServiceTest {
         facNew.setDisplayName("DisplayName1New");
         facNew.setName("Name");
         facNew.setEnabled(true);
+        facNew.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         idp2New.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{facNew});
 
         // Initialize New Resident Identity Provider 3.
@@ -893,6 +897,7 @@ public class IdentityProviderManagementServiceTest {
         facNew.setDisplayName("SAML2SSO");
         facNew.setName("saml2sso");
         facNew.setEnabled(true);
+        facNew.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         newIdp.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{facNew});
         identityProviderManagementService.updateResidentIdP((IdentityProvider) newIdp);
 
@@ -915,6 +920,7 @@ public class IdentityProviderManagementServiceTest {
         facNew.setDisplayName("SAML2SSO");
         facNew.setName("saml2sso");
         facNew.setEnabled(true);
+        facNew.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         newIdp.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{facNew});
         identityProviderManagementService.updateResidentIdP((IdentityProvider) newIdp);
 
@@ -950,6 +956,7 @@ public class IdentityProviderManagementServiceTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
+        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1103,6 +1110,7 @@ public class IdentityProviderManagementServiceTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName");
         federatedAuthenticatorConfig.setName("SAMLSSOAuthenticator");
         federatedAuthenticatorConfig.setEnabled(true);
+        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         Property property1 = new Property();
         property1.setName("SPEntityId");
         property1.setValue("wso2-is");

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAOTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAOTest.java
@@ -39,7 +39,8 @@ import org.wso2.carbon.identity.application.common.model.PermissionsAndRoleConfi
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.ProvisioningConnectorConfig;
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
-import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -743,8 +744,8 @@ public class CacheBackedIdPMgtDAOTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
-        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        federatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -848,8 +849,8 @@ public class CacheBackedIdPMgtDAOTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
-        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        federatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -907,8 +908,8 @@ public class CacheBackedIdPMgtDAOTest {
         newFederatedAuthenticatorConfig.setDisplayName("DisplayName1New");
         newFederatedAuthenticatorConfig.setName("Name");
         newFederatedAuthenticatorConfig.setEnabled(true);
-        newFederatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        newFederatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        newFederatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        newFederatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         Property property1New = new Property();
         property1New.setName("Property1New");
         property1New.setValue("value1New");
@@ -1456,8 +1457,8 @@ public class CacheBackedIdPMgtDAOTest {
         FederatedAuthenticatorConfig federatedAuthenticatorConfig = new FederatedAuthenticatorConfig();
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
-        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        federatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         federatedAuthenticatorConfig.setEnabled(true);
         Property property1 = new Property();
         property1.setName("Property1");

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAOTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAOTest.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.identity.application.common.model.PermissionsAndRoleConfi
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.ProvisioningConnectorConfig;
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -742,6 +743,7 @@ public class CacheBackedIdPMgtDAOTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
+        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -845,6 +847,7 @@ public class CacheBackedIdPMgtDAOTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
+        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -902,6 +905,7 @@ public class CacheBackedIdPMgtDAOTest {
         newFederatedAuthenticatorConfig.setDisplayName("DisplayName1New");
         newFederatedAuthenticatorConfig.setName("Name");
         newFederatedAuthenticatorConfig.setEnabled(true);
+        newFederatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         Property property1New = new Property();
         property1New.setName("Property1New");
         property1New.setValue("value1New");
@@ -1449,6 +1453,7 @@ public class CacheBackedIdPMgtDAOTest {
         FederatedAuthenticatorConfig federatedAuthenticatorConfig = new FederatedAuthenticatorConfig();
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
+        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         federatedAuthenticatorConfig.setEnabled(true);
         Property property1 = new Property();
         property1.setName("Property1");

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAOTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAOTest.java
@@ -744,7 +744,7 @@ public class CacheBackedIdPMgtDAOTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -849,7 +849,7 @@ public class CacheBackedIdPMgtDAOTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -908,7 +908,7 @@ public class CacheBackedIdPMgtDAOTest {
         newFederatedAuthenticatorConfig.setName("Name");
         newFederatedAuthenticatorConfig.setEnabled(true);
         newFederatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        newFederatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        newFederatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         Property property1New = new Property();
         property1New.setName("Property1New");
         property1New.setValue("value1New");
@@ -1457,7 +1457,7 @@ public class CacheBackedIdPMgtDAOTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         federatedAuthenticatorConfig.setEnabled(true);
         Property property1 = new Property();
         property1.setName("Property1");

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAOTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAOTest.java
@@ -744,6 +744,7 @@ public class CacheBackedIdPMgtDAOTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -848,6 +849,7 @@ public class CacheBackedIdPMgtDAOTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -906,6 +908,7 @@ public class CacheBackedIdPMgtDAOTest {
         newFederatedAuthenticatorConfig.setName("Name");
         newFederatedAuthenticatorConfig.setEnabled(true);
         newFederatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        newFederatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         Property property1New = new Property();
         property1New.setName("Property1New");
         property1New.setValue("value1New");
@@ -1454,6 +1457,7 @@ public class CacheBackedIdPMgtDAOTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         federatedAuthenticatorConfig.setEnabled(true);
         Property property1 = new Property();
         property1.setName("Property1");

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.identity.application.common.model.PermissionsAndRoleConfi
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.ProvisioningConnectorConfig;
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -588,6 +589,7 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
+        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1104,6 +1106,7 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
+        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1161,6 +1164,7 @@ public class IdPManagementDAOTest {
         newFederatedAuthenticatorConfig.setDisplayName("DisplayName1New");
         newFederatedAuthenticatorConfig.setName("Name");
         newFederatedAuthenticatorConfig.setEnabled(true);
+        newFederatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         Property property1New = new Property();
         property1New.setName("Property1New");
         property1New.setValue("value1New");
@@ -1733,6 +1737,7 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
+        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1864,6 +1869,7 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
+        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
@@ -587,6 +587,7 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1106,6 +1107,7 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1164,6 +1166,7 @@ public class IdPManagementDAOTest {
         newFederatedAuthenticatorConfig.setName("Name");
         newFederatedAuthenticatorConfig.setEnabled(true);
         newFederatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        newFederatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         Property property1New = new Property();
         property1New.setName("Property1New");
         property1New.setValue("value1New");
@@ -1737,6 +1740,7 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1870,6 +1874,7 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
@@ -587,7 +587,7 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1107,7 +1107,7 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1166,7 +1166,7 @@ public class IdPManagementDAOTest {
         newFederatedAuthenticatorConfig.setName("Name");
         newFederatedAuthenticatorConfig.setEnabled(true);
         newFederatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        newFederatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        newFederatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         Property property1New = new Property();
         property1New.setName("Property1New");
         property1New.setValue("value1New");
@@ -1740,7 +1740,7 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1874,7 +1874,7 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
         federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.EXTERNAL_ACCOUNT);
+        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
@@ -40,7 +40,8 @@ import org.wso2.carbon.identity.application.common.model.PermissionsAndRoleConfi
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.ProvisioningConnectorConfig;
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
-import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -586,8 +587,8 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
-        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        federatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1106,8 +1107,8 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
-        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        federatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1165,8 +1166,8 @@ public class IdPManagementDAOTest {
         newFederatedAuthenticatorConfig.setDisplayName("DisplayName1New");
         newFederatedAuthenticatorConfig.setName("Name");
         newFederatedAuthenticatorConfig.setEnabled(true);
-        newFederatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        newFederatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        newFederatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        newFederatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         Property property1New = new Property();
         property1New.setName("Property1New");
         property1New.setValue("value1New");
@@ -1739,8 +1740,8 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
-        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        federatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");
@@ -1873,8 +1874,8 @@ public class IdPManagementDAOTest {
         federatedAuthenticatorConfig.setDisplayName("DisplayName1");
         federatedAuthenticatorConfig.setName("Name");
         federatedAuthenticatorConfig.setEnabled(true);
-        federatedAuthenticatorConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
-        federatedAuthenticatorConfig.setAuthenticationType(IdentityConstants.AuthenticationType.IDENTIFICATION);
+        federatedAuthenticatorConfig.setDefinedByType(DefinedByType.SYSTEM);
+        federatedAuthenticatorConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         Property property1 = new Property();
         property1.setName("Property1");
         property1.setValue("value1");

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
@@ -71,10 +71,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.*;
 import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.RESET_PROVISIONING_ENTITIES_ON_CONFIG_UPDATE;
 
 /**
@@ -1032,6 +1029,7 @@ public class IdPManagementDAOTest {
                     value, authenticator, tenantId, TENANT_DOMAIN);
             if (isExist) {
                 assertEquals(idpResult.getIdentityProviderName(), idpName);
+                assertNotNull(idpResult.getDefaultAuthenticatorConfig().getDefinedByType());
             } else {
                 assertNull(idpResult);
             }
@@ -1084,6 +1082,7 @@ public class IdPManagementDAOTest {
 
             if (isExist) {
                 assertEquals(idpResult.getIdentityProviderName(), idpName);
+                assertNotNull(idpResult.getDefaultAuthenticatorConfig().getDefinedByType());
             } else {
                 assertNull(idpResult);
             }
@@ -1748,6 +1747,7 @@ public class IdPManagementDAOTest {
         property2.setConfidential(false);
         federatedAuthenticatorConfig.setProperties(new Property[]{property1, property2});
         idp1.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{federatedAuthenticatorConfig});
+        idp1.setDefaultAuthenticatorConfig(federatedAuthenticatorConfig);
 
         ProvisioningConnectorConfig provisioningConnectorConfig1 = new ProvisioningConnectorConfig();
         provisioningConnectorConfig1.setName("ProvisiningConfig1");

--- a/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
@@ -1,4 +1,4 @@
-<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:ax2161="http://common.application.identity.carbon.wso2.org/xsd" xmlns:ax2163="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ax2164="http://script.model.common.application.identity.carbon.wso2.org/xsd" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:ax2166="http://base.identity.carbon.wso2.org/xsd" xmlns:tns="http://mgt.application.identity.carbon.wso2.org" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://mgt.application.identity.carbon.wso2.org">
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:ax2161="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:ax2163="http://common.application.identity.carbon.wso2.org/xsd" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:ax2165="http://script.model.common.application.identity.carbon.wso2.org/xsd" xmlns:ax2167="http://base.identity.carbon.wso2.org/xsd" xmlns:tns="http://mgt.application.identity.carbon.wso2.org" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://mgt.application.identity.carbon.wso2.org">
     <wsdl:documentation>IdentityApplicationManagementService</wsdl:documentation>
     <wsdl:types>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://common.application.identity.carbon.wso2.org/xsd">
@@ -11,7 +11,7 @@
             </xs:complexType>
             <xs:complexType name="IdentityApplicationManagementClientException">
                 <xs:complexContent>
-                    <xs:extension base="ax2161:IdentityApplicationManagementException">
+                    <xs:extension base="ax2163:IdentityApplicationManagementException">
                         <xs:sequence>
                             <xs:element maxOccurs="unbounded" minOccurs="0" name="messages" nillable="true" type="xs:string"/>
                         </xs:sequence>
@@ -19,46 +19,269 @@
                 </xs:complexContent>
             </xs:complexType>
         </xs:schema>
-        <xs:schema xmlns:ax2168="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:ax2162="http://common.application.identity.carbon.wso2.org/xsd" xmlns:ns="http://org.apache.axis2/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://org.apache.axis2/xsd">
-            <xs:import namespace="http://common.application.identity.carbon.wso2.org/xsd"/>
+        <xs:schema xmlns:ax2162="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:ax2164="http://common.application.identity.carbon.wso2.org/xsd" xmlns:ns="http://org.apache.axis2/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://org.apache.axis2/xsd">
             <xs:import namespace="http://model.common.application.identity.carbon.wso2.org/xsd"/>
-            <xs:element name="IdentityApplicationManagementServiceIdentityApplicationManagementException">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="IdentityApplicationManagementException" nillable="true" type="ax2161:IdentityApplicationManagementException"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="createApplication">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2168:ServiceProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllApplicationBasicInfo">
+            <xs:import namespace="http://common.application.identity.carbon.wso2.org/xsd"/>
+            <xs:element name="getCustomInboundAuthenticatorConfigs">
                 <xs:complexType>
                     <xs:sequence/>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getAllApplicationBasicInfoResponse">
+            <xs:element name="getCustomInboundAuthenticatorConfigsResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:ApplicationBasicInfo"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:InboundAuthenticationRequestConfig"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getApplicationBasicInfo">
+            <xs:element name="IdentityApplicationManagementServiceIdentityApplicationManagementException">
                 <xs:complexType>
                     <xs:sequence>
+                        <xs:element minOccurs="0" name="IdentityApplicationManagementException" nillable="true" type="ax2163:IdentityApplicationManagementException"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="createApplicationWithTemplate">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2161:ServiceProvider"/>
+                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="createApplicationWithTemplateResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2161:ServiceProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllPaginatedApplicationBasicInfo">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="pageNumber" type="xs:int"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllPaginatedApplicationBasicInfoResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:ApplicationBasicInfo"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getPaginatedApplicationBasicInfo">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="pageNumber" type="xs:int"/>
                         <xs:element minOccurs="0" name="filter" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getApplicationBasicInfoResponse">
+            <xs:element name="getPaginatedApplicationBasicInfoResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:ApplicationBasicInfo"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:ApplicationBasicInfo"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllRequestPathAuthenticators">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllRequestPathAuthenticatorsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:RequestPathAuthenticatorConfig"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAuthenticationTemplatesJSON">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAuthenticationTemplatesJSONResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="IdentityApplicationManagementServiceIdentityApplicationManagementClientException">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="IdentityApplicationManagementClientException" nillable="true" type="ax2163:IdentityApplicationManagementClientException"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="createApplicationTemplateFromSP">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2161:ServiceProvider"/>
+                        <xs:element minOccurs="0" name="spTemplate" nillable="true" type="ax2161:SpTemplate"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="isExistingApplicationTemplate">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="isExistingApplicationTemplateResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllApplicationTemplateInfo">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllApplicationTemplateInfoResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:SpTemplate"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getApplication">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getApplicationResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2161:ServiceProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getIdentityProvider">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="federatedIdPName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getIdentityProviderResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2161:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getApplicationTemplate">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getApplicationTemplateResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2161:SpTemplate"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="createApplicationTemplate">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="spTemplate" nillable="true" type="ax2161:SpTemplate"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="exportApplication">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="exportSecrets" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="exportApplicationResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="importApplication">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="spFileContent" nillable="true" type="ax2161:SpFileContent"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="importApplicationResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2161:ImportResponse"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllLocalClaimUris">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllLocalClaimUrisResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllLocalAuthenticators">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllLocalAuthenticatorsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:LocalAuthenticatorConfig"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllIdentityProviders">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllIdentityProvidersResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deleteApplication">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="updateApplication">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2161:ServiceProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deleteApplicationTemplate">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -88,117 +311,17 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="updateApplication">
+            <xs:element name="getApplicationBasicInfo">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2168:ServiceProvider"/>
+                        <xs:element minOccurs="0" name="filter" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="deleteApplication">
+            <xs:element name="getApplicationBasicInfoResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllIdentityProviders">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllIdentityProvidersResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllLocalAuthenticators">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllLocalAuthenticatorsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:LocalAuthenticatorConfig"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllLocalClaimUris">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllLocalClaimUrisResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="importApplication">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="spFileContent" nillable="true" type="ax2168:SpFileContent"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="importApplicationResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2168:ImportResponse"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="exportApplication">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="exportSecrets" type="xs:boolean"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="exportApplicationResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="IdentityApplicationManagementServiceIdentityApplicationManagementClientException">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="IdentityApplicationManagementClientException" nillable="true" type="ax2161:IdentityApplicationManagementClientException"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="createApplicationTemplate">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="spTemplate" nillable="true" type="ax2168:SpTemplate"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getApplicationTemplate">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getApplicationTemplateResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2168:SpTemplate"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="deleteApplicationTemplate">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:ApplicationBasicInfo"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -206,241 +329,33 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="spTemplate" nillable="true" type="ax2168:SpTemplate"/>
+                        <xs:element minOccurs="0" name="spTemplate" nillable="true" type="ax2161:SpTemplate"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getIdentityProvider">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="federatedIdPName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getIdentityProviderResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2168:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getApplication">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getApplicationResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2168:ServiceProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="createApplicationWithTemplate">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2168:ServiceProvider"/>
-                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="createApplicationWithTemplateResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2168:ServiceProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllPaginatedApplicationBasicInfo">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="pageNumber" type="xs:int"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllPaginatedApplicationBasicInfoResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:ApplicationBasicInfo"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getPaginatedApplicationBasicInfo">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="pageNumber" type="xs:int"/>
-                        <xs:element minOccurs="0" name="filter" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getPaginatedApplicationBasicInfoResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:ApplicationBasicInfo"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllRequestPathAuthenticators">
+            <xs:element name="getAllApplicationBasicInfo">
                 <xs:complexType>
                     <xs:sequence/>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getAllRequestPathAuthenticatorsResponse">
+            <xs:element name="getAllApplicationBasicInfoResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:RequestPathAuthenticatorConfig"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:ApplicationBasicInfo"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getAuthenticationTemplatesJSON">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAuthenticationTemplatesJSONResponse">
+            <xs:element name="createApplication">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="createApplicationTemplateFromSP">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2168:ServiceProvider"/>
-                        <xs:element minOccurs="0" name="spTemplate" nillable="true" type="ax2168:SpTemplate"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="isExistingApplicationTemplate">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="isExistingApplicationTemplateResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllApplicationTemplateInfo">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllApplicationTemplateInfoResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:SpTemplate"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getCustomInboundAuthenticatorConfigs">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getCustomInboundAuthenticatorConfigsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:InboundAuthenticationRequestConfig"/>
+                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2161:ServiceProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
         </xs:schema>
-        <xs:schema xmlns:ax2165="http://script.model.common.application.identity.carbon.wso2.org/xsd" xmlns:ax2167="http://base.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://model.common.application.identity.carbon.wso2.org/xsd">
+        <xs:schema xmlns:ax2168="http://base.identity.carbon.wso2.org/xsd" xmlns:ax2166="http://script.model.common.application.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://model.common.application.identity.carbon.wso2.org/xsd">
             <xs:import namespace="http://script.model.common.application.identity.carbon.wso2.org/xsd"/>
             <xs:import namespace="http://base.identity.carbon.wso2.org/xsd"/>
-            <xs:complexType name="ServiceProvider">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="APIBasedAuthenticationEnabled" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="accessUrl" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="applicationEnabled" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="applicationID" type="xs:int"/>
-                    <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="applicationResourceId" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="associatedRolesConfig" nillable="true" type="ax2163:AssociatedRolesConfig"/>
-                    <xs:element minOccurs="0" name="b2BSelfServiceApp" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="certificateContent" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="claimConfig" nillable="true" type="ax2163:ClaimConfig"/>
-                    <xs:element minOccurs="0" name="clientAttestationMetaData" nillable="true" type="ax2163:ClientAttestationMetaData"/>
-                    <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="discoverable" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="imageUrl" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="inboundAuthenticationConfig" nillable="true" type="ax2163:InboundAuthenticationConfig"/>
-                    <xs:element minOccurs="0" name="inboundProvisioningConfig" nillable="true" type="ax2163:InboundProvisioningConfig"/>
-                    <xs:element minOccurs="0" name="jwksUri" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="localAndOutBoundAuthenticationConfig" nillable="true" type="ax2163:LocalAndOutboundAuthenticationConfig"/>
-                    <xs:element minOccurs="0" name="managementApp" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="outboundProvisioningConfig" nillable="true" type="ax2163:OutboundProvisioningConfig"/>
-                    <xs:element minOccurs="0" name="owner" nillable="true" type="ax2163:User"/>
-                    <xs:element minOccurs="0" name="permissionAndRoleConfig" nillable="true" type="ax2163:PermissionsAndRoleConfig"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="requestPathAuthenticatorConfigs" nillable="true" type="ax2163:RequestPathAuthenticatorConfig"/>
-                    <xs:element minOccurs="0" name="saasApp" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="spProperties" nillable="true" type="ax2163:ServiceProviderProperty"/>
-                    <xs:element minOccurs="0" name="templateId" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="templateVersion" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="tenantDomain" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="trustedAppMetadata" nillable="true" type="ax2163:SpTrustedAppMetadata"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="AssociatedRolesConfig">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="allowedAudience" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="roles" nillable="true" type="ax2163:RoleV2"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="RoleV2">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="id" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="ClaimConfig">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="alwaysSendMappedLocalSubjectId" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="claimMappings" nillable="true" type="ax2163:ClaimMapping"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpClaims" nillable="true" type="ax2163:Claim"/>
-                    <xs:element minOccurs="0" name="localClaimDialect" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="mappedLocalSubjectMandatory" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="roleClaimURI" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="spClaimDialects" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="userClaimURI" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="ClaimMapping">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="defaultValue" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="localClaim" nillable="true" type="ax2163:Claim"/>
-                    <xs:element minOccurs="0" name="mandatory" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="remoteClaim" nillable="true" type="ax2163:Claim"/>
-                    <xs:element minOccurs="0" name="requested" type="xs:boolean"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="Claim">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="claimId" type="xs:int"/>
-                    <xs:element minOccurs="0" name="claimUri" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="ClientAttestationMetaData">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="androidAttestationServiceCredentials" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="androidPackageName" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="appleAppId" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="attestationEnabled" type="xs:boolean"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="InboundAuthenticationConfig">
-                <xs:sequence>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="inboundAuthenticationRequestConfigs" nillable="true" type="ax2163:InboundAuthenticationRequestConfig"/>
-                </xs:sequence>
-            </xs:complexType>
             <xs:complexType name="InboundAuthenticationRequestConfig">
                 <xs:sequence>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="data" nillable="true" type="xs:string"/>
@@ -449,8 +364,8 @@
                     <xs:element minOccurs="0" name="inboundAuthType" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="inboundConfigType" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="inboundConfiguration" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="inboundConfigurationProtocol" nillable="true" type="ax2163:InboundConfigurationProtocol"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2163:Property"/>
+                    <xs:element minOccurs="0" name="inboundConfigurationProtocol" nillable="true" type="ax2161:InboundConfigurationProtocol"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2161:Property"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType abstract="true" name="InboundConfigurationProtocol">
@@ -469,7 +384,7 @@
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="options" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="regex" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="required" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="subProperties" nillable="true" type="ax2163:SubProperty"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="subProperties" nillable="true" type="ax2161:SubProperty"/>
                     <xs:element minOccurs="0" name="type" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="value" nillable="true" type="xs:string"/>
                 </xs:sequence>
@@ -490,6 +405,91 @@
                     <xs:element minOccurs="0" name="value" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
+            <xs:complexType name="ServiceProvider">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="APIBasedAuthenticationEnabled" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="accessUrl" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="applicationEnabled" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="applicationID" type="xs:int"/>
+                    <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="applicationResourceId" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="associatedRolesConfig" nillable="true" type="ax2161:AssociatedRolesConfig"/>
+                    <xs:element minOccurs="0" name="b2BSelfServiceApp" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="certificateContent" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="claimConfig" nillable="true" type="ax2161:ClaimConfig"/>
+                    <xs:element minOccurs="0" name="clientAttestationMetaData" nillable="true" type="ax2161:ClientAttestationMetaData"/>
+                    <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="discoverable" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="imageUrl" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="inboundAuthenticationConfig" nillable="true" type="ax2161:InboundAuthenticationConfig"/>
+                    <xs:element minOccurs="0" name="inboundProvisioningConfig" nillable="true" type="ax2161:InboundProvisioningConfig"/>
+                    <xs:element minOccurs="0" name="jwksUri" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="localAndOutBoundAuthenticationConfig" nillable="true" type="ax2161:LocalAndOutboundAuthenticationConfig"/>
+                    <xs:element minOccurs="0" name="managementApp" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="outboundProvisioningConfig" nillable="true" type="ax2161:OutboundProvisioningConfig"/>
+                    <xs:element minOccurs="0" name="owner" nillable="true" type="ax2161:User"/>
+                    <xs:element minOccurs="0" name="permissionAndRoleConfig" nillable="true" type="ax2161:PermissionsAndRoleConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="requestPathAuthenticatorConfigs" nillable="true" type="ax2161:RequestPathAuthenticatorConfig"/>
+                    <xs:element minOccurs="0" name="saasApp" type="xs:boolean"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="spProperties" nillable="true" type="ax2161:ServiceProviderProperty"/>
+                    <xs:element minOccurs="0" name="templateId" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="templateVersion" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="tenantDomain" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="trustedAppMetadata" nillable="true" type="ax2161:SpTrustedAppMetadata"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="AssociatedRolesConfig">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="allowedAudience" nillable="true" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="roles" nillable="true" type="ax2161:RoleV2"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="RoleV2">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="id" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="ClaimConfig">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="alwaysSendMappedLocalSubjectId" type="xs:boolean"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="claimMappings" nillable="true" type="ax2161:ClaimMapping"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpClaims" nillable="true" type="ax2161:Claim"/>
+                    <xs:element minOccurs="0" name="localClaimDialect" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="mappedLocalSubjectMandatory" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="roleClaimURI" nillable="true" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="spClaimDialects" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="userClaimURI" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="ClaimMapping">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="defaultValue" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="localClaim" nillable="true" type="ax2161:Claim"/>
+                    <xs:element minOccurs="0" name="mandatory" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="remoteClaim" nillable="true" type="ax2161:Claim"/>
+                    <xs:element minOccurs="0" name="requested" type="xs:boolean"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="Claim">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="claimId" type="xs:int"/>
+                    <xs:element minOccurs="0" name="claimUri" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="ClientAttestationMetaData">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="androidAttestationServiceCredentials" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="androidPackageName" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="appleAppId" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="attestationEnabled" type="xs:boolean"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="InboundAuthenticationConfig">
+                <xs:sequence>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="inboundAuthenticationRequestConfigs" nillable="true" type="ax2161:InboundAuthenticationRequestConfig"/>
+                </xs:sequence>
+            </xs:complexType>
             <xs:complexType name="InboundProvisioningConfig">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="dumbMode" type="xs:boolean"/>
@@ -500,10 +500,10 @@
             <xs:complexType name="LocalAndOutboundAuthenticationConfig">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="alwaysSendBackAuthenticatedListOfIdPs" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="authenticationScriptConfig" nillable="true" type="ax2164:AuthenticationScriptConfig"/>
-                    <xs:element minOccurs="0" name="authenticationStepForAttributes" nillable="true" type="ax2163:AuthenticationStep"/>
-                    <xs:element minOccurs="0" name="authenticationStepForSubject" nillable="true" type="ax2163:AuthenticationStep"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="authenticationSteps" nillable="true" type="ax2163:AuthenticationStep"/>
+                    <xs:element minOccurs="0" name="authenticationScriptConfig" nillable="true" type="ax2165:AuthenticationScriptConfig"/>
+                    <xs:element minOccurs="0" name="authenticationStepForAttributes" nillable="true" type="ax2161:AuthenticationStep"/>
+                    <xs:element minOccurs="0" name="authenticationStepForSubject" nillable="true" type="ax2161:AuthenticationStep"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="authenticationSteps" nillable="true" type="ax2161:AuthenticationStep"/>
                     <xs:element minOccurs="0" name="authenticationType" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="enableAuthorization" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="skipConsent" type="xs:boolean"/>
@@ -518,8 +518,8 @@
             <xs:complexType name="AuthenticationStep">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="attributeStep" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="federatedIdentityProviders" nillable="true" type="ax2163:IdentityProvider"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="localAuthenticatorConfigs" nillable="true" type="ax2163:LocalAuthenticatorConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="federatedIdentityProviders" nillable="true" type="ax2161:IdentityProvider"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="localAuthenticatorConfigs" nillable="true" type="ax2161:LocalAuthenticatorConfig"/>
                     <xs:element minOccurs="0" name="stepOrder" type="xs:int"/>
                     <xs:element minOccurs="0" name="subjectStep" type="xs:boolean"/>
                 </xs:sequence>
@@ -528,26 +528,26 @@
                 <xs:sequence>
                     <xs:element minOccurs="0" name="alias" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="certificate" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="certificateInfoArray" nillable="true" type="ax2163:CertificateInfo"/>
-                    <xs:element minOccurs="0" name="claimConfig" nillable="true" type="ax2163:ClaimConfig"/>
-                    <xs:element minOccurs="0" name="defaultAuthenticatorConfig" nillable="true" type="ax2163:FederatedAuthenticatorConfig"/>
-                    <xs:element minOccurs="0" name="defaultProvisioningConnectorConfig" nillable="true" type="ax2163:ProvisioningConnectorConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="certificateInfoArray" nillable="true" type="ax2161:CertificateInfo"/>
+                    <xs:element minOccurs="0" name="claimConfig" nillable="true" type="ax2161:ClaimConfig"/>
+                    <xs:element minOccurs="0" name="defaultAuthenticatorConfig" nillable="true" type="ax2161:FederatedAuthenticatorConfig"/>
+                    <xs:element minOccurs="0" name="defaultProvisioningConnectorConfig" nillable="true" type="ax2161:ProvisioningConnectorConfig"/>
                     <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="enable" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="federatedAssociationConfig" nillable="true" type="ax2163:FederatedAssociationConfig"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="federatedAuthenticatorConfigs" nillable="true" type="ax2163:FederatedAuthenticatorConfig"/>
+                    <xs:element minOccurs="0" name="federatedAssociationConfig" nillable="true" type="ax2161:FederatedAssociationConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="federatedAuthenticatorConfigs" nillable="true" type="ax2161:FederatedAuthenticatorConfig"/>
                     <xs:element minOccurs="0" name="federationHub" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="homeRealmId" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="id" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idPGroupConfig" nillable="true" type="ax2163:IdPGroup"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idPGroupConfig" nillable="true" type="ax2161:IdPGroup"/>
                     <xs:element minOccurs="0" name="identityProviderDescription" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="identityProviderName" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpProperties" nillable="true" type="ax2163:IdentityProviderProperty"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpProperties" nillable="true" type="ax2161:IdentityProviderProperty"/>
                     <xs:element minOccurs="0" name="imageUrl" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="justInTimeProvisioningConfig" nillable="true" type="ax2163:JustInTimeProvisioningConfig"/>
-                    <xs:element minOccurs="0" name="permissionAndRoleConfig" nillable="true" type="ax2163:PermissionsAndRoleConfig"/>
+                    <xs:element minOccurs="0" name="justInTimeProvisioningConfig" nillable="true" type="ax2161:JustInTimeProvisioningConfig"/>
+                    <xs:element minOccurs="0" name="permissionAndRoleConfig" nillable="true" type="ax2161:PermissionsAndRoleConfig"/>
                     <xs:element minOccurs="0" name="primary" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningConnectorConfigs" nillable="true" type="ax2163:ProvisioningConnectorConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningConnectorConfigs" nillable="true" type="ax2161:ProvisioningConnectorConfig"/>
                     <xs:element minOccurs="0" name="provisioningRole" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="resourceId" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="templateId" nillable="true" type="xs:string"/>
@@ -562,11 +562,12 @@
             </xs:complexType>
             <xs:complexType name="FederatedAuthenticatorConfig">
                 <xs:sequence>
-                    <xs:element minOccurs="0" name="definedByType" nillable="true" type="ax2166:IdentityConstants_DefinedByType"/>
+                    <xs:element minOccurs="0" name="authenticationType" nillable="true" type="ax2168:IdentityConstants_AuthenticationType"/>
+                    <xs:element minOccurs="0" name="definedByType" nillable="true" type="ax2168:IdentityConstants_DefinedByType"/>
                     <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="enabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2163:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2161:Property"/>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="tags" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
                 </xs:sequence>
@@ -576,7 +577,7 @@
                     <xs:element minOccurs="0" name="blocking" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="enabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningProperties" nillable="true" type="ax2163:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningProperties" nillable="true" type="ax2161:Property"/>
                     <xs:element minOccurs="0" name="rulesEnabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
                 </xs:sequence>
@@ -603,7 +604,7 @@
             </xs:complexType>
             <xs:complexType name="JustInTimeProvisioningConfig">
                 <xs:complexContent>
-                    <xs:extension base="ax2163:InboundProvisioningConfig">
+                    <xs:extension base="ax2161:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="attributeSyncMethod" nillable="true" type="xs:string"/>
@@ -618,8 +619,8 @@
             <xs:complexType name="PermissionsAndRoleConfig">
                 <xs:sequence>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="idpRoles" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="permissions" nillable="true" type="ax2163:ApplicationPermission"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="roleMappings" nillable="true" type="ax2163:RoleMapping"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="permissions" nillable="true" type="ax2161:ApplicationPermission"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="roleMappings" nillable="true" type="ax2161:RoleMapping"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="ApplicationPermission">
@@ -629,7 +630,7 @@
             </xs:complexType>
             <xs:complexType name="RoleMapping">
                 <xs:sequence>
-                    <xs:element minOccurs="0" name="localRole" nillable="true" type="ax2163:LocalRole"/>
+                    <xs:element minOccurs="0" name="localRole" nillable="true" type="ax2161:LocalRole"/>
                     <xs:element minOccurs="0" name="remoteRole" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
@@ -641,11 +642,12 @@
             </xs:complexType>
             <xs:complexType name="LocalAuthenticatorConfig">
                 <xs:sequence>
-                    <xs:element minOccurs="0" name="definedByType" nillable="true" type="ax2166:IdentityConstants_DefinedByType"/>
+                    <xs:element minOccurs="0" name="authenticationType" nillable="true" type="ax2168:IdentityConstants_AuthenticationType"/>
+                    <xs:element minOccurs="0" name="definedByType" nillable="true" type="ax2168:IdentityConstants_DefinedByType"/>
                     <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="enabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2163:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2161:Property"/>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="tags" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
                 </xs:sequence>
@@ -653,7 +655,7 @@
             <xs:complexType name="OutboundProvisioningConfig">
                 <xs:sequence>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="provisionByRoleList" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningIdentityProviders" nillable="true" type="ax2163:IdentityProvider"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningIdentityProviders" nillable="true" type="ax2161:IdentityProvider"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="User">
@@ -667,7 +669,7 @@
             </xs:complexType>
             <xs:complexType name="RequestPathAuthenticatorConfig">
                 <xs:complexContent>
-                    <xs:extension base="ax2163:LocalAuthenticatorConfig">
+                    <xs:extension base="ax2161:LocalAuthenticatorConfig">
                         <xs:sequence/>
                     </xs:extension>
                 </xs:complexContent>
@@ -691,7 +693,7 @@
             <xs:complexType name="ApplicationBasicInfo">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="accessUrl" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="appOwner" nillable="true" type="ax2163:User"/>
+                    <xs:element minOccurs="0" name="appOwner" nillable="true" type="ax2161:User"/>
                     <xs:element minOccurs="0" name="applicationId" type="xs:int"/>
                     <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="applicationResourceId" nillable="true" type="xs:string"/>
@@ -701,6 +703,13 @@
                     <xs:element minOccurs="0" name="issuer" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="tenantDomain" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="uuid" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="SpTemplate">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="content" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="SpFileContent">
@@ -718,21 +727,22 @@
                     <xs:element minOccurs="0" name="responseCode" type="xs:int"/>
                 </xs:sequence>
             </xs:complexType>
-            <xs:complexType name="SpTemplate">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="content" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
         </xs:schema>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://base.identity.carbon.wso2.org/xsd">
-            <xs:simpleType name="IdentityConstants_DefinedByType">
-                <xs:restriction base="xs:string">
-                    <xs:enumeration value="SYSTEM"/>
-                    <xs:enumeration value="USER"/>
-                </xs:restriction>
-            </xs:simpleType>
+            <xs:complexType name="IdentityConstants_AuthenticationType">
+                <xs:complexContent>
+                    <xs:extension base="xs:Enum">
+                        <xs:sequence/>
+                    </xs:extension>
+                </xs:complexContent>
+            </xs:complexType>
+            <xs:complexType name="IdentityConstants_DefinedByType">
+                <xs:complexContent>
+                    <xs:extension base="xs:Enum">
+                        <xs:sequence/>
+                    </xs:extension>
+                </xs:complexContent>
+            </xs:complexType>
         </xs:schema>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://script.model.common.application.identity.carbon.wso2.org/xsd">
             <xs:complexType name="AuthenticationScriptConfig">

--- a/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
@@ -1,4 +1,4 @@
-<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ax2159="http://common.application.identity.carbon.wso2.org/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://mgt.application.identity.carbon.wso2.org" xmlns:ax2161="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:ax2162="http://script.model.common.application.identity.carbon.wso2.org/xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://mgt.application.identity.carbon.wso2.org">
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:ax2161="http://common.application.identity.carbon.wso2.org/xsd" xmlns:ax2163="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ax2164="http://script.model.common.application.identity.carbon.wso2.org/xsd" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:ax2166="http://base.identity.carbon.wso2.org/xsd" xmlns:tns="http://mgt.application.identity.carbon.wso2.org" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://mgt.application.identity.carbon.wso2.org">
     <wsdl:documentation>IdentityApplicationManagementService</wsdl:documentation>
     <wsdl:types>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://common.application.identity.carbon.wso2.org/xsd">
@@ -11,7 +11,7 @@
             </xs:complexType>
             <xs:complexType name="IdentityApplicationManagementClientException">
                 <xs:complexContent>
-                    <xs:extension base="ax2159:IdentityApplicationManagementException">
+                    <xs:extension base="ax2161:IdentityApplicationManagementException">
                         <xs:sequence>
                             <xs:element maxOccurs="unbounded" minOccurs="0" name="messages" nillable="true" type="xs:string"/>
                         </xs:sequence>
@@ -19,82 +19,58 @@
                 </xs:complexContent>
             </xs:complexType>
         </xs:schema>
-        <xs:schema xmlns:ax2160="http://common.application.identity.carbon.wso2.org/xsd" xmlns:ax2164="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:ns="http://org.apache.axis2/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://org.apache.axis2/xsd">
+        <xs:schema xmlns:ax2168="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:ax2162="http://common.application.identity.carbon.wso2.org/xsd" xmlns:ns="http://org.apache.axis2/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://org.apache.axis2/xsd">
             <xs:import namespace="http://common.application.identity.carbon.wso2.org/xsd"/>
             <xs:import namespace="http://model.common.application.identity.carbon.wso2.org/xsd"/>
             <xs:element name="IdentityApplicationManagementServiceIdentityApplicationManagementException">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="IdentityApplicationManagementException" nillable="true" type="ax2159:IdentityApplicationManagementException"/>
+                        <xs:element minOccurs="0" name="IdentityApplicationManagementException" nillable="true" type="ax2161:IdentityApplicationManagementException"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
             <xs:element name="createApplication">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2161:ServiceProvider"/>
+                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2168:ServiceProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="IdentityApplicationManagementServiceIdentityApplicationManagementClientException">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="IdentityApplicationManagementClientException" nillable="true" type="ax2159:IdentityApplicationManagementClientException"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="updateApplicationTemplate">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="spTemplate" nillable="true" type="ax2161:SpTemplate"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="deleteApplicationTemplate">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getApplicationTemplate">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getApplicationTemplateResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2161:SpTemplate"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllIdentityProviders">
+            <xs:element name="getAllApplicationBasicInfo">
                 <xs:complexType>
                     <xs:sequence/>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getAllIdentityProvidersResponse">
+            <xs:element name="getAllApplicationBasicInfoResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:IdentityProvider"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:ApplicationBasicInfo"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="updateApplication">
+            <xs:element name="getApplicationBasicInfo">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2161:ServiceProvider"/>
+                        <xs:element minOccurs="0" name="filter" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="deleteApplication">
+            <xs:element name="getApplicationBasicInfoResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:ApplicationBasicInfo"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getCountOfAllApplications">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getCountOfAllApplicationsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:int"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -112,29 +88,29 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getCountOfAllApplications">
+            <xs:element name="updateApplication">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2168:ServiceProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deleteApplication">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllIdentityProviders">
                 <xs:complexType>
                     <xs:sequence/>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getCountOfAllApplicationsResponse">
+            <xs:element name="getAllIdentityProvidersResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:int"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getApplicationBasicInfo">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="filter" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getApplicationBasicInfoResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:ApplicationBasicInfo"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -146,7 +122,7 @@
             <xs:element name="getAllLocalAuthenticatorsResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:LocalAuthenticatorConfig"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:LocalAuthenticatorConfig"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -165,26 +141,14 @@
             <xs:element name="importApplication">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="spFileContent" nillable="true" type="ax2161:SpFileContent"/>
+                        <xs:element minOccurs="0" name="spFileContent" nillable="true" type="ax2168:SpFileContent"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
             <xs:element name="importApplicationResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2161:ImportResponse"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllApplicationBasicInfo">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllApplicationBasicInfoResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:ApplicationBasicInfo"/>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2168:ImportResponse"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -203,24 +167,46 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="IdentityApplicationManagementServiceIdentityApplicationManagementClientException">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="IdentityApplicationManagementClientException" nillable="true" type="ax2161:IdentityApplicationManagementClientException"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="createApplicationTemplate">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="spTemplate" nillable="true" type="ax2161:SpTemplate"/>
+                        <xs:element minOccurs="0" name="spTemplate" nillable="true" type="ax2168:SpTemplate"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getApplication">
+            <xs:element name="getApplicationTemplate">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getApplicationResponse">
+            <xs:element name="getApplicationTemplateResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2161:ServiceProvider"/>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2168:SpTemplate"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deleteApplicationTemplate">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="updateApplicationTemplate">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="spTemplate" nillable="true" type="ax2168:SpTemplate"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -234,7 +220,77 @@
             <xs:element name="getIdentityProviderResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2161:IdentityProvider"/>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2168:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getApplication">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getApplicationResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2168:ServiceProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="createApplicationWithTemplate">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2168:ServiceProvider"/>
+                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="createApplicationWithTemplateResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2168:ServiceProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllPaginatedApplicationBasicInfo">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="pageNumber" type="xs:int"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllPaginatedApplicationBasicInfoResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:ApplicationBasicInfo"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getPaginatedApplicationBasicInfo">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="pageNumber" type="xs:int"/>
+                        <xs:element minOccurs="0" name="filter" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getPaginatedApplicationBasicInfoResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:ApplicationBasicInfo"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllRequestPathAuthenticators">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllRequestPathAuthenticatorsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:RequestPathAuthenticatorConfig"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -250,91 +306,11 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="createApplicationWithTemplate">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2161:ServiceProvider"/>
-                        <xs:element minOccurs="0" name="templateName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="createApplicationWithTemplateResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2161:ServiceProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getPaginatedApplicationBasicInfo">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="pageNumber" type="xs:int"/>
-                        <xs:element minOccurs="0" name="filter" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getPaginatedApplicationBasicInfoResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:ApplicationBasicInfo"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllPaginatedApplicationBasicInfo">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="pageNumber" type="xs:int"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllPaginatedApplicationBasicInfoResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:ApplicationBasicInfo"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
             <xs:element name="createApplicationTemplateFromSP">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2161:ServiceProvider"/>
-                        <xs:element minOccurs="0" name="spTemplate" nillable="true" type="ax2161:SpTemplate"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllRequestPathAuthenticators">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllRequestPathAuthenticatorsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:RequestPathAuthenticatorConfig"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getCustomInboundAuthenticatorConfigs">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getCustomInboundAuthenticatorConfigsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:InboundAuthenticationRequestConfig"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllApplicationTemplateInfo">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllApplicationTemplateInfoResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2161:SpTemplate"/>
+                        <xs:element minOccurs="0" name="serviceProvider" nillable="true" type="ax2168:ServiceProvider"/>
+                        <xs:element minOccurs="0" name="spTemplate" nillable="true" type="ax2168:SpTemplate"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -352,9 +328,34 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="getAllApplicationTemplateInfo">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllApplicationTemplateInfoResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:SpTemplate"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getCustomInboundAuthenticatorConfigs">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getCustomInboundAuthenticatorConfigsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2168:InboundAuthenticationRequestConfig"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
         </xs:schema>
-        <xs:schema xmlns:ax2163="http://script.model.common.application.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://model.common.application.identity.carbon.wso2.org/xsd">
+        <xs:schema xmlns:ax2165="http://script.model.common.application.identity.carbon.wso2.org/xsd" xmlns:ax2167="http://base.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://model.common.application.identity.carbon.wso2.org/xsd">
             <xs:import namespace="http://script.model.common.application.identity.carbon.wso2.org/xsd"/>
+            <xs:import namespace="http://base.identity.carbon.wso2.org/xsd"/>
             <xs:complexType name="ServiceProvider">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="APIBasedAuthenticationEnabled" type="xs:boolean"/>
@@ -363,35 +364,35 @@
                     <xs:element minOccurs="0" name="applicationID" type="xs:int"/>
                     <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="applicationResourceId" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="associatedRolesConfig" nillable="true" type="ax2161:AssociatedRolesConfig"/>
+                    <xs:element minOccurs="0" name="associatedRolesConfig" nillable="true" type="ax2163:AssociatedRolesConfig"/>
                     <xs:element minOccurs="0" name="b2BSelfServiceApp" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="certificateContent" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="claimConfig" nillable="true" type="ax2161:ClaimConfig"/>
-                    <xs:element minOccurs="0" name="clientAttestationMetaData" nillable="true" type="ax2161:ClientAttestationMetaData"/>
+                    <xs:element minOccurs="0" name="claimConfig" nillable="true" type="ax2163:ClaimConfig"/>
+                    <xs:element minOccurs="0" name="clientAttestationMetaData" nillable="true" type="ax2163:ClientAttestationMetaData"/>
                     <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="discoverable" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="imageUrl" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="inboundAuthenticationConfig" nillable="true" type="ax2161:InboundAuthenticationConfig"/>
-                    <xs:element minOccurs="0" name="inboundProvisioningConfig" nillable="true" type="ax2161:InboundProvisioningConfig"/>
+                    <xs:element minOccurs="0" name="inboundAuthenticationConfig" nillable="true" type="ax2163:InboundAuthenticationConfig"/>
+                    <xs:element minOccurs="0" name="inboundProvisioningConfig" nillable="true" type="ax2163:InboundProvisioningConfig"/>
                     <xs:element minOccurs="0" name="jwksUri" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="localAndOutBoundAuthenticationConfig" nillable="true" type="ax2161:LocalAndOutboundAuthenticationConfig"/>
+                    <xs:element minOccurs="0" name="localAndOutBoundAuthenticationConfig" nillable="true" type="ax2163:LocalAndOutboundAuthenticationConfig"/>
                     <xs:element minOccurs="0" name="managementApp" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="outboundProvisioningConfig" nillable="true" type="ax2161:OutboundProvisioningConfig"/>
-                    <xs:element minOccurs="0" name="owner" nillable="true" type="ax2161:User"/>
-                    <xs:element minOccurs="0" name="permissionAndRoleConfig" nillable="true" type="ax2161:PermissionsAndRoleConfig"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="requestPathAuthenticatorConfigs" nillable="true" type="ax2161:RequestPathAuthenticatorConfig"/>
+                    <xs:element minOccurs="0" name="outboundProvisioningConfig" nillable="true" type="ax2163:OutboundProvisioningConfig"/>
+                    <xs:element minOccurs="0" name="owner" nillable="true" type="ax2163:User"/>
+                    <xs:element minOccurs="0" name="permissionAndRoleConfig" nillable="true" type="ax2163:PermissionsAndRoleConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="requestPathAuthenticatorConfigs" nillable="true" type="ax2163:RequestPathAuthenticatorConfig"/>
                     <xs:element minOccurs="0" name="saasApp" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="spProperties" nillable="true" type="ax2161:ServiceProviderProperty"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="spProperties" nillable="true" type="ax2163:ServiceProviderProperty"/>
                     <xs:element minOccurs="0" name="templateId" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="templateVersion" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="tenantDomain" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="trustedAppMetadata" nillable="true" type="ax2161:SpTrustedAppMetadata"/>
+                    <xs:element minOccurs="0" name="trustedAppMetadata" nillable="true" type="ax2163:SpTrustedAppMetadata"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="AssociatedRolesConfig">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="allowedAudience" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="roles" nillable="true" type="ax2161:RoleV2"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="roles" nillable="true" type="ax2163:RoleV2"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="RoleV2">
@@ -403,8 +404,8 @@
             <xs:complexType name="ClaimConfig">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="alwaysSendMappedLocalSubjectId" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="claimMappings" nillable="true" type="ax2161:ClaimMapping"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpClaims" nillable="true" type="ax2161:Claim"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="claimMappings" nillable="true" type="ax2163:ClaimMapping"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpClaims" nillable="true" type="ax2163:Claim"/>
                     <xs:element minOccurs="0" name="localClaimDialect" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="mappedLocalSubjectMandatory" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="roleClaimURI" nillable="true" type="xs:string"/>
@@ -415,9 +416,9 @@
             <xs:complexType name="ClaimMapping">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="defaultValue" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="localClaim" nillable="true" type="ax2161:Claim"/>
+                    <xs:element minOccurs="0" name="localClaim" nillable="true" type="ax2163:Claim"/>
                     <xs:element minOccurs="0" name="mandatory" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="remoteClaim" nillable="true" type="ax2161:Claim"/>
+                    <xs:element minOccurs="0" name="remoteClaim" nillable="true" type="ax2163:Claim"/>
                     <xs:element minOccurs="0" name="requested" type="xs:boolean"/>
                 </xs:sequence>
             </xs:complexType>
@@ -437,7 +438,7 @@
             </xs:complexType>
             <xs:complexType name="InboundAuthenticationConfig">
                 <xs:sequence>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="inboundAuthenticationRequestConfigs" nillable="true" type="ax2161:InboundAuthenticationRequestConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="inboundAuthenticationRequestConfigs" nillable="true" type="ax2163:InboundAuthenticationRequestConfig"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="InboundAuthenticationRequestConfig">
@@ -448,8 +449,8 @@
                     <xs:element minOccurs="0" name="inboundAuthType" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="inboundConfigType" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="inboundConfiguration" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="inboundConfigurationProtocol" nillable="true" type="ax2161:InboundConfigurationProtocol"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2161:Property"/>
+                    <xs:element minOccurs="0" name="inboundConfigurationProtocol" nillable="true" type="ax2163:InboundConfigurationProtocol"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2163:Property"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType abstract="true" name="InboundConfigurationProtocol">
@@ -468,7 +469,7 @@
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="options" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="regex" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="required" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="subProperties" nillable="true" type="ax2161:SubProperty"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="subProperties" nillable="true" type="ax2163:SubProperty"/>
                     <xs:element minOccurs="0" name="type" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="value" nillable="true" type="xs:string"/>
                 </xs:sequence>
@@ -499,10 +500,10 @@
             <xs:complexType name="LocalAndOutboundAuthenticationConfig">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="alwaysSendBackAuthenticatedListOfIdPs" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="authenticationScriptConfig" nillable="true" type="ax2162:AuthenticationScriptConfig"/>
-                    <xs:element minOccurs="0" name="authenticationStepForAttributes" nillable="true" type="ax2161:AuthenticationStep"/>
-                    <xs:element minOccurs="0" name="authenticationStepForSubject" nillable="true" type="ax2161:AuthenticationStep"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="authenticationSteps" nillable="true" type="ax2161:AuthenticationStep"/>
+                    <xs:element minOccurs="0" name="authenticationScriptConfig" nillable="true" type="ax2164:AuthenticationScriptConfig"/>
+                    <xs:element minOccurs="0" name="authenticationStepForAttributes" nillable="true" type="ax2163:AuthenticationStep"/>
+                    <xs:element minOccurs="0" name="authenticationStepForSubject" nillable="true" type="ax2163:AuthenticationStep"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="authenticationSteps" nillable="true" type="ax2163:AuthenticationStep"/>
                     <xs:element minOccurs="0" name="authenticationType" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="enableAuthorization" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="skipConsent" type="xs:boolean"/>
@@ -517,8 +518,8 @@
             <xs:complexType name="AuthenticationStep">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="attributeStep" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="federatedIdentityProviders" nillable="true" type="ax2161:IdentityProvider"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="localAuthenticatorConfigs" nillable="true" type="ax2161:LocalAuthenticatorConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="federatedIdentityProviders" nillable="true" type="ax2163:IdentityProvider"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="localAuthenticatorConfigs" nillable="true" type="ax2163:LocalAuthenticatorConfig"/>
                     <xs:element minOccurs="0" name="stepOrder" type="xs:int"/>
                     <xs:element minOccurs="0" name="subjectStep" type="xs:boolean"/>
                 </xs:sequence>
@@ -527,26 +528,26 @@
                 <xs:sequence>
                     <xs:element minOccurs="0" name="alias" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="certificate" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="certificateInfoArray" nillable="true" type="ax2161:CertificateInfo"/>
-                    <xs:element minOccurs="0" name="claimConfig" nillable="true" type="ax2161:ClaimConfig"/>
-                    <xs:element minOccurs="0" name="defaultAuthenticatorConfig" nillable="true" type="ax2161:FederatedAuthenticatorConfig"/>
-                    <xs:element minOccurs="0" name="defaultProvisioningConnectorConfig" nillable="true" type="ax2161:ProvisioningConnectorConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="certificateInfoArray" nillable="true" type="ax2163:CertificateInfo"/>
+                    <xs:element minOccurs="0" name="claimConfig" nillable="true" type="ax2163:ClaimConfig"/>
+                    <xs:element minOccurs="0" name="defaultAuthenticatorConfig" nillable="true" type="ax2163:FederatedAuthenticatorConfig"/>
+                    <xs:element minOccurs="0" name="defaultProvisioningConnectorConfig" nillable="true" type="ax2163:ProvisioningConnectorConfig"/>
                     <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="enable" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="federatedAssociationConfig" nillable="true" type="ax2161:FederatedAssociationConfig"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="federatedAuthenticatorConfigs" nillable="true" type="ax2161:FederatedAuthenticatorConfig"/>
+                    <xs:element minOccurs="0" name="federatedAssociationConfig" nillable="true" type="ax2163:FederatedAssociationConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="federatedAuthenticatorConfigs" nillable="true" type="ax2163:FederatedAuthenticatorConfig"/>
                     <xs:element minOccurs="0" name="federationHub" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="homeRealmId" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="id" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idPGroupConfig" nillable="true" type="ax2161:IdPGroup"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idPGroupConfig" nillable="true" type="ax2163:IdPGroup"/>
                     <xs:element minOccurs="0" name="identityProviderDescription" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="identityProviderName" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpProperties" nillable="true" type="ax2161:IdentityProviderProperty"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpProperties" nillable="true" type="ax2163:IdentityProviderProperty"/>
                     <xs:element minOccurs="0" name="imageUrl" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="justInTimeProvisioningConfig" nillable="true" type="ax2161:JustInTimeProvisioningConfig"/>
-                    <xs:element minOccurs="0" name="permissionAndRoleConfig" nillable="true" type="ax2161:PermissionsAndRoleConfig"/>
+                    <xs:element minOccurs="0" name="justInTimeProvisioningConfig" nillable="true" type="ax2163:JustInTimeProvisioningConfig"/>
+                    <xs:element minOccurs="0" name="permissionAndRoleConfig" nillable="true" type="ax2163:PermissionsAndRoleConfig"/>
                     <xs:element minOccurs="0" name="primary" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningConnectorConfigs" nillable="true" type="ax2161:ProvisioningConnectorConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningConnectorConfigs" nillable="true" type="ax2163:ProvisioningConnectorConfig"/>
                     <xs:element minOccurs="0" name="provisioningRole" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="resourceId" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="templateId" nillable="true" type="xs:string"/>
@@ -561,10 +562,11 @@
             </xs:complexType>
             <xs:complexType name="FederatedAuthenticatorConfig">
                 <xs:sequence>
+                    <xs:element minOccurs="0" name="definedByType" nillable="true" type="ax2166:IdentityConstants_DefinedByType"/>
                     <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="enabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2161:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2163:Property"/>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="tags" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
                 </xs:sequence>
@@ -574,7 +576,7 @@
                     <xs:element minOccurs="0" name="blocking" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="enabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningProperties" nillable="true" type="ax2161:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningProperties" nillable="true" type="ax2163:Property"/>
                     <xs:element minOccurs="0" name="rulesEnabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
                 </xs:sequence>
@@ -601,7 +603,7 @@
             </xs:complexType>
             <xs:complexType name="JustInTimeProvisioningConfig">
                 <xs:complexContent>
-                    <xs:extension base="ax2161:InboundProvisioningConfig">
+                    <xs:extension base="ax2163:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="attributeSyncMethod" nillable="true" type="xs:string"/>
@@ -616,8 +618,8 @@
             <xs:complexType name="PermissionsAndRoleConfig">
                 <xs:sequence>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="idpRoles" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="permissions" nillable="true" type="ax2161:ApplicationPermission"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="roleMappings" nillable="true" type="ax2161:RoleMapping"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="permissions" nillable="true" type="ax2163:ApplicationPermission"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="roleMappings" nillable="true" type="ax2163:RoleMapping"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="ApplicationPermission">
@@ -627,7 +629,7 @@
             </xs:complexType>
             <xs:complexType name="RoleMapping">
                 <xs:sequence>
-                    <xs:element minOccurs="0" name="localRole" nillable="true" type="ax2161:LocalRole"/>
+                    <xs:element minOccurs="0" name="localRole" nillable="true" type="ax2163:LocalRole"/>
                     <xs:element minOccurs="0" name="remoteRole" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
@@ -639,10 +641,11 @@
             </xs:complexType>
             <xs:complexType name="LocalAuthenticatorConfig">
                 <xs:sequence>
+                    <xs:element minOccurs="0" name="definedByType" nillable="true" type="ax2166:IdentityConstants_DefinedByType"/>
                     <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="enabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2161:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2163:Property"/>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="tags" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
                 </xs:sequence>
@@ -650,7 +653,7 @@
             <xs:complexType name="OutboundProvisioningConfig">
                 <xs:sequence>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="provisionByRoleList" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningIdentityProviders" nillable="true" type="ax2161:IdentityProvider"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningIdentityProviders" nillable="true" type="ax2163:IdentityProvider"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="User">
@@ -664,7 +667,7 @@
             </xs:complexType>
             <xs:complexType name="RequestPathAuthenticatorConfig">
                 <xs:complexContent>
-                    <xs:extension base="ax2161:LocalAuthenticatorConfig">
+                    <xs:extension base="ax2163:LocalAuthenticatorConfig">
                         <xs:sequence/>
                     </xs:extension>
                 </xs:complexContent>
@@ -685,17 +688,10 @@
                     <xs:element minOccurs="0" name="isFidoTrusted" type="xs:boolean"/>
                 </xs:sequence>
             </xs:complexType>
-            <xs:complexType name="SpTemplate">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="content" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
             <xs:complexType name="ApplicationBasicInfo">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="accessUrl" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="appOwner" nillable="true" type="ax2161:User"/>
+                    <xs:element minOccurs="0" name="appOwner" nillable="true" type="ax2163:User"/>
                     <xs:element minOccurs="0" name="applicationId" type="xs:int"/>
                     <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="applicationResourceId" nillable="true" type="xs:string"/>
@@ -722,6 +718,21 @@
                     <xs:element minOccurs="0" name="responseCode" type="xs:int"/>
                 </xs:sequence>
             </xs:complexType>
+            <xs:complexType name="SpTemplate">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="content" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+        </xs:schema>
+        <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://base.identity.carbon.wso2.org/xsd">
+            <xs:simpleType name="IdentityConstants_DefinedByType">
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="SYSTEM"/>
+                    <xs:enumeration value="USER"/>
+                </xs:restriction>
+            </xs:simpleType>
         </xs:schema>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://script.model.common.application.identity.carbon.wso2.org/xsd">
             <xs:complexType name="AuthenticationScriptConfig">

--- a/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
@@ -316,6 +316,40 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="addIdP">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2410:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deleteIdP">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="idPName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="updateIdP">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="oldIdPName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2410:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllIdPs">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllIdPsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="getIdPByName">
                 <xs:complexType>
                     <xs:sequence>
@@ -339,40 +373,6 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllIdPs">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllIdPsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="addIdP">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2410:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="deleteIdP">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="idPName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="updateIdP">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="oldIdPName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2410:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -407,13 +407,12 @@
                     <xs:element minOccurs="0" name="errorCode" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
-            <xs:complexType name="IdentityConstants_DefinedByType">
-                <xs:complexContent>
-                    <xs:extension base="xs:Enum">
-                        <xs:sequence/>
-                    </xs:extension>
-                </xs:complexContent>
-            </xs:complexType>
+            <xs:simpleType name="IdentityConstants_DefinedByType">
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="SYSTEM"/>
+                    <xs:enumeration value="USER"/>
+                </xs:restriction>
+            </xs:simpleType>
         </xs:schema>
         <xs:schema xmlns:ax2406="http://base.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://mgt.idp.carbon.wso2.org/xsd">
             <xs:import namespace="http://base.identity.carbon.wso2.org/xsd"/>

--- a/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
@@ -1,14 +1,76 @@
-
-<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ax2443="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:ns="http://mgt.idp.carbon.wso2.org" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:ax2439="http://mgt.idp.carbon.wso2.org/xsd" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:ax2440="http://base.identity.carbon.wso2.org/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://mgt.idp.carbon.wso2.org">
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ax2400="http://mgt.idp.carbon.wso2.org/xsd" xmlns:ax2401="http://base.identity.carbon.wso2.org/xsd" xmlns:ax2404="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:ns="http://mgt.idp.carbon.wso2.org" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://mgt.idp.carbon.wso2.org">
     <wsdl:documentation>IdentityProviderMgtService</wsdl:documentation>
     <wsdl:types>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://model.common.application.identity.carbon.wso2.org/xsd">
+            <xs:complexType name="IdentityProvider">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="alias" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="certificate" nillable="true" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="certificateInfoArray" nillable="true" type="ax2404:CertificateInfo"/>
+                    <xs:element minOccurs="0" name="claimConfig" nillable="true" type="ax2404:ClaimConfig"/>
+                    <xs:element minOccurs="0" name="defaultAuthenticatorConfig" nillable="true" type="ax2404:FederatedAuthenticatorConfig"/>
+                    <xs:element minOccurs="0" name="defaultProvisioningConnectorConfig" nillable="true" type="ax2404:ProvisioningConnectorConfig"/>
+                    <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="enable" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="federatedAssociationConfig" nillable="true" type="ax2404:FederatedAssociationConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="federatedAuthenticatorConfigs" nillable="true" type="ax2404:FederatedAuthenticatorConfig"/>
+                    <xs:element minOccurs="0" name="federationHub" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="homeRealmId" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="id" nillable="true" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idPGroupConfig" nillable="true" type="ax2404:IdPGroup"/>
+                    <xs:element minOccurs="0" name="identityProviderDescription" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="identityProviderName" nillable="true" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpProperties" nillable="true" type="ax2404:IdentityProviderProperty"/>
+                    <xs:element minOccurs="0" name="imageUrl" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="justInTimeProvisioningConfig" nillable="true" type="ax2404:JustInTimeProvisioningConfig"/>
+                    <xs:element minOccurs="0" name="permissionAndRoleConfig" nillable="true" type="ax2404:PermissionsAndRoleConfig"/>
+                    <xs:element minOccurs="0" name="primary" type="xs:boolean"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningConnectorConfigs" nillable="true" type="ax2404:ProvisioningConnectorConfig"/>
+                    <xs:element minOccurs="0" name="provisioningRole" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="resourceId" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="templateId" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="trustedTokenIssuer" type="xs:boolean"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="CertificateInfo">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="certValue" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="thumbPrint" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="ClaimConfig">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="alwaysSendMappedLocalSubjectId" type="xs:boolean"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="claimMappings" nillable="true" type="ax2404:ClaimMapping"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpClaims" nillable="true" type="ax2404:Claim"/>
+                    <xs:element minOccurs="0" name="localClaimDialect" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="mappedLocalSubjectMandatory" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="roleClaimURI" nillable="true" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="spClaimDialects" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="userClaimURI" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="ClaimMapping">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="defaultValue" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="localClaim" nillable="true" type="ax2404:Claim"/>
+                    <xs:element minOccurs="0" name="mandatory" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="remoteClaim" nillable="true" type="ax2404:Claim"/>
+                    <xs:element minOccurs="0" name="requested" type="xs:boolean"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="Claim">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="claimId" type="xs:int"/>
+                    <xs:element minOccurs="0" name="claimUri" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
             <xs:complexType name="FederatedAuthenticatorConfig">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="enabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2443:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2404:Property"/>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="tags" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
                 </xs:sequence>
@@ -26,7 +88,7 @@
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="options" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="regex" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="required" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="subProperties" nillable="true" type="ax2443:SubProperty"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="subProperties" nillable="true" type="ax2404:SubProperty"/>
                     <xs:element minOccurs="0" name="type" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="value" nillable="true" type="xs:string"/>
                 </xs:sequence>
@@ -52,72 +114,9 @@
                     <xs:element minOccurs="0" name="blocking" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="enabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningProperties" nillable="true" type="ax2443:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningProperties" nillable="true" type="ax2404:Property"/>
                     <xs:element minOccurs="0" name="rulesEnabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="IdentityProvider">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="alias" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="certificate" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="certificateInfoArray" nillable="true" type="ax2443:CertificateInfo"/>
-                    <xs:element minOccurs="0" name="claimConfig" nillable="true" type="ax2443:ClaimConfig"/>
-                    <xs:element minOccurs="0" name="defaultAuthenticatorConfig" nillable="true" type="ax2443:FederatedAuthenticatorConfig"/>
-                    <xs:element minOccurs="0" name="defaultProvisioningConnectorConfig" nillable="true" type="ax2443:ProvisioningConnectorConfig"/>
-                    <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="enable" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="federatedAssociationConfig" nillable="true" type="ax2443:FederatedAssociationConfig"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="federatedAuthenticatorConfigs" nillable="true" type="ax2443:FederatedAuthenticatorConfig"/>
-                    <xs:element minOccurs="0" name="federationHub" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="homeRealmId" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="id" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idPGroupConfig" nillable="true" type="ax2443:IdPGroup"/>
-                    <xs:element minOccurs="0" name="identityProviderDescription" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="identityProviderName" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpProperties" nillable="true" type="ax2443:IdentityProviderProperty"/>
-                    <xs:element minOccurs="0" name="imageUrl" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="justInTimeProvisioningConfig" nillable="true" type="ax2443:JustInTimeProvisioningConfig"/>
-                    <xs:element minOccurs="0" name="permissionAndRoleConfig" nillable="true" type="ax2443:PermissionsAndRoleConfig"/>
-                    <xs:element minOccurs="0" name="primary" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningConnectorConfigs" nillable="true" type="ax2443:ProvisioningConnectorConfig"/>
-                    <xs:element minOccurs="0" name="provisioningRole" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="resourceId" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="templateId" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="trustedTokenIssuer" type="xs:boolean"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="CertificateInfo">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="certValue" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="thumbPrint" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="ClaimConfig">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="alwaysSendMappedLocalSubjectId" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="claimMappings" nillable="true" type="ax2443:ClaimMapping"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpClaims" nillable="true" type="ax2443:Claim"/>
-                    <xs:element minOccurs="0" name="localClaimDialect" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="mappedLocalSubjectMandatory" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="roleClaimURI" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="spClaimDialects" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="userClaimURI" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="ClaimMapping">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="defaultValue" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="localClaim" nillable="true" type="ax2443:Claim"/>
-                    <xs:element minOccurs="0" name="mandatory" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="remoteClaim" nillable="true" type="ax2443:Claim"/>
-                    <xs:element minOccurs="0" name="requested" type="xs:boolean"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="Claim">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="claimId" type="xs:int"/>
-                    <xs:element minOccurs="0" name="claimUri" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="FederatedAssociationConfig">
@@ -149,7 +148,7 @@
             </xs:complexType>
             <xs:complexType name="JustInTimeProvisioningConfig">
                 <xs:complexContent>
-                    <xs:extension base="ax2443:InboundProvisioningConfig">
+                    <xs:extension base="ax2404:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="attributeSyncMethod" nillable="true" type="xs:string"/>
@@ -164,8 +163,8 @@
             <xs:complexType name="PermissionsAndRoleConfig">
                 <xs:sequence>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="idpRoles" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="permissions" nillable="true" type="ax2443:ApplicationPermission"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="roleMappings" nillable="true" type="ax2443:RoleMapping"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="permissions" nillable="true" type="ax2404:ApplicationPermission"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="roleMappings" nillable="true" type="ax2404:RoleMapping"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="ApplicationPermission">
@@ -175,7 +174,7 @@
             </xs:complexType>
             <xs:complexType name="RoleMapping">
                 <xs:sequence>
-                    <xs:element minOccurs="0" name="localRole" nillable="true" type="ax2443:LocalRole"/>
+                    <xs:element minOccurs="0" name="localRole" nillable="true" type="ax2404:LocalRole"/>
                     <xs:element minOccurs="0" name="remoteRole" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
@@ -186,37 +185,13 @@
                 </xs:sequence>
             </xs:complexType>
         </xs:schema>
-        <xs:schema xmlns:ax2444="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:ax2442="http://mgt.idp.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://mgt.idp.carbon.wso2.org">
+        <xs:schema xmlns:ax2403="http://mgt.idp.carbon.wso2.org/xsd" xmlns:ax2405="http://model.common.application.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://mgt.idp.carbon.wso2.org">
             <xs:import namespace="http://mgt.idp.carbon.wso2.org/xsd"/>
             <xs:import namespace="http://model.common.application.identity.carbon.wso2.org/xsd"/>
             <xs:element name="IdentityProviderMgtServiceIdentityProviderManagementException">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="IdentityProviderManagementException" nillable="true" type="ax2439:IdentityProviderManagementException"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllFederatedAuthenticators">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllFederatedAuthenticatorsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2443:FederatedAuthenticatorConfig"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllProvisioningConnectors">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllProvisioningConnectorsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2443:ProvisioningConnectorConfig"/>
+                        <xs:element minOccurs="0" name="IdentityProviderManagementException" nillable="true" type="ax2400:IdentityProviderManagementException"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -228,7 +203,7 @@
             <xs:element name="getResidentIdPResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2443:IdentityProvider"/>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2404:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -242,7 +217,7 @@
             <xs:element name="getIdPByNameResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2443:IdentityProvider"/>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2404:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -254,14 +229,14 @@
             <xs:element name="getAllIdPsResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2443:IdentityProvider"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2404:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
             <xs:element name="addIdP">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2443:IdentityProvider"/>
+                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2404:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -276,26 +251,14 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="oldIdPName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2443:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllLocalClaimUris">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllLocalClaimUrisResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2404:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
             <xs:element name="updateResidentIdP">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2443:IdentityProvider"/>
+                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2404:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -321,7 +284,7 @@
             <xs:element name="getAllPaginatedIdpInfoResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2443:IdentityProvider"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2404:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -336,7 +299,7 @@
             <xs:element name="getPaginatedIdpInfoResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2443:IdentityProvider"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2404:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -364,7 +327,7 @@
             <xs:element name="getAllIdPsSearchResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2443:IdentityProvider"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2404:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -376,7 +339,7 @@
             <xs:element name="getEnabledAllIdPsResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2443:IdentityProvider"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2404:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -399,6 +362,42 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="getAllLocalClaimUris">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllLocalClaimUrisResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllFederatedAuthenticators">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllFederatedAuthenticatorsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2404:FederatedAuthenticatorConfig"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllProvisioningConnectors">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllProvisioningConnectorsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2404:ProvisioningConnectorConfig"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
         </xs:schema>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://base.identity.carbon.wso2.org/xsd">
             <xs:complexType name="IdentityException">
@@ -407,11 +406,11 @@
                 </xs:sequence>
             </xs:complexType>
         </xs:schema>
-        <xs:schema xmlns:ax2441="http://base.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://mgt.idp.carbon.wso2.org/xsd">
+        <xs:schema xmlns:ax2402="http://base.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://mgt.idp.carbon.wso2.org/xsd">
             <xs:import namespace="http://base.identity.carbon.wso2.org/xsd"/>
             <xs:complexType name="IdentityProviderManagementException">
                 <xs:complexContent>
-                    <xs:extension base="ax2440:IdentityException">
+                    <xs:extension base="ax2401:IdentityException">
                         <xs:sequence/>
                     </xs:extension>
                 </xs:complexContent>

--- a/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
@@ -1,31 +1,32 @@
-<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ax2400="http://mgt.idp.carbon.wso2.org/xsd" xmlns:ax2401="http://base.identity.carbon.wso2.org/xsd" xmlns:ax2404="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:ns="http://mgt.idp.carbon.wso2.org" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://mgt.idp.carbon.wso2.org">
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ns="http://mgt.idp.carbon.wso2.org" xmlns:ax2404="http://mgt.idp.carbon.wso2.org/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:ax2405="http://base.identity.carbon.wso2.org/xsd" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:ax2408="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://mgt.idp.carbon.wso2.org">
     <wsdl:documentation>IdentityProviderMgtService</wsdl:documentation>
     <wsdl:types>
-        <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://model.common.application.identity.carbon.wso2.org/xsd">
+        <xs:schema xmlns:ax2409="http://base.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://model.common.application.identity.carbon.wso2.org/xsd">
+            <xs:import namespace="http://base.identity.carbon.wso2.org/xsd"/>
             <xs:complexType name="IdentityProvider">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="alias" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="certificate" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="certificateInfoArray" nillable="true" type="ax2404:CertificateInfo"/>
-                    <xs:element minOccurs="0" name="claimConfig" nillable="true" type="ax2404:ClaimConfig"/>
-                    <xs:element minOccurs="0" name="defaultAuthenticatorConfig" nillable="true" type="ax2404:FederatedAuthenticatorConfig"/>
-                    <xs:element minOccurs="0" name="defaultProvisioningConnectorConfig" nillable="true" type="ax2404:ProvisioningConnectorConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="certificateInfoArray" nillable="true" type="ax2408:CertificateInfo"/>
+                    <xs:element minOccurs="0" name="claimConfig" nillable="true" type="ax2408:ClaimConfig"/>
+                    <xs:element minOccurs="0" name="defaultAuthenticatorConfig" nillable="true" type="ax2408:FederatedAuthenticatorConfig"/>
+                    <xs:element minOccurs="0" name="defaultProvisioningConnectorConfig" nillable="true" type="ax2408:ProvisioningConnectorConfig"/>
                     <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="enable" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="federatedAssociationConfig" nillable="true" type="ax2404:FederatedAssociationConfig"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="federatedAuthenticatorConfigs" nillable="true" type="ax2404:FederatedAuthenticatorConfig"/>
+                    <xs:element minOccurs="0" name="federatedAssociationConfig" nillable="true" type="ax2408:FederatedAssociationConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="federatedAuthenticatorConfigs" nillable="true" type="ax2408:FederatedAuthenticatorConfig"/>
                     <xs:element minOccurs="0" name="federationHub" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="homeRealmId" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="id" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idPGroupConfig" nillable="true" type="ax2404:IdPGroup"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idPGroupConfig" nillable="true" type="ax2408:IdPGroup"/>
                     <xs:element minOccurs="0" name="identityProviderDescription" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="identityProviderName" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpProperties" nillable="true" type="ax2404:IdentityProviderProperty"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpProperties" nillable="true" type="ax2408:IdentityProviderProperty"/>
                     <xs:element minOccurs="0" name="imageUrl" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="justInTimeProvisioningConfig" nillable="true" type="ax2404:JustInTimeProvisioningConfig"/>
-                    <xs:element minOccurs="0" name="permissionAndRoleConfig" nillable="true" type="ax2404:PermissionsAndRoleConfig"/>
+                    <xs:element minOccurs="0" name="justInTimeProvisioningConfig" nillable="true" type="ax2408:JustInTimeProvisioningConfig"/>
+                    <xs:element minOccurs="0" name="permissionAndRoleConfig" nillable="true" type="ax2408:PermissionsAndRoleConfig"/>
                     <xs:element minOccurs="0" name="primary" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningConnectorConfigs" nillable="true" type="ax2404:ProvisioningConnectorConfig"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningConnectorConfigs" nillable="true" type="ax2408:ProvisioningConnectorConfig"/>
                     <xs:element minOccurs="0" name="provisioningRole" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="resourceId" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="templateId" nillable="true" type="xs:string"/>
@@ -41,8 +42,8 @@
             <xs:complexType name="ClaimConfig">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="alwaysSendMappedLocalSubjectId" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="claimMappings" nillable="true" type="ax2404:ClaimMapping"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpClaims" nillable="true" type="ax2404:Claim"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="claimMappings" nillable="true" type="ax2408:ClaimMapping"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="idpClaims" nillable="true" type="ax2408:Claim"/>
                     <xs:element minOccurs="0" name="localClaimDialect" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="mappedLocalSubjectMandatory" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="roleClaimURI" nillable="true" type="xs:string"/>
@@ -53,9 +54,9 @@
             <xs:complexType name="ClaimMapping">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="defaultValue" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="localClaim" nillable="true" type="ax2404:Claim"/>
+                    <xs:element minOccurs="0" name="localClaim" nillable="true" type="ax2408:Claim"/>
                     <xs:element minOccurs="0" name="mandatory" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="remoteClaim" nillable="true" type="ax2404:Claim"/>
+                    <xs:element minOccurs="0" name="remoteClaim" nillable="true" type="ax2408:Claim"/>
                     <xs:element minOccurs="0" name="requested" type="xs:boolean"/>
                 </xs:sequence>
             </xs:complexType>
@@ -67,10 +68,11 @@
             </xs:complexType>
             <xs:complexType name="FederatedAuthenticatorConfig">
                 <xs:sequence>
+                    <xs:element minOccurs="0" name="definedByType" nillable="true" type="ax2405:IdentityConstants_DefinedByType"/>
                     <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="enabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2404:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2408:Property"/>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="tags" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
                 </xs:sequence>
@@ -88,7 +90,7 @@
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="options" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="regex" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="required" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="subProperties" nillable="true" type="ax2404:SubProperty"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="subProperties" nillable="true" type="ax2408:SubProperty"/>
                     <xs:element minOccurs="0" name="type" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="value" nillable="true" type="xs:string"/>
                 </xs:sequence>
@@ -114,7 +116,7 @@
                     <xs:element minOccurs="0" name="blocking" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="enabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningProperties" nillable="true" type="ax2404:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningProperties" nillable="true" type="ax2408:Property"/>
                     <xs:element minOccurs="0" name="rulesEnabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
                 </xs:sequence>
@@ -148,7 +150,7 @@
             </xs:complexType>
             <xs:complexType name="JustInTimeProvisioningConfig">
                 <xs:complexContent>
-                    <xs:extension base="ax2404:InboundProvisioningConfig">
+                    <xs:extension base="ax2408:InboundProvisioningConfig">
                         <xs:sequence>
                             <xs:element minOccurs="0" name="associateLocalUserEnabled" type="xs:boolean"/>
                             <xs:element minOccurs="0" name="attributeSyncMethod" nillable="true" type="xs:string"/>
@@ -163,8 +165,8 @@
             <xs:complexType name="PermissionsAndRoleConfig">
                 <xs:sequence>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="idpRoles" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="permissions" nillable="true" type="ax2404:ApplicationPermission"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="roleMappings" nillable="true" type="ax2404:RoleMapping"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="permissions" nillable="true" type="ax2408:ApplicationPermission"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="roleMappings" nillable="true" type="ax2408:RoleMapping"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="ApplicationPermission">
@@ -174,7 +176,7 @@
             </xs:complexType>
             <xs:complexType name="RoleMapping">
                 <xs:sequence>
-                    <xs:element minOccurs="0" name="localRole" nillable="true" type="ax2404:LocalRole"/>
+                    <xs:element minOccurs="0" name="localRole" nillable="true" type="ax2408:LocalRole"/>
                     <xs:element minOccurs="0" name="remoteRole" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
@@ -185,80 +187,20 @@
                 </xs:sequence>
             </xs:complexType>
         </xs:schema>
-        <xs:schema xmlns:ax2403="http://mgt.idp.carbon.wso2.org/xsd" xmlns:ax2405="http://model.common.application.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://mgt.idp.carbon.wso2.org">
+        <xs:schema xmlns:ax2410="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:ax2407="http://mgt.idp.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://mgt.idp.carbon.wso2.org">
             <xs:import namespace="http://mgt.idp.carbon.wso2.org/xsd"/>
             <xs:import namespace="http://model.common.application.identity.carbon.wso2.org/xsd"/>
             <xs:element name="IdentityProviderMgtServiceIdentityProviderManagementException">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="IdentityProviderManagementException" nillable="true" type="ax2400:IdentityProviderManagementException"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getResidentIdP">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getResidentIdPResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2404:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getIdPByName">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="idPName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getIdPByNameResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2404:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllIdPs">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllIdPsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2404:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="addIdP">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2404:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="deleteIdP">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="idPName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="updateIdP">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="oldIdPName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2404:IdentityProvider"/>
+                        <xs:element minOccurs="0" name="IdentityProviderManagementException" nillable="true" type="ax2404:IdentityProviderManagementException"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
             <xs:element name="updateResidentIdP">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2404:IdentityProvider"/>
+                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2410:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -284,7 +226,7 @@
             <xs:element name="getAllPaginatedIdpInfoResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2404:IdentityProvider"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -299,7 +241,7 @@
             <xs:element name="getPaginatedIdpInfoResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2404:IdentityProvider"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -327,7 +269,7 @@
             <xs:element name="getAllIdPsSearchResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2404:IdentityProvider"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -339,7 +281,7 @@
             <xs:element name="getEnabledAllIdPsResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2404:IdentityProvider"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -374,6 +316,66 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="getIdPByName">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="idPName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getIdPByNameResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getResidentIdP">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getResidentIdPResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllIdPs">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllIdPsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="addIdP">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2410:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deleteIdP">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="idPName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="updateIdP">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="oldIdPName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2410:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="getAllFederatedAuthenticators">
                 <xs:complexType>
                     <xs:sequence/>
@@ -382,7 +384,7 @@
             <xs:element name="getAllFederatedAuthenticatorsResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2404:FederatedAuthenticatorConfig"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:FederatedAuthenticatorConfig"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -394,7 +396,7 @@
             <xs:element name="getAllProvisioningConnectorsResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2404:ProvisioningConnectorConfig"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:ProvisioningConnectorConfig"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -405,12 +407,19 @@
                     <xs:element minOccurs="0" name="errorCode" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
+            <xs:complexType name="IdentityConstants_DefinedByType">
+                <xs:complexContent>
+                    <xs:extension base="xs:Enum">
+                        <xs:sequence/>
+                    </xs:extension>
+                </xs:complexContent>
+            </xs:complexType>
         </xs:schema>
-        <xs:schema xmlns:ax2402="http://base.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://mgt.idp.carbon.wso2.org/xsd">
+        <xs:schema xmlns:ax2406="http://base.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://mgt.idp.carbon.wso2.org/xsd">
             <xs:import namespace="http://base.identity.carbon.wso2.org/xsd"/>
             <xs:complexType name="IdentityProviderManagementException">
                 <xs:complexContent>
-                    <xs:extension base="ax2401:IdentityException">
+                    <xs:extension base="ax2405:IdentityException">
                         <xs:sequence/>
                     </xs:extension>
                 </xs:complexContent>

--- a/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
@@ -3,6 +3,62 @@
     <wsdl:types>
         <xs:schema xmlns:ax2409="http://base.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://model.common.application.identity.carbon.wso2.org/xsd">
             <xs:import namespace="http://base.identity.carbon.wso2.org/xsd"/>
+            <xs:complexType name="FederatedAuthenticatorConfig">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="authenticationType" nillable="true" type="ax2405:IdentityConstants_AuthenticationType"/>
+                    <xs:element minOccurs="0" name="definedByType" nillable="true" type="ax2405:IdentityConstants_DefinedByType"/>
+                    <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="enabled" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2408:Property"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="tags" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="Property">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="advanced" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="confidential" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="defaultValue" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="displayOrder" type="xs:int"/>
+                    <xs:element minOccurs="0" name="groupId" type="xs:int"/>
+                    <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="options" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="regex" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="required" type="xs:boolean"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="subProperties" nillable="true" type="ax2408:SubProperty"/>
+                    <xs:element minOccurs="0" name="type" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="value" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="SubProperty">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="advanced" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="confidential" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="defaultValue" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="displayOrder" type="xs:int"/>
+                    <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="options" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="regex" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="required" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="type" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="value" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="ProvisioningConnectorConfig">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="blocking" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="enabled" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningProperties" nillable="true" type="ax2408:Property"/>
+                    <xs:element minOccurs="0" name="rulesEnabled" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
+                </xs:sequence>
+            </xs:complexType>
             <xs:complexType name="IdentityProvider">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="alias" nillable="true" type="xs:string"/>
@@ -64,61 +120,6 @@
                 <xs:sequence>
                     <xs:element minOccurs="0" name="claimId" type="xs:int"/>
                     <xs:element minOccurs="0" name="claimUri" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="FederatedAuthenticatorConfig">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="definedByType" nillable="true" type="ax2405:IdentityConstants_DefinedByType"/>
-                    <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="enabled" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="properties" nillable="true" type="ax2408:Property"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="tags" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="Property">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="advanced" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="confidential" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="defaultValue" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="displayOrder" type="xs:int"/>
-                    <xs:element minOccurs="0" name="groupId" type="xs:int"/>
-                    <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="options" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="regex" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="required" type="xs:boolean"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="subProperties" nillable="true" type="ax2408:SubProperty"/>
-                    <xs:element minOccurs="0" name="type" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="value" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="SubProperty">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="advanced" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="confidential" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="defaultValue" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="description" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="displayName" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="displayOrder" type="xs:int"/>
-                    <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="options" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="regex" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="required" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="type" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="value" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
-            <xs:complexType name="ProvisioningConnectorConfig">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="blocking" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="enabled" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="provisioningProperties" nillable="true" type="ax2408:Property"/>
-                    <xs:element minOccurs="0" name="rulesEnabled" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="FederatedAssociationConfig">
@@ -197,22 +198,106 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="updateResidentIdP">
+            <xs:element name="getAllFederatedAuthenticators">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllFederatedAuthenticatorsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:FederatedAuthenticatorConfig"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllProvisioningConnectors">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllProvisioningConnectorsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:ProvisioningConnectorConfig"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getIdPByName">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="idPName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getIdPByNameResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getResidentIdP">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getResidentIdPResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllLocalClaimUris">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllLocalClaimUrisResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllIdPs">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllIdPsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="addIdP">
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2410:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getAllIdpCount">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllIdpCountResponse">
+            <xs:element name="deleteIdP">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:int"/>
+                        <xs:element minOccurs="0" name="idPName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="updateIdP">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="oldIdPName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2410:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="updateResidentIdP">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2410:IdentityProvider"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -227,6 +312,18 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllIdpCount">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllIdpCountResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:int"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -259,6 +356,18 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="getEnabledAllIdPs">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getEnabledAllIdPsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="getAllIdPsSearch">
                 <xs:complexType>
                     <xs:sequence>
@@ -267,18 +376,6 @@
                 </xs:complexType>
             </xs:element>
             <xs:element name="getAllIdPsSearchResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getEnabledAllIdPs">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getEnabledAllIdPsResponse">
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
@@ -304,102 +401,6 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getAllLocalClaimUris">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllLocalClaimUrisResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="addIdP">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2410:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="deleteIdP">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="idPName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="updateIdP">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="oldIdPName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="identityProvider" nillable="true" type="ax2410:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllIdPs">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllIdPsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getIdPByName">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="idPName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getIdPByNameResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getResidentIdP">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getResidentIdPResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2410:IdentityProvider"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllFederatedAuthenticators">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllFederatedAuthenticatorsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:FederatedAuthenticatorConfig"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllProvisioningConnectors">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllProvisioningConnectorsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax2410:ProvisioningConnectorConfig"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
         </xs:schema>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://base.identity.carbon.wso2.org/xsd">
             <xs:complexType name="IdentityException">
@@ -407,12 +408,20 @@
                     <xs:element minOccurs="0" name="errorCode" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
-            <xs:simpleType name="IdentityConstants_DefinedByType">
-                <xs:restriction base="xs:string">
-                    <xs:enumeration value="SYSTEM"/>
-                    <xs:enumeration value="USER"/>
-                </xs:restriction>
-            </xs:simpleType>
+            <xs:complexType name="IdentityConstants_AuthenticationType">
+                <xs:complexContent>
+                    <xs:extension base="xs:Enum">
+                        <xs:sequence/>
+                    </xs:extension>
+                </xs:complexContent>
+            </xs:complexType>
+            <xs:complexType name="IdentityConstants_DefinedByType">
+                <xs:complexContent>
+                    <xs:extension base="xs:Enum">
+                        <xs:sequence/>
+                    </xs:extension>
+                </xs:complexContent>
+            </xs:complexType>
         </xs:schema>
         <xs:schema xmlns:ax2406="http://base.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://mgt.idp.carbon.wso2.org/xsd">
             <xs:import namespace="http://base.identity.carbon.wso2.org/xsd"/>


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/21111

With this following properties will be introduce to the authenticator configs and Application Authenticators.
- `DefinedBy` - to indicate whether the authenticator is system-defined or user-defined. 
1. SYSTEM: Sytem defined authenticators, all the existing authenticators  are this type.
2. USER: User defined authenticators, all the custom authenticators of authentication extension come under this type.
- `AuthenticationType` - To indicate whether authenticator is one of following
 1. IDENTIFICATION: This authenticator collects the identifier and authenticates user accounts.
 3. VERIFICATION_ONLY: This authenticator can only verify users in the second or subsequent steps of the login 
process.


With this PR following changes are added.

1. Add new authenticator property DefinedBy
2. Add new property for authenticator config objects to hold the authenticator definedBy type.
3. Update the config creation and saving logic to accommodate this new property.

NOTE: These property values are hardcoded for now. Saving and retrieving with DBs will supported by a separate PR.