### PR TITLE
Template IdV event listener

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1405,6 +1405,12 @@
                        type="org.wso2.carbon.identity.role.v2.mgt.core.listener.RoleManagementListener"
                        name="org.wso2.carbon.identity.provisioning.listener.ProvisioningRoleMgtListener"
                        orderId="999" enable="true"/>
+        
+        <!-- User Identity Verification Event Listener -->
+        <EventListener id="identity_verification_event_listener"
+                       type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
+                       name="org.wso2.carbon.extension.identity.verification.mgt.listeners.IdVUserOperationEventListener"
+                       orderId="120" enable="true"/>
     </EventListeners>
 
     <!-- These recorders are used to write user delete information to specific sources. Default event recorder is CSV

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2392,6 +2392,13 @@
                        enable="{{event.default_listener.basic_user_info_provider.enable}}">
         </EventListener>
 
+        <!-- User Identity Verification Event Listener -->
+        <EventListener id="identity_verification_event_listener"
+                       type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
+                       name="org.wso2.carbon.extension.identity.verification.mgt.listeners.IdVUserOperationEventListener"
+                       orderId="{{event.default_listener.identity_verification_event_listener.priority}}"
+                       enable="{{event.default_listener.identity_verification_event_listener.enable}}"/>
+
         <!-- Custom Event Listeners -->
         {% for listener in event_listener %}
         <EventListener id="{{listener.id}}"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -628,6 +628,9 @@
   "event.default_listener.group_management_v2_audit_logger.priority": "10",
   "event.default_listener.group_management_v2_audit_logger.enable": true,
 
+  "event.default_listener.identity_verification_event_listener.priority": "120",
+  "event.default_listener.identity_verification_event_listener.enable": true,
+
   "event.default_recorder.user_delete_event.name": "org.wso2.carbon.user.mgt.recorder.DefaultUserDeletionEventRecorder",
   "event.default_recorder.user_delete_event.enable": false,
   "event.default_recorder.user_delete_event.write_to_separate_csv.enable": false,


### PR DESCRIPTION
### Purpose

Template to change the default execution order id (which is 150 ), since the default order id was overridden by another listener.

The selected default order id is `120`, which is not occupied by other `UserOperationEventListener` listeners.

<img width="581" alt="Screenshot 2024-12-25 at 20 30 32" src="https://github.com/user-attachments/assets/74cb64a7-cf54-48b4-b34c-00d4bc1967b1" />


Note : In Asgardeo, this issue does not exist because the `IdVUserOperationEventListener` is configured with a priority of 120 through the deployment.toml file.
