### PR TITLE
Consider password policy rules from the old connector

### DIFF
--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/pom.xml
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/pom.xml
@@ -52,6 +52,15 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.idp.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -106,6 +115,8 @@
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt.*;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.idp.mgt;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.common.model.*;version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.input.validation.mgt.internal,

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationDataHolder.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationDataHolder.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementServic
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.input.validation.mgt.model.FieldValidationConfigurationHandler;
 import org.wso2.carbon.identity.input.validation.mgt.model.Validator;
+import org.wso2.carbon.idp.mgt.IdpManager;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,6 +35,7 @@ public class InputValidationDataHolder {
     private static InputValidationDataHolder instance = new InputValidationDataHolder();
     private static ConfigurationManager configurationManager = null;
     private ClaimMetadataManagementService claimMetadataManagementService;
+    private IdpManager idpManager;
     private static Map<String, Validator> validators = new HashMap<>();
     private static Map<String, FieldValidationConfigurationHandler> validationConfigurationHandlers = new HashMap<>();
 
@@ -95,5 +97,25 @@ public class InputValidationDataHolder {
     public void setClaimMetadataManagementService(ClaimMetadataManagementService claimMetadataManagementService) {
 
         this.claimMetadataManagementService = claimMetadataManagementService;
+    }
+
+    /**
+     * Get IdpManager.
+     *
+     * @return IdpManager.
+     */
+    public IdpManager getIdpManager() {
+
+        return idpManager;
+    }
+
+    /**
+     * Set IdpManager.
+     *
+     * @param idpManager IdpManager.
+     */
+    public void setIdpManager(IdpManager idpManager) {
+
+        this.idpManager = idpManager;
     }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationServiceComponent.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/internal/InputValidationServiceComponent.java
@@ -47,6 +47,7 @@ import org.wso2.carbon.identity.input.validation.mgt.model.validators.UpperCaseV
 import org.wso2.carbon.identity.input.validation.mgt.services.InputValidationManagementService;
 import org.wso2.carbon.identity.input.validation.mgt.services.InputValidationManagementServiceImpl;
 import org.wso2.carbon.identity.input.validation.mgt.userinfo.UserInfoHandlerImpl;
+import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.utils.multitenancy.userinfo.UserInfoHandler;
 
@@ -196,5 +197,21 @@ public class InputValidationServiceComponent {
     protected void unsetClaimMetaMgtService(ClaimMetadataManagementService claimMetaMgtService) {
 
         InputValidationDataHolder.getInstance().setClaimMetadataManagementService(null);
+    }
+
+    @Reference(
+            name = "IdentityProviderManager",
+            service = org.wso2.carbon.idp.mgt.IdpManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdpManager")
+    protected void setIdpManager(IdpManager idpManager) {
+
+        InputValidationDataHolder.getInstance().setIdpManager(idpManager);
+    }
+
+    protected void unsetIdpManager(IdpManager idpManager) {
+
+        InputValidationDataHolder.getInstance().setIdpManager(null);
     }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementServiceImpl.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementServiceImpl.java
@@ -492,22 +492,6 @@ public class InputValidationManagementServiceImpl implements InputValidationMana
     }
 
     /**
-     * Method to get password policy handler configuration names.
-     *
-     * @return  Password policy configuration.
-     * @throws InputValidationMgtServerException If an error occurred when getting password policy configuration.
-     */
-    public String[] getPropertyNames() {
-
-        List<String> properties = new ArrayList<>();
-        properties.add(PW_POLICY_ENABLE);
-        properties.add(PW_POLICY_MIN_LENGTH);
-        properties.add(PW_POLICY_MAX_LENGTH);
-        properties.add(PW_POLICY_PATTERN);
-        return properties.toArray(new String[0]);
-    }
-
-    /**
      * Method to get password policy handler configuration.
      *
      * @param tenantDomain  Tenant domain name.

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementServiceImpl.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementServiceImpl.java
@@ -21,11 +21,15 @@ package org.wso2.carbon.identity.input.validation.mgt.services;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.IdentityProviderProperty;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resources;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtClientException;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtException;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtServerException;
@@ -36,6 +40,9 @@ import org.wso2.carbon.identity.input.validation.mgt.model.ValidationConfigurati
 import org.wso2.carbon.identity.input.validation.mgt.model.Validator;
 import org.wso2.carbon.identity.input.validation.mgt.model.ValidatorConfiguration;
 import org.wso2.carbon.identity.input.validation.mgt.model.validators.AbstractRegExValidator;
+import org.wso2.carbon.identity.input.validation.mgt.utils.Constants;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.IdpManager;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -45,6 +52,9 @@ import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.input.validation.mgt.internal.InputValidationDataHolder.getFieldValidationConfigurationHandlers;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.MAX_LENGTH;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.MIN_LENGTH;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.PASSWORD;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.REGEX;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.RULES;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.VALIDATION_TYPE;
@@ -55,6 +65,10 @@ import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Erro
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.FIELD_VALIDATION_CONFIG_HANDLER_MAP;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.INPUT_VAL_CONFIG_RESOURCE_NAME_PREFIX;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.INPUT_VAL_CONFIG_RESOURCE_TYPE_NAME;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.PW_POLICY_ENABLE;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.PW_POLICY_MAX_LENGTH;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.PW_POLICY_MIN_LENGTH;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.PW_POLICY_PATTERN;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.SUPPORTED_PARAMS;
 
 /**
@@ -165,7 +179,7 @@ public class InputValidationManagementServiceImpl implements InputValidationMana
 
         return InputValidationDataHolder.getFieldValidationConfigurationHandlers();
     }
-    
+
     public ValidationConfiguration getConfigurationFromUserStore(String tenantDomain, String field)
             throws InputValidationMgtException {
 
@@ -375,13 +389,34 @@ public class InputValidationManagementServiceImpl implements InputValidationMana
      * @param resource  Resource.
      * @return Validation Configuration.
      */
-    private ValidationConfiguration buildValidationConfigFromResource(Resource resource) {
+    private ValidationConfiguration buildValidationConfigFromResource(Resource resource)
+            throws InputValidationMgtServerException {
 
         ValidationConfiguration configuration = new ValidationConfiguration();
-        configuration.setField(resource.getResourceName().substring(
-                resource.getResourceName().lastIndexOf("-") + 1));
-        Map<String, String> attributesMap = resource.getAttributes().stream()
+        String field = resource.getResourceName().substring(
+                resource.getResourceName().lastIndexOf("-") + 1);
+        configuration.setField(field);
+        Map<String, String> attributesMap = new HashMap<>();
+        if (StringUtils.equals(field, PASSWORD) && isPasswordPolicyHandlerEnabled()) {
+            Map<String, String> passwordPolicyConfig = getPasswordPolicyConfiguration(resource.getTenantDomain());
+            if (passwordPolicyConfig.containsKey(PW_POLICY_ENABLE) && Boolean.parseBoolean(
+                    passwordPolicyConfig.get(PW_POLICY_ENABLE))) {
+                attributesMap.put(VALIDATION_TYPE, RULES);
+                for (Map.Entry<String, String> entry : passwordPolicyConfig.entrySet()) {
+                    String key = entry.getKey();
+                    if (StringUtils.equalsIgnoreCase(PW_POLICY_MIN_LENGTH, key)) {
+                        attributesMap.put("LengthValidator." + MIN_LENGTH, entry.getValue());
+                    } else if (StringUtils.equalsIgnoreCase(PW_POLICY_MAX_LENGTH, key)) {
+                        attributesMap.put("LengthValidator." + MAX_LENGTH, entry.getValue());
+                    } else if (StringUtils.equalsIgnoreCase(PW_POLICY_PATTERN, key)) {
+                        attributesMap.put("PatternValidator.Pattern", entry.getValue());
+                    }
+                }
+            }
+        } else {
+            attributesMap = resource.getAttributes().stream()
                     .collect(Collectors.toMap(Attribute::getKey, Attribute::getValue));
+        }
 
         // Build rules configurations from mapping.
         Map<String, Map<String, String>> validatorConfig = buildValidatorConfigGroup(attributesMap);
@@ -436,5 +471,69 @@ public class InputValidationManagementServiceImpl implements InputValidationMana
     private ConfigurationManager getConfigurationManager() {
 
         return InputValidationDataHolder.getConfigurationManager();
+    }
+
+    /**
+     * Method to check whether the password policy handler is enabled.
+     *
+     * @return  True if password policy handler is enabled.
+     */
+    public boolean isPasswordPolicyHandlerEnabled() {
+
+        String passwordPolicyHandlerEnabled =
+                IdentityUtil.getProperty(Constants.PW_POLICY_HANDLER_ENABLED);
+        if (StringUtils.isBlank(passwordPolicyHandlerEnabled)) {
+            /*
+            This indicates config not in the identity.xml. In that case, we need to maintain default behaviour.
+             */
+            return false;
+        }
+        return Boolean.parseBoolean(passwordPolicyHandlerEnabled);
+    }
+
+    /**
+     * Method to get password policy handler configuration names.
+     *
+     * @return  Password policy configuration.
+     * @throws InputValidationMgtServerException If an error occurred when getting password policy configuration.
+     */
+    public String[] getPropertyNames() {
+
+        List<String> properties = new ArrayList<>();
+        properties.add(PW_POLICY_ENABLE);
+        properties.add(PW_POLICY_MIN_LENGTH);
+        properties.add(PW_POLICY_MAX_LENGTH);
+        properties.add(PW_POLICY_PATTERN);
+        return properties.toArray(new String[0]);
+    }
+
+    /**
+     * Method to get password policy handler configuration.
+     *
+     * @param tenantDomain  Tenant domain name.
+     * @return  Password policy configuration.
+     * @throws InputValidationMgtServerException If an error occurred when getting password policy configuration.
+     */
+    public Map<String, String> getPasswordPolicyConfiguration(String tenantDomain)
+            throws InputValidationMgtServerException {
+
+        IdpManager identityProviderManager = InputValidationDataHolder.getInstance().getIdpManager();
+        IdentityProvider residentIdp = null;
+        try {
+            residentIdp = identityProviderManager.getResidentIdP(tenantDomain);
+        } catch (IdentityProviderManagementException e) {
+            String errorMsg = String.format("Error while retrieving resident Idp for %s tenant.", tenantDomain);
+            throw new InputValidationMgtServerException(e.getErrorCode(), errorMsg, e);
+        }
+        IdentityProviderProperty[] identityMgtProperties = residentIdp.getIdpProperties();
+        Map<String, String> configMap = new HashMap<>();
+        for (IdentityProviderProperty identityMgtProperty : identityMgtProperties) {
+            if (IdentityEventConstants.PropertyConfig.ALREADY_WRITTEN_PROPERTY_KEY
+                    .equals(identityMgtProperty.getName())) {
+                continue;
+            }
+            configMap.put(identityMgtProperty.getName(), identityMgtProperty.getValue());
+        }
+        return configMap;
     }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -51,6 +51,11 @@ public class Constants {
             }});
     public static final String EMAIL_CLAIM_URI = "http://wso2.org/claims/emailaddress";
     public static final String SUPER_TENANT_DOMAIN = "carbon.super";
+    public static final String PW_POLICY_HANDLER_ENABLED = "PasswordPolicy.PasswordPolicyValidationHandler.Enable";
+    public static final String PW_POLICY_ENABLE = "passwordPolicy.enable";
+    public static final String PW_POLICY_MIN_LENGTH = "passwordPolicy.min.length";
+    public static final String PW_POLICY_MAX_LENGTH = "passwordPolicy.max.length";
+    public static final String PW_POLICY_PATTERN = "passwordPolicy.pattern";
 
     /**
      * Class contains the configuration related constants.


### PR DESCRIPTION
### Proposed changes in this pull request

The default password validation can be disabled by below config.
```
[event.default_listener.validation]  
enable = false
```

The previous password policy handler can be enabled by below config.
```
[identity_mgt.password_policy.password_policy_validation_handler]  
enable = true
```

The validation rules API which provides the validation rules should consider the password rules configured in the old password policy connector if it is enabled as described above.

### Related Issues
- https://github.com/wso2/product-is/issues/22108
