### PR TITLE
Terminating all the active sessions of users whose password changed in devportal

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/UserSessionTerminationListener.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/listener/UserSessionTerminationListener.java
@@ -78,6 +78,26 @@ public class UserSessionTerminationListener extends AbstractIdentityUserOperatio
     }
 
     @Override
+    public boolean doPostUpdateCredential(String username, Object credential, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+
+        if (!IdentityMgtServiceDataHolder.getInstance().isUserSessionMappingEnabled()) {
+            return true;
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Terminating all the active sessions of the password updated user: " + username);
+        }
+
+        terminateSessionsOfUser(username, userStoreManager);
+        return true;
+    }
+
+    @Override
     public boolean doPreDeleteUser(String username, UserStoreManager userStoreManager) throws UserStoreException {
 
         if (!isEnable()) {


### PR DESCRIPTION
## Purpose
- If the user change the password through devportal in current implemtation the user session will not terminated.
- From this change all the active sessions will terminate when password is changed through devportal
- Related issue - https://github.com/wso2-enterprise/wso2-iam-internal/issues/2436

## Approach
- Similar to doPostUpdateCredentialByAdmin check whether the user session mapping enabled and AbstractUserOperationEventListener is enabled. 