### PR TITLE
Enable Child Org Notification Template Overriding Capability

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -795,10 +795,16 @@
     <APIResource name="Email Template Management API v1/v2"
                  identifier="/o/api/server/v(.*)/email/template-types" requiresAuthorization="true"
                  description="API representation of the Email Template Management API"
-                 type="CONSOLE_ORG_LEVEL">
+                 type="ORGANIZATION">
         <Scopes>
-            <Scope displayName="View Email Template" name="internal_org_email_mgt_view" 
-                    description="View email templates and types in the organization"/>
+            <Scope displayName="View Email Template" name="internal_org_email_mgt_view"
+                   description="View email templates and types in the organization"/>
+            <Scope displayName="Create Email Template" name="internal_org_email_mgt_create"
+                   description="Create new email template and types in the organization"/>
+            <Scope displayName="Update Email Template" name="internal_org_email_mgt_update"
+                   description="Update email templates and types in the organization"/>
+            <Scope displayName="Delete Email Template" name="internal_org_email_mgt_delete"
+                   description="Delete email templates and types in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Notification Template Management API"
@@ -818,10 +824,16 @@
     <APIResource name="Notification Template Management API"
                  identifier="/o/api/server/v(.*)/notification/(?:email|sms)/template-types" requiresAuthorization="true"
                  description="API representation of the Notification Template Management API"
-                 type="CONSOLE_ORG_LEVEL">
+                 type="ORGANIZATION">
         <Scopes>
             <Scope displayName="View Notification Template" name="internal_org_template_mgt_view"
                    description="View notification templates and types in the organization"/>
+            <Scope displayName="Create Notification Template" name="internal_org_template_mgt_create"
+                   description="Create notification templates and types in the organization"/>
+            <Scope displayName="Update Notification Template" name="internal_org_template_mgt_update"
+                   description="Update notification templates and types in the organization"/>
+            <Scope displayName="Delete Notification Template" name="internal_org_template_mgt_delete"
+                   description="Delete notification templates and types in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Entitlement Management API" identifier="/api/identity/entitlement/"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -804,10 +804,16 @@
     <APIResource name="Email Template Management API v1/v2"
                  identifier="/o/api/server/v(.*)/email/template-types" requiresAuthorization="true"
                  description="API representation of the Email Template Management API"
-                 type="CONSOLE_ORG_LEVEL">
+                 type="ORGANIZATION">
         <Scopes>
-            <Scope displayName="View Email Template" name="internal_org_email_mgt_view" 
+            <Scope displayName="View Email Template" name="internal_org_email_mgt_view"
                     description="View email templates and types in the organization"/>
+            <Scope displayName="Create Email Template" name="internal_org_email_mgt_create"
+                    description="Create new email template and types in the organization"/>
+            <Scope displayName="Update Email Template" name="internal_org_email_mgt_update"
+                    description="Update email templates and types in the organization"/>
+            <Scope displayName="Delete Email Template" name="internal_org_email_mgt_delete"
+                    description="Delete email templates and types in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Notification Template Management API"
@@ -827,10 +833,16 @@
     <APIResource name="Notification Template Management API"
                  identifier="/o/api/server/v(.*)/notification/(?:email|sms)/template-types" requiresAuthorization="true"
                  description="API representation of the Notification Template Management API"
-                 type="CONSOLE_ORG_LEVEL">
+                 type="ORGANIZATION">
         <Scopes>
             <Scope displayName="View Notification Template" name="internal_org_template_mgt_view"
                    description="View notification templates and types in the organization"/>
+            <Scope displayName="Create Notification Template" name="internal_org_template_mgt_create"
+                   description="Create notification templates and types in the organization"/>
+            <Scope displayName="Update Notification Template" name="internal_org_template_mgt_update"
+                   description="Update notification templates and types in the organization"/>
+            <Scope displayName="Delete Notification Template" name="internal_org_template_mgt_delete"
+                   description="Delete notification templates and types in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Entitlement Management API" identifier="/api/identity/entitlement/"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -656,10 +656,28 @@
 
     <!-- [Organization] Notification Template Management API -->
     <Resource context="(.*)/o/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="GET">
-        <Scopes>internal_org_email_mgt_view,internal_org_template_mgt_view</Scopes>
+        <Scopes>internal_org_template_mgt_view</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="POST">
+        <Scopes>internal_org_template_mgt_create</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="PUT">
+        <Scopes>internal_org_template_mgt_update</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="DELETE">
+        <Scopes>internal_org_template_mgt_delete</Scopes>
     </Resource>
     <Resource context="(.*)/o/api/server/v(.*)/notification/sms/template-types(.*)" secured="true" http-method="GET">
         <Scopes>internal_org_template_mgt_view</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v(.*)/notification/sms/template-types(.*)" secured="true" http-method="POST">
+        <Scopes>internal_org_template_mgt_create</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v(.*)/notification/sms/template-types(.*)" secured="true" http-method="PUT">
+        <Scopes>internal_org_template_mgt_update</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v(.*)/notification/sms/template-types(.*)" secured="true" http-method="DELETE">
+        <Scopes>internal_org_template_mgt_delete</Scopes>
     </Resource>
 
     <!-- Notification Template Management API -->
@@ -694,6 +712,15 @@
     <!-- [Organization] Email Template Management API v1/v2 -->
     <Resource context="(.*)/o/api/server/v(.*)/email/template-types(.*)" secured="true" http-method="GET">
         <Scopes>internal_org_email_mgt_view</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v(.*)/email/template-types(.*)" secured="true" http-method="POST">
+        <Scopes>internal_org_email_mgt_create</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v(.*)/email/template-types/(.*)" secured="true" http-method="PUT">
+        <Scopes>internal_org_email_mgt_update</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v(.*)/email/template-types/(.*)" secured="true" http-method="DELETE">
+        <Scopes>internal_org_email_mgt_delete</Scopes>
     </Resource>
 
     <!-- Email Template Management API v1/v2 -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -707,8 +707,26 @@
         <Resource context="(.*)/o/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="GET">
             <Scopes>internal_org_template_mgt_view</Scopes>
         </Resource>
+        <Resource context="(.*)/o/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="POST">
+            <Scopes>internal_org_template_mgt_create</Scopes>
+        </Resource>
+        <Resource context="(.*)/o/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="PUT">
+            <Scopes>internal_org_template_mgt_update</Scopes>
+        </Resource>
+        <Resource context="(.*)/o/api/server/v(.*)/notification/email/template-types(.*)" secured="true" http-method="DELETE">
+            <Scopes>internal_org_template_mgt_delete</Scopes>
+        </Resource>
         <Resource context="(.*)/o/api/server/v(.*)/notification/sms/template-types(.*)" secured="true" http-method="GET">
             <Scopes>internal_org_template_mgt_view</Scopes>
+        </Resource>
+        <Resource context="(.*)/o/api/server/v(.*)/notification/sms/template-types(.*)" secured="true" http-method="POST">
+            <Scopes>internal_org_template_mgt_create</Scopes>
+        </Resource>
+        <Resource context="(.*)/o/api/server/v(.*)/notification/sms/template-types(.*)" secured="true" http-method="PUT">
+            <Scopes>internal_org_template_mgt_update</Scopes>
+        </Resource>
+        <Resource context="(.*)/o/api/server/v(.*)/notification/sms/template-types(.*)" secured="true" http-method="DELETE">
+            <Scopes>internal_org_template_mgt_delete</Scopes>
         </Resource>
 
         <!-- Notification Template Management API -->
@@ -743,6 +761,15 @@
         <!-- [Organization] Email Template Management API v1/v2 -->
         <Resource context="(.*)/o/api/server/v(.*)/email/template-types(.*)" secured="true" http-method="GET">
             <Scopes>internal_org_email_mgt_view</Scopes>
+        </Resource>
+         <Resource context="(.*)/o/api/server/v(.*)/email/template-types(.*)" secured="true" http-method="POST">
+            <Scopes>internal_org_email_mgt_create</Scopes>
+        </Resource>
+        <Resource context="(.*)/o/api/server/v(.*)/email/template-types/(.*)" secured="true" http-method="PUT">
+            <Scopes>internal_org_email_mgt_update</Scopes>
+        </Resource>
+        <Resource context="(.*)/o/api/server/v(.*)/email/template-types/(.*)" secured="true" http-method="DELETE">
+            <Scopes>internal_org_email_mgt_delete</Scopes>
         </Resource>
 
         <!-- Email Template Management API v1/v2 -->


### PR DESCRIPTION
### Purpose
- $Subject
- The following scopes are introduced in Notification and Email template management APIs in order to enable child org overriding capabilities in notification templates.
    - Email v1/ v2 API
        - `POST` /o/api/server/v(.*)/email/template-types - `internal_org_email_mgt_create`
        - `PUT` /o/api/server/v(.*)/email/template-types - `internal_org_email_mgt_update`
        - `DELETE` /o/api/server/v(.*)/email/template-types - `internal_org_email_mgt_delete`
    - Notification API
        -  `POST` /o/api/server/v(.*)/notification/(?:email|sms)/template-type - `internal_org_template_mgt_create`
        -  `PUT`  /o/api/server/v(.*)/notification/(?:email|sms)/template-type - `internal_org_template_mgt_update`
        - `DELETE`  /o/api/server/v(.*)/notification/(?:email|sms)/template-type - `internal_org_template_mgt_delete`