### PR TITLE
Register the application templates API under the application view scope

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -70,7 +70,6 @@
                 <Scope name="internal_governance_view"/>
                 <Scope name="internal_userstore_view"/>
                 <Scope name="internal_shared_application_view"/>
-                <Scope name="internal_extensions_view"/>
                 <Scope name="internal_secret_mgt_view"/>
             </Read>
         </Scopes>
@@ -783,7 +782,6 @@
                 <Scope name="internal_org_role_mgt_view"/>
                 <Scope name="internal_org_userstore_view"/>
                 <Scope name="internal_org_idp_view"/>
-                <Scope name="internal_org_extensions_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -111,7 +111,6 @@
                 <Scope name="internal_governance_view"/>
                 <Scope name="internal_userstore_view"/>
                 <Scope name="internal_shared_application_view"/>
-                <Scope name="internal_extensions_view"/>
                 <Scope name="internal_secret_mgt_view"/>
             </Read>
         </Scopes>
@@ -824,7 +823,6 @@
                 <Scope name="internal_org_role_mgt_view"/>
                 <Scope name="internal_org_userstore_view"/>
                 <Scope name="internal_org_idp_view"/>
-                <Scope name="internal_org_extensions_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -1111,11 +1111,17 @@
     </Resource>
 
     <!-- [Organization] Extension Management API -->
+    <Resource context="(.*)/o/api/server/v1/extensions/applications(.*)" secured="true" http-method="GET">
+        <Scopes>internal_org_application_mgt_view</Scopes>
+    </Resource>
     <Resource context="(.*)/o/api/server/v1/extensions(.*)" secured="true" http-method="GET">
         <Scopes>internal_org_extensions_view</Scopes>
     </Resource>
 
     <!-- Extension Management API -->
+    <Resource context="(.*)/api/server/v1/extensions/applications(.*)" secured="true" http-method="GET">
+        <Scopes>internal_application_mgt_view</Scopes>
+    </Resource>
     <Resource context="(.*)/api/server/v1/extensions(.*)" secured="true" http-method="GET">
         <Scopes>internal_extensions_view</Scopes>
     </Resource>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -1175,11 +1175,17 @@
         </Resource>
 
         <!-- [Organization] Extension Management API -->
+        <Resource context="(.*)/o/api/server/v1/extensions/applications(.*)" secured="true" http-method="GET">
+            <Scopes>internal_org_application_mgt_view</Scopes>
+        </Resource>
         <Resource context="(.*)/o/api/server/v1/extensions(.*)" secured="true" http-method="GET">
             <Scopes>internal_org_extensions_view</Scopes>
         </Resource>
 
         <!-- Extension Management API -->
+        <Resource context="(.*)/api/server/v1/extensions/applications(.*)" secured="true" http-method="GET">
+            <Scopes>internal_application_mgt_view</Scopes>
+        </Resource>
         <Resource context="(.*)/api/server/v1/extensions(.*)" secured="true" http-method="GET">
             <Scopes>internal_extensions_view</Scopes>
         </Resource>


### PR DESCRIPTION
## Purpose
Usable application templates were introduced to the extension management API as part of the SSO templates onboarding feature. However, the applications feature requires the `internal_extensions_view` scope to retrieve application templates from the extension management API. Adding this scope to the applications feature would necessitate a console role migration, as it cannot be implemented in a backward-compatible manner for the UI.  

To address this, this PR registers the application templates endpoint as a separate API with the `internal_application_mgt_view` scope, allowing application templates to be extracted without requiring additional scopes. Other templates in the extension management API will still be accessed using the `internal_extensions_view` scope to maintain backward compatibility.

Additionally, this PR removes the previously added `internal_extensions_view` scope for applications feature, as it is no longer needed. Application templates can now be accessed using the `internal_application_mgt_view` scope.

## Related Issue
- https://github.com/wso2/product-is/issues/21146