### PR TITLE
Add spId query param to non organization authenticator auth redirects

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -75,9 +75,11 @@ import org.wso2.carbon.utils.DiagnosticLog;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -96,6 +98,7 @@ import javax.servlet.http.HttpServletResponse;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ACCOUNT_DISABLED_CLAIM_URI;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ACCOUNT_UNLOCK_TIME_CLAIM;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUTHENTICATOR;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AnalyticsAttributes.SESSION_ID;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.BACK_TO_FIRST_STEP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ERROR_DESCRIPTION_APP_DISABLED;
@@ -393,6 +396,23 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
 
                 if (!context.isLogoutRequest()) {
                     FrameworkUtils.getAuthenticationRequestHandler().handle(request, responseWrapper, context);
+                    if (!ORGANIZATION_AUTHENTICATOR.equals(request.getParameter(AUTHENTICATOR))) {
+                        String redirectURL = responseWrapper.getRedirectURL();
+                        URI uri = new URI(redirectURL);
+                        String query = uri.getRawQuery();
+                        if (StringUtils.isNotBlank(query)) {
+                            if (!query.contains(FrameworkConstants.REQUEST_PARAM_SP_UUID + "=")) {
+                                redirectURL = redirectURL + "&" + FrameworkConstants.REQUEST_PARAM_SP_UUID
+                                        + "=" + URLEncoder.encode(context.getServiceProviderResourceId(),
+                                        StandardCharsets.UTF_8.name());
+                            }
+                        } else {
+                            redirectURL = redirectURL + "?" + FrameworkConstants.REQUEST_PARAM_SP_UUID
+                                    + "=" + URLEncoder.encode(context.getServiceProviderResourceId(),
+                                    StandardCharsets.UTF_8.name());
+                        }
+                        responseWrapper.sendRedirect(redirectURL);
+                    }
                 } else {
                     FrameworkUtils.getLogoutRequestHandler().handle(request, responseWrapper, context);
                 }


### PR DESCRIPTION
### Proposed changes in this pull request

The MFA authentication pages does not applying application even though application level branding is enabled. This is due to the authenticator page URL not having the `spId` parameter. 
This PR adds the spId parameter to all authentication redirect urls that are run through the default request coordinator if they are not being processed through `OrganizationAuthenticator`.  This is since when OrganizationAuthenticator handles the request, it's at the point of SSO ing to sub org. At this point the context still holds the main organization applications `spId'. Hence adding that `spId` will result in having main org app branding in the sub org application. This scenario is already handled separately.
