### PR TITLE
Add spId query param to non organization authenticator auth redirects

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -78,6 +78,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -127,6 +128,9 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
     private static final String ACR_VALUES_ATTRIBUTE = "acr_values";
     private static final String REQUESTED_ATTRIBUTES = "requested_attributes";
     private static final String SERVICE_PROVIDER_QUERY_KEY = "serviceProvider";
+    private static final String ORGANIZATION_AUTHENTICATOR = "OrganizationAuthenticator";
+    private static final String QUERY_ATTRIBUTE_SEPARATOR = "&";
+    private static final String REQUEST_PARAM_KEY_AUTHENTICATOR = "authenticator";
 
     public static DefaultRequestCoordinator getInstance() {
 
@@ -393,6 +397,15 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
 
                 if (!context.isLogoutRequest()) {
                     FrameworkUtils.getAuthenticationRequestHandler().handle(request, responseWrapper, context);
+                    if (!ORGANIZATION_AUTHENTICATOR.equals(request.getParameter(REQUEST_PARAM_KEY_AUTHENTICATOR))) {
+                        String redirectURL = responseWrapper.getRedirectURL();
+                        if (!StringUtils.contains(redirectURL, "spId=")) {
+                            redirectURL += QUERY_ATTRIBUTE_SEPARATOR + FrameworkConstants.REQUEST_PARAM_SP_UUID + "=" +
+                                    URLEncoder.encode(context.getServiceProviderResourceId(),
+                                            StandardCharsets.UTF_8.name());
+                            responseWrapper.sendRedirect(redirectURL);
+                        }
+                    }
                 } else {
                     FrameworkUtils.getLogoutRequestHandler().handle(request, responseWrapper, context);
                 }


### PR DESCRIPTION
### Proposed changes in this pull request

The MFA authentication pages does not applying application even though application level branding is enabled. This is due to the authenticator page URL not having the `spId` parameter. 
This PR adds the spId parameter to all authentication redirect urls that are run through the default request coordinator if they are not being processed through `OrganizationAuthenticator`.  This is since when OrganizationAuthenticator handles the request, it's at the point of SSO ing to sub org. At this point the context still holds the main organization applications `spId'. Hence adding that `spId` will result in having main org app branding in the sub org application. This scenario is already handled separately.


### Related Issue
> https://github.com/wso2-enterprise/asgardeo-product/issues/26160