### PR TITLE
Improve to show error page with reason after failed authentication

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/exception/ShowAuthFailureReasonException.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/exception/ShowAuthFailureReasonException.java
@@ -1,0 +1,18 @@
+package org.wso2.carbon.identity.application.authentication.framework.exception;
+
+/**
+ * Exception class to be used when the authentication failure reason should be shown to the user.
+ */
+public class ShowAuthFailureReasonException extends FrameworkException {
+
+    public ShowAuthFailureReasonException(String message) {
+
+        super(message);
+    }
+
+    public ShowAuthFailureReasonException(String message, Throwable cause) {
+
+        super(message, cause);
+    }
+
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -47,6 +47,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.I
 import org.wso2.carbon.identity.application.authentication.framework.exception.JsFailureException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.MisconfigurationException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.PostAuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.ShowAuthFailureReasonException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.RequestCoordinator;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceComponent;
@@ -449,6 +450,12 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     e.getErrorCode());
             FrameworkUtils.sendToRetryPage(request, responseWrapper, context, errorWrapper.getStatus(),
                     errorWrapper.getStatusMsg());
+        } catch (ShowAuthFailureReasonException e) {
+            publishAuthenticationFailure(request, context, context.getSequenceConfig().getAuthenticatedUser(),
+                    e.getErrorCode());
+            if (log.isDebugEnabled()) {
+                log.debug("User will be redirected to the error page provided by the authenticator.");
+            }
         } catch (Exception e) {
             if ((e instanceof FrameworkException)
                     && (NONCE_ERROR_CODE.equals(((FrameworkException) e).getErrorCode()))) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandler.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.JsFailureException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.ShowAuthFailureReasonException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.sequence.SequenceHandler;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationError;
@@ -80,6 +81,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.BACK_TO_FIRST_STEP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.JSAttributes.PROP_CURRENT_NODE;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.POLYGLOT_CLASS;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.SHOW_AUTH_FAILURE_REASON_PAGE;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.promptOnLongWait;
 
 /**
@@ -395,6 +397,14 @@ public class GraphBasedSequenceHandler extends DefaultStepBasedSequenceHandler i
                     params.put(LogConstants.InputKeys.APPLICATION_NAME,
                             applicationName));
             diagnosticLogBuilder.inputParams(params);
+        }
+        boolean showAuthFailureReason = context.getProperty(SHOW_AUTH_FAILURE_REASON_PAGE) != null &&
+                (boolean) context.getProperty(SHOW_AUTH_FAILURE_REASON_PAGE);
+        if (showAuthFailureReason) {
+            context.setRequestAuthenticated(false);
+            context.getSequenceConfig().setCompleted(true);
+            context.removeProperty(SHOW_AUTH_FAILURE_REASON_PAGE);
+            throw new ShowAuthFailureReasonException("Authentication failed reason page has to be displayed.");
         }
         if (node.isShowErrorPage()) {
             // Set parameters specific to sendError function to context if isShowErrorPage  is true

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -192,6 +192,8 @@ public abstract class FrameworkConstants {
     public static final String USE_IDP_ROLE_CLAIM_AS_IDP_GROUP_CLAIM =
             "UseIDPRoleClaimAsIDPGroupClaim";
 
+    public static final String SHOW_AUTH_FAILURE_REASON_PAGE = "ShowAuthFailureReasonPage";
+
     // Current session thread local identifier.
     public static final String CURRENT_SESSION_IDENTIFIER = "currentSessionIdentifier";
     public static final String CURRENT_TOKEN_IDENTIFIER = "currentTokenIdentifier";


### PR DESCRIPTION
Currently, when an authentication step fails, if authenticator has the retryAuthenticationEnabled as true, the same authenticator will be executed and prompted for a user input and the error reason is showed on that page.If retryAuthenticationEnabled is set to false, the user will be sent to the caller path of the application.

For push notification based authentication, during an authentication failure situation like user denying the request, the user has to be shown with an error page saying the relevant failure reason. Since, we show the errors when retrying the authenticator in our current implementation, this requirement cannot be fulfilled.

This PR will enable the authenticator to redirect to an error page when the authentication failure occurs.