### PR TITLE
Add logic to resolve the primary user store domain name for the JIT configuration in the connection template

### DIFF
--- a/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/main/java/org/wso2/carbon/identity/extension/mgt/internal/ExtensionManagerComponent.java
+++ b/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/main/java/org/wso2/carbon/identity/extension/mgt/internal/ExtensionManagerComponent.java
@@ -213,7 +213,9 @@ public class ExtensionManagerComponent {
 
         Path templatePath = extensionResourcePath.resolve(TEMPLATE_FILE_NAME);
         if (Files.exists(templatePath) && Files.isRegularFile(templatePath)) {
-            return readJSONFile(templatePath);
+            JSONObject template = readJSONFile(templatePath);
+            ExtensionMgtUtils.resolveConnectionJITPrimaryDomainName(template);
+            return template;
         }
         return null;
     }

--- a/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/main/java/org/wso2/carbon/identity/extension/mgt/utils/ExtensionMgtConstants.java
+++ b/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/main/java/org/wso2/carbon/identity/extension/mgt/utils/ExtensionMgtConstants.java
@@ -62,4 +62,12 @@ public class ExtensionMgtConstants {
     public static final String KEY = "key";
 
     public static final String VALUE = "value";
+
+    public static final String IDP_CONFIG_KEY = "idp";
+
+    public static final String IDP_PROVISIONING_CONFIG_KEY = "provisioning";
+
+    public static final String IDP_PROVISIONING_JIT_CONFIG_KEY = "jit";
+
+    public static final String IDP_PROVISIONING_JIT_DOMAIN_NAME_KEY = "userstore";
 }

--- a/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/test/java/org/wso2/carbon/identity/extension/mgt/TestUtils.java
+++ b/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/test/java/org/wso2/carbon/identity/extension/mgt/TestUtils.java
@@ -40,7 +40,7 @@ public class TestUtils {
      * Read the extension resource info.json.
      *
      * @param type Extension resource type.
-     * @param id Extension resource identifier.
+     * @param id   Extension resource identifier.
      * @return content of the info file.
      * @throws IOException Exception when file reading fails.
      */
@@ -54,7 +54,7 @@ public class TestUtils {
      * Read the extension resource template.json.
      *
      * @param type Extension resource type.
-     * @param id Extension resource identifier.
+     * @param id   Extension resource identifier.
      * @return content of the template file.
      * @throws IOException Exception when file reading fails.
      */

--- a/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/test/java/org/wso2/carbon/identity/extension/mgt/TestUtils.java
+++ b/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/test/java/org/wso2/carbon/identity/extension/mgt/TestUtils.java
@@ -51,6 +51,20 @@ public class TestUtils {
     }
 
     /**
+     * Read the extension resource template.json.
+     *
+     * @param type Extension resource type.
+     * @param id Extension resource identifier.
+     * @return content of the template file.
+     * @throws IOException Exception when file reading fails.
+     */
+    public static String readExtensionResourceTemplate(String type, String id) throws IOException {
+
+        return readResource(EXTENSION_RESOURCE_PATH + type + PATH_SEPARATOR + id + PATH_SEPARATOR +
+                ExtensionMgtConstants.TEMPLATE_FILE_NAME);
+    }
+
+    /**
      * Read a resource in current class path.
      *
      * @param path File path to be read.

--- a/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/test/java/org/wso2/carbon/identity/extension/mgt/utils/ExtensionMgtUtilsTest.java
+++ b/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/test/java/org/wso2/carbon/identity/extension/mgt/utils/ExtensionMgtUtilsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.extension.mgt.utils;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.mockito.MockedStatic;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.extension.mgt.TestUtils;
+import org.wso2.carbon.user.core.UserCoreConstants;
+
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Unit tests for ExtensionMgtUtils.
+ */
+@Test
+public class ExtensionMgtUtilsTest {
+
+    private final static String CONNECTION_EXTENSIONS = "connections";
+    private final static String CONNECTION_TEMPLATE_ID_1 = "template-1";
+    private final static String UPDATED_PRIMARY_DOMAIN_NAME = "WSO2.ORG";
+
+    @Test(description = "Verify the `resolveConnectionJITPrimaryDomainName` method when the primary domain name " +
+            "remains unchanged.")
+    public void testResolveConnectionJITPrimaryDomainNameMethodForDefaultPrimaryDomain() throws IOException {
+
+        JSONObject sampleConnectionTemplate =
+                new JSONObject(
+                        TestUtils.readExtensionResourceTemplate(CONNECTION_EXTENSIONS, CONNECTION_TEMPLATE_ID_1));
+
+        try (MockedStatic<IdentityUtil> identityUtilMockedStatic = mockStatic(IdentityUtil.class)) {
+            identityUtilMockedStatic.when(IdentityUtil::getPrimaryDomainName)
+                    .thenReturn(UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME);
+
+            ExtensionMgtUtils.resolveConnectionJITPrimaryDomainName(sampleConnectionTemplate);
+            String primaryDomainName = sampleConnectionTemplate.getJSONObject(ExtensionMgtConstants.IDP_CONFIG_KEY)
+                    .getJSONObject(ExtensionMgtConstants.IDP_PROVISIONING_CONFIG_KEY)
+                    .getJSONObject(ExtensionMgtConstants.IDP_PROVISIONING_JIT_CONFIG_KEY)
+                    .getString(ExtensionMgtConstants.IDP_PROVISIONING_JIT_DOMAIN_NAME_KEY);
+            Assert.assertEquals(primaryDomainName, UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME);
+        }
+    }
+
+    @Test(description = "Verify the `resolveConnectionJITPrimaryDomainName` method when the primary domain name " +
+            "is changed.")
+    public void testResolveConnectionJITPrimaryDomainNameMethodForChangedPrimaryDomain() throws IOException {
+
+        JSONObject sampleConnectionTemplate =
+                new JSONObject(
+                        TestUtils.readExtensionResourceTemplate(CONNECTION_EXTENSIONS, CONNECTION_TEMPLATE_ID_1));
+
+        try (MockedStatic<IdentityUtil> identityUtilMockedStatic = mockStatic(IdentityUtil.class)) {
+            identityUtilMockedStatic.when(IdentityUtil::getPrimaryDomainName).thenReturn(UPDATED_PRIMARY_DOMAIN_NAME);
+
+            ExtensionMgtUtils.resolveConnectionJITPrimaryDomainName(sampleConnectionTemplate);
+            String primaryDomainName = sampleConnectionTemplate.getJSONObject(ExtensionMgtConstants.IDP_CONFIG_KEY)
+                    .getJSONObject(ExtensionMgtConstants.IDP_PROVISIONING_CONFIG_KEY)
+                    .getJSONObject(ExtensionMgtConstants.IDP_PROVISIONING_JIT_CONFIG_KEY)
+                    .getString(ExtensionMgtConstants.IDP_PROVISIONING_JIT_DOMAIN_NAME_KEY);
+            Assert.assertEquals(primaryDomainName, UPDATED_PRIMARY_DOMAIN_NAME);
+        }
+    }
+}

--- a/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/test/resources/extensions/connections/template-1/template.json
+++ b/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/test/resources/extensions/connections/template-1/template.json
@@ -1,0 +1,214 @@
+{
+  "id": "apple-idp",
+  "name": "Apple",
+  "description": "Login users with their Apple IDs.",
+  "docLink": "/guides/authentication/social-login/add-apple-login/",
+  "image": "assets/images/logos/apple.svg",
+  "category": "DEFAULT",
+  "displayOrder": 5,
+  "services": [],
+  "tags": [ "Social-Login" ],
+  "idp": {
+    "name": "Apple",
+    "description": "",
+    "image": "",
+    "isPrimary": false,
+    "isFederationHub": false,
+    "homeRealmIdentifier": "",
+    "certificate": {
+      "certificates": []
+    },
+    "alias": "https://localhost:9444/oauth2/token",
+    "idpIssuerName": "",
+    "claims": {
+      "userIdClaim": {
+        "uri": "email"
+      },
+      "roleClaim": {
+        "uri": "http://wso2.org/claims/role"
+      },
+      "mappings": [
+        {
+          "idpClaim": "email",
+          "localClaim": {
+            "id": "aHR0cDovL3dzbzIub3JnL2NsYWltcy9lbWFpbGFkZHJlc3M",
+            "uri": "http://wso2.org/claims/emailaddress",
+            "displayName": "Email"
+          }
+        },
+        {
+          "idpClaim": "firstName",
+          "localClaim": {
+            "id": "aHR0cDovL3dzbzIub3JnL2NsYWltcy9naXZlbm5hbWU",
+            "uri": "http://wso2.org/claims/givenname",
+            "displayName": "First Name"
+          }
+        },
+        {
+          "idpClaim": "lastName",
+          "localClaim": {
+            "id": "aHR0cDovL3dzbzIub3JnL2NsYWltcy9sYXN0bmFtZQ",
+            "uri": "http://wso2.org/claims/lastname",
+            "displayName": "Last Name"
+          }
+        }
+      ],
+      "provisioningClaims": []
+    },
+    "roles": {
+      "mappings": [],
+      "outboundProvisioningRoles": []
+    },
+    "provisioning": {
+      "jit": {
+        "isEnabled": true,
+        "scheme": "PROVISION_SILENTLY",
+        "userstore": "PRIMARY",
+        "attributeSyncMethod": "NONE"
+      }
+    },
+    "federatedAuthenticators": {
+      "defaultAuthenticatorId": "QXBwbGVPSURDQXV0aGVudGljYXRvcg",
+      "authenticators": [
+        {
+          "authenticatorId": "QXBwbGVPSURDQXV0aGVudGljYXRvcg",
+          "isEnabled": true,
+          "properties": [
+            {
+              "key": "ClientId",
+              "displayName": "Services ID (Client ID)",
+              "description": "Enter Apple IDP services ID value",
+              "type": "STRING",
+              "displayOrder": 1,
+              "regex": ".*",
+              "isMandatory": true,
+              "isConfidential": false,
+              "options": [],
+              "defaultValue": "",
+              "subProperties": []
+            },
+            {
+              "key": "TeamId",
+              "displayName": "Team ID",
+              "description": "Enter Apple developer team ID value",
+              "type": "STRING",
+              "displayOrder": 2,
+              "regex": ".*",
+              "isMandatory": true,
+              "isConfidential": false,
+              "options": [],
+              "defaultValue": "",
+              "subProperties": []
+            },
+            {
+              "key": "KeyId",
+              "displayName": "Key ID",
+              "description": "Enter key ID value of the private key",
+              "type": "STRING",
+              "displayOrder": 3,
+              "regex": ".*",
+              "isMandatory": true,
+              "isConfidential": false,
+              "options": [],
+              "defaultValue": "",
+              "subProperties": []
+            },
+            {
+              "key": "PrivateKey",
+              "displayName": "Private Key",
+              "description": "Enter Apple private key generated for the app",
+              "type": "STRING",
+              "displayOrder": 4,
+              "regex": ".*",
+              "isMandatory": true,
+              "isConfidential": true,
+              "options": [],
+              "defaultValue": "",
+              "subProperties": []
+            },
+            {
+              "key": "SecretValidityPeriod",
+              "displayName": "Client Secret Validity Period",
+              "description": "Enter the validity period of the generated client secret in seconds.",
+              "type": "STRING",
+              "displayOrder": 5,
+              "regex": ".*",
+              "isMandatory": false,
+              "isConfidential": false,
+              "options": [],
+              "defaultValue": "15777000",
+              "subProperties": []
+            },
+            {
+              "key": "callbackUrl",
+              "displayName": "Callback URL",
+              "description": "Enter the callback URL used to obtain Apple credentials.",
+              "type": "STRING",
+              "displayOrder": 6,
+              "regex": ".*",
+              "isMandatory": true,
+              "isConfidential": false,
+              "options": [],
+              "defaultValue": "",
+              "subProperties": []
+            },
+            {
+              "key": "Scopes",
+              "displayName": "Scopes",
+              "description": "Enter a space separated list of scopes to request from the user.",
+              "type": "STRING",
+              "displayOrder": 7,
+              "regex": ".*",
+              "isMandatory": false,
+              "isConfidential": false,
+              "options": [],
+              "defaultValue": "",
+              "subProperties": []
+            },
+            {
+              "key": "AdditionalQueryParameters",
+              "displayName": "Additional Query Parameters",
+              "description": "Additional query parameters to be sent to Apple.",
+              "type": "STRING",
+              "displayOrder": 8,
+              "regex": ".*",
+              "isMandatory": false,
+              "isConfidential": false,
+              "options": [],
+              "defaultValue": "",
+              "subProperties": []
+            },
+            {
+              "key": "ClientSecret",
+              "displayName": "Client Secret",
+              "description": "Apple client secret generated for the app",
+              "type": "STRING",
+              "displayOrder": 9,
+              "regex": ".*",
+              "isMandatory": false,
+              "isConfidential": true,
+              "options": [],
+              "defaultValue": "",
+              "subProperties": []
+            },
+            {
+              "key": "RegenerateClientSecret",
+              "displayName": "Regenerate Client Secret",
+              "description": "Specifies if the client secret should be re-generated.",
+              "type": "BOOLEAN",
+              "displayOrder": 10,
+              "regex": ".*",
+              "isMandatory": false,
+              "isConfidential": false,
+              "options": [],
+              "defaultValue": "",
+              "subProperties": []
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "type": "SOCIAL",
+  "templateId": "apple-idp"
+}

--- a/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/test/resources/testng.xml
+++ b/components/extension-mgt/org.wso2.carbon.identity.extension.mgt/src/test/resources/testng.xml
@@ -20,6 +20,7 @@
     <test name="org.wso2.carbon.identity.extension.mgt.test" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.carbon.identity.extension.mgt.function.JSONObjectToExtensionInfoTest"/>
+            <class name="org.wso2.carbon.identity.extension.mgt.utils.ExtensionMgtUtilsTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
### Purpose
For connection templates with the JIT provisioning user store configured as `PRIMARY`, this change will verify if the primary user store domain name has been updated by the user. If so, the logic will replace the user store name with the updated primary domain name.

### Related Issue
- https://github.com/wso2/product-is/issues/21348