### PR TITLE
Add configurations to support to force registry storage for selected tenants

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -89,6 +89,14 @@
         <XACML>{{data_storage_type.xacml}}</XACML>
     </DataStorageType>
 
+    <NotificationTemplates>
+        <LegacyTenants>
+            {% for tenant in notification_templates.legacy_tenants %}
+            <Tenant>{{tenant}}</Tenant>
+            {% endfor %}
+        </LegacyTenants>
+    </NotificationTemplates>
+
     <!-- Time configurations are in minutes -->
     <TimeConfig>
         <SessionIdleTimeout>{{session.timeout.idle_session_timeout}}</SessionIdleTimeout>


### PR DESCRIPTION
$subject. Introduce configurations needed for https://github.com/wso2-extensions/identity-event-handler-notification/pull/266

Sample configuration:
```
[notification_templates]
legacy_tenants = ["foo.com", "bar.org"]
```