### PR TITLE
Fail user provision on blocking outbound provision fail

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -537,6 +537,9 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
                     .handle(mappedRoles, subjectIdentifier, extAttributesValueMap, userStoreDomain,
                             context.getTenantDomain());
         } catch (FrameworkException e) {
+            if (FrameworkUtils.isAuthenticationFailOnJitFail()) {
+                throw e;
+            }
             log.error("User provisioning failed!", e);
         } finally {
             IdentityUtil.threadLocalProperties.get().remove(FrameworkConstants.IDP_TO_LOCAL_ROLE_MAPPING);
@@ -569,6 +572,9 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
                     .handleWithV2Roles(assignedRoleIdList, subjectIdentifier, extAttributesValueMap, userStoreDomain,
                             context.getTenantDomain());
         } catch (FrameworkException e) {
+            if (FrameworkUtils.isAuthenticationFailOnJitFail()) {
+                throw e;
+            }
             log.error("User provisioning failed!", e);
         } finally {
             IdentityApplicationManagementUtil.resetThreadLocalProvisioningServiceProvider();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -537,9 +537,6 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
                     .handle(mappedRoles, subjectIdentifier, extAttributesValueMap, userStoreDomain,
                             context.getTenantDomain());
         } catch (FrameworkException e) {
-            if (FrameworkUtils.isAuthenticationFailOnJitFail()) {
-                throw e;
-            }
             log.error("User provisioning failed!", e);
         } finally {
             IdentityUtil.threadLocalProperties.get().remove(FrameworkConstants.IDP_TO_LOCAL_ROLE_MAPPING);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2942,6 +2942,16 @@ public class FrameworkUtils {
                 IdentityUtil.getProperty("JITProvisioning.SkipUsernamePatternValidation"));
     }
 
+    /**
+     * This method determines whether authentication flow should be break if JIT provisioning has failed.
+     *
+     * @return boolean Whether to fail the authentication flow.
+     */
+    public static boolean isAuthenticationFailOnJitFail() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty("JITProvisioning.FailAuthnOnProvisionFailure"));
+    }
+
 
     /**
      * This method is to provide flag about Adaptive authentication is availability.

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/IdentityProvisioningConstants.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/IdentityProvisioningConstants.java
@@ -49,6 +49,7 @@ public class IdentityProvisioningConstants {
     // Outbound provisioning constants.
     public static final String USE_USER_TENANT_DOMAIN_FOR_OUTBOUND_PROVISIONING_IN_SAAS_APPS = "OutboundProvisioning.useUserTenantDomainInSaasApps";
     public static final String APPLICATION_BASED_OUTBOUND_PROVISIONING_ENABLED = "OutboundProvisioning.enableApplicationBasedOutboundProvisioning";
+    public static final String FAIL_ON_BLOCKING_OUTBOUND_PROVISION_FAILURE = "OutboundProvisioning.FailOnBlockingOutboundProvisionFailure";
 
     public static class SQLQueries {
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/OutboundProvisioningManager.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/OutboundProvisioningManager.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.application.common.model.RoleMapping;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.provisioning.cache.ServiceProviderProvisioningConnectorCache;
 import org.wso2.carbon.identity.provisioning.cache.ServiceProviderProvisioningConnectorCacheEntry;
 import org.wso2.carbon.identity.provisioning.cache.ServiceProviderProvisioningConnectorCacheKey;
@@ -75,6 +76,7 @@ import java.util.stream.Collectors;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.CONSOLE_APPLICATION_NAME;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.LOCAL_SP;
 import static org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants.ASK_PASSWORD_CLAIM;
+import static org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants.FAIL_ON_BLOCKING_OUTBOUND_PROVISION_FAILURE;
 import static org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants.GROUP_CLAIM_URI;
 import static org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants.SELF_SIGNUP_ROLE;
 import static org.wso2.carbon.identity.provisioning.ProvisioningUtil.isApplicationBasedOutboundProvisioningEnabled;
@@ -677,9 +679,23 @@ public class OutboundProvisioningManager {
                     //DO Rollback
                 }
             } catch (Exception e) { //call() of Callable interface throws this exception
+                if (isFailOnBlockingOutBoundProvisionEnabled()) {
+                    throw new IdentityProvisioningException(e.getMessage());
+                }
                 handleException(idPName, connectorType, provisioningEntity, executors, e);
             }
         }
+    }
+
+    /**
+     * When outbound provisioning with blocking mode is enabled for any specific provisioning connector, check whether
+     * the flow should break if the outbound provisioning has failed.
+     *
+     * @return Whether request should be failed if outbound provisioning has failed in blocking outbound provision flow.
+     */
+    private boolean isFailOnBlockingOutBoundProvisionEnabled() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(FAIL_ON_BLOCKING_OUTBOUND_PROVISION_FAILURE));
     }
 
     private ProvisioningEntity getInboundProvisioningEntity(ProvisioningEntity provisioningEntity,

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisioningThread.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisioningThread.java
@@ -80,6 +80,12 @@ public class ProvisioningThread implements Callable<Boolean> {
             } else {
                 PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomainName, true);
             }
+
+            /* Skip outbound provisioning triggered for JIT provisioning flow, where the JIT outbound is disabled for
+               the configured connector. */
+            if (provisioningEntity.isJitProvisioning() && !connector.isJitProvisioningEnabled()) {
+                return true;
+            }
             ProvisionedIdentifier provisionedIdentifier = null;
             // real provisioning happens now.
             provisionedIdentifier = connector.provision(provisioningEntity);

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/test/java/org/wso2/carbon/identity/provisioning/ProvisioningThreadTest.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/test/java/org/wso2/carbon/identity/provisioning/ProvisioningThreadTest.java
@@ -126,6 +126,28 @@ public class ProvisioningThreadTest {
         }
     }
 
+    @Test
+    public void testJITProvisionFlowWithJitOutboundDisabledConnector() throws IdentityProvisioningException {
+
+        System.setProperty("carbon.home", "");
+        try (MockedStatic<PrivilegedCarbonContext> privilegedCarbonContext = mockStatic(PrivilegedCarbonContext.class);
+             MockedStatic<ProvisioningEntityCache> provisioningEntityCache =
+                     mockStatic(ProvisioningEntityCache.class)) {
+
+            provisioningEntity = new ProvisioningEntity(USER, POST, null);
+            provisioningEntity.setJitProvisioning(true);
+            CacheBackedProvisioningMgtDAO cacheBackedProvisioningMgtDAO =
+                    mockCacheBackedProvisioningMgtDAO(privilegedCarbonContext, provisioningEntityCache);
+            ProvisioningThread provisioningThread =
+                    new ProvisioningThread(provisioningEntity, "", mockConnector, connectorType,
+                            idPName, cacheBackedProvisioningMgtDAO);
+
+            when(mockConnector.isJitProvisioningEnabled()).thenReturn(false);
+            Boolean result = provisioningThread.call();
+            Assert.assertTrue(result);
+        }
+    }
+
     private CacheBackedProvisioningMgtDAO mockCacheBackedProvisioningMgtDAO(
             MockedStatic<PrivilegedCarbonContext> privilegedCarbonContext,
             MockedStatic<ProvisioningEntityCache> provisioningEntityCache) {

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/test/java/org/wso2/carbon/identity/provisioning/ProvisioningThreadTest.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/test/java/org/wso2/carbon/identity/provisioning/ProvisioningThreadTest.java
@@ -92,6 +92,8 @@ public class ProvisioningThreadTest {
                 PrivilegedCarbonContext.class)) {
             provisioningEntity = new ProvisioningEntity((ProvisioningEntityType) entityType,
                     (ProvisioningOperation) entityOperation, attributeMap);
+            provisioningEntity.setJitProvisioning(true);
+            when(mockConnector.isJitProvisioningEnabled()).thenReturn(true);
             CacheBackedProvisioningMgtDAO mockCacheBackedProvisioningMgDAO = mock(CacheBackedProvisioningMgtDAO.class);
             mockCarbonContext(privilegedCarbonContext);
             doNothing().when(mockCacheBackedProvisioningMgDAO).addProvisioningEntity(idPName, connectorType,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1223,12 +1223,14 @@
     <JITProvisioning>
         <UserNameProvisioningUI>/accountrecoveryendpoint/register.do</UserNameProvisioningUI>
         <PasswordProvisioningUI>/accountrecoveryendpoint/signup.do</PasswordProvisioningUI>
+        <FailAuthnOnProvisionFailure>false</FailAuthnOnProvisionFailure>
         <EnableEnhancedFeature>false</EnableEnhancedFeature>
     </JITProvisioning>
 
     <OutboundProvisioning>
         <ResetProvisioningEntitiesOnConfigUpdate>true</ResetProvisioningEntitiesOnConfigUpdate>
         <enableApplicationBasedOutboundProvisioning>false</enableApplicationBasedOutboundProvisioning>
+        <FailOnBlockingOutboundProvisionFailure>false</FailOnBlockingOutboundProvisionFailure>
     </OutboundProvisioning>
 
     <EventListeners>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2034,6 +2034,7 @@
             <useUserTenantDomainInSaasApps>{{outbound_provisioning_management.use_user_tenant_domain_in_saas_apps}}</useUserTenantDomainInSaasApps>
         {% endif %}
         <enableApplicationBasedOutboundProvisioning>{{outbound_provisioning_management.enable_application_based_outbound_provisioning}}</enableApplicationBasedOutboundProvisioning>
+        <FailOnBlockingOutboundProvisionFailure>{{outbound_provisioning_management.fail_on_blocking_outbound_provision_failure}}</FailOnBlockingOutboundProvisionFailure>
     </OutboundProvisioning>
 
     <Actions>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1984,6 +1984,7 @@
     <JITProvisioning>
         <UserNameProvisioningUI>{{authentication.jit_provisioning.username_provisioning_url}}</UserNameProvisioningUI>
         <PasswordProvisioningUI>{{authentication.jit_provisioning.password_provisioning_url}}</PasswordProvisioningUI>
+        <FailAuthnOnProvisionFailure>{{authentication.jit_provisioning.fail_authn_on_provision_failure}}</FailAuthnOnProvisionFailure>
         <SkipUsernamePatternValidation>{{authentication.jit_provisioning.skip_username_pattern_validation}}</SkipUsernamePatternValidation>
         <EnableEnhancedFeature>{{authentication.jit_provisioning.enable_enhanced_feature}}</EnableEnhancedFeature>
         <!-- Claims which must not delete during the syncing process of existing claim mappings with IDP claim mappings

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -522,6 +522,7 @@
   "authentication.jit_provisioning.username_provisioning_url": "/accountrecoveryendpoint/register.do",
   "authentication.jit_provisioning.password_provisioning_url": "/accountrecoveryendpoint/signup.do",
   "authentication.jit_provisioning.skip_username_pattern_validation": false,
+  "authentication.jit_provisioning.fail_authn_on_provision_failure": false,
   "authentication.jit_provisioning.enable_enhanced_feature": false,
 
   "application_mgt.enable_role_validation": false,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -517,6 +517,7 @@
   "idp_role_management.return_manually_added_local_roles": true,
   "outbound_provisioning_management.reset_provisioning_entities_on_config_update": true,
   "outbound_provisioning_management.enable_application_based_outbound_provisioning": false,
+  "outbound_provisioning_management.fail_on_blocking_outbound_provision_failure": false,
 
   "authentication_policy.check_account_exist": true,
   "authentication.jit_provisioning.username_provisioning_url": "/accountrecoveryendpoint/register.do",


### PR DESCRIPTION
### Proposed changes in this pull request

Provide configurations to fail the authentication when the JIT provisioning fail and fail provisioning when outbound provisioning fail.

```
[authentication.jit_provisioning]
fail_authn_on_provision_failure=true

[outbound_provisioning_management]
fail_on_blocking_outbound_provision_failure=true
```

### Related Issues
- https://github.com/wso2/product-is/issues/21396
- https://github.com/wso2/product-is/issues/21429
