### PR TITLE
Remove the usages of deprecated addKeyStore method in KeyStore Manager

### DIFF
--- a/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/keystore/KeyStoreAdmin.java
+++ b/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/keystore/KeyStoreAdmin.java
@@ -58,6 +58,7 @@ import java.security.cert.X509Certificate;
 import java.text.Format;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 
@@ -141,12 +142,25 @@ public class KeyStoreAdmin {
     public void addKeyStore(byte[] content, String filename, String password, String provider,
                             String type, String pvtkeyPass) throws SecurityConfigException {
 
+        char[] passwordChar = new char[0];
+        char[] privateKeyPasswordChar = new char[0];
         try {
-            keyStoreManager.addKeyStore(content, filename, password, provider, type, pvtkeyPass);
+            if (password == null) {
+                throw new SecurityException("Key store password can't be null");
+            }
+
+            passwordChar = password.toCharArray();
+            if (pvtkeyPass != null) {
+                privateKeyPasswordChar = pvtkeyPass.toCharArray();
+            }
+            keyStoreManager.addKeyStore(content, filename, passwordChar, provider, type, privateKeyPasswordChar);
         } catch (SecurityException e) {
             String msg = "Error when adding a keyStore";
             log.error(msg, e);
             throw new SecurityConfigException(msg, e);
+        } finally {
+            Arrays.fill(passwordChar, '\0');
+            Arrays.fill(privateKeyPasswordChar, '\0');
         }
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Remove the usages of deprecated addKeyStore method in KeyStore Manager

Use [1] instead of [2].


[1] https://github.com/wso2/carbon-kernel/blob/0111c22e9e2f59865964900e1da064d4c1faff25/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java#L209-L263

[2] https://github.com/wso2/carbon-kernel/blob/0111c22e9e2f59865964900e1da064d4c1faff25/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java#L209-L263