### PR TITLE
Introduce new scope version for api resource collection

### DIFF
--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionManagerImpl.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionManagerImpl.java
@@ -191,6 +191,10 @@ public class APIResourceCollectionManagerImpl implements APIResourceCollectionMa
                 .type(apiResourceCollection.getType())
                 .readScopes(apiResourceCollection.getReadScopes())
                 .writeScopes(apiResourceCollection.getWriteScopes())
+                .legacyReadScopes(apiResourceCollection.getLegacyReadScopes())
+                .legacyWriteScopes(apiResourceCollection.getLegacyWriteScopes())
+                .viewFeatureScope(apiResourceCollection.getViewFeatureScope())
+                .editFeatureScope(apiResourceCollection.getEditFeatureScope())
                 .apiResources(apiResourceCollection.getApiResources())
                 .build();
     }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/constant/APIResourceCollectionManagementConstants.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/constant/APIResourceCollectionManagementConstants.java
@@ -58,7 +58,7 @@ public class APIResourceCollectionManagementConstants {
         public static final String VERSION = "version";
         public static final String VIEW_ACTION = "view";
         public static final String EDIT_ACTION = "edit";
-        public static final String SCOPE_COLLECTION_VERSION_V1 = "v1";
+        public static final String COLLECTION_VERSION_V0 = "v0";
     }
 
     /**

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/constant/APIResourceCollectionManagementConstants.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/constant/APIResourceCollectionManagementConstants.java
@@ -55,8 +55,8 @@ public class APIResourceCollectionManagementConstants {
         public static final String READ = "Read";
         public static final String FEATURE = "Feature";
         public static final String VERSION = "version";
-        public static final String VIEW_FEATURE_SCOPE_PREFIX = "_view";
-        public static final String EDIT_FEATURE_SCOPE_PREFIX = "_edit";
+        public static final String VIEW_FEATURE_SCOPE_SUFFIX = "_view";
+        public static final String EDIT_FEATURE_SCOPE_SUFFIX = "_edit";
         public static final String CONSOLE_SCOPE_PREFIX = "console:";
         public static final String COLLECTION_VERSION_V0 = "v0";
     }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/constant/APIResourceCollectionManagementConstants.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/constant/APIResourceCollectionManagementConstants.java
@@ -54,10 +54,10 @@ public class APIResourceCollectionManagementConstants {
         public static final String TYPE = "type";
         public static final String READ = "Read";
         public static final String FEATURE = "Feature";
-        public static final String ACTION = "action";
         public static final String VERSION = "version";
-        public static final String VIEW_ACTION = "view";
-        public static final String EDIT_ACTION = "edit";
+        public static final String VIEW_FEATURE_SCOPE_PREFIX = "_view";
+        public static final String EDIT_FEATURE_SCOPE_PREFIX = "_edit";
+        public static final String CONSOLE_SCOPE_PREFIX = "console:";
         public static final String COLLECTION_VERSION_V0 = "v0";
     }
 

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/constant/APIResourceCollectionManagementConstants.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/constant/APIResourceCollectionManagementConstants.java
@@ -54,6 +54,11 @@ public class APIResourceCollectionManagementConstants {
         public static final String TYPE = "type";
         public static final String READ = "Read";
         public static final String FEATURE = "Feature";
+        public static final String ACTION = "action";
+        public static final String VERSION = "version";
+        public static final String VIEW_ACTION = "view";
+        public static final String EDIT_ACTION = "edit";
+        public static final String SCOPE_COLLECTION_VERSION_V1 = "v1";
     }
 
     /**

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/model/APIResourceCollection.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/model/APIResourceCollection.java
@@ -34,6 +34,10 @@ public class APIResourceCollection {
     private String type;
     private List<String> readScopes;
     private List<String> writeScopes;
+    private List<String> legacyReadScopes;
+    private List<String> legacyWriteScopes;
+    private String viewFeatureScope;
+    private String editFeatureScope;
     private Map<String, List<APIResource>> apiResources;
 
     public APIResourceCollection() {
@@ -48,6 +52,10 @@ public class APIResourceCollection {
             this.apiResources = apiResourceCollectionBuilder.apiResources;
             this.readScopes = apiResourceCollectionBuilder.readScopes;
             this.writeScopes = apiResourceCollectionBuilder.writeScopes;
+            this.legacyReadScopes = apiResourceCollectionBuilder.legacyReadScopes;
+            this.legacyWriteScopes = apiResourceCollectionBuilder.legacyWriteScopes;
+            this.viewFeatureScope = apiResourceCollectionBuilder.viewFeatureScope;
+            this.editFeatureScope = apiResourceCollectionBuilder.editFeatureScope;
     }
 
     public String getId() {
@@ -100,6 +108,46 @@ public class APIResourceCollection {
         this.writeScopes = writeScopes;
     }
 
+    public List<String> getLegacyReadScopes() {
+
+        return legacyReadScopes;
+    }
+
+    public void setLegacyReadScopes(List<String> legacyReadScopes) {
+
+        this.legacyReadScopes = legacyReadScopes;
+    }
+
+    public List<String> getLegacyWriteScopes() {
+
+        return legacyWriteScopes;
+    }
+
+    public void setLegacyWriteScopes(List<String> legacyWriteScopes) {
+
+        this.legacyWriteScopes = legacyWriteScopes;
+    }
+
+    public String getViewFeatureScope() {
+
+        return viewFeatureScope;
+    }
+
+    public void setViewFeatureScope(String viewFeatureScope) {
+
+        this.viewFeatureScope = viewFeatureScope;
+    }
+
+    public String getEditFeatureScope() {
+
+        return editFeatureScope;
+    }
+
+    public void setEditFeatureScope(String editFeatureScope) {
+
+        this.editFeatureScope = editFeatureScope;
+    }
+
     /**
      * Builder class for API Resource Collection.
      */
@@ -111,6 +159,10 @@ public class APIResourceCollection {
         private String type;
         private List<String> readScopes;
         private List<String> writeScopes;
+        private List<String> legacyReadScopes;
+        private List<String> legacyWriteScopes;
+        private String viewFeatureScope;
+        private String editFeatureScope;
         private Map<String, List<APIResource>> apiResources;
 
         public APIResourceCollectionBuilder() {
@@ -149,6 +201,31 @@ public class APIResourceCollection {
         public APIResourceCollectionBuilder writeScopes(List<String> writeScopes) {
 
             this.writeScopes = writeScopes;
+            return this;
+        }
+
+
+        public APIResourceCollectionBuilder legacyReadScopes(List<String> legacyReadScopes) {
+
+            this.legacyReadScopes = legacyReadScopes;
+            return this;
+        }
+
+        public APIResourceCollectionBuilder legacyWriteScopes(List<String> legacyWriteScopes) {
+
+            this.legacyWriteScopes = legacyWriteScopes;
+            return this;
+        }
+
+        public APIResourceCollectionBuilder viewFeatureScope(String viewFeatureScope) {
+
+            this.viewFeatureScope = viewFeatureScope;
+            return this;
+        }
+
+        public APIResourceCollectionBuilder editFeatureScope(String editFeatureScope) {
+
+            this.editFeatureScope = editFeatureScope;
             return this;
         }
 

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionMgtConfigBuilder.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionMgtConfigBuilder.java
@@ -124,9 +124,9 @@ public class APIResourceCollectionMgtConfigBuilder {
                     .getAttributeValue(new QName(APIResourceCollectionConfigBuilderConstants.VERSION));
             OMElement scopesElement = apiResourceCollection.getFirstChildWithName(
                     new QName(APIResourceCollectionConfigBuilderConstants.SCOPES_ELEMENT));
-            Set<String> readScopeSet = new HashSet<>();
-            Set<String> writeScopeSet = new HashSet<>();
             if (scopesElement != null) {
+                Set<String> readScopeSet = new HashSet<>();
+                Set<String> writeScopeSet = new HashSet<>();
                 Iterator<?> actionElements = scopesElement.getChildElements();
                 while (actionElements.hasNext()) {
                     OMElement actionElement = (OMElement) actionElements.next();
@@ -174,20 +174,20 @@ public class APIResourceCollectionMgtConfigBuilder {
                         }
                     }
                 }
-            }
-            if (APIResourceCollectionConfigBuilderConstants.COLLECTION_VERSION_V0
-                    .equals(collectionVersion)) {
-                apiResourceCollectionObj.setLegacyReadScopes(new ArrayList<>(readScopeSet));
-                apiResourceCollectionObj.setLegacyWriteScopes(new ArrayList<>(writeScopeSet));
-                if (apiResourceCollectionObj.getReadScopes() == null) {
+                if (APIResourceCollectionConfigBuilderConstants.COLLECTION_VERSION_V0
+                        .equals(collectionVersion)) {
+                    apiResourceCollectionObj.setLegacyReadScopes(new ArrayList<>(readScopeSet));
+                    apiResourceCollectionObj.setLegacyWriteScopes(new ArrayList<>(writeScopeSet));
+                    if (apiResourceCollectionObj.getReadScopes() == null) {
+                        apiResourceCollectionObj.setReadScopes(new ArrayList<>(readScopeSet));
+                    }
+                    if (apiResourceCollectionObj.getWriteScopes() == null) {
+                        apiResourceCollectionObj.setWriteScopes(new ArrayList<>(writeScopeSet));
+                    }
+                } else {
                     apiResourceCollectionObj.setReadScopes(new ArrayList<>(readScopeSet));
-                }
-                if (apiResourceCollectionObj.getWriteScopes() == null) {
                     apiResourceCollectionObj.setWriteScopes(new ArrayList<>(writeScopeSet));
                 }
-            } else {
-                apiResourceCollectionObj.setReadScopes(new ArrayList<>(readScopeSet));
-                apiResourceCollectionObj.setWriteScopes(new ArrayList<>(writeScopeSet));
             }
             apiResourceCollectionMgtConfigurations.put(apiResourceCollectionObj.getId(), apiResourceCollectionObj);
         }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionMgtConfigBuilder.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionMgtConfigBuilder.java
@@ -156,13 +156,10 @@ public class APIResourceCollectionMgtConfigBuilder {
                             if (isReadAction) {
                                 readScopeSet.add(scopeName);
                             } else if (isFeatureAction) {
-                                String scopeAction = scope.getAttributeValue(
-                                        new QName(APIResourceCollectionConfigBuilderConstants.ACTION));
-                                if (APIResourceCollectionConfigBuilderConstants.VIEW_ACTION.equals(scopeAction)) {
+                                if (isViewFeatureScope(scopeName)) {
                                     apiResourceCollectionObj.setViewFeatureScope(scopeName);
                                     readScopeSet.add(scopeName);
-                                } else if (APIResourceCollectionConfigBuilderConstants.EDIT_ACTION
-                                        .equals(scopeAction)) {
+                                } else if (isEditFeatureScope(scopeName)) {
                                     apiResourceCollectionObj.setEditFeatureScope(scopeName);
                                     writeScopeSet.add(scopeName);
                                 } else {
@@ -210,5 +207,19 @@ public class APIResourceCollectionMgtConfigBuilder {
                         element.getAttributeValue(new QName(APIResourceCollectionConfigBuilderConstants.DISPLAY_NAME)))
                 .type(element.getAttributeValue(new QName(APIResourceCollectionConfigBuilderConstants.TYPE)))
                 .build();
+    }
+
+    private boolean isViewFeatureScope(String scope) {
+
+        return StringUtils.isNotBlank(scope) &&
+                scope.startsWith(APIResourceCollectionConfigBuilderConstants.CONSOLE_SCOPE_PREFIX) &&
+                scope.endsWith(APIResourceCollectionConfigBuilderConstants.VIEW_FEATURE_SCOPE_PREFIX);
+    }
+
+    private boolean isEditFeatureScope(String scope) {
+
+        return StringUtils.isNotBlank(scope) &&
+                scope.startsWith(APIResourceCollectionConfigBuilderConstants.CONSOLE_SCOPE_PREFIX) &&
+                scope.endsWith(APIResourceCollectionConfigBuilderConstants.EDIT_FEATURE_SCOPE_PREFIX);
     }
 }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionMgtConfigBuilder.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionMgtConfigBuilder.java
@@ -213,13 +213,13 @@ public class APIResourceCollectionMgtConfigBuilder {
 
         return StringUtils.isNotBlank(scope) &&
                 scope.startsWith(APIResourceCollectionConfigBuilderConstants.CONSOLE_SCOPE_PREFIX) &&
-                scope.endsWith(APIResourceCollectionConfigBuilderConstants.VIEW_FEATURE_SCOPE_PREFIX);
+                scope.endsWith(APIResourceCollectionConfigBuilderConstants.VIEW_FEATURE_SCOPE_SUFFIX);
     }
 
     private boolean isEditFeatureScope(String scope) {
 
         return StringUtils.isNotBlank(scope) &&
                 scope.startsWith(APIResourceCollectionConfigBuilderConstants.CONSOLE_SCOPE_PREFIX) &&
-                scope.endsWith(APIResourceCollectionConfigBuilderConstants.EDIT_FEATURE_SCOPE_PREFIX);
+                scope.endsWith(APIResourceCollectionConfigBuilderConstants.EDIT_FEATURE_SCOPE_SUFFIX);
     }
 }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionMgtConfigBuilder.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionMgtConfigBuilder.java
@@ -120,46 +120,44 @@ public class APIResourceCollectionMgtConfigBuilder {
             if (apiResourceCollectionObj == null) {
                 continue;
             }
-            // Fetch scopes.
-            Iterator<OMElement> scopesElements = apiResourceCollection.getChildrenWithName(
+            String collectionVersion = apiResourceCollection
+                    .getAttributeValue(new QName(APIResourceCollectionConfigBuilderConstants.VERSION));
+            OMElement scopesElement = apiResourceCollection.getFirstChildWithName(
                     new QName(APIResourceCollectionConfigBuilderConstants.SCOPES_ELEMENT));
             Set<String> readScopeSet = new HashSet<>();
             Set<String> writeScopeSet = new HashSet<>();
-            Set<String> legacyReadScopeSet = new HashSet<>();
-            Set<String> legacyWriteScopeSet = new HashSet<>();
-            while (scopesElements.hasNext()) {
-                OMElement scopesCollection = scopesElements.next();
-                String scopesCollectionVersion = scopesCollection.getAttributeValue(
-                        new QName(APIResourceCollectionConfigBuilderConstants.VERSION));
-                Iterator<?> actionElements = scopesCollection.getChildElements();
-                if (APIResourceCollectionConfigBuilderConstants.SCOPE_COLLECTION_VERSION_V1
-                        .equals(scopesCollectionVersion)) {
-                    // Process new scopes with feature scopes.
-                    while (actionElements.hasNext()) {
-                        OMElement actionElement = (OMElement) actionElements.next();
-                        if (actionElement == null) {
-                            continue;
-                        }
-                        Iterator<OMElement> scopes = actionElement.getChildrenWithName(
-                                new QName(APIResourceCollectionConfigBuilderConstants.SCOPE_ELEMENT));
-                        while (scopes.hasNext()) {
-                            OMElement scope = scopes.next();
-                            String scopeName = scope.getAttributeValue(
-                                    new QName(APIResourceCollectionConfigBuilderConstants.NAME));
-                            // All the collections have specifically defined two feature scopes (view, edit)
-                            // for each action. These two will be assigned to console roles. Based on the
-                            // feature scope, we will assign the read and write scopes to the console roles.
-                            // This help to introduce new scopes without migrating the console roles.
-                            String scopeAction = scope.getAttributeValue(
-                                    new QName(APIResourceCollectionConfigBuilderConstants.ACTION));
-                            // Read and old Feature scope are considered as read scopes.
-                            boolean isReadAction = APIResourceCollectionConfigBuilderConstants.READ
-                                    .equals(actionElement.getLocalName());
-                            boolean isFeatureAction = APIResourceCollectionConfigBuilderConstants.FEATURE.
-                                    equals(actionElement.getLocalName());
+            if (scopesElement != null) {
+                Iterator<?> actionElements = scopesElement.getChildElements();
+                while (actionElements.hasNext()) {
+                    OMElement actionElement = (OMElement) actionElements.next();
+                    if (actionElement == null) {
+                        continue;
+                    }
+                    Iterator<OMElement> scopes = actionElement.getChildrenWithName(
+                            new QName(APIResourceCollectionConfigBuilderConstants.SCOPE_ELEMENT));
+                    while (scopes.hasNext()) {
+                        OMElement scope = scopes.next();
+                        String scopeName = scope.getAttributeValue(
+                                new QName(APIResourceCollectionConfigBuilderConstants.NAME));
+                        // Read and old Feature scope are considered as read scopes.
+                        boolean isReadAction = APIResourceCollectionConfigBuilderConstants.READ
+                                .equals(actionElement.getLocalName());
+                        boolean isFeatureAction = APIResourceCollectionConfigBuilderConstants.FEATURE.
+                                equals(actionElement.getLocalName());
+                        if (APIResourceCollectionConfigBuilderConstants.COLLECTION_VERSION_V0
+                                .equals(collectionVersion)) {
+                            if (isReadAction || isFeatureAction) {
+                                readScopeSet.add(scopeName);
+                            } else {
+                                writeScopeSet.add(scopeName);
+                            }
+                        } else {
+                            // Process new scopes with feature scopes.
                             if (isReadAction) {
                                 readScopeSet.add(scopeName);
                             } else if (isFeatureAction) {
+                                String scopeAction = scope.getAttributeValue(
+                                        new QName(APIResourceCollectionConfigBuilderConstants.ACTION));
                                 if (APIResourceCollectionConfigBuilderConstants.VIEW_ACTION.equals(scopeAction)) {
                                     apiResourceCollectionObj.setViewFeatureScope(scopeName);
                                     readScopeSet.add(scopeName);
@@ -175,37 +173,22 @@ public class APIResourceCollectionMgtConfigBuilder {
                             }
                         }
                     }
-                } else {
-                    // Process legacy scopes.
-                    while (actionElements.hasNext()) {
-                        OMElement actionElement = (OMElement) actionElements.next();
-                        if (actionElement == null) {
-                            continue;
-                        }
-                        Iterator<OMElement> scopes = actionElement.getChildrenWithName(
-                                new QName(APIResourceCollectionConfigBuilderConstants.SCOPE_ELEMENT));
-                        while (scopes.hasNext()) {
-                            OMElement scope = scopes.next();
-                            String scopeName = scope.getAttributeValue(
-                                    new QName(APIResourceCollectionConfigBuilderConstants.NAME));
-                            // Read and old Feature scope are considered as read scopes.
-                            boolean isReadAction = APIResourceCollectionConfigBuilderConstants.READ
-                                    .equals(actionElement.getLocalName());
-                            boolean isFeatureAction = APIResourceCollectionConfigBuilderConstants.FEATURE.
-                                    equals(actionElement.getLocalName());
-                            if (isReadAction || isFeatureAction) {
-                                legacyReadScopeSet.add(scopeName);
-                            } else {
-                                legacyWriteScopeSet.add(scopeName);
-                            }
-                        }
-                    }
                 }
             }
-            apiResourceCollectionObj.setReadScopes(new ArrayList<>(readScopeSet));
-            apiResourceCollectionObj.setWriteScopes(new ArrayList<>(writeScopeSet));
-            apiResourceCollectionObj.setLegacyReadScopes(new ArrayList<>(legacyReadScopeSet));
-            apiResourceCollectionObj.setLegacyWriteScopes(new ArrayList<>(legacyWriteScopeSet));
+            if (APIResourceCollectionConfigBuilderConstants.COLLECTION_VERSION_V0
+                    .equals(collectionVersion)) {
+                apiResourceCollectionObj.setLegacyReadScopes(new ArrayList<>(readScopeSet));
+                apiResourceCollectionObj.setLegacyWriteScopes(new ArrayList<>(writeScopeSet));
+                if (apiResourceCollectionObj.getReadScopes() == null) {
+                    apiResourceCollectionObj.setReadScopes(new ArrayList<>(readScopeSet));
+                }
+                if (apiResourceCollectionObj.getWriteScopes() == null) {
+                    apiResourceCollectionObj.setWriteScopes(new ArrayList<>(writeScopeSet));
+                }
+            } else {
+                apiResourceCollectionObj.setReadScopes(new ArrayList<>(readScopeSet));
+                apiResourceCollectionObj.setWriteScopes(new ArrayList<>(writeScopeSet));
+            }
             apiResourceCollectionMgtConfigurations.put(apiResourceCollectionObj.getId(), apiResourceCollectionObj);
         }
     }
@@ -217,7 +200,7 @@ public class APIResourceCollectionMgtConfigBuilder {
         String encodedName = Base64.getEncoder().encodeToString(name.getBytes(StandardCharsets.UTF_8)).replace(
                 APIResourceCollectionManagementConstants.EQUAL_SIGN, StringUtils.EMPTY);
         if (apiResourceCollectionMgtConfigurations.containsKey(encodedName)) {
-            return null;
+            return apiResourceCollectionMgtConfigurations.get(encodedName);
         }
 
         return new APIResourceCollection.APIResourceCollectionBuilder()

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionMgtConfigBuilderTest.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionMgtConfigBuilderTest.java
@@ -1,0 +1,34 @@
+package org.wso2.carbon.identity.api.resource.collection.mgt;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.api.resource.collection.mgt.model.APIResourceCollection;
+import org.wso2.carbon.identity.api.resource.collection.mgt.util.APIResourceCollectionMgtConfigBuilder;
+import org.wso2.carbon.identity.common.testng.WithAxisConfiguration;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.event.IdentityEventException;
+
+import java.util.Map;
+
+@WithCarbonHome
+@WithAxisConfiguration
+public class APIResourceCollectionMgtConfigBuilderTest {
+
+    APIResourceCollectionMgtConfigBuilder configBuilder;
+
+    @BeforeMethod
+    public void setUp() throws IdentityEventException {
+        configBuilder = APIResourceCollectionMgtConfigBuilder.getInstance();
+    }
+
+    @Test
+    public void testGetApIResourceCollections() {
+
+        APIResourceCollectionMgtConfigBuilder instance = APIResourceCollectionMgtConfigBuilder.getInstance();
+        Map<String, APIResourceCollection> apiResourceCollectionMap = instance
+                .getApiResourceCollectionMgtConfigurations();
+        Assert.assertNotNull(apiResourceCollectionMap);
+        Assert.assertFalse(apiResourceCollectionMap.isEmpty());
+    }
+}

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/resources/repository/conf/api-resource-collection.xml
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/resources/repository/conf/api-resource-collection.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  ~ Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<APIResourceCollections>
+    <APIResourceCollection name="apiResources" displayName="API Resources" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:apiResources"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_api_resource_update"/>
+            </Update>
+            <Create>
+                <Scope name="internal_api_resource_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_api_resource_view"/>
+            </Read>
+            <Delete>
+                <Scope name="internal_api_resource_delete"/>
+            </Delete>
+        </Scopes>
+    </APIResourceCollection>
+
+    <!--    New API Resource Collections-->
+    <APIResourceCollection name="apiResources" displayName="API Resources" type="tenant">
+        <Scopes>
+            <Feature>
+                <Scope name="console:apiResources"/>
+                <Scope name="console:apiResources_view"/>
+                <Scope name="console:apiResources_edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_api_resource_update"/>
+            </Update>
+            <Create>
+                <Scope name="internal_api_resource_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_api_resource_view"/>
+            </Read>
+            <Delete>
+                <Scope name="internal_api_resource_delete"/>
+            </Delete>
+        </Scopes>
+    </APIResourceCollection>
+</APIResourceCollections>

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/resources/repository/conf/carbon.xml
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/resources/repository/conf/carbon.xml
@@ -1,0 +1,686 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  ~ Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!--
+    This is the main server configuration file
+
+    ${carbon.home} represents the carbon.home system property.
+    Other system properties can be specified in a similar manner.
+-->
+<Server xmlns="http://wso2.org/projects/carbon/carbon.xml">
+
+    <!--
+       Product Name
+    -->
+    <Name>WSO2 Identity Server</Name>
+
+    <!--
+       machine readable unique key to identify each product
+    -->
+    <ServerKey>IS</ServerKey>
+
+    <!--
+       Product Version
+    -->
+    <Version>5.3.0</Version>
+
+    <!--
+       Host name or IP address of the machine hosting this server
+       e.g. www.wso2.org, 192.168.1.10
+       This is will become part of the End Point Reference of the
+       services deployed on this server instance.
+    -->
+    <HostName>localhost</HostName>
+
+    <!--
+    Host name to be used for the Carbon management console
+    -->
+    <MgtHostName>localhost</MgtHostName>
+
+    <!--
+        The URL of the back end server. This is where the admin services are hosted and
+        will be used by the clients in the front end server.
+        This is required only for the Front-end server. This is used when seperating BE server from FE server
+       -->
+    <ServerURL>local:/${carbon.context}/services/</ServerURL>
+    <!--
+    <ServerURL>https://localhost:${carbon.management.port}${carbon.context}/services/</ServerURL>
+    -->
+    <!--
+    The URL of the index page. This is where the user will be redirected after signing in to the
+    carbon server.
+    -->
+    <!-- IndexPageURL>/carbon/admin/index.jsp</IndexPageURL-->
+
+    <!--
+    For cApp deployment, we have to identify the roles that can be acted by the current server.
+    The following property is used for that purpose. Any number of roles can be defined here.
+    Regular expressions can be used in the role.
+    Ex : <Role>.*</Role> means this server can act any role
+    -->
+    <ServerRoles>
+        <Role>IdentityServer</Role>
+    </ServerRoles>
+
+    <!-- uncommnet this line to subscribe to a bam instance automatically -->
+    <!--<BamServerURL>https://bamhost:bamport/services/</BamServerURL>-->
+
+    <!--
+       The fully qualified name of the server
+    -->
+    <Package>org.wso2.carbon</Package>
+
+    <!--
+       Webapp context root of WSO2 Carbon management console.
+    -->
+    <WebContextRoot>/</WebContextRoot>
+
+    <!--
+    	Proxy context path is a useful parameter to add a proxy path when a Carbon server is fronted by reverse proxy. In addtion
+        to the proxy host and proxy port this parameter allows you add a path component to external URLs. e.g.
+     		URL of the Carbon server -> https://10.100.1.1:9443/carbon
+   		URL of the reverse proxy -> https://prod.abc.com/appserver/carbon
+
+   	appserver - proxy context path. This specially required whenever you are generating URLs to displace in
+   	Carbon UI components.
+    -->
+    <!--
+    	<MgtProxyContextPath></MgtProxyContextPath>
+    	<ProxyContextPath></ProxyContextPath>
+    -->
+
+    <!-- In-order to  get the registry http Port from the back-end when the default http transport is not the same-->
+    <!--RegistryHttpPort>9763</RegistryHttpPort-->
+
+    <!--
+    Number of items to be displayed on a management console page. This is used at the
+    backend server for pagination of various items.
+    -->
+    <ItemsPerPage>15</ItemsPerPage>
+
+    <!-- The endpoint URL of the cloud instance management Web service -->
+    <!--<InstanceMgtWSEndpoint>https://ec2.amazonaws.com/</InstanceMgtWSEndpoint>-->
+
+    <!--
+       Ports used by this server
+    -->
+    <Ports>
+
+        <!-- Ports offset. This entry will set the value of the ports defined below to
+         the define value + Offset.
+         e.g. Offset=2 and HTTPS port=9443 will set the effective HTTPS port to 9445
+         -->
+        <Offset>0</Offset>
+
+        <!-- The JMX Ports -->
+        <JMX>
+            <!--The port RMI registry is exposed-->
+            <RMIRegistryPort>9999</RMIRegistryPort>
+            <!--The port RMI server should be exposed-->
+            <RMIServerPort>11111</RMIServerPort>
+        </JMX>
+
+        <!-- Embedded LDAP server specific ports -->
+        <EmbeddedLDAP>
+            <!-- Port which embedded LDAP server runs -->
+            <LDAPServerPort>10389</LDAPServerPort>
+            <!-- Port which KDC (Kerberos Key Distribution Center) server runs -->
+            <KDCServerPort>8000</KDCServerPort>
+        </EmbeddedLDAP>
+
+        <!--
+                 Override datasources JNDIproviderPort defined in bps.xml and datasources.properties files
+        -->
+        <!--<JNDIProviderPort>2199</JNDIProviderPort>-->
+        <!--Override receive port of thrift based entitlement service.-->
+        <ThriftEntitlementReceivePort>10500</ThriftEntitlementReceivePort>
+
+        <!--
+         This is the proxy port of the worker cluster. These need to be configured in a scenario where
+         manager node is not exposed through the load balancer through which the workers are exposed
+         therefore doesn't have a proxy port.
+        <WorkerHttpProxyPort>80</WorkerHttpProxyPort>
+        <WorkerHttpsProxyPort>443</WorkerHttpsProxyPort>
+        -->
+
+    </Ports>
+
+    <!--
+        JNDI Configuration
+    -->
+    <JNDI>
+        <!--
+             The fully qualified name of the default initial context factory
+        -->
+        <DefaultInitialContextFactory>org.wso2.carbon.tomcat.jndi.CarbonJavaURLContextFactory</DefaultInitialContextFactory>
+        <!--
+             The restrictions that are done to various JNDI Contexts in a Multi-tenant environment
+        -->
+        <Restrictions>
+            <!--
+                Contexts that will be available only to the super-tenant
+            -->
+            <!-- <SuperTenantOnly>
+                <UrlContexts>
+                    <UrlContext>
+                        <Scheme>foo</Scheme>
+                    </UrlContext>
+                    <UrlContext>
+                        <Scheme>bar</Scheme>
+                    </UrlContext>
+                </UrlContexts>
+            </SuperTenantOnly> -->
+            <!--
+                Contexts that are common to all tenants
+            -->
+            <AllTenants>
+                <UrlContexts>
+                    <UrlContext>
+                        <Scheme>java</Scheme>
+                    </UrlContext>
+                    <!-- <UrlContext>
+                        <Scheme>foo</Scheme>
+                    </UrlContext> -->
+                </UrlContexts>
+            </AllTenants>
+            <!--
+                 All other contexts not mentioned above will be available on a per-tenant basis
+                 (i.e. will not be shared among tenants)
+            -->
+        </Restrictions>
+    </JNDI>
+
+    <!--
+        Property to determine if the server is running an a cloud deployment environment.
+        This property should only be used to determine deployment specific details that are
+        applicable only in a cloud deployment, i.e when the server deployed *-as-a-service.
+    -->
+    <IsCloudDeployment>false</IsCloudDeployment>
+
+    <!--
+	Property to determine whether usage data should be collected for metering purposes
+    -->
+    <EnableMetering>false</EnableMetering>
+
+    <!-- The Max time a thread should take for execution in seconds -->
+    <MaxThreadExecutionTime>600</MaxThreadExecutionTime>
+
+    <!--
+        A flag to enable or disable Ghost Deployer. By default this is set to false. That is
+        because the Ghost Deployer works only with the HTTP/S transports. If you are using
+        other transports, don't enable Ghost Deployer.
+    -->
+    <GhostDeployment>
+        <Enabled>false</Enabled>
+    </GhostDeployment>
+
+
+    <!--
+        Eager loading or lazy loading is a design pattern commonly used in computer programming which
+        will initialize an object upon creation or load on-demand. In carbon, lazy loading is used to
+        load tenant when a request is received only. Similarly Eager loading is used to enable load
+        existing tenants after carbon server starts up. Using this feature, you will be able to include
+        or exclude tenants which are to be loaded when server startup.
+
+        We can enable only one LoadingPolicy at a given time.
+
+        1. Tenant Lazy Loading
+           This is the default behaviour and enabled by default. With this policy, tenants are not loaded at
+           server startup, but loaded based on-demand (i.e when a request is received for a tenant).
+           The default tenant idle time is 30 minutes.
+
+        2. Tenant Eager Loading
+           This is by default not enabled. It can be be enabled by un-commenting the <EagerLoading> section.
+           The eager loading configurations supported are as below. These configurations can be given as the
+           value for <Include> element with eager loading.
+                (i)Load all tenants when server startup             -   *
+                (ii)Load all tenants except foo.com & bar.com       -   *,!foo.com,!bar.com
+                (iii)Load only foo.com &  bar.com to be included    -   foo.com,bar.com
+    -->
+    <Tenant>
+        <LoadingPolicy>
+            <LazyLoading>
+                <IdleTime>30</IdleTime>
+            </LazyLoading>
+            <!-- <EagerLoading>
+                   <Include>*,!foo.com,!bar.com</Include>
+            </EagerLoading>-->
+        </LoadingPolicy>
+    </Tenant>
+
+    <!--
+     Caching related configurations
+    -->
+    <Cache>
+        <!-- Default cache timeout in minutes -->
+        <DefaultCacheTimeout>15</DefaultCacheTimeout>
+    </Cache>
+
+    <!--
+    Axis2 related configurations
+    -->
+    <Axis2Config>
+        <!--
+             Location of the Axis2 Services & Modules repository
+
+             This can be a directory in the local file system, or a URL.
+
+             e.g.
+             1. /home/wso2wsas/repository/ - An absolute path
+             2. repository - In this case, the path is relative to CARBON_HOME
+             3. file:///home/wso2wsas/repository/
+             4. http://wso2wsas/repository/
+        -->
+        <RepositoryLocation>${carbon.home}/repository/deployment/server/</RepositoryLocation>
+
+        <!--
+         Deployment update interval in seconds. This is the interval between repository listener
+         executions.
+        -->
+        <DeploymentUpdateInterval>15</DeploymentUpdateInterval>
+
+        <!--
+            Location of the main Axis2 configuration descriptor file, a.k.a. axis2.xml file
+
+            This can be a file on the local file system, or a URL
+
+            e.g.
+            1. /home/repository/axis2.xml - An absolute path
+            2. conf/axis2.xml - In this case, the path is relative to CARBON_HOME
+            3. file:///home/carbon/repository/axis2.xml
+            4. http://repository/conf/axis2.xml
+        -->
+        <ConfigurationFile>${carbon.home}/repository/conf/axis2/axis2.xml</ConfigurationFile>
+
+        <!--
+          ServiceGroupContextIdleTime, which will be set in ConfigurationContex
+          for multiple clients which are going to access the same ServiceGroupContext
+          Default Value is 30 Sec.
+        -->
+        <ServiceGroupContextIdleTime>30000</ServiceGroupContextIdleTime>
+
+        <!--
+          This repository location is used to crete the client side configuration
+          context used by the server when calling admin services.
+        -->
+        <ClientRepositoryLocation>${carbon.home}/repository/deployment/client/</ClientRepositoryLocation>
+        <!-- This axis2 xml is used in createing the configuration context by the FE server
+         calling to BE server -->
+        <clientAxis2XmlLocation>${carbon.home}/repository/conf/axis2/axis2_client.xml</clientAxis2XmlLocation>
+        <!-- If this parameter is set, the ?wsdl on an admin service will not give the admin service wsdl. -->
+        <HideAdminServiceWSDLs>true</HideAdminServiceWSDLs>
+
+        <!--WARNING-Use With Care! Uncommenting bellow parameter would expose all AdminServices in HTTP transport.
+        With HTTP transport your credentials and data routed in public channels are vulnerable for sniffing attacks.
+        Use bellow parameter ONLY if your communication channels are confirmed to be secured by other means -->
+        <!--HttpAdminServices>*</HttpAdminServices-->
+
+    </Axis2Config>
+
+    <!--
+       The default user roles which will be created when the server
+       is started up for the first time.
+    -->
+    <ServiceUserRoles>
+        <Role>
+            <Name>admin</Name>
+            <Description>Default Administrator Role</Description>
+        </Role>
+        <Role>
+            <Name>user</Name>
+            <Description>Default User Role</Description>
+        </Role>
+    </ServiceUserRoles>
+
+    <!--
+      Enable following config to allow Emails as usernames.
+    -->
+    <!--EnableEmailUserName>true</EnableEmailUserName-->
+
+    <!--
+      Security configurations
+    -->
+    <Security>
+        <!--
+            KeyStore which will be used for encrypting/decrypting passwords
+            and other sensitive information.
+        -->
+        <KeyStore>
+            <!-- Keystore file location-->
+            <Location>${carbon.home}/repository/resources/security/wso2carbon.jks</Location>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>JKS</Type>
+            <!-- Keystore password-->
+            <Password>wso2carbon</Password>
+            <!-- Private Key alias-->
+            <KeyAlias>wso2carbon</KeyAlias>
+            <!-- Private Key password-->
+            <KeyPassword>wso2carbon</KeyPassword>
+        </KeyStore>
+
+        <!--
+            System wide trust-store which is used to maintain the certificates of all
+            the trusted parties.
+        -->
+        <TrustStore>
+            <!-- trust-store file location -->
+            <Location>${carbon.home}/repository/resources/security/client-truststore.jks</Location>
+            <!-- trust-store type (JKS/PKCS12 etc.) -->
+            <Type>JKS</Type>
+            <!-- trust-store password -->
+            <Password>wso2carbon</Password>
+        </TrustStore>
+
+        <!--
+            The Authenticator configuration to be used at the JVM level. We extend the
+            java.net.Authenticator to make it possible to authenticate to given servers and
+            proxies.
+        -->
+        <NetworkAuthenticatorConfig>
+            <!--
+                Below is a sample configuration for a single authenticator. Please note that
+                all child elements are mandatory. Not having some child elements would lead to
+                exceptions at runtime.
+            -->
+            <!-- <Credential> -->
+            <!--
+                the pattern that would match a subset of URLs for which this authenticator
+                would be used
+            -->
+            <!-- <Pattern>regularExpression</Pattern> -->
+            <!--
+                the type of this authenticator. Allowed values are:
+                1. server
+                2. proxy
+            -->
+            <!-- <Type>proxy</Type> -->
+            <!-- the username used to log in to server/proxy -->
+            <!-- <Username>username</Username> -->
+            <!-- the password used to log in to server/proxy -->
+            <!-- <Password>password</Password> -->
+            <!-- </Credential> -->
+        </NetworkAuthenticatorConfig>
+
+        <!--
+         The Tomcat realm to be used for hosted Web applications. Allowed values are;
+         1. UserManager
+         2. Memory
+
+         If this is set to 'UserManager', the realm will pick users & roles from the system's
+         WSO2 User Manager. If it is set to 'memory', the realm will pick users & roles from
+         CARBON_HOME/repository/conf/tomcat/tomcat-users.xml
+        -->
+        <TomcatRealm>UserManager</TomcatRealm>
+
+        <!--Option to disable storing of tokens issued by STS-->
+        <DisableTokenStore>false</DisableTokenStore>
+
+        <STSCallBackHandlerName>org.wso2.carbon.identity.provider.AttributeCallbackHandler</STSCallBackHandlerName>
+
+        <!--
+         Security token store class name. If this is not set, default class will be
+         org.wso2.carbon.security.util.SecurityTokenStore
+        -->
+        <TokenStoreClassName>org.wso2.carbon.identity.sts.store.DBTokenStore</TokenStoreClassName>
+
+        <XSSPreventionConfig>
+            <Enabled>true</Enabled>
+            <Rule>allow</Rule>
+            <Patterns>
+                <!--Pattern></Pattern-->
+            </Patterns>
+        </XSSPreventionConfig>
+    </Security>
+    <HideMenuItemIds>
+        <HideMenuItemId>claim_mgt_menu</HideMenuItemId>
+        <HideMenuItemId>identity_mgt_emailtemplate_menu</HideMenuItemId>
+        <HideMenuItemId>identity_security_questions_menu</HideMenuItemId>
+    </HideMenuItemIds>
+
+    <!--
+       The temporary work directory
+    -->
+    <WorkDirectory>${carbon.home}/tmp/work</WorkDirectory>
+
+    <!--
+       House-keeping configuration
+    -->
+    <HouseKeeping>
+
+        <!--
+           true  - Start House-keeping thread on server startup
+           false - Do not start House-keeping thread on server startup.
+                   The user will run it manually as and when he wishes.
+        -->
+        <AutoStart>true</AutoStart>
+
+        <!--
+           The interval in *minutes*, between house-keeping runs
+        -->
+        <Interval>10</Interval>
+
+        <!--
+          The maximum time in *minutes*, temp files are allowed to live
+          in the system. Files/directories which were modified more than
+          "MaxTempFileLifetime" minutes ago will be removed by the
+          house-keeping task
+        -->
+        <MaxTempFileLifetime>30</MaxTempFileLifetime>
+    </HouseKeeping>
+
+    <!--
+       Configuration for handling different types of file upload & other file uploading related
+       config parameters.
+       To map all actions to a particular FileUploadExecutor, use
+       <Action>*</Action>
+    -->
+    <FileUploadConfig>
+        <!--
+           The total file upload size limit in MB
+        -->
+        <TotalFileSizeLimit>100</TotalFileSizeLimit>
+
+        <Mapping>
+            <Actions>
+                <Action>keystore</Action>
+                <Action>certificate</Action>
+                <Action>*</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.AnyFileUploadExecutor</Class>
+        </Mapping>
+
+        <Mapping>
+            <Actions>
+                <Action>jarZip</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.JarZipUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>dbs</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.DBSFileUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>tools</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.ToolsFileUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>toolsAny</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.ToolsAnyFileUploadExecutor</Class>
+        </Mapping>
+    </FileUploadConfig>
+
+    <!-- FileNameRegEx is used to validate the file input/upload/write-out names.
+    e.g.
+     <FileNameRegEx>^(?!(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\.[^.])?$)[^&lt;&gt:"/\\|?*\x00-\x1F][^&lt;&gt:"/\\|?*\x00-\x1F\ .]$</FileNameRegEx>
+    -->
+    <!--<FileNameRegEx></FileNameRegEx>-->
+
+    <!--
+       Processors which process special HTTP GET requests such as ?wsdl, ?policy etc.
+
+       In order to plug in a processor to handle a special request, simply add an entry to this
+       section.
+
+       The value of the Item element is the first parameter in the query string(e.g. ?wsdl)
+       which needs special processing
+
+       The value of the Class element is a class which implements
+       org.wso2.carbon.transport.HttpGetRequestProcessor
+    -->
+    <HttpGetRequestProcessors>
+        <Processor>
+            <Item>info</Item>
+            <Class>org.wso2.carbon.core.transports.util.InfoProcessor</Class>
+        </Processor>
+        <Processor>
+            <Item>wsdl</Item>
+            <Class>org.wso2.carbon.core.transports.util.Wsdl11Processor</Class>
+        </Processor>
+        <Processor>
+            <Item>wsdl2</Item>
+            <Class>org.wso2.carbon.core.transports.util.Wsdl20Processor</Class>
+        </Processor>
+        <Processor>
+            <Item>xsd</Item>
+            <Class>org.wso2.carbon.core.transports.util.XsdProcessor</Class>
+        </Processor>
+    </HttpGetRequestProcessors>
+
+    <!-- Deployment Synchronizer Configuration. Enable value to true when running with "svn based" dep sync.
+	In master nodes you need to set both AutoCommit and AutoCheckout to true
+	and in  worker nodes set only AutoCheckout to true.
+    -->
+    <DeploymentSynchronizer>
+        <Enabled>false</Enabled>
+        <AutoCommit>false</AutoCommit>
+        <AutoCheckout>true</AutoCheckout>
+        <RepositoryType>svn</RepositoryType>
+        <SvnUrl>http://svnrepo.example.com/repos/</SvnUrl>
+        <SvnUser>username</SvnUser>
+        <SvnPassword>password</SvnPassword>
+        <SvnUrlAppendTenantId>true</SvnUrlAppendTenantId>
+    </DeploymentSynchronizer>
+
+    <!-- Deployment Synchronizer Configuration. Uncomment the following section when running with "registry based" dep sync.
+        In master nodes you need to set both AutoCommit and AutoCheckout to true
+        and in  worker nodes set only AutoCheckout to true.
+    -->
+    <!--<DeploymentSynchronizer>
+        <Enabled>true</Enabled>
+        <AutoCommit>false</AutoCommit>
+        <AutoCheckout>true</AutoCheckout>
+    </DeploymentSynchronizer>-->
+
+    <!-- Mediation persistence configurations. Only valid if mediation features are available i.e. ESB -->
+    <!--<MediationConfig>
+        <LoadFromRegistry>false</LoadFromRegistry>
+        <SaveToFile>false</SaveToFile>
+        <Persistence>enabled</Persistence>
+        <RegistryPersistence>enabled</RegistryPersistence>
+    </MediationConfig>-->
+
+    <!--
+    Server intializing code, specified as implementation classes of org.wso2.carbon.core.ServerInitializer.
+    This code will be run when the Carbon server is initialized
+    -->
+    <ServerInitializers>
+        <!--<Initializer></Initializer>-->
+    </ServerInitializers>
+
+    <!--
+    Indicates whether the Carbon Servlet is required by the system, and whether it should be
+    registered
+    -->
+    <RequireCarbonServlet>${require.carbon.servlet}</RequireCarbonServlet>
+
+    <!--
+    Carbon H2 OSGI Configuration
+    By default non of the servers start.
+        name="web" - Start the web server with the H2 Console
+        name="webPort" - The port (default: 8082)
+        name="webAllowOthers" - Allow other computers to connect
+        name="webSSL" - Use encrypted (HTTPS) connections
+        name="tcp" - Start the TCP server
+        name="tcpPort" - The port (default: 9092)
+        name="tcpAllowOthers" - Allow other computers to connect
+        name="tcpSSL" - Use encrypted (SSL) connections
+        name="pg" - Start the PG server
+        name="pgPort"  - The port (default: 5435)
+        name="pgAllowOthers"  - Allow other computers to connect
+        name="trace" - Print additional trace information; for all servers
+        name="baseDir" - The base directory for H2 databases; for all servers
+    -->
+    <!--H2DatabaseConfiguration>
+        <property name="web" />
+        <property name="webPort">8082</property>
+        <property name="webAllowOthers" />
+        <property name="webSSL" />
+        <property name="tcp" />
+        <property name="tcpPort">9092</property>
+        <property name="tcpAllowOthers" />
+        <property name="tcpSSL" />
+        <property name="pg" />
+        <property name="pgPort">5435</property>
+        <property name="pgAllowOthers" />
+        <property name="trace" />
+        <property name="baseDir">${carbon.home}</property>
+    </H2DatabaseConfiguration-->
+    <!--Disabling statistics reporter by default-->
+    <StatisticsReporterDisabled>true</StatisticsReporterDisabled>
+
+    <!-- Enable accessing Admin Console via HTTP -->
+    <!-- EnableHTTPAdminConsole>true</EnableHTTPAdminConsole -->
+
+    <!--
+       Default Feature Repository of WSO2 Carbon.
+    -->
+    <FeatureRepository>
+        <RepositoryName>default repository</RepositoryName>
+        <RepositoryURL>http://product-dist.wso2.com/p2/carbon/releases/wilkes/</RepositoryURL>
+    </FeatureRepository>
+
+    <!--
+	Configure API Management
+   -->
+    <APIManagement>
+
+        <!--Uses the embedded API Manager by default. If you want to use an external
+        API Manager instance to manage APIs, configure below  externalAPIManager-->
+
+        <Enabled>true</Enabled>
+
+        <!--Uncomment and configure API Gateway and
+        Publisher URLs to use external API Manager instance-->
+
+        <!--ExternalAPIManager>
+
+            <APIGatewayURL>http://localhost:8281</APIGatewayURL>
+            <APIPublisherURL>http://localhost:8281/publisher</APIPublisherURL>
+
+        </ExternalAPIManager-->
+
+        <LoadAPIContextsInServerStartup>true</LoadAPIContextsInServerStartup>
+    </APIManagement>
+</Server>

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/resources/repository/conf/carbon.xml
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/resources/repository/conf/carbon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
-  ~ Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/resources/testng.xml
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/resources/testng.xml
@@ -22,6 +22,7 @@
     <test name="api-resource-collection-mgt-tests" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.carbon.identity.api.resource.collection.mgt.APIResourceCollectionManagerTest"/>
+            <class name="org.wso2.carbon.identity.api.resource.collection.mgt.APIResourceCollectionMgtConfigBuilderTest"/>
         </classes>
     </test>
 </suite>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -18,29 +18,10 @@
   -->
 
 <APIResourceCollections>
-    <APIResourceCollection name="apiResources" displayName="API Resources" type="tenant">
-       <Scopes>
+    <APIResourceCollection name="apiResources" displayName="API Resources" type="tenant" version="v0">
+        <Scopes>
             <Feature>
                 <Scope name="console:apiResources"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_api_resource_update"/>
-            </Update>
-            <Create>
-                <Scope name="internal_api_resource_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_api_resource_view"/>
-            </Read>
-            <Delete>
-                <Scope name="internal_api_resource_delete"/>
-            </Delete>
-        </Scopes>
-        <Scopes version="v1">
-            <Feature>
-                <Scope name="console:apiResources"/>
-                <Scope name="console:apiResources_view" action="view"/>
-                <Scope name="console:apiResources_edit" action="edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_api_resource_update"/>
@@ -56,8 +37,8 @@
             </Delete>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="applications" displayName="Applications" type="tenant">
-       <Scopes>
+    <APIResourceCollection name="applications" displayName="Applications" type="tenant" version="v0">
+        <Scopes>
             <Feature>
                 <Scope name="console:applications"/>
             </Feature>
@@ -92,7 +73,847 @@
                 <Scope name="internal_secret_mgt_view"/>
             </Read>
         </Scopes>
-        <Scopes version="v1">
+    </APIResourceCollection>
+    <APIResourceCollection name="branding" displayName="Branding" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:branding"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_branding_preference_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_branding_preference_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_branding_preference_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_application_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="approvals" displayName="Approvals" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:workflowApprovals"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_humantask_view"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_humantask_view"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_humantask_view"/>
+            </Create>
+            <Read>
+                <Scope name="internal_humantask_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="attributeDialects" displayName="Attribute Dialects" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:attributes"/>
+            </Feature>
+            <Create>
+                <Scope name="internal_claim_meta_create"/>
+            </Create>
+            <Update>
+                <Scope name="internal_claim_meta_update"/>
+                <Scope name="internal_governance_update"/>
+            </Update>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_claim_meta_view"/>
+                <Scope name="internal_governance_view"/>
+            </Read>
+            <Delete>
+                <Scope name="internal_claim_meta_delete"/>
+            </Delete>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="certificates" displayName="Certificates" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:certificates"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_keystore_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_keystore_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_keystore_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_keystore_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="consoleSettings" displayName="Console Settings" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:settings"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_application_mgt_update"/>
+                <Scope name="internal_user_mgt_update"/>
+            </Update>
+            <Delete>
+            </Delete>
+            <Create>
+                <Scope name="internal_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_session_view"/>
+                <Scope name="internal_governance_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="emailTemplates" displayName="Email Templates" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:emailTemplates"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_email_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_email_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_email_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_email_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="smsTemplates" displayName="SMS Templates" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:smsTemplates"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_template_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_template_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_template_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_template_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="groups" displayName="Groups" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:groups"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_group_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_group_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="gettingStarted" displayName="Home Page" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:home"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_application_mgt_update"/>
+            </Update>
+            <Delete/>
+            <Create>
+                <Scope name="internal_application_mgt_create"/>
+                <Scope name="internal_idp_create"/>
+                <Scope name="internal_user_mgt_create"/>
+                <Scope name="internal_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_application_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="connections" displayName="Connections" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:idps"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_idp_update"/>
+                <Scope name="internal_governance_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_idp_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_idp_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
+                <Scope name="internal_authenticator_view"/>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_extensions_view"/>
+                <Scope name="internal_config_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="identityVerificationProviders" displayName="Identity Verification Providers" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:idvps"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_idvp_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_idvp_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_idvp_add"/>
+            </Create>
+            <Read>
+                <Scope name="internal_idvp_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="loginAndRegistration" displayName="Login And Registration" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:loginAndRegistration"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_governance_update"/>
+            </Update>
+            <Delete/>
+            <Create/>
+            <Read>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_validation_rule_mgt_update"/>
+                <Scope name="internal_config_update"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_group_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="notificationChannels" displayName="Notification Channels" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:notificationChannels"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_notification_senders_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_notification_senders_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_notification_senders_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_notification_senders_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="oidcScopes" displayName="OIDC Scopes" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:scopes:oidc"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_oidc_scope_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_oidc_scope_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_oidc_scope_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_oidc_scope_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="organizations" displayName="Organizations" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:organizations"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_organization_update"/>
+                <Scope name="internal_organization_config_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_organization_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_organization_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_organization_view"/>
+                <Scope name="internal_organization_config_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="organizationDiscovery" displayName="Organization Discovery" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:organizationDiscovery"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_organization_discovery_update"/>
+                <Scope name="internal_organization_config_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_organization_discovery_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_organization_discovery_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_organization_discovery_view"/>
+                <Scope name="internal_organization_view"/>
+                <Scope name="internal_organization_config_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="residentOutboundProvisioning" displayName="Resident Application Outbound Provisioning" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:residentOutboundProvisioning"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_application_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_application_mgt_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_application_mgt_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_application_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="roles" displayName="Roles" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:roles"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_role_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_role_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_api_resource_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="rolesV1" displayName="Roles" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:roles"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_role_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_role_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_permission_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="users" displayName="Users" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:users"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_user_mgt_update"/>
+                <Scope name="internal_session_delete"/>
+                <Scope name="internal_group_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_user_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_user_mgt_create"/>
+                <Scope name="internal_bulk_resource_create"/>
+                <Scope name="internal_offline_invite"/>
+            </Create>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_login"/>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_session_view"/>
+                <Scope name="internal_claim_meta_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="userStores" displayName="User Stores" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:userstores"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_userstore_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_userstore_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_userstore_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="actions" displayName="Actions" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:actions"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_action_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_action_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_action_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_action_mgt_view"/>
+                <Scope name="internal_rule_metadata_view"/>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="tenants" displayName="Root Organizations" type="tenant" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:tenants"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_modify_tenants"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_modify_tenants"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_create_tenants"/>
+            </Create>
+            <Read>
+                <Scope name="internal_list_tenants"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <!--    Organization API Resource Collections-->
+    <APIResourceCollection name="org_consoleSettings" displayName="Console Settings" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:settings"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_application_mgt_update"/>
+                <Scope name="internal_org_user_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_guest_mgt_invite_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_guest_mgt_invite_list"/>
+                <Scope name="internal_org_idp_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_session_view"/>
+                <Scope name="internal_org_governance_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_connections" displayName="Connections" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:idps"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_idp_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_idp_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_idp_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_idp_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_authenticator_view"/>
+                <Scope name="internal_org_governance_view"/>
+                <Scope name="internal_org_extensions_view"/>
+                <Scope name="internal_org_config_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_users" displayName="Users" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:users"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_user_mgt_update"/>
+                <Scope name="internal_org_session_delete"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_user_mgt_delete"/>
+                <Scope name="internal_org_guest_mgt_invite_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_user_mgt_create"/>
+                <Scope name="internal_org_guest_mgt_invite_add"/>
+                <Scope name="internal_org_bulk_resource_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_governance_view"/>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_session_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_guest_mgt_invite_list"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_organizations" displayName="Organizations" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:organizations"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_organization_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_organization_delete"/>
+                <Scope name="internal_org_config_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_organization_create"/>
+                <Scope name="internal_org_config_mgt_add"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_organization_view"/>
+                <Scope name="internal_org_config_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_groups" displayName="Groups" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:groups"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_group_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_group_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_roles" displayName="Roles" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:roles"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_role_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_role_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_application_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_idp_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_rolesV1" displayName="Roles" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:roles"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_role_mgt_update"/>
+            </Update>
+            <Delete/>
+            <Create>
+                <Scope name="internal_org_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_permission_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_applications" displayName="Applications" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:applications"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_application_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_application_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_application_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_idp_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_branding" displayName="Branding" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:branding"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_branding_preference_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_branding_preference_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_branding_preference_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_emailTemplates" displayName="Email Templates" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:emailTemplates"/>
+            </Feature>
+            <Update>
+            </Update>
+            <Delete>
+            </Delete>
+            <Create>
+            </Create>
+            <Read>
+                <Scope name="internal_org_email_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_smsTemplates" displayName="SMS Templates" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:smsTemplates"/>
+            </Feature>
+            <Update>
+            </Update>
+            <Delete>
+            </Delete>
+            <Create>
+            </Create>
+            <Read>
+                <Scope name="internal_org_template_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_gettingStarted" displayName="Home Page" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:home"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_application_mgt_update"/>
+            </Update>
+            <Delete/>
+            <Create>
+                <Scope name="internal_org_application_mgt_create"/>
+                <Scope name="internal_org_idp_create"/>
+                <Scope name="internal_org_user_mgt_create"/>
+                <Scope name="internal_org_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_apiResources" displayName="API Resources" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:apiResources"/>
+            </Feature>
+            <Read>
+                <Scope name="internal_org_api_resource_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_userStores" displayName="User Stores" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:userstores"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_userstore_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_userstore_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_userstore_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_attributeDialects" displayName="Attribute Dialects" type="organization" version="v0">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:attributes"/>
+            </Feature>
+            <Create>
+            </Create>
+            <Update>
+                <Scope name="internal_org_claim_meta_update"/>
+            </Update>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+            </Read>
+            <Delete>
+            </Delete>
+        </Scopes>
+    </APIResourceCollection>
+
+    <!--    New API Resource Collections-->
+    <APIResourceCollection name="apiResources" displayName="API Resources" type="tenant">
+        <Scopes>
+            <Feature>
+                <Scope name="console:apiResources"/>
+                <Scope name="console:apiResources_view" action="view"/>
+                <Scope name="console:apiResources_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_api_resource_update"/>
+            </Update>
+            <Create>
+                <Scope name="internal_api_resource_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_api_resource_view"/>
+            </Read>
+            <Delete>
+                <Scope name="internal_api_resource_delete"/>
+            </Delete>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="applications" displayName="Applications" type="tenant">
+        <Scopes>
             <Feature>
                 <Scope name="console:applications"/>
                 <Scope name="console:applications_view" action="view"/>
@@ -131,24 +952,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="branding" displayName="Branding" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:branding"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_branding_preference_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_branding_preference_update"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_branding_preference_update"/>
-            </Create>
-            <Read>
-                <Scope name="internal_application_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:branding"/>
                 <Scope name="console:branding_view" action="view"/>
@@ -169,24 +973,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="approvals" displayName="Approvals" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:workflowApprovals"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_humantask_view"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_humantask_view"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_humantask_view"/>
-            </Create>
-            <Read>
-                <Scope name="internal_humantask_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:workflowApprovals"/>
                 <Scope name="console:workflowApprovals_view" action="view"/>
@@ -207,27 +994,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="attributeDialects" displayName="Attribute Dialects" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:attributes"/>
-            </Feature>
-            <Create>
-                <Scope name="internal_claim_meta_create"/>
-            </Create>
-            <Update>
-                <Scope name="internal_claim_meta_update"/>
-                <Scope name="internal_governance_update"/>
-            </Update>
-            <Read>
-                <Scope name="internal_userstore_view"/>
-                <Scope name="internal_claim_meta_view"/>
-                <Scope name="internal_governance_view"/>
-            </Read>
-            <Delete>
-                <Scope name="internal_claim_meta_delete"/>
-            </Delete>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:attributes"/>
                 <Scope name="console:attributes_view" action="view"/>
@@ -251,24 +1018,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="certificates" displayName="Certificates" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:certificates"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_keystore_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_keystore_update"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_keystore_update"/>
-            </Create>
-            <Read>
-                <Scope name="internal_keystore_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:certificates"/>
                 <Scope name="console:certificates_view" action="view"/>
@@ -289,32 +1039,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="consoleSettings" displayName="Console Settings" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:settings"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_application_mgt_update"/>
-                <Scope name="internal_user_mgt_update"/>
-            </Update>
-            <Delete>
-            </Delete>
-            <Create>
-                <Scope name="internal_role_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_application_mgt_view"/>
-                <Scope name="internal_user_mgt_list"/>
-                <Scope name="internal_user_mgt_view"/>
-                <Scope name="internal_userstore_view"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_idp_view"/>
-                <Scope name="internal_group_mgt_view"/>
-                <Scope name="internal_session_view"/>
-                <Scope name="internal_governance_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:settings"/>
                 <Scope name="console:settings_view" action="view"/>
@@ -343,24 +1068,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="emailTemplates" displayName="Email Templates" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:emailTemplates"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_email_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_email_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_email_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_email_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:emailTemplates"/>
                 <Scope name="console:emailTemplates_view" action="view"/>
@@ -381,24 +1089,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="smsTemplates" displayName="SMS Templates" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:smsTemplates"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_template_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_template_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_template_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_template_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:smsTemplates"/>
                 <Scope name="console:smsTemplates_view" action="view"/>
@@ -419,28 +1110,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="groups" displayName="Groups" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:groups"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_group_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_group_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_group_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_user_mgt_view"/>
-                <Scope name="internal_user_mgt_list"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_group_mgt_view"/>
-                <Scope name="internal_userstore_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:groups"/>
                 <Scope name="console:groups_view" action="view"/>
@@ -465,25 +1135,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="gettingStarted" displayName="Home Page" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:home"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_application_mgt_update"/>
-            </Update>
-            <Delete/>
-            <Create>
-                <Scope name="internal_application_mgt_create"/>
-                <Scope name="internal_idp_create"/>
-                <Scope name="internal_user_mgt_create"/>
-                <Scope name="internal_group_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_application_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:home"/>
                 <Scope name="console:home_view" action="view"/>
@@ -505,32 +1157,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="connections" displayName="Connections" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:idps"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_idp_update"/>
-                <Scope name="internal_governance_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_idp_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_idp_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_userstore_view"/>
-                <Scope name="internal_idp_view"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_claim_meta_view"/>
-                <Scope name="internal_authenticator_view"/>
-                <Scope name="internal_governance_view"/>
-                <Scope name="internal_extensions_view"/>
-                <Scope name="internal_config_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:idps"/>
                 <Scope name="console:idps_view" action="view"/>
@@ -559,24 +1186,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="identityVerificationProviders" displayName="Identity Verification Providers" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:idvps"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_idvp_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_idvp_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_idvp_add"/>
-            </Create>
-            <Read>
-                <Scope name="internal_idvp_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:idvps"/>
                 <Scope name="console:idvps_view" action="view"/>
@@ -597,24 +1207,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="loginAndRegistration" displayName="Login And Registration" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:loginAndRegistration"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_governance_update"/>
-            </Update>
-            <Delete/>
-            <Create/>
-            <Read>
-                <Scope name="internal_governance_view"/>
-                <Scope name="internal_validation_rule_mgt_update"/>
-                <Scope name="internal_config_update"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_group_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:loginAndRegistration"/>
                 <Scope name="console:loginAndRegistration_view" action="view"/>
@@ -635,24 +1228,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="notificationChannels" displayName="Notification Channels" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:notificationChannels"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_notification_senders_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_notification_senders_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_notification_senders_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_notification_senders_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:notificationChannels"/>
                 <Scope name="console:notificationChannels_view" action="view"/>
@@ -673,25 +1249,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="oidcScopes" displayName="OIDC Scopes" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:scopes:oidc"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_oidc_scope_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_oidc_scope_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_oidc_scope_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_oidc_scope_mgt_view"/>
-                <Scope name="internal_claim_meta_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:scopes:oidc"/>
                 <Scope name="console:scopes:oidc_view" action="view"/>
@@ -713,26 +1271,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="organizations" displayName="Organizations" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:organizations"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_organization_update"/>
-                <Scope name="internal_organization_config_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_organization_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_organization_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_organization_view"/>
-                <Scope name="internal_organization_config_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:organizations"/>
                 <Scope name="console:organizations_view" action="view"/>
@@ -755,27 +1294,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="organizationDiscovery" displayName="Organization Discovery" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:organizationDiscovery"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_organization_discovery_update"/>
-                <Scope name="internal_organization_config_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_organization_discovery_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_organization_discovery_update"/>
-            </Create>
-            <Read>
-                <Scope name="internal_organization_discovery_view"/>
-                <Scope name="internal_organization_view"/>
-                <Scope name="internal_organization_config_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:organizationDiscovery"/>
                 <Scope name="console:organizationDiscovery_view" action="view"/>
@@ -799,25 +1318,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="residentOutboundProvisioning" displayName="Resident Application Outbound Provisioning" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:residentOutboundProvisioning"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_application_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_application_mgt_update"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_application_mgt_update"/>
-            </Create>
-            <Read>
-                <Scope name="internal_idp_view"/>
-                <Scope name="internal_application_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:residentOutboundProvisioning"/>
                 <Scope name="console:residentOutboundProvisioning_view" action="view"/>
@@ -839,31 +1340,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="roles" displayName="Roles" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:roles"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_role_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_role_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_role_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_user_mgt_view"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_userstore_view"/>
-                <Scope name="internal_group_mgt_view"/>
-                <Scope name="internal_application_mgt_view"/>
-                <Scope name="internal_user_mgt_list"/>
-                <Scope name="internal_idp_view"/>
-                <Scope name="internal_api_resource_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:roles"/>
                 <Scope name="console:roles_view" action="view"/>
@@ -891,29 +1368,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="rolesV1" displayName="Roles" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:roles"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_role_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_role_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_role_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_user_mgt_view"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_userstore_view"/>
-                <Scope name="internal_group_mgt_view"/>
-                <Scope name="internal_permission_mgt_view"/>
-                <Scope name="internal_user_mgt_list"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:roles"/>
                 <Scope name="console:roles_view" action="view"/>
@@ -939,36 +1394,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="users" displayName="Users" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:users"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_user_mgt_update"/>
-                <Scope name="internal_session_delete"/>
-                <Scope name="internal_group_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_user_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_user_mgt_create"/>
-                <Scope name="internal_bulk_resource_create"/>
-                <Scope name="internal_offline_invite"/>
-            </Create>
-            <Read>
-                <Scope name="internal_userstore_view"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_group_mgt_view"/>
-                <Scope name="internal_governance_view"/>
-                <Scope name="internal_login"/>
-                <Scope name="internal_user_mgt_view"/>
-                <Scope name="internal_user_mgt_list"/>
-                <Scope name="internal_session_view"/>
-                <Scope name="internal_claim_meta_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:users"/>
                 <Scope name="console:users_view" action="view"/>
@@ -1001,24 +1427,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="userStores" displayName="User Stores" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:userstores"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_userstore_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_userstore_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_userstore_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_userstore_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:userstores"/>
                 <Scope name="console:userstores_view" action="view"/>
@@ -1039,27 +1448,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="actions" displayName="Actions" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:actions"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_action_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_action_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_action_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_action_mgt_view"/>
-                <Scope name="internal_rule_metadata_view"/>
-                <Scope name="internal_application_mgt_view"/>
-                <Scope name="internal_claim_meta_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:actions"/>
                 <Scope name="console:actions_view" action="view"/>
@@ -1083,24 +1472,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="tenants" displayName="Root Organizations" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:tenants"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_modify_tenants"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_modify_tenants"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_create_tenants"/>
-            </Create>
-            <Read>
-                <Scope name="internal_list_tenants"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:tenants"/>
                 <Scope name="console:tenants_view" action="view"/>
@@ -1120,36 +1492,9 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-<!--    Organization API Resource Collections-->
+    <!--    New Organization API Resource Collections-->
     <APIResourceCollection name="org_consoleSettings" displayName="Console Settings" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:settings"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_application_mgt_update"/>
-                <Scope name="internal_org_user_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_guest_mgt_invite_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_role_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_application_mgt_view"/>
-                <Scope name="internal_org_user_mgt_list"/>
-                <Scope name="internal_org_user_mgt_view"/>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_role_mgt_view"/>
-                <Scope name="internal_org_guest_mgt_invite_list"/>
-                <Scope name="internal_org_idp_view"/>
-                <Scope name="internal_org_group_mgt_view"/>
-                <Scope name="internal_org_session_view"/>
-                <Scope name="internal_org_governance_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:settings"/>
                 <Scope name="console:org:settings_view" action="view"/>
@@ -1180,31 +1525,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_connections" displayName="Connections" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:idps"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_idp_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_idp_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_idp_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_idp_view"/>
-                <Scope name="internal_org_role_mgt_view"/>
-                <Scope name="internal_org_claim_meta_view"/>
-                <Scope name="internal_org_authenticator_view"/>
-                <Scope name="internal_org_governance_view"/>
-                <Scope name="internal_org_extensions_view"/>
-                <Scope name="internal_org_config_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:idps"/>
                 <Scope name="console:org:idps_view" action="view"/>
@@ -1232,36 +1553,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_users" displayName="Users" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:users"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_user_mgt_update"/>
-                <Scope name="internal_org_session_delete"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_user_mgt_delete"/>
-                <Scope name="internal_org_guest_mgt_invite_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_user_mgt_create"/>
-                <Scope name="internal_org_guest_mgt_invite_add"/>
-                <Scope name="internal_org_bulk_resource_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_role_mgt_view"/>
-                <Scope name="internal_org_group_mgt_view"/>
-                <Scope name="internal_org_governance_view"/>
-                <Scope name="internal_org_user_mgt_view"/>
-                <Scope name="internal_org_user_mgt_list"/>
-                <Scope name="internal_org_session_view"/>
-                <Scope name="internal_org_claim_meta_view"/>
-                <Scope name="internal_org_guest_mgt_invite_list"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:users"/>
                 <Scope name="console:org:users_view" action="view"/>
@@ -1294,27 +1586,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_organizations" displayName="Organizations" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:organizations"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_organization_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_organization_delete"/>
-                <Scope name="internal_org_config_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_organization_create"/>
-                <Scope name="internal_org_config_mgt_add"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_organization_view"/>
-                <Scope name="internal_org_config_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:organizations"/>
                 <Scope name="console:org:organizations_view" action="view"/>
@@ -1338,28 +1610,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_groups" displayName="Groups" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:groups"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_group_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_group_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_group_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_user_mgt_view"/>
-                <Scope name="internal_org_user_mgt_list"/>
-                <Scope name="internal_org_role_mgt_view"/>
-                <Scope name="internal_org_group_mgt_view"/>
-                <Scope name="internal_org_userstore_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:groups"/>
                 <Scope name="console:org:groups_view" action="view"/>
@@ -1384,30 +1635,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_roles" displayName="Roles" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:roles"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_role_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_role_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_role_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_user_mgt_view"/>
-                <Scope name="internal_org_role_mgt_view"/>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_group_mgt_view"/>
-                <Scope name="internal_org_application_mgt_view"/>
-                <Scope name="internal_org_user_mgt_list"/>
-                <Scope name="internal_org_idp_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:roles"/>
                 <Scope name="console:org:roles_view" action="view"/>
@@ -1434,27 +1662,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_rolesV1" displayName="Roles" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:roles"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_role_mgt_update"/>
-            </Update>
-            <Delete/>
-            <Create>
-                <Scope name="internal_org_role_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_user_mgt_view"/>
-                <Scope name="internal_org_role_mgt_view"/>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_group_mgt_view"/>
-                <Scope name="internal_org_permission_mgt_view"/>
-                <Scope name="internal_org_user_mgt_list"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:roles"/>
                 <Scope name="console:org:roles_view" action="view"/>
@@ -1478,28 +1686,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_applications" displayName="Applications" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:applications"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_application_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_application_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_application_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_application_mgt_view"/>
-                <Scope name="internal_org_claim_meta_view"/>
-                <Scope name="internal_org_role_mgt_view"/>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_idp_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:applications"/>
                 <Scope name="console:org:applications_view" action="view"/>
@@ -1524,24 +1711,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_branding" displayName="Branding" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:branding"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_branding_preference_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_branding_preference_update"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_branding_preference_update"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_application_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:branding"/>
                 <Scope name="console:org:branding_view" action="view"/>
@@ -1562,21 +1732,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_emailTemplates" displayName="Email Templates" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:emailTemplates"/>
-            </Feature>
-            <Update>
-            </Update>
-            <Delete>
-            </Delete>
-            <Create>
-            </Create>
-            <Read>
-                <Scope name="internal_org_email_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:emailTemplates"/>
                 <Scope name="console:org:emailTemplates_view" action="view"/>
@@ -1594,21 +1750,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_smsTemplates" displayName="SMS Templates" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:smsTemplates"/>
-            </Feature>
-            <Update>
-            </Update>
-            <Delete>
-            </Delete>
-            <Create>
-            </Create>
-            <Read>
-                <Scope name="internal_org_template_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:smsTemplates"/>
                 <Scope name="console:org:smsTemplates_view" action="view"/>
@@ -1626,25 +1768,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_gettingStarted" displayName="Home Page" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:home"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_application_mgt_update"/>
-            </Update>
-            <Delete/>
-            <Create>
-                <Scope name="internal_org_application_mgt_create"/>
-                <Scope name="internal_org_idp_create"/>
-                <Scope name="internal_org_user_mgt_create"/>
-                <Scope name="internal_org_group_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_application_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:home"/>
                 <Scope name="console:org:home_view" action="view"/>
@@ -1666,15 +1790,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_apiResources" displayName="API Resources" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:apiResources"/>
-            </Feature>
-            <Read>
-                <Scope name="internal_org_api_resource_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:apiResources"/>
                 <Scope name="console:org:apiResources_view" action="view"/>
@@ -1686,24 +1802,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_userStores" displayName="User Stores" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:userstores"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_userstore_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_userstore_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_userstore_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_userstore_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:userstores"/>
                 <Scope name="console:org:userstores_view" action="view"/>
@@ -1724,23 +1823,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_attributeDialects" displayName="Attribute Dialects" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:attributes"/>
-            </Feature>
-            <Create>
-            </Create>
-            <Update>
-                <Scope name="internal_org_claim_meta_update"/>
-            </Update>
-            <Read>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_claim_meta_view"/>
-            </Read>
-            <Delete>
-            </Delete>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:attributes"/>
                 <Scope name="console:org:attributes_view" action="view"/>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -199,25 +199,6 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="smsTemplates" displayName="SMS Templates" type="tenant" version="v0">
-        <Scopes>
-            <Feature>
-                <Scope name="console:smsTemplates"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_template_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_template_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_template_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_template_mgt_view"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
     <APIResourceCollection name="groups" displayName="Groups" type="tenant" version="v0">
         <Scopes>
             <Feature>
@@ -284,7 +265,6 @@
                 <Scope name="internal_authenticator_view"/>
                 <Scope name="internal_governance_view"/>
                 <Scope name="internal_extensions_view"/>
-                <Scope name="internal_config_mgt_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>
@@ -321,8 +301,6 @@
                 <Scope name="internal_governance_view"/>
                 <Scope name="internal_validation_rule_mgt_update"/>
                 <Scope name="internal_config_update"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_group_mgt_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>
@@ -372,7 +350,6 @@
             </Feature>
             <Update>
                 <Scope name="internal_organization_update"/>
-                <Scope name="internal_organization_config_update"/>
             </Update>
             <Delete>
                 <Scope name="internal_organization_delete"/>
@@ -393,7 +370,6 @@
             </Feature>
             <Update>
                 <Scope name="internal_organization_discovery_update"/>
-                <Scope name="internal_organization_config_update"/>
             </Update>
             <Delete>
                 <Scope name="internal_organization_discovery_delete"/>
@@ -528,47 +504,6 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="actions" displayName="Actions" type="tenant" version="v0">
-        <Scopes>
-            <Feature>
-                <Scope name="console:actions"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_action_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_action_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_action_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_action_mgt_view"/>
-                <Scope name="internal_rule_metadata_view"/>
-                <Scope name="internal_application_mgt_view"/>
-                <Scope name="internal_claim_meta_view"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
-    <APIResourceCollection name="tenants" displayName="Root Organizations" type="tenant" version="v0">
-        <Scopes>
-            <Feature>
-                <Scope name="console:tenants"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_modify_tenants"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_modify_tenants"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_create_tenants"/>
-            </Create>
-            <Read>
-                <Scope name="internal_list_tenants"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
     <!--    Organization API Resource Collections-->
     <APIResourceCollection name="org_consoleSettings" displayName="Console Settings" type="organization" version="v0">
         <Scopes>
@@ -621,7 +556,6 @@
                 <Scope name="internal_org_authenticator_view"/>
                 <Scope name="internal_org_governance_view"/>
                 <Scope name="internal_org_extensions_view"/>
-                <Scope name="internal_org_config_mgt_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>
@@ -709,9 +643,6 @@
             <Update>
                 <Scope name="internal_org_role_mgt_update"/>
             </Update>
-            <Delete>
-                <Scope name="internal_org_role_mgt_delete"/>
-            </Delete>
             <Create>
                 <Scope name="internal_org_role_mgt_create"/>
             </Create>
@@ -806,22 +737,6 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="org_smsTemplates" displayName="SMS Templates" type="organization" version="v0">
-        <Scopes>
-            <Feature>
-                <Scope name="console:org:smsTemplates"/>
-            </Feature>
-            <Update>
-            </Update>
-            <Delete>
-            </Delete>
-            <Create>
-            </Create>
-            <Read>
-                <Scope name="internal_org_template_mgt_view"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
     <APIResourceCollection name="org_gettingStarted" displayName="Home Page" type="organization" version="v0">
         <Scopes>
             <Feature>
@@ -850,43 +765,6 @@
             <Read>
                 <Scope name="internal_org_api_resource_view"/>
             </Read>
-        </Scopes>
-    </APIResourceCollection>
-    <APIResourceCollection name="org_userStores" displayName="User Stores" type="organization" version="v0">
-        <Scopes>
-            <Feature>
-                <Scope name="console:org:userstores"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_userstore_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_userstore_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_userstore_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_userstore_view"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
-    <APIResourceCollection name="org_attributeDialects" displayName="Attribute Dialects" type="organization" version="v0">
-        <Scopes>
-            <Feature>
-                <Scope name="console:org:attributes"/>
-            </Feature>
-            <Create>
-            </Create>
-            <Update>
-                <Scope name="internal_org_claim_meta_update"/>
-            </Update>
-            <Read>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_claim_meta_view"/>
-            </Read>
-            <Delete>
-            </Delete>
         </Scopes>
     </APIResourceCollection>
 

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -19,7 +19,7 @@
 
 <APIResourceCollections>
     <APIResourceCollection name="apiResources" displayName="API Resources" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:apiResources"/>
             </Feature>
@@ -36,9 +36,28 @@
                 <Scope name="internal_api_resource_delete"/>
             </Delete>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:apiResources"/>
+                <Scope name="console:apiResources_view" action="view"/>
+                <Scope name="console:apiResources_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_api_resource_update"/>
+            </Update>
+            <Create>
+                <Scope name="internal_api_resource_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_api_resource_view"/>
+            </Read>
+            <Delete>
+                <Scope name="internal_api_resource_delete"/>
+            </Delete>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="applications" displayName="Applications" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:applications"/>
             </Feature>
@@ -73,9 +92,46 @@
                 <Scope name="internal_secret_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:applications"/>
+                <Scope name="console:applications_view" action="view"/>
+                <Scope name="console:applications_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_application_mgt_update"/>
+                <Scope name="internal_secret_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_application_mgt_delete"/>
+                <Scope name="internal_shared_application_delete"/>
+                <Scope name="internal_secret_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_application_mgt_create"/>
+                <Scope name="internal_shared_application_create"/>
+                <Scope name="internal_secret_mgt_add"/>
+            </Create>
+            <Read>
+                <Scope name="internal_cors_origins_view"/>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_oidc_scope_mgt_view"/>
+                <Scope name="internal_organization_view"/>
+                <Scope name="internal_api_resource_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_shared_application_view"/>
+                <Scope name="internal_secret_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="branding" displayName="Branding" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:branding"/>
             </Feature>
@@ -92,9 +148,28 @@
                 <Scope name="internal_application_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:branding"/>
+                <Scope name="console:branding_view" action="view"/>
+                <Scope name="console:branding_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_branding_preference_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_branding_preference_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_branding_preference_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_application_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="approvals" displayName="Approvals" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:workflowApprovals"/>
             </Feature>
@@ -111,9 +186,28 @@
                 <Scope name="internal_humantask_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:workflowApprovals"/>
+                <Scope name="console:workflowApprovals_view" action="view"/>
+                <Scope name="console:workflowApprovals_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_humantask_view"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_humantask_view"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_humantask_view"/>
+            </Create>
+            <Read>
+                <Scope name="internal_humantask_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="attributeDialects" displayName="Attribute Dialects" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:attributes"/>
             </Feature>
@@ -133,9 +227,31 @@
                 <Scope name="internal_claim_meta_delete"/>
             </Delete>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:attributes"/>
+                <Scope name="console:attributes_view" action="view"/>
+                <Scope name="console:attributes_edit" action="edit"/>
+            </Feature>
+            <Create>
+                <Scope name="internal_claim_meta_create"/>
+            </Create>
+            <Update>
+                <Scope name="internal_claim_meta_update"/>
+                <Scope name="internal_governance_update"/>
+            </Update>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_claim_meta_view"/>
+                <Scope name="internal_governance_view"/>
+            </Read>
+            <Delete>
+                <Scope name="internal_claim_meta_delete"/>
+            </Delete>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="certificates" displayName="Certificates" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:certificates"/>
             </Feature>
@@ -152,9 +268,28 @@
                 <Scope name="internal_keystore_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:certificates"/>
+                <Scope name="console:certificates_view" action="view"/>
+                <Scope name="console:certificates_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_keystore_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_keystore_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_keystore_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_keystore_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="consoleSettings" displayName="Console Settings" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:settings"/>
             </Feature>
@@ -179,9 +314,36 @@
                 <Scope name="internal_governance_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:settings"/>
+                <Scope name="console:settings_view" action="view"/>
+                <Scope name="console:settings_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_application_mgt_update"/>
+                <Scope name="internal_user_mgt_update"/>
+            </Update>
+            <Delete>
+            </Delete>
+            <Create>
+                <Scope name="internal_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_session_view"/>
+                <Scope name="internal_governance_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="emailTemplates" displayName="Email Templates" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:emailTemplates"/>
             </Feature>
@@ -198,9 +360,28 @@
                 <Scope name="internal_email_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:emailTemplates"/>
+                <Scope name="console:emailTemplates_view" action="view"/>
+                <Scope name="console:emailTemplates_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_email_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_email_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_email_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_email_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="smsTemplates" displayName="SMS Templates" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:smsTemplates"/>
             </Feature>
@@ -217,9 +398,28 @@
                 <Scope name="internal_template_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:smsTemplates"/>
+                <Scope name="console:smsTemplates_view" action="view"/>
+                <Scope name="console:smsTemplates_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_template_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_template_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_template_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_template_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="groups" displayName="Groups" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:groups"/>
             </Feature>
@@ -240,9 +440,32 @@
                 <Scope name="internal_userstore_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:groups"/>
+                <Scope name="console:groups_view" action="view"/>
+                <Scope name="console:groups_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_group_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_group_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="gettingStarted" displayName="Home Page" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:home"/>
             </Feature>
@@ -260,9 +483,29 @@
                 <Scope name="internal_application_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:home"/>
+                <Scope name="console:home_view" action="view"/>
+                <Scope name="console:home_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_application_mgt_update"/>
+            </Update>
+            <Delete/>
+            <Create>
+                <Scope name="internal_application_mgt_create"/>
+                <Scope name="internal_idp_create"/>
+                <Scope name="internal_user_mgt_create"/>
+                <Scope name="internal_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_application_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="connections" displayName="Connections" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:idps"/>
             </Feature>
@@ -287,9 +530,36 @@
                 <Scope name="internal_config_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:idps"/>
+                <Scope name="console:idps_view" action="view"/>
+                <Scope name="console:idps_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_idp_update"/>
+                <Scope name="internal_governance_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_idp_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_idp_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
+                <Scope name="internal_authenticator_view"/>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_extensions_view"/>
+                <Scope name="internal_config_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="identityVerificationProviders" displayName="Identity Verification Providers" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:idvps"/>
             </Feature>
@@ -306,9 +576,28 @@
                 <Scope name="internal_idvp_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:idvps"/>
+                <Scope name="console:idvps_view" action="view"/>
+                <Scope name="console:idvps_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_idvp_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_idvp_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_idvp_add"/>
+            </Create>
+            <Read>
+                <Scope name="internal_idvp_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="loginAndRegistration" displayName="Login And Registration" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:loginAndRegistration"/>
             </Feature>
@@ -325,9 +614,28 @@
                 <Scope name="internal_group_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:loginAndRegistration"/>
+                <Scope name="console:loginAndRegistration_view" action="view"/>
+                <Scope name="console:loginAndRegistration_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_governance_update"/>
+            </Update>
+            <Delete/>
+            <Create/>
+            <Read>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_validation_rule_mgt_update"/>
+                <Scope name="internal_config_update"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_group_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="notificationChannels" displayName="Notification Channels" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:notificationChannels"/>
             </Feature>
@@ -344,9 +652,28 @@
                 <Scope name="internal_notification_senders_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:notificationChannels"/>
+                <Scope name="console:notificationChannels_view" action="view"/>
+                <Scope name="console:notificationChannels_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_notification_senders_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_notification_senders_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_notification_senders_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_notification_senders_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="oidcScopes" displayName="OIDC Scopes" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:scopes:oidc"/>
             </Feature>
@@ -364,9 +691,29 @@
                 <Scope name="internal_claim_meta_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:scopes:oidc"/>
+                <Scope name="console:scopes:oidc_view" action="view"/>
+                <Scope name="console:scopes:oidc_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_oidc_scope_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_oidc_scope_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_oidc_scope_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_oidc_scope_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="organizations" displayName="Organizations" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:organizations"/>
             </Feature>
@@ -385,9 +732,30 @@
                 <Scope name="internal_organization_config_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:organizations"/>
+                <Scope name="console:organizations_view" action="view"/>
+                <Scope name="console:organizations_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_organization_update"/>
+                <Scope name="internal_organization_config_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_organization_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_organization_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_organization_view"/>
+                <Scope name="internal_organization_config_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="organizationDiscovery" displayName="Organization Discovery" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:organizationDiscovery"/>
             </Feature>
@@ -407,9 +775,31 @@
                 <Scope name="internal_organization_config_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:organizationDiscovery"/>
+                <Scope name="console:organizationDiscovery_view" action="view"/>
+                <Scope name="console:organizationDiscovery_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_organization_discovery_update"/>
+                <Scope name="internal_organization_config_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_organization_discovery_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_organization_discovery_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_organization_discovery_view"/>
+                <Scope name="internal_organization_view"/>
+                <Scope name="internal_organization_config_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="residentOutboundProvisioning" displayName="Resident Application Outbound Provisioning" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:residentOutboundProvisioning"/>
             </Feature>
@@ -427,9 +817,29 @@
                 <Scope name="internal_application_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:residentOutboundProvisioning"/>
+                <Scope name="console:residentOutboundProvisioning_view" action="view"/>
+                <Scope name="console:residentOutboundProvisioning_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_application_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_application_mgt_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_application_mgt_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_application_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="roles" displayName="Roles" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:roles"/>
             </Feature>
@@ -453,9 +863,35 @@
                 <Scope name="internal_api_resource_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:roles"/>
+                <Scope name="console:roles_view" action="view"/>
+                <Scope name="console:roles_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_role_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_role_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_api_resource_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="rolesV1" displayName="Roles" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:roles"/>
             </Feature>
@@ -477,9 +913,33 @@
                 <Scope name="internal_user_mgt_list"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:roles"/>
+                <Scope name="console:roles_view" action="view"/>
+                <Scope name="console:roles_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_role_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_role_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_permission_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="users" displayName="Users" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:users"/>
             </Feature>
@@ -508,9 +968,40 @@
                 <Scope name="internal_claim_meta_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:users"/>
+                <Scope name="console:users_view" action="view"/>
+                <Scope name="console:users_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_user_mgt_update"/>
+                <Scope name="internal_session_delete"/>
+                <Scope name="internal_group_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_user_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_user_mgt_create"/>
+                <Scope name="internal_bulk_resource_create"/>
+                <Scope name="internal_offline_invite"/>
+            </Create>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_login"/>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_session_view"/>
+                <Scope name="internal_claim_meta_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="userStores" displayName="User Stores" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:userstores"/>
             </Feature>
@@ -527,9 +1018,28 @@
                 <Scope name="internal_userstore_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:userstores"/>
+                <Scope name="console:userstores_view" action="view"/>
+                <Scope name="console:userstores_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_userstore_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_userstore_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_userstore_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="actions" displayName="Actions" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:actions"/>
             </Feature>
@@ -549,11 +1059,52 @@
                 <Scope name="internal_claim_meta_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:actions"/>
+                <Scope name="console:actions_view" action="view"/>
+                <Scope name="console:actions_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_action_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_action_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_action_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_action_mgt_view"/>
+                <Scope name="internal_rule_metadata_view"/>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="tenants" displayName="Root Organizations" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:tenants"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_modify_tenants"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_modify_tenants"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_create_tenants"/>
+            </Create>
+            <Read>
+                <Scope name="internal_list_tenants"/>
+            </Read>
+        </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:tenants"/>
+                <Scope name="console:tenants_view" action="view"/>
+                <Scope name="console:tenants_edit" action="edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_modify_tenants"/>
@@ -571,7 +1122,7 @@
     </APIResourceCollection>
 <!--    Organization API Resource Collections-->
     <APIResourceCollection name="org_consoleSettings" displayName="Console Settings" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:settings"/>
             </Feature>
@@ -598,9 +1149,38 @@
                 <Scope name="internal_org_governance_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:settings"/>
+                <Scope name="console:org:settings_view" action="view"/>
+                <Scope name="console:org:settings_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_application_mgt_update"/>
+                <Scope name="internal_org_user_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_guest_mgt_invite_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_guest_mgt_invite_list"/>
+                <Scope name="internal_org_idp_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_session_view"/>
+                <Scope name="internal_org_governance_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_connections" displayName="Connections" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:idps"/>
             </Feature>
@@ -624,9 +1204,35 @@
                 <Scope name="internal_org_config_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:idps"/>
+                <Scope name="console:org:idps_view" action="view"/>
+                <Scope name="console:org:idps_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_idp_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_idp_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_idp_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_idp_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_authenticator_view"/>
+                <Scope name="internal_org_governance_view"/>
+                <Scope name="internal_org_extensions_view"/>
+                <Scope name="internal_org_config_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_users" displayName="Users" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:users"/>
             </Feature>
@@ -655,9 +1261,40 @@
                 <Scope name="internal_org_guest_mgt_invite_list"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:users"/>
+                <Scope name="console:org:users_view" action="view"/>
+                <Scope name="console:org:users_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_user_mgt_update"/>
+                <Scope name="internal_org_session_delete"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_user_mgt_delete"/>
+                <Scope name="internal_org_guest_mgt_invite_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_user_mgt_create"/>
+                <Scope name="internal_org_guest_mgt_invite_add"/>
+                <Scope name="internal_org_bulk_resource_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_governance_view"/>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_session_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_guest_mgt_invite_list"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_organizations" displayName="Organizations" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:organizations"/>
             </Feature>
@@ -677,9 +1314,31 @@
                 <Scope name="internal_org_config_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:organizations"/>
+                <Scope name="console:org:organizations_view" action="view"/>
+                <Scope name="console:org:organizations_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_organization_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_organization_delete"/>
+                <Scope name="internal_org_config_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_organization_create"/>
+                <Scope name="internal_org_config_mgt_add"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_organization_view"/>
+                <Scope name="internal_org_config_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_groups" displayName="Groups" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:groups"/>
             </Feature>
@@ -700,9 +1359,32 @@
                 <Scope name="internal_org_userstore_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:groups"/>
+                <Scope name="console:org:groups_view" action="view"/>
+                <Scope name="console:org:groups_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_group_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_group_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_roles" displayName="Roles" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:roles"/>
             </Feature>
@@ -725,9 +1407,34 @@
                 <Scope name="internal_org_idp_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:roles"/>
+                <Scope name="console:org:roles_view" action="view"/>
+                <Scope name="console:org:roles_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_role_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_role_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_application_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_idp_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_rolesV1" displayName="Roles" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:roles"/>
             </Feature>
@@ -747,9 +1454,31 @@
                 <Scope name="internal_org_user_mgt_list"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:roles"/>
+                <Scope name="console:org:roles_view" action="view"/>
+                <Scope name="console:org:roles_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_role_mgt_update"/>
+            </Update>
+            <Delete/>
+            <Create>
+                <Scope name="internal_org_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_permission_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_applications" displayName="Applications" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:applications"/>
             </Feature>
@@ -770,9 +1499,32 @@
                 <Scope name="internal_org_idp_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:applications"/>
+                <Scope name="console:org:applications_view" action="view"/>
+                <Scope name="console:org:applications_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_application_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_application_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_application_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_idp_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_branding" displayName="Branding" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:branding"/>
             </Feature>
@@ -789,9 +1541,28 @@
                 <Scope name="internal_org_application_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:branding"/>
+                <Scope name="console:org:branding_view" action="view"/>
+                <Scope name="console:org:branding_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_branding_preference_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_branding_preference_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_branding_preference_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_emailTemplates" displayName="Email Templates" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:emailTemplates"/>
             </Feature>
@@ -805,9 +1576,25 @@
                 <Scope name="internal_org_email_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:emailTemplates"/>
+                <Scope name="console:org:emailTemplates_view" action="view"/>
+                <Scope name="console:org:emailTemplates_edit" action="edit"/>
+            </Feature>
+            <Update>
+            </Update>
+            <Delete>
+            </Delete>
+            <Create>
+            </Create>
+            <Read>
+                <Scope name="internal_org_email_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_smsTemplates" displayName="SMS Templates" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:smsTemplates"/>
             </Feature>
@@ -821,9 +1608,25 @@
                 <Scope name="internal_org_template_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:smsTemplates"/>
+                <Scope name="console:org:smsTemplates_view" action="view"/>
+                <Scope name="console:org:smsTemplates_edit" action="edit"/>
+            </Feature>
+            <Update>
+            </Update>
+            <Delete>
+            </Delete>
+            <Create>
+            </Create>
+            <Read>
+                <Scope name="internal_org_template_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_gettingStarted" displayName="Home Page" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:home"/>
             </Feature>
@@ -841,9 +1644,29 @@
                 <Scope name="internal_org_application_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:home"/>
+                <Scope name="console:org:home_view" action="view"/>
+                <Scope name="console:org:home_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_application_mgt_update"/>
+            </Update>
+            <Delete/>
+            <Create>
+                <Scope name="internal_org_application_mgt_create"/>
+                <Scope name="internal_org_idp_create"/>
+                <Scope name="internal_org_user_mgt_create"/>
+                <Scope name="internal_org_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_apiResources" displayName="API Resources" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:apiResources"/>
             </Feature>
@@ -851,9 +1674,19 @@
                 <Scope name="internal_org_api_resource_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:apiResources"/>
+                <Scope name="console:org:apiResources_view" action="view"/>
+                <Scope name="console:org:apiResources_edit" action="edit"/>
+            </Feature>
+            <Read>
+                <Scope name="internal_org_api_resource_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_userStores" displayName="User Stores" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:userstores"/>
             </Feature>
@@ -870,11 +1703,48 @@
                 <Scope name="internal_org_userstore_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:userstores"/>
+                <Scope name="console:org:userstores_view" action="view"/>
+                <Scope name="console:org:userstores_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_userstore_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_userstore_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_userstore_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_attributeDialects" displayName="Attribute Dialects" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:attributes"/>
+            </Feature>
+            <Create>
+            </Create>
+            <Update>
+                <Scope name="internal_org_claim_meta_update"/>
+            </Update>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+            </Read>
+            <Delete>
+            </Delete>
+        </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:attributes"/>
+                <Scope name="console:org:attributes_view" action="view"/>
+                <Scope name="console:org:attributes_edit" action="edit"/>
             </Feature>
             <Create>
             </Create>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -895,8 +895,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:apiResources"/>
-                <Scope name="console:apiResources_view" action="view"/>
-                <Scope name="console:apiResources_edit" action="edit"/>
+                <Scope name="console:apiResources_view"/>
+                <Scope name="console:apiResources_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_api_resource_update"/>
@@ -916,8 +916,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:applications"/>
-                <Scope name="console:applications_view" action="view"/>
-                <Scope name="console:applications_edit" action="edit"/>
+                <Scope name="console:applications_view"/>
+                <Scope name="console:applications_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -955,8 +955,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:branding"/>
-                <Scope name="console:branding_view" action="view"/>
-                <Scope name="console:branding_edit" action="edit"/>
+                <Scope name="console:branding_view"/>
+                <Scope name="console:branding_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_branding_preference_update"/>
@@ -976,8 +976,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:workflowApprovals"/>
-                <Scope name="console:workflowApprovals_view" action="view"/>
-                <Scope name="console:workflowApprovals_edit" action="edit"/>
+                <Scope name="console:workflowApprovals_view"/>
+                <Scope name="console:workflowApprovals_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_humantask_view"/>
@@ -997,8 +997,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:attributes"/>
-                <Scope name="console:attributes_view" action="view"/>
-                <Scope name="console:attributes_edit" action="edit"/>
+                <Scope name="console:attributes_view"/>
+                <Scope name="console:attributes_edit"/>
             </Feature>
             <Create>
                 <Scope name="internal_claim_meta_create"/>
@@ -1021,8 +1021,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:certificates"/>
-                <Scope name="console:certificates_view" action="view"/>
-                <Scope name="console:certificates_edit" action="edit"/>
+                <Scope name="console:certificates_view"/>
+                <Scope name="console:certificates_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_keystore_update"/>
@@ -1042,8 +1042,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:settings"/>
-                <Scope name="console:settings_view" action="view"/>
-                <Scope name="console:settings_edit" action="edit"/>
+                <Scope name="console:settings_view"/>
+                <Scope name="console:settings_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -1071,8 +1071,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:emailTemplates"/>
-                <Scope name="console:emailTemplates_view" action="view"/>
-                <Scope name="console:emailTemplates_edit" action="edit"/>
+                <Scope name="console:emailTemplates_view"/>
+                <Scope name="console:emailTemplates_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_email_mgt_update"/>
@@ -1092,8 +1092,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:smsTemplates"/>
-                <Scope name="console:smsTemplates_view" action="view"/>
-                <Scope name="console:smsTemplates_edit" action="edit"/>
+                <Scope name="console:smsTemplates_view"/>
+                <Scope name="console:smsTemplates_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_template_mgt_update"/>
@@ -1113,8 +1113,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:groups"/>
-                <Scope name="console:groups_view" action="view"/>
-                <Scope name="console:groups_edit" action="edit"/>
+                <Scope name="console:groups_view"/>
+                <Scope name="console:groups_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_group_mgt_update"/>
@@ -1138,8 +1138,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:home"/>
-                <Scope name="console:home_view" action="view"/>
-                <Scope name="console:home_edit" action="edit"/>
+                <Scope name="console:home_view"/>
+                <Scope name="console:home_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -1160,8 +1160,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:idps"/>
-                <Scope name="console:idps_view" action="view"/>
-                <Scope name="console:idps_edit" action="edit"/>
+                <Scope name="console:idps_view"/>
+                <Scope name="console:idps_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_idp_update"/>
@@ -1189,8 +1189,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:idvps"/>
-                <Scope name="console:idvps_view" action="view"/>
-                <Scope name="console:idvps_edit" action="edit"/>
+                <Scope name="console:idvps_view"/>
+                <Scope name="console:idvps_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_idvp_update"/>
@@ -1210,8 +1210,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:loginAndRegistration"/>
-                <Scope name="console:loginAndRegistration_view" action="view"/>
-                <Scope name="console:loginAndRegistration_edit" action="edit"/>
+                <Scope name="console:loginAndRegistration_view"/>
+                <Scope name="console:loginAndRegistration_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_governance_update"/>
@@ -1231,8 +1231,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:notificationChannels"/>
-                <Scope name="console:notificationChannels_view" action="view"/>
-                <Scope name="console:notificationChannels_edit" action="edit"/>
+                <Scope name="console:notificationChannels_view"/>
+                <Scope name="console:notificationChannels_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_notification_senders_update"/>
@@ -1252,8 +1252,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:scopes:oidc"/>
-                <Scope name="console:scopes:oidc_view" action="view"/>
-                <Scope name="console:scopes:oidc_edit" action="edit"/>
+                <Scope name="console:scopes:oidc_view"/>
+                <Scope name="console:scopes:oidc_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_oidc_scope_mgt_update"/>
@@ -1274,8 +1274,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:organizations"/>
-                <Scope name="console:organizations_view" action="view"/>
-                <Scope name="console:organizations_edit" action="edit"/>
+                <Scope name="console:organizations_view"/>
+                <Scope name="console:organizations_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_organization_update"/>
@@ -1297,8 +1297,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:organizationDiscovery"/>
-                <Scope name="console:organizationDiscovery_view" action="view"/>
-                <Scope name="console:organizationDiscovery_edit" action="edit"/>
+                <Scope name="console:organizationDiscovery_view"/>
+                <Scope name="console:organizationDiscovery_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_organization_discovery_update"/>
@@ -1321,8 +1321,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:residentOutboundProvisioning"/>
-                <Scope name="console:residentOutboundProvisioning_view" action="view"/>
-                <Scope name="console:residentOutboundProvisioning_edit" action="edit"/>
+                <Scope name="console:residentOutboundProvisioning_view"/>
+                <Scope name="console:residentOutboundProvisioning_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -1343,8 +1343,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:roles"/>
-                <Scope name="console:roles_view" action="view"/>
-                <Scope name="console:roles_edit" action="edit"/>
+                <Scope name="console:roles_view"/>
+                <Scope name="console:roles_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_role_mgt_update"/>
@@ -1371,8 +1371,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:roles"/>
-                <Scope name="console:roles_view" action="view"/>
-                <Scope name="console:roles_edit" action="edit"/>
+                <Scope name="console:roles_view"/>
+                <Scope name="console:roles_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_role_mgt_update"/>
@@ -1397,8 +1397,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:users"/>
-                <Scope name="console:users_view" action="view"/>
-                <Scope name="console:users_edit" action="edit"/>
+                <Scope name="console:users_view"/>
+                <Scope name="console:users_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_user_mgt_update"/>
@@ -1430,8 +1430,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:userstores"/>
-                <Scope name="console:userstores_view" action="view"/>
-                <Scope name="console:userstores_edit" action="edit"/>
+                <Scope name="console:userstores_view"/>
+                <Scope name="console:userstores_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_userstore_update"/>
@@ -1451,8 +1451,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:actions"/>
-                <Scope name="console:actions_view" action="view"/>
-                <Scope name="console:actions_edit" action="edit"/>
+                <Scope name="console:actions_view"/>
+                <Scope name="console:actions_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_action_mgt_update"/>
@@ -1475,8 +1475,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:tenants"/>
-                <Scope name="console:tenants_view" action="view"/>
-                <Scope name="console:tenants_edit" action="edit"/>
+                <Scope name="console:tenants_view"/>
+                <Scope name="console:tenants_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_modify_tenants"/>
@@ -1497,8 +1497,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:settings"/>
-                <Scope name="console:org:settings_view" action="view"/>
-                <Scope name="console:org:settings_edit" action="edit"/>
+                <Scope name="console:org:settings_view"/>
+                <Scope name="console:org:settings_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_application_mgt_update"/>
@@ -1528,8 +1528,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:idps"/>
-                <Scope name="console:org:idps_view" action="view"/>
-                <Scope name="console:org:idps_edit" action="edit"/>
+                <Scope name="console:org:idps_view"/>
+                <Scope name="console:org:idps_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_idp_update"/>
@@ -1556,8 +1556,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:users"/>
-                <Scope name="console:org:users_view" action="view"/>
-                <Scope name="console:org:users_edit" action="edit"/>
+                <Scope name="console:org:users_view"/>
+                <Scope name="console:org:users_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_user_mgt_update"/>
@@ -1589,8 +1589,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:organizations"/>
-                <Scope name="console:org:organizations_view" action="view"/>
-                <Scope name="console:org:organizations_edit" action="edit"/>
+                <Scope name="console:org:organizations_view"/>
+                <Scope name="console:org:organizations_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_organization_update"/>
@@ -1613,8 +1613,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:groups"/>
-                <Scope name="console:org:groups_view" action="view"/>
-                <Scope name="console:org:groups_edit" action="edit"/>
+                <Scope name="console:org:groups_view"/>
+                <Scope name="console:org:groups_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_group_mgt_update"/>
@@ -1638,8 +1638,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:roles"/>
-                <Scope name="console:org:roles_view" action="view"/>
-                <Scope name="console:org:roles_edit" action="edit"/>
+                <Scope name="console:org:roles_view"/>
+                <Scope name="console:org:roles_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_role_mgt_update"/>
@@ -1665,8 +1665,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:roles"/>
-                <Scope name="console:org:roles_view" action="view"/>
-                <Scope name="console:org:roles_edit" action="edit"/>
+                <Scope name="console:org:roles_view"/>
+                <Scope name="console:org:roles_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_role_mgt_update"/>
@@ -1689,8 +1689,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:applications"/>
-                <Scope name="console:org:applications_view" action="view"/>
-                <Scope name="console:org:applications_edit" action="edit"/>
+                <Scope name="console:org:applications_view"/>
+                <Scope name="console:org:applications_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_application_mgt_update"/>
@@ -1714,8 +1714,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:branding"/>
-                <Scope name="console:org:branding_view" action="view"/>
-                <Scope name="console:org:branding_edit" action="edit"/>
+                <Scope name="console:org:branding_view"/>
+                <Scope name="console:org:branding_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_branding_preference_update"/>
@@ -1735,8 +1735,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:emailTemplates"/>
-                <Scope name="console:org:emailTemplates_view" action="view"/>
-                <Scope name="console:org:emailTemplates_edit" action="edit"/>
+                <Scope name="console:org:emailTemplates_view"/>
+                <Scope name="console:org:emailTemplates_edit"/>
             </Feature>
             <Update>
             </Update>
@@ -1753,8 +1753,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:smsTemplates"/>
-                <Scope name="console:org:smsTemplates_view" action="view"/>
-                <Scope name="console:org:smsTemplates_edit" action="edit"/>
+                <Scope name="console:org:smsTemplates_view"/>
+                <Scope name="console:org:smsTemplates_edit"/>
             </Feature>
             <Update>
             </Update>
@@ -1771,8 +1771,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:home"/>
-                <Scope name="console:org:home_view" action="view"/>
-                <Scope name="console:org:home_edit" action="edit"/>
+                <Scope name="console:org:home_view"/>
+                <Scope name="console:org:home_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_application_mgt_update"/>
@@ -1793,8 +1793,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:apiResources"/>
-                <Scope name="console:org:apiResources_view" action="view"/>
-                <Scope name="console:org:apiResources_edit" action="edit"/>
+                <Scope name="console:org:apiResources_view"/>
+                <Scope name="console:org:apiResources_edit"/>
             </Feature>
             <Read>
                 <Scope name="internal_org_api_resource_view"/>
@@ -1805,8 +1805,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:userstores"/>
-                <Scope name="console:org:userstores_view" action="view"/>
-                <Scope name="console:org:userstores_edit" action="edit"/>
+                <Scope name="console:org:userstores_view"/>
+                <Scope name="console:org:userstores_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_userstore_update"/>
@@ -1826,8 +1826,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:attributes"/>
-                <Scope name="console:org:attributes_view" action="view"/>
-                <Scope name="console:org:attributes_edit" action="edit"/>
+                <Scope name="console:org:attributes_view"/>
+                <Scope name="console:org:attributes_edit"/>
             </Feature>
             <Create>
             </Create>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -44,17 +44,14 @@
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
-                <Scope name="internal_secret_mgt_update"/>
             </Update>
             <Delete>
                 <Scope name="internal_application_mgt_delete"/>
                 <Scope name="internal_shared_application_delete"/>
-                <Scope name="internal_secret_mgt_delete"/>
             </Delete>
             <Create>
                 <Scope name="internal_application_mgt_create"/>
                 <Scope name="internal_shared_application_create"/>
-                <Scope name="internal_secret_mgt_add"/>
             </Create>
             <Read>
                 <Scope name="internal_cors_origins_view"/>
@@ -70,7 +67,6 @@
                 <Scope name="internal_governance_view"/>
                 <Scope name="internal_userstore_view"/>
                 <Scope name="internal_shared_application_view"/>
-                <Scope name="internal_secret_mgt_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -24,7 +24,7 @@
             {% if collection.scopes.feature %}
             <Feature>
                 {% for scope in collection.scopes.feature %}
-                <Scope name="{{ scope.name }}" action="{{ scope.action }}"/>
+                <Scope name="{{ scope.name }}"/>
                 {% endfor %}
             </Feature>
             {% endif %}
@@ -936,8 +936,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:apiResources"/>
-                <Scope name="console:apiResources_view" action="view"/>
-                <Scope name="console:apiResources_edit" action="edit"/>
+                <Scope name="console:apiResources_view"/>
+                <Scope name="console:apiResources_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_api_resource_update"/>
@@ -957,8 +957,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:applications"/>
-                <Scope name="console:applications_view" action="view"/>
-                <Scope name="console:applications_edit" action="edit"/>
+                <Scope name="console:applications_view"/>
+                <Scope name="console:applications_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -996,8 +996,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:branding"/>
-                <Scope name="console:branding_view" action="view"/>
-                <Scope name="console:branding_edit" action="edit"/>
+                <Scope name="console:branding_view"/>
+                <Scope name="console:branding_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_branding_preference_update"/>
@@ -1017,8 +1017,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:workflowApprovals"/>
-                <Scope name="console:workflowApprovals_view" action="view"/>
-                <Scope name="console:workflowApprovals_edit" action="edit"/>
+                <Scope name="console:workflowApprovals_view"/>
+                <Scope name="console:workflowApprovals_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_humantask_view"/>
@@ -1038,8 +1038,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:attributes"/>
-                <Scope name="console:attributes_view" action="view"/>
-                <Scope name="console:attributes_edit" action="edit"/>
+                <Scope name="console:attributes_view"/>
+                <Scope name="console:attributes_edit"/>
             </Feature>
             <Create>
                 <Scope name="internal_claim_meta_create"/>
@@ -1062,8 +1062,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:certificates"/>
-                <Scope name="console:certificates_view" action="view"/>
-                <Scope name="console:certificates_edit" action="edit"/>
+                <Scope name="console:certificates_view"/>
+                <Scope name="console:certificates_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_keystore_update"/>
@@ -1083,8 +1083,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:settings"/>
-                <Scope name="console:settings_view" action="view"/>
-                <Scope name="console:settings_edit" action="edit"/>
+                <Scope name="console:settings_view"/>
+                <Scope name="console:settings_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -1112,8 +1112,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:emailTemplates"/>
-                <Scope name="console:emailTemplates_view" action="view"/>
-                <Scope name="console:emailTemplates_edit" action="edit"/>
+                <Scope name="console:emailTemplates_view"/>
+                <Scope name="console:emailTemplates_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_email_mgt_update"/>
@@ -1133,8 +1133,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:smsTemplates"/>
-                <Scope name="console:smsTemplates_view" action="view"/>
-                <Scope name="console:smsTemplates_edit" action="edit"/>
+                <Scope name="console:smsTemplates_view"/>
+                <Scope name="console:smsTemplates_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_template_mgt_update"/>
@@ -1154,8 +1154,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:groups"/>
-                <Scope name="console:groups_view" action="view"/>
-                <Scope name="console:groups_edit" action="edit"/>
+                <Scope name="console:groups_view"/>
+                <Scope name="console:groups_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_group_mgt_update"/>
@@ -1179,8 +1179,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:home"/>
-                <Scope name="console:home_view" action="view"/>
-                <Scope name="console:home_edit" action="edit"/>
+                <Scope name="console:home_view"/>
+                <Scope name="console:home_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -1201,8 +1201,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:idps"/>
-                <Scope name="console:idps_view" action="view"/>
-                <Scope name="console:idps_edit" action="edit"/>
+                <Scope name="console:idps_view"/>
+                <Scope name="console:idps_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_idp_update"/>
@@ -1230,8 +1230,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:idvps"/>
-                <Scope name="console:idvps_view" action="view"/>
-                <Scope name="console:idvps_edit" action="edit"/>
+                <Scope name="console:idvps_view"/>
+                <Scope name="console:idvps_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_idvp_update"/>
@@ -1251,8 +1251,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:loginAndRegistration"/>
-                <Scope name="console:loginAndRegistration_view" action="view"/>
-                <Scope name="console:loginAndRegistration_edit" action="edit"/>
+                <Scope name="console:loginAndRegistration_view"/>
+                <Scope name="console:loginAndRegistration_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_governance_update"/>
@@ -1272,8 +1272,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:notificationChannels"/>
-                <Scope name="console:notificationChannels_view" action="view"/>
-                <Scope name="console:notificationChannels_edit" action="edit"/>
+                <Scope name="console:notificationChannels_view"/>
+                <Scope name="console:notificationChannels_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_notification_senders_update"/>
@@ -1293,8 +1293,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:scopes:oidc"/>
-                <Scope name="console:scopes:oidc_view" action="view"/>
-                <Scope name="console:scopes:oidc_edit" action="edit"/>
+                <Scope name="console:scopes:oidc_view"/>
+                <Scope name="console:scopes:oidc_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_oidc_scope_mgt_update"/>
@@ -1315,8 +1315,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:organizations"/>
-                <Scope name="console:organizations_view" action="view"/>
-                <Scope name="console:organizations_edit" action="edit"/>
+                <Scope name="console:organizations_view"/>
+                <Scope name="console:organizations_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_organization_update"/>
@@ -1338,8 +1338,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:organizationDiscovery"/>
-                <Scope name="console:organizationDiscovery_view" action="view"/>
-                <Scope name="console:organizationDiscovery_edit" action="edit"/>
+                <Scope name="console:organizationDiscovery_view"/>
+                <Scope name="console:organizationDiscovery_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_organization_discovery_update"/>
@@ -1362,8 +1362,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:residentOutboundProvisioning"/>
-                <Scope name="console:residentOutboundProvisioning_view" action="view"/>
-                <Scope name="console:residentOutboundProvisioning_edit" action="edit"/>
+                <Scope name="console:residentOutboundProvisioning_view"/>
+                <Scope name="console:residentOutboundProvisioning_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -1384,8 +1384,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:roles"/>
-                <Scope name="console:roles_view" action="view"/>
-                <Scope name="console:roles_edit" action="edit"/>
+                <Scope name="console:roles_view"/>
+                <Scope name="console:roles_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_role_mgt_update"/>
@@ -1412,8 +1412,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:roles"/>
-                <Scope name="console:roles_view" action="view"/>
-                <Scope name="console:roles_edit" action="edit"/>
+                <Scope name="console:roles_view"/>
+                <Scope name="console:roles_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_role_mgt_update"/>
@@ -1438,8 +1438,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:users"/>
-                <Scope name="console:users_view" action="view"/>
-                <Scope name="console:users_edit" action="edit"/>
+                <Scope name="console:users_view"/>
+                <Scope name="console:users_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_user_mgt_update"/>
@@ -1471,8 +1471,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:userstores"/>
-                <Scope name="console:userstores_view" action="view"/>
-                <Scope name="console:userstores_edit" action="edit"/>
+                <Scope name="console:userstores_view"/>
+                <Scope name="console:userstores_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_userstore_update"/>
@@ -1492,8 +1492,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:actions"/>
-                <Scope name="console:actions_view" action="view"/>
-                <Scope name="console:actions_edit" action="edit"/>
+                <Scope name="console:actions_view"/>
+                <Scope name="console:actions_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_action_mgt_update"/>
@@ -1516,8 +1516,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:tenants"/>
-                <Scope name="console:tenants_view" action="view"/>
-                <Scope name="console:tenants_edit" action="edit"/>
+                <Scope name="console:tenants_view"/>
+                <Scope name="console:tenants_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_modify_tenants"/>
@@ -1538,8 +1538,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:settings"/>
-                <Scope name="console:org:settings_view" action="view"/>
-                <Scope name="console:org:settings_edit" action="edit"/>
+                <Scope name="console:org:settings_view"/>
+                <Scope name="console:org:settings_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_application_mgt_update"/>
@@ -1569,8 +1569,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:idps"/>
-                <Scope name="console:org:idps_view" action="view"/>
-                <Scope name="console:org:idps_edit" action="edit"/>
+                <Scope name="console:org:idps_view"/>
+                <Scope name="console:org:idps_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_idp_update"/>
@@ -1597,8 +1597,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:users"/>
-                <Scope name="console:org:users_view" action="view"/>
-                <Scope name="console:org:users_edit" action="edit"/>
+                <Scope name="console:org:users_view"/>
+                <Scope name="console:org:users_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_user_mgt_update"/>
@@ -1630,8 +1630,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:organizations"/>
-                <Scope name="console:org:organizations_view" action="view"/>
-                <Scope name="console:org:organizations_edit" action="edit"/>
+                <Scope name="console:org:organizations_view"/>
+                <Scope name="console:org:organizations_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_organization_update"/>
@@ -1654,8 +1654,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:groups"/>
-                <Scope name="console:org:groups_view" action="view"/>
-                <Scope name="console:org:groups_edit" action="edit"/>
+                <Scope name="console:org:groups_view"/>
+                <Scope name="console:org:groups_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_group_mgt_update"/>
@@ -1679,8 +1679,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:roles"/>
-                <Scope name="console:org:roles_view" action="view"/>
-                <Scope name="console:org:roles_edit" action="edit"/>
+                <Scope name="console:org:roles_view"/>
+                <Scope name="console:org:roles_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_role_mgt_update"/>
@@ -1706,8 +1706,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:roles"/>
-                <Scope name="console:org:roles_view" action="view"/>
-                <Scope name="console:org:roles_edit" action="edit"/>
+                <Scope name="console:org:roles_view"/>
+                <Scope name="console:org:roles_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_role_mgt_update"/>
@@ -1730,8 +1730,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:applications"/>
-                <Scope name="console:org:applications_view" action="view"/>
-                <Scope name="console:org:applications_edit" action="edit"/>
+                <Scope name="console:org:applications_view"/>
+                <Scope name="console:org:applications_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_application_mgt_update"/>
@@ -1755,8 +1755,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:branding"/>
-                <Scope name="console:org:branding_view" action="view"/>
-                <Scope name="console:org:branding_edit" action="edit"/>
+                <Scope name="console:org:branding_view"/>
+                <Scope name="console:org:branding_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_branding_preference_update"/>
@@ -1776,8 +1776,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:emailTemplates"/>
-                <Scope name="console:org:emailTemplates_view" action="view"/>
-                <Scope name="console:org:emailTemplates_edit" action="edit"/>
+                <Scope name="console:org:emailTemplates_view"/>
+                <Scope name="console:org:emailTemplates_edit"/>
             </Feature>
             <Update>
             </Update>
@@ -1794,8 +1794,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:smsTemplates"/>
-                <Scope name="console:org:smsTemplates_view" action="view"/>
-                <Scope name="console:org:smsTemplates_edit" action="edit"/>
+                <Scope name="console:org:smsTemplates_view"/>
+                <Scope name="console:org:smsTemplates_edit"/>
             </Feature>
             <Update>
             </Update>
@@ -1812,8 +1812,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:home"/>
-                <Scope name="console:org:home_view" action="view"/>
-                <Scope name="console:org:home_edit" action="edit"/>
+                <Scope name="console:org:home_view"/>
+                <Scope name="console:org:home_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_application_mgt_update"/>
@@ -1834,8 +1834,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:apiResources"/>
-                <Scope name="console:org:apiResources_view" action="view"/>
-                <Scope name="console:org:apiResources_edit" action="edit"/>
+                <Scope name="console:org:apiResources_view"/>
+                <Scope name="console:org:apiResources_edit"/>
             </Feature>
             <Read>
                 <Scope name="internal_org_api_resource_view"/>
@@ -1846,8 +1846,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:userstores"/>
-                <Scope name="console:org:userstores_view" action="view"/>
-                <Scope name="console:org:userstores_edit" action="edit"/>
+                <Scope name="console:org:userstores_view"/>
+                <Scope name="console:org:userstores_edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_userstore_update"/>
@@ -1867,8 +1867,8 @@
         <Scopes>
             <Feature>
                 <Scope name="console:org:attributes"/>
-                <Scope name="console:org:attributes_view" action="view"/>
-                <Scope name="console:org:attributes_edit" action="edit"/>
+                <Scope name="console:org:attributes_view"/>
+                <Scope name="console:org:attributes_edit"/>
             </Feature>
             <Create>
             </Create>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -59,6 +59,7 @@
         </Scopes>
     </APIResourceCollection>
     {% endfor %}
+<!--    Legacy API Resource Collections (version as v0)-->
     <APIResourceCollection name="apiResources" displayName="API Resources" type="tenant" version="v0">
        <Scopes>
             <Feature>
@@ -610,7 +611,7 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-<!--    Organization API Resource Collections-->
+<!--    Legacy Organization API Resource Collections (version as v0)-->
     <APIResourceCollection name="org_consoleSettings" displayName="Console Settings" type="organization" version="v0">
        <Scopes>
             <Feature>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -19,49 +19,47 @@
 
 <APIResourceCollections>
     {% for collection in api_resource_collections %}
-    <APIResourceCollection name="{{ collection.name }}" displayName="{{ collection.displayName }}" type="{{ collection.type | default('Unknown') }}" enabled="{{ collection.enabled | default('true') }}">
-        {% for scopes in collection.scopes %}
-        <Scopes version="{{ scopes.version }}">
-            {% if scopes.feature %}
+    <APIResourceCollection name="{{ collection.name }}" displayName="{{ collection.displayName }}" type="{{ collection.type | default('Unknown') }}" {% if collection.version %} version="{{ collection.version }}"{% endif %} enabled="{{ collection.enabled | default('true') }}">
+       <Scopes>
+            {% if collection.scopes.feature %}
             <Feature>
-                {% for scope in scopes.feature %}
+                {% for scope in collection.scopes.feature %}
                 <Scope name="{{ scope.name }}" action="{{ scope.action }}"/>
                 {% endfor %}
             </Feature>
             {% endif %}
             {% if collection.scopes.create %}
             <Create>
-                {% for scope in scopes.create %}
+                {% for scope in collection.scopes.create %}
                 <Scope name="{{ scope.name }}"/>
                 {% endfor %}
             </Create>
             {% endif %}
             {% if collection.scopes.update %}
             <Update>
-                {% for scope in scopes.update %}
+                {% for scope in collection.scopes.update %}
                 <Scope name="{{ scope.name }}"/>
                 {% endfor %}
             </Update>
             {% endif %}
             {% if collection.scopes.read %}
             <Read>
-                {% for scope in scopes.read %}
+                {% for scope in collection.scopes.read %}
                 <Scope name="{{ scope.name }}"/>
                 {% endfor %}
             </Read>
             {% endif %}
             {% if collection.scopes.delete %}
             <Delete>
-                {% for scope in scopes.delete %}
+                {% for scope in collection.scopes.delete %}
                 <Scope name="{{ scope.name }}"/>
                 {% endfor %}
             </Delete>
             {% endif %}
         </Scopes>
-        {% endfor %}
     </APIResourceCollection>
     {% endfor %}
-    <APIResourceCollection name="apiResources" displayName="API Resources" type="tenant">
+    <APIResourceCollection name="apiResources" displayName="API Resources" type="tenant" version="v0">
        <Scopes>
             <Feature>
                 <Scope name="console:apiResources"/>
@@ -79,27 +77,8 @@
                 <Scope name="internal_api_resource_delete"/>
             </Delete>
         </Scopes>
-        <Scopes version="v1">
-            <Feature>
-                <Scope name="console:apiResources"/>
-                <Scope name="console:apiResources_view" action="view"/>
-                <Scope name="console:apiResources_edit" action="edit"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_api_resource_update"/>
-            </Update>
-            <Create>
-                <Scope name="internal_api_resource_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_api_resource_view"/>
-            </Read>
-            <Delete>
-                <Scope name="internal_api_resource_delete"/>
-            </Delete>
-        </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="applications" displayName="Applications" type="tenant">
+    <APIResourceCollection name="applications" displayName="Applications" type="tenant" version="v0">
        <Scopes>
             <Feature>
                 <Scope name="console:applications"/>
@@ -135,7 +114,847 @@
                 <Scope name="internal_secret_mgt_view"/>
             </Read>
         </Scopes>
-        <Scopes version="v1">
+    </APIResourceCollection>
+    <APIResourceCollection name="branding" displayName="Branding" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:branding"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_branding_preference_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_branding_preference_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_branding_preference_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_application_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="approvals" displayName="Approvals" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:workflowApprovals"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_humantask_view"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_humantask_view"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_humantask_view"/>
+            </Create>
+            <Read>
+                <Scope name="internal_humantask_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="attributeDialects" displayName="Attribute Dialects" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:attributes"/>
+            </Feature>
+            <Create>
+                <Scope name="internal_claim_meta_create"/>
+            </Create>
+            <Update>
+                <Scope name="internal_claim_meta_update"/>
+                <Scope name="internal_governance_update"/>
+            </Update>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_claim_meta_view"/>
+                <Scope name="internal_governance_view"/>
+            </Read>
+            <Delete>
+                <Scope name="internal_claim_meta_delete"/>
+            </Delete>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="certificates" displayName="Certificates" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:certificates"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_keystore_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_keystore_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_keystore_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_keystore_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="consoleSettings" displayName="Console Settings" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:settings"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_application_mgt_update"/>
+                <Scope name="internal_user_mgt_update"/>
+            </Update>
+            <Delete>
+            </Delete>
+            <Create>
+                <Scope name="internal_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_session_view"/>
+                <Scope name="internal_governance_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="emailTemplates" displayName="Email Templates" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:emailTemplates"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_email_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_email_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_email_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_email_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="smsTemplates" displayName="SMS Templates" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:smsTemplates"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_template_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_template_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_template_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_template_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="groups" displayName="Groups" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:groups"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_group_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_group_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="gettingStarted" displayName="Home Page" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:home"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_application_mgt_update"/>
+            </Update>
+            <Delete/>
+            <Create>
+                <Scope name="internal_application_mgt_create"/>
+                <Scope name="internal_idp_create"/>
+                <Scope name="internal_user_mgt_create"/>
+                <Scope name="internal_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_application_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="connections" displayName="Connections" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:idps"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_idp_update"/>
+                <Scope name="internal_governance_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_idp_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_idp_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
+                <Scope name="internal_authenticator_view"/>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_extensions_view"/>
+                <Scope name="internal_config_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="identityVerificationProviders" displayName="Identity Verification Providers" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:idvps"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_idvp_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_idvp_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_idvp_add"/>
+            </Create>
+            <Read>
+                <Scope name="internal_idvp_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="loginAndRegistration" displayName="Login And Registration" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:loginAndRegistration"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_governance_update"/>
+            </Update>
+            <Delete/>
+            <Create/>
+            <Read>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_validation_rule_mgt_update"/>
+                <Scope name="internal_config_update"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_group_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="notificationChannels" displayName="Notification Channels" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:notificationChannels"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_notification_senders_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_notification_senders_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_notification_senders_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_notification_senders_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="oidcScopes" displayName="OIDC Scopes" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:scopes:oidc"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_oidc_scope_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_oidc_scope_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_oidc_scope_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_oidc_scope_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="organizations" displayName="Organizations" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:organizations"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_organization_update"/>
+                <Scope name="internal_organization_config_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_organization_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_organization_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_organization_view"/>
+                <Scope name="internal_organization_config_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="organizationDiscovery" displayName="Organization Discovery" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:organizationDiscovery"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_organization_discovery_update"/>
+                <Scope name="internal_organization_config_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_organization_discovery_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_organization_discovery_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_organization_discovery_view"/>
+                <Scope name="internal_organization_view"/>
+                <Scope name="internal_organization_config_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="residentOutboundProvisioning" displayName="Resident Application Outbound Provisioning" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:residentOutboundProvisioning"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_application_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_application_mgt_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_application_mgt_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_application_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="roles" displayName="Roles" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:roles"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_role_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_role_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_api_resource_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="rolesV1" displayName="Roles" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:roles"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_role_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_role_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_permission_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="users" displayName="Users" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:users"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_user_mgt_update"/>
+                <Scope name="internal_session_delete"/>
+                <Scope name="internal_group_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_user_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_user_mgt_create"/>
+                <Scope name="internal_bulk_resource_create"/>
+                <Scope name="internal_offline_invite"/>
+            </Create>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_login"/>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_session_view"/>
+                <Scope name="internal_claim_meta_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="userStores" displayName="User Stores" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:userstores"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_userstore_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_userstore_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_userstore_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="actions" displayName="Actions" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:actions"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_action_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_action_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_action_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_action_mgt_view"/>
+                <Scope name="internal_rule_metadata_view"/>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="tenants" displayName="Root Organizations" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:tenants"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_modify_tenants"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_modify_tenants"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_create_tenants"/>
+            </Create>
+            <Read>
+                <Scope name="internal_list_tenants"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+<!--    Organization API Resource Collections-->
+    <APIResourceCollection name="org_consoleSettings" displayName="Console Settings" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:settings"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_application_mgt_update"/>
+                <Scope name="internal_org_user_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_guest_mgt_invite_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_guest_mgt_invite_list"/>
+                <Scope name="internal_org_idp_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_session_view"/>
+                <Scope name="internal_org_governance_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_connections" displayName="Connections" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:idps"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_idp_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_idp_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_idp_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_idp_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_authenticator_view"/>
+                <Scope name="internal_org_governance_view"/>
+                <Scope name="internal_org_extensions_view"/>
+                <Scope name="internal_org_config_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_users" displayName="Users" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:users"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_user_mgt_update"/>
+                <Scope name="internal_org_session_delete"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_user_mgt_delete"/>
+                <Scope name="internal_org_guest_mgt_invite_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_user_mgt_create"/>
+                <Scope name="internal_org_guest_mgt_invite_add"/>
+                <Scope name="internal_org_bulk_resource_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_governance_view"/>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_session_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_guest_mgt_invite_list"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_organizations" displayName="Organizations" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:organizations"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_organization_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_organization_delete"/>
+                <Scope name="internal_org_config_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_organization_create"/>
+                <Scope name="internal_org_config_mgt_add"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_organization_view"/>
+                <Scope name="internal_org_config_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_groups" displayName="Groups" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:groups"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_group_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_group_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_roles" displayName="Roles" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:roles"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_role_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_role_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_application_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_idp_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_rolesV1" displayName="Roles" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:roles"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_role_mgt_update"/>
+            </Update>
+            <Delete/>
+            <Create>
+                <Scope name="internal_org_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_permission_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_applications" displayName="Applications" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:applications"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_application_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_application_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_application_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_idp_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_branding" displayName="Branding" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:branding"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_branding_preference_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_branding_preference_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_branding_preference_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_emailTemplates" displayName="Email Templates" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:emailTemplates"/>
+            </Feature>
+            <Update>
+            </Update>
+            <Delete>
+            </Delete>
+            <Create>
+            </Create>
+            <Read>
+                <Scope name="internal_org_email_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_smsTemplates" displayName="SMS Templates" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:smsTemplates"/>
+            </Feature>
+            <Update>
+            </Update>
+            <Delete>
+            </Delete>
+            <Create>
+            </Create>
+            <Read>
+                <Scope name="internal_org_template_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_gettingStarted" displayName="Home Page" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:home"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_application_mgt_update"/>
+            </Update>
+            <Delete/>
+            <Create>
+                <Scope name="internal_org_application_mgt_create"/>
+                <Scope name="internal_org_idp_create"/>
+                <Scope name="internal_org_user_mgt_create"/>
+                <Scope name="internal_org_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_apiResources" displayName="API Resources" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:apiResources"/>
+            </Feature>
+            <Read>
+                <Scope name="internal_org_api_resource_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_userStores" displayName="User Stores" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:userstores"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_userstore_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_userstore_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_userstore_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_attributeDialects" displayName="Attribute Dialects" type="organization" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:org:attributes"/>
+            </Feature>
+            <Create>
+            </Create>
+            <Update>
+                <Scope name="internal_org_claim_meta_update"/>
+            </Update>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+            </Read>
+            <Delete>
+            </Delete>
+        </Scopes>
+    </APIResourceCollection>
+
+<!--    New API Resource Collections-->
+    <APIResourceCollection name="apiResources" displayName="API Resources" type="tenant">
+        <Scopes>
+            <Feature>
+                <Scope name="console:apiResources"/>
+                <Scope name="console:apiResources_view" action="view"/>
+                <Scope name="console:apiResources_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_api_resource_update"/>
+            </Update>
+            <Create>
+                <Scope name="internal_api_resource_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_api_resource_view"/>
+            </Read>
+            <Delete>
+                <Scope name="internal_api_resource_delete"/>
+            </Delete>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="applications" displayName="Applications" type="tenant">
+        <Scopes>
             <Feature>
                 <Scope name="console:applications"/>
                 <Scope name="console:applications_view" action="view"/>
@@ -174,24 +993,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="branding" displayName="Branding" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:branding"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_branding_preference_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_branding_preference_update"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_branding_preference_update"/>
-            </Create>
-            <Read>
-                <Scope name="internal_application_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:branding"/>
                 <Scope name="console:branding_view" action="view"/>
@@ -212,24 +1014,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="approvals" displayName="Approvals" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:workflowApprovals"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_humantask_view"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_humantask_view"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_humantask_view"/>
-            </Create>
-            <Read>
-                <Scope name="internal_humantask_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:workflowApprovals"/>
                 <Scope name="console:workflowApprovals_view" action="view"/>
@@ -250,27 +1035,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="attributeDialects" displayName="Attribute Dialects" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:attributes"/>
-            </Feature>
-            <Create>
-                <Scope name="internal_claim_meta_create"/>
-            </Create>
-            <Update>
-                <Scope name="internal_claim_meta_update"/>
-                <Scope name="internal_governance_update"/>
-            </Update>
-            <Read>
-                <Scope name="internal_userstore_view"/>
-                <Scope name="internal_claim_meta_view"/>
-                <Scope name="internal_governance_view"/>
-            </Read>
-            <Delete>
-                <Scope name="internal_claim_meta_delete"/>
-            </Delete>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:attributes"/>
                 <Scope name="console:attributes_view" action="view"/>
@@ -294,24 +1059,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="certificates" displayName="Certificates" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:certificates"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_keystore_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_keystore_update"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_keystore_update"/>
-            </Create>
-            <Read>
-                <Scope name="internal_keystore_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:certificates"/>
                 <Scope name="console:certificates_view" action="view"/>
@@ -332,32 +1080,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="consoleSettings" displayName="Console Settings" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:settings"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_application_mgt_update"/>
-                <Scope name="internal_user_mgt_update"/>
-            </Update>
-            <Delete>
-            </Delete>
-            <Create>
-                <Scope name="internal_role_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_application_mgt_view"/>
-                <Scope name="internal_user_mgt_list"/>
-                <Scope name="internal_user_mgt_view"/>
-                <Scope name="internal_userstore_view"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_idp_view"/>
-                <Scope name="internal_group_mgt_view"/>
-                <Scope name="internal_session_view"/>
-                <Scope name="internal_governance_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:settings"/>
                 <Scope name="console:settings_view" action="view"/>
@@ -386,24 +1109,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="emailTemplates" displayName="Email Templates" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:emailTemplates"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_email_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_email_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_email_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_email_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:emailTemplates"/>
                 <Scope name="console:emailTemplates_view" action="view"/>
@@ -424,24 +1130,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="smsTemplates" displayName="SMS Templates" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:smsTemplates"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_template_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_template_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_template_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_template_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:smsTemplates"/>
                 <Scope name="console:smsTemplates_view" action="view"/>
@@ -462,28 +1151,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="groups" displayName="Groups" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:groups"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_group_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_group_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_group_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_user_mgt_view"/>
-                <Scope name="internal_user_mgt_list"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_group_mgt_view"/>
-                <Scope name="internal_userstore_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:groups"/>
                 <Scope name="console:groups_view" action="view"/>
@@ -508,25 +1176,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="gettingStarted" displayName="Home Page" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:home"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_application_mgt_update"/>
-            </Update>
-            <Delete/>
-            <Create>
-                <Scope name="internal_application_mgt_create"/>
-                <Scope name="internal_idp_create"/>
-                <Scope name="internal_user_mgt_create"/>
-                <Scope name="internal_group_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_application_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:home"/>
                 <Scope name="console:home_view" action="view"/>
@@ -548,32 +1198,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="connections" displayName="Connections" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:idps"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_idp_update"/>
-                <Scope name="internal_governance_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_idp_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_idp_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_userstore_view"/>
-                <Scope name="internal_idp_view"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_claim_meta_view"/>
-                <Scope name="internal_authenticator_view"/>
-                <Scope name="internal_governance_view"/>
-                <Scope name="internal_extensions_view"/>
-                <Scope name="internal_config_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:idps"/>
                 <Scope name="console:idps_view" action="view"/>
@@ -602,24 +1227,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="identityVerificationProviders" displayName="Identity Verification Providers" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:idvps"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_idvp_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_idvp_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_idvp_add"/>
-            </Create>
-            <Read>
-                <Scope name="internal_idvp_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:idvps"/>
                 <Scope name="console:idvps_view" action="view"/>
@@ -640,24 +1248,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="loginAndRegistration" displayName="Login And Registration" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:loginAndRegistration"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_governance_update"/>
-            </Update>
-            <Delete/>
-            <Create/>
-            <Read>
-                <Scope name="internal_governance_view"/>
-                <Scope name="internal_validation_rule_mgt_update"/>
-                <Scope name="internal_config_update"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_group_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:loginAndRegistration"/>
                 <Scope name="console:loginAndRegistration_view" action="view"/>
@@ -678,24 +1269,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="notificationChannels" displayName="Notification Channels" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:notificationChannels"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_notification_senders_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_notification_senders_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_notification_senders_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_notification_senders_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:notificationChannels"/>
                 <Scope name="console:notificationChannels_view" action="view"/>
@@ -716,25 +1290,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="oidcScopes" displayName="OIDC Scopes" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:scopes:oidc"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_oidc_scope_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_oidc_scope_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_oidc_scope_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_oidc_scope_mgt_view"/>
-                <Scope name="internal_claim_meta_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:scopes:oidc"/>
                 <Scope name="console:scopes:oidc_view" action="view"/>
@@ -756,26 +1312,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="organizations" displayName="Organizations" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:organizations"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_organization_update"/>
-                <Scope name="internal_organization_config_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_organization_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_organization_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_organization_view"/>
-                <Scope name="internal_organization_config_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:organizations"/>
                 <Scope name="console:organizations_view" action="view"/>
@@ -798,27 +1335,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="organizationDiscovery" displayName="Organization Discovery" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:organizationDiscovery"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_organization_discovery_update"/>
-                <Scope name="internal_organization_config_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_organization_discovery_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_organization_discovery_update"/>
-            </Create>
-            <Read>
-                <Scope name="internal_organization_discovery_view"/>
-                <Scope name="internal_organization_view"/>
-                <Scope name="internal_organization_config_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:organizationDiscovery"/>
                 <Scope name="console:organizationDiscovery_view" action="view"/>
@@ -842,25 +1359,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="residentOutboundProvisioning" displayName="Resident Application Outbound Provisioning" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:residentOutboundProvisioning"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_application_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_application_mgt_update"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_application_mgt_update"/>
-            </Create>
-            <Read>
-                <Scope name="internal_idp_view"/>
-                <Scope name="internal_application_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:residentOutboundProvisioning"/>
                 <Scope name="console:residentOutboundProvisioning_view" action="view"/>
@@ -882,31 +1381,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="roles" displayName="Roles" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:roles"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_role_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_role_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_role_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_user_mgt_view"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_userstore_view"/>
-                <Scope name="internal_group_mgt_view"/>
-                <Scope name="internal_application_mgt_view"/>
-                <Scope name="internal_user_mgt_list"/>
-                <Scope name="internal_idp_view"/>
-                <Scope name="internal_api_resource_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:roles"/>
                 <Scope name="console:roles_view" action="view"/>
@@ -934,29 +1409,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="rolesV1" displayName="Roles" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:roles"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_role_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_role_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_role_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_user_mgt_view"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_userstore_view"/>
-                <Scope name="internal_group_mgt_view"/>
-                <Scope name="internal_permission_mgt_view"/>
-                <Scope name="internal_user_mgt_list"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:roles"/>
                 <Scope name="console:roles_view" action="view"/>
@@ -982,36 +1435,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="users" displayName="Users" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:users"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_user_mgt_update"/>
-                <Scope name="internal_session_delete"/>
-                <Scope name="internal_group_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_user_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_user_mgt_create"/>
-                <Scope name="internal_bulk_resource_create"/>
-                <Scope name="internal_offline_invite"/>
-            </Create>
-            <Read>
-                <Scope name="internal_userstore_view"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_group_mgt_view"/>
-                <Scope name="internal_governance_view"/>
-                <Scope name="internal_login"/>
-                <Scope name="internal_user_mgt_view"/>
-                <Scope name="internal_user_mgt_list"/>
-                <Scope name="internal_session_view"/>
-                <Scope name="internal_claim_meta_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:users"/>
                 <Scope name="console:users_view" action="view"/>
@@ -1044,24 +1468,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="userStores" displayName="User Stores" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:userstores"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_userstore_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_userstore_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_userstore_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_userstore_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:userstores"/>
                 <Scope name="console:userstores_view" action="view"/>
@@ -1082,27 +1489,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="actions" displayName="Actions" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:actions"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_action_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_action_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_action_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_action_mgt_view"/>
-                <Scope name="internal_rule_metadata_view"/>
-                <Scope name="internal_application_mgt_view"/>
-                <Scope name="internal_claim_meta_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:actions"/>
                 <Scope name="console:actions_view" action="view"/>
@@ -1126,24 +1513,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="tenants" displayName="Root Organizations" type="tenant">
-       <Scopes>
-            <Feature>
-                <Scope name="console:tenants"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_modify_tenants"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_modify_tenants"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_create_tenants"/>
-            </Create>
-            <Read>
-                <Scope name="internal_list_tenants"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:tenants"/>
                 <Scope name="console:tenants_view" action="view"/>
@@ -1163,36 +1533,9 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-<!--    Organization API Resource Collections-->
+<!--    New Organization API Resource Collections-->
     <APIResourceCollection name="org_consoleSettings" displayName="Console Settings" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:settings"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_application_mgt_update"/>
-                <Scope name="internal_org_user_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_guest_mgt_invite_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_role_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_application_mgt_view"/>
-                <Scope name="internal_org_user_mgt_list"/>
-                <Scope name="internal_org_user_mgt_view"/>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_role_mgt_view"/>
-                <Scope name="internal_org_guest_mgt_invite_list"/>
-                <Scope name="internal_org_idp_view"/>
-                <Scope name="internal_org_group_mgt_view"/>
-                <Scope name="internal_org_session_view"/>
-                <Scope name="internal_org_governance_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:settings"/>
                 <Scope name="console:org:settings_view" action="view"/>
@@ -1223,31 +1566,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_connections" displayName="Connections" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:idps"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_idp_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_idp_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_idp_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_idp_view"/>
-                <Scope name="internal_org_role_mgt_view"/>
-                <Scope name="internal_org_claim_meta_view"/>
-                <Scope name="internal_org_authenticator_view"/>
-                <Scope name="internal_org_governance_view"/>
-                <Scope name="internal_org_extensions_view"/>
-                <Scope name="internal_org_config_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:idps"/>
                 <Scope name="console:org:idps_view" action="view"/>
@@ -1275,36 +1594,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_users" displayName="Users" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:users"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_user_mgt_update"/>
-                <Scope name="internal_org_session_delete"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_user_mgt_delete"/>
-                <Scope name="internal_org_guest_mgt_invite_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_user_mgt_create"/>
-                <Scope name="internal_org_guest_mgt_invite_add"/>
-                <Scope name="internal_org_bulk_resource_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_role_mgt_view"/>
-                <Scope name="internal_org_group_mgt_view"/>
-                <Scope name="internal_org_governance_view"/>
-                <Scope name="internal_org_user_mgt_view"/>
-                <Scope name="internal_org_user_mgt_list"/>
-                <Scope name="internal_org_session_view"/>
-                <Scope name="internal_org_claim_meta_view"/>
-                <Scope name="internal_org_guest_mgt_invite_list"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:users"/>
                 <Scope name="console:org:users_view" action="view"/>
@@ -1337,27 +1627,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_organizations" displayName="Organizations" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:organizations"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_organization_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_organization_delete"/>
-                <Scope name="internal_org_config_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_organization_create"/>
-                <Scope name="internal_org_config_mgt_add"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_organization_view"/>
-                <Scope name="internal_org_config_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:organizations"/>
                 <Scope name="console:org:organizations_view" action="view"/>
@@ -1381,28 +1651,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_groups" displayName="Groups" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:groups"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_group_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_group_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_group_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_user_mgt_view"/>
-                <Scope name="internal_org_user_mgt_list"/>
-                <Scope name="internal_org_role_mgt_view"/>
-                <Scope name="internal_org_group_mgt_view"/>
-                <Scope name="internal_org_userstore_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:groups"/>
                 <Scope name="console:org:groups_view" action="view"/>
@@ -1427,30 +1676,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_roles" displayName="Roles" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:roles"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_role_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_role_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_role_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_user_mgt_view"/>
-                <Scope name="internal_org_role_mgt_view"/>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_group_mgt_view"/>
-                <Scope name="internal_org_application_mgt_view"/>
-                <Scope name="internal_org_user_mgt_list"/>
-                <Scope name="internal_org_idp_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:roles"/>
                 <Scope name="console:org:roles_view" action="view"/>
@@ -1477,27 +1703,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_rolesV1" displayName="Roles" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:roles"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_role_mgt_update"/>
-            </Update>
-            <Delete/>
-            <Create>
-                <Scope name="internal_org_role_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_user_mgt_view"/>
-                <Scope name="internal_org_role_mgt_view"/>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_group_mgt_view"/>
-                <Scope name="internal_org_permission_mgt_view"/>
-                <Scope name="internal_org_user_mgt_list"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:roles"/>
                 <Scope name="console:org:roles_view" action="view"/>
@@ -1521,28 +1727,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_applications" displayName="Applications" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:applications"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_application_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_application_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_application_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_application_mgt_view"/>
-                <Scope name="internal_org_claim_meta_view"/>
-                <Scope name="internal_org_role_mgt_view"/>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_idp_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:applications"/>
                 <Scope name="console:org:applications_view" action="view"/>
@@ -1567,24 +1752,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_branding" displayName="Branding" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:branding"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_branding_preference_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_branding_preference_update"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_branding_preference_update"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_application_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:branding"/>
                 <Scope name="console:org:branding_view" action="view"/>
@@ -1605,21 +1773,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_emailTemplates" displayName="Email Templates" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:emailTemplates"/>
-            </Feature>
-            <Update>
-            </Update>
-            <Delete>
-            </Delete>
-            <Create>
-            </Create>
-            <Read>
-                <Scope name="internal_org_email_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:emailTemplates"/>
                 <Scope name="console:org:emailTemplates_view" action="view"/>
@@ -1637,21 +1791,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_smsTemplates" displayName="SMS Templates" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:smsTemplates"/>
-            </Feature>
-            <Update>
-            </Update>
-            <Delete>
-            </Delete>
-            <Create>
-            </Create>
-            <Read>
-                <Scope name="internal_org_template_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:smsTemplates"/>
                 <Scope name="console:org:smsTemplates_view" action="view"/>
@@ -1669,25 +1809,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_gettingStarted" displayName="Home Page" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:home"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_application_mgt_update"/>
-            </Update>
-            <Delete/>
-            <Create>
-                <Scope name="internal_org_application_mgt_create"/>
-                <Scope name="internal_org_idp_create"/>
-                <Scope name="internal_org_user_mgt_create"/>
-                <Scope name="internal_org_group_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_application_mgt_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:home"/>
                 <Scope name="console:org:home_view" action="view"/>
@@ -1709,15 +1831,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_apiResources" displayName="API Resources" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:apiResources"/>
-            </Feature>
-            <Read>
-                <Scope name="internal_org_api_resource_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:apiResources"/>
                 <Scope name="console:org:apiResources_view" action="view"/>
@@ -1729,24 +1843,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_userStores" displayName="User Stores" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:userstores"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_userstore_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_userstore_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_userstore_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_userstore_view"/>
-            </Read>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:userstores"/>
                 <Scope name="console:org:userstores_view" action="view"/>
@@ -1767,23 +1864,7 @@
         </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_attributeDialects" displayName="Attribute Dialects" type="organization">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:attributes"/>
-            </Feature>
-            <Create>
-            </Create>
-            <Update>
-                <Scope name="internal_org_claim_meta_update"/>
-            </Update>
-            <Read>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_claim_meta_view"/>
-            </Read>
-            <Delete>
-            </Delete>
-        </Scopes>
-        <Scopes version="v1">
+        <Scopes>
             <Feature>
                 <Scope name="console:org:attributes"/>
                 <Scope name="console:org:attributes_view" action="view"/>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -86,17 +86,14 @@
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
-                <Scope name="internal_secret_mgt_update"/>
             </Update>
             <Delete>
                 <Scope name="internal_application_mgt_delete"/>
                 <Scope name="internal_shared_application_delete"/>
-                <Scope name="internal_secret_mgt_delete"/>
             </Delete>
             <Create>
                 <Scope name="internal_application_mgt_create"/>
                 <Scope name="internal_shared_application_create"/>
-                <Scope name="internal_secret_mgt_add"/>
             </Create>
             <Read>
                 <Scope name="internal_cors_origins_view"/>
@@ -112,7 +109,6 @@
                 <Scope name="internal_governance_view"/>
                 <Scope name="internal_userstore_view"/>
                 <Scope name="internal_shared_application_view"/>
-                <Scope name="internal_secret_mgt_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -241,25 +241,6 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="smsTemplates" displayName="SMS Templates" type="tenant" version="v0">
-       <Scopes>
-            <Feature>
-                <Scope name="console:smsTemplates"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_template_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_template_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_template_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_template_mgt_view"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
     <APIResourceCollection name="groups" displayName="Groups" type="tenant" version="v0">
        <Scopes>
             <Feature>
@@ -326,7 +307,6 @@
                 <Scope name="internal_authenticator_view"/>
                 <Scope name="internal_governance_view"/>
                 <Scope name="internal_extensions_view"/>
-                <Scope name="internal_config_mgt_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>
@@ -363,8 +343,6 @@
                 <Scope name="internal_governance_view"/>
                 <Scope name="internal_validation_rule_mgt_update"/>
                 <Scope name="internal_config_update"/>
-                <Scope name="internal_role_mgt_view"/>
-                <Scope name="internal_group_mgt_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>
@@ -414,7 +392,6 @@
             </Feature>
             <Update>
                 <Scope name="internal_organization_update"/>
-                <Scope name="internal_organization_config_update"/>
             </Update>
             <Delete>
                 <Scope name="internal_organization_delete"/>
@@ -435,7 +412,6 @@
             </Feature>
             <Update>
                 <Scope name="internal_organization_discovery_update"/>
-                <Scope name="internal_organization_config_update"/>
             </Update>
             <Delete>
                 <Scope name="internal_organization_discovery_delete"/>
@@ -570,47 +546,6 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="actions" displayName="Actions" type="tenant" version="v0">
-       <Scopes>
-            <Feature>
-                <Scope name="console:actions"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_action_mgt_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_action_mgt_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_action_mgt_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_action_mgt_view"/>
-                <Scope name="internal_rule_metadata_view"/>
-                <Scope name="internal_application_mgt_view"/>
-                <Scope name="internal_claim_meta_view"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
-    <APIResourceCollection name="tenants" displayName="Root Organizations" type="tenant" version="v0">
-       <Scopes>
-            <Feature>
-                <Scope name="console:tenants"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_modify_tenants"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_modify_tenants"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_create_tenants"/>
-            </Create>
-            <Read>
-                <Scope name="internal_list_tenants"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
 <!--    Legacy Organization API Resource Collections (version as v0)-->
     <APIResourceCollection name="org_consoleSettings" displayName="Console Settings" type="organization" version="v0">
        <Scopes>
@@ -663,7 +598,6 @@
                 <Scope name="internal_org_authenticator_view"/>
                 <Scope name="internal_org_governance_view"/>
                 <Scope name="internal_org_extensions_view"/>
-                <Scope name="internal_org_config_mgt_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>
@@ -751,9 +685,6 @@
             <Update>
                 <Scope name="internal_org_role_mgt_update"/>
             </Update>
-            <Delete>
-                <Scope name="internal_org_role_mgt_delete"/>
-            </Delete>
             <Create>
                 <Scope name="internal_org_role_mgt_create"/>
             </Create>
@@ -848,22 +779,6 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    <APIResourceCollection name="org_smsTemplates" displayName="SMS Templates" type="organization" version="v0">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:smsTemplates"/>
-            </Feature>
-            <Update>
-            </Update>
-            <Delete>
-            </Delete>
-            <Create>
-            </Create>
-            <Read>
-                <Scope name="internal_org_template_mgt_view"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
     <APIResourceCollection name="org_gettingStarted" displayName="Home Page" type="organization" version="v0">
        <Scopes>
             <Feature>
@@ -882,53 +797,6 @@
             <Read>
                 <Scope name="internal_org_application_mgt_view"/>
             </Read>
-        </Scopes>
-    </APIResourceCollection>
-    <APIResourceCollection name="org_apiResources" displayName="API Resources" type="organization" version="v0">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:apiResources"/>
-            </Feature>
-            <Read>
-                <Scope name="internal_org_api_resource_view"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
-    <APIResourceCollection name="org_userStores" displayName="User Stores" type="organization" version="v0">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:userstores"/>
-            </Feature>
-            <Update>
-                <Scope name="internal_org_userstore_update"/>
-            </Update>
-            <Delete>
-                <Scope name="internal_org_userstore_delete"/>
-            </Delete>
-            <Create>
-                <Scope name="internal_org_userstore_create"/>
-            </Create>
-            <Read>
-                <Scope name="internal_org_userstore_view"/>
-            </Read>
-        </Scopes>
-    </APIResourceCollection>
-    <APIResourceCollection name="org_attributeDialects" displayName="Attribute Dialects" type="organization" version="v0">
-       <Scopes>
-            <Feature>
-                <Scope name="console:org:attributes"/>
-            </Feature>
-            <Create>
-            </Create>
-            <Update>
-                <Scope name="internal_org_claim_meta_update"/>
-            </Update>
-            <Read>
-                <Scope name="internal_org_userstore_view"/>
-                <Scope name="internal_org_claim_meta_view"/>
-            </Read>
-            <Delete>
-            </Delete>
         </Scopes>
     </APIResourceCollection>
 

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -20,47 +20,49 @@
 <APIResourceCollections>
     {% for collection in api_resource_collections %}
     <APIResourceCollection name="{{ collection.name }}" displayName="{{ collection.displayName }}" type="{{ collection.type | default('Unknown') }}" enabled="{{ collection.enabled | default('true') }}">
-        <Scopes>
-            {% if collection.scopes.feature %}
+        {% for scopes in collection.scopes %}
+        <Scopes version="{{ scopes.version }}">
+            {% if scopes.feature %}
             <Feature>
-                {% for scope in collection.scopes.feature %}
-                <Scope name="{{ scope.name }}"/>
+                {% for scope in scopes.feature %}
+                <Scope name="{{ scope.name }}" action="{{ scope.action }}"/>
                 {% endfor %}
             </Feature>
             {% endif %}
             {% if collection.scopes.create %}
             <Create>
-                {% for scope in collection.scopes.create %}
+                {% for scope in scopes.create %}
                 <Scope name="{{ scope.name }}"/>
                 {% endfor %}
             </Create>
             {% endif %}
             {% if collection.scopes.update %}
             <Update>
-                {% for scope in collection.scopes.update %}
+                {% for scope in scopes.update %}
                 <Scope name="{{ scope.name }}"/>
                 {% endfor %}
             </Update>
             {% endif %}
             {% if collection.scopes.read %}
             <Read>
-                {% for scope in collection.scopes.read %}
+                {% for scope in scopes.read %}
                 <Scope name="{{ scope.name }}"/>
                 {% endfor %}
             </Read>
             {% endif %}
             {% if collection.scopes.delete %}
             <Delete>
-                {% for scope in collection.scopes.delete %}
+                {% for scope in scopes.delete %}
                 <Scope name="{{ scope.name }}"/>
                 {% endfor %}
             </Delete>
             {% endif %}
         </Scopes>
+        {% endfor %}
     </APIResourceCollection>
     {% endfor %}
     <APIResourceCollection name="apiResources" displayName="API Resources" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:apiResources"/>
             </Feature>
@@ -77,9 +79,28 @@
                 <Scope name="internal_api_resource_delete"/>
             </Delete>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:apiResources"/>
+                <Scope name="console:apiResources_view" action="view"/>
+                <Scope name="console:apiResources_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_api_resource_update"/>
+            </Update>
+            <Create>
+                <Scope name="internal_api_resource_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_api_resource_view"/>
+            </Read>
+            <Delete>
+                <Scope name="internal_api_resource_delete"/>
+            </Delete>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="applications" displayName="Applications" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:applications"/>
             </Feature>
@@ -114,9 +135,46 @@
                 <Scope name="internal_secret_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:applications"/>
+                <Scope name="console:applications_view" action="view"/>
+                <Scope name="console:applications_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_application_mgt_update"/>
+                <Scope name="internal_secret_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_application_mgt_delete"/>
+                <Scope name="internal_shared_application_delete"/>
+                <Scope name="internal_secret_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_application_mgt_create"/>
+                <Scope name="internal_shared_application_create"/>
+                <Scope name="internal_secret_mgt_add"/>
+            </Create>
+            <Read>
+                <Scope name="internal_cors_origins_view"/>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_oidc_scope_mgt_view"/>
+                <Scope name="internal_organization_view"/>
+                <Scope name="internal_api_resource_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_shared_application_view"/>
+                <Scope name="internal_secret_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="branding" displayName="Branding" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:branding"/>
             </Feature>
@@ -133,9 +191,28 @@
                 <Scope name="internal_application_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:branding"/>
+                <Scope name="console:branding_view" action="view"/>
+                <Scope name="console:branding_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_branding_preference_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_branding_preference_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_branding_preference_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_application_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="approvals" displayName="Approvals" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:workflowApprovals"/>
             </Feature>
@@ -152,9 +229,28 @@
                 <Scope name="internal_humantask_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:workflowApprovals"/>
+                <Scope name="console:workflowApprovals_view" action="view"/>
+                <Scope name="console:workflowApprovals_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_humantask_view"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_humantask_view"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_humantask_view"/>
+            </Create>
+            <Read>
+                <Scope name="internal_humantask_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="attributeDialects" displayName="Attribute Dialects" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:attributes"/>
             </Feature>
@@ -174,9 +270,31 @@
                 <Scope name="internal_claim_meta_delete"/>
             </Delete>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:attributes"/>
+                <Scope name="console:attributes_view" action="view"/>
+                <Scope name="console:attributes_edit" action="edit"/>
+            </Feature>
+            <Create>
+                <Scope name="internal_claim_meta_create"/>
+            </Create>
+            <Update>
+                <Scope name="internal_claim_meta_update"/>
+                <Scope name="internal_governance_update"/>
+            </Update>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_claim_meta_view"/>
+                <Scope name="internal_governance_view"/>
+            </Read>
+            <Delete>
+                <Scope name="internal_claim_meta_delete"/>
+            </Delete>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="certificates" displayName="Certificates" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:certificates"/>
             </Feature>
@@ -193,9 +311,28 @@
                 <Scope name="internal_keystore_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:certificates"/>
+                <Scope name="console:certificates_view" action="view"/>
+                <Scope name="console:certificates_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_keystore_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_keystore_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_keystore_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_keystore_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="consoleSettings" displayName="Console Settings" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:settings"/>
             </Feature>
@@ -220,9 +357,36 @@
                 <Scope name="internal_governance_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:settings"/>
+                <Scope name="console:settings_view" action="view"/>
+                <Scope name="console:settings_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_application_mgt_update"/>
+                <Scope name="internal_user_mgt_update"/>
+            </Update>
+            <Delete>
+            </Delete>
+            <Create>
+                <Scope name="internal_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_session_view"/>
+                <Scope name="internal_governance_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="emailTemplates" displayName="Email Templates" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:emailTemplates"/>
             </Feature>
@@ -239,9 +403,28 @@
                 <Scope name="internal_email_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:emailTemplates"/>
+                <Scope name="console:emailTemplates_view" action="view"/>
+                <Scope name="console:emailTemplates_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_email_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_email_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_email_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_email_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="smsTemplates" displayName="SMS Templates" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:smsTemplates"/>
             </Feature>
@@ -258,9 +441,28 @@
                 <Scope name="internal_template_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:smsTemplates"/>
+                <Scope name="console:smsTemplates_view" action="view"/>
+                <Scope name="console:smsTemplates_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_template_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_template_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_template_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_template_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="groups" displayName="Groups" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:groups"/>
             </Feature>
@@ -281,9 +483,32 @@
                 <Scope name="internal_userstore_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:groups"/>
+                <Scope name="console:groups_view" action="view"/>
+                <Scope name="console:groups_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_group_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_group_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="gettingStarted" displayName="Home Page" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:home"/>
             </Feature>
@@ -301,9 +526,29 @@
                 <Scope name="internal_application_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:home"/>
+                <Scope name="console:home_view" action="view"/>
+                <Scope name="console:home_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_application_mgt_update"/>
+            </Update>
+            <Delete/>
+            <Create>
+                <Scope name="internal_application_mgt_create"/>
+                <Scope name="internal_idp_create"/>
+                <Scope name="internal_user_mgt_create"/>
+                <Scope name="internal_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_application_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="connections" displayName="Connections" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:idps"/>
             </Feature>
@@ -328,9 +573,36 @@
                 <Scope name="internal_config_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:idps"/>
+                <Scope name="console:idps_view" action="view"/>
+                <Scope name="console:idps_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_idp_update"/>
+                <Scope name="internal_governance_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_idp_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_idp_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
+                <Scope name="internal_authenticator_view"/>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_extensions_view"/>
+                <Scope name="internal_config_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="identityVerificationProviders" displayName="Identity Verification Providers" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:idvps"/>
             </Feature>
@@ -347,9 +619,28 @@
                 <Scope name="internal_idvp_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:idvps"/>
+                <Scope name="console:idvps_view" action="view"/>
+                <Scope name="console:idvps_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_idvp_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_idvp_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_idvp_add"/>
+            </Create>
+            <Read>
+                <Scope name="internal_idvp_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="loginAndRegistration" displayName="Login And Registration" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:loginAndRegistration"/>
             </Feature>
@@ -366,9 +657,28 @@
                 <Scope name="internal_group_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:loginAndRegistration"/>
+                <Scope name="console:loginAndRegistration_view" action="view"/>
+                <Scope name="console:loginAndRegistration_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_governance_update"/>
+            </Update>
+            <Delete/>
+            <Create/>
+            <Read>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_validation_rule_mgt_update"/>
+                <Scope name="internal_config_update"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_group_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="notificationChannels" displayName="Notification Channels" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:notificationChannels"/>
             </Feature>
@@ -385,9 +695,28 @@
                 <Scope name="internal_notification_senders_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:notificationChannels"/>
+                <Scope name="console:notificationChannels_view" action="view"/>
+                <Scope name="console:notificationChannels_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_notification_senders_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_notification_senders_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_notification_senders_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_notification_senders_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="oidcScopes" displayName="OIDC Scopes" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:scopes:oidc"/>
             </Feature>
@@ -405,9 +734,29 @@
                 <Scope name="internal_claim_meta_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:scopes:oidc"/>
+                <Scope name="console:scopes:oidc_view" action="view"/>
+                <Scope name="console:scopes:oidc_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_oidc_scope_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_oidc_scope_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_oidc_scope_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_oidc_scope_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="organizations" displayName="Organizations" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:organizations"/>
             </Feature>
@@ -426,9 +775,30 @@
                 <Scope name="internal_organization_config_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:organizations"/>
+                <Scope name="console:organizations_view" action="view"/>
+                <Scope name="console:organizations_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_organization_update"/>
+                <Scope name="internal_organization_config_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_organization_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_organization_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_organization_view"/>
+                <Scope name="internal_organization_config_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="organizationDiscovery" displayName="Organization Discovery" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:organizationDiscovery"/>
             </Feature>
@@ -448,9 +818,31 @@
                 <Scope name="internal_organization_config_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:organizationDiscovery"/>
+                <Scope name="console:organizationDiscovery_view" action="view"/>
+                <Scope name="console:organizationDiscovery_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_organization_discovery_update"/>
+                <Scope name="internal_organization_config_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_organization_discovery_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_organization_discovery_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_organization_discovery_view"/>
+                <Scope name="internal_organization_view"/>
+                <Scope name="internal_organization_config_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="residentOutboundProvisioning" displayName="Resident Application Outbound Provisioning" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:residentOutboundProvisioning"/>
             </Feature>
@@ -468,9 +860,29 @@
                 <Scope name="internal_application_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:residentOutboundProvisioning"/>
+                <Scope name="console:residentOutboundProvisioning_view" action="view"/>
+                <Scope name="console:residentOutboundProvisioning_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_application_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_application_mgt_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_application_mgt_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_application_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="roles" displayName="Roles" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:roles"/>
             </Feature>
@@ -494,9 +906,35 @@
                 <Scope name="internal_api_resource_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:roles"/>
+                <Scope name="console:roles_view" action="view"/>
+                <Scope name="console:roles_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_role_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_role_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_idp_view"/>
+                <Scope name="internal_api_resource_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="rolesV1" displayName="Roles" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:roles"/>
             </Feature>
@@ -518,9 +956,33 @@
                 <Scope name="internal_user_mgt_list"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:roles"/>
+                <Scope name="console:roles_view" action="view"/>
+                <Scope name="console:roles_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_role_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_role_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_permission_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="users" displayName="Users" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:users"/>
             </Feature>
@@ -549,9 +1011,40 @@
                 <Scope name="internal_claim_meta_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:users"/>
+                <Scope name="console:users_view" action="view"/>
+                <Scope name="console:users_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_user_mgt_update"/>
+                <Scope name="internal_session_delete"/>
+                <Scope name="internal_group_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_user_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_user_mgt_create"/>
+                <Scope name="internal_bulk_resource_create"/>
+                <Scope name="internal_offline_invite"/>
+            </Create>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_login"/>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_session_view"/>
+                <Scope name="internal_claim_meta_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="userStores" displayName="User Stores" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:userstores"/>
             </Feature>
@@ -568,9 +1061,28 @@
                 <Scope name="internal_userstore_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:userstores"/>
+                <Scope name="console:userstores_view" action="view"/>
+                <Scope name="console:userstores_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_userstore_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_userstore_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_userstore_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="actions" displayName="Actions" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:actions"/>
             </Feature>
@@ -590,11 +1102,52 @@
                 <Scope name="internal_claim_meta_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:actions"/>
+                <Scope name="console:actions_view" action="view"/>
+                <Scope name="console:actions_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_action_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_action_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_action_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_action_mgt_view"/>
+                <Scope name="internal_rule_metadata_view"/>
+                <Scope name="internal_application_mgt_view"/>
+                <Scope name="internal_claim_meta_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="tenants" displayName="Root Organizations" type="tenant">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:tenants"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_modify_tenants"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_modify_tenants"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_create_tenants"/>
+            </Create>
+            <Read>
+                <Scope name="internal_list_tenants"/>
+            </Read>
+        </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:tenants"/>
+                <Scope name="console:tenants_view" action="view"/>
+                <Scope name="console:tenants_edit" action="edit"/>
             </Feature>
             <Update>
                 <Scope name="internal_modify_tenants"/>
@@ -612,7 +1165,7 @@
     </APIResourceCollection>
 <!--    Organization API Resource Collections-->
     <APIResourceCollection name="org_consoleSettings" displayName="Console Settings" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:settings"/>
             </Feature>
@@ -639,9 +1192,38 @@
                 <Scope name="internal_org_governance_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:settings"/>
+                <Scope name="console:org:settings_view" action="view"/>
+                <Scope name="console:org:settings_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_application_mgt_update"/>
+                <Scope name="internal_org_user_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_guest_mgt_invite_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_guest_mgt_invite_list"/>
+                <Scope name="internal_org_idp_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_session_view"/>
+                <Scope name="internal_org_governance_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_connections" displayName="Connections" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:idps"/>
             </Feature>
@@ -665,9 +1247,35 @@
                 <Scope name="internal_org_config_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:idps"/>
+                <Scope name="console:org:idps_view" action="view"/>
+                <Scope name="console:org:idps_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_idp_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_idp_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_idp_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_idp_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_authenticator_view"/>
+                <Scope name="internal_org_governance_view"/>
+                <Scope name="internal_org_extensions_view"/>
+                <Scope name="internal_org_config_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_users" displayName="Users" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:users"/>
             </Feature>
@@ -696,9 +1304,40 @@
                 <Scope name="internal_org_guest_mgt_invite_list"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:users"/>
+                <Scope name="console:org:users_view" action="view"/>
+                <Scope name="console:org:users_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_user_mgt_update"/>
+                <Scope name="internal_org_session_delete"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_user_mgt_delete"/>
+                <Scope name="internal_org_guest_mgt_invite_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_user_mgt_create"/>
+                <Scope name="internal_org_guest_mgt_invite_add"/>
+                <Scope name="internal_org_bulk_resource_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_governance_view"/>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_session_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_guest_mgt_invite_list"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_organizations" displayName="Organizations" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:organizations"/>
             </Feature>
@@ -718,9 +1357,31 @@
                 <Scope name="internal_org_config_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:organizations"/>
+                <Scope name="console:org:organizations_view" action="view"/>
+                <Scope name="console:org:organizations_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_organization_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_organization_delete"/>
+                <Scope name="internal_org_config_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_organization_create"/>
+                <Scope name="internal_org_config_mgt_add"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_organization_view"/>
+                <Scope name="internal_org_config_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_groups" displayName="Groups" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:groups"/>
             </Feature>
@@ -741,9 +1402,32 @@
                 <Scope name="internal_org_userstore_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:groups"/>
+                <Scope name="console:org:groups_view" action="view"/>
+                <Scope name="console:org:groups_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_group_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_group_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_roles" displayName="Roles" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:roles"/>
             </Feature>
@@ -766,9 +1450,34 @@
                 <Scope name="internal_org_idp_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:roles"/>
+                <Scope name="console:org:roles_view" action="view"/>
+                <Scope name="console:org:roles_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_role_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_role_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_application_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_idp_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_rolesV1" displayName="Roles" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:roles"/>
             </Feature>
@@ -788,9 +1497,31 @@
                 <Scope name="internal_org_user_mgt_list"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:roles"/>
+                <Scope name="console:org:roles_view" action="view"/>
+                <Scope name="console:org:roles_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_role_mgt_update"/>
+            </Update>
+            <Delete/>
+            <Create>
+                <Scope name="internal_org_role_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_permission_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_applications" displayName="Applications" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:applications"/>
             </Feature>
@@ -811,9 +1542,32 @@
                 <Scope name="internal_org_idp_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:applications"/>
+                <Scope name="console:org:applications_view" action="view"/>
+                <Scope name="console:org:applications_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_application_mgt_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_application_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_application_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_idp_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_branding" displayName="Branding" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:branding"/>
             </Feature>
@@ -830,9 +1584,28 @@
                 <Scope name="internal_org_application_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:branding"/>
+                <Scope name="console:org:branding_view" action="view"/>
+                <Scope name="console:org:branding_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_branding_preference_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_branding_preference_update"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_branding_preference_update"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_emailTemplates" displayName="Email Templates" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:emailTemplates"/>
             </Feature>
@@ -846,9 +1619,25 @@
                 <Scope name="internal_org_email_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:emailTemplates"/>
+                <Scope name="console:org:emailTemplates_view" action="view"/>
+                <Scope name="console:org:emailTemplates_edit" action="edit"/>
+            </Feature>
+            <Update>
+            </Update>
+            <Delete>
+            </Delete>
+            <Create>
+            </Create>
+            <Read>
+                <Scope name="internal_org_email_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_smsTemplates" displayName="SMS Templates" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:smsTemplates"/>
             </Feature>
@@ -862,9 +1651,25 @@
                 <Scope name="internal_org_template_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:smsTemplates"/>
+                <Scope name="console:org:smsTemplates_view" action="view"/>
+                <Scope name="console:org:smsTemplates_edit" action="edit"/>
+            </Feature>
+            <Update>
+            </Update>
+            <Delete>
+            </Delete>
+            <Create>
+            </Create>
+            <Read>
+                <Scope name="internal_org_template_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_gettingStarted" displayName="Home Page" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:home"/>
             </Feature>
@@ -882,9 +1687,29 @@
                 <Scope name="internal_org_application_mgt_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:home"/>
+                <Scope name="console:org:home_view" action="view"/>
+                <Scope name="console:org:home_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_application_mgt_update"/>
+            </Update>
+            <Delete/>
+            <Create>
+                <Scope name="internal_org_application_mgt_create"/>
+                <Scope name="internal_org_idp_create"/>
+                <Scope name="internal_org_user_mgt_create"/>
+                <Scope name="internal_org_group_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_application_mgt_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_apiResources" displayName="API Resources" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:apiResources"/>
             </Feature>
@@ -892,9 +1717,19 @@
                 <Scope name="internal_org_api_resource_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:apiResources"/>
+                <Scope name="console:org:apiResources_view" action="view"/>
+                <Scope name="console:org:apiResources_edit" action="edit"/>
+            </Feature>
+            <Read>
+                <Scope name="internal_org_api_resource_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_userStores" displayName="User Stores" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:userstores"/>
             </Feature>
@@ -911,11 +1746,48 @@
                 <Scope name="internal_org_userstore_view"/>
             </Read>
         </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:userstores"/>
+                <Scope name="console:org:userstores_view" action="view"/>
+                <Scope name="console:org:userstores_edit" action="edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_userstore_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_userstore_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_userstore_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+            </Read>
+        </Scopes>
     </APIResourceCollection>
     <APIResourceCollection name="org_attributeDialects" displayName="Attribute Dialects" type="organization">
-        <Scopes>
+       <Scopes>
             <Feature>
                 <Scope name="console:org:attributes"/>
+            </Feature>
+            <Create>
+            </Create>
+            <Update>
+                <Scope name="internal_org_claim_meta_update"/>
+            </Update>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+            </Read>
+            <Delete>
+            </Delete>
+        </Scopes>
+        <Scopes version="v1">
+            <Feature>
+                <Scope name="console:org:attributes"/>
+                <Scope name="console:org:attributes_view" action="view"/>
+                <Scope name="console:org:attributes_edit" action="edit"/>
             </Feature>
             <Create>
             </Create>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -924,6 +924,10 @@
         <Scopes>
             <Scope displayName="Application Feature" name="console:applications" 
                     description="Manage applications from the Console"/>
+            <Scope displayName="Application View Feature" name="console:applications_view"
+                   description="Manage views of applications from the Console"/>
+            <Scope displayName="Application Edit Feature" name="console:applications_edit"
+                   description="Manage edits of applications from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Application Management Feature" identifier="console:org:applications"
@@ -933,6 +937,10 @@
         <Scopes>
             <Scope displayName="Application Feature" name="console:org:applications"
                    description="Manage applications in the organization from the Console"/>
+            <Scope displayName="Application View Feature" name="console:org:applications_view"
+                   description="Manage views of applications in the organization from the Console"/>
+            <Scope displayName="Application Edit Feature" name="console:org:applications_edit"
+                   description="Manage edits of applications in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Branding Management Feature" identifier="console:branding"
@@ -942,6 +950,10 @@
         <Scopes>
             <Scope displayName="Branding Feature" name="console:branding"
                     description="Manage branding from the Console"/>
+            <Scope displayName="Branding View Feature" name="console:branding_view"
+                   description="Manage views of branding from the Console"/>
+            <Scope displayName="Branding Edit Feature" name="console:branding_edit"
+                   description="Manage edits of branding from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Branding Management Feature" identifier="console:org:branding"
@@ -951,6 +963,10 @@
         <Scopes>
             <Scope displayName="Branding Feature" name="console:org:branding"
                    description="Manage branding in the organization from the Console"/>
+            <Scope displayName="Branding View Feature" name="console:org:branding_view"
+                   description="Manage views of branding in the organization from the Console"/>
+            <Scope displayName="Branding Edit Feature" name="console:org:branding_edit"
+                   description="Manage edits of branding in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Attribute Management Feature" identifier="console:attributes"
@@ -960,6 +976,10 @@
         <Scopes>
             <Scope displayName="Attribute Feature" name="console:attributes" 
                     description="Manage user attributes from the Console"/>
+            <Scope displayName="Attribute View Feature" name="console:attributes_view"
+                   description="Manage views of user attributes from the Console"/>
+            <Scope displayName="Attribute Edit Feature" name="console:attributes_edit"
+                   description="Manage edits of user attributes from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Attribute Management Feature" identifier="console:org:attributes"
@@ -969,6 +989,10 @@
         <Scopes>
             <Scope displayName="Attribute Feature" name="console:org:attributes"
                    description="Manage user attributes from the Console"/>
+            <Scope displayName="Attribute View Feature" name="console:org:attributes_view"
+                   description="Manage views of user attributes from the Console"/>
+            <Scope displayName="Attribute Edit Feature" name="console:org:attributes_edit"
+                   description="Manage edits of user attributes from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Store Management Feature" identifier="console:userstores"
@@ -978,6 +1002,10 @@
         <Scopes>
             <Scope displayName="User Store Feature" name="console:userstores" 
                     description="Manage user stores from the Console"/>
+            <Scope displayName="User views of Store View Feature" name="console:userstores_view"
+                   description="Manage user stores from the Console"/>
+            <Scope displayName="User Store Edit Feature" name="console:userstores_edit"
+                   description="Manage edits of user stores from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Store Management Feature" identifier="console:org:userstores"
@@ -987,6 +1015,10 @@
         <Scopes>
             <Scope displayName="User Store Feature" name="console:org:userstores"
                    description="Manage user stores from the Console"/>
+            <Scope displayName="User Store View Feature" name="console:org:userstores_view"
+                   description="Manage views of user stores from the Console"/>
+            <Scope displayName="User Store Edit Feature" name="console:org:userstores_edit"
+                   description="Manage edits of user stores from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Group Management Feature" identifier="console:groups"
@@ -996,6 +1028,10 @@
         <Scopes>
             <Scope displayName="Group Feature" name="console:groups" 
                     description="Manage groups from the Console"/>
+            <Scope displayName="Group View Feature" name="console:groups_view"
+                   description="Manage views of groups from the Console"/>
+            <Scope displayName="Group Edit Feature" name="console:groups_edit"
+                   description="Manage edits of groups from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Group Management Feature" identifier="console:org:groups"
@@ -1005,6 +1041,10 @@
         <Scopes>
             <Scope displayName="Group Feature" name="console:org:groups"
                    description="Manage groups in the organization from the Console"/>
+            <Scope displayName="Group View Feature" name="console:org:groups_view"
+                   description="Manage views of groups in the organization from the Console"/>
+            <Scope displayName="Group Edit Feature" name="console:org:groups_edit"
+                   description="Manage edits of groups in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Identity Provider Management Feature" identifier="console:idps"
@@ -1014,6 +1054,10 @@
         <Scopes>
             <Scope displayName="Identity Provider Feature" name="console:idps" 
                     description="Manage identity providers from the Console"/>
+            <Scope displayName="Identity Provider View Feature" name="console:idps_view"
+                   description="Manage views of identity providers from the Console"/>
+            <Scope displayName="Identity Provider Edit Feature" name="console:idps_edit"
+                   description="Manage edits of identity providers from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Identity Provider Management Feature" identifier="console:org:idps"
@@ -1023,6 +1067,10 @@
         <Scopes>
             <Scope displayName="Identity Provider Feature" name="console:org:idps"
                    description="Manage identity providers in the organization from the Console"/>
+            <Scope displayName="Identity Provider View Feature" name="console:org:idps_view"
+                   description="Manage views of identity providers in the organization from the Console"/>
+            <Scope displayName="Identity Provider Edit Feature" name="console:org:idps_edit"
+                   description="Manage edits of identity providers in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="API Resource Management Feature" identifier="console:apiResources"
@@ -1032,6 +1080,10 @@
         <Scopes>
             <Scope displayName="API Resource Feature" name="console:apiResources" 
                     description="Manage api resources from the Console"/>
+            <Scope displayName="API Resource View Feature" name="console:apiResources_view"
+                   description="Manage views of api resources from the Console"/>
+            <Scope displayName="API Resource Edit Feature" name="console:apiResources_edit"
+                   description="Manage edits of api resources from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="API Resource Management Feature" identifier="console:org:apiResources"
@@ -1041,6 +1093,10 @@
         <Scopes>
             <Scope displayName="API Resource Feature" name="console:org:apiResources"
                    description="Manage api resources in the organization from the Console"/>
+            <Scope displayName="API Resource View Feature" name="console:org:apiResources_view"
+                   description="Manage views of api resources in the organization from the Console"/>
+            <Scope displayName="API Resource Edit Feature" name="console:org:apiResources_edit"
+                   description="Manage edits of api resources in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="OIDC Scope Management Feature" identifier="console:scopes:oidc"
@@ -1050,6 +1106,10 @@
         <Scopes>
             <Scope displayName="OIDC Scope Feature" name="console:scopes:oidc" 
                     description="Manage OIDC scopes from the Console"/>
+            <Scope displayName="OIDC Scope View Feature" name="console:scopes:oidc_view"
+                   description="Manage views of OIDC scopes from the Console"/>
+            <Scope displayName="OIDC Scope Edit Feature" name="console:scopes:oidc_edit"
+                   description="Manage edits of OIDC scopes from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Login And Registration Management Feature" identifier="console:loginAndRegistration"
@@ -1059,6 +1119,10 @@
         <Scopes>
             <Scope displayName="Login And Registration Feature" name="console:loginAndRegistration" 
                     description="Manage login and regisgtration from the Console"/>
+            <Scope displayName="Login And Registration View Feature" name="console:loginAndRegistration_view"
+                   description="Manage views of login and regisgtration from the Console"/>
+            <Scope displayName="Login And Registration Edit Feature" name="console:loginAndRegistration_edit"
+                   description="Manage edits of login and regisgtration from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Organization Management Feature" identifier="console:organizations"
@@ -1068,6 +1132,10 @@
         <Scopes>
             <Scope displayName="Organization Feature" name="console:organizations" 
                     description="Manage organizations from the Console"/>
+            <Scope displayName="Organization View Feature" name="console:organizations_view"
+                   description="Manage views of organizations from the Console"/>
+            <Scope displayName="Organization Edit Feature" name="console:organizations_edit"
+                   description="Manage edits of organizations from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Organization Management Feature" identifier="console:org:organizations"
@@ -1077,6 +1145,10 @@
         <Scopes>
             <Scope displayName="Organization Feature" name="console:org:organizations"
                    description="Manage organizations in the organization from the Console"/>
+            <Scope displayName="Organization View Feature" name="console:org:organizations_view"
+                   description="Manage views of organizations in the organization from the Console"/>
+            <Scope displayName="Organization Edit Feature" name="console:org:organizations_edit"
+                   description="Manage edits of organizations in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Organization Discovery Management Feature" identifier="console:organizationDiscovery"
@@ -1086,6 +1158,10 @@
         <Scopes>
             <Scope displayName="Organization Discovery Feature" name="console:organizationDiscovery" 
                     description="Manage organization discovery from the Console"/>
+            <Scope displayName="Organization Discovery View Feature" name="console:organizationDiscovery_view"
+                   description="Manage views of organization discovery from the Console"/>
+            <Scope displayName="Organization Discovery Edit Feature" name="console:organizationDiscovery_edit"
+                   description="Manage edits of organization discovery from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Resident Application Outbound Provisioning Configuration Feature" identifier="console:residentOutboundProvisioning"
@@ -1095,6 +1171,10 @@
         <Scopes>
             <Scope displayName="Resident Application Outbound Provisioning Feature" name="console:residentOutboundProvisioning" 
                     description="Manage resident application outbound provisioning configuration from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning View Feature" name="console:residentOutboundProvisioning_view"
+                   description="Manage views of resident application outbound provisioning configuration from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning Edit Feature" name="console:residentOutboundProvisioning_edit"
+                   description="Manage edits of resident application outbound provisioning configuration from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Management Feature" identifier="console:roles"
@@ -1104,6 +1184,10 @@
         <Scopes>
             <Scope displayName="Role Feature" name="console:roles"
                     description="Manage roles from the Console"/>
+            <Scope displayName="Role View Feature" name="console:roles_view"
+                   description="Manage views of roles from the Console"/>
+            <Scope displayName="Role Edit Feature" name="console:roles_edit"
+                   description="Manage edits of roles from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Management Feature" identifier="console:org:roles"
@@ -1113,6 +1197,10 @@
         <Scopes>
             <Scope displayName="Role Feature" name="console:org:roles"
                    description="Manage roles in the organization from the Console"/>
+            <Scope displayName="Role View Feature" name="console:org:roles_view"
+                   description="Manage views of roles in the organization from the Console"/>
+            <Scope displayName="Role Edit Feature" name="console:org:roles_edit"
+                   description="Manage edits of roles in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Management Feature" identifier="console:users"
@@ -1122,6 +1210,10 @@
         <Scopes>
             <Scope displayName="User Feature" name="console:users" 
                     description="Manage users from the Console"/>
+            <Scope displayName="User View Feature" name="console:users_view"
+                   description="Manage views of users from the Console"/>
+            <Scope displayName="User Edit Feature" name="console:users_edit"
+                   description="Manage edits of users from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Management Feature" identifier="console:org:users"
@@ -1131,6 +1223,10 @@
         <Scopes>
             <Scope displayName="User Feature" name="console:org:users"
                    description="Manage users in the organization from the Console"/>
+            <Scope displayName="User View Feature" name="console:org:users_view"
+                   description="Manage views of users in the organization from the Console"/>
+            <Scope displayName="User Edit Feature" name="console:org:users_edit"
+                   description="Manage edits of users in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Server Management Feature" identifier="console:server"
@@ -1149,6 +1245,10 @@
         <Scopes>
             <Scope displayName="Workflow Approval Feature" name="console:workflowApprovals" 
                     description="Manage workflow approvals from the Console"/>
+            <Scope displayName="Workflow Approval View Feature" name="console:workflowApprovals_view"
+                   description="Manage views of workflow approvals from the Console"/>
+            <Scope displayName="Workflow Approval Edit Feature" name="console:workflowApprovals_edit"
+                   description="Manage edits of workflow approvals from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Notification Channel Management Feature" identifier="console:notificationChannels"
@@ -1158,6 +1258,10 @@
         <Scopes>
             <Scope displayName="Notification Channel Feature" name="console:notificationChannels" 
                     description="Manage notification channels from the Console"/>
+            <Scope displayName="Notification Channel View Feature" name="console:notificationChannels_view"
+                   description="Manage views of notification channels from the Console"/>
+            <Scope displayName="Notification Channel Edit Feature" name="console:notificationChannels_edit"
+                   description="Manage edits of notification channels from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Identity Verification Provider Management Feature" identifier="console:idvps"
@@ -1167,6 +1271,10 @@
         <Scopes>
             <Scope displayName="Identity Verification Provider Feature" name="console:idvps" 
                     description="Manage identity verfication providers from the Console"/>
+            <Scope displayName="Identity Verification Provider View Feature" name="console:idvps_view"
+                   description="Manage views of identity verfication providers from the Console"/>
+            <Scope displayName="Identity Verification Provider Edit Feature" name="console:idvps_edit"
+                   description="Manage edits of identity verfication providers from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Event Publishing Management Feature" identifier="console:eventPublishing"
@@ -1185,6 +1293,10 @@
         <Scopes>
             <Scope displayName="Email Template Feature" name="console:emailTemplates" 
                     description="Manage email templates from the Console"/>
+            <Scope displayName="Email Template View Feature" name="console:emailTemplates_view"
+                   description="Manage views of email templates from the Console"/>
+            <Scope displayName="Email Template Edit Feature" name="console:emailTemplates_edit"
+                   description="Manage edits of email templates from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Email Template Management Feature" identifier="console:org:emailTemplates"
@@ -1194,6 +1306,10 @@
         <Scopes>
             <Scope displayName="Email Template Feature" name="console:org:emailTemplates"
                    description="Manage email templates in the organization from the Console"/>
+            <Scope displayName="Email Template View Feature" name="console:org:emailTemplates_view"
+                   description="Manage views of email templates in the organization from the Console"/>
+            <Scope displayName="Email Template Edit Feature" name="console:org:emailTemplates_edit"
+                   description="Manage edits of email templates in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="SMS Template Management Feature" identifier="console:smsTemplates"
@@ -1203,6 +1319,10 @@
         <Scopes>
             <Scope displayName="SMS Template Feature" name="console:smsTemplates"
                    description="Manage SMS templates from the Console"/>
+            <Scope displayName="SMS Template View Feature" name="console:smsTemplates_view"
+                   description="Manage views of SMS templates from the Console"/>
+            <Scope displayName="SMS Template Edit Feature" name="console:smsTemplates_edit"
+                   description="Manage edits of SMS templates from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="SMS Template Management Feature" identifier="console:org:smsTemplates"
@@ -1212,6 +1332,10 @@
         <Scopes>
             <Scope displayName="SMS Template Feature" name="console:org:smsTemplates"
                    description="Manage SMS templates in the organization from the Console"/>
+            <Scope displayName="SMS Template View Feature" name="console:org:smsTemplates_view"
+                   description="Manage views of SMS templates in the organization from the Console"/>
+            <Scope displayName="SMS Template Edit Feature" name="console:org:smsTemplates_edit"
+                   description="Manage edits of SMS templates in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Console Setting Management Feature" identifier="console:settings"
@@ -1221,6 +1345,10 @@
         <Scopes>
             <Scope displayName="Console Setting Feature" name="console:settings" 
                     description="Manage console setting from the Console"/>
+            <Scope displayName="Console Setting View Feature" name="console:settings_view"
+                   description="Manage views of console setting from the Console"/>
+            <Scope displayName="Console Setting Edit Feature" name="console:settings_edit"
+                   description="Manage edits of console setting from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Console Setting Management Feature" identifier="console:org:settings"
@@ -1230,6 +1358,10 @@
         <Scopes>
             <Scope displayName="Console Setting Feature" name="console:org:settings"
                    description="Manage console setting in the organization from the Console"/>
+            <Scope displayName="Console Setting View Feature" name="console:org:settings_view"
+                   description="Manage views of console setting in the organization from the Console"/>
+            <Scope displayName="Console Setting Edit Feature" name="console:org:settings_edit"
+                   description="Manage edits of console setting in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Getting Started Feature" identifier="console:home"
@@ -1239,6 +1371,10 @@
         <Scopes>
             <Scope displayName="Getting Started Feature" name="console:home" 
                     description="Manage home settings from the Console"/>
+            <Scope displayName="Getting Started View Feature" name="console:home_view"
+                   description="Manage views of home settings from the Console"/>
+            <Scope displayName="Getting Started Edit Feature" name="console:home_edit"
+                   description="Manage edits of home settings from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Getting Started Feature" identifier="console:org:home"
@@ -1248,6 +1384,10 @@
         <Scopes>
             <Scope displayName="Getting Started Feature" name="console:org:home"
                    description="Manage home settings in the organization from the Console"/>
+            <Scope displayName="Getting Started View Feature" name="console:org:home_view"
+                   description="Manage views of home settings in the organization from the Console"/>
+            <Scope displayName="Getting Started Edit Feature" name="console:org:home_edit"
+                   description="Manage edits of home settings in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Secret Management Feature" identifier="console:secretsManagement"
@@ -1266,6 +1406,10 @@
         <Scopes>
             <Scope displayName="Certificate Feature" name="console:certificates" 
                     description="Manage certificates from the Console"/>
+            <Scope displayName="Certificate View Feature" name="console:certificates_view"
+                   description="Manage views of certificates from the Console"/>
+            <Scope displayName="Certificate Edit Feature" name="console:certificates_edit"
+                   description="Manage edits of certificates from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Action Management Feature" identifier="console:actions"
@@ -1275,6 +1419,10 @@
         <Scopes>
             <Scope displayName="Action Feature" name="console:actions" 
                     description="Manage actions from the Console"/>
+            <Scope displayName="Action View Feature" name="console:actions_view"
+                   description="Manage views of actions from the Console"/>
+            <Scope displayName="Action Edit Feature" name="console:actions_edit"
+                   description="Manage edits of actions from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Tenant Management Feature" identifier="console:tenants"
@@ -1284,6 +1432,10 @@
         <Scopes>
             <Scope displayName="Tenants Feature" name="console:tenants" 
                    description="Manage tenants from the Console"/>
+            <Scope displayName="Tenants View Feature" name="console:tenants_view"
+                   description="Manage views of tenants from the Console"/>
+            <Scope displayName="Tenants Edit Feature" name="console:tenants_edit"
+                   description="Manage edits of tenants from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Offline User Onboard API" identifier="/o/api/users/v1/offline-invite-link/"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -933,6 +933,10 @@
         <Scopes>
             <Scope displayName="Application Feature" name="console:applications" 
                     description="Manage applications from the Console"/>
+            <Scope displayName="Application View Feature" name="console:applications_view"
+                                description="Manage views of applications from the Console"/>
+            <Scope displayName="Application Edit Feature" name="console:applications_edit"
+                                description="Manage edits of applications from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Application Management Feature" identifier="console:org:applications"
@@ -942,6 +946,10 @@
         <Scopes>
             <Scope displayName="Application Feature" name="console:org:applications"
                    description="Manage applications in the organization from the Console"/>
+            <Scope displayName="Application View Feature" name="console:org:applications_view"
+                   description="Manage views of applications in the organization from the Console"/>
+            <Scope displayName="Application Edit Feature" name="console:org:applications_edit"
+                   description="Manage edits of applications in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Branding Management Feature" identifier="console:branding"
@@ -951,6 +959,10 @@
         <Scopes>
             <Scope displayName="Branding Feature" name="console:branding"
                     description="Manage branding from the Console"/>
+            <Scope displayName="Branding View Feature" name="console:branding_view"
+                    description="Manage views of branding from the Console"/>
+            <Scope displayName="Branding Edit Feature" name="console:branding_edit"
+                    description="Manage edits of branding from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Branding Management Feature" identifier="console:org:branding"
@@ -960,6 +972,10 @@
         <Scopes>
             <Scope displayName="Branding Feature" name="console:org:branding"
                    description="Manage branding in the organization from the Console"/>
+            <Scope displayName="Branding View Feature" name="console:org:branding_view"
+                   description="Manage views of branding in the organization from the Console"/>
+            <Scope displayName="Branding Edit Feature" name="console:org:branding_edit"
+                   description="Manage edits of branding in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Attribute Management Feature" identifier="console:attributes"
@@ -969,6 +985,10 @@
         <Scopes>
             <Scope displayName="Attribute Feature" name="console:attributes" 
                     description="Manage user attributes from the Console"/>
+            <Scope displayName="Attribute View Feature" name="console:attributes_view"
+                    description="Manage views of user attributes from the Console"/>
+            <Scope displayName="Attribute Edit Feature" name="console:attributes_edit"
+                    description="Manage edits of user attributes from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Attribute Management Feature" identifier="console:org:attributes"
@@ -978,6 +998,10 @@
            <Scopes>
                <Scope displayName="Attribute Feature" name="console:org:attributes"
                        description="Manage user attributes from the Console"/>
+               <Scope displayName="Attribute View Feature" name="console:org:attributes_view"
+                       description="Manage views of user attributes from the Console"/>
+               <Scope displayName="Attribute Edit Feature" name="console:org:attributes_edit"
+                       description="Manage edits of user attributes from the Console"/>
            </Scopes>
     </APIResource>
     <APIResource name="User Store Management Feature" identifier="console:userstores"
@@ -987,6 +1011,10 @@
         <Scopes>
             <Scope displayName="User Store Feature" name="console:userstores" 
                     description="Manage user stores from the Console"/>
+            <Scope displayName="User views of Store View Feature" name="console:userstores_view"
+                    description="Manage user stores from the Console"/>
+            <Scope displayName="User Store Edit Feature" name="console:userstores_edit"
+                    description="Manage edits of user stores from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Store Management Feature" identifier="console:org:userstores"
@@ -996,6 +1024,10 @@
         <Scopes>
             <Scope displayName="User Store Feature" name="console:org:userstores"
                     description="Manage user stores from the Console"/>
+            <Scope displayName="User Store View Feature" name="console:org:userstores_view"
+                    description="Manage views of user stores from the Console"/>
+            <Scope displayName="User Store Edit Feature" name="console:org:userstores_edit"
+                    description="Manage edits of user stores from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Group Management Feature" identifier="console:groups"
@@ -1005,6 +1037,10 @@
         <Scopes>
             <Scope displayName="Group Feature" name="console:groups" 
                     description="Manage groups from the Console"/>
+            <Scope displayName="Group View Feature" name="console:groups_view"
+                    description="Manage views of groups from the Console"/>
+            <Scope displayName="Group Edit Feature" name="console:groups_edit"
+                    description="Manage edits of groups from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Group Management Feature" identifier="console:org:groups"
@@ -1014,6 +1050,10 @@
         <Scopes>
             <Scope displayName="Group Feature" name="console:org:groups"
                    description="Manage groups in the organization from the Console"/>
+            <Scope displayName="Group View Feature" name="console:org:groups_view"
+                   description="Manage views of groups in the organization from the Console"/>
+            <Scope displayName="Group Edit Feature" name="console:org:groups_edit"
+                   description="Manage edits of groups in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Identity Provider Management Feature" identifier="console:idps"
@@ -1023,6 +1063,10 @@
         <Scopes>
             <Scope displayName="Identity Provider Feature" name="console:idps" 
                     description="Manage identity providers from the Console"/>
+            <Scope displayName="Identity Provider View Feature" name="console:idps_view"
+                    description="Manage views of identity providers from the Console"/>
+            <Scope displayName="Identity Provider Edit Feature" name="console:idps_edit"
+                    description="Manage edits of identity providers from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Identity Provider Management Feature" identifier="console:org:idps"
@@ -1032,6 +1076,10 @@
         <Scopes>
             <Scope displayName="Identity Provider Feature" name="console:org:idps"
                    description="Manage identity providers in the organization from the Console"/>
+            <Scope displayName="Identity Provider View Feature" name="console:org:idps_view"
+                   description="Manage views of identity providers in the organization from the Console"/>
+            <Scope displayName="Identity Provider Edit Feature" name="console:org:idps_edit"
+                   description="Manage edits of identity providers in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="API Resource Management Feature" identifier="console:apiResources"
@@ -1041,6 +1089,10 @@
         <Scopes>
             <Scope displayName="API Resource Feature" name="console:apiResources" 
                     description="Manage api resources from the Console"/>
+            <Scope displayName="API Resource View Feature" name="console:apiResources_view"
+                                description="Manage views of api resources from the Console"/>
+            <Scope displayName="API Resource Edit Feature" name="console:apiResources_edit"
+                                description="Manage edits of api resources from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="API Resource Management Feature" identifier="console:org:apiResources"
@@ -1050,6 +1102,10 @@
         <Scopes>
             <Scope displayName="API Resource Feature" name="console:org:apiResources"
                     description="Manage api resources in the organization from the Console"/>
+            <Scope displayName="API Resource View Feature" name="console:org:apiResources_view"
+                    description="Manage views of api resources in the organization from the Console"/>
+            <Scope displayName="API Resource Edit Feature" name="console:org:apiResources_edit"
+                    description="Manage edits of api resources in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="OIDC Scope Management Feature" identifier="console:scopes:oidc"
@@ -1059,6 +1115,10 @@
         <Scopes>
             <Scope displayName="OIDC Scope Feature" name="console:scopes:oidc" 
                     description="Manage OIDC scopes from the Console"/>
+            <Scope displayName="OIDC Scope View Feature" name="console:scopes:oidc_view"
+                    description="Manage views of OIDC scopes from the Console"/>
+            <Scope displayName="OIDC Scope Edit Feature" name="console:scopes:oidc_edit"
+                    description="Manage edits of OIDC scopes from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Login And Registration Management Feature" identifier="console:loginAndRegistration"
@@ -1068,6 +1128,10 @@
         <Scopes>
             <Scope displayName="Login And Registration Feature" name="console:loginAndRegistration" 
                     description="Manage login and regisgtration from the Console"/>
+            <Scope displayName="Login And Registration View Feature" name="console:loginAndRegistration_view"
+                    description="Manage views of login and regisgtration from the Console"/>
+            <Scope displayName="Login And Registration Edit Feature" name="console:loginAndRegistration_edit"
+                    description="Manage edits of login and regisgtration from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Organization Management Feature" identifier="console:organizations"
@@ -1077,6 +1141,10 @@
         <Scopes>
             <Scope displayName="Organization Feature" name="console:organizations" 
                     description="Manage organizations from the Console"/>
+            <Scope displayName="Organization View Feature" name="console:organizations_view"
+                    description="Manage views of organizations from the Console"/>
+            <Scope displayName="Organization Edit Feature" name="console:organizations_edit"
+                    description="Manage edits of organizations from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Organization Management Feature" identifier="console:org:organizations"
@@ -1086,6 +1154,10 @@
         <Scopes>
             <Scope displayName="Organization Feature" name="console:org:organizations"
                    description="Manage organizations in the organization from the Console"/>
+            <Scope displayName="Organization View Feature" name="console:org:organizations_view"
+                   description="Manage views of organizations in the organization from the Console"/>
+            <Scope displayName="Organization Edit Feature" name="console:org:organizations_edit"
+                   description="Manage edits of organizations in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Organization Discovery Management Feature" identifier="console:organizationDiscovery"
@@ -1095,6 +1167,10 @@
         <Scopes>
             <Scope displayName="Organization Discovery Feature" name="console:organizationDiscovery" 
                     description="Manage organization discovery from the Console"/>
+            <Scope displayName="Organization Discovery View Feature" name="console:organizationDiscovery_view"
+                    description="Manage views of organization discovery from the Console"/>
+            <Scope displayName="Organization Discovery Edit Feature" name="console:organizationDiscovery_edit"
+                    description="Manage edits of organization discovery from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Resident Application Outbound Provisioning Configuration Feature" identifier="console:residentOutboundProvisioning"
@@ -1104,6 +1180,10 @@
         <Scopes>
             <Scope displayName="Resident Application Outbound Provisioning Feature" name="console:residentOutboundProvisioning" 
                     description="Manage resident application outbound provisioning configuration from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning View Feature" name="console:residentOutboundProvisioning_view"
+                    description="Manage views of resident application outbound provisioning configuration from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning Edit Feature" name="console:residentOutboundProvisioning_edit"
+                    description="Manage edits of resident application outbound provisioning configuration from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Management Feature" identifier="console:roles"
@@ -1113,6 +1193,10 @@
         <Scopes>
             <Scope displayName="Role Feature" name="console:roles" 
                     description="Manage roles from the Console"/>
+            <Scope displayName="Role View Feature" name="console:roles_view"
+                    description="Manage views of roles from the Console"/>
+            <Scope displayName="Role Edit Feature" name="console:roles_edit"
+                    description="Manage edits of roles from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Management Feature" identifier="console:org:roles"
@@ -1122,6 +1206,10 @@
         <Scopes>
             <Scope displayName="Role Feature" name="console:org:roles"
                    description="Manage roles in the organization from the Console"/>
+            <Scope displayName="Role View Feature" name="console:org:roles_view"
+                   description="Manage views of roles in the organization from the Console"/>
+            <Scope displayName="Role Edit Feature" name="console:org:roles_edit"
+                   description="Manage edits of roles in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Management Feature" identifier="console:users"
@@ -1131,6 +1219,10 @@
         <Scopes>
             <Scope displayName="User Feature" name="console:users" 
                     description="Manage users from the Console"/>
+            <Scope displayName="User View Feature" name="console:users_view"
+                    description="Manage views of users from the Console"/>
+            <Scope displayName="User Edit Feature" name="console:users_edit"
+                    description="Manage edits of users from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Management Feature" identifier="console:org:users"
@@ -1140,6 +1232,10 @@
         <Scopes>
             <Scope displayName="User Feature" name="console:org:users"
                    description="Manage users in the organization from the Console"/>
+            <Scope displayName="User View Feature" name="console:org:users_view"
+                   description="Manage views of users in the organization from the Console"/>
+            <Scope displayName="User Edit Feature" name="console:org:users_edit"
+                   description="Manage edits of users in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Server Management Feature" identifier="console:server"
@@ -1158,6 +1254,10 @@
         <Scopes>
             <Scope displayName="Workflow Approval Feature" name="console:workflowApprovals" 
                     description="Manage workflow approvals from the Console"/>
+            <Scope displayName="Workflow Approval View Feature" name="console:workflowApprovals_view"
+                    description="Manage views of workflow approvals from the Console"/>
+            <Scope displayName="Workflow Approval Edit Feature" name="console:workflowApprovals_edit"
+                    description="Manage edits of workflow approvals from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Notification Channel Management Feature" identifier="console:notificationChannels"
@@ -1167,6 +1267,10 @@
         <Scopes>
             <Scope displayName="Notification Channel Feature" name="console:notificationChannels" 
                     description="Manage notification channels from the Console"/>
+            <Scope displayName="Notification Channel View Feature" name="console:notificationChannels_view"
+                    description="Manage views of notification channels from the Console"/>
+            <Scope displayName="Notification Channel Edit Feature" name="console:notificationChannels_edit"
+                    description="Manage edits of notification channels from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Identity Verification Provider Management Feature" identifier="console:idvps"
@@ -1176,6 +1280,10 @@
         <Scopes>
             <Scope displayName="Identity Verification Provider Feature" name="console:idvps" 
                     description="Manage identity verfication providers from the Console"/>
+            <Scope displayName="Identity Verification Provider View Feature" name="console:idvps_view"
+                    description="Manage views of identity verfication providers from the Console"/>
+            <Scope displayName="Identity Verification Provider Edit Feature" name="console:idvps_edit"
+                    description="Manage edits of identity verfication providers from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Event Publishing Management Feature" identifier="console:eventPublishing"
@@ -1194,6 +1302,10 @@
         <Scopes>
             <Scope displayName="Email Template Feature" name="console:emailTemplates" 
                     description="Manage email templates from the Console"/>
+            <Scope displayName="Email Template View Feature" name="console:emailTemplates_view"
+                    description="Manage views of email templates from the Console"/>
+            <Scope displayName="Email Template Edit Feature" name="console:emailTemplates_edit"
+                    description="Manage edits of email templates from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Email Template Management Feature" identifier="console:org:emailTemplates"
@@ -1203,6 +1315,10 @@
         <Scopes>
             <Scope displayName="Email Template Feature" name="console:org:emailTemplates"
                    description="Manage email templates in the organization from the Console"/>
+            <Scope displayName="Email Template View Feature" name="console:org:emailTemplates_view"
+                   description="Manage views of email templates in the organization from the Console"/>
+            <Scope displayName="Email Template Edit Feature" name="console:org:emailTemplates_edit"
+                   description="Manage edits of email templates in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="SMS Template Management Feature" identifier="console:smsTemplates"
@@ -1212,6 +1328,10 @@
         <Scopes>
             <Scope displayName="SMS Template Feature" name="console:smsTemplates"
                    description="Manage SMS templates from the Console"/>
+            <Scope displayName="SMS Template View Feature" name="console:smsTemplates_view"
+                   description="Manage views of SMS templates from the Console"/>
+            <Scope displayName="SMS Template Edit Feature" name="console:smsTemplates_edit"
+                   description="Manage edits of SMS templates from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="SMS Template Management Feature" identifier="console:org:smsTemplates"
@@ -1221,6 +1341,10 @@
         <Scopes>
             <Scope displayName="SMS Template Feature" name="console:org:smsTemplates"
                    description="Manage SMS templates in the organization from the Console"/>
+            <Scope displayName="SMS Template View Feature" name="console:org:smsTemplates_view"
+                   description="Manage views of SMS templates in the organization from the Console"/>
+            <Scope displayName="SMS Template Edit Feature" name="console:org:smsTemplates_edit"
+                   description="Manage edits of SMS templates in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Console Setting Management Feature" identifier="console:settings"
@@ -1230,6 +1354,10 @@
         <Scopes>
             <Scope displayName="Console Setting Feature" name="console:settings" 
                     description="Manage console setting from the Console"/>
+            <Scope displayName="Console Setting View Feature" name="console:settings_view"
+                    description="Manage views of console setting from the Console"/>
+            <Scope displayName="Console Setting Edit Feature" name="console:settings_edit"
+                    description="Manage edits of console setting from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Console Setting Management Feature" identifier="console:org:settings"
@@ -1239,6 +1367,10 @@
         <Scopes>
             <Scope displayName="Console Setting Feature" name="console:org:settings"
                    description="Manage console setting in the organization from the Console"/>
+            <Scope displayName="Console Setting View Feature" name="console:org:settings_view"
+                   description="Manage views of console setting in the organization from the Console"/>
+            <Scope displayName="Console Setting Edit Feature" name="console:org:settings_edit"
+                   description="Manage edits of console setting in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Getting Started Feature" identifier="console:home"
@@ -1248,6 +1380,10 @@
         <Scopes>
             <Scope displayName="Getting Started Feature" name="console:home" 
                     description="Manage home settings from the Console"/>
+            <Scope displayName="Getting Started View Feature" name="console:home_view"
+                    description="Manage views of home settings from the Console"/>
+            <Scope displayName="Getting Started Edit Feature" name="console:home_edit"
+                    description="Manage edits of home settings from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Getting Started Feature" identifier="console:org:home"
@@ -1257,6 +1393,10 @@
         <Scopes>
             <Scope displayName="Getting Started Feature" name="console:org:home"
                    description="Manage home settings in the organization from the Console"/>
+            <Scope displayName="Getting Started View Feature" name="console:org:home_view"
+                   description="Manage views of home settings in the organization from the Console"/>
+            <Scope displayName="Getting Started Edit Feature" name="console:org:home_edit"
+                   description="Manage edits of home settings in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Secret Management Feature" identifier="console:secretsManagement"
@@ -1275,6 +1415,10 @@
         <Scopes>
             <Scope displayName="Certificate Feature" name="console:certificates" 
                     description="Manage certificates from the Console"/>
+            <Scope displayName="Certificate View Feature" name="console:certificates_view"
+                    description="Manage views of certificates from the Console"/>
+            <Scope displayName="Certificate Edit Feature" name="console:certificates_edit"
+                    description="Manage edits of certificates from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Action Management Feature" identifier="console:actions"
@@ -1284,6 +1428,10 @@
         <Scopes>
             <Scope displayName="Action Feature" name="console:actions" 
                     description="Manage actions from the Console"/>
+            <Scope displayName="Action View Feature" name="console:actions_view"
+                    description="Manage views of actions from the Console"/>
+            <Scope displayName="Action Edit Feature" name="console:actions_edit"
+                    description="Manage edits of actions from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Tenant Management Feature" identifier="console:tenants"
@@ -1293,6 +1441,10 @@
         <Scopes>
             <Scope displayName="Tenants Feature" name="console:tenants" 
                    description="Manage tenants from the Console"/>
+            <Scope displayName="Tenants View Feature" name="console:tenants_view"
+                   description="Manage views of tenants from the Console"/>
+            <Scope displayName="Tenants Edit Feature" name="console:tenants_edit"
+                   description="Manage edits of tenants from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Offline User Onboard API" identifier="/o/api/users/v1/offline-invite-link/"


### PR DESCRIPTION
### Proposed changes in this pull request
Previously, newly added scopes to the API resource collection did not reflect in existing console roles. In this PR, we have introduced a way to support this. Specifically, we have introduced a new collection version and set previous collection as  v0, which includes two feature scopes used for collection viewing and editing. We should set those scopes with `console:` prefix and _view or _edit suffix. Going forward, we will only use these feature scopes when granting permissions to console roles. Previous collections should be versioned as v0.

```
# API Resource collection for Diagnostic Logs
[[api_resource_collections]]
name = "diagnosticLogs"
displayName = "Diagnostic Logs"
type = "tenant"
version="v0"

[[api_resource_collections.scopes.feature]]
name="console:diagnosticLogs"

[[api_resource_collections.scopes.read]]
name="internal_application_mgt_view"


# Newly Added API Resource collection for Diagnostic Logs
[[api_resource_collections]]
name = "diagnosticLogs"
displayName = "Diagnostic Logs"
type = "tenant"

[[api_resource_collections.scopes.feature]]
name="console:diagnosticLogs"

# New view feature scope
[[api_resource_collections.scopes.feature]]
name="console:diagnosticLogs_view"

# New edit feature scope
[[api_resource_collections.scopes.feature]]
name="console:diagnosticLogs_edit"

[[api_resource_collections.scopes.read]]
name="internal_application_mgt_view"
```

### Related Issues
- https://github.com/wso2/product-is/issues/22071