### PR TITLE
Update api-resource-collection.xml for updated organization discovery configuration scopes.

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -373,6 +373,7 @@
             </Feature>
             <Update>
                 <Scope name="internal_organization_update"/>
+                <Scope name="internal_organization_config_update"/>
             </Update>
             <Delete>
                 <Scope name="internal_organization_delete"/>
@@ -395,6 +396,7 @@
             </Feature>
             <Update>
                 <Scope name="internal_organization_discovery_update"/>
+                <Scope name="internal_organization_config_update"/>
             </Update>
             <Delete>
                 <Scope name="internal_organization_discovery_delete"/>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -414,6 +414,7 @@
             </Feature>
             <Update>
                 <Scope name="internal_organization_update"/>
+                <Scope name="internal_organization_config_update"/>
             </Update>
             <Delete>
                 <Scope name="internal_organization_delete"/>
@@ -436,6 +437,7 @@
             </Feature>
             <Update>
                 <Scope name="internal_organization_discovery_update"/>
+                <Scope name="internal_organization_config_update"/>
             </Update>
             <Delete>
                 <Scope name="internal_organization_discovery_delete"/>


### PR DESCRIPTION
### Purpose

Along with the related issue [2], The console was improved to send a PUT request to update the organization discovery configs instead of POST and DELETE calls. Along with this pr, the `internal_organization_config_update` scope will be added which is required to call the PUT endpoint. 

In order to ensure compatibility and to reduce issues in case the improvements done in [2] is reverted, the removal of  
`internal_organization_config_add` and `internal_organization_config_delete` scopes will done separately via the below pr
- https://github.com/wso2/carbon-identity-framework/pull/6161
 
### Related issues
- https://github.com/wso2/product-is/issues/21572
- https://github.com/wso2/product-is/issues/21610