### PR TITLE
Support ruleMeta api for preUpdatePassword flow

### DIFF
--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/main/java/org/wso2/carbon/identity/rule/metadata/config/FieldDefinitionConfig.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/main/java/org/wso2/carbon/identity/rule/metadata/config/FieldDefinitionConfig.java
@@ -93,6 +93,8 @@ public class FieldDefinitionConfig {
         for (String operatorName : operatorNames) {
             if (operatorConfig.getOperatorsMap().containsKey(operatorName)) {
                 operators.add(operatorConfig.getOperatorsMap().get(operatorName));
+            } else {
+                throw new IllegalArgumentException("Invalid operator: " + operatorName + " provided");
             }
         }
         return operators;

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/main/java/org/wso2/carbon/identity/rule/metadata/model/Field.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/main/java/org/wso2/carbon/identity/rule/metadata/model/Field.java
@@ -33,7 +33,7 @@ public class Field {
     @JsonCreator
     public Field(@JsonProperty("name") String name, @JsonProperty("displayName") String displayName) {
 
-        validate(name, displayName);
+        validate(name);
         this.name = name;
         this.displayName = displayName;
     }
@@ -48,14 +48,10 @@ public class Field {
         return displayName;
     }
 
-    private void validate(String name, String displayName) {
+    private void validate(String name) {
 
         if (StringUtils.isBlank(name)) {
             throw new IllegalArgumentException("Field 'name' cannot be null or empty.");
-        }
-
-        if (StringUtils.isBlank(displayName)) {
-            throw new IllegalArgumentException("Field 'displayName' cannot be null or empty.");
         }
     }
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/main/java/org/wso2/carbon/identity/rule/metadata/model/FlowType.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/main/java/org/wso2/carbon/identity/rule/metadata/model/FlowType.java
@@ -25,7 +25,8 @@ import org.wso2.carbon.identity.rule.metadata.util.RuleMetadataExceptionBuilder;
  * Enum class to represent the flow types.
  */
 public enum FlowType {
-    PRE_ISSUE_ACCESS_TOKEN("preIssueAccessToken");
+    PRE_ISSUE_ACCESS_TOKEN("preIssueAccessToken"),
+    PRE_UPDATE_PASSWORD("preUpdatePassword");
 
     private final String flowAlias;
 

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/main/java/org/wso2/carbon/identity/rule/metadata/model/OptionsInputValue.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/main/java/org/wso2/carbon/identity/rule/metadata/model/OptionsInputValue.java
@@ -40,19 +40,11 @@ public class OptionsInputValue extends Value {
                              @JsonProperty("values") List<OptionsValue> values) {
 
         super(InputType.OPTIONS, valueType);
-        validate(values);
         this.values = values;
     }
 
     public List<OptionsValue> getValues() {
 
         return values;
-    }
-
-    private void validate(List<OptionsValue> values) {
-
-        if (values == null || values.isEmpty()) {
-            throw new IllegalArgumentException("'values' cannot be null or empty.");
-        }
     }
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/main/java/org/wso2/carbon/identity/rule/metadata/model/OptionsReferenceValue.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/main/java/org/wso2/carbon/identity/rule/metadata/model/OptionsReferenceValue.java
@@ -114,10 +114,6 @@ public class OptionsReferenceValue extends Value {
                 throw new IllegalArgumentException("'valueDisplayAttribute' cannot be empty.");
             }
 
-            if (links == null || links.isEmpty()) {
-                throw new IllegalArgumentException("'links' cannot be null or empty.");
-            }
-
             return new OptionsReferenceValue(this);
         }
     }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/java/org/wso2/carbon/identity/rule/metadata/config/FieldDefinitionConfigTest.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/java/org/wso2/carbon/identity/rule/metadata/config/FieldDefinitionConfigTest.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 
 import static org.mockito.Mockito.mockStatic;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -153,7 +154,6 @@ public class FieldDefinitionConfigTest {
 
         return new Object[][]{
                 {"configs/invalid-fields-missing-field-name.json"},
-                {"configs/invalid-fields-missing-field-displayname.json"},
                 {"configs/invalid-fields-unregistered-operator.json"},
                 {"configs/invalid-fields-invalid-input-type.json"},
                 {"configs/invalid-fields-invalid-value-type.json"},
@@ -163,7 +163,6 @@ public class FieldDefinitionConfigTest {
                 {"configs/invalid-fields-missing-link-href.json"},
                 {"configs/invalid-fields-missing-link-method.json"},
                 {"configs/invalid-fields-missing-link-rel.json"},
-                {"configs/invalid-fields-missing-values.json"},
                 {"unavailable-file.json"}
         };
     }
@@ -174,5 +173,25 @@ public class FieldDefinitionConfigTest {
 
         FieldDefinitionConfig.load(filePath.equals("unavailable-file.json") ? new File(filePath) :
                 new File(getClass().getClassLoader().getResource(filePath).getFile()), operatorConfig);
+    }
+
+    @DataProvider(name = "validConfigFiles")
+    public Object[][] validConfigFiles() {
+
+        return new Object[][]{
+                {"configs/invalid-fields-missing-field-displayname.json"},
+                {"configs/invalid-fields-missing-values.json"},
+        };
+    }
+
+    @Test(dataProvider = "validConfigFiles")
+    public void testLoadFieldDefinitionsFromValidConfig(String filePath) throws RuleMetadataConfigException {
+
+        try {
+            FieldDefinitionConfig.load(filePath.equals("unavailable-file.json") ? new File(filePath) :
+                    new File(getClass().getClassLoader().getResource(filePath).getFile()), operatorConfig);
+        } catch (Exception e) {
+            fail();
+        }
     }
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/java/org/wso2/carbon/identity/rule/metadata/config/FlowConfigTest.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/java/org/wso2/carbon/identity/rule/metadata/config/FlowConfigTest.java
@@ -133,6 +133,18 @@ public class FlowConfigTest {
         Value grantTypeValue = new OptionsInputValue(Value.ValueType.STRING, optionsValues);
         fieldDefinitionMap.put("grantType", new FieldDefinition(grantTypeField, operators, grantTypeValue));
 
+        Field flowField = new Field("flow", "flow");
+        List<OptionsValue> flowOptionsValues = Arrays.asList(
+                new OptionsValue("admin_initiated_password_reset", "Admin initiated password reset"),
+                new OptionsValue("admin_initiated_password_update", "Admin initiated password update"),
+                new OptionsValue("admin_initiated_user_invite_to_set_password",
+                        "Admin initiated user invite to set password"),
+                new OptionsValue("application_initiated_password_update", "Application initiated password update"),
+                new OptionsValue("user_initiated_password_reset", "User initiated password reset"),
+                new OptionsValue("user_initiated_password_update", "User initiated password update"));
+        Value flowValue = new OptionsInputValue(Value.ValueType.STRING, flowOptionsValues);
+        fieldDefinitionMap.put("flow", new FieldDefinition(flowField, operators, flowValue));
+
         return fieldDefinitionMap;
     }
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/java/org/wso2/carbon/identity/rule/metadata/provider/StaticRuleMetadataProviderTest.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/java/org/wso2/carbon/identity/rule/metadata/provider/StaticRuleMetadataProviderTest.java
@@ -107,10 +107,12 @@ public class StaticRuleMetadataProviderTest {
         assertEquals(applicationFieldValue.getValueDisplayAttribute(), "name");
 
         assertEquals(applicationFieldValue.getLinks().size(), 2);
-        assertEquals(applicationFieldValue.getLinks().get(0).getHref(), "/applications?offset=0&limit=10");
+        assertEquals(applicationFieldValue.getLinks().get(0).getHref(),
+                "/applications?excludeSystemPortals=true&offset=0&limit=10");
         assertEquals(applicationFieldValue.getLinks().get(0).getRel(), "values");
         assertEquals(applicationFieldValue.getLinks().get(0).getMethod(), "GET");
-        assertEquals(applicationFieldValue.getLinks().get(1).getHref(), "/applications?filter=name+eq+*&limit=10");
+        assertEquals(applicationFieldValue.getLinks().get(1).getHref(),
+                "/applications?excludeSystemPortals=true&filter=name+eq+*&limit=10");
         assertEquals(applicationFieldValue.getLinks().get(1).getRel(), "filter");
         assertEquals(applicationFieldValue.getLinks().get(1).getMethod(), "GET");
 

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-fields-unregistered-operator.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-fields-unregistered-operator.json
@@ -6,7 +6,7 @@
     "operators": [
       "equals",
       "notEquals",
-      "contains"
+      "startsWith"
     ],
     "value": {
       "inputType": "options",

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-flows-unregistered-field.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-flows-unregistered-field.json
@@ -1,7 +1,13 @@
 {
   "preIssueAccessToken": [
-    "application",
-    "grantType",
-    "invalid"
+    {
+      "fieldName": "application"
+    },
+    {
+      "fieldName": "grantType"
+    },
+    {
+      "fieldName": "invalid"
+    }
   ]
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-flows-unregistered-flow.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-flows-unregistered-flow.json
@@ -1,6 +1,10 @@
 {
   "invalid": [
-    "application",
-    "grantType"
+    {
+      "fieldName": "application"
+    },
+    {
+      "fieldName": "grantType"
+    }
   ]
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-field-name.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-field-name.json
@@ -1,17 +1,10 @@
 {
-  "preIssueAccessToken": [
-    {
-      "fieldName": "application"
-    },
-    {
-      "fieldName": "grantType"
-    }
-  ],
   "preUpdatePassword": [
     {
       "fieldName": "flow",
       "overrides": {
         "field": {
+          "name": "flow",
           "displayName": "flow"
         },
         "value": {

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-with-empty-field-displayName.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-with-empty-field-displayName.json
@@ -1,19 +1,9 @@
 {
-  "preIssueAccessToken": [
-    {
-      "fieldName": "application"
-    },
-    {
-      "fieldName": "grantType"
-    }
-  ],
   "preUpdatePassword": [
     {
       "fieldName": "flow",
       "overrides": {
-        "field": {
-          "displayName": "flow"
-        },
+        "field": {},
         "value": {
           "values": [
             {

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-with-empty-option-input-values.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-with-empty-option-input-values.json
@@ -1,0 +1,15 @@
+{
+  "preUpdatePassword": [
+    {
+      "fieldName": "flow",
+      "overrides": {
+        "field": {
+            "displayName": "flow"
+        },
+        "value": {
+          "values": []
+        }
+      }
+    }
+  ]
+}

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-with-empty-option-reference-links.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-with-empty-option-reference-links.json
@@ -1,0 +1,12 @@
+{
+  "preIssueAccessToken": [
+    {
+      "fieldName": "application",
+      "overrides": {
+        "value": {
+          "links": []
+        }
+      }
+    }
+  ]
+}

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-with-invalid-option-input-value.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-with-invalid-option-input-value.json
@@ -1,20 +1,14 @@
 {
-  "preIssueAccessToken": [
-    {
-      "fieldName": "application"
-    },
-    {
-      "fieldName": "grantType"
-    }
-  ],
   "preUpdatePassword": [
     {
       "fieldName": "flow",
       "overrides": {
         "field": {
-          "displayName": "flow"
+            "displayName": "flow"
         },
         "value": {
+          "inputType": "options",
+          "valueType": "string",
           "values": [
             {
               "name": "adminInitiatedPasswordReset",

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-with-invalid-option-reference-value.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-with-invalid-option-reference-value.json
@@ -1,0 +1,27 @@
+{
+  "preIssueAccessToken": [
+    {
+      "fieldName": "application",
+      "overrides": {
+        "value": {
+          "inputType": "options",
+          "valueType": "reference",
+          "valueReferenceAttribute": "id",
+          "valueDisplayAttribute": "name",
+          "links": [
+            {
+              "href": "/applications?excludeSystemPortals=true&offset=0&limit=10",
+              "method": "GET",
+              "rel": "values"
+            },
+            {
+              "href": "/applications?excludeSystemPortals=true&filter=name+eq+*&limit=10",
+              "method": "GET",
+              "rel": "filter"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-without-option-input-values.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-without-option-input-values.json
@@ -1,0 +1,13 @@
+{
+  "preUpdatePassword": [
+    {
+      "fieldName": "flow",
+      "overrides": {
+        "field": {
+            "displayName": "flow"
+        },
+        "value": {}
+      }
+    }
+  ]
+}

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-without-option-reference-links.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/invalid-overridden-flows-without-option-reference-links.json
@@ -1,0 +1,13 @@
+{
+  "preIssueAccessToken": [
+    {
+      "fieldName": "application",
+      "overrides": {
+        "field": {
+          "displayName": "application"
+        },
+        "value": {}
+      }
+    }
+  ]
+}

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/repository/resources/identity/rulemeta/fields.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/repository/resources/identity/rulemeta/fields.json
@@ -71,32 +71,7 @@
     "value": {
       "inputType": "options",
       "valueType": "string",
-      "values": [
-        {
-          "name": "admin_initiated_password_reset",
-          "displayName": "Admin initiated password reset"
-        },
-        {
-          "name": "admin_initiated_password_update",
-          "displayName": "Admin initiated password update"
-        },
-        {
-          "name": "admin_initiated_user_invite_to_set_password",
-          "displayName": "Admin initiated user invite to set password"
-        },
-        {
-          "name": "application_initiated_password_update",
-          "displayName": "Application initiated password update"
-        },
-        {
-          "name": "user_initiated_password_reset",
-          "displayName": "User initiated password reset"
-        },
-        {
-          "name": "user_initiated_password_update",
-          "displayName": "User initiated password update"
-        }
-      ]
+      "values": []
     }
   }
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/repository/resources/identity/rulemeta/fields.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/repository/resources/identity/rulemeta/fields.json
@@ -15,12 +15,12 @@
       "valueDisplayAttribute": "name",
       "links": [
         {
-          "href": "/applications?offset=0&limit=10",
+          "href": "/applications?excludeSystemPortals=true&offset=0&limit=10",
           "method": "GET",
           "rel": "values"
         },
         {
-          "href": "/applications?filter=name+eq+*&limit=10",
+          "href": "/applications?excludeSystemPortals=true&filter=name+eq+*&limit=10",
           "method": "GET",
           "rel": "filter"
         }
@@ -55,13 +55,48 @@
         {
           "name": "client_credentials",
           "displayName": "client credentials"
+        }
+      ]
+    }
+  },
+  "flow": {
+    "field": {
+      "name": "flow",
+      "displayName": "flow"
+    },
+    "operators": [
+      "equals",
+      "notEquals"
+    ],
+    "value": {
+      "inputType": "options",
+      "valueType": "string",
+      "values": [
+        {
+          "name": "admin_initiated_password_reset",
+          "displayName": "Admin initiated password reset"
         },
         {
-          "name": "urn:ietf:params:oauth:grant-type:token-exchange",
-          "displayName": "token exchange"
+          "name": "admin_initiated_password_update",
+          "displayName": "Admin initiated password update"
+        },
+        {
+          "name": "admin_initiated_user_invite_to_set_password",
+          "displayName": "Admin initiated user invite to set password"
+        },
+        {
+          "name": "application_initiated_password_update",
+          "displayName": "Application initiated password update"
+        },
+        {
+          "name": "user_initiated_password_reset",
+          "displayName": "User initiated password reset"
+        },
+        {
+          "name": "user_initiated_password_update",
+          "displayName": "User initiated password update"
         }
       ]
     }
   }
 }
-

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/repository/resources/identity/rulemeta/flows.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/repository/resources/identity/rulemeta/flows.json
@@ -12,7 +12,6 @@
       "fieldName": "flow",
       "overrides": {
         "field": {
-          "name": "flow",
           "displayName": "flow"
         },
         "value": {

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/repository/resources/identity/rulemeta/flows.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/repository/resources/identity/rulemeta/flows.json
@@ -1,6 +1,49 @@
 {
   "preIssueAccessToken": [
-    "application",
-    "grantType"
+    {
+      "fieldName": "application"
+    },
+    {
+      "fieldName": "grantType"
+    }
+  ],
+  "preUpdatePassword": [
+    {
+      "fieldName": "flow",
+      "overrides": {
+        "field": {
+          "name": "flow",
+          "displayName": "flow"
+        },
+        "value": {
+          "values": [
+            {
+              "name": "admin_initiated_password_reset",
+              "displayName": "Admin initiated password reset"
+            },
+            {
+              "name": "admin_initiated_password_update",
+              "displayName": "Admin initiated password update"
+            },
+            {
+              "name": "admin_initiated_user_invite_to_set_password",
+              "displayName": "Admin initiated user invite to set password"
+            },
+            {
+              "name": "application_initiated_password_update",
+              "displayName": "Application initiated password update"
+            },
+            {
+              "name": "user_initiated_password_reset",
+              "displayName": "User initiated password reset"
+            },
+            {
+              "name": "user_initiated_password_update",
+              "displayName": "User initiated password update"
+            }
+          ]
+        }
+      }
+    }
   ]
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/valid-flows.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/valid-flows.json
@@ -6,44 +6,5 @@
     {
       "fieldName": "grantType"
     }
-  ],
-  "preUpdatePassword": [
-    {
-      "fieldName": "flow",
-      "overrides": {
-        "field": {
-          "name": "flow",
-          "displayName": "flow"
-        },
-        "value": {
-          "values": [
-            {
-              "name": "admin_initiated_password_reset",
-              "displayName": "Admin initiated password reset"
-            },
-            {
-              "name": "admin_initiated_password_update",
-              "displayName": "Admin initiated password update"
-            },
-            {
-              "name": "admin_initiated_user_invite_to_set_password",
-              "displayName": "Admin initiated user invite to set password"
-            },
-            {
-              "name": "application_initiated_password_update",
-              "displayName": "Application initiated password update"
-            },
-            {
-              "name": "user_initiated_password_reset",
-              "displayName": "User initiated password reset"
-            },
-            {
-              "name": "user_initiated_password_update",
-              "displayName": "User initiated password update"
-            }
-          ]
-        }
-      }
-    }
   ]
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/valid-flows.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/valid-flows.json
@@ -1,6 +1,49 @@
 {
   "preIssueAccessToken": [
-    "application",
-    "grantType"
+    {
+      "fieldName": "application"
+    },
+    {
+      "fieldName": "grantType"
+    }
+  ],
+  "preUpdatePassword": [
+    {
+      "fieldName": "flow",
+      "overrides": {
+        "field": {
+          "name": "flow",
+          "displayName": "flow"
+        },
+        "value": {
+          "values": [
+            {
+              "name": "admin_initiated_password_reset",
+              "displayName": "Admin initiated password reset"
+            },
+            {
+              "name": "admin_initiated_password_update",
+              "displayName": "Admin initiated password update"
+            },
+            {
+              "name": "admin_initiated_user_invite_to_set_password",
+              "displayName": "Admin initiated user invite to set password"
+            },
+            {
+              "name": "application_initiated_password_update",
+              "displayName": "Application initiated password update"
+            },
+            {
+              "name": "user_initiated_password_reset",
+              "displayName": "User initiated password reset"
+            },
+            {
+              "name": "user_initiated_password_update",
+              "displayName": "User initiated password update"
+            }
+          ]
+        }
+      }
+    }
   ]
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/valid-overridden-flows.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/valid-overridden-flows.json
@@ -1,10 +1,23 @@
 {
   "preIssueAccessToken": [
     {
-      "fieldName": "application"
-    },
-    {
-      "fieldName": "grantType"
+      "fieldName": "application",
+      "overrides": {
+        "value": {
+          "links": [
+            {
+              "href": "/applications?excludeSystemPortals=true&offset=0&limit=10",
+              "method": "GET",
+              "rel": "values"
+            },
+            {
+              "href": "/applications?excludeSystemPortals=true&filter=name+eq+*&limit=10",
+              "method": "GET",
+              "rel": "filter"
+            }
+          ]
+        }
+      }
     }
   ],
   "preUpdatePassword": [

--- a/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/fields.json
+++ b/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/fields.json
@@ -71,32 +71,7 @@
     "value": {
       "inputType": "options",
       "valueType": "string",
-      "values": [
-        {
-          "name": "admin_initiated_password_reset",
-          "displayName": "Admin initiated password reset"
-        },
-        {
-          "name": "admin_initiated_password_update",
-          "displayName": "Admin initiated password update"
-        },
-        {
-          "name": "admin_initiated_user_invite_to_set_password",
-          "displayName": "Admin initiated user invite to set password"
-        },
-        {
-          "name": "application_initiated_password_update",
-          "displayName": "Application initiated password update"
-        },
-        {
-          "name": "user_initiated_password_reset",
-          "displayName": "User initiated password reset"
-        },
-        {
-          "name": "user_initiated_password_update",
-          "displayName": "User initiated password update"
-        }
-      ]
+      "values": []
     }
   }
 }

--- a/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/fields.json
+++ b/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/fields.json
@@ -58,5 +58,45 @@
         }
       ]
     }
+  },
+  "flow": {
+    "field": {
+      "name": "flow",
+      "displayName": "flow"
+    },
+    "operators": [
+      "equals",
+      "notEquals"
+    ],
+    "value": {
+      "inputType": "options",
+      "valueType": "string",
+      "values": [
+        {
+          "name": "admin_initiated_password_reset",
+          "displayName": "Admin initiated password reset"
+        },
+        {
+          "name": "admin_initiated_password_update",
+          "displayName": "Admin initiated password update"
+        },
+        {
+          "name": "admin_initiated_user_invite_to_set_password",
+          "displayName": "Admin initiated user invite to set password"
+        },
+        {
+          "name": "application_initiated_password_update",
+          "displayName": "Application initiated password update"
+        },
+        {
+          "name": "user_initiated_password_reset",
+          "displayName": "User initiated password reset"
+        },
+        {
+          "name": "user_initiated_password_update",
+          "displayName": "User initiated password update"
+        }
+      ]
+    }
   }
 }

--- a/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/flows.json
+++ b/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/flows.json
@@ -1,6 +1,49 @@
 {
   "preIssueAccessToken": [
-    "application",
-    "grantType"
+    {
+      "fieldName": "application"
+    },
+    {
+      "fieldName": "grantType"
+    }
+  ],
+  "preUpdatePassword": [
+    {
+      "fieldName": "flow",
+      "overrides": {
+        "field": {
+          "name": "flow",
+          "displayName": "flow"
+        },
+        "value": {
+          "values": [
+            {
+              "name": "admin_initiated_password_reset",
+              "displayName": "Admin initiated password reset"
+            },
+            {
+              "name": "admin_initiated_password_update",
+              "displayName": "Admin initiated password update"
+            },
+            {
+              "name": "admin_initiated_user_invite_to_set_password",
+              "displayName": "Admin initiated user invite to set password"
+            },
+            {
+              "name": "application_initiated_password_update",
+              "displayName": "Application initiated password update"
+            },
+            {
+              "name": "user_initiated_password_reset",
+              "displayName": "User initiated password reset"
+            },
+            {
+              "name": "user_initiated_password_update",
+              "displayName": "User initiated password update"
+            }
+          ]
+        }
+      }
+    }
   ]
 }


### PR DESCRIPTION
### Proposed changes in this pull request

1. Add new field related to preUpdatePassword flow
2. Provide override support in flows.json file when the fields are required to update.
3. Enable ruleMeta for preUpdatePasswordFlow

Sample response 

```
[
    {
        "field": {
            "name": "flow",
            "displayName": "flow"
        },
        "operators": [
            {
                "name": "equals",
                "displayName": "equals"
            },
            {
                "name": "notEquals",
                "displayName": "not equals"
            }
        ],
        "value": {
            "inputType": "options",
            "valueType": "string",
            "values": [
                {
                    "name": "admin_initiated_password_reset",
                    "displayName": "Admin initiated password reset"
                },
                {
                    "name": "admin_initiated_password_update",
                    "displayName": "Admin initiated password update"
                },
                {
                    "name": "admin_initiated_user_invite_to_set_password",
                    "displayName": "Admin initiated user invite to set password"
                },
                {
                    "name": "application_initiated_password_update",
                    "displayName": "Application initiated password update"
                },
                {
                    "name": "user_initiated_password_reset",
                    "displayName": "User initiated password reset"
                },
                {
                    "name": "user_initiated_password_update",
                    "displayName": "User initiated password update"
                }
            ]
        }
    }
]
```

### Related Issue
- https://github.com/wso2/product-is/issues/22717