### PR TITLE
Change Pre Update Password Action Request Attribute - initiator to initiatorType

### DIFF
--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/execution/PreUpdatePasswordActionRequestBuilder.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/execution/PreUpdatePasswordActionRequestBuilder.java
@@ -99,7 +99,7 @@ public class PreUpdatePasswordActionRequestBuilder implements ActionExecutionReq
     private Event getEvent() throws ActionExecutionRequestBuilderException {
 
         return new PreUpdatePasswordEvent.Builder()
-                .initiator(getInitiator())
+                .initiatorType(getInitiatorType())
                 .action(getAction())
                 .tenant(getTenant())
                 .user(getUser())
@@ -107,7 +107,7 @@ public class PreUpdatePasswordActionRequestBuilder implements ActionExecutionReq
                 .build();
     }
 
-    private PreUpdatePasswordEvent.FlowInitiator getInitiator() throws ActionExecutionRequestBuilderException {
+    private PreUpdatePasswordEvent.FlowInitiatorType getInitiatorType() throws ActionExecutionRequestBuilderException {
 
         Flow flow = IdentityContext.getThreadLocalIdentityContext().getFlow();
         if (flow == null) {
@@ -116,11 +116,11 @@ public class PreUpdatePasswordActionRequestBuilder implements ActionExecutionReq
 
         switch(flow.getInitiatingPersona()) {
             case ADMIN:
-                return PreUpdatePasswordEvent.FlowInitiator.ADMIN;
+                return PreUpdatePasswordEvent.FlowInitiatorType.ADMIN;
             case APPLICATION:
-                return PreUpdatePasswordEvent.FlowInitiator.APPLICATION;
+                return PreUpdatePasswordEvent.FlowInitiatorType.APPLICATION;
             case USER:
-                return PreUpdatePasswordEvent.FlowInitiator.USER;
+                return PreUpdatePasswordEvent.FlowInitiatorType.USER;
             default:
                 break;
         }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/service/model/PreUpdatePasswordEvent.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/service/model/PreUpdatePasswordEvent.java
@@ -36,7 +36,7 @@ public class PreUpdatePasswordEvent extends Event {
      * FlowInitiator Enum.
      * Defines the initiator type for the password update flow.
      */
-    public enum FlowInitiator {
+    public enum FlowInitiatorType {
         USER,
         ADMIN,
         APPLICATION
@@ -52,12 +52,12 @@ public class PreUpdatePasswordEvent extends Event {
         INVITE
     }
 
-    private final FlowInitiator initiator;
+    private final FlowInitiatorType initiatorType;
     private final Action action;
 
     private PreUpdatePasswordEvent(Builder builder) {
 
-        this.initiator = builder.initiator;
+        this.initiatorType = builder.initiatorType;
         this.action = builder.action;
         this.request = builder.request;
         this.organization = builder.organization;
@@ -66,9 +66,9 @@ public class PreUpdatePasswordEvent extends Event {
         this.userStore = builder.userStore;
     }
 
-    public FlowInitiator getInitiator() {
+    public FlowInitiatorType getInitiatorType() {
 
-        return initiator;
+        return initiatorType;
     }
 
     public Action getAction() {
@@ -86,7 +86,7 @@ public class PreUpdatePasswordEvent extends Event {
         private Organization organization;
         private User user;
         private UserStore userStore;
-        private FlowInitiator initiator;
+        private FlowInitiatorType initiatorType;
         private Action action;
 
         public Builder request(Request request) {
@@ -119,9 +119,9 @@ public class PreUpdatePasswordEvent extends Event {
             return this;
         }
 
-        public Builder initiator(FlowInitiator initiator) {
+        public Builder initiatorType(FlowInitiatorType initiatorType) {
 
-            this.initiator = initiator;
+            this.initiatorType = initiatorType;
             return this;
         }
 

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/execution/PreUpdatePasswordActionRequestBuilderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/execution/PreUpdatePasswordActionRequestBuilderTest.java
@@ -148,7 +148,7 @@ public class PreUpdatePasswordActionRequestBuilderTest {
         assertTrue(actionExecutionRequest.getEvent() instanceof PreUpdatePasswordEvent);
 
         PreUpdatePasswordEvent preUpdatePasswordEvent = (PreUpdatePasswordEvent) actionExecutionRequest.getEvent();
-        assertEquals(preUpdatePasswordEvent.getInitiator(), PreUpdatePasswordEvent.FlowInitiator.USER);
+        assertEquals(preUpdatePasswordEvent.getInitiatorType(), PreUpdatePasswordEvent.FlowInitiatorType.USER);
         assertEquals(preUpdatePasswordEvent.getAction(), PreUpdatePasswordEvent.Action.UPDATE);
 
         assertEquals(preUpdatePasswordEvent.getUserStore().getName(), TEST_USER_STORE_DOMAIN_NAME);
@@ -178,7 +178,7 @@ public class PreUpdatePasswordActionRequestBuilderTest {
         assertTrue(actionExecutionRequest.getEvent() instanceof PreUpdatePasswordEvent);
 
         PreUpdatePasswordEvent preUpdatePasswordEvent = (PreUpdatePasswordEvent) actionExecutionRequest.getEvent();
-        assertEquals(preUpdatePasswordEvent.getInitiator(), PreUpdatePasswordEvent.FlowInitiator.APPLICATION);
+        assertEquals(preUpdatePasswordEvent.getInitiatorType(), PreUpdatePasswordEvent.FlowInitiatorType.APPLICATION);
         assertEquals(preUpdatePasswordEvent.getAction(), PreUpdatePasswordEvent.Action.RESET);
 
         assertEquals(preUpdatePasswordEvent.getUserStore().getName(), TEST_USER_STORE_DOMAIN_NAME);


### PR DESCRIPTION
Updates the "initiator" attribute of the Pre Update Password Action Request, as "initiatorType".

Resolves : https://github.com/wso2/product-is/issues/22727