### PR TITLE
Remove Password_Update flow from Identity Context

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Flow.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Flow.java
@@ -32,8 +32,6 @@ public class Flow {
     private static final Map<Name, EnumSet<InitiatingPersona>> FLOW_DEFINITIONS = new EnumMap<>(Name.class);
 
     static {
-        FLOW_DEFINITIONS.put(Name.PASSWORD_UPDATE,
-                EnumSet.of(InitiatingPersona.ADMIN, InitiatingPersona.APPLICATION, InitiatingPersona.USER));
         FLOW_DEFINITIONS.put(Name.PASSWORD_RESET,
                 EnumSet.of(InitiatingPersona.ADMIN, InitiatingPersona.APPLICATION, InitiatingPersona.USER));
         FLOW_DEFINITIONS.put(Name.USER_REGISTRATION_INVITE_WITH_PASSWORD,
@@ -48,7 +46,6 @@ public class Flow {
      */
     public enum Name {
 
-        PASSWORD_UPDATE,
         PASSWORD_RESET,
         USER_REGISTRATION_INVITE_WITH_PASSWORD,
         PROFILE_UPDATE

--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/core/listener/ActionUserOperationEventListener.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/core/listener/ActionUserOperationEventListener.java
@@ -116,7 +116,7 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
             return false;
         }
 
-        return flow.getName() == Flow.Name.PASSWORD_UPDATE || flow.getName() == Flow.Name.PASSWORD_RESET ||
+        return flow.getName() == Flow.Name.PASSWORD_RESET ||
                 flow.getName() == Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD ||
                 flow.getName() == Flow.Name.PROFILE_UPDATE;
     }

--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/test/java/org/wso2/carbon/identity/user/action/ActionUserOperationEventListenerTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/test/java/org/wso2/carbon/identity/user/action/ActionUserOperationEventListenerTest.java
@@ -68,7 +68,7 @@ public class ActionUserOperationEventListenerTest {
         listener = new ActionUserOperationEventListener();
         userCoreUtil.when(() -> UserCoreUtil.getDomainName(any())).thenReturn("PRIMARY");
         IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.PASSWORD_UPDATE)
+                .name(Flow.Name.PASSWORD_RESET)
                 .initiatingPersona(Flow.InitiatingPersona.USER)
                 .build());
     }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/execution/PreUpdatePasswordActionRequestBuilder.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/execution/PreUpdatePasswordActionRequestBuilder.java
@@ -135,8 +135,8 @@ public class PreUpdatePasswordActionRequestBuilder implements ActionExecutionReq
         }
 
         switch (flow.getName()) {
-            case PASSWORD_UPDATE:
             case PROFILE_UPDATE:
+                // Password update is a sub-flow of profile update.
                 return PreUpdatePasswordEvent.Action.UPDATE;
             case PASSWORD_RESET:
                 return PreUpdatePasswordEvent.Action.RESET;

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/core/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
@@ -92,18 +92,21 @@ public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEv
     private String getFlowFromContext() throws RuleEvaluationDataProviderException {
 
         Flow flow = IdentityContext.getThreadLocalIdentityContext().getFlow();
-        if ((flow.getName() == Flow.Name.PASSWORD_UPDATE || flow.getName() == Flow.Name.PROFILE_UPDATE) &&
+        if (flow.getName() == Flow.Name.PROFILE_UPDATE &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN) {
+            // Password update is a sub-flow of profile update.
             return PasswordUpdateFlowType.ADMIN_INITIATED_PASSWORD_UPDATE.getFlowName();
         }
 
-        if ((flow.getName() == Flow.Name.PASSWORD_UPDATE || flow.getName() == Flow.Name.PROFILE_UPDATE) &&
+        if (flow.getName() == Flow.Name.PROFILE_UPDATE &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.APPLICATION) {
+            // Password update is a sub-flow of profile update.
             return PasswordUpdateFlowType.APPLICATION_INITIATED_PASSWORD_UPDATE.getFlowName();
         }
 
-        if ((flow.getName() == Flow.Name.PASSWORD_UPDATE || flow.getName() == Flow.Name.PROFILE_UPDATE) &&
+        if (flow.getName() == Flow.Name.PROFILE_UPDATE &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.USER) {
+            // Password update is a sub-flow of profile update.
             return PasswordUpdateFlowType.USER_INITIATED_PASSWORD_UPDATE.getFlowName();
         }
 

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/execution/PreUpdatePasswordActionRequestBuilderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/execution/PreUpdatePasswordActionRequestBuilderTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.user.pre.update.password.action.execution;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.action.execution.exception.ActionExecutionRequestBuilderException;
 import org.wso2.carbon.identity.action.execution.model.ActionExecutionRequest;
@@ -131,13 +132,31 @@ public class PreUpdatePasswordActionRequestBuilderTest {
         assertEquals(preUpdatePasswordActionRequestBuilder.getSupportedActionType(), ActionType.PRE_UPDATE_PASSWORD);
     }
 
-    @Test
-    public void testRequestBuilder() throws ActionExecutionRequestBuilderException {
+    @DataProvider(name = "flowData")
+    public Object[][] flowData() {
 
-        IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.PASSWORD_UPDATE)
-                .initiatingPersona(Flow.InitiatingPersona.USER)
-                .build());
+        return new Object[][]{
+                {buildMockedFlow(Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.USER),
+                        PreUpdatePasswordEvent.Action.UPDATE, PreUpdatePasswordEvent.FlowInitiatorType.USER},
+                {buildMockedFlow(Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.APPLICATION),
+                        PreUpdatePasswordEvent.Action.UPDATE, PreUpdatePasswordEvent.FlowInitiatorType.APPLICATION},
+                {buildMockedFlow(Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.ADMIN),
+                        PreUpdatePasswordEvent.Action.UPDATE, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN},
+                {buildMockedFlow(Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.USER),
+                        PreUpdatePasswordEvent.Action.RESET, PreUpdatePasswordEvent.FlowInitiatorType.USER},
+                {buildMockedFlow(Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.ADMIN),
+                        PreUpdatePasswordEvent.Action.RESET, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN},
+                {buildMockedFlow(Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD, Flow.InitiatingPersona.ADMIN),
+                        PreUpdatePasswordEvent.Action.INVITE, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN}
+        };
+    }
+
+    @Test(dataProvider = "flowData")
+    public void testRequestBuilder(Flow mockedFlow, PreUpdatePasswordEvent.Action expectedAction,
+                                   PreUpdatePasswordEvent.FlowInitiatorType expectedInitiatorType)
+            throws ActionExecutionRequestBuilderException {
+
+        IdentityContext.getThreadLocalIdentityContext().setFlow(mockedFlow);
         eventContext.put("action", preUpdatePasswordAction);
 
         ActionExecutionRequest actionExecutionRequest = preUpdatePasswordActionRequestBuilder
@@ -148,8 +167,8 @@ public class PreUpdatePasswordActionRequestBuilderTest {
         assertTrue(actionExecutionRequest.getEvent() instanceof PreUpdatePasswordEvent);
 
         PreUpdatePasswordEvent preUpdatePasswordEvent = (PreUpdatePasswordEvent) actionExecutionRequest.getEvent();
-        assertEquals(preUpdatePasswordEvent.getInitiatorType(), PreUpdatePasswordEvent.FlowInitiatorType.USER);
-        assertEquals(preUpdatePasswordEvent.getAction(), PreUpdatePasswordEvent.Action.UPDATE);
+        assertEquals(preUpdatePasswordEvent.getInitiatorType(), expectedInitiatorType);
+        assertEquals(preUpdatePasswordEvent.getAction(), expectedAction);
 
         assertEquals(preUpdatePasswordEvent.getUserStore().getName(), TEST_USER_STORE_DOMAIN_NAME);
         assertEquals(preUpdatePasswordEvent.getUserStore().getId(), TEST_USER_STORE_DOMAIN_ID);
@@ -161,13 +180,14 @@ public class PreUpdatePasswordActionRequestBuilderTest {
         assertTrue(passwordUpdatingUser.getUpdatingCredential() instanceof String);
     }
 
-    @Test
-    public void testRequestBuilderWithUnEncryptedCredential() throws ActionExecutionRequestBuilderException {
+    @Test(dataProvider = "flowData")
+    public void testRequestBuilderWithUnEncryptedCredential(Flow mockedFlow,
+                                                            PreUpdatePasswordEvent.Action expectedAction,
+                                                            PreUpdatePasswordEvent.FlowInitiatorType
+                                                                        expectedInitiatorType)
+            throws ActionExecutionRequestBuilderException {
 
-        IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.PASSWORD_RESET)
-                .initiatingPersona(Flow.InitiatingPersona.APPLICATION)
-                .build());
+        IdentityContext.getThreadLocalIdentityContext().setFlow(mockedFlow);
         eventContext.put("action", preUpdatePasswordActionWithoutCert);
 
         ActionExecutionRequest actionExecutionRequest = preUpdatePasswordActionRequestBuilder
@@ -178,8 +198,8 @@ public class PreUpdatePasswordActionRequestBuilderTest {
         assertTrue(actionExecutionRequest.getEvent() instanceof PreUpdatePasswordEvent);
 
         PreUpdatePasswordEvent preUpdatePasswordEvent = (PreUpdatePasswordEvent) actionExecutionRequest.getEvent();
-        assertEquals(preUpdatePasswordEvent.getInitiatorType(), PreUpdatePasswordEvent.FlowInitiatorType.APPLICATION);
-        assertEquals(preUpdatePasswordEvent.getAction(), PreUpdatePasswordEvent.Action.RESET);
+        assertEquals(preUpdatePasswordEvent.getInitiatorType(), expectedInitiatorType);
+        assertEquals(preUpdatePasswordEvent.getAction(), expectedAction);
 
         assertEquals(preUpdatePasswordEvent.getUserStore().getName(), TEST_USER_STORE_DOMAIN_NAME);
         assertEquals(preUpdatePasswordEvent.getUserStore().getId(), TEST_USER_STORE_DOMAIN_ID);
@@ -189,5 +209,13 @@ public class PreUpdatePasswordActionRequestBuilderTest {
         assertEquals(passwordUpdatingUser.getId(), TEST_ID);
         assertNotNull(passwordUpdatingUser.getUpdatingCredential());
         assertTrue(passwordUpdatingUser.getUpdatingCredential() instanceof Credential);
+    }
+
+    private static Flow buildMockedFlow(Flow.Name flowName, Flow.InitiatingPersona initiatingPersona) {
+
+        return new Flow.Builder()
+                .name(flowName)
+                .initiatingPersona(initiatingPersona)
+                .build();
     }
 }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
@@ -82,9 +82,9 @@ public class PreUpdatePasswordActionRuleEvaluationDataProviderTest {
     public Object[][] flowData() {
 
         return new Object[][]{
-                {Flow.Name.PASSWORD_UPDATE, Flow.InitiatingPersona.ADMIN, "adminInitiatedPasswordUpdate"},
-                {Flow.Name.PASSWORD_UPDATE, Flow.InitiatingPersona.USER, "userInitiatedPasswordUpdate"},
-                {Flow.Name.PASSWORD_UPDATE, Flow.InitiatingPersona.APPLICATION, "applicationInitiatedPasswordUpdate"},
+                {Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.ADMIN, "adminInitiatedPasswordUpdate"},
+                {Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.USER, "userInitiatedPasswordUpdate"},
+                {Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.APPLICATION, "applicationInitiatedPasswordUpdate"},
                 {Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.ADMIN, "adminInitiatedPasswordReset"},
                 {Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.USER, "userInitiatedPasswordReset"},
                 {Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD, Flow.InitiatingPersona.ADMIN,


### PR DESCRIPTION
### Proposed changes in this pull request
- Removing Password Update flow, since now it is not used in the product flows.
- Profile Update flow covers the Password Update flow.

Depends on: https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/612

### Related Issue
- https://github.com/wso2/product-is/issues/23067