### PR TITLE
Fix unit tests in action mgt

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/ActionExecutorServiceImplTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/ActionExecutorServiceImplTest.java
@@ -99,6 +99,7 @@ public class ActionExecutorServiceImplTest {
         actionExecutorConfigStatic = mockStatic(ActionExecutorConfig.class);
         ActionExecutorConfig actionExecutorConfig = mock(ActionExecutorConfig.class);
         actionExecutorConfigStatic.when(ActionExecutorConfig::getInstance).thenReturn(actionExecutorConfig);
+        when(actionExecutorConfig.getHttpConnectionPoolSize()).thenReturn(20);
         MockitoAnnotations.openMocks(this);
         ActionExecutionServiceComponentHolder actionExecutionServiceComponentHolder =
                 ActionExecutionServiceComponentHolder.getInstance();

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/APIClientTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/APIClientTest.java
@@ -81,6 +81,7 @@ public class APIClientTest {
         actionExecutorConfigStatic = mockStatic(ActionExecutorConfig.class);
         ActionExecutorConfig actionExecutorConfig = mock(ActionExecutorConfig.class);
         actionExecutorConfigStatic.when(ActionExecutorConfig::getInstance).thenReturn(actionExecutorConfig);
+        when(actionExecutorConfig.getHttpConnectionPoolSize()).thenReturn(20);
         MockitoAnnotations.openMocks(this);
         when(actionExecutorConfig.getHttpRequestRetryCount()).thenReturn(2);
         setField(apiClient, "httpClient", httpClient);


### PR DESCRIPTION
### Purpose

Note $subject

The constructor of the APIClient class sets PoolingHttpClientConnectionManager's maxTotal field to 0 which throws an exception [1]. 0 is set due to ActionExecutorConfig.getInstance().getHttpConnectionPoolSize() mocked method returning 0. This PR sets the mocked method's return value to a positive value to avoid the error.

[1] https://github.com/wso2/carbon-identity-framework/blob/ba952e5fbc5d466d9fcfc650fd924a662cbc6405/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/util/APIClient.java#L68-L69