### PR TITLE
Refactor action execution request data model

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/Header.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/Header.java
@@ -18,8 +18,6 @@
 
 package org.wso2.carbon.identity.action.execution.model;
 
-import java.util.Locale;
-
 /**
  * This class models the Header.
  * Header is the entity that represents additional headers sent in the action request.
@@ -32,7 +30,7 @@ public class Header {
     public Header(String name, String[] value) {
 
         // Headers are case-insensitive. Therefore, convert the key to lowercase before initiating.
-        this.name = name.toLowerCase(Locale.ROOT);
+        this.name = name;
         this.value = value;
     }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/Header.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/Header.java
@@ -28,8 +28,7 @@ public class Header {
     private final String[] value;
 
     public Header(String name, String[] value) {
-
-        // Headers are case-insensitive. Therefore, convert the key to lowercase before initiating.
+        
         this.name = name;
         this.value = value;
     }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/Header.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/Header.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.action.execution.model;
 
+import java.util.Locale;
+
 /**
  * This class models the Header.
  * Header is the entity that represents additional headers sent in the action request.
@@ -29,7 +31,8 @@ public class Header {
 
     public Header(String name, String[] value) {
 
-        this.name = name;
+        // Headers are case-insensitive. Therefore, convert the key to lowercase before initiating.
+        this.name = name.toLowerCase(Locale.ROOT);
         this.value = value;
     }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/Header.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/Header.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.action.execution.model;
+
+/**
+ * This class models the Header.
+ * Header is the entity that represents additional headers sent in the action request.
+ */
+public class Header {
+
+    private final String name;
+    private final String[] value;
+
+    public Header(String name, String[] value) {
+
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public String[] getValue() {
+
+        return value;
+    }
+}

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/Param.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/Param.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.action.execution.model;
+
+/**
+ * This class models the Param.
+ * Param is the entity that represents additional params sent in the action request.
+ */
+public class Param {
+
+    private final String name;
+    private final String[] value;
+
+    public Param(String name, String[] value) {
+
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public String[] getValue() {
+
+        return value;
+    }
+}

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/Request.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/Request.java
@@ -18,9 +18,9 @@
 
 package org.wso2.carbon.identity.action.execution.model;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 /**
  * This class models the Request.
@@ -30,25 +30,25 @@ import java.util.Map;
  */
 public abstract class Request {
 
-    protected Map<String, String[]> additionalHeaders = new HashMap<>();
-    protected Map<String, String[]> additionalParams = new HashMap<>();
+    protected List<Header> additionalHeaders = new ArrayList<>();
+    protected List<Param> additionalParams = new ArrayList<>();
 
-    public Map<String, String[]> getAdditionalHeaders() {
+    public List<Header> getAdditionalHeaders() {
 
-        return additionalHeaders != null ? Collections.unmodifiableMap(additionalHeaders) : Collections.emptyMap();
+        return additionalHeaders != null ? Collections.unmodifiableList(additionalHeaders) : Collections.emptyList();
     }
 
-    public void setAdditionalHeaders(Map<String, String[]> additionalHeaders) {
+    public void setAdditionalHeaders(List<Header> additionalHeaders) {
 
         this.additionalHeaders = additionalHeaders;
     }
 
-    public Map<String, String[]> getAdditionalParams() {
+    public List<Param> getAdditionalParams() {
 
-        return additionalParams != null ? Collections.unmodifiableMap(additionalParams) : Collections.emptyMap();
+        return additionalParams != null ? Collections.unmodifiableList(additionalParams) : Collections.emptyList();
     }
 
-    public void setAdditionalParams(Map<String, String[]> additionalParams) {
+    public void setAdditionalParams(List<Param> additionalParams) {
 
         this.additionalParams = additionalParams;
     }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/util/RequestFilter.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/util/RequestFilter.java
@@ -19,10 +19,12 @@
 package org.wso2.carbon.identity.action.execution.util;
 
 import org.wso2.carbon.identity.action.execution.model.ActionType;
+import org.wso2.carbon.identity.action.execution.model.Header;
+import org.wso2.carbon.identity.action.execution.model.Param;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -32,31 +34,31 @@ import java.util.Set;
  */
 public class RequestFilter {
 
-    public static Map<String, String[]> getFilteredHeaders(Map<String, String[]> headers, ActionType actionType) {
+    public static List<Header> getFilteredHeaders(List<Header> headers, ActionType actionType) {
 
-        Map<String, String[]> filteredHeaders = new HashMap<>();
+        List<Header> filteredHeaders = new ArrayList<>();
         Set<String> excludedHeaders = ActionExecutorConfig.getInstance()
                 .getExcludedHeadersInActionRequestForActionType(actionType);
 
-        headers.forEach((key, value) -> {
+        headers.forEach(header -> {
             // Headers are case-insensitive. Therefore, convert the key to lowercase before comparing.
-            if (!excludedHeaders.contains(key.toLowerCase(Locale.ROOT))) {
-                filteredHeaders.put(key, value);
+            if (!excludedHeaders.contains(header.getName().toLowerCase(Locale.ROOT))) {
+                filteredHeaders.add(header);
             }
         });
 
         return filteredHeaders;
     }
 
-    public static Map<String, String[]> getFilteredParams(Map<String, String[]> params, ActionType actionType) {
+    public static List<Param> getFilteredParams(List<Param> params, ActionType actionType) {
 
-        Map<String, String[]> filteredParams = new HashMap<>();
+        List<Param> filteredParams = new ArrayList<>();
         Set<String> excludedParams = ActionExecutorConfig.getInstance()
                 .getExcludedParamsInActionRequestForActionType(actionType);
 
-        params.forEach((key, value) -> {
-            if (!excludedParams.contains(key)) {
-                filteredParams.put(key, value);
+        params.forEach(param -> {
+            if (!excludedParams.contains(param.getName())) {
+                filteredParams.add(param);
             }
         });
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/util/RequestFilter.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/util/RequestFilter.java
@@ -24,7 +24,6 @@ import org.wso2.carbon.identity.action.execution.model.Param;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -41,8 +40,7 @@ public class RequestFilter {
                 .getExcludedHeadersInActionRequestForActionType(actionType);
 
         headers.forEach(header -> {
-            // Headers are case-insensitive. Therefore, convert the key to lowercase before comparing.
-            if (!excludedHeaders.contains(header.getName().toLowerCase(Locale.ROOT))) {
+            if (!excludedHeaders.contains(header.getName())) {
                 filteredHeaders.add(header);
             }
         });

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/util/RequestFilter.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/util/RequestFilter.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.action.execution.model.Param;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -40,7 +41,7 @@ public class RequestFilter {
                 .getExcludedHeadersInActionRequestForActionType(actionType);
 
         headers.forEach(header -> {
-            if (!excludedHeaders.contains(header.getName())) {
+            if (!excludedHeaders.contains(header.getName().toLowerCase(Locale.ROOT))) {
                 filteredHeaders.add(header);
             }
         });

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/ActionExecutorServiceImplTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/ActionExecutorServiceImplTest.java
@@ -41,8 +41,10 @@ import org.wso2.carbon.identity.action.execution.model.ActionType;
 import org.wso2.carbon.identity.action.execution.model.AllowedOperation;
 import org.wso2.carbon.identity.action.execution.model.Application;
 import org.wso2.carbon.identity.action.execution.model.Event;
+import org.wso2.carbon.identity.action.execution.model.Header;
 import org.wso2.carbon.identity.action.execution.model.Operation;
 import org.wso2.carbon.identity.action.execution.model.Organization;
+import org.wso2.carbon.identity.action.execution.model.Param;
 import org.wso2.carbon.identity.action.execution.model.Request;
 import org.wso2.carbon.identity.action.execution.model.Tenant;
 import org.wso2.carbon.identity.action.execution.model.User;
@@ -265,8 +267,8 @@ public class ActionExecutorServiceImplTest {
                 .thenReturn(actionExecutionResponseProcessor);
 
         // Mock RequestFilter used in Request class
-        requestFilter.when(() -> RequestFilter.getFilteredHeaders(any(), any())).thenReturn(new HashMap<>());
-        requestFilter.when(() -> RequestFilter.getFilteredParams(any(), any())).thenReturn(new HashMap<>());
+        requestFilter.when(() -> RequestFilter.getFilteredHeaders(any(), any())).thenReturn(new ArrayList<Header>());
+        requestFilter.when(() -> RequestFilter.getFilteredParams(any(), any())).thenReturn(new ArrayList<Param>());
 
         ActionExecutionRequest actionExecutionRequest = createActionExecutionRequest(actionType);
 
@@ -520,16 +522,16 @@ public class ActionExecutorServiceImplTest {
 
     private ActionExecutionRequest createActionExecutionRequest(ActionType actionType) throws Exception {
 
-        Map<String, String[]> headers = new HashMap<>();
-        headers.put("Content-Type", new String[]{"application/json"});
-        headers.put("X-Header-1", new String[]{"X-header-1-value"});
-        headers.put("X-Header-2", new String[]{"X-header-2-value"});
-        headers.put("X-Header-3", new String[]{"X-header-3-value"});
+        List<Header> headers = new ArrayList<>();
+        headers.add(new Header("Content-Type", new String[]{"application/json"}));
+        headers.add(new Header("X-Header-1", new String[]{"X-header-1-value"}));
+        headers.add(new Header("X-Header-2", new String[]{"X-header-2-value"}));
+        headers.add(new Header("X-Header-3", new String[]{"X-header-3-value"}));
 
-        Map<String, String[]> params = new HashMap<>();
-        params.put("x-param-1", new String[]{"X-param-1-value"});
-        params.put("x-param-2", new String[]{"X-param-2-value"});
-        params.put("x-param-3", new String[]{"X-param-3-value"});
+        List<Param> params = new ArrayList<>();
+        params.add(new Param("x-param-1", new String[]{"X-param-1-value"}));
+        params.add(new Param("x-param-2", new String[]{"X-param-2-value"}));
+        params.add(new Param("x-param-3", new String[]{"X-param-3-value"}));
 
         Request request = spy(mock(ConcreteRequest.class));
         setField(request, "additionalHeaders", headers);

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/RequestFilterTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/RequestFilterTest.java
@@ -24,10 +24,12 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.action.execution.model.ActionType;
+import org.wso2.carbon.identity.action.execution.model.Header;
+import org.wso2.carbon.identity.action.execution.model.Param;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Map;
+import java.util.List;
 import java.util.Set;
 
 import static org.mockito.Mockito.mockStatic;
@@ -62,16 +64,21 @@ public class RequestFilterTest {
         Mockito.when(config.getExcludedHeadersInActionRequestForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN))
                 .thenReturn(excludedHeaders);
 
-        Map<String, String[]> headers = new HashMap<>();
-        headers.put("Content-Type", new String[]{"application/json"});
-        headers.put("X-Header-1", new String[]{"X-header-1-value"});
-        headers.put("X-Header-3", new String[]{"X-header-3-value"});
+        List<Header> headers = new ArrayList<>();
+        headers.add(new Header("Content-Type", new String[]{"application/json"}));
+        headers.add(new Header("X-Header-1", new String[]{"X-header-1-value"}));
+        headers.add(new Header("X-Header-3", new String[]{"X-header-3-value"}));
 
-        Map<String, String[]> filteredHeaders =
+        List<Header> filteredHeaders =
                 RequestFilter.getFilteredHeaders(headers, ActionType.PRE_ISSUE_ACCESS_TOKEN);
         assertEquals(filteredHeaders.size(), 2);
-        assertEquals(filteredHeaders.get("Content-Type"), new String[]{"application/json"});
-        assertEquals(filteredHeaders.get("X-Header-3"), new String[]{"X-header-3-value"});
+        filteredHeaders.forEach(filteredHeader -> {
+            if (filteredHeader.getName().equalsIgnoreCase("Content-Type")) {
+                assertEquals(filteredHeader.getValue(), new String[]{"application/json"});
+            } else if (filteredHeader.getName().equalsIgnoreCase("X-Header-3")) {
+                assertEquals(filteredHeader.getValue(), new String[]{"X-header-3-value"});
+            }
+        });
     }
 
     @Test
@@ -85,15 +92,20 @@ public class RequestFilterTest {
         Mockito.when(config.getExcludedParamsInActionRequestForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN))
                 .thenReturn(excludedParams);
 
-        Map<String, String[]> params = new HashMap<>();
-        params.put("x-param-1", new String[]{"X-param-1-value"});
-        params.put("X-Param-2", new String[]{"X-Param-2-Value"});
-        params.put("x-param-3", new String[]{"X-param-3-value"});
+        List<Param> params = new ArrayList<>();
+        params.add(new Param("x-param-1", new String[]{"X-param-1-value"}));
+        params.add(new Param("X-Param-2", new String[]{"X-Param-2-Value"}));
+        params.add(new Param("x-param-3", new String[]{"X-param-3-value"}));
 
-        Map<String, String[]> filteredParams =
+        List<Param> filteredParams =
                 RequestFilter.getFilteredParams(params, ActionType.PRE_ISSUE_ACCESS_TOKEN);
         assertEquals(filteredParams.size(), 2);
-        assertEquals(filteredParams.get("x-param-3"), new String[]{"X-param-3-value"});
-        assertEquals(filteredParams.get("X-Param-2"), new String[]{"X-Param-2-Value"});
+        filteredParams.forEach(filteredParam -> {
+            if (filteredParam.getName().equalsIgnoreCase("x-param-3")) {
+                assertEquals(filteredParam.getValue(), new String[]{"X-param-3-value"});
+            } else if (filteredParam.getName().equalsIgnoreCase("X-Param-2")) {
+                assertEquals(filteredParam.getValue(), new String[]{"X-Param-2-Value"});
+            }
+        });
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/RequestFilterTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/RequestFilterTest.java
@@ -101,9 +101,9 @@ public class RequestFilterTest {
                 RequestFilter.getFilteredParams(params, ActionType.PRE_ISSUE_ACCESS_TOKEN);
         assertEquals(filteredParams.size(), 2);
         filteredParams.forEach(filteredParam -> {
-            if (filteredParam.getName().equalsIgnoreCase("x-param-3")) {
+            if (filteredParam.getName().equals("x-param-3")) {
                 assertEquals(filteredParam.getValue(), new String[]{"X-param-3-value"});
-            } else if (filteredParam.getName().equalsIgnoreCase("X-Param-2")) {
+            } else if (filteredParam.getName().equals("X-Param-2")) {
                 assertEquals(filteredParam.getValue(), new String[]{"X-Param-2-Value"});
             }
         });

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/RequestFilterTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/RequestFilterTest.java
@@ -73,9 +73,9 @@ public class RequestFilterTest {
                 RequestFilter.getFilteredHeaders(headers, ActionType.PRE_ISSUE_ACCESS_TOKEN);
         assertEquals(filteredHeaders.size(), 2);
         filteredHeaders.forEach(filteredHeader -> {
-            if (filteredHeader.getName().equalsIgnoreCase("Content-Type")) {
+            if (filteredHeader.getName().equals("Content-Type")) {
                 assertEquals(filteredHeader.getValue(), new String[]{"application/json"});
-            } else if (filteredHeader.getName().equalsIgnoreCase("X-Header-3")) {
+            } else if (filteredHeader.getName().equals("X-Header-3")) {
                 assertEquals(filteredHeader.getValue(), new String[]{"X-header-3-value"});
             }
         });


### PR DESCRIPTION
### Description
This PR updateds the action execution component by refactoring the data types of the `additionalHeaders` and `additionalParams` fields in the action request object to align with the API contract.

**Updated request object:**
```
{
    "additionalHeaders": [
        {
            "name": "accept",
            "value": [
                "application/json"
            ]
        },
        {
            "name": "cache-control",
            "value": [
                "no-cache"
            ]
        }
    ],
    "additionalParams": [
        {
            "name": "TestParam",
            "value": [
                "test"
            ]
        }
    ],
    "clientId": "r***************************a",
    "grantType": "client_credentials",
    "scopes": [
        "test_scope_1",
        "test_scope_2"
    ]
}
```

**Related Issue:**
- https://github.com/wso2/product-is/issues/21305

**Related PRs:**
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2590

**Followup Actions:**
- Merge https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2590
