### PR TITLE
Validate system authenticators names at registering.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -34,6 +34,7 @@ public abstract class FrameworkConstants {
     public static final String COMMONAUTH_COOKIE = "commonAuthId";
     public static final String ALLOW_SESSION_CREATION = "allowSessionCreation";
     public static final String CONTEXT_PROP_INVALID_EMAIL_USERNAME = "InvalidEmailUsername";
+    public static final String CUSTOM_AUTHENTICATOR_PREFIX = "custom-";
     // Cookie used for post authenticaion sequence tracking
     public static final String PASTR_COOKIE = "pastr";
     public static final String CLAIM_URI_WSO2_EXT_IDP = "http://wso2.org/claims/externalIDP";


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/23020

With this PR, verify that the registering system-defined authenticator name starts with the `custom-` prefix, which is reserved for user-defined authenticators, if so ignore that authenticator and add warn log.