### PR TITLE
Fix high I/O issue when removing session data

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -316,7 +316,6 @@ public class SessionDataStore {
             sessionCleanUpService.activateCleanUp();
         }
 
-
         String checkExistingEntryForDeleteOperationInsertProperty = IdentityUtil.getProperty(
                 "JDBCPersistenceManager.SessionDataPersist.CheckExistingEntryForDeleteOperationInsert");
         if (StringUtils.isNotBlank(checkExistingEntryForDeleteOperationInsertProperty)) {
@@ -440,25 +439,25 @@ public class SessionDataStore {
 
     private String getSqlGetLastOperation(Connection connection) throws SQLException {
 
-        String sqlGetLastOperation;
+        String sqlGetLastOperationQuery;
         String driverName = connection.getMetaData().getDriverName();
         if (driverName.contains(MYSQL_DATABASE) || driverName.contains(MARIA_DATABASE)
                 || driverName.contains(H2_DATABASE)) {
-            sqlGetLastOperation = SQL_RETRIEVE_LAST_SESSION_DATA_OPERATION_MYSQL;
+            sqlGetLastOperationQuery = SQL_RETRIEVE_LAST_SESSION_DATA_OPERATION_MYSQL;
         } else if (connection.getMetaData().getDatabaseProductName().contains(DB2_DATABASE)) {
-            sqlGetLastOperation = SQL_RETRIEVE_LAST_SESSION_DATA_OPERATION_DB2SQL;
+            sqlGetLastOperationQuery = SQL_RETRIEVE_LAST_SESSION_DATA_OPERATION_DB2SQL;
         } else if (driverName.contains(MS_SQL_DATABASE)
                 || driverName.contains(MICROSOFT_DATABASE)) {
-            sqlGetLastOperation = SQL_RETRIEVE_LAST_SESSION_DATA_OPERATION_MSSQL;
+            sqlGetLastOperationQuery = SQL_RETRIEVE_LAST_SESSION_DATA_OPERATION_MSSQL;
         } else if (driverName.contains(POSTGRESQL_DATABASE)) {
-            sqlGetLastOperation = SQL_RETRIEVE_LAST_SESSION_DATA_OPERATION_POSTGRESQL;
+            sqlGetLastOperationQuery = SQL_RETRIEVE_LAST_SESSION_DATA_OPERATION_POSTGRESQL;
         } else if (driverName.contains(INFORMIX_DATABASE)) {
             // Driver name = "IBM Informix JDBC Driver for IBM Informix Dynamic Server"
-            sqlGetLastOperation = SQL_RETRIEVE_LAST_SESSION_DATA_OPERATION_INFORMIX;
+            sqlGetLastOperationQuery = SQL_RETRIEVE_LAST_SESSION_DATA_OPERATION_INFORMIX;
         } else {
-            sqlGetLastOperation = SQL_RETRIEVE_LAST_SESSION_DATA_OPERATION_ORACLE;
+            sqlGetLastOperationQuery = SQL_RETRIEVE_LAST_SESSION_DATA_OPERATION_ORACLE;
         }
-        return sqlGetLastOperation;
+        return sqlGetLastOperationQuery;
     }
 
     public void storeSessionData(String key, String type, Object entry) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -399,7 +399,15 @@ public class SessionDataStore {
         return null;
     }
 
-    public boolean isSessionDataExist(String key, String type, String requiredOperation) {
+    /**
+     * Validate last operation performed on the session data with given key and type.
+     *
+     * @param key               Session data key.
+     * @param type              Session data type.
+     * @param requiredOperation Required operation to validate.
+     * @return True if the last operation is same as the required operation.
+     */
+    public boolean validateLastOperationOnSessionData(String key, String type, String requiredOperation) {
 
         if (!enablePersist) {
             return false;
@@ -658,7 +666,8 @@ public class SessionDataStore {
             tempAuthnContextDataDeleteQueue.push(new SessionContextDO(key, type, null, nanoTime));
             return;
         }
-        if (checkExistingEntryForDeleteOperationInsert && isSessionDataExist(key, type, OPERATION_DELETE)) {
+        if (checkExistingEntryForDeleteOperationInsert &&
+                validateLastOperationOnSessionData(key, type, OPERATION_DELETE)) {
             return;
         }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStoreTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStoreTest.java
@@ -131,7 +131,7 @@ public class SessionDataStoreTest extends DataStoreBaseTest {
     }
 
     @DataProvider
-    public Object[][] getIsSessionExistData() {
+    public Object[][] getValidateLastOperationOnSessionData() {
 
         return new Object[][]{
                 {"00000001", "sessionType", OPERATION_STORE, true},
@@ -141,9 +141,9 @@ public class SessionDataStoreTest extends DataStoreBaseTest {
         };
     }
 
-    @Test(dependsOnMethods = "testRemoveSessionData", dataProvider = "getIsSessionExistData")
-    public void testIsSessionExist(String key, String type, String operation, boolean isExist) throws
-            Exception {
+    @Test(dependsOnMethods = "testRemoveSessionData", dataProvider = "getValidateLastOperationOnSessionData")
+    public void testValidateLastOperationOnSessionData(String key, String type, String operation, boolean isExist)
+            throws Exception {
 
         try (MockedStatic<CarbonContext> carbonContext = mockStatic(CarbonContext.class);
              MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
@@ -159,12 +159,13 @@ public class SessionDataStoreTest extends DataStoreBaseTest {
             mockCarbonContext(carbonContext);
             mockIdentityUtils(identityTenantUtil, idPManagementUtil, identityUtil);
             mockDataHolder(frameworkServiceDataHolder);
-            boolean isSessionDataExist = SessionDataStore.getInstance().isSessionDataExist(key, type, operation);
+            boolean isSessionDataExist = SessionDataStore.getInstance()
+                    .validateLastOperationOnSessionData(key, type, operation);
             assertEquals(isSessionDataExist, isExist);
         }
     }
 
-    @Test(dependsOnMethods = "testIsSessionExist")
+    @Test(dependsOnMethods = "testValidateLastOperationOnSessionData")
     public void testRemoveExpiredSessionData() throws Exception {
 
         try (MockedStatic<CarbonContext> carbonContext = mockStatic(CarbonContext.class);

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -66,6 +66,7 @@
             <UserSessionMapping>
                 <Enable>{{session_data.persistence.enable_user_session_mapping}}</Enable>
             </UserSessionMapping>
+            <CheckExistingEntryForDeleteOperationInsert>{{session_data.session_data_persist.check_existing_entry_for_delete_operation_insert}}</CheckExistingEntryForDeleteOperationInsert>
         </SessionDataPersist>
         <PushedAuthReqCleanUp>
             <Enable>{{par.cleanup.enable_expired_requests_cleanup}}</Enable>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -31,6 +31,7 @@
   "session_data.cleanup.enable_pre_session_data_cleanup": true,
   "session_data.cleanup.enable_periodic_pre_session_data_cleanup": true,
   "session_data.session_data_persist.session_and_temp_data_separation_enabled.enable": true,
+  "session_data.session_data_persist.check_existing_entry_for_delete_operation_insert": false,
   "session_data.cleanup.pre_session_data_cleanup_thread_pool_size": "20",
   "session.nonce.cookie.enabled": true,
   "session.nonce.cookie.default_whitelist_authenticators": ["MagicLinkAuthenticator"],


### PR DESCRIPTION
**Purpose**
When clearing session data, we add an entry with DELETE_OPERATION. Before the insertion, we check for already existing Delete Operation entry by using `getSessionContextDataByOperation ` method. This method retrieves the BLOB object and set to session data which cause high I/O. From this PR, we adds a new method to check the existence of session data without retrieving BLOB object. Additionally this check also will have a perf hit. Therefore, we have introduced a configuration to enable the check.

Issue - https://github.com/wso2/product-is/issues/21139