### PR TITLE
Add new client to call organization discovery configuration API

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/OrganizationDiscoveryConfigDataRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/OrganizationDiscoveryConfigDataRetrievalClient.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.mgt.endpoint.util.client;
 
-import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -45,6 +44,7 @@ public class OrganizationDiscoveryConfigDataRetrievalClient {
     private static final String PROPERTIES = "properties";
     private static final String VALUE = "value";
     private static final String KEY = "key";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
 
     public Map<String, String> getDiscoveryConfiguration(String tenantDomain)
             throws OrganizationDiscoveryConfigDataRetrievalClientException {
@@ -97,6 +97,6 @@ public class OrganizationDiscoveryConfigDataRetrievalClient {
                 + String.valueOf(IdentityManagementServiceUtil.getInstance().getAppPassword());
         byte[] encoding = Base64.encodeBase64(toEncode.getBytes());
         String authHeader = new String(encoding, Charset.defaultCharset());
-        httpMethod.addHeader(HTTPConstants.HEADER_AUTHORIZATION, CLIENT + authHeader);
+        httpMethod.addHeader(AUTHORIZATION_HEADER, CLIENT + authHeader);
     }
 }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/OrganizationDiscoveryConfigDataRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/OrganizationDiscoveryConfigDataRetrievalClient.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.mgt.endpoint.util.client;
+
+import org.apache.axis2.transport.http.HTTPConstants;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil;
+import org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementServiceUtil;
+import org.wso2.carbon.utils.HTTPClientUtils;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+
+public class OrganizationDiscoveryConfigDataRetrievalClient {
+
+    private static final String CLIENT = "Client ";
+    private static final String ORG_DISCOVERY_CONFIG_ENDPOINT = "/api/server/v1/organization-configs/discovery";
+    private static final String PROPERTIES = "properties";
+    private static final String VALUE = "value";
+    private static final String KEY = "key";
+
+    public Map<String, String> getDiscoveryConfiguration(String tenantDomain)
+            throws OrganizationDiscoveryConfigDataRetrievalClientException {
+
+        Map<String, String> organizationDiscoveryConfig = new HashMap<>();
+
+        try (CloseableHttpClient httpClient = HTTPClientUtils.createClientWithCustomVerifier().build()) {
+            HttpGet request = new HttpGet(getOrganizationDiscoveryConfigEndpoint(tenantDomain));
+            setAuthorizationHeader(request);
+
+            try (CloseableHttpResponse httpResponse = httpClient.execute(request)) {
+                if (httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+                    JSONObject configObject =  new JSONObject(new JSONTokener(new InputStreamReader(
+                            httpResponse.getEntity().getContent())));
+
+                    if (configObject.has(PROPERTIES) && configObject.get(PROPERTIES) instanceof JSONArray) {
+                        JSONArray properties = configObject.getJSONArray(PROPERTIES);
+                        for (int i = 0; i < properties.length(); i++) {
+                            JSONObject property = properties.getJSONObject(i);
+                            organizationDiscoveryConfig.put(property.getString(KEY), property.getString(VALUE));
+                        }
+                    }
+                }
+                return organizationDiscoveryConfig;
+
+            } finally {
+                request.releaseConnection();
+            }
+        } catch (IOException e) {
+            throw new OrganizationDiscoveryConfigDataRetrievalClientException("Error while retrieving organization " +
+                    "discovery configuration for tenant: " + tenantDomain, e);
+        }
+
+    }
+
+    private String getOrganizationDiscoveryConfigEndpoint(String tenantDomain)
+            throws OrganizationDiscoveryConfigDataRetrievalClientException {
+
+        try {
+            return IdentityManagementEndpointUtil.getBasePath(tenantDomain, ORG_DISCOVERY_CONFIG_ENDPOINT);
+        } catch (ApiException e) {
+            throw new OrganizationDiscoveryConfigDataRetrievalClientException("Error while building url for context: " +
+                    ORG_DISCOVERY_CONFIG_ENDPOINT);
+        }
+    }
+
+    private void setAuthorizationHeader(HttpRequestBase httpMethod) {
+
+        String toEncode = IdentityManagementServiceUtil.getInstance().getAppName() + ":"
+                + String.valueOf(IdentityManagementServiceUtil.getInstance().getAppPassword());
+        byte[] encoding = Base64.encodeBase64(toEncode.getBytes());
+        String authHeader = new String(encoding, Charset.defaultCharset());
+        httpMethod.addHeader(HTTPConstants.HEADER_AUTHORIZATION, CLIENT + authHeader);
+    }
+}

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/OrganizationDiscoveryConfigDataRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/OrganizationDiscoveryConfigDataRetrievalClient.java
@@ -37,6 +37,10 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Client which interacts with the organization discovery configuration API
+ * to retrieve organization discovery configuration data.
+ */
 public class OrganizationDiscoveryConfigDataRetrievalClient {
 
     private static final String CLIENT = "Client ";
@@ -46,6 +50,14 @@ public class OrganizationDiscoveryConfigDataRetrievalClient {
     private static final String KEY = "key";
     private static final String AUTHORIZATION_HEADER = "Authorization";
 
+    /**
+     * Retrieves organization discovery configuration data for a given organization.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return Organization discovery configuration data.
+     * @throws OrganizationDiscoveryConfigDataRetrievalClientException If an error occurs while retrieving organization
+     *                                                                 discovery configuration data.
+     */
     public Map<String, String> getDiscoveryConfiguration(String tenantDomain)
             throws OrganizationDiscoveryConfigDataRetrievalClientException {
 
@@ -57,7 +69,7 @@ public class OrganizationDiscoveryConfigDataRetrievalClient {
 
             try (CloseableHttpResponse httpResponse = httpClient.execute(request)) {
                 if (httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
-                    JSONObject configObject =  new JSONObject(new JSONTokener(new InputStreamReader(
+                    JSONObject configObject = new JSONObject(new JSONTokener(new InputStreamReader(
                             httpResponse.getEntity().getContent())));
 
                     if (configObject.has(PROPERTIES) && configObject.get(PROPERTIES) instanceof JSONArray) {
@@ -69,7 +81,6 @@ public class OrganizationDiscoveryConfigDataRetrievalClient {
                     }
                 }
                 return organizationDiscoveryConfig;
-
             } finally {
                 request.releaseConnection();
             }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/OrganizationDiscoveryConfigDataRetrievalClientException.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/OrganizationDiscoveryConfigDataRetrievalClientException.java
@@ -18,7 +18,12 @@
 
 package org.wso2.carbon.identity.mgt.endpoint.util.client;
 
-public class OrganizationDiscoveryConfigDataRetrievalClientException extends Exception {
+import org.wso2.carbon.identity.base.IdentityException;
+
+/**
+ * Exception for organization discovery config data retrieval.
+ */
+public class OrganizationDiscoveryConfigDataRetrievalClientException extends IdentityException {
 
     /**
      * Client Exception with error message.
@@ -26,6 +31,7 @@ public class OrganizationDiscoveryConfigDataRetrievalClientException extends Exc
      * @param message Error message.
      */
     public OrganizationDiscoveryConfigDataRetrievalClientException(String message) {
+
         super(message);
     }
 
@@ -36,7 +42,21 @@ public class OrganizationDiscoveryConfigDataRetrievalClientException extends Exc
      * @param throwable Throwable.
      */
     public OrganizationDiscoveryConfigDataRetrievalClientException(String message, Throwable throwable) {
+
         super(message, throwable);
+    }
+
+    /**
+     * Client exception with error code, message and a throwable.
+     *
+     * @param errorCode Error code.
+     * @param message   Error message.
+     * @param throwable Throwable.
+     */
+    public OrganizationDiscoveryConfigDataRetrievalClientException(String errorCode, String message,
+                                                                   Throwable throwable) {
+
+        super(errorCode, message, throwable);
     }
 
 }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/OrganizationDiscoveryConfigDataRetrievalClientException.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/OrganizationDiscoveryConfigDataRetrievalClientException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.mgt.endpoint.util.client;
+
+public class OrganizationDiscoveryConfigDataRetrievalClientException extends Exception {
+
+    /**
+     * Client Exception with error message.
+     *
+     * @param message Error message.
+     */
+    public OrganizationDiscoveryConfigDataRetrievalClientException(String message) {
+        super(message);
+    }
+
+    /**
+     * Client exception with message and a throwable.
+     *
+     * @param message   Error message.
+     * @param throwable Throwable.
+     */
+    public OrganizationDiscoveryConfigDataRetrievalClientException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+
+}

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/test/java/org/wso2/carbon/identity/mgt/endpoint/util/OrganizationDiscoveryConfigDataRetrievalClientTest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/test/java/org/wso2/carbon/identity/mgt/endpoint/util/OrganizationDiscoveryConfigDataRetrievalClientTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.mgt.endpoint.util;
+
+import org.mockito.MockedStatic;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.mgt.endpoint.util.client.OrganizationDiscoveryConfigDataRetrievalClient;
+import org.wso2.carbon.utils.HTTPClientUtils;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+public class OrganizationDiscoveryConfigDataRetrievalClientTest extends RetrievalClientBaseTest {
+
+    private final OrganizationDiscoveryConfigDataRetrievalClient orgDiscoveryConfigDataRetrievalClient =
+            new OrganizationDiscoveryConfigDataRetrievalClient();
+
+    @BeforeTest
+    public void setMockData() throws IOException {
+
+        setMockJsonResponse(readResource("OrganizationDiscoveryConfigResponse.json"));
+    }
+
+    @Test
+    public void testGetDiscoveryConfiguration() throws Exception {
+
+        try (MockedStatic<IdentityManagementServiceUtil> identityMgtServiceUtil = mockStatic(
+                IdentityManagementServiceUtil.class);
+             MockedStatic<HTTPClientUtils> httpclientUtil = mockStatic(HTTPClientUtils.class)) {
+            identityMgtServiceUtil.when(IdentityManagementServiceUtil::getInstance)
+                    .thenReturn(identityManagementServiceUtil);
+            httpclientUtil.when(HTTPClientUtils::createClientWithCustomVerifier).thenReturn(httpClientBuilder);
+            Map<String, String> result =
+                    orgDiscoveryConfigDataRetrievalClient.getDiscoveryConfiguration(SUPER_TENANT_DOMAIN);
+            Assert.assertEquals(result.size(), 2);
+            Assert.assertEquals(result.get("emailDomain.enable"), "true");
+            Assert.assertEquals(result.get("emailDomainBasedSelfSignup.enable"), "true");
+        }
+    }
+}

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/test/java/org/wso2/carbon/identity/mgt/endpoint/util/OrganizationDiscoveryConfigDataRetrievalClientTest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/test/java/org/wso2/carbon/identity/mgt/endpoint/util/OrganizationDiscoveryConfigDataRetrievalClientTest.java
@@ -28,8 +28,11 @@ import org.wso2.carbon.utils.HTTPClientUtils;
 import java.io.IOException;
 import java.util.Map;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mockStatic;
 
+/**
+ * Unit tests for OrganizationDiscoveryConfigDataRetrievalClient class.
+ */
 public class OrganizationDiscoveryConfigDataRetrievalClientTest extends RetrievalClientBaseTest {
 
     private final OrganizationDiscoveryConfigDataRetrievalClient orgDiscoveryConfigDataRetrievalClient =

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/test/resources/responses/OrganizationDiscoveryConfigResponse.json
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/test/resources/responses/OrganizationDiscoveryConfigResponse.json
@@ -1,0 +1,12 @@
+{
+  "properties": [
+    {
+      "key": "emailDomain.enable",
+      "value": "true"
+    },
+    {
+      "key": "emailDomainBasedSelfSignup.enable",
+      "value": "true"
+    }
+  ]
+}

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/test/resources/testng.xml
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/test/resources/testng.xml
@@ -31,6 +31,7 @@
             <class name="org.wso2.carbon.identity.mgt.endpoint.util.IdentityProviderDataRetrievalClientTest"/>
             <class name="org.wso2.carbon.identity.mgt.endpoint.util.RecoveryApiV2Test"/>
             <class name="org.wso2.carbon.identity.mgt.endpoint.util.ValidationConfigurationRetrievalClientTest"/>
+            <class name="org.wso2.carbon.identity.mgt.endpoint.util.OrganizationDiscoveryConfigDataRetrievalClientTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
### Proposed changes in this pull request
This PR adds a new client to call the organization discovery configuration API in order to retrieve the discovery configurations of a specific organization  

### When should this PR be merged
This should be merged after all prs of the below task is merged.
- https://github.com/wso2/product-is/issues/21572

### Related issue
- https://github.com/wso2/product-is/issues/21595
