### PR TITLE
Add sub org API resource feature scope and api-collection entry

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -858,4 +858,14 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
+    <APIResourceCollection name="org_apiResources" displayName="API Resources" type="organization">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:apiResources"/>
+            </Feature>
+            <Read>
+                <Scope name="internal_org_api_resource_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
 </APIResourceCollections>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -899,4 +899,14 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
+    <APIResourceCollection name="org_apiResources" displayName="API Resources" type="organization">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:apiResources"/>
+            </Feature>
+            <Read>
+                <Scope name="internal_org_api_resource_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
 </APIResourceCollections>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -956,6 +956,15 @@
                     description="Manage api resources from the Console"/>
         </Scopes>
     </APIResource>
+    <APIResource name="API Resource Management Feature" identifier="console:org:apiResources"
+                 requiresAuthorization="true"
+                 description="Resource representation of the API Resource Management Feature"
+                 type="CONSOLE_ORG_FEATURE">
+        <Scopes>
+            <Scope displayName="API Resource Feature" name="console:org:apiResources"
+                   description="Manage api resources in the organization from the Console"/>
+        </Scopes>
+    </APIResource>
     <APIResource name="OIDC Scope Management Feature" identifier="console:scopes:oidc"
                  requiresAuthorization="true"
                  description="Resource representation of the OIDC Scope Management Feature"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -965,6 +965,15 @@
                     description="Manage api resources from the Console"/>
         </Scopes>
     </APIResource>
+    <APIResource name="API Resource Management Feature" identifier="console:org:apiResources"
+                 requiresAuthorization="true"
+                 description="Resource representation of the API Resource Management Feature"
+                 type="CONSOLE_ORG_FEATURE">
+        <Scopes>
+            <Scope displayName="API Resource Feature" name="console:org:apiResources"
+                    description="Manage api resources in the organization from the Console"/>
+        </Scopes>
+    </APIResource>
     <APIResource name="OIDC Scope Management Feature" identifier="console:scopes:oidc"
                  requiresAuthorization="true"
                  description="Resource representation of the OIDC Scope Management Feature"


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject
- This is added to give the capability to view the API Resources from the Console application in sub organization level which is tracked from [1]

[1] https://github.com/wso2/identity-apps/pull/7226