### PR TITLE
Deprecate buildTenantKeyStoreName

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/pom.xml
+++ b/components/identity-core/org.wso2.carbon.identity.core/pom.xml
@@ -195,6 +195,7 @@
                             org.wso2.carbon.stratos.common.*;version="${carbon.commons.imp.pkg.version}",
                             org.wso2.carbon.utils;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.utils.multitenancy;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.utils.security;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.*;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.organization.management.service.*;version="${org.wso2.carbon.identity.organization.management.core.version.range}",
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/IdentityKeyStoreResolver.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/IdentityKeyStoreResolver.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverException;
 import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.utils.CarbonUtils;
+import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import java.io.File;
 import java.security.Key;
@@ -96,7 +97,7 @@ public class IdentityKeyStoreResolver {
             }
 
             // Get tenant keystore from keyStoreManager
-            String tenantKeyStoreName = IdentityKeyStoreResolverUtil.buildTenantKeyStoreName(tenantDomain);
+            String tenantKeyStoreName = KeystoreUtils.getKeyStoreFileLocation(tenantDomain);
             return keyStoreManager.getKeyStore(tenantKeyStoreName);
         } catch (Exception e) {
             throw new IdentityKeyStoreResolverException(
@@ -177,7 +178,7 @@ public class IdentityKeyStoreResolver {
             if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
                 privateKey = keyStoreManager.getDefaultPrivateKey();
             } else {
-                String tenantKeyStoreName = IdentityKeyStoreResolverUtil.buildTenantKeyStoreName(tenantDomain);
+                String tenantKeyStoreName = KeystoreUtils.getKeyStoreFileLocation(tenantDomain);
                 privateKey = keyStoreManager.getPrivateKey(tenantKeyStoreName, tenantDomain);
             }
         } catch (Exception e) {
@@ -266,7 +267,7 @@ public class IdentityKeyStoreResolver {
             if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
                 publicCert = keyStoreManager.getDefaultPrimaryCertificate();
             } else {
-                String tenantKeyStoreName = IdentityKeyStoreResolverUtil.buildTenantKeyStoreName(tenantDomain);
+                String tenantKeyStoreName = KeystoreUtils.getKeyStoreFileLocation(tenantDomain);
                 publicCert = keyStoreManager.getCertificate(tenantKeyStoreName, tenantDomain);
             }
         } catch (Exception e) {
@@ -403,7 +404,7 @@ public class IdentityKeyStoreResolver {
             }
         }
 
-        return IdentityKeyStoreResolverUtil.buildTenantKeyStoreName(tenantDomain);
+        return KeystoreUtils.getKeyStoreFileLocation(tenantDomain);
     }
 
     /**
@@ -480,7 +481,7 @@ public class IdentityKeyStoreResolver {
 
             int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
             KeyStoreManager keyStoreManager = KeyStoreManager.getInstance(tenantId);
-            String keyStoreName = IdentityKeyStoreResolverUtil.buildTenantKeyStoreName(tenantDomain);
+            String keyStoreName = KeystoreUtils.getKeyStoreFileLocation(tenantDomain);
             switch (configName) {
                 case (RegistryResources.SecurityManagement.CustomKeyStore.PROP_LOCATION):
                     // Returning only key store name because tenant key stores reside within the registry.

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityKeyStoreResolverUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityKeyStoreResolverUtil.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.core.util;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.core.RegistryResources;
 import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants.ErrorMessages;
+import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import javax.xml.namespace.QName;
 
@@ -34,17 +35,13 @@ public class IdentityKeyStoreResolverUtil {
      *
      * @param tenantDomain Tenant domain name.
      * @return tenant key store name as String.
-     * @throws IdentityKeyStoreResolverException if tenant domain is null or empty.
+     *
+     * @deprecated Use {@link KeystoreUtils#getKeyStoreFileLocation(String)}
      */
-    public static String buildTenantKeyStoreName(String tenantDomain) throws IdentityKeyStoreResolverException {
+    @Deprecated
+    public static String buildTenantKeyStoreName(String tenantDomain) {
 
-        if (StringUtils.isEmpty(tenantDomain)) {
-            throw new IdentityKeyStoreResolverException(
-                    ErrorMessages.ERROR_CODE_INVALID_ARGUMENT.getCode(),
-                    String.format(ErrorMessages.ERROR_CODE_INVALID_ARGUMENT.getDescription(), "Tenant domain"));
-        }
-        String ksName = tenantDomain.trim().replace(".", "-");
-        return ksName + IdentityKeyStoreResolverConstants.KEY_STORE_EXTENSION;
+        return KeystoreUtils.getKeyStoreFileLocation(tenantDomain);
     }
 
     /**

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -68,6 +68,7 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.NetworkUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -2016,7 +2017,7 @@ public class IdentityUtil {
             }
         } else {
             try {
-                String tenantKeyStoreName = IdentityKeyStoreResolverUtil.buildTenantKeyStoreName(tenantDomain);
+                String tenantKeyStoreName = KeystoreUtils.getKeyStoreFileLocation(tenantDomain);
                 IdentityTenantUtil.initializeRegistry(tenantId);
                 privateKey = (PrivateKey) keyStoreManager.getPrivateKey(tenantKeyStoreName, tenantDomain);
             } catch (IdentityException e) {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/util/IdentityKeyStoreResolverUtilTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/util/IdentityKeyStoreResolverUtilTest.java
@@ -24,7 +24,6 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 
 import static org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverUtil.buildCustomKeyStoreName;
-import static org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverUtil.buildTenantKeyStoreName;
 import static org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverUtil.getQNameWithIdentityNameSpace;
 
 import javax.xml.namespace.QName;
@@ -43,12 +42,6 @@ public class IdentityKeyStoreResolverUtilTest {
         };
     }
 
-    @Test(dataProvider = "CorrectTenantKeyStoreNameDataProvider")
-    public void testCorrectBuildTenantKeyStoreName(String tenantDomain, String expectedResult) throws IdentityKeyStoreResolverException {
-
-        assertEquals(expectedResult, buildTenantKeyStoreName(tenantDomain));
-    }
-
     @DataProvider(name = "IncorrectTenantKeyStoreNameDataProvider")
     public Object[] incorrectTenantKeyStoreNameDataProvider() {
 
@@ -56,12 +49,6 @@ public class IdentityKeyStoreResolverUtilTest {
                 "",
                 null
         };
-    }
-
-    @Test(dataProvider = "IncorrectTenantKeyStoreNameDataProvider", expectedExceptions = IdentityKeyStoreResolverException.class)
-    public void testIncorrectBuildTenantKeyStoreName(String tenantDomain) throws IdentityKeyStoreResolverException {
-
-        buildTenantKeyStoreName(tenantDomain);
     }
 
     @DataProvider(name = "CorrectCustomKeyStoreNameDataProvider")


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request focuses on updating the `IdentityKeyStoreResolver` class and related utilities to use the `KeystoreUtils` class for key store file location retrieval. The changes involve replacing the existing method `IdentityKeyStoreResolverUtil.buildTenantKeyStoreName` with `KeystoreUtils.getKeyStoreFileLocation`.
