### PR TITLE
Improve the logic to build error message when error description is null in ActionUserOperationEventListener

### DIFF
--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/core/listener/ActionUserOperationEventListener.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/core/listener/ActionUserOperationEventListener.java
@@ -135,6 +135,10 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
 
     private String buildErrorMessage(String message, String description) {
 
+        if (description == null) {
+            return message;
+        }
+
         return message + ". " + description;
     }
 }

--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/test/java/org/wso2/carbon/identity/user/action/ActionUserOperationEventListenerTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/test/java/org/wso2/carbon/identity/user/action/ActionUserOperationEventListenerTest.java
@@ -97,7 +97,7 @@ public class ActionUserOperationEventListenerTest {
     }
 
     @Test
-    public void testDoPreUpdateCredentialByAdminWithID_WithDisabledListener()
+    public void testPreUpdatePasswordActionExecutionWithDisabledListener()
             throws UserStoreException, UnsupportedSecretTypeException {
 
         IdentityEventListenerConfig mockConfig = mock(IdentityEventListenerConfig.class);
@@ -111,7 +111,7 @@ public class ActionUserOperationEventListenerTest {
     }
 
     @Test
-    public void testDoPreUpdateCredentialByAdminWithID_Success()
+    public void testPreUpdatePasswordActionExecutionSuccess()
             throws UserStoreException, ActionExecutionException, UnsupportedSecretTypeException {
 
         ActionExecutionStatus<Success> successStatus =
@@ -126,7 +126,7 @@ public class ActionUserOperationEventListenerTest {
     }
 
     @Test
-    public void testDoPreUpdateCredentialByAdminWithID_Failed() throws ActionExecutionException {
+    public void testPreUpdatePasswordActionExecutionFailure() throws ActionExecutionException {
 
         Failure failureResponse = new Failure("FailureReason", "FailureDescription");
         ActionExecutionStatus<Failure> failedStatus = new FailedStatus(failureResponse);
@@ -145,7 +145,26 @@ public class ActionUserOperationEventListenerTest {
     }
 
     @Test
-    public void testDoPreUpdateCredentialByAdminWithID_Error() throws ActionExecutionException {
+    public void testPreUpdatePasswordActionExecutionFailureWithoutDescription() throws ActionExecutionException {
+
+        Failure failureResponse = new Failure("FailureReason", null);
+        ActionExecutionStatus<Failure> failedStatus = new FailedStatus(failureResponse);
+        doReturn(failedStatus).when(mockExecutor).execute(any(), any());
+        doReturn(ActionType.PRE_UPDATE_PASSWORD).when(mockExecutor).getSupportedActionType();
+        UserActionExecutorFactory.registerUserActionExecutor(mockExecutor);
+
+        try {
+            listener.doPreUpdateCredentialByAdminWithID(USER_NAME, Secret.getSecret(PASSWORD), userStoreManager);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof UserStoreClientException);
+            Assert.assertEquals(e.getMessage(), "FailureReason");
+            Assert.assertEquals(((UserStoreClientException) e).getErrorCode(),
+                    PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED);
+        }
+    }
+
+    @Test
+    public void testPreUpdatePasswordActionExecutionError() throws ActionExecutionException {
 
         Error errorResponse = new Error("ErrorMessage", "ErrorDescription");
         ActionExecutionStatus<Error> errorStatus = new ErrorStatus(errorResponse);
@@ -163,7 +182,7 @@ public class ActionUserOperationEventListenerTest {
     }
 
     @Test
-    public void testDoPreUpdateCredentialByAdminWithID_UnsupportedSecret() throws ActionExecutionException {
+    public void testPreUpdatePasswordActionExecutionWithUnsupportedSecret() throws ActionExecutionException {
 
         Error errorResponse = new Error("ErrorMessage", "ErrorDescription");
         ActionExecutionStatus<Error> errorStatus = new ErrorStatus(errorResponse);
@@ -181,7 +200,7 @@ public class ActionUserOperationEventListenerTest {
     }
 
     @Test
-    public void testDoPreUpdateCredentialByAdminWithID_UnknownStatus()
+    public void testPreUpdatePasswordActionExecutionWithUnknownStatus()
             throws UserStoreException, ActionExecutionException, UnsupportedSecretTypeException {
 
         ActionExecutionStatus<?> unknownStatus = mock(ActionExecutionStatus.class);
@@ -195,7 +214,7 @@ public class ActionUserOperationEventListenerTest {
     }
 
     @Test
-    public void testDoPreUpdateCredentialByAdminWithID_ActionExecutionException() throws ActionExecutionException {
+    public void testPreUpdatePasswordActionExecutionWithActionExecutionException() throws ActionExecutionException {
 
         doThrow(new ActionExecutionException("Execution error")).when(mockExecutor).execute(any(), any());
         doReturn(ActionType.PRE_UPDATE_PASSWORD).when(mockExecutor).getSupportedActionType();


### PR DESCRIPTION
### Proposed changes in this pull request

1. With this PR it will improve building the error message logic
2. If the error description is null, only the error message will be returned, otherwise error message and description will be concatenated.

### Related Issue
- 