### PR TITLE
Hide pushEnrollData from authentication redirect url

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -1958,7 +1958,7 @@ public class FrameworkUtils {
         List<String> queryParams;
         String action;
         if (!configAvailable) {
-            queryParams = Arrays.asList("loggedInUser", "ske");
+            queryParams = Arrays.asList("loggedInUser", "ske", "pushEnrollData");
             action = "exclude";
         } else {
             queryParams = FileBasedConfigurationBuilder.getInstance()


### PR DESCRIPTION
During a push device progressive enrollment flow, in order to embed the registration data into the QR code in the UI, the data string is being sent through the redirect url query param. Hence this string makes the redirection url lengthy, we will be hiding it from the url. But mechanisms are implemented to retrieve the value of the pushEnrollData in jsp files.

Related issue:
- https://github.com/wso2/product-is/issues/22503