### PR TITLE
Remove secretManagement APIResourceCollection

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -428,25 +428,6 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="secretsManagement" displayName="Secrets Management" type="tenant">
-        <Scopes>
-            <Feature>
-                <Scope name="console:secretsManagement"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_secret_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_secret_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_secret_mgt_add"/>
-            </Create>
-            <Read>
-                <Scope name="internal_secret_mgt_view"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
     <APIResourceCollection name="roles" displayName="Roles" type="tenant">
         <Scopes>
             <Feature>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -469,25 +469,6 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="secretsManagement" displayName="Secrets Management" type="tenant">
-        <Scopes>
-            <Feature>
-                <Scope name="console:secretsManagement"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_secret_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_secret_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_secret_mgt_add"/>
-            </Create>
-            <Read>
-                <Scope name="internal_secret_mgt_view"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
     <APIResourceCollection name="roles" displayName="Roles" type="tenant">
         <Scopes>
             <Feature>


### PR DESCRIPTION
### Proposed changes in this pull request

- https://github.com/wso2/product-is/issues/22162

This pull request includes changes to the API resource management feature, specifically the removal of the `secretsManagement` API resource collection from two XML files. This change affects the scopes related to secrets management, including create, read, update, and delete operations.

Changes to API resource management:

* [`features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml`](diffhunk://#diff-3f84f2fc41782b93036d6233268491eda9c179f357755bd84fb13a798eb34badL431-L449): Removed the `secretsManagement` API resource collection and its associated scopes.
* [`features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2`](diffhunk://#diff-a2db3b627822a2fef1faa05dbc072adb80137338c607f5e6c8ccfeb7295c7f33L472-L490): Removed the `secretsManagement` API resource collection and its associated scopes.
