### PR TITLE
Exclude adding the spid to external calls

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -97,7 +97,6 @@ import javax.servlet.http.HttpServletResponse;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ACCOUNT_DISABLED_CLAIM_URI;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ACCOUNT_UNLOCK_TIME_CLAIM;
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUTHENTICATOR;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AnalyticsAttributes.SESSION_ID;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.BACK_TO_FIRST_STEP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ERROR_DESCRIPTION_APP_DISABLED;
@@ -396,8 +395,11 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
 
                 if (!context.isLogoutRequest()) {
                     FrameworkUtils.getAuthenticationRequestHandler().handle(request, responseWrapper, context);
-                    // Adding spIp param to the redirect URL if the authenticator is not the organization authenticator.
-                    if (!ORGANIZATION_AUTHENTICATOR.equals(request.getParameter(AUTHENTICATOR))) {
+
+                    // Adding spId param to the redirect URL if it is not an external system call.
+                    boolean isExternalCall = Boolean.TRUE.equals(
+                            request.getAttribute(FrameworkConstants.IS_EXTERNAL_CALL));
+                    if (!isExternalCall) {
                         addServiceProviderIdToRedirectUrl(responseWrapper, context);
                     }
                 } else {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -763,6 +763,13 @@ public class DefaultStepHandler implements StepHandler {
                 handleAPIBasedAuthenticationData(request, authenticator, context);
             }
 
+            /* Marking the flow as an external call for downstream components.
+             This is used to ensure things like additional params are not attached to
+             external calls.*/
+            if (authenticator instanceof FederatedApplicationAuthenticator) {
+                request.setAttribute(FrameworkConstants.IS_EXTERNAL_CALL, true);
+            }
+
             if (LOG.isDebugEnabled()) {
                 LOG.debug(authenticator.getName() + " returned: " + status.toString());
             }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -265,6 +265,7 @@ public abstract class FrameworkConstants {
 
     // The constant to used as the attribute key or the property key of the federated tokens.
     public static final String FEDERATED_TOKENS = "federated_tokens";
+    public static final String IS_EXTERNAL_CALL = "IS_EXTERNAL_CALL";
 
     private FrameworkConstants() {
 


### PR DESCRIPTION
Earlier the spId was added to external calls. This PR excludes adding the spid to external calls. 
The code specifically handling the Organization authenticator is removed as it is a federated authenticator it is already covered by the isExternalCall check.

fixes: https://github.com/wso2/product-is/issues/22667