### PR TITLE
Add the default `tenant_domain_illegal_characters_regex` for the Console

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1175,6 +1175,7 @@
     "userStores",
     "users"
   ],
+  "console.ui.multi_tenancy.tenant_domain_illegal_characters_regex": ".*[^a-z0-9._-].*",
   "console.theme": "wso2is",
   "console.session.params.userIdleTimeOut": 600,
   "console.session.params.userIdleWarningTimeOut": 580,


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request includes a change to the `features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json` file. The change adds a new configuration setting for tenant domain validation.

Configuration updates:

* Added `console.ui.multi_tenancy.tenant_domain_illegal_characters_regex` to specify a regex pattern for illegal characters in tenant domains.

### When should this PR be merged

With https://github.com/wso2/identity-apps/pull/7338


### Related Issues 

- https://github.com/wso2/product-is/issues/21997

### Related PRs

- `identity-apps`:  https://github.com/wso2/identity-apps/pull/7338