### PR TITLE
Get the Org Login IDP for slo requests coming from sub-organizations

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
@@ -75,6 +75,7 @@ public class ApplicationConstants {
     public static final String PURPOSE_GROUP_TYPE_SYSTEM = "SYSTEM";
     public static final String PURPOSE_GROUP_SHARED = "SHARED";
     public static final String IS_FRAGMENT_APP = "isFragmentApp";
+    public static final String DEFAULT_BACKCHANNEL_LOGOUT_URL = "/identity/oidc/slo";
 
     public static final String TENANT_DEFAULT_SP_TEMPLATE_NAME = "default";
     public static final String MY_SQL = "MySQL";

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -839,11 +839,10 @@ public class IdentityProviderManager implements IdpManager {
             }
         }
 
-        if (identityProvider == null || StringUtils.isBlank(identityProvider.getId())) {
-            // Get the SSO IDP for back-channel logout requests coming from sub-organizations.
-            if (idPName.contains(IdentityUtil.getHostName()) && ISSUER_PATTERN.matcher(idPName).matches()) {
-                identityProvider = getSSOIDP(idPName, tenantId, tenantDomain);
-            }
+        // Get the SSO IDP for back-channel logout requests coming from sub-organizations.
+        if ((identityProvider == null || StringUtils.isBlank(identityProvider.getId()))
+                && idPName.contains(IdentityUtil.getHostName()) && ISSUER_PATTERN.matcher(idPName).matches()) {
+            identityProvider = getSSOIDP(idPName, tenantId, tenantDomain);
         }
 
         return identityProvider;

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -97,7 +97,7 @@ public class IdentityProviderManager implements IdpManager {
     private static final String JWKS_URI = "jwksUri";
     private static final String OAUTH2_JWKS_EP_URL = "oauth2/jwks";
     private static final String OAUTH2_TOKEN_EP_URL = "oauth2/token";
-    private static final Pattern ISSUER_PATTERN = Pattern.compile("(.+)/o/(.+)/oauth2/token");
+    private static final Pattern ISSUER_PATTERN = Pattern.compile("^https?://[^/]+/o/([^/]+)/oauth2/token$");
     private static final String ORGANIZATION_LOGIN_IDP_NAME = "SSO";
     private static final int OTP_CODE_MIN_LENGTH = 4;
     private static final int OTP_CODE_MAX_LENGTH = 10;

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagerTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.idp.mgt;
+
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.IdentityProviderProperty;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.idp.mgt.dao.CacheBackedIdPMgtDAO;
+import org.wso2.carbon.idp.mgt.dao.FileBasedIdPMgtDAO;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@WithCarbonHome
+//@WithRealmService(injectToSingletons = {IdpMgtServiceComponentHolder.class}, initUserStoreManager = true)
+public class IdentityProviderManagerTest {
+
+    private static final String ORGANIZATION_LOGIN_IDP_NAME = "SSO";
+    private static final String JWKS_URI = "jwksUri";
+    private static final String OAUTH2_TOKEN_EP_URL = "/oauth2/token";
+    private static final String OAUTH2_JWKS_EP_URL = "/oauth2/jwks";
+    private static final String TENANT_DOMAIN = "foo.com";
+    private static final String IDP_NAME = "https://localhost/oauth2/token";
+
+    @Mock
+    private CacheBackedIdPMgtDAO dao;
+    @Mock
+    private FileBasedIdPMgtDAO mockFileBasedDao;
+
+    private IdentityProviderManager identityProviderManager;
+
+    @BeforeMethod
+    public void setUpClass() throws NoSuchFieldException, IllegalAccessException {
+
+        identityProviderManager = IdentityProviderManager.getInstance();
+        // Use reflection to inject the mock dao into the static field.
+        Field daoField = IdentityProviderManager.class.getDeclaredField("dao");
+        daoField.setAccessible(true);
+        daoField.set(identityProviderManager, dao);
+    }
+
+    @BeforeTest
+    public void setUp() {
+        // Initialize mocks
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test(description = "Tests get IdP by name when file based IdP is not available.")
+    public void testGetIdPByName() throws IdentityProviderManagementException {
+
+        IdentityProvider mockIdP = new IdentityProvider();
+        mockIdP.setId("123");
+        when(dao.getIdPByName(null, IDP_NAME, 1, TENANT_DOMAIN)).thenReturn(mockIdP);
+
+        try (MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil = mockStatic(IdentityTenantUtil.class)) {
+            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(1);
+
+            IdentityProvider result = identityProviderManager.getIdPByName(IDP_NAME, TENANT_DOMAIN, true);
+
+            assertNotNull(result);
+            assertEquals("123", result.getId());
+        }
+    }
+
+    @Test(description = "Tests get SSO IDP with JWKS URI.")
+    public void testGetSSOIDPWithJWKSUri() throws IdentityProviderManagementException {
+        String jwtIssuer = "https://localhost/o/ba972190-391a-42a0-92e8-5eb58fbcfae3/oauth2/token";
+        IdentityProvider ssoIdP = new IdentityProvider();
+        ssoIdP.setId("ssoIdP");
+        ssoIdP.setIdpProperties(new IdentityProviderProperty[0]);
+
+        when(dao.getIdPByName(null, jwtIssuer, 1, TENANT_DOMAIN)).thenReturn(null);
+        when(dao.getIdPByName(null, ORGANIZATION_LOGIN_IDP_NAME, 1, TENANT_DOMAIN)).thenReturn(ssoIdP);
+
+        try (MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<IdentityUtil> mockedIdentityUtil = mockStatic(IdentityUtil.class)) {
+
+            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(1);
+            mockedIdentityUtil.when(IdentityUtil::getHostName).thenReturn("localhost");
+
+            IdentityProvider result = identityProviderManager.getIdPByName(jwtIssuer, TENANT_DOMAIN, true);
+
+            assertNotNull(result);
+            assertEquals("ssoIdP", result.getId());
+            assertTrue(Arrays.stream(result.getIdpProperties())
+                    .anyMatch(p -> JWKS_URI.equals(p.getName()) &&
+                            p.getValue().equals(jwtIssuer.replace(OAUTH2_TOKEN_EP_URL, OAUTH2_JWKS_EP_URL))));
+        }
+    }
+}

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/resources/testng.xml
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/resources/testng.xml
@@ -27,6 +27,7 @@
             <class name="org.wso2.carbon.idp.mgt.IdentityProviderManagementServiceTest"/>
             <class name="org.wso2.carbon.idp.mgt.listener.IDPMgtAuditLoggerTest"/>
             <class name="org.wso2.carbon.idp.mgt.util.IdPSecretsProcessorTest"/>
+            <class name="org.wso2.carbon.idp.mgt.IdentityProviderManagerTest"/>
         </classes>
     </test>
 </suite>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2553,6 +2553,7 @@
             <Context>/logincontext(.*)</Context>
             <Context>/samlsso(.*)</Context>
             <Context>/identity/metadata/saml2</Context>
+            <Context>/identity/oidc/slo</Context>
             <Context>/longwaitstatus(.*)</Context>
             <Context>/oidc/</Context>
             <Context>/push-auth/(.*)</Context>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3907,6 +3907,7 @@
             <Context>/logincontext(.*)</Context>
             <Context>/samlsso(.*)</Context>
             <Context>/identity/metadata/saml2</Context>
+            <Context>/identity/oidc/slo</Context>
             <Context>/longwaitstatus(.*)</Context>
             <Context>/oidc/</Context>
             <Context>/push-auth/(.*)</Context>


### PR DESCRIPTION
### Summary
This pull request updates identity.xml.j2 file to support OpenID Connect single logout (OIDC SLO).
Get the Org Login IDP for slo requests coming from sub-organizations

### Related Issue
https://github.com/wso2/product-is/issues/22338