### PR TITLE
Validate AuthenticationResultCache expiry

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/AuthenticationResultCache.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/AuthenticationResultCache.java
@@ -110,12 +110,11 @@ public class AuthenticationResultCache extends
     private boolean isCacheEntryExpired(AuthenticationResultCacheEntry entry) {
 
         String createdTimestamp = entry.getResult().getProperty(FrameworkConstants.CREATED_TIMESTAMP).toString();
-        if (createdTimestamp != null) {
-            if (FrameworkUtils.getCurrentStandardNano() >
-                    entry.getValidityPeriod() + Long.parseLong(createdTimestamp) * 1000000) {
-                log.debug("Authentication result cache is expired");
-                return true;
-            }
+        if (createdTimestamp != null &&
+                (FrameworkUtils.getCurrentStandardNano() >
+                    entry.getValidityPeriod() + Long.parseLong(createdTimestamp) * 1000000)) {
+            log.debug("Authentication result cache is expired");
+            return true;
         }
         return false;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/AuthenticationResultCache.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/AuthenticationResultCache.java
@@ -113,9 +113,7 @@ public class AuthenticationResultCache extends
         if (createdTimestamp != null) {
             if (FrameworkUtils.getCurrentStandardNano() >
                     entry.getValidityPeriod() + Long.parseLong(createdTimestamp) * 1000000) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Authentication result cache is expired");
-                }
+                log.debug("Authentication result cache is expired");
                 return true;
             }
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -1193,7 +1193,7 @@ public class FrameworkUtils {
         AuthenticationResultCacheKey cacheKey = new AuthenticationResultCacheKey(key);
         AuthenticationResultCacheEntry cacheEntry = new AuthenticationResultCacheEntry();
         cacheEntry.setResult(authenticationResult);
-        cacheEntry.setValidityPeriod(TimeUnit.MINUTES.toNanos(IdentityUtil.getOperationCleanUpTimeout()));
+        cacheEntry.setValidityPeriod(TimeUnit.MINUTES.toNanos(IdentityUtil.getTempDataCleanUpTimeout()));
         AuthenticationResultCache.getInstance().addToCache(cacheKey, cacheEntry);
     }
 


### PR DESCRIPTION
### Summary

This pull request includes changes to the `AuthenticationResultCache` class to enhance the cache expiration mechanism for authentication results. To change the expiry time of the cache, use the following existing config.
```
[session_data.cleanup]
expire_pre_session_data_after = 60
```

### Related Issue
- https://github.com/wso2/product-is/issues/22194