### PR TITLE
Add ability to switch SAML storage type via config

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/dao/SAMLSSOServiceProviderConstants.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.identity.core.dao;
 
 public class SAMLSSOServiceProviderConstants {
 
+    public static final String SAML_STORAGE_CONFIG = "DataStorageType.SAML";
+
     private SAMLSSOServiceProviderConstants() {
 
     }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -77,7 +77,7 @@
     -->
     <DataStorageType>
         <NotificationTemplates>database</NotificationTemplates>
-<!--        <SAMLConfigs>database</SAMLConfigs>-->
+        <SAML>database</SAML>
 <!--        <KeyStores>database</KeyStores>-->
     </DataStorageType>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -87,6 +87,7 @@
         <NotificationTemplates>{{data_storage_type.notification_templates}}</NotificationTemplates>
         <KeyStores>{{data_storage_type.keystores}}</KeyStores>
         <XACML>{{data_storage_type.xacml}}</XACML>
+        <SAML>{{data_storage_type.saml}}</SAML>
     </DataStorageType>
 
     <!-- Time configurations are in minutes -->


### PR DESCRIPTION
### Proposed changes in this pull request

- Ability to set SAML data storage type to database, registry and hybrid mode via config is implemented
- Default is set to database usage

