### PR TITLE
Fix error logging and throwing error as it is an anti pattern

### DIFF
--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisioningThread.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisioningThread.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -118,9 +118,9 @@ public class ProvisioningThread implements Callable<Boolean> {
             }
             success = true;
         } catch (Exception e) {
-            String errMsg = " Provisioning for Entity " + provisioningEntity.getEntityName() +
+            String errMsg = "Fail the Provisioning for Entity " + provisioningEntity.getEntityName() +
                     " For operation = " + provisioningEntity.getOperation();
-            log.error(errMsg, e);
+            log.warn(errMsg);
             throw new IdentityProvisioningException(errMsg, e);
         } finally {
             PrivilegedCarbonContext.endTenantFlow();


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

The "log and throw" anti-pattern occurs when an exception is logged and then re-thrown, leading to duplicate log entries.

Logging an additional detail is fine as it will not be a redundant information. Hence a warning log is added to notify the outbound provisioning failure.


### Related issues
- https://github.com/wso2/product-is/issues/21039