### PR TITLE
Set setDefaultSharedProfileValueResolvingMethod for local claims in Unified Claim Manager

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/test/java/org/wso2/carbon/identity/claim/metadata/mgt/UnifiedClaimMetadataManagerTest.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/test/java/org/wso2/carbon/identity/claim/metadata/mgt/UnifiedClaimMetadataManagerTest.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -76,6 +77,7 @@ public class UnifiedClaimMetadataManagerTest {
     private final String LOCAL_CLAIM_2 = "http://wso2.org/claims/email";
     private final String LOCAL_CLAIM_3 = "http://wso2.org/claims/country";
     private final String LOCAL_CLAIM_4 = "http://wso2.org/claims/identity/accountLocked";
+    private final String LOCAL_CLAIM_5 = "http://wso2.org/claims/customClaim5";
     private final String EXT_CLAIM_DIALECT_1_CLAIM_1 = "http://abc.org/claim1";
     private final String EXT_CLAIM_DIALECT_1_CLAIM_2 = "http://abc.org/claim2";
     private final String EXT_CLAIM_DIALECT_1_CLAIM_3 = "http://abc.org/claim3";
@@ -226,12 +228,18 @@ public class UnifiedClaimMetadataManagerTest {
     @Test
     public void testGetLocalClaims() throws ClaimMetadataException {
 
+        Map<String, String> claimProperties = new HashMap<>();
+        claimProperties.put(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD,
+                ClaimConstants.SharedProfileValueResolvingMethod.FROM_ORIGIN.getName());
         List<LocalClaim> localClaimsInSystem = new ArrayList<>();
-        localClaimsInSystem.add(new LocalClaim(LOCAL_CLAIM_1));
-        localClaimsInSystem.add(new LocalClaim(LOCAL_CLAIM_2));
+        localClaimsInSystem.add(new LocalClaim(LOCAL_CLAIM_1, new ArrayList<>(), claimProperties));
+        localClaimsInSystem.add(new LocalClaim(LOCAL_CLAIM_2, new ArrayList<>(), claimProperties));
 
+        Map<String, String> claimPropertiesForLocalClaimsInDB = new HashMap<>();
+        claimPropertiesForLocalClaimsInDB.put(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD,
+                ClaimConstants.SharedProfileValueResolvingMethod.FROM_SHARED_PROFILE.getName());
         List<LocalClaim> localClaimsInDB = new ArrayList<>();
-        localClaimsInDB.add(new LocalClaim(LOCAL_CLAIM_3));
+        localClaimsInDB.add(new LocalClaim(LOCAL_CLAIM_3, new ArrayList<>(), claimPropertiesForLocalClaimsInDB));
         localClaimsInDB.add(new LocalClaim(LOCAL_CLAIM_4));
         LocalClaim duplicatedLocalClaim = new LocalClaim(LOCAL_CLAIM_2);
         duplicatedLocalClaim.setMappedAttributes(new ArrayList<>());
@@ -247,38 +255,67 @@ public class UnifiedClaimMetadataManagerTest {
                 .map(LocalClaim::getClaimURI)
                 .collect(Collectors.toList());
         assertTrue(localClaimURIsInResult.contains(LOCAL_CLAIM_1));
-        assertTrue(localClaimURIsInResult.contains(LOCAL_CLAIM_3));
-        assertTrue(localClaimURIsInResult.contains(LOCAL_CLAIM_4));
-        LocalClaim localClaim4 = result.stream()
+        LocalClaim localClaim1 = result.stream()
+                .filter(localClaim -> localClaim.getClaimURI().equals(LOCAL_CLAIM_1))
+                .findFirst()
+                .orElse(null);
+        assertEquals(localClaim1.getClaimProperty(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD),
+                ClaimConstants.SharedProfileValueResolvingMethod.FROM_ORIGIN.getName());
+        LocalClaim localClaim2 = result.stream()
                 .filter(localClaim -> localClaim.getClaimURI().equals(LOCAL_CLAIM_2))
                 .findFirst()
                 .orElse(null);
-        assertNotNull(localClaim4);
-        assertEquals(localClaim4.getMappedAttributes().size(), 1);
-        assertEquals(localClaim4.getMappedAttributes().get(0).getUserStoreDomain(), "PRIMARY");
-        assertEquals(localClaim4.getMappedAttributes().get(0).getAttributeName(), "username");
+        assertNotNull(localClaim2);
+        assertEquals(localClaim2.getClaimProperty(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD),
+                ClaimConstants.SharedProfileValueResolvingMethod.FROM_ORIGIN.getName());
+        assertEquals(localClaim2.getMappedAttributes().size(), 1);
+        assertEquals(localClaim2.getMappedAttributes().get(0).getUserStoreDomain(), "PRIMARY");
+        assertEquals(localClaim2.getMappedAttributes().get(0).getAttributeName(), "username");
+        assertTrue(localClaimURIsInResult.contains(LOCAL_CLAIM_3));
+        LocalClaim localClaim3 = result.stream()
+                .filter(localClaim -> localClaim.getClaimURI().equals(LOCAL_CLAIM_3))
+                .findFirst()
+                .orElse(null);
+        assertEquals(localClaim3.getClaimProperty(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD),
+                ClaimConstants.SharedProfileValueResolvingMethod.FROM_SHARED_PROFILE.getName());
+        assertTrue(localClaimURIsInResult.contains(LOCAL_CLAIM_4));
+        LocalClaim localClaim4 = result.stream()
+                .filter(localClaim -> localClaim.getClaimURI().equals(LOCAL_CLAIM_4))
+                .findFirst()
+                .orElse(null);
+        assertEquals(localClaim4.getClaimProperty(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD),
+                ClaimConstants.SharedProfileValueResolvingMethod.FROM_ORIGIN.getName());
     }
 
     @Test
     public void testGetLocalClaim() throws ClaimMetadataException {
 
-        LocalClaim localClaim = new LocalClaim(LOCAL_CLAIM_1);
+        Map<String, String> claimProperties = new HashMap<>();
+        claimProperties.put(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD,
+                ClaimConstants.SharedProfileValueResolvingMethod.FROM_ORIGIN.getName());
+        LocalClaim localClaim = new LocalClaim(LOCAL_CLAIM_1, new ArrayList<>(), claimProperties);
         when(systemDefaultClaimMetadataManager.getLocalClaim(LOCAL_CLAIM_1, 0))
                 .thenReturn(Optional.of(localClaim));
         when(dbBasedClaimMetadataManager.getLocalClaim(LOCAL_CLAIM_1, 0)).thenReturn(Optional.empty());
         Optional<LocalClaim> result = claimMetadataManager.getLocalClaim(LOCAL_CLAIM_1, 0);
         assertTrue(result.isPresent());
         assertEquals(result.get().getClaimURI(), LOCAL_CLAIM_1);
+        assertEquals(result.get().getClaimProperty(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD),
+                ClaimConstants.SharedProfileValueResolvingMethod.FROM_ORIGIN.getName());
 
-        localClaim = new LocalClaim(LOCAL_CLAIM_2);
+        localClaim = new LocalClaim(LOCAL_CLAIM_2, new ArrayList<>(), claimProperties);
         when(systemDefaultClaimMetadataManager.getLocalClaim(LOCAL_CLAIM_2, 0)).thenReturn(null);
         when(dbBasedClaimMetadataManager.getLocalClaim(LOCAL_CLAIM_2, 0))
                 .thenReturn(Optional.of(localClaim));
         result = claimMetadataManager.getLocalClaim(LOCAL_CLAIM_2, 0);
         assertTrue(result.isPresent());
         assertEquals(result.get().getClaimURI(), LOCAL_CLAIM_2);
+        assertEquals(result.get().getClaimProperty(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD),
+                ClaimConstants.SharedProfileValueResolvingMethod.FROM_ORIGIN.getName());
 
-        LocalClaim localClaimInSystem = new LocalClaim(LOCAL_CLAIM_3);
+        LocalClaim localClaimInSystem = new LocalClaim(LOCAL_CLAIM_3, new ArrayList<>(), claimProperties);
+        when(systemDefaultClaimMetadataManager.getLocalClaim(LOCAL_CLAIM_3, 0))
+                .thenReturn(Optional.of(localClaimInSystem));
         when(systemDefaultClaimMetadataManager.getLocalClaim(LOCAL_CLAIM_3, 0))
                 .thenReturn(Optional.of(localClaimInSystem));
         LocalClaim localClaimInDB = new LocalClaim(LOCAL_CLAIM_3);
@@ -292,11 +329,22 @@ public class UnifiedClaimMetadataManagerTest {
         assertEquals(result.get().getMappedAttributes().size(), 1);
         assertEquals(result.get().getMappedAttributes().get(0).getUserStoreDomain(), "PRIMARY");
         assertEquals(result.get().getMappedAttributes().get(0).getAttributeName(), "country");
+        assertEquals(result.get().getClaimProperty(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD),
+                ClaimConstants.SharedProfileValueResolvingMethod.FROM_ORIGIN.getName());
 
         when(systemDefaultClaimMetadataManager.getLocalClaim(LOCAL_CLAIM_4, 0)).thenReturn(Optional.empty());
         when(dbBasedClaimMetadataManager.getLocalClaim(LOCAL_CLAIM_4, 0)).thenReturn(Optional.empty());
         result = claimMetadataManager.getLocalClaim(LOCAL_CLAIM_4, 0);
         assertFalse(result.isPresent());
+
+        localClaim = new LocalClaim(LOCAL_CLAIM_5);
+        when(systemDefaultClaimMetadataManager.getLocalClaim(LOCAL_CLAIM_5, 0)).thenReturn(Optional.empty());
+        when(dbBasedClaimMetadataManager.getLocalClaim(LOCAL_CLAIM_5, 0)).thenReturn(Optional.of(localClaim));
+        result = claimMetadataManager.getLocalClaim(LOCAL_CLAIM_5, 0);
+        assertTrue(result.isPresent());
+        assertEquals(result.get().getClaimURI(), LOCAL_CLAIM_5);
+        assertEquals(result.get().getClaimProperty(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD),
+                ClaimConstants.SharedProfileValueResolvingMethod.FROM_ORIGIN.getName());
     }
 
     @Test


### PR DESCRIPTION
### Proposed changes in this pull request

For user defined custom claims, there can be cases where SharedProfileValueResolvingMethod claim metadata property is not set.
For system defined claims, there can be cases where system claims were persisted in the DB prior to bringing system claims handled by runtime.

To address the above two cases, relevant default values for SharedProfileValueResolvingMethod property should be set in the unified claim manager service.

**Logic is:**

Check whether the SharedProfileValueResolvingMethod claim property value is empty for the DB persisted claim.
If yes:

1. Check if the claim is a system claim: Then resolve the SharedProfileValueResolvingMethod claim property value from system default claim's properties
2. Check if the claim is a custom claim: Then set "FromOrigin" as the default value for SharedProfileValueResolvingMethod claim property

<!--

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
-->