### PR TITLE
[Public Fix] Add configuration for accepting user credentials in query parameters

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -62,6 +62,8 @@ public class IdentityCoreConstants {
 
     public static final String USER_ACCOUNT_DISABLED = " User account is disabled";
 
+    public static final String ALLOW_SENSITIVE_DATA_IN_URL = "RequestParameters.AllowSensitiveDataInURL";
+
     //UserCoreConstants class define the rest of the relevant error codes.
     public static final String USER_ACCOUNT_LOCKED_ERROR_CODE = "17003";
     public static final String USER_ACCOUNT_DISABLED_ERROR_CODE = "17004";

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -100,6 +100,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
 
+import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.ALLOW_SENSITIVE_DATA_IN_URL;
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.ALPHABET;
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.ENCODED_ZERO;
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.INDEXES;
@@ -1253,6 +1254,16 @@ public class IdentityUtil {
         String disableEmailUsernameValidationProperty = ServerConfiguration.getInstance()
                 .getFirstProperty(DISABLE_EMAIL_USERNAME_VALIDATION);
         return Boolean.parseBoolean(disableEmailUsernameValidationProperty);
+    }
+
+    /**
+     * Checks whether sensitive data is allowed to be included in URLs.
+     *
+     * @return true if sensitive data is allowed in URLs, false otherwise.
+     */
+    public static boolean shouldAllowSensitiveDataInURL() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(ALLOW_SENSITIVE_DATA_IN_URL));
     }
 
      /**

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3332,4 +3332,9 @@
     <CertThumbprint>
         <EnableSHA256>{{cert_thumbprint.enable_sha256}}</EnableSHA256>
     </CertThumbprint>
+
+    <!-- Configuration settings for the request parameters.  -->
+    <RequestParameters>
+        <AllowSensitiveDataInURL>{{request_parameters.allow_sensitive_data_in_url}}</AllowSensitiveDataInURL>
+    </RequestParameters>
 </Server>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -922,5 +922,6 @@
 
   "show_pending_user_information.enable": true,
   "identity_util.enable_sha256": false,
-  "cert_thumbprint.enable_sha256": false
+  "cert_thumbprint.enable_sha256": false,
+  "request_parameters.allow_sensitive_data_in_url": true
 }


### PR DESCRIPTION
Front-port: https://github.com/wso2-support/carbon-identity-framework/pull/3098

### Purpose
This PR adds the configuration request_parameters.allow_sensitive_data_in_url, which allows or prevents the processing of sensitive data (e.g., username, password, client secret) sent as query parameters in requests.