### PR TITLE
Remove transient for UserDefinedAuthenticatorEndpointConfig.

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/UserDefinedFederatedAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/UserDefinedFederatedAuthenticatorConfig.java
@@ -27,7 +27,7 @@ import static org.wso2.carbon.identity.base.AuthenticatorPropertyConstants.TAG_C
  */
 public class UserDefinedFederatedAuthenticatorConfig extends FederatedAuthenticatorConfig {
 
-    private transient UserDefinedAuthenticatorEndpointConfig endpointConfig;
+    private UserDefinedAuthenticatorEndpointConfig endpointConfig;
 
     public UserDefinedFederatedAuthenticatorConfig() {
 


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/22715

Remove transient for UserDefinedAuthenticatorEndpointConfig, as when cloning this attribute of the idp set to null.