### PR TITLE
Fix inconsistencies in JDBC & Registry  XACML Subscriber implementations

### DIFF
--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/HybridSubscriberPersistenceManager.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/HybridSubscriberPersistenceManager.java
@@ -53,11 +53,10 @@ public class HybridSubscriberPersistenceManager implements SubscriberPersistence
     public PublisherDataHolder getSubscriber(String subscriberId, boolean shouldDecryptSecrets)
             throws EntitlementException {
 
-        PublisherDataHolder holder = jdbcSubscriberPersistenceManager.getSubscriber(subscriberId, shouldDecryptSecrets);
-        if (holder == null) {
-            holder = registrySubscriberPersistenceManager.getSubscriber(subscriberId, shouldDecryptSecrets);
+        if (jdbcSubscriberPersistenceManager.isSubscriberExists(subscriberId)) {
+            return jdbcSubscriberPersistenceManager.getSubscriber(subscriberId, shouldDecryptSecrets);
         }
-        return holder;
+        return registrySubscriberPersistenceManager.getSubscriber(subscriberId, shouldDecryptSecrets);
     }
 
     @Override

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/JDBCSubscriberPersistenceManager.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/JDBCSubscriberPersistenceManager.java
@@ -94,6 +94,8 @@ public class JDBCSubscriberPersistenceManager implements SubscriberPersistenceMa
         if (subscriberId == null) {
             throw new EntitlementException(ERROR_SUBSCRIBER_ID_NULL);
         }
+        PublisherPropertyDTO[] propertyDTOsWithEncryptedSecrets = encryptSecretProperties(holder.getPropertyDTOs());
+        holder.setPropertyDTOs(propertyDTOsWithEncryptedSecrets);
 
         if (isSubscriberExists(subscriberId)) {
             throw new EntitlementException("Subscriber ID already exists");
@@ -122,8 +124,8 @@ public class JDBCSubscriberPersistenceManager implements SubscriberPersistenceMa
             PublisherDataHolder oldHolder = getSubscriber(subscriberId, false);
             String updatedModuleName = getUpdatedModuleName(holder, oldHolder);
             PublisherPropertyDTO[] updatedPropertyDTOs = getUpdatedPropertyDTOs(holder, oldHolder);
-            updatedPropertyDTOs = encryptUpdatedSecretProperties(updatedPropertyDTOs);
-            subscriberDAO.updateSubscriber(subscriberId, updatedModuleName, updatedPropertyDTOs, tenantId);
+            PublisherPropertyDTO[] propertyDTOsWithEncryptedSecrets = encryptSecretProperties(updatedPropertyDTOs);
+            subscriberDAO.updateSubscriber(subscriberId, updatedModuleName, propertyDTOsWithEncryptedSecrets, tenantId);
         } else {
             throw new EntitlementException("Subscriber ID does not exist; update cannot be done");
         }
@@ -194,11 +196,11 @@ public class JDBCSubscriberPersistenceManager implements SubscriberPersistenceMa
     }
 
     /**
-     * Sets the base64 encoded secret value of the secret subscriber properties, if it has been updated.
+     * Sets the base64 encoded secret value of the secret subscriber properties.
      *
-     * @param propertyDTOs list of subscriber properties
+     * @param propertyDTOs list of subscriber properties.
      */
-    private PublisherPropertyDTO[] encryptUpdatedSecretProperties(PublisherPropertyDTO[] propertyDTOs)
+    private PublisherPropertyDTO[] encryptSecretProperties(PublisherPropertyDTO[] propertyDTOs)
             throws EntitlementException {
 
         if (propertyDTOs == null) {

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/JDBCSubscriberPersistenceManager.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/JDBCSubscriberPersistenceManager.java
@@ -58,7 +58,7 @@ public class JDBCSubscriberPersistenceManager implements SubscriberPersistenceMa
 
         PublisherDataHolder publisherDataHolder = subscriberDAO.getSubscriber(subscriberId, tenantId);
         if (publisherDataHolder == null) {
-            return null;
+            throw new EntitlementException("No Subscriber is defined for the given Id");
         }
         if (shouldDecryptSecrets) {
             decryptSecretProperties(publisherDataHolder.getPropertyDTOs());


### PR DESCRIPTION
### Proposed changes in this pull request

Fixes for Inconsistencies in JDBC & Registry XACML Subscriber Implementations

**1. Non-Existing Subscriber Retrieval:**

- Current Behavior: The JDBC Subscriber implementation returns null when attempting to retrieve a non-existing subscriber. In contrast, the Registry Subscriber implementation throws an Entitlements exception with the message: “No Subscriber is defined for the given Id.”
- Previous Implementation: The Registry implementation previously threw this exception for non-existing subscribers.
- Resolution: To unify the behavior across both implementations, the JDBC implementation has been updated to throw an exception for non-existing subscribers. This change is captured in commit 7566f25961a490b8c3709db1930bc9d6f8a62e64.

**2. Encryption of Secret Values:**

- Current Behavior: In the JDBC implementation, secret values were not encrypted when adding a new subscriber for the first time. However, encryption was correctly applied when updating existing secret values.
- Resolution: This oversight has been addressed by ensuring that secret values are encrypted when a new subscriber is added for the first time. This fix is implemented in commit c5a3740b79a667bc27ae44ecf587dcbf130d8001.
