### PR TITLE
Introduce password expiry time claim

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -844,6 +844,14 @@
 				<SupportedByDefault />
 				<multiValued>true</multiValued>
 			</Claim>
+			<Claim>
+				<ClaimURI>http://wso2.org/claims/identity/passwordExpiryTime</ClaimURI>
+				<DisplayName>Password Expiry Time</DisplayName>
+				<AttributeID>passwordExpiryTime</AttributeID>
+				<Description>Claim to dynamically calculate password expiry time of user</Description>
+				<ReadOnly>true</ReadOnly>
+				<Returned>request</Returned>
+			</Claim>
 		</Dialect>
 
 		<Dialect dialectURI="http://schemas.xmlsoap.org/ws/2005/05/identity">
@@ -2726,6 +2734,13 @@
 				<SupportedByDefault />
 				<DisplayOrder>14</DisplayOrder>
 				<MappedLocalClaim>http://wso2.org/claims/verifiedMobileNumbers</MappedLocalClaim>
+			</Claim>
+			<Claim>
+				<ClaimURI>urn:scim:wso2:schema:passwordExpiryTime</ClaimURI>
+				<DisplayName>Password Expiry Time</DisplayName>
+				<AttributeID>passwordExpiryTime</AttributeID>
+				<Description>Password Expiry Time</Description>
+				<MappedLocalClaim>http://wso2.org/claims/identity/passwordExpiryTime</MappedLocalClaim>
 			</Claim>
 		</Dialect>
 	</Dialects>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1271,6 +1271,9 @@
             identity data store value is empty for corresponding claim. -->
             <Property name="EnableHybridDataStore">false</Property>
         </EventListener>
+        <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
+                       name="org.wso2.carbon.identity.password.expiry.listener.PasswordExpiryEventListener"
+                       orderId="102" enable="true"/>
         <EventListener type="org.wso2.carbon.identity.core.handler.AbstractIdentityMessageHandler"
                        name="org.wso2.carbon.identity.data.publisher.application.authentication.AuthnDataPublisherProxy"
                        orderId="11" enable="true"/>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2161,6 +2161,11 @@
             store value is empty for corresponding claim. -->
             <Property name="EnableHybridDataStore">{{event.default_listener.governance_identity_store.enable_hybrid_data_store}}</Property>
         </EventListener>
+        <EventListener id="password_expiry"
+                       type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
+                       name="org.wso2.carbon.identity.password.expiry.listener.PasswordExpiryEventListener"
+                       orderId="{{event.default_listener.password_expiry.priority}}"
+                       enable="{{event.default_listener.password_expiry.enable}}"/>
         <EventListener id="application_authentication"
                        type="org.wso2.carbon.identity.core.handler.AbstractIdentityMessageHandler"
                        name="org.wso2.carbon.identity.data.publisher.application.authentication.AuthnDataPublisherProxy"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -550,6 +550,8 @@
   "event.default_listener.governance_identity_store.enable": true,
   "event.default_listener.governance_identity_store.data_store": "org.wso2.carbon.identity.governance.store.JDBCIdentityDataStore",
   "event.default_listener.governance_identity_store.enable_hybrid_data_store": false,
+  "event.default_listener.password_expiry.priority": "102",
+  "event.default_listener.password_expiry.enable": true,
   "event.default_listener.application_authentication.priority": "11",
   "event.default_listener.application_authentication.enable": true,
   "event.default_listener.mutual_tls_authenticator.priority": "919",


### PR DESCRIPTION
Introduce password expiry time claim.

The `passwordExpiryTime` will be introduced as a read-only claim, which will be calculated at runtime and returned only when explicitly requested.

### Related Issues 
- https://github.com/wso2/product-is/issues/20999

### Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/856
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/583