### PR TITLE
Temporarily fix the push auth config

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -717,10 +717,10 @@
   "cache.private_key_jwt.timeout": "300",
   "cache.private_key_jwt.capacity": "5000",
   "cache.push_auth_context_cache.enable": true,
-  "cache.push_auth_context_cache.timeout": "$ref{cache.default_timeout}",
+  "cache.push_auth_context_cache.timeout": "300",
   "cache.push_auth_context_cache.capacity": "$ref{cache.default_capacity}",
   "cache.push_auth_status_cache.enable": true,
-  "cache.push_auth_status_cache.timeout": "$ref{cache.default_timeout}",
+  "cache.push_auth_status_cache.timeout": "300",
   "cache.push_auth_status_cache.capacity": "$ref{cache.default_capacity}",
 
   "resource_access_control.default_access_allow": false,


### PR DESCRIPTION
### Proposed changes in this pull request

$subject

The cache timeout config introduced with the following PR https://github.com/wso2/carbon-identity-framework/pull/6354 is templating the ref value as "300ms" which causes the product start up failure. Instead of referencing the default cache timeout this PR defaults the cache timeout for push_auth feature to 300 as a temporary fix. Need to further investigate on this matter.
cc @ZiyamSanthosh 