### PR TITLE
Fix authentication flow with custom authentication extension.

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/UserDefinedFederatedAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/UserDefinedFederatedAuthenticatorConfig.java
@@ -27,7 +27,7 @@ import static org.wso2.carbon.identity.base.AuthenticatorPropertyConstants.TAG_C
  */
 public class UserDefinedFederatedAuthenticatorConfig extends FederatedAuthenticatorConfig {
 
-    private UserDefinedAuthenticatorEndpointConfig endpointConfig;
+    private transient UserDefinedAuthenticatorEndpointConfig endpointConfig;
 
     public UserDefinedFederatedAuthenticatorConfig() {
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -663,6 +663,7 @@ public class DefaultStepHandler implements StepHandler {
         boolean isNoneCanHandle = true;
         StepConfig stepConfig = sequenceConfig.getStepMap().get(currentStep);
 
+        handleAuthenticatorResolvingForBasicAuthMechanism(context, stepConfig);
         for (AuthenticatorConfig authenticatorConfig : stepConfig.getAuthenticatorList()) {
             ApplicationAuthenticator authenticator = authenticatorConfig
                     .getApplicationAuthenticator();
@@ -694,6 +695,26 @@ public class DefaultStepHandler implements StepHandler {
         }
         if (isNoneCanHandle) {
             throw new FrameworkException("No authenticator can handle the request in step :  " + currentStep);
+        }
+    }
+
+    private void handleAuthenticatorResolvingForBasicAuthMechanism(AuthenticationContext context, StepConfig stepConfig) {
+
+        /* When an authenticator with the basic authentication mechanism (such as basic or identifierFirst) is engaged
+        in the authentication flow, the handleRequest method for that authenticator is automatically triggered at the
+        start, setting setCurrentAuthenticator to the corresponding authenticator. However, when the user provides
+        credentials, the handleResponse method is initiated, and from the method handle(HttpServletRequest,
+        HttpServletResponse) in the DefaultRequestCoordinator class setCurrentAuthenticator is reset to null.
+        As a result, when selecting the appropriate authenticator, the system iterates through the list of
+        authenticators in the step and checks if currentAuthenticator is null. This causes the first authenticator in
+        the step to always be selected. To address this, if currentAuthenticator is null and an authenticator with the
+        basic authentication mechanism is present, we set the corresponding authenticator as the current authenticator.
+         */
+        for (AuthenticatorConfig authenticatorConfig : stepConfig.getAuthenticatorList()) {
+            if (context.getCurrentAuthenticator() == null &&
+                    BASIC_AUTH_MECHANISM.equals(authenticatorConfig.getApplicationAuthenticator().getAuthMechanism())) {
+                context.setCurrentAuthenticator(authenticatorConfig.getName());
+            }
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -698,7 +698,8 @@ public class DefaultStepHandler implements StepHandler {
         }
     }
 
-    private void handleAuthenticatorResolvingForBasicAuthMechanism(AuthenticationContext context, StepConfig stepConfig) {
+    private void handleAuthenticatorResolvingForBasicAuthMechanism(
+            AuthenticationContext context, StepConfig stepConfig) {
 
         /* When an authenticator with the basic authentication mechanism (such as basic or identifierFirst) is engaged
         in the authentication flow, the handleRequest method for that authenticator is automatically triggered at the


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/22715

Fix following issue:
1. When the basic authenticator is engaged in the authentication flow, the handleRequest method for the basic authenticator is automatically triggered at the start, setting setCurrentAuthenticator to the basic authenticator. However, when the user provides a username and password, the handleResponse method is initiated, and at line [1], setCurrentAuthenticator is reset to null. Consequently, when selecting the appropriate authenticator, the system iterates through the list of authenticators in the step and checks if currentAuthenticator is null. As a result, the first authenticator in the step always gets selected.
2. As the UserDefinedAuthenticatorEndpointConfig is not extended Serializable, when trying load the authenticator config from the context cache, there is an error ocurred. This UserDefinedAuthenticatorEndpointConfig does not required in the authentication flow, therefore skip adding that attribute of the localAuthenticator to cache.  

[1].
https://github.com/wso2/carbon-identity-framework/blob/5938f4d060ca17fcfecf53346ad0b2556bb52b0b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java#L350
[2].
https://github.com/wso2/carbon-identity-framework/blob/5938f4d060ca17fcfecf53346ad0b2556bb52b0b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java#L672