### PR TITLE
Support more than one browser switch by resetting initial context

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -243,6 +243,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                 if (request.getAttribute(FrameworkConstants.RESTART_LOGIN_FLOW) != null &&
                         request.getAttribute(FrameworkConstants.RESTART_LOGIN_FLOW).equals("true")) {
                     context = (AuthenticationContext) context.getProperty(FrameworkConstants.INITIAL_CONTEXT);
+                    context.setProperty(FrameworkConstants.INITIAL_CONTEXT, context.clone());
                     context.initializeAnalyticsData();
                     String contextIdIncludedQueryParams = context.getContextIdIncludedQueryParams();
                     contextIdIncludedQueryParams += FrameworkConstants.RESTART_LOGIN_FLOW_QUERY_PARAMS;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
@@ -56,13 +56,16 @@ import javax.servlet.http.HttpServletResponse;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUTHENTICATOR;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ERROR_DESCRIPTION_APP_DISABLED;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ERROR_STATUS_APP_DISABLED;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ORGANIZATION_AUTHENTICATOR;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.LOGOUT;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.TENANT_DOMAIN;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.TYPE;
@@ -278,6 +281,73 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
             Assert.assertEquals(statusMsg, ERROR_DESCRIPTION_APP_DISABLED);
 
         } catch (IdentityApplicationManagementException | IOException | URISyntaxException e) {
+            Assert.fail("Exception occurred: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testNonNullContext() {
+
+        try (MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class);
+             MockedStatic<ApplicationManagementService> applicationManagementService =
+                     mockStatic(ApplicationManagementService.class)) {
+
+            String relyingParty = "console";
+            String tenantDomain = "carbon.super";
+            String restartLoginFlow = "true";
+
+            HttpServletRequest requestMock = spy(HttpServletRequest.class);
+            HttpServletResponse responseMock = spy(HttpServletResponse.class);
+            CommonAuthRequestWrapper request = new CommonAuthRequestWrapper(requestMock);
+            CommonAuthResponseWrapper response = new CommonAuthResponseWrapper(responseMock);
+            DefaultAuthenticationRequestHandler authenticationRequestHandler =
+                    mock(DefaultAuthenticationRequestHandler.class);
+
+            DefaultRequestCoordinator defaultRequestCoordinator = new DefaultRequestCoordinator();
+
+            // Mocking request parameters
+            when(request.getParameter(FrameworkConstants.RequestParams.ISSUER)).thenReturn(relyingParty);
+            when(request.getParameter(TENANT_DOMAIN)).thenReturn(tenantDomain);
+            when(request.getAttribute(FrameworkConstants.RESTART_LOGIN_FLOW)).thenReturn(restartLoginFlow);
+            when(request.getParameter(AUTHENTICATOR)).thenReturn(ORGANIZATION_AUTHENTICATOR);
+
+            // Creating a new AuthenticationContext
+            AuthenticationContext context = new AuthenticationContext();
+            context.setTenantDomain(tenantDomain);
+            context.setServiceProviderName("consoleApplication");
+            context.setRequestType("oauth2");
+            context.setProperty(FrameworkConstants.INITIAL_CONTEXT, context.clone());
+
+            frameworkUtils.when(() -> FrameworkUtils.sendToRetryPage(any(), any(), any()))
+                    .thenThrow(new NullPointerException("Error occurred"));
+
+            when(FrameworkUtils.getContextData(request)).thenAnswer(invocation -> context);
+            when(FrameworkUtils.getAuthenticationRequestHandler()).thenReturn(authenticationRequestHandler);
+            doNothing().when(authenticationRequestHandler).handle(request, response, context);
+
+            // Mocking ApplicationManagementService behavior
+            ApplicationManagementServiceImpl mockApplicationManagementService =
+                    mock(ApplicationManagementServiceImpl.class);
+            applicationManagementService.when(ApplicationManagementService::getInstance)
+                    .thenReturn(mockApplicationManagementService);
+
+            // Mocking ServiceProvider and its properties
+            ServiceProvider serviceProvider = mock(ServiceProvider.class);
+            when(serviceProvider.isApplicationEnabled()).thenReturn(true);
+            when(mockApplicationManagementService.getServiceProviderByClientId(anyString(), anyString(), anyString()))
+                    .thenReturn(serviceProvider);
+
+            // Invoke handle method
+            defaultRequestCoordinator.handle(request, response);
+            // Return the context to the initial state
+            when(FrameworkUtils.getContextData(request)).thenAnswer(
+                    invocation -> context.getProperty(FrameworkConstants.INITIAL_CONTEXT));
+            // Invoke handle method again
+            defaultRequestCoordinator.handle(request, response);
+
+        } catch (NullPointerException e) {
+            Assert.fail("NullPointerException occurred: " + e.getMessage());
+        } catch (Exception e) {
             Assert.fail("Exception occurred: " + e.getMessage());
         }
     }


### PR DESCRIPTION
### Proposed changes in this pull request

This PR sets the initial context param in the context once again if the login flow has been restarted due to nonce cookie validation failure. This failure occurs when a browser switch occurs. Previously without this value, if a second browser switch occurs the flow stopped throwing an NPE.

### Related issues
- https://github.com/wso2/product-is/issues/21298
