### PR TITLE
[Claim][IS] Add Shared Type Local Claim and Map to SCIM2 Claim

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -957,6 +957,14 @@
 				<Returned>request</Returned>
 				<SharedProfileValueResolvingMethod>FromOrigin</SharedProfileValueResolvingMethod>
 			</Claim>
+			<Claim>
+				<ClaimURI>http://wso2.org/claims/identity/sharedType</ClaimURI>
+				<DisplayName>Shared Type</DisplayName>
+				<AttributeID>sharedType</AttributeID>
+				<Description>Claim to represent the shared type of the user.</Description>
+				<ReadOnly />
+				<SharedProfileValueResolvingMethod>FromSharedProfile</SharedProfileValueResolvingMethod>
+			</Claim>
 		</Dialect>
 
 		<Dialect dialectURI="http://schemas.xmlsoap.org/ws/2005/05/identity">
@@ -2846,6 +2854,15 @@
 				<AttributeID>passwordExpiryTime</AttributeID>
 				<Description>Password Expiry Time</Description>
 				<MappedLocalClaim>http://wso2.org/claims/identity/passwordExpiryTime</MappedLocalClaim>
+			</Claim>
+			<Claim>
+				<ClaimURI>urn:scim:wso2:schema:sharedType</ClaimURI>
+				<DisplayName>Shared Type</DisplayName>
+				<AttributeID>sharedType</AttributeID>
+				<Description>Shared type of the user</Description>
+				<DisplayOrder>1</DisplayOrder>
+				<SupportedByDefault />
+				<MappedLocalClaim>http://wso2.org/claims/identity/sharedType</MappedLocalClaim>
 			</Claim>
 		</Dialect>
 	</Dialects>

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -961,7 +961,7 @@
 				<ClaimURI>http://wso2.org/claims/identity/sharedType</ClaimURI>
 				<DisplayName>Shared Type</DisplayName>
 				<AttributeID>sharedType</AttributeID>
-				<Description>Claim to represent the shared type of the user.</Description>
+				<Description>Claim to represent the shared type of the user</Description>
 				<ReadOnly />
 				<SharedProfileValueResolvingMethod>FromSharedProfile</SharedProfileValueResolvingMethod>
 			</Claim>
@@ -2860,8 +2860,6 @@
 				<DisplayName>Shared Type</DisplayName>
 				<AttributeID>sharedType</AttributeID>
 				<Description>Shared type of the user</Description>
-				<DisplayOrder>1</DisplayOrder>
-				<SupportedByDefault />
 				<MappedLocalClaim>http://wso2.org/claims/identity/sharedType</MappedLocalClaim>
 			</Claim>
 		</Dialect>


### PR DESCRIPTION
## Purpose
Introduce a new local claim to represent the shared type of a user and map it to a corresponding SCIM2 claim to support displaying user shared type in user profiles.

## Goals
- Define a new claim to indicate the shared type of a user.
- Ensure that the claim is mapped to SCIM2 for consistent API responses.
- Mark the claim as read-only and resolve its value from the shared profile.

## Approach
- Added a new local claim `http://wso2.org/claims/identity/sharedType` with `ReadOnly` and `SharedProfileValueResolvingMethod` attributes.
- Mapped the local claim to a SCIM2 claim `urn:scim:wso2:schema:sharedType` to be exposed via SCIM APIs.
- Set `SupportedByDefault` and `MappedLocalClaim` properties in the SCIM2 claim definition.

## Related PRs
Merge before: [[Claim][IS] Update SCIM2 Schema to Include Shared Type Attribute #613](https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/613)
Merge before: [[Claim] Return Shared Type Claim in User Profile Responses #475](https://github.com/wso2-extensions/identity-organization-management/pull/475)

---

## Related Issues
[Display user shared type in shared user profile #23071](https://github.com/wso2/product-is/issues/23071)