### PR TITLE
Fix unnecessary diagnostic log in token flow

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImpl.java
@@ -117,10 +117,8 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
             DIAGNOSTIC_LOGGER.logActionInitiation(action);
             return execute(action, eventContext);
         } catch (ActionExecutionRuntimeException e) {
-            DIAGNOSTIC_LOGGER.logSkippedActionExecution(actionType);
             LOG.debug("Skip executing actions for action type: " + actionType.name(), e);
-            // Skip executing actions when no action available or due to a failure in retrieving actions,
-            // is considered as action execution being successful.
+            // Skip executing actions when no action available is considered as action execution being successful.
             return new SuccessStatus.Builder().setResponseContext(eventContext).build();
         }
     }
@@ -144,10 +142,8 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
         try {
             return execute(action, eventContext);
         } catch (ActionExecutionRuntimeException e) {
-            DIAGNOSTIC_LOGGER.logSkippedActionExecution(actionType);
             LOG.debug("Skip executing actions for action type: " + actionType.name(), e);
-            // Skip executing actions when no action available or due to a failure in retrieving actions,
-            // is considered as action execution being successful.
+            // Skip executing actions when no action available is considered as action execution being successful.
             return new SuccessStatus.Builder().setResponseContext(eventContext).build();
         }
     }
@@ -191,13 +187,13 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
     }
 
     private List<Action> getActionsByActionType(ActionType actionType, String tenantDomain) throws
-            ActionExecutionRuntimeException {
+            ActionExecutionException {
 
         try {
             return ActionExecutionServiceComponentHolder.getInstance().getActionManagementService()
                     .getActionsByActionType(Action.ActionTypes.valueOf(actionType.name()).getPathParam(), tenantDomain);
         } catch (ActionMgtException e) {
-            throw new ActionExecutionRuntimeException("Error occurred while retrieving actions.", e);
+            throw new ActionExecutionException("Error occurred while retrieving actions.", e);
         }
     }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/util/ActionExecutionDiagnosticLogger.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/util/ActionExecutionDiagnosticLogger.java
@@ -21,7 +21,6 @@ package org.wso2.carbon.identity.action.execution.util;
 import org.apache.http.client.methods.HttpPost;
 import org.wso2.carbon.identity.action.execution.ActionExecutionLogConstants;
 import org.wso2.carbon.identity.action.execution.model.ActionInvocationResponse;
-import org.wso2.carbon.identity.action.execution.model.ActionType;
 import org.wso2.carbon.identity.action.management.model.Action;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.utils.DiagnosticLog;
@@ -45,19 +44,6 @@ public class ActionExecutionDiagnosticLogger {
                         ActionExecutionLogConstants.ActionIDs.EXECUTE_ACTION,
                         action.getType().getDisplayName() + " action execution is initiated.",
                         DiagnosticLog.ResultStatus.SUCCESS));
-    }
-
-    public void logSkippedActionExecution(ActionType actionType) {
-
-        if (!LoggerUtils.isDiagnosticLogsEnabled()) {
-            return;
-        }
-
-        triggerLogEvent(
-                initializeDiagnosticLogBuilder(
-                        ActionExecutionLogConstants.ActionIDs.EXECUTE_ACTION,
-                        "Skip executing action for " + actionType + " type.",
-                        DiagnosticLog.ResultStatus.FAILED));
     }
 
     public void logActionRequest(Action action) {

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImplTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImplTest.java
@@ -231,6 +231,16 @@ public class ActionExecutorServiceImplTest {
     }
 
     @Test(expectedExceptions = ActionExecutionException.class,
+            expectedExceptionsMessageRegExp = "Error occurred while retrieving actions.")
+    public void testActionExecuteWithActionFailureWhenInvalidActionGiven() throws Exception {
+
+        when(actionManagementService.getActionsByActionType(any(), any())).thenThrow(
+                new ActionMgtException("Error occurred while retrieving actions."));
+
+        actionExecutorService.execute(ActionType.PRE_ISSUE_ACCESS_TOKEN, any(), any());
+    }
+
+    @Test(expectedExceptions = ActionExecutionException.class,
             expectedExceptionsMessageRegExp = "Failed to build the request payload for action type: " +
                     "PRE_ISSUE_ACCESS_TOKEN")
     public void testActionExecuteFailureWhenBuildingActionExecutionRequestForActionId() throws Exception {


### PR DESCRIPTION
#### Proposed changes

- Mainly this PR includes the fix for the referenced issue regarding diagnostic logs. 
- Additionally it changes the behavior to only consider "No actions found" scenario to be a SUCCESS status and consider "Error occurred while retrieving actions" as failure scenario where it throws an ActionExecutionException to destruct the access token issuance.

#### Related issues

- https://github.com/wso2/product-is/issues/21825