### PR TITLE
Fix custom connector updating issue.

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementFacade.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementFacade.java
@@ -352,11 +352,11 @@ public class IdPManagementFacade {
             return;
         }
         FederatedAuthenticatorConfig newFederatedAuth = newIdentityProvider.getFederatedAuthenticatorConfigs()[0];
-        FederatedAuthenticatorConfig oldFederatedAuth = oldIdentityProvider.getFederatedAuthenticatorConfigs()[0];
         if (newFederatedAuth.getDefinedByType() == AuthenticatorPropertyConstants.DefinedByType.SYSTEM) {
             return;
         }
 
+        FederatedAuthenticatorConfig oldFederatedAuth = oldIdentityProvider.getFederatedAuthenticatorConfigs()[0];
         if (StringUtils.equals(newFederatedAuth.getName(), oldFederatedAuth.getName())) {
             endpointConfigurationManager.updateEndpointConfig(newIdentityProvider.getFederatedAuthenticatorConfigs()[0],
                     oldIdentityProvider.getFederatedAuthenticatorConfigs()[0],


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/22293

`FederatedAuthenticatorConfig oldFederatedAuth = oldIdentityProvider.getFederatedAuthenticatorConfigs()[0];` will be executed only for USER defined authenticators, where always there will be a federated authenticator in the IdP.