### PR TITLE
Show legacy role claim based on a config when group role separation is enabled

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementServiceImpl.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementServiceImpl.java
@@ -191,7 +191,7 @@ public class ClaimMetadataManagementServiceImpl implements ClaimMetadataManageme
         // Add listener
 
         boolean isGroupRoleSeparationEnabled = IdentityUtil.isGroupsVsRolesSeparationImprovementsEnabled();
-        boolean isShowRoleClaimOnGroupRoleSeparation = IdentityUtil.isShowRoleClaimOnGroupRoleSeparationEnabled();
+        boolean isShowRoleClaimOnGroupRoleSeparation = IdentityUtil.isShowLegacyRoleClaimOnGroupRoleSeparationEnabled();
         List<LocalClaim> filteredLocalClaims = new ArrayList<>(localClaims.size());
 
         for (LocalClaim claim : localClaims) {

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementServiceImpl.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementServiceImpl.java
@@ -191,10 +191,12 @@ public class ClaimMetadataManagementServiceImpl implements ClaimMetadataManageme
         // Add listener
 
         boolean isGroupRoleSeparationEnabled = IdentityUtil.isGroupsVsRolesSeparationImprovementsEnabled();
+        boolean isShowRoleClaimOnGroupRoleSeparation = IdentityUtil.isShowRoleClaimOnGroupRoleSeparationEnabled();
         List<LocalClaim> filteredLocalClaims = new ArrayList<>(localClaims.size());
 
         for (LocalClaim claim : localClaims) {
-            if (isGroupRoleSeparationEnabled && UserCoreConstants.ROLE_CLAIM.equals(claim.getClaimURI())) {
+            if (isGroupRoleSeparationEnabled && !isShowRoleClaimOnGroupRoleSeparation &&
+                    UserCoreConstants.ROLE_CLAIM.equals(claim.getClaimURI())) {
                 continue;
             }
             // Add `UniquenessScope` property for claims that only have legacy `isUnique` property.

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/DefaultClaimMetadataStore.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/DefaultClaimMetadataStore.java
@@ -458,7 +458,8 @@ public class DefaultClaimMetadataStore implements ClaimMetadataStore {
         // Filter the local claim `role` when groups vs roles separation is enabled. This claim is
         // considered as a legacy claim going forward, thus `roles` and `groups` claims should be used
         // instead.
-        if (IdentityUtil.isGroupsVsRolesSeparationImprovementsEnabled() && UserCoreConstants.ROLE_CLAIM.
+        if (IdentityUtil.isGroupsVsRolesSeparationImprovementsEnabled() &&
+                !IdentityUtil.isShowRoleClaimOnGroupRoleSeparationEnabled() && UserCoreConstants.ROLE_CLAIM.
                 equals(localClaim.getClaimURI())) {
             if (log.isDebugEnabled()) {
                 log.debug("Skipping the legacy role claim: " + localClaim.getClaimURI() + ", when getting " +

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/DefaultClaimMetadataStore.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/DefaultClaimMetadataStore.java
@@ -21,7 +21,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.internal.IdentityClaimManagementServiceDataHolder;
-import org.wso2.carbon.identity.claim.metadata.mgt.internal.ReadOnlyClaimMetadataManager;
 import org.wso2.carbon.identity.claim.metadata.mgt.internal.ReadWriteClaimMetadataManager;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ClaimDialect;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
@@ -459,7 +458,7 @@ public class DefaultClaimMetadataStore implements ClaimMetadataStore {
         // considered as a legacy claim going forward, thus `roles` and `groups` claims should be used
         // instead.
         if (IdentityUtil.isGroupsVsRolesSeparationImprovementsEnabled() &&
-                !IdentityUtil.isShowRoleClaimOnGroupRoleSeparationEnabled() && UserCoreConstants.ROLE_CLAIM.
+                !IdentityUtil.isShowLegacyRoleClaimOnGroupRoleSeparationEnabled() && UserCoreConstants.ROLE_CLAIM.
                 equals(localClaim.getClaimURI())) {
             if (log.isDebugEnabled()) {
                 log.debug("Skipping the legacy role claim: " + localClaim.getClaimURI() + ", when getting " +

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -158,6 +158,7 @@ public class IdentityUtil {
     private static final String APPLICATION_DOMAIN = "Application";
     private static final String WORKFLOW_DOMAIN = "Workflow";
     private static Boolean groupsVsRolesSeparationImprovementsEnabled;
+    private static Boolean showRoleClaimOnGroupRoleSeparationEnabled;
     private static String JAVAX_TRANSFORMER_PROP_VAL = "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl";
 
     // System Property for trust managers.
@@ -1625,6 +1626,30 @@ public class IdentityUtil {
 
         } catch (UserStoreException | CarbonException e) {
             log.warn("Property value parsing error: GroupAndRoleSeparationEnabled, thus considered as FALSE");
+            return Boolean.FALSE;
+        }
+    }
+
+    /**
+     * Check with authorization manager whether show role claim on group role separation config is set to true.
+     *
+     * @return Where show role claim on group role separation enabled or not.
+     */
+    public static boolean isShowRoleClaimOnGroupRoleSeparationEnabled() {
+
+        try {
+            UserRealm userRealm = AdminServicesUtil.getUserRealm();
+            if(userRealm == null) {
+                log.warn("Unable to find the user realm, thus ShowRoleClaimOnGroupRoleSeparationEnabled is set as FALSE.");
+                return Boolean.FALSE;
+            }
+            if (showRoleClaimOnGroupRoleSeparationEnabled == null) {
+                showRoleClaimOnGroupRoleSeparationEnabled = UserCoreUtil.isShowRoleClaimOnGroupRoleSeparationEnabled(
+                        userRealm.getRealmConfiguration());
+            }
+            return showRoleClaimOnGroupRoleSeparationEnabled;
+        } catch (UserStoreException | CarbonException e) {
+            log.warn("Property value parsing error: ShowRoleClaimOnGroupRoleSeparationEnabled, thus considered as FALSE");
             return Boolean.FALSE;
         }
     }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -158,7 +158,7 @@ public class IdentityUtil {
     private static final String APPLICATION_DOMAIN = "Application";
     private static final String WORKFLOW_DOMAIN = "Workflow";
     private static Boolean groupsVsRolesSeparationImprovementsEnabled;
-    private static Boolean showRoleClaimOnGroupRoleSeparationEnabled;
+    private static Boolean showLegacyRoleClaimOnGroupRoleSeparationEnabled;
     private static String JAVAX_TRANSFORMER_PROP_VAL = "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl";
 
     // System Property for trust managers.
@@ -1635,19 +1635,20 @@ public class IdentityUtil {
      *
      * @return Where show role claim on group role separation enabled or not.
      */
-    public static boolean isShowRoleClaimOnGroupRoleSeparationEnabled() {
+    public static boolean isShowLegacyRoleClaimOnGroupRoleSeparationEnabled() {
 
         try {
             UserRealm userRealm = AdminServicesUtil.getUserRealm();
-            if(userRealm == null) {
+            if (userRealm == null) {
                 log.warn("Unable to find the user realm, thus ShowRoleClaimOnGroupRoleSeparationEnabled is set as FALSE.");
                 return Boolean.FALSE;
             }
-            if (showRoleClaimOnGroupRoleSeparationEnabled == null) {
-                showRoleClaimOnGroupRoleSeparationEnabled = UserCoreUtil.isShowRoleClaimOnGroupRoleSeparationEnabled(
+            if (showLegacyRoleClaimOnGroupRoleSeparationEnabled == null) {
+                showLegacyRoleClaimOnGroupRoleSeparationEnabled =
+                        UserCoreUtil.isShowLegacyRoleClaimOnGroupRoleSeparationEnabled(
                         userRealm.getRealmConfiguration());
             }
-            return showRoleClaimOnGroupRoleSeparationEnabled;
+            return showLegacyRoleClaimOnGroupRoleSeparationEnabled;
         } catch (UserStoreException | CarbonException e) {
             log.warn("Property value parsing error: ShowRoleClaimOnGroupRoleSeparationEnabled, thus considered as FALSE");
             return Boolean.FALSE;

--- a/pom.xml
+++ b/pom.xml
@@ -1826,7 +1826,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.10.27</carbon.kernel.version>
+        <carbon.kernel.version>4.10.28</carbon.kernel.version>
         <carbon.kernel.feature.version>4.7.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>


### PR DESCRIPTION
### Proposed changes in this pull request

Based on the following configuration, show legacy role claim when group role separation is enabled.

```
[authorization_manager.properties]
ShowLegacyRoleClaim = false
```

The default value is `false` and hence the current behavior of not returning the `role` claim will be preserved.

## Related Issue
- https://github.com/wso2/product-is/issues/21830

## Depends on
- https://github.com/wso2/carbon-kernel/pull/4142