### PR TITLE
Add profile update flow to Identity Context and update the password action builders

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Flow.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Flow.java
@@ -38,6 +38,8 @@ public class Flow {
                 EnumSet.of(InitiatingPersona.ADMIN, InitiatingPersona.APPLICATION, InitiatingPersona.USER));
         FLOW_DEFINITIONS.put(Name.USER_REGISTRATION_INVITE_WITH_PASSWORD,
                 EnumSet.of(InitiatingPersona.ADMIN, InitiatingPersona.APPLICATION));
+        FLOW_DEFINITIONS.put(Name.PROFILE_UPDATE,
+                EnumSet.of(InitiatingPersona.ADMIN, InitiatingPersona.APPLICATION, InitiatingPersona.USER));
     }
 
     /**
@@ -48,7 +50,8 @@ public class Flow {
 
         PASSWORD_UPDATE,
         PASSWORD_RESET,
-        USER_REGISTRATION_INVITE_WITH_PASSWORD
+        USER_REGISTRATION_INVITE_WITH_PASSWORD,
+        PROFILE_UPDATE
     }
 
     /**

--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/core/listener/ActionUserOperationEventListener.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/core/listener/ActionUserOperationEventListener.java
@@ -117,7 +117,8 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
         }
 
         return flow.getName() == Flow.Name.PASSWORD_UPDATE || flow.getName() == Flow.Name.PASSWORD_RESET ||
-                flow.getName() == Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD;
+                flow.getName() == Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD ||
+                flow.getName() == Flow.Name.PROFILE_UPDATE;
     }
 
     private char[] getSecret(Object credential) throws UserStoreException {

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/execution/PreUpdatePasswordActionRequestBuilder.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/execution/PreUpdatePasswordActionRequestBuilder.java
@@ -136,6 +136,7 @@ public class PreUpdatePasswordActionRequestBuilder implements ActionExecutionReq
 
         switch (flow.getName()) {
             case PASSWORD_UPDATE:
+            case PROFILE_UPDATE:
                 return PreUpdatePasswordEvent.Action.UPDATE;
             case PASSWORD_RESET:
                 return PreUpdatePasswordEvent.Action.RESET;

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
@@ -92,17 +92,17 @@ public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEv
     private String getFlowFromContext() throws RuleEvaluationDataProviderException {
 
         Flow flow = IdentityContext.getThreadLocalIdentityContext().getFlow();
-        if (flow.getName() == Flow.Name.PASSWORD_UPDATE &&
+        if ((flow.getName() == Flow.Name.PASSWORD_UPDATE || flow.getName() == Flow.Name.PROFILE_UPDATE) &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN) {
             return PasswordUpdateFlowType.ADMIN_INITIATED_PASSWORD_UPDATE.getFlowName();
         }
 
-        if (flow.getName() == Flow.Name.PASSWORD_UPDATE &&
+        if ((flow.getName() == Flow.Name.PASSWORD_UPDATE || flow.getName() == Flow.Name.PROFILE_UPDATE) &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.APPLICATION) {
             return PasswordUpdateFlowType.APPLICATION_INITIATED_PASSWORD_UPDATE.getFlowName();
         }
 
-        if (flow.getName() == Flow.Name.PASSWORD_UPDATE &&
+        if ((flow.getName() == Flow.Name.PASSWORD_UPDATE || flow.getName() == Flow.Name.PROFILE_UPDATE) &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.USER) {
             return PasswordUpdateFlowType.USER_INITIATED_PASSWORD_UPDATE.getFlowName();
         }


### PR DESCRIPTION
### Proposed changes in this pull request

1. This will add new PROFILE_UPDATE flow to the Identity Context flows
2. Update the password update request builder and the rule evaluation data provider to support those flows

### Related Issue
- 