### PR TITLE
Add new config to define default scopes

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1258,6 +1258,15 @@
         </AllowedScopes>
         {% endif %}
 
+        % if oauth.default_requested_scopes is defined %}
+        <!-- Configuration to pass a list of default requested scopes. -->
+        <DefaultRequestedScopes>
+            {%for scope in oauth.default_requested_scopes%}
+            <Scope>{{scope}}</Scope>
+            {% endfor %}
+        </DefaultRequestedScopes>
+        {% endif %}
+
         {% if oauth.drop_unregistered_scopes is defined %}
         <!--
         By enabling this config, any unregistered scopes(excluding internal scopes and allowed scopes)


### PR DESCRIPTION
### Purpose

With this PR, we introduced the below config to add default scopes.   

```
[oauth]
default_requested_scopes = ["default", "scope1"]
```
Here we use those config values to resolve scope validation failure with custom scope validators.

### Related Issue
https://github.com/wso2/product-is/issues/22234