### PR TITLE
Address the issue of storing policy metadata in the cache without adhering to the config

### DIFF
--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/JDBCPolicyPersistenceManager.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/JDBCPolicyPersistenceManager.java
@@ -149,7 +149,7 @@ public class JDBCPolicyPersistenceManager extends AbstractPolicyFinderModule imp
 
         // Find policy attributes
         List<AttributeDTO> attributeDTOs = null;
-        if (StringUtils.isNotBlank(policy.getPolicy())) {
+        if (StringUtils.isNotBlank(policy.getPolicy()) && EntitlementUtil.isPolicyMetadataStoringEnabled()) {
             PolicyAttributeBuilder policyAttributeBuilder = new PolicyAttributeBuilder(policy.getPolicy());
             attributeDTOs = policyAttributeBuilder.getAttributesFromPolicy();
         }

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/test/java/org/wso2/carbon/identity/entitlement/persistence/HybridPolicyPersistenceManagerTest.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/test/java/org/wso2/carbon/identity/entitlement/persistence/HybridPolicyPersistenceManagerTest.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.entitlement.persistence;
 
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
@@ -49,8 +48,7 @@ public class HybridPolicyPersistenceManagerTest extends PolicyPersistenceManager
     private JDBCPolicyPersistenceManager jdbcPolicyPersistenceManager;
     private RegistryPolicyPersistenceManager registryPolicyPersistenceManager;
 
-    @BeforeMethod
-    public void setUp() throws Exception {
+    public PolicyPersistenceManager createPolicyPersistenceManager() {
 
         Properties storeProps = new Properties();
         policyPersistenceManager = new HybridPolicyPersistenceManager();
@@ -58,6 +56,7 @@ public class HybridPolicyPersistenceManagerTest extends PolicyPersistenceManager
         jdbcPolicyPersistenceManager = new JDBCPolicyPersistenceManager();
         registryPolicyPersistenceManager = new RegistryPolicyPersistenceManager();
         registryPolicyPersistenceManager.init(storeProps);
+        return policyPersistenceManager;
     }
 
     @Test(priority = 13)

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/test/java/org/wso2/carbon/identity/entitlement/persistence/JDBCPolicyPersistenceManagerTest.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/test/java/org/wso2/carbon/identity/entitlement/persistence/JDBCPolicyPersistenceManagerTest.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.entitlement.persistence;
 
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
@@ -39,10 +38,9 @@ import static org.testng.Assert.assertTrue;
 @WithH2Database(files = {"dbscripts/h2.sql"})
 public class JDBCPolicyPersistenceManagerTest extends PolicyPersistenceManagerTest {
 
-    @BeforeMethod
-    public void setUp() throws Exception {
+    public PolicyPersistenceManager createPolicyPersistenceManager() {
 
-        policyPersistenceManager = new JDBCPolicyPersistenceManager();
+        return new JDBCPolicyPersistenceManager();
     }
 
     @Test

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/test/java/org/wso2/carbon/identity/entitlement/persistence/PolicyPersistenceManagerTest.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/test/java/org/wso2/carbon/identity/entitlement/persistence/PolicyPersistenceManagerTest.java
@@ -19,7 +19,7 @@
 package org.wso2.carbon.identity.entitlement.persistence;
 
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.entitlement.EntitlementException;
 import org.wso2.carbon.identity.entitlement.PDPConstants;
@@ -75,12 +75,13 @@ public abstract class PolicyPersistenceManagerTest {
     PolicyStoreDTO pdpPolicyWithEmptyId;
     PolicyStoreDTO pdpPolicyWithEmptyVersion;
 
-    @BeforeClass
-    public void setUpClass() {
+    @BeforeMethod
+    public void setUp() {
 
         Properties engineProperties = new Properties();
         engineProperties.put(PDPConstants.MAX_NO_OF_POLICY_VERSIONS, "4");
         EntitlementConfigHolder.getInstance().setEngineProperties(engineProperties);
+        policyPersistenceManager = createPolicyPersistenceManager();
 
         samplePAPPolicy1 = new PolicyDTO(SAMPLE_POLICY_ID_1);
         samplePAPPolicy1.setPolicy(SAMPLE_POLICY_STRING_1);
@@ -151,6 +152,22 @@ public abstract class PolicyPersistenceManagerTest {
         assertEquals(policyFromStorage.getPolicyEditorData(), samplePAPPolicy1.getPolicyEditorData());
         assertEquals(policyFromStorage.getPolicyOrder(), samplePAPPolicy1.getPolicyOrder());
         assertEquals(policyFromStorage.getAttributeDTOs().length, 4);
+    }
+
+    @Test(priority = 3, dependsOnMethods = {"testAddPAPPolicy"})
+    public void testAddPAPPolicyWhenPolicyMetaDataStoringDisabled() throws Exception {
+
+        Properties properties = EntitlementConfigHolder.getInstance().getEngineProperties();
+        properties.setProperty(PDPConstants.STORE_POLICY_META_DATA, "false");
+        EntitlementConfigHolder.getInstance().setEngineProperties(properties);
+
+        policyPersistenceManager.addOrUpdatePolicy(samplePAPPolicy1, true);
+        // Verify weather the policy meta-data was not stored for PAP policy.
+        PolicyDTO papPolicyFromStorage = policyPersistenceManager.getPAPPolicy(samplePDPPolicy1.getPolicyId());
+        assertEquals(papPolicyFromStorage.getAttributeDTOs().length, 0);
+
+        properties.setProperty(PDPConstants.STORE_POLICY_META_DATA, "true");
+        EntitlementConfigHolder.getInstance().setEngineProperties(properties);
     }
 
     @Test(priority = 3)
@@ -479,4 +496,11 @@ public abstract class PolicyPersistenceManagerTest {
         policyStoreDTO.setSetOrder(setOrder);
         return policyStoreDTO;
     }
+
+    /**
+     * Abstract method to create the policy persistence manager.
+     *
+     * @return The policy persistence manager.
+     */
+    public abstract PolicyPersistenceManager createPolicyPersistenceManager();
 }

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/test/java/org/wso2/carbon/identity/entitlement/persistence/RegistryPolicyPersistenceManagerTest.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/test/java/org/wso2/carbon/identity/entitlement/persistence/RegistryPolicyPersistenceManagerTest.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.entitlement.persistence;
 
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
@@ -41,12 +40,12 @@ import static org.testng.Assert.assertTrue;
 @WithH2Database(files = {"dbscripts/h2.sql"})
 public class RegistryPolicyPersistenceManagerTest extends PolicyPersistenceManagerTest {
 
-    @BeforeMethod
-    public void setUp() throws Exception {
+    public PolicyPersistenceManager createPolicyPersistenceManager() {
 
         Properties storeProps = new Properties();
         policyPersistenceManager = new RegistryPolicyPersistenceManager();
         policyPersistenceManager.init(storeProps);
+        return policyPersistenceManager;
     }
 
     @Test


### PR DESCRIPTION
### Issue Description

The Policy Persistence Managers are responsible for storing policy-related metadata based on a server configuration. If that configuration is disabled, the associated metadata is not stored.

However, even when the configuration is disabled, adding a new papa policy results in the policy being cached with its metadata, despite it not being stored in the database. Consequently, when retrieving the policy from the cache, the policy object includes this metadata.

The root cause of this issue is that we are filtering out policy metadata in the DAO layer(https://github.com/wso2/carbon-identity-framework/blob/ccc2502bcc8321bcaeafeff1e21567aebe542375/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/dao/PolicyDAO.java#L124-L126) but not in the Policy Persistence Manager. As a result, when a policy is added to the policy cache (https://github.com/wso2/carbon-identity-framework/blob/25a710f8a8092cf334932560922b5817aefd4d9e/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/persistence/cache/CacheBackedPolicyDAO.java#L60-L61), it always contains metadata, regardless of whether the metadata storage configuration is enabled or disabled.


### Proposed solution

- Add policy meta data to the policy object based on the meta data storing server config in Policy Persistence Manager. (93085cdd9a6767fcc1d40a9ffe52bc922a397483)
- Improve Unit tests to cover above scenario. (61efef8ece995af1a360b72969faa3da2113f6ee)
