### PR TITLE
Refactor to expose only necessary APIs.

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/pom.xml
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/pom.xml
@@ -77,9 +77,13 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>
                             org.wso2.carbon.identity.action.execution.internal,
+                            org.wso2.carbon.identity.action.execution.impl,
+                            org.wso2.carbon.identity.action.execution.util,
                         </Private-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.action.execution.internal,
+                            !org.wso2.carbon.identity.action.execution.impl,
+                            !org.wso2.carbon.identity.action.execution.util,
                             org.wso2.carbon.identity.action.execution.*;
                             version="${carbon.identity.package.export.version}"
                         </Export-Package>

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutionRequestBuilderFactory.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutionRequestBuilderFactory.java
@@ -16,8 +16,9 @@
  * under the License.
  */
 
-package org.wso2.carbon.identity.action.execution;
+package org.wso2.carbon.identity.action.execution.impl;
 
+import org.wso2.carbon.identity.action.execution.ActionExecutionRequestBuilder;
 import org.wso2.carbon.identity.action.execution.model.ActionExecutionRequest;
 import org.wso2.carbon.identity.action.execution.model.ActionType;
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutionResponseProcessorFactory.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutionResponseProcessorFactory.java
@@ -16,8 +16,9 @@
  * under the License.
  */
 
-package org.wso2.carbon.identity.action.execution;
+package org.wso2.carbon.identity.action.execution.impl;
 
+import org.wso2.carbon.identity.action.execution.ActionExecutionResponseProcessor;
 import org.wso2.carbon.identity.action.execution.model.ActionType;
 
 import java.util.HashMap;

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImpl.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.wso2.carbon.identity.action.execution;
+package org.wso2.carbon.identity.action.execution.impl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,6 +24,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.action.execution.ActionExecutionRequestBuilder;
+import org.wso2.carbon.identity.action.execution.ActionExecutionResponseProcessor;
+import org.wso2.carbon.identity.action.execution.ActionExecutorService;
 import org.wso2.carbon.identity.action.execution.exception.ActionExecutionException;
 import org.wso2.carbon.identity.action.execution.exception.ActionExecutionRequestBuilderException;
 import org.wso2.carbon.identity.action.execution.exception.ActionExecutionResponseProcessorException;

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/ActionExecutionServiceComponent.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/ActionExecutionServiceComponent.java
@@ -29,11 +29,11 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.action.execution.ActionExecutionRequestBuilder;
-import org.wso2.carbon.identity.action.execution.ActionExecutionRequestBuilderFactory;
 import org.wso2.carbon.identity.action.execution.ActionExecutionResponseProcessor;
-import org.wso2.carbon.identity.action.execution.ActionExecutionResponseProcessorFactory;
 import org.wso2.carbon.identity.action.execution.ActionExecutorService;
-import org.wso2.carbon.identity.action.execution.ActionExecutorServiceImpl;
+import org.wso2.carbon.identity.action.execution.impl.ActionExecutionRequestBuilderFactory;
+import org.wso2.carbon.identity.action.execution.impl.ActionExecutionResponseProcessorFactory;
+import org.wso2.carbon.identity.action.execution.impl.ActionExecutorServiceImpl;
 import org.wso2.carbon.identity.action.management.ActionManagementService;
 
 /**

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutionRequestBuilderFactoryTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutionRequestBuilderFactoryTest.java
@@ -16,12 +16,13 @@
  * under the License.
  */
 
-package org.wso2.carbon.identity.action.execution;
+package org.wso2.carbon.identity.action.execution.impl;
 
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.execution.ActionExecutionRequestBuilder;
 import org.wso2.carbon.identity.action.execution.model.ActionType;
 
 import static org.mockito.Mockito.when;

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutionResponseProcessorFactoryTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutionResponseProcessorFactoryTest.java
@@ -16,12 +16,13 @@
  * under the License.
  */
 
-package org.wso2.carbon.identity.action.execution;
+package org.wso2.carbon.identity.action.execution.impl;
 
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.execution.ActionExecutionResponseProcessor;
 import org.wso2.carbon.identity.action.execution.model.ActionType;
 
 import static org.mockito.Mockito.when;

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImplTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImplTest.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.wso2.carbon.identity.action.execution;
+package org.wso2.carbon.identity.action.execution.impl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -28,6 +28,8 @@ import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.execution.ActionExecutionRequestBuilder;
+import org.wso2.carbon.identity.action.execution.ActionExecutionResponseProcessor;
 import org.wso2.carbon.identity.action.execution.exception.ActionExecutionException;
 import org.wso2.carbon.identity.action.execution.exception.ActionExecutionRequestBuilderException;
 import org.wso2.carbon.identity.action.execution.internal.ActionExecutionServiceComponentHolder;

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/resources/testng.xml
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/resources/testng.xml
@@ -30,13 +30,13 @@
     </test>
     <test name="action-execution-configuration-test">
         <classes>
-            <class name="org.wso2.carbon.identity.action.execution.ActionExecutionRequestBuilderFactoryTest"/>
-            <class name="org.wso2.carbon.identity.action.execution.ActionExecutionResponseProcessorFactoryTest"/>
+            <class name="org.wso2.carbon.identity.action.execution.impl.ActionExecutionRequestBuilderFactoryTest"/>
+            <class name="org.wso2.carbon.identity.action.execution.impl.ActionExecutionResponseProcessorFactoryTest"/>
         </classes>
     </test>
     <test name="action-execution-service-test">
         <classes>
-            <class name="org.wso2.carbon.identity.action.execution.ActionExecutorServiceImplTest"/>
+            <class name="org.wso2.carbon.identity.action.execution.impl.ActionExecutorServiceImplTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves https://github.com/wso2/product-is/issues/21417

- Move service implementation classes to 'impl' package
- Expose only service interfaces at the root of the component, 'model' and 'exception' packages

### When should this PR be merged

ASAP

### System Impact

None as there are no other components that consumes packages converted to private packages

### Customer Impact

Change API contracts in implementation level only. So no impact to external users.