### PR TITLE
Remove exceptions thrown on validations in deleteActionById api

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/service/impl/ActionManagementServiceImpl.java
@@ -175,10 +175,12 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         if (LOG.isDebugEnabled()) {
             LOG.debug(String.format("Deleting Action for Action Type: %s and Action ID: %s", actionType, actionId));
         }
-        String resolvedActionType = getActionTypeFromPath(actionType);
-        ActionDTO existingActionDTO = checkIfActionExists(resolvedActionType, actionId, tenantDomain);
-        DAO_FACADE.deleteAction(existingActionDTO, IdentityTenantUtil.getTenantId(tenantDomain));
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.DELETE, actionType, actionId);
+        ActionDTO existingActionDTO = DAO_FACADE.getActionByActionId(getActionTypeFromPath(actionType), actionId,
+                IdentityTenantUtil.getTenantId(tenantDomain));
+        if (existingActionDTO != null) {
+            DAO_FACADE.deleteAction(existingActionDTO, IdentityTenantUtil.getTenantId(tenantDomain));
+            auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.DELETE, actionType, actionId);
+        }
     }
 
     /**

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/service/ActionManagementServiceImplTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/service/ActionManagementServiceImplTest.java
@@ -310,6 +310,16 @@ public class ActionManagementServiceImplTest {
         Assert.assertNull(actions.get(PRE_ISSUE_ACCESS_TOKEN_PATH));
     }
 
+    @Test(priority = 14)
+    public void testDeleteNonExistingAction() {
+
+        try {
+            actionManagementService.deleteAction(PRE_ISSUE_ACCESS_TOKEN_PATH, "invalid_id", TENANT_DOMAIN);
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+
     private Map<String, String> resolveAuthPropertiesMap(Authentication authentication, String actionId)
             throws SecretManagementException {
 


### PR DESCRIPTION
### Proposed changes in this pull request
Previously when the given action id is invalid or not existing, it throws an client exception informing that there isn't any action configured for the given id. 
This PR will remove that validation and gives success response in all scenarios.

### Related issue
- https://github.com/wso2/product-is/issues/22022