### PR TITLE
Introduce a config to allow system prefix for roles

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleConstants.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleConstants.java
@@ -80,6 +80,9 @@ public class RoleConstants {
     public static final String NEW_ROLE_NAME = "newRoleName";
     public static final String FAILURE_REASON = "failureReason";
 
+    // Role management service configurations.
+    public static final String ALLOW_SYSTEM_PREFIX_FOR_ROLES = "RoleMgt.AllowSystemPrefixForRoles";
+
     /**
      * Grouping of constants related to database table names.
      */

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
@@ -49,6 +49,7 @@ import org.wso2.carbon.identity.role.v2.mgt.core.model.Role;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleDTO;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.UserBasicInfo;
+import org.wso2.carbon.identity.role.v2.mgt.core.util.RoleManagementUtils;
 import org.wso2.carbon.identity.role.v2.mgt.core.util.UserIDResolver;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -81,7 +82,8 @@ public class RoleManagementServiceImpl implements RoleManagementService {
                                  List<Permission> permissions, String audience, String audienceId, String tenantDomain)
             throws IdentityRoleManagementException {
 
-        if (StringUtils.startsWithIgnoreCase(roleName, UserCoreConstants.INTERNAL_SYSTEM_ROLE_PREFIX)) {
+        if (!RoleManagementUtils.isAllowSystemPrefixForRole() &&
+                StringUtils.startsWithIgnoreCase(roleName, UserCoreConstants.INTERNAL_SYSTEM_ROLE_PREFIX)) {
             String errorMessage = String.format("Invalid role name: %s. Role names with the prefix: %s, is not allowed"
                             + " to be created from externally in the system.", roleName,
                     UserCoreConstants.INTERNAL_SYSTEM_ROLE_PREFIX);

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/util/RoleManagementUtils.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/util/RoleManagementUtils.java
@@ -21,12 +21,15 @@ package org.wso2.carbon.identity.role.v2.mgt.core.util;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;
 import org.wso2.carbon.identity.role.v2.mgt.core.dao.RoleDAO;
 import org.wso2.carbon.identity.role.v2.mgt.core.dao.RoleMgtDAOFactory;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
 
 import java.util.Locale;
+
+import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.ALLOW_SYSTEM_PREFIX_FOR_ROLES;
 
 /**
  * Util class for role management functionality.
@@ -75,5 +78,16 @@ public class RoleManagementUtils {
     public static boolean isSharedRole(String roleId, String tenantDomain) throws IdentityRoleManagementException {
 
         return roleDAO.isSharedRole(roleId, tenantDomain);
+    }
+
+    /**
+     * Get the configuration to allow adding roles with the system_ prefix. This config should be enabled only if
+     * IS is used as a KM for APIM.
+     *
+     * @return True, if it is allowed to add roles with system_ prefix.
+     */
+    public static boolean isAllowSystemPrefixForRole() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(ALLOW_SYSTEM_PREFIX_FOR_ROLES));
     }
 }

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImplTest.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImplTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.role.v2.mgt.core;
+
+import org.apache.commons.lang.StringUtils;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.CarbonBaseConstants;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.role.v2.mgt.core.dao.RoleDAO;
+import org.wso2.carbon.identity.role.v2.mgt.core.dao.RoleMgtDAOFactory;
+import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementClientException;
+import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
+import org.wso2.carbon.identity.testutil.IdentityBaseTest;
+import org.wso2.carbon.user.core.UserCoreConstants;
+
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.ALLOW_SYSTEM_PREFIX_FOR_ROLES;
+import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.APPLICATION;
+import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+
+public class RoleManagementServiceImplTest extends IdentityBaseTest {
+
+    @Mock
+    private RoleDAO roleDAO;
+
+    private RoleManagementServiceImpl roleManagementService;
+
+    private MockedStatic<RoleMgtDAOFactory> roleMgtDAOFactory;
+    private MockedStatic<PrivilegedCarbonContext> privilegedCarbonContext;
+
+    private static final String USERNAME = "user";
+    private static final String audienceId = "testId";
+    private static final String roleId = "testRoleId";
+
+    @BeforeMethod
+    public void setUp() {
+
+        MockitoAnnotations.openMocks(this);
+        mockCarbonContextForTenant();
+
+        roleMgtDAOFactory = mockStatic(RoleMgtDAOFactory.class);
+        RoleMgtDAOFactory mockRoleMgtDAOFactory = mock(RoleMgtDAOFactory.class);
+        roleMgtDAOFactory.when(RoleMgtDAOFactory::getInstance)
+                .thenReturn(mockRoleMgtDAOFactory);
+        when(mockRoleMgtDAOFactory.getRoleDAO()).thenReturn(roleDAO);
+
+        roleManagementService = new RoleManagementServiceImpl();
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+
+        privilegedCarbonContext.close();
+        roleMgtDAOFactory.close();
+    }
+
+    @DataProvider(name = "addRoleWithSystemPrefixData")
+    public Object[][] addRoleWithSystemPrefixData() {
+
+        return new Object[][]{
+                {false, "testRole", false},
+                {false, "system_testRole", true},
+                {true, "testRole", false},
+                {true, "system_testRole", false},
+        };
+    }
+
+    @Test(dataProvider = "addRoleWithSystemPrefixData")
+    public void testAddRoleWithSystemPrefix(boolean allowSystemPrefix, String roleName, boolean errorScenario)
+            throws IdentityRoleManagementException {
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<RoleManagementEventPublisherProxy> roleManagementEventPublisherProxy
+                     = mockStatic(RoleManagementEventPublisherProxy.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(ALLOW_SYSTEM_PREFIX_FOR_ROLES))
+                    .thenReturn(String.valueOf(allowSystemPrefix));
+
+            RoleBasicInfo mockRoleBasicInfo = new RoleBasicInfo(roleId, roleName);
+            mockRoleBasicInfo.setAudience(APPLICATION);
+            when(roleDAO.addRole(anyString(), anyList(), anyList(), anyList(), anyString(), anyString(), anyString()))
+                    .thenReturn(mockRoleBasicInfo);
+            when(roleDAO.getRoleBasicInfoById(anyString(), anyString())).thenReturn(mockRoleBasicInfo);
+
+            RoleManagementEventPublisherProxy mockRoleMgtEventPublisherProxy = mock(
+                    RoleManagementEventPublisherProxy.class);
+            roleManagementEventPublisherProxy.when(RoleManagementEventPublisherProxy::getInstance)
+                    .thenReturn(mockRoleMgtEventPublisherProxy);
+            lenient().doNothing().when(mockRoleMgtEventPublisherProxy).publishPreAddRoleWithException(anyString(),
+                    anyList(), anyList(), anyList(), anyString(), anyString(), anyString());
+            lenient().doNothing().when(mockRoleMgtEventPublisherProxy).publishPostAddRole(anyString(), anyString(),
+                    anyList(), anyList(), anyList(), anyString(), anyString(), anyString());
+
+            RoleBasicInfo addedRole = roleManagementService.addRole(roleName, new ArrayList<>(), new ArrayList<>(),
+                    new ArrayList<>(), APPLICATION, audienceId, SUPER_TENANT_DOMAIN_NAME);
+            if (errorScenario) {
+                fail("An exception should have been thrown.");
+            }
+            assertNotNull(addedRole, "Role should have been added successfully.");
+
+        } catch (IdentityRoleManagementClientException e) {
+            if (errorScenario) {
+                assertTrue(StringUtils.contains(e.getMessage(), String.format("Role names with the prefix: %s, " +
+                        "is not allowed", UserCoreConstants.INTERNAL_SYSTEM_ROLE_PREFIX)));
+            } else {
+                fail("An exception should not have been thrown.");
+            }
+        }
+    }
+
+    private void mockCarbonContextForTenant() {
+
+        String carbonHome = Paths.get(System.getProperty("user.dir"), "target", "test-classes").toString();
+        System.setProperty(CarbonBaseConstants.CARBON_HOME, carbonHome);
+
+        privilegedCarbonContext = mockStatic(PrivilegedCarbonContext.class);
+        PrivilegedCarbonContext mockPrivilegedCarbonContext = mock(PrivilegedCarbonContext.class);
+        privilegedCarbonContext.when(PrivilegedCarbonContext::getThreadLocalCarbonContext)
+                .thenReturn(mockPrivilegedCarbonContext);
+        when(mockPrivilegedCarbonContext.getUsername()).thenReturn(USERNAME);
+    }
+}

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImplTest.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImplTest.java
@@ -36,6 +36,9 @@ import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
 import org.wso2.carbon.identity.testutil.IdentityBaseTest;
 import org.wso2.carbon.user.core.UserCoreConstants;
 
+import java.nio.file.Paths;
+import java.util.ArrayList;
+
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.lenient;
@@ -48,9 +51,6 @@ import static org.testng.Assert.fail;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.ALLOW_SYSTEM_PREFIX_FOR_ROLES;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.APPLICATION;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
-
-import java.nio.file.Paths;
-import java.util.ArrayList;
 
 public class RoleManagementServiceImplTest extends IdentityBaseTest {
 

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/resources/testng.xml
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/resources/testng.xml
@@ -23,6 +23,7 @@
     <test name="identity-role-mgt-test-all">
         <classes>
             <class name="org.wso2.carbon.identity.role.v2.mgt.core.dao.RoleDAOTest"/>
+            <class name="org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementServiceImplTest"/>
         </classes>
     </test>
 </suite>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2037,6 +2037,13 @@
         <TrustedAppMaxThumbprintCount>{{application_mgt.trusted_app_max_thumbprint_count}}</TrustedAppMaxThumbprintCount>
     </ApplicationMgt>
 
+    <!--Role management service configurations-->
+    <RoleMgt>
+        {% if role_mgt.allow_system_prefix_for_role is defined %}
+        <AllowSystemPrefixForRoles>{{role_mgt.allow_system_prefix_for_role}}</AllowSystemPrefixForRoles>
+        {% endif %}
+    </RoleMgt>
+
     <OutboundProvisioning>
         {% if outbound_provisioning_management.reset_provisioning_entities_on_config_update is defined %}
             <!--


### PR DESCRIPTION
With the current role management model, we do not allow the creation of roles with system_ prefix as it is used for the special roles created by the system in order to maintain the backward compatibility. But for IS KM connector only, we will be allowing the creation of roles with system_ prefix which will be allowed through the config:

```
[role_mgt]
allow_system_prefix_for_role = true
```
This config will be disabled by default for IS, and for IS KM it can be enabled if needed as above.