### PR TITLE
Change IdentityUserIdResolverListener order

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityUserIdResolverListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/IdentityUserIdResolverListener.java
@@ -60,11 +60,13 @@ public class IdentityUserIdResolverListener extends AbstractIdentityUserOperatio
     @Override
     public int getExecutionOrderId() {
 
+        // Set the order ID to a high value to ensure this listener executes after all other listeners,
+        // except for the {@link ActionUserOperationEventListener}
         int orderId = getOrderId();
         if (orderId != IdentityCoreConstants.EVENT_LISTENER_ORDER_ID) {
             return orderId;
         }
-        return 15;
+        return 9999;
     }
 
     @Override

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -602,7 +602,7 @@
   "event.default_listener.client_certificate_authentication_handler.enable": true,
   "event.default_listener.username_resolver.priority": "14",
   "event.default_listener.username_resolver.enable": true,
-  "event.default_listener.userid_resolver.priority": "15",
+  "event.default_listener.userid_resolver.priority": "9999",
   "event.default_listener.userid_resolver.enable": true,
   "event.default_listener.claim_encryption.priority": "13",
   "event.default_listener.claim_encryption.enable": true,


### PR DESCRIPTION
### Proposed changes in this pull request

1. IdentityUserIdResolverListener is used to invoke listeners with id. 
2. Since `ActionUserOperationEventListener` is expected to be executed at last, this is considered to be the last executing listener before `ActionUserOperationEventListener`

### Related Issue
- https://github.com/wso2/product-is/issues/22761