### PR TITLE
Remove roles and groups view scope check from login and registrations

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1344,9 +1344,7 @@
   "console.login_and_registration.enabled": true,
   "console.login_and_registration.scopes.feature": ["console:loginAndRegistration"],
   "console.login_and_registration.scopes.read": [
-    "internal_governance_view",
-    "internal_group_mgt_view",
-    "internal_role_mgt_view"
+    "internal_governance_view"
   ],
   "console.login_and_registration.scopes.update": [
     "internal_governance_update",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1495,6 +1495,17 @@
     "internal_application_mgt_view"
   ],
   "console.resident_outbound_provisioning.scopes.update": ["internal_application_mgt_update"],
+  "console.rule_based_password_expiry.enabled": true,
+  "console.rule_based_password_expiry.scopes.read": [
+    "internal_governance_view",
+    "internal_group_mgt_view",
+    "internal_role_mgt_view"
+  ],
+  "console.rule_based_password_expiry.scopes.update": [
+    "internal_config_update",
+    "internal_governance_update",
+    "internal_validation_rule_mgt_update"
+  ],
   "console.console_settings.enabled": true,
   "console.console_settings.disabled_features": [
     "consoleSettings.invitedExternalAdmins",


### PR DESCRIPTION
### Proposed changes in this pull request

This PR removes the role and group view scope check from the login and registration sections.

The initial plan was to modify the token issuance logic to include these missing scopes in the console user token. However, this approach was revised. Instead of requiring these scopes, we decided to hide rule-based password expiry functionality for users without these permissions.

As a result, this PR removes the check on role and group scopes in the login and registration section.

### Related Issues
- https://github.com/wso2/product-is/issues/21041
