### PR TITLE
Fix unit test

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -546,6 +546,7 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
             when(mockedSessionDataStore.getSessionData(anyString(), anyString()))
                     .thenReturn(mockedAuthenticationResultCacheEntry);
             when(mockedAuthenticationResultCacheEntry.getResult()).thenReturn(mockedAuthenticationResult);
+            when(mockedAuthenticationResultCacheEntry.getValidityPeriod()).thenReturn(-60000000L);
             when(mockedAuthenticationResult.getProperty(anyString())).thenReturn(System.currentTimeMillis());
 
             AuthenticationResultCacheEntry result = authenticationCacheSpy.getValueFromCache(key);


### PR DESCRIPTION
This pull request includes a small change to the `FrameworkUtilsTest.java` file. The change adds a new mock behavior to the `testGetAuthenticationResultFromSessionDataStoreExpired` method to return a validity period of 0.

### Related issue
- https://github.com/wso2/carbon-identity-framework/pull/6330