### PR TITLE
Introduce ExcludedUserStoreDomains constant.

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
@@ -39,7 +39,7 @@ public class ClaimConstants {
 
     public static final String DEFAULT_ATTRIBUTE = "DefaultAttribute";
     public static final String MAPPED_LOCAL_CLAIM_PROPERTY = "MappedLocalClaim";
-    public static final String EXCLUDED_USER_STORE_DOMAINS_PROPERTY = "ExcludedUserStoreDomains";
+    public static final String EXCLUDED_USER_STORES_PROPERTY = "ExcludedUserStores";
     public static final String MIN_LENGTH = "minLength";
     public static final String MAX_LENGTH = "maxLength";
 

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
@@ -39,6 +39,7 @@ public class ClaimConstants {
 
     public static final String DEFAULT_ATTRIBUTE = "DefaultAttribute";
     public static final String MAPPED_LOCAL_CLAIM_PROPERTY = "MappedLocalClaim";
+    public static final String EXCLUDED_USER_STORE_DOMAINS_PROPERTY = "ExcludedUserStoreDomains";
     public static final String MIN_LENGTH = "minLength";
     public static final String MAX_LENGTH = "maxLength";
 


### PR DESCRIPTION
### Proposed changes in this pull request
Introduce new claim property to have excluded user store domain names.

### Related Issues
- https://github.com/wso2/product-is/issues/19991

### Related PRs
- https://github.com/wso2/carbon-kernel/pull/4110
- https://github.com/wso2-extensions/identity-governance/pull/872

### Additional Context
Multiple Emails and Mobile Numbers Feature: This improvement is particularly beneficial for features like multiple emails and mobile numbers per user. With this feature enabled, UIs display multiple claims instead of a single claim, treating one as the primary number. By excluding user stores that do not support certain attributes, we prevent errors when these features attempt to update unsupported attributes.
