### PR TITLE
Add new authenticator configs for user defined auth extensions.

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/UserDefinedAuthenticatorEndpointConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/UserDefinedAuthenticatorEndpointConfig.java
@@ -18,9 +18,11 @@
 
 package org.wso2.carbon.identity.application.common.model;
 
+import org.wso2.carbon.identity.action.management.model.AuthProperty;
 import org.wso2.carbon.identity.action.management.model.Authentication;
 import org.wso2.carbon.identity.action.management.model.EndpointConfig;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -38,6 +40,40 @@ public class UserDefinedAuthenticatorEndpointConfig {
     public EndpointConfig getEndpointConfig() {
 
         return endpointConfig;
+    }
+
+    /**
+     * Get the URI of the authenticator endpoint of the user defined authenticator.
+     *
+     * @return URI of the authenticator endpoint.
+     */
+    public String getAuthenticatorEndpointUri() {
+
+        return endpointConfig.getUri();
+    }
+
+    /**
+     * Get the authentication type of the authenticator endpoint of the user defined authenticator.
+     *
+     * @return Authentication type of the authenticator endpoint.
+     */
+    public String getAuthenticatorEndpointAuthenticationType() {
+
+        return endpointConfig.getAuthentication().getType().getName();
+    }
+
+    /**
+     * Get the authentication properties of the authenticator endpoint of the user defined authenticator.
+     *
+     * @return Authentication properties of the authenticator endpoint.
+     */
+    public Map<String, String> getAuthenticatorEndpointAuthenticationProperties() {
+
+        Map<String, String> propertyMap = new HashMap<>();
+        for (AuthProperty prop: endpointConfig.getAuthentication().getProperties()) {
+            propertyMap.put(prop.getName(), prop.getValue());
+        }
+        return propertyMap;
     }
 
     /**

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/test/java/org/wso2/carbon/identity/application/common/model/test/UserDefinedAuthenticatorTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/test/java/org/wso2/carbon/identity/application/common/model/test/UserDefinedAuthenticatorTest.java
@@ -85,11 +85,9 @@ public class UserDefinedAuthenticatorTest {
         endpointConfigBuilder.authenticationProperties(endpointConfig);
         UserDefinedAuthenticatorEndpointConfig authEndpointConfig = endpointConfigBuilder.build();
 
-        assertEquals(authEndpointConfig.getEndpointConfig().getUri(), uri);
-        assertEquals(authEndpointConfig.getEndpointConfig().getAuthentication().getType().getName(),
-                authenticationType);
-        assertEquals(authEndpointConfig.getEndpointConfig().getAuthentication().getProperties().size(),
-                endpointConfig.size());
+        assertEquals(authEndpointConfig.getAuthenticatorEndpointUri(), uri);
+        assertEquals(authEndpointConfig.getAuthenticatorEndpointAuthenticationType(), authenticationType);
+        assertEquals(authEndpointConfig.getAuthenticatorEndpointAuthenticationProperties(), endpointConfig);
     }
 
     @DataProvider(name = "invalidEndpointConfig")


### PR DESCRIPTION
Issue: 
- https://github.com/wso2/product-is/issues/21216

With this PR, we added getters to retrieve the endpoint configurations of user defined authenticators.

Related PR:
- https://github.com/wso2/carbon-identity-framework/pull/6108