### PR TITLE
Update api-resource-collection.xml to delete unused organization discovery config scopes.

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -376,11 +376,9 @@
             </Update>
             <Delete>
                 <Scope name="internal_organization_delete"/>
-                <Scope name="internal_organization_config_delete"/>
             </Delete>
             <Create>
                 <Scope name="internal_organization_create"/>
-                <Scope name="internal_organization_config_add"/>
             </Create>
             <Read>
                 <Scope name="internal_organization_view"/>
@@ -398,11 +396,9 @@
             </Update>
             <Delete>
                 <Scope name="internal_organization_discovery_delete"/>
-                <Scope name="internal_organization_config_delete"/>
             </Delete>
             <Create>
                 <Scope name="internal_organization_discovery_update"/>
-                <Scope name="internal_organization_config_add"/>
             </Create>
             <Read>
                 <Scope name="internal_organization_discovery_view"/>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -417,11 +417,9 @@
             </Update>
             <Delete>
                 <Scope name="internal_organization_delete"/>
-                <Scope name="internal_organization_config_delete"/>
             </Delete>
             <Create>
                 <Scope name="internal_organization_create"/>
-                <Scope name="internal_organization_config_add"/>
             </Create>
             <Read>
                 <Scope name="internal_organization_view"/>
@@ -439,11 +437,9 @@
             </Update>
             <Delete>
                 <Scope name="internal_organization_discovery_delete"/>
-                <Scope name="internal_organization_config_delete"/>
             </Delete>
             <Create>
                 <Scope name="internal_organization_discovery_update"/>
-                <Scope name="internal_organization_config_add"/>
             </Create>
             <Read>
                 <Scope name="internal_organization_discovery_view"/>


### PR DESCRIPTION
### Purpose

This pr removes `internal_organization_config_add` and `internal_organization_config_delete` scopes since they are no longer used. 

### Related pr
- https://github.com/wso2/carbon-identity-framework/pull/6145
 
### Related issues
- https://github.com/wso2/product-is/issues/21572
- https://github.com/wso2/product-is/issues/21610