### PR TITLE
Improve authentication flow.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.base.AuthenticatorPropertyConstants;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
@@ -94,7 +95,8 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
         // if an authentication flow
         if (!context.isLogoutRequest()) {
             boolean skipPrompt = isSkipPrompt(context);
-            if (!skipPrompt && (!canHandle(request)
+            if (!AuthenticatorPropertyConstants.DefinedByType.USER.equals(getDefinedByType())
+                    && !skipPrompt && (!canHandle(request)
                     || Boolean.TRUE.equals(request.getAttribute(FrameworkConstants.REQ_ATTR_HANDLED)))) {
                 if (getName().equals(context.getProperty(FrameworkConstants.LAST_FAILED_AUTHENTICATOR))) {
                     context.setRetrying(true);


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/22715

This PR fixes an error in the following authentication flow:

    Step 1: Federated authenticator (Google or a custom federated authenticator)
    Step 2: A single custom authenticator

Since there is only one custom authenticator in Step 2, its authentication process is initiated after Step 1. However, because request.getAttribute(FrameworkConstants.REQ_ATTR_HANDLED) remains true from the last request to the IS server, the initiateAuthenticationRequest() method is invoked.

For user-defined authenticators, this method should not be invoked. Therefore, a new condition is added to ensure that initiateAuthenticationRequest() is executed only when the user-defined type is not USER.