### PR TITLE
Add config changes to support multiple email addresses and mobile numbers per user

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -804,6 +804,42 @@
 				<ReadOnly>true</ReadOnly>
 				<Description>Set the user preferred MFA option</Description>
 			</Claim>
+			<Claim>
+				<ClaimURI>http://wso2.org/claims/emailAddresses</ClaimURI>
+				<DisplayName>Email Addresses</DisplayName>
+				<AttributeID>emailAddresses</AttributeID>
+				<Description>Claim to store email addresses of the user</Description>
+				<ReadOnly>false</ReadOnly>
+				<DisplayOrder>11</DisplayOrder>
+				<SupportedByDefault />
+			</Claim>
+			<Claim>
+				<ClaimURI>http://wso2.org/claims/verifiedEmailAddresses</ClaimURI>
+				<DisplayName>Verified Email Addresses</DisplayName>
+				<AttributeID>verifiedEmailAddresses</AttributeID>
+				<Description>Claim to store verified email addresses of the user</Description>
+				<ReadOnly>false</ReadOnly>
+				<DisplayOrder>12</DisplayOrder>
+				<SupportedByDefault />
+			</Claim>
+			<Claim>
+				<ClaimURI>http://wso2.org/claims/mobileNumbers</ClaimURI>
+				<DisplayName>Mobile Numbers</DisplayName>
+				<AttributeID>mobileNumbers</AttributeID>
+				<Description>Claim to store mobile numbers of the user</Description>
+				<ReadOnly>false</ReadOnly>
+				<DisplayOrder>13</DisplayOrder>
+				<SupportedByDefault />
+			</Claim>
+			<Claim>
+				<ClaimURI>http://wso2.org/claims/verifiedMobileNumbers</ClaimURI>
+				<DisplayName>Verified Mobile Numbers</DisplayName>
+				<AttributeID>verifiedMobileNumbers</AttributeID>
+				<Description>Claim to store verified mobile numbers of the user</Description>
+				<ReadOnly>false</ReadOnly>
+				<DisplayOrder>14</DisplayOrder>
+				<SupportedByDefault />
+			</Claim>
 		</Dialect>
 
 		<Dialect dialectURI="http://schemas.xmlsoap.org/ws/2005/05/identity">
@@ -2648,6 +2684,44 @@
 				<DisplayOrder>1</DisplayOrder>
 				<SupportedByDefault/>
 				<MappedLocalClaim>http://wso2.org/claims/identity/preferredMFAOption</MappedLocalClaim>
+			</Claim>
+		</Dialect>
+		<Dialect dialectURI="urn:scim:wso2:schema">
+			<Claim>
+				<ClaimURI>urn:scim:wso2:schema:emailAddresses</ClaimURI>
+				<DisplayName>Email Addresses</DisplayName>
+				<AttributeID>emailAddresses</AttributeID>
+				<Description>Email Addresses</Description>
+				<SupportedByDefault />
+				<DisplayOrder>11</DisplayOrder>
+				<MappedLocalClaim>http://wso2.org/claims/emailAddresses</MappedLocalClaim>
+			</Claim>
+			<Claim>
+				<ClaimURI>urn:scim:wso2:schema:verifiedEmailAddresses</ClaimURI>
+				<DisplayName>Verified Email Addresses</DisplayName>
+				<AttributeID>verifiedEmailAddresses</AttributeID>
+				<Description>Verified Email Addresses</Description>
+				<SupportedByDefault />
+				<DisplayOrder>12</DisplayOrder>
+				<MappedLocalClaim>http://wso2.org/claims/verifiedEmailAddresses</MappedLocalClaim>
+			</Claim>
+			<Claim>
+				<ClaimURI>urn:scim:wso2:schema:mobileNumbers</ClaimURI>
+				<DisplayName>Mobile Numbers</DisplayName>
+				<AttributeID>mobileNumbers</AttributeID>
+				<Description>Mobile Numbers</Description>
+				<SupportedByDefault />
+				<DisplayOrder>13</DisplayOrder>
+				<MappedLocalClaim>http://wso2.org/claims/mobileNumbers</MappedLocalClaim>
+			</Claim>
+			<Claim>
+				<ClaimURI>urn:scim:wso2:schema:verifiedMobileNumbers</ClaimURI>
+				<DisplayName>Verified Mobile Numbers</DisplayName>
+				<AttributeID>verifiedMobileNumbers</AttributeID>
+				<Description>Verified Mobile Numbers</Description>
+				<SupportedByDefault />
+				<DisplayOrder>14</DisplayOrder>
+				<MappedLocalClaim>http://wso2.org/claims/verifiedMobileNumbers</MappedLocalClaim>
 			</Claim>
 		</Dialect>
 	</Dialects>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1869,6 +1869,9 @@
           <!-- When updating the claim value, it can be validated against the provided regex pattern.
           To enable this option,'EnableUserClaimInputRegexValidation' should be set to true. -->
           <EnableUserClaimInputRegexValidation>{{identity_mgt.enable_user_claim_input_regex_validation}}</EnableUserClaimInputRegexValidation>
+
+        <!-- Enable support for storing multiple email addresses and mobile numbers per user. -->
+        <EnableMultipleEmailsAndMobileNumbers>{{identity_mgt.user_claim_update.enable_multiple_emails_and_mobile_numbers}}</EnableMultipleEmailsAndMobileNumbers>
     </UserClaimUpdate>
 
      <AccountSuspension>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -491,6 +491,7 @@
   "identity_mgt.user_claim_update.uniqueness.enable": false,
   "identity_mgt.user_claim_update.uniqueness.listener_priority": "2",
   "identity_mgt.user_claim_update.uniqueness.scope_within_userstore": false,
+  "identity_mgt.user_claim_update.enable_multiple_emails_and_mobile_numbers": false,
 
   "event.default_listener.system_api_resource_management_listener.priority": "211",
   "event.default_listener.system_api_resource_management_listener.enable": true,


### PR DESCRIPTION
Reverts wso2/carbon-identity-framework#5998, these changes were reverted due to following integration test failure.

```
 [ERROR] Failures: 
 [ERROR] org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaUserTestCase.createClaims(org.wso2.identity.integration.test.scim2.rest.api.customSchema.SCIM2CustomSchemaUserTestCase)
 [ERROR] Run 1: SCIM2CustomSchemaUserTestCase.createClaims:153 » NoSuchMethod org.wso2.carbon....
 [ERROR] Run 2: SCIM2CustomSchemaUserTestCase.createClaims:153 » NoSuchMethod org.wso2.carbon....
 ```

This failure is addressed in following PR.
- https://github.com/wso2/product-is/pull/21294

Local integration tests (is-tests-scim2) were executed against the changes, and the build completed successfully.
<img width="793" alt="image" src="https://github.com/user-attachments/assets/23bc6ff5-5b59-4d5f-949f-dcd758271236">
