### PR TITLE
Fix server startup created time null issue

### DIFF
--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/internal/ConfigurationManagerComponent.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/internal/ConfigurationManagerComponent.java
@@ -85,11 +85,11 @@ public class ConfigurationManagerComponent {
                     new ConfigurationManagerConfigurationHolder();
             configurationManagerConfigurationHolder.setConfigurationDAOS(configurationDAOs);
 
-            bundleContext.registerService(ConfigurationManager.class.getName(),
-                    new ConfigurationManagerImpl(configurationManagerConfigurationHolder), null);
             ConfigurationManagerComponentDataHolder.getInstance().setConfigurationManagementEnabled
                     (isConfigurationManagementEnabled());
             setUseCreatedTime();
+            bundleContext.registerService(ConfigurationManager.class.getName(),
+                    new ConfigurationManagerImpl(configurationManagerConfigurationHolder), null);
         } catch (Throwable e) {
             log.error("Error while activating ConfigurationManagerComponent.", e);
         }


### PR DESCRIPTION
### Purpose
In server startup, through the X509 we are persisting few resources to the configuration manager. But after activating only the created time is set.
This PR fixes that.

This pull request includes a minor but important change to the `ConfigurationManagerComponent` class. The change involves moving the registration of the `ConfigurationManager` service to ensure it occurs after setting the `useCreatedTime` flag.

* [`components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/internal/ConfigurationManagerComponent.java`](diffhunk://#diff-27f00bceb57a6b7cd0a4ebacf5a05335b9888f3c4cbb55153f1895c6e5168eafL88-R92): Moved the `bundleContext.registerService` call to occur after setting the `useCreatedTime` flag to ensure proper initialization order.