### PR TITLE
Add config to read TokenType for custom token issuers

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -450,11 +450,13 @@
         <!--<SupportedTokenTypes>-->
             <!--<SupportedTokenType>-->
                 <!--<TokenTypeName>Default</TokenTypeName>-->
+                <!--<TokenType>JWT</TokenType>-->
                 <!--<TokenTypeImplClass>org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImpl</TokenTypeImplClass>-->
                 <!--<PersistAccessTokenAlias>true</PersistAccessTokenAlias>-->
             <!--</SupportedTokenType>-->
             <!--<SupportedTokenType>-->
                 <!--<TokenTypeName>JWT</TokenTypeName>-->
+                <!--<TokenType>JWT</TokenType>-->
                 <!--<TokenTypeImplClass>org.wso2.carbon.identity.oauth2.token.JWTTokenIssuer</TokenTypeImplClass>-->
                 <!--<PersistAccessTokenAlias>true</PersistAccessTokenAlias>-->
             <!--</SupportedTokenType>-->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -275,6 +275,7 @@
         -->
         {% if oauth.extensions.token_generator is defined %}
         <IdentityOAuthTokenGenerator>{{oauth.extensions.token_generator}}</IdentityOAuthTokenGenerator>
+        <TokenType>{{oauth.extensions.token_type}}</TokenType>
         {% else %}
         <IdentityOAuthTokenGenerator>org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImpl</IdentityOAuthTokenGenerator>
         {% endif %}
@@ -749,6 +750,7 @@
            {% for token_type in oauth.extensions.token_types %}
            <SupportedTokenType>
               <TokenTypeName>{{token_type.name}}</TokenTypeName>
+              <TokenType>{{token_type.type}}</TokenType>
               <TokenTypeImplClass>{{token_type.issuer}}</TokenTypeImplClass>
               {% if token_type.persist_access_token_alias is defined %}
               <PersistAccessTokenAlias>{{token_type.persist_access_token_alias}}</PersistAccessTokenAlias>


### PR DESCRIPTION
### Proposed changes in this pull request
Ability to read the TokenType for custom token issuers.

### Related Git Issues
- https://github.com/wso2/product-is/issues/20994
- https://github.com/wso2/product-is/issues/21122
- https://github.com/wso2/product-is/issues/21355

### Related PRs
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2625