### PR TITLE
Modify Authentication Object building logic in UserDefinedAuthenticatorEndpointConfig

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/dao/impl/ActionManagementDAOImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/dao/impl/ActionManagementDAOImpl.java
@@ -348,7 +348,7 @@ public class ActionManagementDAOImpl implements ActionManagementDAO {
 
         Authentication authentication;
         Authentication.Type authnType =
-                Authentication.Type.valueOf(propertiesFromDB.remove(ActionMgtConstants.AUTHN_TYPE_PROPERTY));
+                Authentication.Type.valueOfName(propertiesFromDB.remove(ActionMgtConstants.AUTHN_TYPE_PROPERTY));
         switch (authnType) {
             case BASIC:
                 authentication = new Authentication.BasicAuthBuilder(

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/model/Authentication.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/model/Authentication.java
@@ -64,6 +64,20 @@ public class Authentication {
 
             return name;
         }
+
+        public static Type valueOfName(String name) {
+
+            if (name == null || name.isEmpty()) {
+                throw new IllegalArgumentException("Authentication type cannot be null or empty.");
+            }
+
+            for (Type type : Type.values()) {
+                if (type.name.equalsIgnoreCase(name)) {
+                    return type;
+                }
+            }
+            throw new IllegalArgumentException("Invalid authentication type: " + name);
+        }
     }
 
     /**

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/UserDefinedAuthenticatorEndpointConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/UserDefinedAuthenticatorEndpointConfig.java
@@ -138,7 +138,7 @@ public class UserDefinedAuthenticatorEndpointConfig {
 
             // Both authenticationType and authenticationProperties is required to build the authentication.
             return new Authentication.AuthenticationBuilder()
-                    .type(Authentication.Type.valueOf(authenticationType))
+                    .type(Authentication.Type.valueOfName(authenticationType))
                     .properties(authenticationProperties)
                     .build();
         }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementFacade.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementFacade.java
@@ -361,9 +361,10 @@ public class IdPManagementFacade {
             endpointConfigurationManager.updateEndpointConfig(newIdentityProvider.getFederatedAuthenticatorConfigs()[0],
                     oldIdentityProvider.getFederatedAuthenticatorConfigs()[0],
                     tenantDomain);
+        } else {
+            endpointConfigurationManager.deleteEndpointConfig(oldFederatedAuth, tenantDomain);
+            endpointConfigurationManager.addEndpointConfig(newFederatedAuth, tenantDomain);
         }
-        endpointConfigurationManager.deleteEndpointConfig(oldFederatedAuth, tenantDomain);
-        endpointConfigurationManager.addEndpointConfig(newFederatedAuth, tenantDomain);
     }
 
     private void deleteEndpointConfig(IdentityProvider identityProvider, String tenantDomain)


### PR DESCRIPTION
### Proposed changes in this pull request

1. Improved the logic to not to build an authentication object when authentication properties are not provided (Authentication properties is a required attribute of the authentication object)
2. Improved missing logic in `updateEndpointConfig` in `IdpManagementFacade` 
   - When following api is invoked, it is expected to delete current endpoint config and add new endpoint config. https://is.docs.wso2.com/en/next/apis/idp/#tag/Federated-Authenticators/operation/updateFederatedAuthenticators 
   - When following api is invoked, it is expected to only update the existing endpoint config https://is.docs.wso2.com/en/next/apis/idp/#tag/Federated-Authenticators/operation/updateFederatedAuthenticator
   
### Related Issue
- https://github.com/wso2/product-is/issues/22564