### PR TITLE
Added empty service can be used to guarantee the order of activation

### DIFF
--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/internal/ConfigurationManagerComponent.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/internal/ConfigurationManagerComponent.java
@@ -33,6 +33,8 @@ import org.wso2.carbon.identity.configuration.mgt.core.dao.ConfigurationDAO;
 import org.wso2.carbon.identity.configuration.mgt.core.dao.impl.CachedBackedConfigurationDAO;
 import org.wso2.carbon.identity.configuration.mgt.core.dao.impl.ConfigurationDAOImpl;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ConfigurationManagerConfigurationHolder;
+import org.wso2.carbon.identity.core.util.ConfigurationManagerInitializedEvent;
+import org.wso2.carbon.identity.core.util.ConfigurationManagerInitializedEventImpl;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
@@ -90,6 +92,11 @@ public class ConfigurationManagerComponent {
             ConfigurationManagerComponentDataHolder.getInstance().setConfigurationManagementEnabled
                     (isConfigurationManagementEnabled());
             setUseCreatedTime();
+
+            // Register initialize service To guarantee the activation order. Component which is referring this
+            // service will wait until this component activated.
+            ctxt.getBundleContext().registerService(ConfigurationManagerInitializedEvent.class.getName(),
+                    new ConfigurationManagerInitializedEventImpl(), null);
         } catch (Throwable e) {
             log.error("Error while activating ConfigurationManagerComponent.", e);
         }

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/internal/ConfigurationManagerComponent.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/internal/ConfigurationManagerComponent.java
@@ -33,8 +33,8 @@ import org.wso2.carbon.identity.configuration.mgt.core.dao.ConfigurationDAO;
 import org.wso2.carbon.identity.configuration.mgt.core.dao.impl.CachedBackedConfigurationDAO;
 import org.wso2.carbon.identity.configuration.mgt.core.dao.impl.ConfigurationDAOImpl;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ConfigurationManagerConfigurationHolder;
-import org.wso2.carbon.identity.core.util.ConfigurationManagerInitializedEvent;
-import org.wso2.carbon.identity.core.util.ConfigurationManagerInitializedEventImpl;
+import org.wso2.carbon.identity.configuration.mgt.core.util.ConfigurationManagerInitializedEvent;
+import org.wso2.carbon.identity.configuration.mgt.core.util.ConfigurationManagerInitializedEventImpl;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
@@ -95,7 +95,7 @@ public class ConfigurationManagerComponent {
 
             // Register initialize service To guarantee the activation order. Component which is referring this
             // service will wait until this component activated.
-            ctxt.getBundleContext().registerService(ConfigurationManagerInitializedEvent.class.getName(),
+            bundleContext.registerService(ConfigurationManagerInitializedEvent.class.getName(),
                     new ConfigurationManagerInitializedEventImpl(), null);
         } catch (Throwable e) {
             log.error("Error while activating ConfigurationManagerComponent.", e);

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/util/ConfigurationManagerInitializedEvent.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/util/ConfigurationManagerInitializedEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.configuration.mgt.core.util;
+
+/**
+ * This empty service can be used to guarantee the order of activation ( No need to have empty service if
+ * there is a valid service).
+ * If we need to activate a component after org.wso2.carbon.identity.configuration.mgt.core is activated, within that service
+ * can refer to this empty service which will guarantee that, org.wso2.carbon.identity.configuration.mgt.core will activated
+ * before that.
+ */
+
+public interface ConfigurationManagerInitializedEvent {
+}

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/util/ConfigurationManagerInitializedEventImpl.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/util/ConfigurationManagerInitializedEventImpl.java
@@ -26,5 +26,5 @@ package org.wso2.carbon.identity.configuration.mgt.core.util;
  * before that.
  */
 
-public interface ConfigurationManagerInitializedEventImpl implements ConfigurationManagerInitializedEvent {
+public class ConfigurationManagerInitializedEventImpl implements ConfigurationManagerInitializedEvent {
 }

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/util/ConfigurationManagerInitializedEventImpl.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/util/ConfigurationManagerInitializedEventImpl.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.configuration.mgt.core.util;
+
+/**
+ * This empty service can be used to guarantee the order of activation ( No need to have empty service if
+ * there is a valid service).
+ * If we need to activate a component after org.wso2.carbon.identity.configuration.mgt.core is activated, within that service
+ * can refer to this empty service which will guarantee that, org.wso2.carbon.identity.configuration.mgt.core will activated
+ * before that.
+ */
+
+public interface ConfigurationManagerInitializedEventImpl implements ConfigurationManagerInitializedEvent {
+}


### PR DESCRIPTION
### Purpose
Used a similar approach as in `IdentityCoreServiceComponent` [1]

[1] https://github.com/wso2/carbon-identity-framework/blob/v7.7.123/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/IdentityCoreServiceComponent.java#L194-L196

This pull request introduces a new service to ensure the proper activation order of components in the `configuration-mgt` module. The most important changes include adding the `ConfigurationManagerInitializedEvent` interface and its implementation, and registering this service during the activation of the `ConfigurationManagerComponent`.

### Ensuring Activation Order:

* [`ConfigurationManagerComponent.java`](diffhunk://#diff-27f00bceb57a6b7cd0a4ebacf5a05335b9888f3c4cbb55153f1895c6e5168eafR36-R37): Imported `ConfigurationManagerInitializedEvent` and `ConfigurationManagerInitializedEventImpl` classes. Added code to register the `ConfigurationManagerInitializedEvent` service during the activation of the component. [[1]](diffhunk://#diff-27f00bceb57a6b7cd0a4ebacf5a05335b9888f3c4cbb55153f1895c6e5168eafR36-R37) [[2]](diffhunk://#diff-27f00bceb57a6b7cd0a4ebacf5a05335b9888f3c4cbb55153f1895c6e5168eafR95-R99)

* [`ConfigurationManagerInitializedEvent.java`](diffhunk://#diff-dac05c44e49e9934ac80fadd47758b3baeee7fa76c3d871ebba5ac49a32c88a0R1-R30): Added a new interface `ConfigurationManagerInitializedEvent` to guarantee the order of activation.

* [`ConfigurationManagerInitializedEventImpl.java`](diffhunk://#diff-1e500f0517695fdb70bb2469b9ada5f73fcc66cd9b039f4b62a86a07b0d978abR1-R30): Added a new implementation class `ConfigurationManagerInitializedEventImpl` for the `ConfigurationManagerInitializedEvent` interface.