### PR TITLE
Remove dual scopes from Notification template api access controls 

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -626,25 +626,6 @@
         <Scopes>internal_claim_meta_delete</Scopes>
     </Resource>
 
-    <!-- [Organization] Email Template Management API v1/v2 -->
-    <Resource context="(.*)/o/api/server/v(.*)/email/template-types(.*)" secured="true" http-method="GET">
-        <Scopes>internal_org_email_mgt_view</Scopes>
-    </Resource>
-
-    <!-- Email Template Management API v1/v2 -->
-    <Resource context="(.*)/api/server/v(.*)/email/template-types(.*)" secured="true" http-method="GET">
-        <Scopes>internal_email_mgt_view</Scopes>
-    </Resource>
-    <Resource context="(.*)/api/server/v(.*)/email/template-types(.*)" secured="true" http-method="POST">
-        <Scopes>internal_email_mgt_create</Scopes>
-    </Resource>
-    <Resource context="(.*)/api/server/v(.*)/email/template-types/(.*)" secured="true" http-method="PUT">
-        <Scopes>internal_email_mgt_update</Scopes>
-    </Resource>
-    <Resource context="(.*)/api/server/v1(.*)/email/template-types/(.*)" secured="true" http-method="DELETE">
-        <Scopes>internal_email_mgt_delete</Scopes>
-    </Resource>
-
     <!-- [Organization] Notification Template Management API -->
     <Resource context="(.*)/o/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="GET">
         <Scopes>internal_org_email_mgt_view,internal_org_template_mgt_view</Scopes>
@@ -680,6 +661,25 @@
     </Resource>
     <Resource context="(.*)/api/server/v(.*)/notification/reset-template-type" secured="true" http-method="POST">
         <Scopes>internal_template_mgt_delete</Scopes>
+    </Resource>
+
+    <!-- [Organization] Email Template Management API v1/v2 -->
+    <Resource context="(.*)/o/api/server/v(.*)/email/template-types(.*)" secured="true" http-method="GET">
+        <Scopes>internal_org_email_mgt_view</Scopes>
+    </Resource>
+
+    <!-- Email Template Management API v1/v2 -->
+    <Resource context="(.*)/api/server/v(.*)/email/template-types(.*)" secured="true" http-method="GET">
+        <Scopes>internal_email_mgt_view</Scopes>
+    </Resource>
+    <Resource context="(.*)/api/server/v(.*)/email/template-types(.*)" secured="true" http-method="POST">
+        <Scopes>internal_email_mgt_create</Scopes>
+    </Resource>
+    <Resource context="(.*)/api/server/v(.*)/email/template-types/(.*)" secured="true" http-method="PUT">
+        <Scopes>internal_email_mgt_update</Scopes>
+    </Resource>
+    <Resource context="(.*)/api/server/v1(.*)/email/template-types/(.*)" secured="true" http-method="DELETE">
+        <Scopes>internal_email_mgt_delete</Scopes>
     </Resource>
 
     <!-- Keystore Management API -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -675,6 +675,43 @@
             <Scopes>internal_claim_meta_delete</Scopes>
         </Resource>
 
+        <!-- [Organization] Notification Template Management API -->
+        <Resource context="(.*)/o/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="GET">
+            <Scopes>internal_org_template_mgt_view</Scopes>
+        </Resource>
+        <Resource context="(.*)/o/api/server/v(.*)/notification/sms/template-types(.*)" secured="true" http-method="GET">
+            <Scopes>internal_org_template_mgt_view</Scopes>
+        </Resource>
+
+        <!-- Notification Template Management API -->
+        <Resource context="(.*)/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="GET">
+            <Scopes>internal_template_mgt_view</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="POST">
+            <Scopes>internal_template_mgt_create</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v(.*)/notification/email/template-types/(.*)" secured="true" http-method="PUT">
+            <Scopes>internal_template_mgt_update</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v(.*)/notification/email/template-types/(.*)" secured="true" http-method="DELETE">
+            <Scopes>internal_template_mgt_delete</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v(.*)/notification/sms/template-types(.*)" secured="true" http-method="GET">
+            <Scopes>internal_template_mgt_view</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v(.*)/notification/sms/template-types(.*)" secured="true" http-method="POST">
+            <Scopes>internal_template_mgt_create</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v(.*)/notification/sms/template-types/(.*)" secured="true" http-method="PUT">
+            <Scopes>internal_template_mgt_update</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v(.*)/notification/sms/template-types/(.*)" secured="true" http-method="DELETE">
+            <Scopes>internal_template_mgt_delete</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v(.*)/notification/reset-template-type" secured="true" http-method="POST">
+            <Scopes>internal_template_mgt_delete</Scopes>
+        </Resource>
+
         <!-- [Organization] Email Template Management API v1/v2 -->
         <Resource context="(.*)/o/api/server/v(.*)/email/template-types(.*)" secured="true" http-method="GET">
             <Scopes>internal_org_email_mgt_view</Scopes>
@@ -692,43 +729,6 @@
         </Resource>
         <Resource context="(.*)/api/server/v(.*)/email/template-types/(.*)" secured="true" http-method="DELETE">
             <Scopes>internal_email_mgt_delete</Scopes>
-        </Resource>
-
-        <!-- [Organization] Notification Template Management API -->
-        <Resource context="(.*)/o/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="GET">
-            <Scopes>internal_org_email_mgt_view,internal_org_template_mgt_view</Scopes>
-        </Resource>
-        <Resource context="(.*)/o/api/server/v(.*)/notification/sms/template-types(.*)" secured="true" http-method="GET">
-            <Scopes>internal_org_template_mgt_view</Scopes>
-        </Resource>
-
-        <!-- Notification Template Management API -->
-        <Resource context="(.*)/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="GET">
-            <Scopes>internal_email_mgt_view,internal_template_mgt_view</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="POST">
-            <Scopes>internal_email_mgt_create,internal_template_mgt_create</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v(.*)/notification/email/template-types/(.*)" secured="true" http-method="PUT">
-            <Scopes>internal_email_mgt_update,internal_template_mgt_update</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v(.*)/notification/email/template-types/(.*)" secured="true" http-method="DELETE">
-            <Scopes>internal_email_mgt_delete,internal_template_mgt_delete</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v(.*)/notification/sms/template-types(.*)" secured="true" http-method="GET">
-            <Scopes>internal_template_mgt_view</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v(.*)/notification/sms/template-types(.*)" secured="true" http-method="POST">
-            <Scopes>internal_template_mgt_create</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v(.*)/notification/sms/template-types/(.*)" secured="true" http-method="PUT">
-            <Scopes>internal_template_mgt_update</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v(.*)/notification/sms/template-types/(.*)" secured="true" http-method="DELETE">
-            <Scopes>internal_template_mgt_delete</Scopes>
-        </Resource>
-        <Resource context="(.*)/api/server/v(.*)/notification/reset-template-type" secured="true" http-method="POST">
-            <Scopes>internal_template_mgt_delete</Scopes>
         </Resource>
 
         <!-- Keystore Management API -->


### PR DESCRIPTION
### Proposed changes in this pull request
The added configuration of two scopes for the same endpoint is wrong and is not currently supported. This PR fixes that by removing the old scope from the previous email template management API and keeps the new scope configuration.
This also places the notification template management API(NTM) access control definitions above email template management API(ETM)  access control definitions since the ETM API access control definition regex pattern could match the  NTM API access control definitions, resulting in the NTM requiring the ETM scopes to function.

### Related Issue 
- https://github.com/wso2/product-is/issues/21209

### Related PR 
- https://github.com/wso2/carbon-identity-framework/pull/5784