### PR TITLE
Fix serialization error at authentication context cloning.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/AuthenticatorConfig.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/AuthenticatorConfig.java
@@ -20,7 +20,9 @@ package org.wso2.carbon.identity.application.authentication.framework.config.mod
 
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorStateInfo;
+import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.UserDefinedFederatedAuthenticatorConfig;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -127,6 +129,23 @@ public class AuthenticatorConfig implements Serializable {
 
     public void setIdPs(Map<String, IdentityProvider> idPs) {
 
+
+        if (idPs != null) {
+            /* Remove non-serializable UserDefinedAuthenticatorEndpointConfig objects from the
+             UserDefinedFederatedAuthenticatorConfig in the context. The UserDefinedAuthenticatorEndpointConfig contains
+             the endpoint URI and the authentication type of the corresponding action. However, this information is not
+             used in the authentication flow. Instead, the action ID in the authenticator property is used to resolve
+             the corresponding action.
+             TOD0: https://github.com/wso2/product-is/issues/22907
+             [Robust solution for serialization error at authentication context cloning] */
+            for (IdentityProvider idp : idPs.values()) {
+                for (FederatedAuthenticatorConfig authConfig : idp.getFederatedAuthenticatorConfigs()) {
+                    if (authConfig instanceof UserDefinedFederatedAuthenticatorConfig) {
+                        ((UserDefinedFederatedAuthenticatorConfig) authConfig).setEndpointConfig(null);
+                    }
+                }
+            }
+        }
         this.idps = idPs;
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
@@ -22,17 +22,12 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.SerializationUtils;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorStateInfo;
-import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
-import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationRequest;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
-import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
-import org.wso2.carbon.identity.application.common.model.IdentityProvider;
-import org.wso2.carbon.identity.application.common.model.UserDefinedFederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -860,43 +855,6 @@ public class AuthenticationContext extends MessageContext implements Serializabl
      */
     public Object clone () {
 
-        removeNonSerializableObjects();
         return SerializationUtils.clone(this);
-    }
-
-    private void removeNonSerializableObjects() {
-
-        /* Remove non-serializable UserDefinedAuthenticatorEndpointConfig objects from the
-         UserDefinedFederatedAuthenticatorConfig in the context. The UserDefinedAuthenticatorEndpointConfig contains
-         the endpoint URI and the authentication type of the corresponding action. However, this information is not
-         used in the authentication flow. Instead, the action ID in the authenticator property is used to resolve the
-         corresponding action. */
-        if (sequenceConfig == null || sequenceConfig.getStepMap() == null) {
-            return;
-        }
-
-        for (StepConfig stepConfig : sequenceConfig.getStepMap().values()) {
-            if (stepConfig == null || stepConfig.getAuthenticatorList() == null) {
-                continue;
-            }
-
-            for (AuthenticatorConfig authenticatorConfig : stepConfig.getAuthenticatorList()) {
-                if (stepConfig.getAuthenticatorList() == null) {
-                    continue;
-                }
-
-                for (IdentityProvider idp : authenticatorConfig.getIdps().values()) {
-                    if (idp == null || idp.getFederatedAuthenticatorConfigs() == null) {
-                        continue;
-                    }
-
-                    for (FederatedAuthenticatorConfig authConfig : idp.getFederatedAuthenticatorConfigs()) {
-                        if (authConfig instanceof UserDefinedFederatedAuthenticatorConfig) {
-                            ((UserDefinedFederatedAuthenticatorConfig) authConfig).setEndpointConfig(null);
-                        }
-                    }
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/22715

As the UserDefinedAuthenticatorEndpointConfig is not extended Serializable, when trying load the authenticator config from the context cache, there is an error ocurred. This UserDefinedAuthenticatorEndpointConfig does not required in the authentication flow, therefore set null for endpointConfig for custom federated authenticator at AuthenticatorConfig.