### PR TITLE
Add configs related to run suspension task from master-node.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1174,6 +1174,7 @@
 
     <AccountSuspension>
         <UseIdentityClaims>true</UseIdentityClaims>
+        <RunTaskInClusterMode>false</RunTaskInClusterMode>
     </AccountSuspension>
 
     <SCIM2MultiAttributeFiltering>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1174,7 +1174,7 @@
 
     <AccountSuspension>
         <UseIdentityClaims>true</UseIdentityClaims>
-        <RunTaskInClusterMode>false</RunTaskInClusterMode>
+        <ExecuteTaskOnMasterNode>false</ExecuteTaskOnMasterNode>
     </AccountSuspension>
 
     <SCIM2MultiAttributeFiltering>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1913,7 +1913,7 @@
 
      <AccountSuspension>
         <UseIdentityClaims>{{identity_mgt_account_suspension.use_identity_claims}}</UseIdentityClaims>
-        <RunTaskInClusterMode>{{identity_mgt_account_suspension.run_task_in_cluster_mode}}</RunTaskInClusterMode>
+        <ExecuteTaskOnMasterNode>{{identity_mgt_account_suspension.execute_task_on_master_node}}</ExecuteTaskOnMasterNode>
      </AccountSuspension>
 
      <SCIM2MultiAttributeFiltering>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1913,6 +1913,7 @@
 
      <AccountSuspension>
         <UseIdentityClaims>{{identity_mgt_account_suspension.use_identity_claims}}</UseIdentityClaims>
+        <RunTaskInClusterMode>{{identity_mgt_account_suspension.run_task_in_cluster_mode}}</RunTaskInClusterMode>
      </AccountSuspension>
 
      <SCIM2MultiAttributeFiltering>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -503,6 +503,7 @@
   "event.default_listener.system_api_authorization_management_listener.enable": true,
 
   "identity_mgt_account_suspension.use_identity_claims": true,
+  "identity_mgt_account_suspension.run_task_in_cluster_mode": false,
 
   "identity_mgt.enable_user_claim_input_regex_validation": true,
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -503,7 +503,7 @@
   "event.default_listener.system_api_authorization_management_listener.enable": true,
 
   "identity_mgt_account_suspension.use_identity_claims": true,
-  "identity_mgt_account_suspension.run_task_in_cluster_mode": false,
+  "identity_mgt_account_suspension.execute_task_on_master_node": false,
 
   "identity_mgt.enable_user_claim_input_regex_validation": true,
 


### PR DESCRIPTION
### Proposed changes in this pull request

Need to add the following config to enable the above feature
```
[identity_mgt_account_suspension]
execute_task_on_master_node = true
```

Issue: https://github.com/wso2/product-is/issues/9829

