### PR TITLE
Add create and delete scopes to access control for SCIM2 Roles endpoint in org level

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -655,8 +655,12 @@
         <Scopes>
             <Scope displayName="View Role" name="internal_org_role_mgt_view" 
                     description="View roles details in the organization"/>
+            <Scope displayName="Create Role" name="internal_org_role_mgt_create"
+                    description="Create new roles in the organization"/>
             <Scope displayName="Update Role" name="internal_org_role_mgt_update" 
                     description="Update roles details in the organization"/>
+            <Scope displayName="Delete Role" name="internal_org_role_mgt_delete"
+                    description="Delete roles in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="SCIM2 Bulk API" identifier="/scim2/Bulk" requiresAuthorization="true"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -664,8 +664,12 @@
         <Scopes>
             <Scope displayName="View Role" name="internal_org_role_mgt_view" 
                     description="View roles details in the organization"/>
+            <Scope displayName="Create Role" name="internal_org_role_mgt_create"
+                    description="Create new roles in the organization"/>
             <Scope displayName="Update Role" name="internal_org_role_mgt_update" 
                     description="Update roles details in the organization"/>
+            <Scope displayName="Delete Role" name="internal_org_role_mgt_delete"
+                    description="Delete roles in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="SCIM2 Bulk API" identifier="/scim2/Bulk" requiresAuthorization="true"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -326,6 +326,9 @@
         <Permissions>/permission/admin/manage/identity/rolemgt/view</Permissions>
         <Scopes>internal_org_role_mgt_view</Scopes>
     </Resource>
+    <Resource context="(.*)/o/scim2/v2/Roles(.*)" secured="true" http-method="POST">
+        <Scopes>internal_org_role_mgt_create</Scopes>
+    </Resource>
     <Resource context="(.*)/o/scim2/v2/Roles/(.*)" secured="true" http-method="PUT">
         <Permissions>/permission/admin/manage/identity/rolemgt/update</Permissions>
         <Scopes>internal_org_role_mgt_update</Scopes>
@@ -333,6 +336,9 @@
     <Resource context="(.*)/o/scim2/v2/Roles/(.*)" secured="true" http-method="PATCH">
         <Permissions>/permission/admin/manage/identity/rolemgt/update</Permissions>
         <Scopes>internal_org_role_mgt_update</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/scim2/v2/Roles/(.*)" secured="true" http-method="DELETE">
+        <Scopes>internal_org_role_mgt_delete</Scopes>
     </Resource>
 
     <!-- SCIM2 Users API -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -350,6 +350,9 @@
             <Permissions>/permission/admin/manage/identity/rolemgt/view</Permissions>
             <Scopes>internal_org_role_mgt_view</Scopes>
         </Resource>
+        <Resource context="(.*)/o/scim2/v2/Roles(.*)" secured="true" http-method="POST">
+             <Scopes>internal_org_role_mgt_create</Scopes>
+        </Resource>
         <Resource context="(.*)/o/scim2/v2/Roles/(.*)" secured="true" http-method="PUT">
             <Permissions>/permission/admin/manage/identity/rolemgt/update</Permissions>
             <Scopes>internal_org_role_mgt_update</Scopes>
@@ -357,6 +360,9 @@
         <Resource context="(.*)/o/scim2/v2/Roles/(.*)" secured="true" http-method="PATCH">
             <Permissions>/permission/admin/manage/identity/rolemgt/update</Permissions>
             <Scopes>internal_org_role_mgt_update</Scopes>
+        </Resource>
+        <Resource context="(.*)/o/scim2/v2/Roles/(.*)" secured="true" http-method="DELETE">
+            <Scopes>internal_org_role_mgt_delete</Scopes>
         </Resource>
 
         <!-- SCIM2 Users API -->


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject
- Improvement for https://github.com/wso2/product-is/issues/21208
- Allowing to create and delete sub organization level roles through the implementation of [1]
- Before merging this, we need to merge [1]

[1] https://github.com/wso2/carbon-identity-framework/pull/6010