### PR TITLE
Enable showAuthFailureReason for basic authenticator by default

### DIFF
--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -64,6 +64,7 @@
   "authentication.authenticator.basic.parameters.AuthMechanism": "basic",
   "authentication.authenticator.basic.parameters.Tags": "Username-Password",
   "authentication.authenticator.basic.parameters.redirectToRetryPageOnAccountLock": "false",
+  "authentication.authenticator.basic.parameters.showAuthFailureReason": "true",
 
   "authentication.authenticator.basic_request_path.name": "BasicAuthRequestPathAuthenticator",
   "authentication.authenticator.basic_request_path.enable": true,


### PR DESCRIPTION
### Proposed changes in this pull request

- Enable showing auth failure reason for Identity Server by default

### Purpose
- With https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2489, password grant, will also use the below config to show authentication failure reason.

```
[authentication.authenticator.basic.parameters]
showAuthFailureReason = true
```

However currently, authentication failure reason is shown by default in Password Grant. To unify this behaviour without adding additional configurations for password grant and basic authenticator, we need to enable the above config in Identity Server by default.

