### PR TITLE
Expose cache packages from action-mgt and certificate-mgt components

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.management/pom.xml
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/pom.xml
@@ -89,7 +89,6 @@
                         </Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>
-                            org.wso2.carbon.identity.action.management.cache,
                             org.wso2.carbon.identity.action.management.constant,
                             org.wso2.carbon.identity.action.management.dao.*,
                             org.wso2.carbon.identity.action.management.internal,
@@ -97,6 +96,7 @@
                             org.wso2.carbon.identity.action.management.util
                         </Private-Package>
                         <Export-Package>
+                            org.wso2.carbon.identity.action.management.cache,
                             org.wso2.carbon.identity.action.management.constant.error,
                             org.wso2.carbon.identity.action.management.exception,
                             org.wso2.carbon.identity.action.management.model,

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/cache/ActionCacheEntry.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/cache/ActionCacheEntry.java
@@ -28,6 +28,7 @@ import java.util.List;
  */
 public class ActionCacheEntry extends CacheEntry {
 
+    private static final long serialVersionUID = 2789265346825849739L;
     private List<Action> actionsOfActionType;
 
     public ActionCacheEntry(List<Action> actionsOfActionType) {

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/cache/ActionTypeCacheKey.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/cache/ActionTypeCacheKey.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.identity.core.cache.CacheKey;
  */
 public class ActionTypeCacheKey extends CacheKey {
 
+    private static final long serialVersionUID = 8132735629148475983L;
     private final String actionType;
 
     public ActionTypeCacheKey(String actionType) {

--- a/components/certificate-mgt/org.wso2.carbon.identity.certificate.management/pom.xml
+++ b/components/certificate-mgt/org.wso2.carbon.identity.certificate.management/pom.xml
@@ -75,7 +75,6 @@
                         </Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>
-                            org.wso2.carbon.identity.certificate.management.cache,
                             org.wso2.carbon.identity.certificate.management.constant,
                             org.wso2.carbon.identity.certificate.management.dao.*,
                             org.wso2.carbon.identity.certificate.management.internal,
@@ -83,6 +82,7 @@
                             org.wso2.carbon.identity.certificate.management.util;
                         </Private-Package>
                         <Export-Package>
+                            org.wso2.carbon.identity.certificate.management.cache,
                             org.wso2.carbon.identity.certificate.management.exception,
                             org.wso2.carbon.identity.certificate.management.model,
                             org.wso2.carbon.identity.certificate.management.service;

--- a/components/certificate-mgt/org.wso2.carbon.identity.certificate.management/src/main/java/org/wso2/carbon/identity/certificate/management/cache/CertificateIdCacheKey.java
+++ b/components/certificate-mgt/org.wso2.carbon.identity.certificate.management/src/main/java/org/wso2/carbon/identity/certificate/management/cache/CertificateIdCacheKey.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.identity.core.cache.CacheKey;
  */
 public class CertificateIdCacheKey extends CacheKey {
 
+    private static final long serialVersionUID = 5691238745928475691L;
     private final String certificateId;
 
     public CertificateIdCacheKey(String certificateId) {


### PR DESCRIPTION
### Proposed changes in this pull request
1. Expose cache package from the action-mgt osgi service
2. Expose cache package from the certificate-mgt osgi service

In clustered nodes, cache invalidation is handled by hazelcast where it requires the cache classes to be available in the runtime. Hence we have to expose the classes from the osgi services.

### Related Issue:
- https://github.com/wso2/product-is/issues/22013