### PR TITLE
Support rule management and rule execution for pre update password action

### DIFF
--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/model/FlowType.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/model/FlowType.java
@@ -23,5 +23,6 @@ package org.wso2.carbon.identity.rule.evaluation.model;
  */
 public enum FlowType {
 
-    PRE_ISSUE_ACCESS_TOKEN;
+    PRE_ISSUE_ACCESS_TOKEN,
+    PRE_UPDATE_PASSWORD
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.management/src/main/java/org/wso2/carbon/identity/rule/management/model/FlowType.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.management/src/main/java/org/wso2/carbon/identity/rule/management/model/FlowType.java
@@ -23,5 +23,6 @@ package org.wso2.carbon.identity.rule.management.model;
  */
 public enum FlowType {
 
-    PRE_ISSUE_ACCESS_TOKEN;
+    PRE_ISSUE_ACCESS_TOKEN,
+    PRE_UPDATE_PASSWORD,
 }

--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/UserActionServiceComponent.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/UserActionServiceComponent.java
@@ -60,13 +60,7 @@ public class UserActionServiceComponent {
     @Deactivate
     protected void deactivate(ComponentContext context) {
 
-        try {
-            BundleContext bundleCtx = context.getBundleContext();
-            bundleCtx.ungetService(bundleCtx.getServiceReference(ActionUserOperationEventListener.class));
-            LOG.debug("User Action bundle is deactivated");
-        } catch (Throwable e) {
-            LOG.error("Error while deactivating User Action service component.", e);
-        }
+        LOG.debug("User Action bundle is deactivated");
     }
 
     @Reference(

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/pom.xml
@@ -47,6 +47,10 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.rule.evaluation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.user.action</artifactId>
         </dependency>
         <dependency>
@@ -93,6 +97,7 @@
                             org.wso2.carbon.identity.user.pre.update.password.action.core.constant,
                             org.wso2.carbon.identity.user.pre.update.password.action.core.execution,
                             org.wso2.carbon.identity.user.pre.update.password.action.core.management,
+                            org.wso2.carbon.identity.user.pre.update.password.action.core.rule,
                             org.wso2.carbon.identity.user.pre.update.password.action.internal
                         </Private-Package>
                         <Export-Package>
@@ -122,6 +127,9 @@
                             org.wso2.carbon.identity.certificate.management.service; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.certificate.management.exception; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.certificate.management.model; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.rule.evaluation.model; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.rule.evaluation.exception; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.rule.evaluation.provider; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.user.action.service; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.user.action.service.model; version="${carbon.identity.package.import.version.range}"
                         </Import-Package>

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/management/PreUpdatePasswordActionConverter.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/management/PreUpdatePasswordActionConverter.java
@@ -86,6 +86,7 @@ public class PreUpdatePasswordActionConverter implements ActionConverter {
                 .status(actionDTO.getStatus())
                 .endpoint(actionDTO.getEndpoint())
                 .passwordSharing(passwordSharingBuilder.build())
+                .rule(actionDTO.getActionRule())
                 .build();
     }
 }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.user.pre.update.password.action.core.rule;
+
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
+import org.wso2.carbon.identity.rule.evaluation.exception.RuleEvaluationDataProviderException;
+import org.wso2.carbon.identity.rule.evaluation.model.Field;
+import org.wso2.carbon.identity.rule.evaluation.model.FieldValue;
+import org.wso2.carbon.identity.rule.evaluation.model.FlowContext;
+import org.wso2.carbon.identity.rule.evaluation.model.FlowType;
+import org.wso2.carbon.identity.rule.evaluation.model.RuleEvaluationContext;
+import org.wso2.carbon.identity.rule.evaluation.model.ValueType;
+import org.wso2.carbon.identity.rule.evaluation.provider.RuleEvaluationDataProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Rule evaluation data provider for pre update password flow.
+ * This class provides the data required for rule evaluation in pre update password flow.
+ */
+public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEvaluationDataProvider {
+
+    /**
+     * Supported flows for pre update password action.
+     */
+    private enum PasswordUpdateFlowType {
+        ADMIN_INITIATED_PASSWORD_RESET("admin_initiated_password_reset"),
+        ADMIN_INITIATED_PASSWORD_UPDATE("admin_initiated_password_update"),
+        ADMIN_INITIATED_USER_INVITE_TO_SET_PASSWORD("admin_initiated_user_invite_to_set_password"),
+        APPLICATION_INITIATED_PASSWORD_UPDATE("application_initiated_password_update"),
+        USER_INITIATED_PASSWORD_UPDATE("user_initiated_password_update"),
+        USER_INITIATED_PASSWORD_RESET("user_initiated_password_reset");
+
+        final String flowName;
+
+        PasswordUpdateFlowType(String flowName) {
+
+            this.flowName = flowName;
+        }
+
+        public String getFlowName() {
+
+            return flowName;
+        }
+    }
+
+    private enum RuleField {
+        FLOW("flow");
+
+        final String fieldName;
+
+        RuleField(String fieldName) {
+
+            this.fieldName = fieldName;
+        }
+
+        public String getFieldName() {
+
+            return fieldName;
+        }
+
+        public static RuleField valueOfFieldName(String fieldName) throws RuleEvaluationDataProviderException {
+
+            for (RuleField ruleField : RuleField.values()) {
+                if (ruleField.getFieldName().equals(fieldName)) {
+                    return ruleField;
+                }
+            }
+
+            throw new RuleEvaluationDataProviderException("Unsupported field: " + fieldName);
+        }
+    }
+
+    @Override
+    public FlowType getSupportedFlowType() {
+
+        return FlowType.PRE_UPDATE_PASSWORD;
+    }
+
+    @Override
+    public List<FieldValue> getEvaluationData(RuleEvaluationContext ruleEvaluationContext,
+                                              FlowContext flowContext, String tenantDomain)
+            throws RuleEvaluationDataProviderException {
+
+        List<FieldValue> fieldValueList = new ArrayList<>();
+        for (Field field : ruleEvaluationContext.getFields()) {
+            if (RuleField.valueOfFieldName(field.getName()) == RuleField.FLOW) {
+                fieldValueList.add(new FieldValue(field.getName(), getFlowFromContext(), ValueType.STRING));
+                break;
+            }
+
+            throw new RuleEvaluationDataProviderException("Unsupported field: " + field.getName());
+        }
+
+        return fieldValueList;
+    }
+
+    private String getFlowFromContext() throws RuleEvaluationDataProviderException {
+
+        Flow flow = IdentityContext.getThreadLocalIdentityContext().getFlow();
+        if (flow.getName() == Flow.Name.PASSWORD_UPDATE &&
+                flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN) {
+            return PasswordUpdateFlowType.ADMIN_INITIATED_PASSWORD_UPDATE.getFlowName();
+        }
+
+        if (flow.getName() == Flow.Name.PASSWORD_UPDATE &&
+                flow.getInitiatingPersona() == Flow.InitiatingPersona.APPLICATION) {
+            return PasswordUpdateFlowType.APPLICATION_INITIATED_PASSWORD_UPDATE.getFlowName();
+        }
+
+        if (flow.getName() == Flow.Name.PASSWORD_UPDATE &&
+                flow.getInitiatingPersona() == Flow.InitiatingPersona.USER) {
+            return PasswordUpdateFlowType.USER_INITIATED_PASSWORD_UPDATE.getFlowName();
+        }
+
+        if (flow.getName() == Flow.Name.PASSWORD_RESET &&
+                flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN) {
+            return PasswordUpdateFlowType.ADMIN_INITIATED_PASSWORD_RESET.getFlowName();
+        }
+
+        if (flow.getName() == Flow.Name.PASSWORD_RESET &&
+                flow.getInitiatingPersona() == Flow.InitiatingPersona.USER) {
+            return PasswordUpdateFlowType.USER_INITIATED_PASSWORD_RESET.getFlowName();
+        }
+
+        if (flow.getName() == Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD &&
+                flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN) {
+            return PasswordUpdateFlowType.ADMIN_INITIATED_USER_INVITE_TO_SET_PASSWORD.getFlowName();
+        }
+
+        throw new RuleEvaluationDataProviderException("Unsupported flow type: " + flow.getName() +
+                " for Pre Update Password Action.");
+    }
+}

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.identity.rule.evaluation.provider.RuleEvaluationDataProvi
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Rule evaluation data provider for pre update password flow.
@@ -38,16 +39,18 @@ import java.util.List;
  */
 public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEvaluationDataProvider {
 
+    private static final String FLOW_FIELD = "flow";
+
     /**
      * Supported flows for pre update password action.
      */
     private enum PasswordUpdateFlowType {
-        ADMIN_INITIATED_PASSWORD_RESET("admin_initiated_password_reset"),
-        ADMIN_INITIATED_PASSWORD_UPDATE("admin_initiated_password_update"),
-        ADMIN_INITIATED_USER_INVITE_TO_SET_PASSWORD("admin_initiated_user_invite_to_set_password"),
-        APPLICATION_INITIATED_PASSWORD_UPDATE("application_initiated_password_update"),
-        USER_INITIATED_PASSWORD_UPDATE("user_initiated_password_update"),
-        USER_INITIATED_PASSWORD_RESET("user_initiated_password_reset");
+        ADMIN_INITIATED_PASSWORD_RESET("adminInitiatedPasswordReset"),
+        ADMIN_INITIATED_PASSWORD_UPDATE("adminInitiatedPasswordUpdate"),
+        ADMIN_INITIATED_USER_INVITE_TO_SET_PASSWORD("adminInitiatedUserInviteToSetPassword"),
+        APPLICATION_INITIATED_PASSWORD_UPDATE("applicationInitiatedPasswordUpdate"),
+        USER_INITIATED_PASSWORD_UPDATE("userInitiatedPasswordUpdate"),
+        USER_INITIATED_PASSWORD_RESET("userInitiatedPasswordReset");
 
         final String flowName;
 
@@ -59,33 +62,6 @@ public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEv
         public String getFlowName() {
 
             return flowName;
-        }
-    }
-
-    private enum RuleField {
-        FLOW("flow");
-
-        final String fieldName;
-
-        RuleField(String fieldName) {
-
-            this.fieldName = fieldName;
-        }
-
-        public String getFieldName() {
-
-            return fieldName;
-        }
-
-        public static RuleField valueOfFieldName(String fieldName) throws RuleEvaluationDataProviderException {
-
-            for (RuleField ruleField : RuleField.values()) {
-                if (ruleField.getFieldName().equals(fieldName)) {
-                    return ruleField;
-                }
-            }
-
-            throw new RuleEvaluationDataProviderException("Unsupported field: " + fieldName);
         }
     }
 
@@ -102,7 +78,7 @@ public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEv
 
         List<FieldValue> fieldValueList = new ArrayList<>();
         for (Field field : ruleEvaluationContext.getFields()) {
-            if (RuleField.valueOfFieldName(field.getName()) == RuleField.FLOW) {
+            if (Objects.equals(field.getName(), FLOW_FIELD)) {
                 fieldValueList.add(new FieldValue(field.getName(), getFlowFromContext(), ValueType.STRING));
                 break;
             } else {

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
@@ -105,9 +105,9 @@ public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEv
             if (RuleField.valueOfFieldName(field.getName()) == RuleField.FLOW) {
                 fieldValueList.add(new FieldValue(field.getName(), getFlowFromContext(), ValueType.STRING));
                 break;
+            } else {
+                throw new RuleEvaluationDataProviderException("Unsupported field: " + field.getName());
             }
-
-            throw new RuleEvaluationDataProviderException("Unsupported field: " + field.getName());
         }
 
         return fieldValueList;

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/PreUpdatePasswordActionServiceComponent.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/PreUpdatePasswordActionServiceComponent.java
@@ -34,12 +34,14 @@ import org.wso2.carbon.identity.action.execution.ActionExecutorService;
 import org.wso2.carbon.identity.action.management.service.ActionConverter;
 import org.wso2.carbon.identity.action.management.service.ActionDTOModelResolver;
 import org.wso2.carbon.identity.certificate.management.service.CertificateManagementService;
+import org.wso2.carbon.identity.rule.evaluation.provider.RuleEvaluationDataProvider;
 import org.wso2.carbon.identity.user.action.service.UserActionExecutor;
 import org.wso2.carbon.identity.user.pre.update.password.action.core.execution.PreUpdatePasswordActionRequestBuilder;
 import org.wso2.carbon.identity.user.pre.update.password.action.core.execution.PreUpdatePasswordResponseProcessor;
 import org.wso2.carbon.identity.user.pre.update.password.action.core.execution.UserPreUpdatePasswordActionExecutor;
 import org.wso2.carbon.identity.user.pre.update.password.action.core.management.PreUpdatePasswordActionConverter;
 import org.wso2.carbon.identity.user.pre.update.password.action.core.management.PreUpdatePasswordActionDTOModelResolver;
+import org.wso2.carbon.identity.user.pre.update.password.action.core.rule.PreUpdatePasswordActionRuleEvaluationDataProvider;
 
 /**
  * Service component for the Pre Update Password Action.
@@ -75,6 +77,10 @@ public class PreUpdatePasswordActionServiceComponent {
 
             bundleCtx.registerService(UserActionExecutor.class, new UserPreUpdatePasswordActionExecutor(), null);
             LOG.debug("User Pre Update Password Action Executor is enabled");
+
+            bundleCtx.registerService(RuleEvaluationDataProvider.class,
+                    new PreUpdatePasswordActionRuleEvaluationDataProvider(), null);
+            LOG.debug("User Pre Update Password Action Rule Evaluation Data Provider is enabled");
 
             LOG.debug("Pre Update Password Action bundle is activated");
         } catch (Throwable e) {

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.user.pre.update.password.action.rule;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
+import org.wso2.carbon.identity.rule.evaluation.exception.RuleEvaluationDataProviderException;
+import org.wso2.carbon.identity.rule.evaluation.model.Field;
+import org.wso2.carbon.identity.rule.evaluation.model.FieldValue;
+import org.wso2.carbon.identity.rule.evaluation.model.FlowContext;
+import org.wso2.carbon.identity.rule.evaluation.model.FlowType;
+import org.wso2.carbon.identity.rule.evaluation.model.RuleEvaluationContext;
+import org.wso2.carbon.identity.rule.evaluation.model.ValueType;
+import org.wso2.carbon.identity.user.pre.update.password.action.core.rule.PreUpdatePasswordActionRuleEvaluationDataProvider;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.doReturn;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test class for PreUpdatePasswordActionRuleEvaluationDataProvider.
+ */
+@WithCarbonHome
+public class PreUpdatePasswordActionRuleEvaluationDataProviderTest {
+
+    @Mock
+    private RuleEvaluationContext ruleEvaluationContext;
+    @Mock
+    private FlowContext flowContext;
+    @Mock
+    private Flow flow;
+
+    private PreUpdatePasswordActionRuleEvaluationDataProvider dataProvider;
+
+    @BeforeMethod
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        dataProvider = new PreUpdatePasswordActionRuleEvaluationDataProvider();
+
+        Field field = new Field("flow", ValueType.STRING);
+        doReturn(Collections.singletonList(field)).when(ruleEvaluationContext).getFields();
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        IdentityContext.destroyCurrentContext();
+    }
+
+    @Test
+    public void testGetSupportedFlowType() {
+
+        assertEquals(dataProvider.getSupportedFlowType(), FlowType.PRE_UPDATE_PASSWORD);
+    }
+
+    @DataProvider(name = "flowData")
+    public Object[][] flowData() {
+
+        return new Object[][]{
+                {Flow.Name.PASSWORD_UPDATE, Flow.InitiatingPersona.ADMIN, "adminInitiatedPasswordUpdate"},
+                {Flow.Name.PASSWORD_UPDATE, Flow.InitiatingPersona.USER, "userInitiatedPasswordUpdate"},
+                {Flow.Name.PASSWORD_UPDATE, Flow.InitiatingPersona.APPLICATION, "applicationInitiatedPasswordUpdate"},
+                {Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.ADMIN, "adminInitiatedPasswordReset"},
+                {Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.USER, "userInitiatedPasswordReset"},
+                {Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD, Flow.InitiatingPersona.ADMIN,
+                        "adminInitiatedUserInviteToSetPassword"}
+        };
+    }
+
+    @Test(dataProvider = "flowData")
+    public void testGetEvaluationData(Flow.Name flowName, Flow.InitiatingPersona initiatingPersona, String fieldValue)
+            throws RuleEvaluationDataProviderException {
+
+        doReturn(flowName).when(flow).getName();
+        doReturn(initiatingPersona).when(flow).getInitiatingPersona();
+        IdentityContext.getThreadLocalIdentityContext().setFlow(flow);
+
+        List<FieldValue> fieldValues = dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");
+        assertEquals(fieldValues.size(), 1);
+        assertEquals(fieldValues.get(0).getValue(), fieldValue);
+    }
+
+    @Test(expectedExceptions = RuleEvaluationDataProviderException.class)
+    public void testGetEvaluationDataWithUnsupportedField() throws RuleEvaluationDataProviderException {
+
+        Field field = new Field("unsupported_field", ValueType.STRING);
+        doReturn(Collections.singletonList(field)).when(ruleEvaluationContext).getFields();
+        dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");
+    }
+
+    @Test(expectedExceptions = RuleEvaluationDataProviderException.class)
+    public void testGetEvaluationDataWithUnsupportedFlow() throws RuleEvaluationDataProviderException {
+
+        doReturn(Flow.Name.PASSWORD_RESET).when(flow).getName();
+        doReturn(Flow.InitiatingPersona.APPLICATION).when(flow).getInitiatingPersona();
+        IdentityContext.getThreadLocalIdentityContext().setFlow(flow);
+
+        dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");
+    }
+}

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
@@ -59,9 +59,9 @@ public class PreUpdatePasswordActionRuleEvaluationDataProviderTest {
 
     @BeforeMethod
     public void setUp() {
+
         MockitoAnnotations.openMocks(this);
         dataProvider = new PreUpdatePasswordActionRuleEvaluationDataProvider();
-
         Field field = new Field("flow", ValueType.STRING);
         doReturn(Collections.singletonList(field)).when(ruleEvaluationContext).getFields();
     }
@@ -119,7 +119,6 @@ public class PreUpdatePasswordActionRuleEvaluationDataProviderTest {
         doReturn(Flow.Name.PASSWORD_RESET).when(flow).getName();
         doReturn(Flow.InitiatingPersona.APPLICATION).when(flow).getInitiatingPersona();
         IdentityContext.getThreadLocalIdentityContext().setFlow(flow);
-
         dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");
     }
 }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/resources/testng.xml
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/resources/testng.xml
@@ -26,6 +26,7 @@
                         <class name="org.wso2.carbon.identity.user.pre.update.password.action.execution.PreUpdatePasswordResponseProcessorTest"></class>
                         <class name="org.wso2.carbon.identity.user.pre.update.password.action.management.PreUpdatePasswordActionConverterTest"></class>
                         <class name="org.wso2.carbon.identity.user.pre.update.password.action.management.PreUpdatePasswordActionDTOModelResolverTest"></class>
+                        <class name="org.wso2.carbon.identity.user.pre.update.password.action.rule.PreUpdatePasswordActionRuleEvaluationDataProviderTest"></class>
                         <class name="org.wso2.carbon.identity.user.pre.update.password.action.model.PreUpdatePasswordActionBuilderTest"></class>
                 </classes>
         </test>


### PR DESCRIPTION
### Proposed changes in this pull request

1. Implement `PreUpdatePasswordActionRuleEvaluationDataProvider` to provide respective data in rule evaluation
2. Minor bug fix of getting NPE when component deactivating of UserActionServiceComponent

### Related Issue
- https://github.com/wso2/product-is/issues/22719