### PR TITLE
Minor improvement to action execute Method.

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutorService.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutorService.java
@@ -51,4 +51,17 @@ public interface ActionExecutorService {
     ActionExecutionStatus execute(ActionType actionType, Map<String, Object> eventContext, String tenantDomain) throws
             ActionExecutionException;
 
+    /**
+     * Resolve the actions by given the action id list and execute them.
+     *
+     * @param actionType    Action Type.
+     * @param actionIdList     Lis of action Ids of the actions that need to be executed.
+     * @param eventContext  The event context of the corresponding flow.
+     * @param tenantDomain  Tenant domain.
+     * @return {@link ActionExecutionStatus} The status of the action execution and the response context.
+     * @throws ActionExecutionException If an error occurs while executing the action.
+     */
+    ActionExecutionStatus execute(ActionType actionType, String[] actionIdList,
+                                  Map<String, Object> eventContext, String tenantDomain)
+            throws ActionExecutionException;
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImpl.java
@@ -106,6 +106,7 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
      * @param tenantDomain  Tenant domain.
      * @return Action execution status.
      */
+    @Override
     public ActionExecutionStatus<?> execute(ActionType actionType, Map<String, Object> eventContext,
                                             String tenantDomain) throws ActionExecutionException {
 
@@ -131,6 +132,7 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
      * @param tenantDomain  Tenant domain.
      * @return Action execution status.
      */
+    @Override
     public ActionExecutionStatus<?> execute(ActionType actionType, String[] actionIdList,
                                             Map<String, Object> eventContext, String tenantDomain)
             throws ActionExecutionException {


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/22165

This will bring the Bring following method which execute the action id list to its interface.

    ActionExecutionStatus execute(ActionType actionType, String[] actionIdList,
                                  Map<String, Object> eventContext, String tenantDomain)
            throws ActionExecutionException;