### PR TITLE
Remove white spaces in claim list for multi-attribute login

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/client/PreferenceRetrievalClient.java
@@ -221,8 +221,11 @@ public class PreferenceRetrievalClient {
         Optional<String> optional = getPropertyValue(tenant, ACCOUNT_MGT_GOVERNANCE, MULTI_ATTRIBUTE_LOGIN_HANDLER,
                 MULTI_ATTRIBUTE_LOGIN_ALLOWED_ATTRIBUTES_PROPERTY);
         if (optional.isPresent()) {
-            return optional.get();
-        } 
+            String claimList = optional.get();
+            if (StringUtils.isNotBlank(claimList)) {
+                return StringUtils.deleteWhitespace(claimList);
+            }
+        }
         return null;
     }
 


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/19527

This PR removes the white spaces in the claim list that allow multi-attribute login when retrieving via the client for the UIs.