### PR TITLE
Handle session retrieval issue for sub org users

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/UserSessionManagementServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/UserSessionManagementServiceImpl.java
@@ -640,7 +640,7 @@ public class UserSessionManagementServiceImpl implements UserSessionManagementSe
             } else {
                 // This block handles the scenario where session tenant domain and login tenant domain are different.
                 if (isOrganization &&
-                        validatePrimaryOrganization(sessionTenantDomain, loginTenantDomain)) {
+                        isSessionTenantPrimaryOrgForLoginTenant(sessionTenantDomain, loginTenantDomain)) {
                     /*
                     When a sub org user authenticates using a shared application, sessions are created for shared app in
                     sub organization and parent app in primary organization. In this case, the session created in
@@ -686,7 +686,7 @@ public class UserSessionManagementServiceImpl implements UserSessionManagementSe
         return true;
     }
 
-    private boolean validatePrimaryOrganization(String sessionTenantDomain, String loginTenantDomain)
+    private boolean isSessionTenantPrimaryOrgForLoginTenant(String sessionTenantDomain, String loginTenantDomain)
             throws OrganizationManagementException {
 
         OrganizationManager organizationManager = FrameworkServiceDataHolder.getInstance().getOrganizationManager();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/UserSessionManagementServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/UserSessionManagementServiceImpl.java
@@ -32,14 +32,21 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.s
 import org.wso2.carbon.identity.application.authentication.framework.exception.session.mgt.SessionManagementServerException;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceComponent;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
+import org.wso2.carbon.identity.application.authentication.framework.model.Application;
 import org.wso2.carbon.identity.application.authentication.framework.model.UserSession;
 import org.wso2.carbon.identity.application.authentication.framework.services.SessionManagementService;
 import org.wso2.carbon.identity.application.authentication.framework.store.UserSessionStore;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authentication.framework.util.SessionMgtConstants;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.identity.user.profile.mgt.AssociatedAccountDTO;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.exception.FederatedAssociationManagerException;
@@ -53,6 +60,7 @@ import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,6 +75,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.SessionMgtConstants.ErrorMessages.ERROR_CODE_INVALID_USER;
 import static org.wso2.carbon.identity.application.authentication.framework.util.SessionMgtConstants.ErrorMessages.ERROR_CODE_UNABLE_TO_AUTHORIZE_USER;
 import static org.wso2.carbon.identity.application.authentication.framework.util.SessionMgtConstants.ErrorMessages.ERROR_CODE_UNABLE_TO_GET_SESSIONS;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.IS_FRAGMENT_APP;
 
 /**
  * This a service class used to manage user sessions.
@@ -583,17 +592,12 @@ public class UserSessionManagementServiceImpl implements UserSessionManagementSe
                 SessionContext sessionContext = FrameworkUtils.getSessionContextFromCache(sessionId,
                         FrameworkUtils.getLoginTenantDomainFromContext());
                 if (sessionContext != null) {
-                    if (sessionContext.getProperties() != null &&
-                            sessionContext.getProperties().get(FrameworkUtils.TENANT_DOMAIN) instanceof String) {
-                        String tenantDomain = (String) sessionContext.getProperties().get(FrameworkUtils.TENANT_DOMAIN);
-                        // User's sessions belongs to the requested tenant is returned.
-                        if (!StringUtils.equals(FrameworkUtils.getLoginTenantDomainFromContext(), tenantDomain)) {
-                            continue;
-                        }
-                    }
                     UserSessionDAO userSessionDAO = new UserSessionDAOImpl();
                     UserSession userSession = userSessionDAO.getSession(sessionId);
                     if (userSession != null) {
+                        if (!isEffectiveSession(sessionContext, userSession)) {
+                            continue;
+                        }
                         if (StringUtils.isNotBlank(idpId)) {
                             userSession.setIdpId(idpId);
                         }
@@ -605,8 +609,84 @@ public class UserSessionManagementServiceImpl implements UserSessionManagementSe
                 }
             }
         }
-
         return sessionsList;
+    }
+
+    private boolean isEffectiveSession(SessionContext sessionContext, UserSession userSession) {
+
+        try {
+            String sessionTenantDomain = null;
+            if (sessionContext.getProperties() != null &&
+                    sessionContext.getProperties().get(FrameworkUtils.TENANT_DOMAIN) instanceof String) {
+                sessionTenantDomain = (String) sessionContext.getProperties().get(FrameworkUtils.TENANT_DOMAIN);
+            }
+            if (StringUtils.isEmpty(sessionTenantDomain)) {
+                return true;
+            }
+            String loginTenantDomain = FrameworkUtils.getLoginTenantDomainFromContext();
+            boolean isOrganization = OrganizationManagementUtil.isOrganization(loginTenantDomain);
+            if (StringUtils.equals(sessionTenantDomain, loginTenantDomain)) {
+                return !(isOrganization & areAllFragmentAppsInUserSession(userSession));
+            } else {
+                if (isOrganization &&
+                        validatePrimaryOrganization(sessionTenantDomain, loginTenantDomain)) {
+                    return true;
+                }
+                return isSaaSAppAvailableInUserSession(userSession);
+            }
+        } catch (OrganizationManagementException | IdentityApplicationManagementException e) {
+            log.error("Error occurred while validating the effective sessions.", e);
+            return true;
+        }
+    }
+
+    private boolean areAllFragmentAppsInUserSession(UserSession userSession)
+            throws IdentityApplicationManagementException {
+
+        ApplicationManagementService applicationManager =
+                FrameworkServiceDataHolder.getInstance().getApplicationManagementService();
+        for (Application app: userSession.getApplications()) {
+            ServiceProvider serviceProvider = applicationManager
+                    .getServiceProvider(Integer.parseInt(app.getAppId()));
+            if (serviceProvider == null) {
+                return false;
+            }
+            boolean isFragmentApp = Arrays.stream(serviceProvider.getSpProperties())
+                    .anyMatch(property -> IS_FRAGMENT_APP.equals(property.getName()) &&
+                    Boolean.parseBoolean(property.getValue()));
+            if (!isFragmentApp) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean validatePrimaryOrganization(String sessionTenantDomain, String loginTenantDomain)
+            throws OrganizationManagementException {
+
+        OrganizationManager organizationManager = FrameworkServiceDataHolder.getInstance().getOrganizationManager();
+        String loginTenantDomainOrgId = organizationManager.resolveOrganizationId(loginTenantDomain);
+        String sessionTenantDomainOrgId = organizationManager.resolveOrganizationId(sessionTenantDomain);
+        String primaryOrgId = organizationManager.getPrimaryOrganizationId(loginTenantDomainOrgId);
+        return StringUtils.equals(primaryOrgId, sessionTenantDomainOrgId);
+    }
+
+    private boolean isSaaSAppAvailableInUserSession(UserSession userSession)
+            throws IdentityApplicationManagementException {
+
+        ApplicationManagementService applicationManager =
+                FrameworkServiceDataHolder.getInstance().getApplicationManagementService();
+        for (Application app: userSession.getApplications()) {
+            ServiceProvider serviceProvider = applicationManager
+                    .getServiceProvider(Integer.parseInt(app.getAppId()));
+            if (serviceProvider == null) {
+                continue;
+            }
+            if (serviceProvider.isSaasApp()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request
This PR is introduced to handle session retrieval issues for sub org users. Currently only the session created in sub org is shown when getting the session list of sub org list. Ideally session created in primary org should be listed and sub org session should not be listed.

When implementing the fix, following cases are considered.
1. Root org normal apps - In this case, session is created for the root org and it should be considered as an effective session since the session retrieval request is also coming from the same root org.
2. B2B applications -  In this case, sessions are created in both root org and B2B org and root org session should be considered as the effective session even though session retrieval request comes from sub org.
3. SaaS applications - In this case, if a user logs into a SaaS app in different tenant, session is created in that tenant. But session retrieval request comes from user resident tenant. But we should return this session as an effective session.
4. Same userstore plugged in different tenants - In this case, same user ID can have different sessions in different tenants. Session retrieval requests can come from different tenants. Here, the sessions belong to the tenant related to session retrieval request should be considered as effective sessions.

Before the fix [1], the behaviour was,
- 1 & 3 cases working as expected.
- Both sessions were listed in case 2.
- All the sessions in different tenants were shown in case 4.

After the fix [1] which is done to address the case 4,
- 1 & 4 cases were handled correctly. 
- Only sub org session is shown in case 2.
- Only the sessions related to session request tenant domain are shown in case 3.

With this fix, we handled the above four cases to have expected behaviour.

[1] - https://github.com/wso2/carbon-identity-framework/pull/5693

Related Issue - https://github.com/wso2/product-is/issues/22310