### PR TITLE
Remove duplicated claim of streetAddress

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -457,14 +457,6 @@
 				<SharedProfileValueResolvingMethod>FromOrigin</SharedProfileValueResolvingMethod>
 			</Claim>
 			<Claim>
-				<ClaimURI>http://wso2.org/claims/streetaddress</ClaimURI>
-				<DisplayName>Address - Street</DisplayName>
-				<AttributeID>streetAddress</AttributeID>
-				<Description>Address - Street</Description>
-				<DisplayOrder>5</DisplayOrder>
-				<SharedProfileValueResolvingMethod>FromOrigin</SharedProfileValueResolvingMethod>
-			</Claim>
-			<Claim>
 				<ClaimURI>http://wso2.org/claims/addresses.locality</ClaimURI>
 				<DisplayName>Address - Locality</DisplayName>
 				<AttributeID>localityAddress</AttributeID>


### PR DESCRIPTION
### Proposed changes in this pull request
The claim `<ClaimURI>http://wso2.org/claims/streetaddress</ClaimURI>` already exist[1]

[1] - https://github.com/wso2/carbon-identity-framework/blame/master/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml#L51~L57

### Related Issues
- https://github.com/wso2/product-is/issues/21864
