### PR TITLE
Add account association API def and permissions

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -542,8 +542,22 @@
         <Scopes>
             <Scope displayName="View User Associations" name="internal_user_association_view" 
                     description="View the associated local/federated accounts of a user in the organization (root)"/>
+            <Scope displayName="Create User Associations" name="internal_user_association_create"
+                   description="Create the associated local/federated accounts of a user in the organization (root)"/>
             <Scope displayName="Delete User Associations" name="internal_user_association_delete" 
                     description="Delete the associated local/federated accounts  of a user in the organization (root)"/>
+        </Scopes>
+    </APIResource>
+    <APIResource name="Association Management API"
+                 identifier="/o/api/users/v1/(.*)/(.*)associations" requiresAuthorization="true"
+                 description="API representation of the Association Management API" type="ORGANIZATION">
+        <Scopes>
+            <Scope displayName="View User Associations" name="internal_org_user_association_view"
+                   description="View the associated local/federated accounts of a user in the organization"/>
+            <Scope displayName="Create User Associations" name="internal_org_user_association_create"
+                   description="Create the associated local/federated accounts of a user in the organization"/>
+            <Scope displayName="Delete User Associations" name="internal_org_user_association_delete"
+                   description="Delete the associated local/federated accounts  of a user in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Authorized Application Management V1/V2 API"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -551,8 +551,22 @@
         <Scopes>
             <Scope displayName="View User Associations" name="internal_user_association_view" 
                     description="View the associated local/federated accounts of a user in the organization (root)"/>
+            <Scope displayName="Create User Associations" name="internal_user_association_create"
+                    description="Create the associated local/federated accounts of a user in the organization (root)"/>
             <Scope displayName="Delete User Associations" name="internal_user_association_delete" 
                     description="Delete the associated local/federated accounts  of a user in the organization (root)"/>
+        </Scopes>
+    </APIResource>
+    <APIResource name="Association Management API"
+                 identifier="/o/api/users/v1/(.*)/(.*)associations" requiresAuthorization="true"
+                 description="API representation of the Association Management API" type="ORGANIZATION">
+        <Scopes>
+            <Scope displayName="View User Associations" name="internal_org_user_association_view"
+                    description="View the associated local/federated accounts of a user in the organization"/>
+            <Scope displayName="Create User Associations" name="internal_org_user_association_create"
+                    description="Create the associated local/federated accounts of a user in the organization"/>
+            <Scope displayName="Delete User Associations" name="internal_org_user_association_delete"
+                    description="Delete the associated local/federated accounts  of a user in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Authorized Application Management V1/V2 API"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -564,6 +564,17 @@
     <Resource context="(.*)/api/identity/user/v1.0/me(.*)" secured="true" http-method="GET"/>
     <Resource context="(.*)/api/identity/user/v1.0/me(.*)" secured="true" http-method="POST"/>
 
+    <!-- [Organization] Association Management API -->
+    <Resource context="(.*)/o/api/users/v1/(.*)/federated-associations" secured="true" http-method="GET">
+        <Scopes>internal_org_user_association_view</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/users/v1/(.*)/federated-associations" secured="true" http-method="POST">
+        <Scopes>internal_org_user_association_create</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/users/v1/(.*)/federated-associations(.*)" secured="true" http-method="DELETE">
+        <Scopes>internal_org_user_association_delete</Scopes>
+    </Resource>
+
     <!-- Association Management API -->
     <Resource context="(.*)/api/users/v1/(.*)/associations" secured="true" http-method="GET">
         <Scopes>internal_user_association_view</Scopes>
@@ -573,6 +584,9 @@
     </Resource>
     <Resource context="(.*)/api/users/v1/(.*)/federated-associations" secured="true" http-method="GET">
         <Scopes>internal_user_association_view</Scopes>
+    </Resource>
+    <Resource context="(.*)/api/users/v1/(.*)/federated-associations" secured="true" http-method="POST">
+        <Scopes>internal_user_association_create</Scopes>
     </Resource>
     <Resource context="(.*)/api/users/v1/(.*)/federated-associations(.*)" secured="true" http-method="DELETE">
         <Scopes>internal_user_association_delete</Scopes>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -613,6 +613,17 @@
         <Resource context="(.*)/api/identity/user/v1.0/me(.*)" secured="true" http-method="GET"/>
         <Resource context="(.*)/api/identity/user/v1.0/me(.*)" secured="true" http-method="POST"/>
 
+        <!-- [Organization] Association Management API -->
+        <Resource context="(.*)/o/api/users/v1/(.*)/federated-associations" secured="true" http-method="GET">
+            <Scopes>internal_org_user_association_view</Scopes>
+        </Resource>
+        <Resource context="(.*)/o/api/users/v1/(.*)/federated-associations" secured="true" http-method="POST">
+            <Scopes>internal_org_user_association_create</Scopes>
+        </Resource>
+        <Resource context="(.*)/o/api/users/v1/(.*)/federated-associations(.*)" secured="true" http-method="DELETE">
+            <Scopes>internal_org_user_association_delete</Scopes>
+        </Resource>
+
         <!-- Association Management API -->
         <Resource context="(.*)/api/users/v1/(.*)/associations" secured="true" http-method="GET">
             <Scopes>internal_user_association_view</Scopes>
@@ -622,6 +633,9 @@
         </Resource>
         <Resource context="(.*)/api/users/v1/(.*)/federated-associations" secured="true" http-method="GET">
             <Scopes>internal_user_association_view</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/users/v1/(.*)/federated-associations" secured="true" http-method="POST">
+            <Scopes>internal_user_association_create</Scopes>
         </Resource>
         <Resource context="(.*)/api/users/v1/(.*)/federated-associations(.*)" secured="true" http-method="DELETE">
             <Scopes>internal_user_association_delete</Scopes>


### PR DESCRIPTION
### Proposed changes in this pull request

- Currently only the scopes related `view` and `delete` operations are available in the User Association API. This PR introduces the scope related to `create` operation.
- Furthermore User Association API is enabled in the organization level as well. 
- Updated the resource-access-control-v2 to enable the new API endpoints.

### Issue

https://github.com/wso2/product-is/issues/22282