### PR TITLE
Add a config to autofill the username with subject attribute while jit provisioning

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -693,7 +693,6 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
             }
             uriBuilder.addParameter(FrameworkConstants.SERVICE_PROVIDER, context.getSequenceConfig()
                     .getApplicationConfig().getApplicationName());
-            uriBuilder.addParameter(FrameworkConstants.USERNAME, username);
             if (!externalIdPConfig.isModifyUserNameAllowed() || (externalIdPConfig.isModifyUserNameAllowed() &&
                     FrameworkUtils.isUsernameFieldAutofillWithSubjectAttr())) {
                 uriBuilder.addParameter(FrameworkConstants.USERNAME, username);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -694,6 +694,10 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
             uriBuilder.addParameter(FrameworkConstants.SERVICE_PROVIDER, context.getSequenceConfig()
                     .getApplicationConfig().getApplicationName());
             uriBuilder.addParameter(FrameworkConstants.USERNAME, username);
+            if (!externalIdPConfig.isModifyUserNameAllowed() || (externalIdPConfig.isModifyUserNameAllowed() &&
+                    FrameworkUtils.isUsernameFieldAutofillWithSubjectAttr())) {
+                uriBuilder.addParameter(FrameworkConstants.USERNAME, username);
+            }
             uriBuilder.addParameter(FrameworkConstants.SKIP_SIGN_UP_ENABLE_CHECK, String.valueOf(true));
             uriBuilder.addParameter(FrameworkConstants.SESSION_DATA_KEY, context.getContextIdentifier());
             addMissingClaims(uriBuilder, context);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -3015,6 +3015,19 @@ public class FrameworkUtils {
     }
 
     /**
+     * Checks if the username field should be autofilled with the subject attribute
+     * during Just-In-Time (JIT) provisioning with prompt for username, password, and consent.
+     *
+     * @return true if the username field should be autofilled with the
+     * subject attribute; false otherwise.
+     */
+    public static boolean isUsernameFieldAutofillWithSubjectAttr() {
+
+        return Boolean.parseBoolean(
+                IdentityUtil.getProperty("JITProvisioning.AutofillUsernameFieldWithSubjectAttribute"));
+    }
+
+    /**
      * This method determines whether username pattern validation should be skipped for JIT provisioning users based
      * on the configuration file.
      *

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandlerTest.java
@@ -134,6 +134,7 @@ public class JITProvisioningPostAuthenticationHandlerTest extends AbstractFramew
         frameworkUtils.close();
         configurationFacade.close();
         carbonUtils.close();
+        privilegedCarbonContextMockedStatic.close();
     }
 
     @Test(description = "This test case tests the Post JIT provisioning handling flow without an authenticated user")

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -85,6 +85,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -92,6 +93,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.REQUEST_PARAM_SP;
@@ -902,6 +904,23 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
 
             String result = FrameworkUtils.getUserIdClaimURI("testIdp", "testTenant");
             assertEquals(result, "http://wso2.org/claims/username");
+        }
+    }
+
+    @Test(description = "Verify that the username auto-fill configuration is retrieved correctly")
+    public void testGetUsernameFieldAutofillWithSubjectAttrConfig() {
+
+        try (MockedStatic<IdentityUtil> identityUtilMockedStatic = mockStatic(IdentityUtil.class)) {
+            identityUtilMockedStatic.when(
+                            () -> IdentityUtil.getProperty(
+                                    eq("JITProvisioning.AutofillUsernameFieldWithSubjectAttribute")))
+                    .thenReturn("true");
+            assertTrue(FrameworkUtils.isUsernameFieldAutofillWithSubjectAttr());
+            identityUtilMockedStatic.when(
+                            () -> IdentityUtil.getProperty(
+                                    eq("JITProvisioning.AutofillUsernameFieldWithSubjectAttribute")))
+                    .thenReturn("false");
+            assertFalse(FrameworkUtils.isUsernameFieldAutofillWithSubjectAttr());
         }
     }
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1237,6 +1237,7 @@
 
     <JITProvisioning>
         <UserNameProvisioningUI>/accountrecoveryendpoint/register.do</UserNameProvisioningUI>
+        <AutofillUsernameFieldWithSubjectAttribute>true</AutofillUsernameFieldWithSubjectAttribute>
         <PasswordProvisioningUI>/accountrecoveryendpoint/signup.do</PasswordProvisioningUI>
         <FailAuthnOnProvisionFailure>false</FailAuthnOnProvisionFailure>
         <EnableEnhancedFeature>false</EnableEnhancedFeature>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2018,6 +2018,7 @@
 
     <JITProvisioning>
         <UserNameProvisioningUI>{{authentication.jit_provisioning.username_provisioning_url}}</UserNameProvisioningUI>
+        <AutofillUsernameFieldWithSubjectAttribute>{{authentication.jit_provisioning.autofill_username_field_with_subject_attribute}}</AutofillUsernameFieldWithSubjectAttribute>
         <PasswordProvisioningUI>{{authentication.jit_provisioning.password_provisioning_url}}</PasswordProvisioningUI>
         <FailAuthnOnProvisionFailure>{{authentication.jit_provisioning.fail_authn_on_provision_failure}}</FailAuthnOnProvisionFailure>
         <SkipUsernamePatternValidation>{{authentication.jit_provisioning.skip_username_pattern_validation}}</SkipUsernamePatternValidation>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -526,6 +526,7 @@
 
   "authentication_policy.check_account_exist": true,
   "authentication.jit_provisioning.username_provisioning_url": "/accountrecoveryendpoint/register.do",
+  "authentication.jit_provisioning.autofill_username_field_with_subject_attribute": true,
   "authentication.jit_provisioning.password_provisioning_url": "/accountrecoveryendpoint/signup.do",
   "authentication.jit_provisioning.skip_username_pattern_validation": false,
   "authentication.jit_provisioning.fail_authn_on_provision_failure": false,


### PR DESCRIPTION
## Purpose
This pr will introduce the changes require to configure the auto populating username with subject attribute.

Since the auto-population of the username field with the subject attribute may already be in use by other customers, we plan to introduce a new configuration to maintain backward compatibility while providing the requested change.

We’ll add a boolean server level configuration option called `AutofillUsernameFieldWithSubjectAttribute` within the JITProvisioning configuration section. Before appending the username to the registration UI redirection URL, we will first verify if the prompt for username, password, and consent provisioning is enabled. If enabled, we will then check if this new configuration is set to `true` and, if so, add the `username` parameter to the registration UI redirection URL.

```bash
[authentication.jit_provisioning]
autofill_username_field_with_subject_attribute = false
```

## Related Issue
- https://github.com/wso2/product-is/issues/21578