### PR TITLE
Add configurations to select certificate validation configuration datasource

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -78,6 +78,7 @@
     <DataStorageType>
         <NotificationTemplates>database</NotificationTemplates>
         <SAML>database</SAML>
+        <CertificateValidation>database</CertificateValidation>
     </DataStorageType>
 
     <!-- Time configurations are in minutes -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -89,6 +89,7 @@
         <NotificationTemplates>{{data_storage_type.notification_templates}}</NotificationTemplates>
         <SAML>{{data_storage_type.saml}}</SAML>
         <XACML>{{data_storage_type.xacml}}</XACML>
+        <CertificateValidation>{{data_storage_type.certificate_validation}}</CertificateValidation>
     </DataStorageType>
 
     <NotificationTemplates>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -12,6 +12,7 @@
   "identity_data_source.skip_claim_metadata_persistence": true,
   "data_storage_type.notification_templates": "database",
   "data_storage_type.saml": "database",
+  "data_storage_type.certificate_validation": "database",
   "database.identity_db.pool_options.maxActive": "50",
   "database.identity_db.pool_options.maxWait": "60000",
   "database.identity_db.pool_options.testOnBorrow": "true",


### PR DESCRIPTION
### Purpose
- https://github.com/wso2/product-is/issues/22408

This pull request introduces changes to support storing certificate validation data in the database. The changes span across multiple configuration files to ensure consistency and proper functionality.

Key changes include:

Configuration updates:

* [`features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml`](diffhunk://#diff-682dcc48fdd68c1974091fb760d1cbfb8b2bf80e05becd70d2c55f5b887b00baR81): Added `<CertificateValidation>database</CertificateValidation>` to the `DataStorageType` section.
* [`features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2`](diffhunk://#diff-1ece24b053d1b4af23eb3fdd3af75e2f8816c34a5685ece650c7882061dff696R92): Added `<CertificateValidation>{{data_storage_type.certificate_validation}}</CertificateValidation>` to the `DataStorageType` section.
* [`features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json`](diffhunk://#diff-ccd8d78f18b752f00ba42b5384248d7b8e8c6cc965a44569e2654ca6ce5bb616R15): Added `"data_storage_type.certificate_validation": "database"` to the JSON configuration.