### PR TITLE
For oracle set parentSchema as schemaName when configured

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/persistence/JDBCPersistenceManager.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/persistence/JDBCPersistenceManager.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.core.persistence;
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.tomcat.jdbc.pool.DataSourceProxy;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
@@ -28,6 +29,7 @@ import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Properties;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -53,6 +55,7 @@ public class JDBCPersistenceManager {
     // This property refers to Active transaction state of postgresql db
     private static final String PG_ACTIVE_SQL_TRANSACTION_STATE = "25001";
     private static final String POSTGRESQL_DATABASE = "PostgreSQL";
+    public static final String PARENT_SCHEMA = "parentSchema";
 
     private JDBCPersistenceManager() {
 
@@ -158,6 +161,21 @@ public class JDBCPersistenceManager {
     public Connection getDBConnection() throws IdentityRuntimeException {
 
         return getDBConnection(true);
+    }
+
+    /**
+     * This method extracts the parent schema of oracle db configurations.
+     *
+     * @return Parent Schema.
+     */
+    public String getParentSchema() {
+
+        String parentSchema = null;
+        Properties properties = ((DataSourceProxy) dataSource).getDbProperties();
+        if (properties != null) {
+            parentSchema = properties.getProperty(PARENT_SCHEMA);
+        }
+        return parentSchema;
     }
 
     /**

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityDatabaseUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityDatabaseUtil.java
@@ -32,6 +32,7 @@ import java.sql.SQLException;
 import javax.sql.DataSource;
 
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.DB2;
+import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.ORACLE;
 
 /**
  * Utility class for database operations.
@@ -44,6 +45,16 @@ public class IdentityDatabaseUtil {
     public static Connection getDBConnection() throws IdentityRuntimeException {
 
         return getDBConnection(true);
+    }
+
+    /**
+     * This method returns the parent schema of oracle db configurations.
+     *
+     * @return Parent Schema.
+     */
+    public static String getParentSchema() {
+
+        return JDBCPersistenceManager.getInstance().getParentSchema();
     }
 
     /**
@@ -212,6 +223,13 @@ public class IdentityDatabaseUtil {
             }
             String schemaName = connection.getSchema();
             String catalogName = connection.getCatalog();
+
+            if (ORACLE.equalsIgnoreCase(connection.getMetaData().getDatabaseProductName())) {
+                String parentSchema = getParentSchema();
+                if (parentSchema != null) {
+                    schemaName = parentSchema;
+                }
+            }
             try (ResultSet resultSet = metaData.getTables(catalogName, schemaName, tableName, new String[]{"TABLE"})) {
                 if (resultSet.next()) {
                     if (log.isDebugEnabled()) {


### PR DESCRIPTION
### Proposed changes in this pull request
During is table exist check, set parentSchema as schemaName if configured.

Related Issues:
- https://github.com/wso2/product-is/issues/22091