### PR TITLE
Fix null property being added to external claims

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/ExternalClaimDAO.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/ExternalClaimDAO.java
@@ -312,7 +312,9 @@ public class ExternalClaimDAO extends ClaimDAO {
                     String mappedURI = rs.getString(SQLConstants.MAPPED_URI_COLUMN);
                     String claimURI = rs.getString(SQLConstants.CLAIM_URI_COLUMN);
                     propmap = new HashMap<>();
-                    propmap.put(claimPropertyName, claimPropertyValue);
+                    if (claimPropertyName != null) {
+                        propmap.put(claimPropertyName, claimPropertyValue);
+                    }
                     ExternalClaim temp = new ExternalClaim(claimDialectURI, claimURI, mappedURI, propmap);
                     claimMap.put(localId, temp);
                 } else {


### PR DESCRIPTION
### Proposed changes in this pull request

If an external claim has no properties (null, null) is added to the property hash map of the claim. It is fixed by this PR.