### PR TITLE
Increase resend code validity period

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -398,7 +398,7 @@
   "identity_mgt.password_reset_email.enable_recaptcha": false,
   "identity_mgt.password_reset_email.reset_mail_validity": "$ref{identity_mgt.default_mail_validity_period}",
   "identity_mgt.notification_channel_recovery.recovery_code_validity": "1m",
-  "identity_mgt.resend_notification.resend_code_validity": "1m",
+  "identity_mgt.resend_notification.resend_code_validity": "2m",
   "identity_mgt.password_reset_email.notify_on_reset": false,
 
   "identity_mgt.lite_user_registration.enable": false,


### PR DESCRIPTION
### Proposed changes in this pull request

- Resolves https://github.com/wso2/product-is/issues/21793
- Increase resend code validity period.

- The resend code validity is set to 1 minute by default in notification-based recovery. However, the UI blocks resending for the first minute. As a result, when the resend button becomes active, the resend code is already invalid, and the resend option cannot be used. To fix this, the resend code validity period has been extended to 2 minutes. 

<img width="481" alt="Screenshot 2024-12-10 at 21 56 26" src="https://github.com/user-attachments/assets/6d070b8f-7225-441b-9748-e42cc261b893">
