### PR TITLE
Fix previous validation error persist in static variable

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/pom.xml
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/pom.xml
@@ -106,6 +106,16 @@
             <artifactId>jaxb-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserInformationRecoveryService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserInformationRecoveryService.java
@@ -206,7 +206,8 @@ public class UserInformationRecoveryService {
                 return bean;
             }
         } catch (IdentityException e1) {
-            bean = UserIdentityManagementUtil.getCustomErrorMessagesToVerifyCode(e1, username);
+            UserIdentityManagementUtil userIdentityManagementUtil = new UserIdentityManagementUtil();
+            bean = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(e1, username);
             if (bean.getError() == null) {
                 bean = handleError(VerificationBean.ERROR_CODE_INVALID_CODE + " Invalid confirmation code for user : "
                         + username, e1);
@@ -244,7 +245,8 @@ public class UserInformationRecoveryService {
 
 
         } catch (IdentityException e) {
-            bean = UserIdentityManagementUtil.getCustomErrorMessagesToVerifyCode(e, username);
+            UserIdentityManagementUtil userIdentityManagementUtil = new UserIdentityManagementUtil();
+            bean = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(e, username);
             if (bean.getError() == null) {
                 bean = handleError(VerificationBean.ERROR_CODE_RECOVERY_NOTIFICATION_FAILURE + ": " + VerificationBean.
                         ERROR_CODE_UNEXPECTED + " Error when sending recovery message for " +
@@ -319,7 +321,8 @@ public class UserInformationRecoveryService {
                 log.error(bean.getError());
             }
         } catch (IdentityException e) {
-            bean = UserIdentityManagementUtil.getCustomErrorMessagesToVerifyCode(e, username);
+            UserIdentityManagementUtil userIdentityManagementUtil = new UserIdentityManagementUtil();
+            bean = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(e, username);
             if (bean.getError() == null) {
                 bean = handleError(VerificationBean.ERROR_CODE_INVALID_CODE + " Error verifying confirmation code for " +
                         "user : " + username, e);
@@ -397,7 +400,8 @@ public class UserInformationRecoveryService {
             }
 
         } catch (IdentityException e) {
-            bean = UserIdentityManagementUtil.getCustomErrorMessagesToVerifyCode(e, username);
+            UserIdentityManagementUtil userIdentityManagementUtil = new UserIdentityManagementUtil();
+            bean = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(e, username);
             if (bean.getError() == null) {
                 bean = handleError(VerificationBean.ERROR_CODE_UNEXPECTED + " Error while updating credential " +
                         "for user: " + username, e);
@@ -696,7 +700,8 @@ public class UserInformationRecoveryService {
                     bean.setVerified(false);
                 }
             } catch (IdentityException e) {
-                bean = UserIdentityManagementUtil.getCustomErrorMessagesToVerifyCode(e, userName);
+                UserIdentityManagementUtil userIdentityManagementUtil = new UserIdentityManagementUtil();
+                bean = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(e, userName);
                 if (bean == null) {
                     bean = handleError(VerificationBean.ERROR_CODE_INVALID_CODE + " " +
                             " Error verifying confirmation code for user : " + userName, e);
@@ -788,7 +793,8 @@ public class UserInformationRecoveryService {
                 }
             } catch (IdentityException e) {
                 log.error("Error while verifying confirmation code.", e);
-                bean = UserIdentityManagementUtil.getCustomErrorMessagesToVerifyCode(e, userName);
+                UserIdentityManagementUtil userIdentityManagementUtil = new UserIdentityManagementUtil();
+                bean = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(e, userName);
                 if (bean == null) {
                     bean = handleError(VerificationBean.ERROR_CODE_INVALID_CODE + " " +
                                        " Error verifying confirmation code for user : " + userName, e);
@@ -1089,14 +1095,15 @@ public class UserInformationRecoveryService {
                 vBean.setVerified(true);
             }
         } catch (UserStoreException | IdentityException e) {
-            vBean = UserIdentityManagementUtil.getCustomErrorMessagesWhenRegistering(e, userName);
+            UserIdentityManagementUtil userIdentityManagementUtil = new UserIdentityManagementUtil();
+            vBean = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(e, userName);
             //Rollback if user exists
             try {
                 if (!e.getMessage().contains(IdentityCoreConstants.EXISTING_USER) && userStoreManager.isExistingUser(userName)) {
                     userStoreManager.deleteUser(userName);
                 }
             } catch (UserStoreException e1) {
-                vBean = UserIdentityManagementUtil.getCustomErrorMessagesWhenRegistering(e1, userName);
+                vBean = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(e1, userName);
             }
 
             return vBean;
@@ -1213,7 +1220,8 @@ public class UserInformationRecoveryService {
                     vBean.setVerified(true);
                 }
             } catch (IdentityException e) {
-                vBean = UserIdentityManagementUtil.getCustomErrorMessagesWhenRegistering(e, userName);
+                UserIdentityManagementUtil userIdentityManagementUtil = new UserIdentityManagementUtil();
+                vBean = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(e, userName);
                 return vBean;
             }
         } finally {
@@ -1321,7 +1329,8 @@ public class UserInformationRecoveryService {
                     log.error("User verification failed against the given confirmation code");
                 }
             } catch (IdentityException e) {
-                bean = UserIdentityManagementUtil.getCustomErrorMessagesToVerifyCode(e, username);
+                UserIdentityManagementUtil userIdentityManagementUtil = new UserIdentityManagementUtil();
+                bean = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(e, username);
                 if (bean.getError() == null) {
                     bean = handleError("Error while validating confirmation code for user : " + username, e);
                 }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/util/UserIdentityManagementUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/util/UserIdentityManagementUtil.java
@@ -85,8 +85,7 @@ public class UserIdentityManagementUtil {
     private static UserChallengesCollectionDTO userChallengesCollectionDTO = new UserChallengesCollectionDTO();
     private static Log log = LogFactory.getLog(UserIdentityManagementUtil.class);
 
-    private UserIdentityManagementUtil() {
-    }
+    private VerificationBean vBeanInstance = new VerificationBean();
 
     /**
      * Returns the registration information such as the temporary password or
@@ -631,6 +630,10 @@ public class UserIdentityManagementUtil {
         }
     }
 
+    /**
+     * @deprecated Use {@link #retrieveCustomErrorMessagesForRegistration} instead.
+     */
+    @Deprecated
     public static VerificationBean getCustomErrorMessagesWhenRegistering(Exception e, String userName) {
         if (e.getMessage() != null) {
             if (e.getMessage().contains(PASSWORD_INVALID)) {
@@ -688,6 +691,68 @@ public class UserIdentityManagementUtil {
         }
     }
 
+    public VerificationBean retrieveCustomErrorMessagesForRegistration(Exception e, String userName) {
+
+        if (e.getMessage() != null) {
+            if (e.getMessage().contains(PASSWORD_INVALID)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_INVALID_CREDENTIALS +
+                        " Credential not valid. Credential must be a non null for the user : " + userName, e);
+            } else if (e.getMessage().contains(EXISTING_USER)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_INVALID_USER +
+                        " Username '" + userName + "' already exists in the system. Please enter another username.", e);
+            } else if (e.getMessage().contains(INVALID_CLAIM_URL)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_UNEXPECTED + " Invalid claim uri has been provided.", e);
+            } else if (e.getMessage().contains(INVALID_USER_NAME)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_INVALID_USER +
+                        " Username " + userName + " is not valid. User name must be a non null", e);
+            } else if (e.getMessage().contains(READ_ONLY_STORE)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_UNEXPECTED +
+                        " Read-only UserStoreManager. Roles cannot be added or modified.", e);
+            } else if (e.getMessage().contains(READ_ONLY_PRIMARY_STORE)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_UNEXPECTED +
+                        " Cannot add role to Read Only user store unless it is primary.", e);
+            } else if (e.getMessage().contains(INVALID_ROLE)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_UNEXPECTED +
+                        " Invalid role name. Role name must be a non null string.", e);
+            } else if (e.getMessage().contains(NO_READ_WRITE_PERMISSIONS)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_UNEXPECTED +
+                        " Role cannot be added. User store is read only or cannot write groups.", e);
+            } else if (e.getMessage().contains(EXISTING_ROLE)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_UNEXPECTED +
+                        " Role already exists in the system. Please enter another role name.", e);
+            } else if (e.getMessage().contains(SHARED_USER_ROLES)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_UNEXPECTED +
+                        " User store doesn't support shared user roles functionality.", e);
+            } else if (e.getMessage().contains(REMOVE_ADMIN_USER)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_UNEXPECTED + " Cannot remove Admin user from Admin role.", e);
+            } else if (e.getMessage().contains(LOGGED_IN_USER)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_UNEXPECTED + " Cannot remove Admin user from Admin role.", e);
+            } else if (e.getMessage().contains(ADMIN_USER)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_UNEXPECTED + " Cannot remove Admin user from Admin role.", e);
+            } else if (e.getMessage().contains(ANONYMOUS_USER)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_UNEXPECTED +
+                        " Cannot delete anonymous user.", e);
+            } else if (e.getMessage().contains(INVALID_OPERATION)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_UNEXPECTED + " Invalid operation. User store is read only.", e);
+            } else if (e.getMessage().contains(PASSWORD_POLICY_VIOLATION)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_UNEXPECTED + " " + e.getMessage(), e);
+            } else {
+                vBeanInstance = handleError(
+                        VerificationBean.ERROR_CODE_UNEXPECTED + " Error occurred while adding user : " + userName, e);
+                return vBeanInstance;
+            }
+            return vBeanInstance;
+        } else {
+            vBeanInstance = handleError(
+                    VerificationBean.ERROR_CODE_UNEXPECTED + " Error occurred while adding user : " + userName, e);
+            return vBeanInstance;
+        }
+    }
+
+    /**
+     * @deprecated Use {@link #getCustomErrorMessagesForCodeVerification} instead.
+     */
+    @Deprecated
     public static VerificationBean getCustomErrorMessagesToVerifyCode(IdentityException e, String userName) {
         if (e.getMessage() != null) {
             if (e.getMessage().contains(VerificationBean.ERROR_CODE_EXPIRED_CODE)) {
@@ -723,6 +788,45 @@ public class UserIdentityManagementUtil {
         } else {
             vBean = handleError(VerificationBean.ERROR_CODE_INVALID_CODE + " No user account found for user", e);
             return vBean;
+        }
+    }
+
+    public VerificationBean getCustomErrorMessagesForCodeVerification(IdentityException e, String userName) {
+
+        if (e.getMessage() != null) {
+            if (e.getMessage().contains(VerificationBean.ERROR_CODE_EXPIRED_CODE)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_EXPIRED_CODE + " The code is " + "expired", e);
+            } else if (e.getMessage().contains(IdentityMgtConstants.ErrorHandling.INVALID_CONFIRMATION_CODE)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_INVALID_CODE + " " +
+                        IdentityMgtConstants.ErrorHandling.INVALID_CONFIRMATION_CODE, e);
+            } else if (e.getMessage().contains(VerificationBean.ERROR_CODE_LOADING_DATA_FAILURE)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_LOADING_DATA_FAILURE + " Error" +
+                        " loading data for user : " + userName, e);
+            } else if (e.getMessage().contains(IdentityMgtConstants.ErrorHandling.EXTERNAL_CODE)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_INVALID_CODE + " " +
+                        IdentityMgtConstants.ErrorHandling.EXTERNAL_CODE + ": " + userName, e);
+            } else if (e.getMessage().contains(IdentityMgtConstants.ErrorHandling.NOTIFICATION_FAILURE)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_RECOVERY_NOTIFICATION_FAILURE + " " + IdentityMgtConstants.
+                        ErrorHandling.NOTIFICATION_FAILURE + ": " + userName, e);
+            } else if (e.getMessage().contains(IdentityMgtConstants.ErrorHandling.ERROR_LOADING_EMAIL_TEMP)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_RECOVERY_NOTIFICATION_FAILURE + ": " + IdentityMgtConstants.
+                        ErrorHandling.ERROR_LOADING_EMAIL_TEMP + " " + userName, e);
+            } else if (e.getMessage().contains(IdentityMgtConstants.ErrorHandling.EXTERNAL_CODE)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_INVALID_CODE + ": " + IdentityMgtConstants.
+                        ErrorHandling.EXTERNAL_CODE + " " + userName, e);
+            } else if (e.getMessage().contains(IdentityMgtConstants.ErrorHandling.CREATING_NOTIFICATION_ERROR)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_RECOVERY_NOTIFICATION_FAILURE + ": " + IdentityMgtConstants.
+                        ErrorHandling.CREATING_NOTIFICATION_ERROR + " " + userName, e);
+            } else if (e.getMessage().contains(VerificationBean.ERROR_CODE_LOADING_DATA_FAILURE)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_LOADING_DATA_FAILURE + " Error" +
+                        " loading data for user : " + userName, e);
+            } else if (e.getMessage().contains(IdentityMgtConstants.ErrorHandling.USER_ACCOUNT)) {
+                vBeanInstance = handleError(VerificationBean.ERROR_CODE_INVALID_CODE + " No user account found for user", e);
+            }
+            return vBeanInstance;
+        } else {
+            vBeanInstance = handleError(VerificationBean.ERROR_CODE_INVALID_CODE + " No user account found for user", e);
+            return vBeanInstance;
         }
     }
 

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/test/java/services/UserInformationRecoveryServiceTest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/test/java/services/UserInformationRecoveryServiceTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package services;
+
+import org.mockito.MockedStatic;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.mgt.IdentityMgtConfig;
+import org.wso2.carbon.identity.mgt.RecoveryProcessor;
+import org.wso2.carbon.identity.mgt.beans.VerificationBean;
+import org.wso2.carbon.identity.mgt.constants.IdentityMgtConstants;
+import org.wso2.carbon.identity.mgt.dto.UserChallengesDTO;
+import org.wso2.carbon.identity.mgt.dto.UserDTO;
+import org.wso2.carbon.identity.mgt.internal.IdentityMgtServiceComponent;
+import org.wso2.carbon.identity.mgt.services.UserInformationRecoveryService;
+import org.wso2.carbon.identity.mgt.util.UserIdentityManagementUtil;
+import org.wso2.carbon.identity.mgt.util.Utils;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.tenant.TenantManager;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+public class UserInformationRecoveryServiceTest {
+
+    private static final String EXISTING_USER = "Username already exists in the system";
+    private static final String INVALID_CLAIM_URL = "InvalidClaimUrl";
+    private static final String EXISTING_ROLE = "RoleExisting";
+    private static final String READ_ONLY_STORE = "User store is read only";
+    private static final String READ_ONLY_PRIMARY_STORE = "ReadOnlyPrimaryUserStoreManager";
+    private static final String INVALID_ROLE = "InvalidRole";
+    private static final String NO_READ_WRITE_PERMISSIONS = "NoReadWritePermission";
+    private static final String PASSWORD_INVALID = "Credential must be a non null string";
+    private static final String INVALID_USER_NAME = "InvalidUserName";
+    private static final String PASSWORD_POLICY_VIOLATION = "Password at least should have";;
+    
+    private UserIdentityManagementUtil userIdentityManagementUtil;
+    private IdentityException mockIdentityException;
+    private Exception mockException;
+
+    @BeforeMethod
+    public void init() {
+
+        userIdentityManagementUtil = new UserIdentityManagementUtil();
+        mockIdentityException = mock(IdentityException.class);
+        mockException = mock(Exception.class);
+
+    }
+
+    @Test
+    public void testVerifyConfirmationCodeFailure() throws IdentityException, UserStoreException {
+
+        try (MockedStatic<IdentityMgtConfig> mockIdentityMgtConfig = mockStatic(IdentityMgtConfig.class);
+             MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<IdentityMgtServiceComponent> identityMgtServiceComponent = mockStatic(IdentityMgtServiceComponent.class)) {
+
+            IdentityMgtConfig identityMgtConfig = mock(IdentityMgtConfig.class);
+            RealmService realmService = mock(RealmService.class);
+            RecoveryProcessor recoveryProcessor = mock(RecoveryProcessor.class);
+            TenantManager tenantManager = mock(TenantManager.class);
+
+            mockIdentityMgtConfig.when(IdentityMgtConfig::getInstance).thenReturn(identityMgtConfig);
+            utils.when(() -> Utils.processUserId(anyString())).thenReturn(new UserDTO(""));
+            identityMgtServiceComponent.when(IdentityMgtServiceComponent::getRealmService).thenReturn(realmService);
+            identityMgtServiceComponent.when(IdentityMgtServiceComponent::getRecoveryProcessor).thenReturn(recoveryProcessor);
+
+
+            when(realmService.getTenantManager()).thenReturn(tenantManager);
+            when(tenantManager.getTenantId(anyString())).thenReturn(-1234);
+            when(recoveryProcessor.verifyConfirmationCode(anyInt(), anyString(), anyString())).thenThrow(new IdentityException(""));
+
+            UserInformationRecoveryService userInformationRecoveryService = new UserInformationRecoveryService();
+            userInformationRecoveryService.verifyConfirmationCode("", "", null);
+            userInformationRecoveryService.updatePassword("", "", "");
+            userInformationRecoveryService.getUserChallengeQuestionIds("", "");
+            userInformationRecoveryService.getUserChallengeQuestion("", "", "");
+            userInformationRecoveryService.getUserChallengeQuestions("", "");
+            userInformationRecoveryService.verifyUserChallengeAnswer("", "", "", "");
+
+            UserChallengesDTO[] userChallengesDTOs = { new UserChallengesDTO() };
+            userInformationRecoveryService.verifyUserChallengeAnswers("", "", userChallengesDTOs);
+        }
+    }
+
+    @Test
+    public void testExpiredCode() {
+        
+        when(mockIdentityException.getMessage()).thenReturn(VerificationBean.ERROR_CODE_EXPIRED_CODE);
+        VerificationBean result = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(mockIdentityException, "testUser");
+        assertNotNull(result);
+        assertEquals("18002 The code is expired", result.getError());
+    }
+
+    @Test
+    public void testInvalidConfirmationCode() {
+        
+        when(mockIdentityException.getMessage()).thenReturn(IdentityMgtConstants.ErrorHandling.INVALID_CONFIRMATION_CODE);
+        VerificationBean result = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(mockIdentityException, "testUser");
+        assertNotNull(result);
+        assertEquals("18001  Invalid confirmation code ", result.getError());
+    }
+
+    @Test
+    public void testLoadingDataFailureCodeVerification() {
+        
+        when(mockIdentityException.getMessage()).thenReturn(VerificationBean.ERROR_CODE_LOADING_DATA_FAILURE);
+        VerificationBean result = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(mockIdentityException, "testUser");
+        assertNotNull(result);
+        assertEquals("18014 Error loading data for user : testUser", result.getError());
+    }
+
+    @Test
+    public void testExternalCodeErrorCodeVerification() {
+
+        when(mockIdentityException.getMessage()).thenReturn(IdentityMgtConstants.ErrorHandling.EXTERNAL_CODE);
+        VerificationBean result = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(mockIdentityException, "testUser");
+        assertNotNull(result);
+        assertEquals("18001 Error occurred while getting external code for user : : testUser", result.getError());
+    }
+
+    @Test
+    public void testNotificationFailureCodeVerification() {
+
+        when(mockIdentityException.getMessage()).thenReturn(IdentityMgtConstants.ErrorHandling.NOTIFICATION_FAILURE);
+        VerificationBean result = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(mockIdentityException, "testUser");
+        assertNotNull(result);
+        assertEquals("18015 Notification sending failure. Notification address is not defined for user:: testUser", result.getError());
+    }
+
+    @Test
+    public void testErrorLoadingEmailTemplateCodeVerification() {
+
+        when(mockIdentityException.getMessage()).thenReturn(IdentityMgtConstants.ErrorHandling.ERROR_LOADING_EMAIL_TEMP);
+        VerificationBean result = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(mockIdentityException, "testUser");
+        assertNotNull(result);
+        assertEquals("18015: Error occurred while loading email templates for user :  testUser", result.getError());
+    }
+
+    @Test
+    public void testCreatingNotificationErrorCodeVerification() {
+
+        when(mockIdentityException.getMessage()).thenReturn(IdentityMgtConstants.ErrorHandling.CREATING_NOTIFICATION_ERROR);
+        VerificationBean result = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(mockIdentityException, "testUser");
+        assertNotNull(result);
+        assertEquals("18015: Error occurred while creating notification for user :  testUser", result.getError());
+    }
+
+    @Test
+    public void testNoUserAccountFoundCodeVerification() {
+        
+        when(mockIdentityException.getMessage()).thenReturn(IdentityMgtConstants.ErrorHandling.USER_ACCOUNT);
+        VerificationBean result = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(mockIdentityException, "testUser");
+        assertNotNull(result);
+        assertEquals("18001 No user account found for user", result.getError());
+    }
+
+    @Test
+    public void testNullExceptionMessageCodeVerification() {
+        
+        when(mockIdentityException.getMessage()).thenReturn(null);
+        VerificationBean result = userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(mockIdentityException, "testUser");
+        assertNotNull(result);
+        assertEquals("18001 No user account found for user", result.getError());
+    }
+
+    @Test
+    public void testInvalidPasswordRegistration() {
+
+        when(mockException.getMessage()).thenReturn(PASSWORD_INVALID);
+        VerificationBean result = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(mockException, "testUser");
+        assertNotNull(result);
+        assertEquals("17002 Credential not valid. Credential must be a non null for the user : testUser", result.getError());
+    }
+
+    @Test
+    public void testExistingUserRegistration() {
+
+        when(mockException.getMessage()).thenReturn(EXISTING_USER);
+        VerificationBean result = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(mockException, "testUser");
+        assertNotNull(result);
+        assertEquals("18003 Username 'testUser' already exists in the system. Please enter another username.", result.getError());
+    }
+
+    @Test
+    public void testInvalidClaimUrlRegistration() {
+
+        when(mockException.getMessage()).thenReturn(INVALID_CLAIM_URL);
+        VerificationBean result = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(mockException, "testUser");
+        assertNotNull(result);
+        assertEquals("18013 Invalid claim uri has been provided.", result.getError());
+    }
+
+    @Test
+    public void testInvalidUserNameRegistration() {
+
+        when(mockException.getMessage()).thenReturn(INVALID_USER_NAME);
+        VerificationBean result = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(mockException, "testUser");
+        assertNotNull(result);
+        assertEquals("18003 Username testUser is not valid. User name must be a non null", result.getError());
+    }
+
+    @Test
+    public void testReadOnlyStoreRegistration() {
+
+        when(mockException.getMessage()).thenReturn(READ_ONLY_STORE);
+        VerificationBean result = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(mockException, "testUser");
+        assertNotNull(result);
+        assertEquals("18013 Read-only UserStoreManager. Roles cannot be added or modified.", result.getError());
+    }
+
+    @Test
+    public void testReadOnlyPrimaryStoreRegistration() {
+
+        when(mockException.getMessage()).thenReturn(READ_ONLY_PRIMARY_STORE);
+        VerificationBean result = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(mockException, "testUser");
+        assertNotNull(result);
+        assertEquals("18013 Cannot add role to Read Only user store unless it is primary.", result.getError());
+    }
+
+    @Test
+    public void testInvalidRoleRegistration() {
+
+        when(mockException.getMessage()).thenReturn(INVALID_ROLE);
+        VerificationBean result = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(mockException, "testUser");
+        assertNotNull(result);
+        assertEquals("18013 Invalid role name. Role name must be a non null string.", result.getError());
+    }
+
+    @Test
+    public void testNoReadWritePermissionsRegistration() {
+
+        when(mockException.getMessage()).thenReturn(NO_READ_WRITE_PERMISSIONS);
+        VerificationBean result = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(mockException, "testUser");
+        assertNotNull(result);
+        assertEquals("18013 Role cannot be added. User store is read only or cannot write groups.", result.getError());
+    }
+
+    @Test
+    public void testExistingRoleRegistration() {
+
+        when(mockException.getMessage()).thenReturn(EXISTING_ROLE);
+        VerificationBean result = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(mockException, "testUser");
+        assertNotNull(result);
+        assertEquals("18013 Role already exists in the system. Please enter another role name.", result.getError());
+    }
+
+    @Test
+    public void testPasswordPolicyViolationRegistration() {
+
+        when(mockException.getMessage()).thenReturn(PASSWORD_POLICY_VIOLATION);
+        VerificationBean result = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(mockException, "testUser");
+        assertNotNull(result);
+        assertEquals("18013 " + PASSWORD_POLICY_VIOLATION, result.getError());
+    }
+
+    @Test
+    public void testUnexpectedErrorRegistration() {
+
+        when(mockException.getMessage()).thenReturn("Some unexpected error");
+        VerificationBean result = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(mockException, "testUser");
+        assertNotNull(result);
+        assertEquals("18013 Error occurred while adding user : testUser", result.getError());
+    }
+
+    @Test
+    public void testNullExceptionMessageRegistration() {
+
+        when(mockException.getMessage()).thenReturn(null);
+        VerificationBean result = userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(mockException, "testUser");
+        assertNotNull(result);
+        assertEquals("18013 Error occurred while adding user : testUser", result.getError());
+    }
+}

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/test/java/util/UserIdentityManagementUtilTest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/test/java/util/UserIdentityManagementUtilTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package util;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.mgt.util.UserIdentityManagementUtil;
+
+public class UserIdentityManagementUtilTest {
+
+    private static final String MOCK_USER = "john";
+
+    @Test
+    public void testRetrieveCustomErrorMessagesForRegistration() {
+
+        UserIdentityManagementUtil userIdentityManagementUtil = new UserIdentityManagementUtil();
+        userIdentityManagementUtil.retrieveCustomErrorMessagesForRegistration(new Exception(), MOCK_USER);
+    }
+
+    @Test
+    public void testGetCustomErrorMessagesForCodeVerification() {
+
+        UserIdentityManagementUtil userIdentityManagementUtil = new UserIdentityManagementUtil();
+        userIdentityManagementUtil.getCustomErrorMessagesForCodeVerification(new IdentityException(""), MOCK_USER);
+    }
+}

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/test/resources/testng.xml
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/test/resources/testng.xml
@@ -24,6 +24,8 @@
             <class name="org.wso2.carbon.identity.mgt.policy.password.DefaultPasswordNamePolicyTest"/>
             <class name="org.wso2.carbon.identity.mgt.policy.password.DefaultPasswordPatternPolicyTest"/>
             <class name="org.wso2.carbon.identity.mgt.policy.password.DefaultPasswordWhitespacePolicyTest"/>
+            <class name="services.UserInformationRecoveryServiceTest"/>
+
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
$subject

The validation bean which keeps the errors shouldn't be a static variable, it should be an instance variable. But the way it has been implemented cause this issue. 

Using instance variable from static methods are not allowed. Hence deprecated the below two static methods, and introduced new methods which are instance level.

- `getCustomErrorMessagesWhenRegistering`  ->  `retrieveCustomErrorMessagesForRegistration`
- `getCustomErrorMessagesToVerifyCode`   -> `getCustomErrorMessagesForCodeVerification`


### Related Issues
- https://github.com/wso2/product-is/issues/21169