### PR TITLE
Update permissions for actions feature.

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -544,6 +544,9 @@
             </Create>
             <Read>
                 <Scope name="internal_action_mgt_view"/>
+                <Scope name="internal_rule_metadata_view"/>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -585,6 +585,9 @@
             </Create>
             <Read>
                 <Scope name="internal_action_mgt_view"/>
+                <Scope name="internal_rule_metadata_view"/>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1211,7 +1211,12 @@
   "console.actions.disabled_features": [],
   "console.actions.scopes.feature": ["console:actions"],
   "console.actions.scopes.create": ["internal_action_mgt_create"],
-  "console.actions.scopes.read": ["internal_action_mgt_view"],
+  "console.actions.scopes.read": [
+    "internal_action_mgt_view",
+    "internal_rule_metadata_view",
+    "internal_application_mgt_view",
+    "internal_claim_meta_view"
+  ],
   "console.actions.scopes.update": ["internal_action_mgt_update"],
   "console.actions.scopes.delete": ["internal_action_mgt_delete"],
   "console.administrators.enabled": false,


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/22445

This PR adds rule metadata view permission and application view permission needed to function rules component in actions.
In addition to that adds claim view permissions which is intended to be used in future.
This is added to avoid the data migration required in current architecture as new permissions onboards. This migration is due to the assignment of fine grained permissions to roles.
