### PR TITLE
Add notification_templates.sms_templates.apply config.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -95,6 +95,9 @@
             <Tenant>{{tenant}}</Tenant>
             {% endfor %}
         </LegacyTenants>
+        <SMSTemplates>
+            <Apply>{{notification_templates.sms_templates.apply}}</Apply>
+        </SMSTemplates>
     </NotificationTemplates>
 
     <!-- Time configurations are in minutes -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1690,6 +1690,8 @@
 
   "oauth.authorize_all_scopes": false,
 
-  "system_applications.system_portals": ["Console", "My Account"]
+  "system_applications.system_portals": ["Console", "My Account"],
+
+  "notification_templates.sms_templates.apply": true
 }
 


### PR DESCRIPTION
### Proposed changes in this pull request

This PR adds a config to control whether to apply sms templates or not.  This config is only introduced as a fall back option disable the fix being introduced for the main issue attacked. 
This will be removed once the fix is confirmed. 

### Related Issue
- https://github.com/wso2/product-is/issues/21620

### Related PRs
- https://github.com/wso2-extensions/identity-local-auth-smsotp/pull/25
- https://github.com/wso2-extensions/identity-event-handler-notification/pull/273
