### PR TITLE
Update API resource collection v0 for email templates

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -723,6 +723,7 @@
                 <Scope name="console:org:emailTemplates"/>
             </Feature>
             <Update>
+                <Scope name="internal_org_email_mgt_update"/>
             </Update>
             <Delete>
             </Delete>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -765,6 +765,7 @@
                 <Scope name="console:org:emailTemplates"/>
             </Feature>
             <Update>
+                <Scope name="internal_org_email_mgt_update"/>
             </Update>
             <Delete>
             </Delete>


### PR DESCRIPTION
### Proposed changes in this pull request
After the backward compatibility support introduced with the https://github.com/wso2/product-is/issues/22071 effort for API resource collections, we need to have the previous scopes related to each API resource collection in IS 7.0.0 in v0 version tag.

Hence, adding the previous scopes available in https://github.com/wso2/carbon-identity-framework/blob/v7.0.78/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2#L759-L774 ((framework version in IS 7.0.0 vanilla pack)) for the v0 tag.