### PR TITLE
Handle HTTP HEAD requests by setting response status to 200 OK

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/servlet/CommonAuthenticationServlet.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/servlet/CommonAuthenticationServlet.java
@@ -55,6 +55,11 @@ public class CommonAuthenticationServlet extends HttpServlet {
     }
 
     @Override
+    protected void doHead(HttpServletRequest request, HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+
+    @Override
     protected void doOptions(HttpServletRequest req, HttpServletResponse resp)
             throws ServletException, IOException {
         resp.setHeader("Allow", "GET, POST, HEAD, OPTIONS");

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/servlet/CommonAuthenticationServletTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/servlet/CommonAuthenticationServletTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.servlet;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.event.IdentityEventConfigBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link CommonAuthenticationServlet}.
+ */
+public class CommonAuthenticationServletTest {
+
+    /**
+     * Sets up the test environment by configuring the carbon home system property
+     * and initializing the {@link CommonAuthenticationServlet} instance.
+     */
+    @BeforeMethod
+    public void setUp() {
+        configureCarbonHome();
+    }
+
+    /**
+     * Tests the {@code doHead} method to ensure it sets the HTTP status to 200 (OK).
+     */
+    @Test
+    public void testDoHead() {
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getMethod()).thenReturn("HEAD");
+        HttpServletResponse spyResponse = spy(HttpServletResponse.class);
+        CommonAuthenticationServlet servlet = new CommonAuthenticationServlet();
+        servlet.doHead(mockRequest, spyResponse);
+        verify(spyResponse, times(1)).setStatus(HttpServletResponse.SC_OK);
+    }
+
+    /**
+     * Configures the carbon home system property for the test environment.
+     */
+    private void configureCarbonHome() {
+        String carbonHome = IdentityEventConfigBuilder.class.getResource("/").getFile();
+        System.setProperty("carbon.home", carbonHome);
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/testng.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/testng.xml
@@ -47,6 +47,8 @@
             <class name="org.wso2.carbon.identity.application.authentication.framework.services.PostAuthenticationMgtServiceTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.services.ConditionalAuthenticationMgtServiceTest"/>
 
+            <class name="org.wso2.carbon.identity.application.authentication.framework.servlet.CommonAuthenticationServletTest"/>
+
             <class name="org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacadeTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.config.loader.UIBasedConfigurationLoaderTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilderTest"/>


### PR DESCRIPTION
# Root Cause
The issue arises when a user with a Microsoft Outlook email address, having "Office 365 Advanced Threat Protection" enabled, logs in using a magic link. After receiving the magic link email and clicking the sign-in button, they encounter an error.

# Related Issues
- https://github.com/wso2/product-is/issues/22393

## Previous Behavior
This issue is caused by the SafeLink protection in Outlook/Office 365, which sends a HEAD request to the original link before redirecting to the browser. WSO2 IS processes the login flow in response to the HEAD request, completing the account login process prematurely. As a result, the magic link becomes invalid, and the user sees an error message when trying to sign in.

https://github.com/user-attachments/assets/daa4e53d-e6ef-4634-a52b-64d1f4d81f9a

# Changes in this Pull Request
This PR introduces a method override to handle HTTP HEAD requests in the `CommonAuthenticationServlet` class. The server will now respond with a status code of 200 OK to HEAD requests, allowing clients to check resource availability without fetching the full content.

## Current Behavior
With the new handling of HTTP HEAD requests, when a user clicks the magic link in the email, the server will respond with a 200 OK status for the HEAD request before redirecting the user to the sign-in page. This prevents premature completion of the login flow, ensuring that the magic link remains valid and the user can successfully sign in without encountering the error.

https://github.com/user-attachments/assets/243469d1-cf78-49ed-b27c-a383c0ed9f1c

