### PR TITLE
Add OrganizationUserSharingHandler for post orgaization creation event.

### DIFF
--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -286,5 +286,9 @@
   "identity_mgt.events.schemes.SharingPolicyCleanUpHandler.subscriptions": [
     "POST_DELETE_ROLE_V2_EVENT",
     "POST_DELETE_USER_WITH_ID"
+  ],
+  "identity_mgt.events.schemes.OrganizationUserSharingHandler.module_index": "45",
+  "identity_mgt.events.schemes.OrganizationUserSharingHandler.subscriptions": [
+    "POST_ADD_ORGANIZATION"
   ]
 }


### PR DESCRIPTION
Reverts wso2/carbon-identity-framework#6384

**Note**:  Should run the integration tests and merge after the following prs are merged
- https://github.com/wso2-extensions/identity-organization-management/pull/438
- https://github.com/wso2/product-is/pull/22518