### PR TITLE
Remove secret mgt scopes form application role

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -44,17 +44,14 @@
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
-                <Scope name="internal_secret_mgt_update"/>
             </Update>
             <Delete>
                 <Scope name="internal_application_mgt_delete"/>
                 <Scope name="internal_shared_application_delete"/>
-                <Scope name="internal_secret_mgt_delete"/>
             </Delete>
             <Create>
                 <Scope name="internal_application_mgt_create"/>
                 <Scope name="internal_shared_application_create"/>
-                <Scope name="internal_secret_mgt_add"/>
             </Create>
             <Read>
                 <Scope name="internal_cors_origins_view"/>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -85,17 +85,14 @@
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
-                <Scope name="internal_secret_mgt_update"/>
             </Update>
             <Delete>
                 <Scope name="internal_application_mgt_delete"/>
                 <Scope name="internal_shared_application_delete"/>
-                <Scope name="internal_secret_mgt_delete"/>
             </Delete>
             <Create>
                 <Scope name="internal_application_mgt_create"/>
                 <Scope name="internal_shared_application_create"/>
-                <Scope name="internal_secret_mgt_add"/>
             </Create>
             <Read>
                 <Scope name="internal_cors_origins_view"/>


### PR DESCRIPTION
This pull request includes changes to the `features/api-resource-mgt` module, specifically in the `api-resource-collection.xml` and `api-resource-collection.xml.j2` files. The main focus of these changes is to remove certain internal scopes related to secret management.

Changes to internal scopes:

* [`features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml`](diffhunk://#diff-3f84f2fc41782b93036d6233268491eda9c179f357755bd84fb13a798eb34badL47-L57): Removed internal scopes `internal_secret_mgt_update`, `internal_secret_mgt_delete`, and `internal_secret_mgt_add`.
* [`features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2`](diffhunk://#diff-a2db3b627822a2fef1faa05dbc072adb80137338c607f5e6c8ccfeb7295c7f33L88-L98): Removed internal scopes `internal_secret_mgt_update`, `internal_secret_mgt_delete`, and `internal_secret_mgt_add`.

___

- https://github.com/wso2/product-is/issues/22162