### PR TITLE
Improve error msg  when updating role name with existing role name.

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -831,8 +831,10 @@ public class RoleDAOImpl implements RoleDAO {
         if (!StringUtils.equalsIgnoreCase(roleName, newRoleName) && isExistingRoleName(newRoleName,
                 roleAudience.getAudience(), roleAudience.getAudienceId(), tenantDomain)) {
             throw new IdentityRoleManagementClientException(RoleConstants.Error.ROLE_ALREADY_EXISTS.getCode(),
-                    "Role already exist for the role name: " + roleName + " audience: " + roleAudience.getAudience()
-                            + " audienceId: " + roleAudience.getAudienceId());
+                    String.format(
+                    "Error while Updating the roleName: %s to : %s. Role already exist for the role name: %s " +
+                            "audience: %s audienceId: %s", roleName, newRoleName, newRoleName,
+                            roleAudience.getAudience(), roleAudience.getAudienceId()));
         }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Updating the roleName: " + roleName + " to :" + newRoleName + " in the tenantDomain: "


### PR DESCRIPTION
### Proposed changes in this pull request
$

Issue: https://github.com/wso2/product-is/issues/21635

Modified response:
```json
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "detail": "Error while Updating the roleName: role1 to : role2. Role already exist for the role name: role2 audience: organization audienceId: 10084a8d-113f-4211-a0d5-efe36b082211",
    "status": "409"
}
```