### PR TITLE
Improve error codes for user defined federated authenticator mgt.

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementFacade.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementFacade.java
@@ -311,7 +311,7 @@ public class IdPManagementFacade {
     }
 
     private IdentityProvider populateEndpointConfig(IdentityProvider identityProvider, String tenantDomain)
-            throws IdentityProviderManagementServerException {
+            throws IdentityProviderManagementException {
 
         if (identityProvider == null || identityProvider.getFederatedAuthenticatorConfigs().length != 1) {
             return identityProvider;
@@ -322,7 +322,7 @@ public class IdPManagementFacade {
     }
 
     private void addEndpointConfig(IdentityProvider identityProvider, String tenantDomain)
-            throws IdentityProviderManagementServerException {
+            throws IdentityProviderManagementException {
 
         if (identityProvider == null || identityProvider.getFederatedAuthenticatorConfigs().length != 1) {
             return;
@@ -333,7 +333,7 @@ public class IdPManagementFacade {
 
     private void updateEndpointConfig(IdentityProvider newIdentityProvider, IdentityProvider oldIdentityProvider,
                                       String tenantDomain)
-            throws IdentityProviderManagementServerException {
+            throws IdentityProviderManagementException {
 
         if (newIdentityProvider == null || newIdentityProvider.getFederatedAuthenticatorConfigs().length != 1) {
             return;
@@ -354,7 +354,7 @@ public class IdPManagementFacade {
     }
 
     private void deleteEndpointConfig(IdentityProvider identityProvider, String tenantDomain)
-            throws IdentityProviderManagementServerException {
+            throws IdentityProviderManagementException {
 
         if (identityProvider == null || identityProvider.getFederatedAuthenticatorConfigs().length != 1) {
             return;

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
@@ -27,7 +27,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.core.util.CryptoUtil;
-import org.wso2.carbon.identity.action.management.exception.ActionMgtException;
+import org.wso2.carbon.identity.action.management.exception.ActionMgtClientException;
+import org.wso2.carbon.identity.action.management.exception.ActionMgtServerException;
 import org.wso2.carbon.identity.action.management.model.Action;
 import org.wso2.carbon.identity.action.management.model.EndpointConfig;
 import org.wso2.carbon.identity.action.management.service.ActionManagementService;
@@ -262,10 +263,23 @@ public class IdentityProviderManagementServiceTest {
 
         ActionManagementService actionManagementServiceForException = mock(ActionManagementService.class);
         when(actionManagementServiceForException.addAction(anyString(), any(), any()))
-                .thenThrow(ActionMgtException.class);
+                .thenThrow(ActionMgtServerException.class);
         IdpMgtServiceComponentHolder.getInstance().setActionManagementService(actionManagementServiceForException);
 
-        assertThrows(IdentityProviderManagementException.class, () ->
+        assertThrows(IdentityProviderManagementServerException.class, () ->
+                identityProviderManagementService.addIdP(idpForErrorScenarios));
+        identityProviderManagementService.getIdPByName(idpForErrorScenarios.getIdentityProviderName());
+    }
+
+    @Test
+    public void testAddIdPActionClientException() throws Exception {
+
+        ActionManagementService actionManagementServiceForException = mock(ActionManagementService.class);
+        when(actionManagementServiceForException.addAction(anyString(), any(), any()))
+                .thenThrow(ActionMgtClientException.class);
+        IdpMgtServiceComponentHolder.getInstance().setActionManagementService(actionManagementServiceForException);
+
+        assertThrows(IdentityProviderManagementClientException.class, () ->
                 identityProviderManagementService.addIdP(idpForErrorScenarios));
         identityProviderManagementService.getIdPByName(idpForErrorScenarios.getIdentityProviderName());
     }
@@ -625,11 +639,12 @@ public class IdentityProviderManagementServiceTest {
         identityProviderManagementService.addIdP(userDefinedIdP);
 
         ActionManagementService actionManagementServiceForException = mock(ActionManagementService.class);
-        doThrow(ActionMgtException.class).when(actionManagementServiceForException).deleteAction(any(), any(), any());
+        doThrow(ActionMgtServerException.class).when(actionManagementServiceForException)
+                .deleteAction(any(), any(), any());
         when(actionManagementServiceForException.getActionByActionId(anyString(), any(), any())).thenReturn(action);
         IdpMgtServiceComponentHolder.getInstance().setActionManagementService(actionManagementServiceForException);
 
-        assertThrows(IdentityProviderManagementException.class, () ->
+        assertThrows(IdentityProviderManagementServerException.class, () ->
                 identityProviderManagementService.deleteIdP(userDefinedIdP.getIdentityProviderName()));
         Assert.assertNotNull(identityProviderManagementService.getIdPByName(userDefinedIdP
                 .getIdentityProviderName()));
@@ -742,7 +757,7 @@ public class IdentityProviderManagementServiceTest {
 
         ActionManagementService actionManagementServiceForException = mock(ActionManagementService.class);
         when(actionManagementServiceForException.updateAction(any(), any(), any(), any()))
-                .thenThrow(ActionMgtException.class);
+                .thenThrow(ActionMgtServerException.class);
         when(actionManagementServiceForException.getActionByActionId(anyString(), any(), any())).thenReturn(action);
         IdpMgtServiceComponentHolder.getInstance().setActionManagementService(actionManagementServiceForException);
 
@@ -900,11 +915,11 @@ public class IdentityProviderManagementServiceTest {
         ActionManagementService actionManagementServiceForException = mock(ActionManagementService.class);
         when(actionManagementServiceForException.addAction(anyString(), any(), any())).thenReturn(action);
         when(actionManagementServiceForException.getActionByActionId(anyString(), any(), any()))
-                .thenThrow(ActionMgtException.class);
+                .thenThrow(ActionMgtServerException.class);
         IdpMgtServiceComponentHolder.getInstance().setActionManagementService(actionManagementServiceForException);
 
-        IdentityProviderManagementException error = assertThrows(IdentityProviderManagementException.class, () ->
-                identityProviderManagementService.addIdP(idpForErrorScenarios));
+        IdentityProviderManagementServerException error = assertThrows(IdentityProviderManagementServerException.class,
+                () -> identityProviderManagementService.addIdP(idpForErrorScenarios));
         assertEquals(error.getErrorCode(), ErrorMessage.ERROR_CODE_RETRIEVING_ENDPOINT_CONFIG.getCode());
     }
 


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/22055

Currently, a server exception is always thrown when attempting to perform endpoint management using the action component. With this PR, it throws a client exception for client-side errors originating from the action component, and a server exception for server-side errors.