### PR TITLE
Refactor to use context objects in execution flow.

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutionRequestBuilder.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutionRequestBuilder.java
@@ -42,7 +42,6 @@ public interface ActionExecutionRequestBuilder {
                                                                ActionExecutionRequestContext actionExecutionContext)
             throws ActionExecutionRequestBuilderException {
 
-        throw new UnsupportedOperationException(
-                "Action request building is not supported for " + getSupportedActionType() + " action type.");
+        return buildActionExecutionRequest(flowContext.getContextData());
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutionRequestBuilder.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutionRequestBuilder.java
@@ -20,7 +20,9 @@ package org.wso2.carbon.identity.action.execution;
 
 import org.wso2.carbon.identity.action.execution.exception.ActionExecutionRequestBuilderException;
 import org.wso2.carbon.identity.action.execution.model.ActionExecutionRequest;
+import org.wso2.carbon.identity.action.execution.model.ActionExecutionRequestContext;
 import org.wso2.carbon.identity.action.execution.model.ActionType;
+import org.wso2.carbon.identity.action.execution.model.FlowContext;
 
 import java.util.Map;
 
@@ -36,4 +38,11 @@ public interface ActionExecutionRequestBuilder {
     ActionExecutionRequest buildActionExecutionRequest(Map<String, Object> eventContext) throws
             ActionExecutionRequestBuilderException;
 
+    default ActionExecutionRequest buildActionExecutionRequest(FlowContext flowContext,
+                                                               ActionExecutionRequestContext actionExecutionContext)
+            throws ActionExecutionRequestBuilderException {
+
+        throw new UnsupportedOperationException(
+                "Action request building is not supported for " + getSupportedActionType() + " action type.");
+    }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutionResponseProcessor.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutionResponseProcessor.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.action.execution;
 
 import org.wso2.carbon.identity.action.execution.exception.ActionExecutionResponseProcessorException;
+import org.wso2.carbon.identity.action.execution.model.ActionExecutionResponseContext;
 import org.wso2.carbon.identity.action.execution.model.ActionExecutionStatus;
 import org.wso2.carbon.identity.action.execution.model.ActionInvocationErrorResponse;
 import org.wso2.carbon.identity.action.execution.model.ActionInvocationFailureResponse;
@@ -30,6 +31,7 @@ import org.wso2.carbon.identity.action.execution.model.ErrorStatus;
 import org.wso2.carbon.identity.action.execution.model.Event;
 import org.wso2.carbon.identity.action.execution.model.FailedStatus;
 import org.wso2.carbon.identity.action.execution.model.Failure;
+import org.wso2.carbon.identity.action.execution.model.FlowContext;
 import org.wso2.carbon.identity.action.execution.model.Incomplete;
 import org.wso2.carbon.identity.action.execution.model.Success;
 
@@ -61,7 +63,9 @@ public interface ActionExecutionResponseProcessor {
      * @throws ActionExecutionResponseProcessorException If an error occurs while processing the response.
      */
     default ActionExecutionStatus<Incomplete> processIncompleteResponse(Map<String, Object> eventContext,
-            Event actionEvent, ActionInvocationIncompleteResponse incompleteResponse) throws
+                                                                        Event actionEvent,
+                                                                        ActionInvocationIncompleteResponse incompleteResponse)
+            throws
             ActionExecutionResponseProcessorException {
 
         throw new UnsupportedOperationException(
@@ -84,5 +88,39 @@ public interface ActionExecutionResponseProcessor {
 
         return new FailedStatus(new Failure(failureResponse.getFailureReason(),
                 failureResponse.getFailureDescription()));
+    }
+
+    default ActionExecutionStatus<Success> processSuccessResponse(FlowContext flowContext,
+                                                                  ActionExecutionResponseContext<ActionInvocationSuccessResponse> responseContext)
+            throws
+            ActionExecutionResponseProcessorException {
+
+        throw new UnsupportedOperationException(
+                "The SUCCESS status is not supported for the action type: " + getSupportedActionType());
+
+    }
+
+    default ActionExecutionStatus<Incomplete> processIncompleteResponse(FlowContext flowContext,
+                                                                        ActionExecutionResponseContext<ActionInvocationIncompleteResponse> responseContext)
+            throws ActionExecutionResponseProcessorException {
+
+        throw new UnsupportedOperationException(
+                "The INCOMPLETE status is not supported for the action type: " + getSupportedActionType());
+    }
+
+    default ActionExecutionStatus<Error> processErrorResponse(FlowContext flowContext,
+                                                              ActionExecutionResponseContext<ActionInvocationErrorResponse> responseContext)
+            throws ActionExecutionResponseProcessorException {
+
+        return new ErrorStatus(new Error(responseContext.getActionInvocationResponse().getErrorMessage(),
+                responseContext.getActionInvocationResponse().getErrorDescription()));
+    }
+
+    default ActionExecutionStatus<Failure> processFailureResponse(FlowContext flowContext,
+                                                                  ActionExecutionResponseContext<ActionInvocationFailureResponse> responseContext)
+            throws ActionExecutionResponseProcessorException {
+
+        return new FailedStatus(new Failure(responseContext.getActionInvocationResponse().getFailureReason(),
+                responseContext.getActionInvocationResponse().getFailureDescription()));
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutionResponseProcessor.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutionResponseProcessor.java
@@ -44,12 +44,26 @@ import java.util.Map;
  */
 public interface ActionExecutionResponseProcessor {
 
+    /**
+     * This method returns the supported action type for the response processor.
+     *
+     * @return The supported action type.
+     */
     ActionType getSupportedActionType();
 
+    /**
+     * This method processes the success response received from the action execution.
+     *
+     * @param eventContext    The event context.
+     * @param actionEvent     The action event.
+     * @param successResponse The success response.
+     * @return The success status.
+     * @throws ActionExecutionResponseProcessorException If an error occurs while processing the response.
+     */
     ActionExecutionStatus<Success> processSuccessResponse(Map<String, Object> eventContext,
                                                           Event actionEvent,
-                                                          ActionInvocationSuccessResponse successResponse) throws
-            ActionExecutionResponseProcessorException;
+                                                          ActionInvocationSuccessResponse successResponse)
+            throws ActionExecutionResponseProcessorException;
 
     /**
      * This method processes the incomplete response received from the action execution. The default implementation
@@ -64,63 +78,119 @@ public interface ActionExecutionResponseProcessor {
      */
     default ActionExecutionStatus<Incomplete> processIncompleteResponse(Map<String, Object> eventContext,
                                                                         Event actionEvent,
-                                                                        ActionInvocationIncompleteResponse incompleteResponse)
-            throws
-            ActionExecutionResponseProcessorException {
+                                                                        ActionInvocationIncompleteResponse
+                                                                                incompleteResponse)
+            throws ActionExecutionResponseProcessorException {
 
         throw new UnsupportedOperationException(
                 "The INCOMPLETE status is not supported for the action type: " + getSupportedActionType());
     }
 
+    /**
+     * This method processes the error response received from the action execution.
+     *
+     * @param eventContext  The event context.
+     * @param actionEvent   The action event.
+     * @param errorResponse The error response.
+     * @return The error status.
+     * @throws ActionExecutionResponseProcessorException If an error occurs while processing the response.
+     */
     default ActionExecutionStatus<Error> processErrorResponse(Map<String, Object> eventContext,
                                                               Event actionEvent,
-                                                              ActionInvocationErrorResponse errorResponse) throws
-            ActionExecutionResponseProcessorException {
+                                                              ActionInvocationErrorResponse errorResponse)
+            throws ActionExecutionResponseProcessorException {
 
         return new ErrorStatus(new Error(errorResponse.getErrorMessage(), errorResponse.getErrorDescription()));
     }
 
+    /**
+     * This method processes the failure response received from the action execution.
+     * The default implementation returns a failed status with the failure reason and description.
+     *
+     * @param eventContext    The event context.
+     * @param actionEvent     The action event.
+     * @param failureResponse The failure response.
+     * @return The failed status.
+     * @throws ActionExecutionResponseProcessorException If an error occurs while processing the response.
+     */
     default ActionExecutionStatus<Failure> processFailureResponse(Map<String, Object> eventContext,
                                                                   Event actionEvent,
                                                                   ActionInvocationFailureResponse failureResponse)
-            throws
-            ActionExecutionResponseProcessorException {
+            throws ActionExecutionResponseProcessorException {
 
         return new FailedStatus(new Failure(failureResponse.getFailureReason(),
                 failureResponse.getFailureDescription()));
     }
 
+    /**
+     * This method processes the success response received from the action execution.
+     *
+     * @param flowContext     The flow context.
+     * @param responseContext The response context.
+     * @return The success status.
+     * @throws ActionExecutionResponseProcessorException If an error occurs while processing the response.
+     */
     default ActionExecutionStatus<Success> processSuccessResponse(FlowContext flowContext,
-                                                                  ActionExecutionResponseContext<ActionInvocationSuccessResponse> responseContext)
-            throws
-            ActionExecutionResponseProcessorException {
+                                                                  ActionExecutionResponseContext
+                                                                          <ActionInvocationSuccessResponse>
+                                                                          responseContext)
+            throws ActionExecutionResponseProcessorException {
 
-        throw new UnsupportedOperationException(
-                "The SUCCESS status is not supported for the action type: " + getSupportedActionType());
+        return processSuccessResponse(flowContext.getContextData(), responseContext.getActionEvent(),
+                responseContext.getActionInvocationResponse());
 
     }
 
+    /**
+     * This method processes the incomplete response received from the action execution.
+     *
+     * @param flowContext     The flow context.
+     * @param responseContext The response context.
+     * @return The incomplete status.
+     * @throws ActionExecutionResponseProcessorException If an error occurs while processing the response.
+     */
     default ActionExecutionStatus<Incomplete> processIncompleteResponse(FlowContext flowContext,
-                                                                        ActionExecutionResponseContext<ActionInvocationIncompleteResponse> responseContext)
+                                                                        ActionExecutionResponseContext
+                                                                                <ActionInvocationIncompleteResponse>
+                                                                                responseContext)
             throws ActionExecutionResponseProcessorException {
 
-        throw new UnsupportedOperationException(
-                "The INCOMPLETE status is not supported for the action type: " + getSupportedActionType());
+        return processIncompleteResponse(flowContext.getContextData(), responseContext.getActionEvent(),
+                responseContext.getActionInvocationResponse());
     }
 
+    /**
+     * This method processes the error response received from the action execution.
+     *
+     * @param flowContext     The flow context.
+     * @param responseContext The response context.
+     * @return The error status.
+     * @throws ActionExecutionResponseProcessorException If an error occurs while processing the response.
+     */
     default ActionExecutionStatus<Error> processErrorResponse(FlowContext flowContext,
-                                                              ActionExecutionResponseContext<ActionInvocationErrorResponse> responseContext)
+                                                              ActionExecutionResponseContext
+                                                                      <ActionInvocationErrorResponse> responseContext)
             throws ActionExecutionResponseProcessorException {
 
-        return new ErrorStatus(new Error(responseContext.getActionInvocationResponse().getErrorMessage(),
-                responseContext.getActionInvocationResponse().getErrorDescription()));
+        return processErrorResponse(flowContext.getContextData(), responseContext.getActionEvent(),
+                responseContext.getActionInvocationResponse());
     }
 
+    /**
+     * This method processes the failure response received from the action execution.
+     *
+     * @param flowContext     The flow context.
+     * @param responseContext The response context.
+     * @return The failed status.
+     * @throws ActionExecutionResponseProcessorException If an error occurs while processing the response.
+     */
     default ActionExecutionStatus<Failure> processFailureResponse(FlowContext flowContext,
-                                                                  ActionExecutionResponseContext<ActionInvocationFailureResponse> responseContext)
+                                                                  ActionExecutionResponseContext
+                                                                          <ActionInvocationFailureResponse>
+                                                                          responseContext)
             throws ActionExecutionResponseProcessorException {
 
-        return new FailedStatus(new Failure(responseContext.getActionInvocationResponse().getFailureReason(),
-                responseContext.getActionInvocationResponse().getFailureDescription()));
+        return processFailureResponse(flowContext.getContextData(), responseContext.getActionEvent(),
+                responseContext.getActionInvocationResponse());
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutorService.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutorService.java
@@ -75,21 +75,26 @@ public interface ActionExecutorService {
      * @return {@link ActionExecutionStatus} The status of the action execution and the response context
      * @throws ActionExecutionException If an error occurs while executing the action
      */
-    ActionExecutionStatus execute(ActionType actionType, FlowContext flowContext, String tenantDomain)
-            throws ActionExecutionException;
+    default ActionExecutionStatus execute(ActionType actionType, FlowContext flowContext, String tenantDomain)
+            throws ActionExecutionException {
+
+        return execute(actionType, flowContext.getContextData(), tenantDomain);
+    }
 
     /**
      * Execute the action based on the action type and the flow context.
      *
      * @param actionType   Action Type
-     * @param actionId     The action Id of the action that need to be executed
+     * @param actionId     The action id of the action that need to be executed
      * @param flowContext  Flow context of the corresponding flow
      * @param tenantDomain Tenant Domain
      * @return {@link ActionExecutionStatus} The status of the action execution and the response context
      * @throws ActionExecutionException If an error occurs while executing the action
      */
-    ActionExecutionStatus execute(ActionType actionType, String actionId,
-                                  FlowContext flowContext, String tenantDomain)
-            throws ActionExecutionException;
+    default ActionExecutionStatus execute(ActionType actionType, String actionId,
+                                          FlowContext flowContext, String tenantDomain)
+            throws ActionExecutionException {
 
+        return execute(actionType, actionId, flowContext.getContextData(), tenantDomain);
+    }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutorService.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/ActionExecutorService.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.action.execution;
 import org.wso2.carbon.identity.action.execution.exception.ActionExecutionException;
 import org.wso2.carbon.identity.action.execution.model.ActionExecutionStatus;
 import org.wso2.carbon.identity.action.execution.model.ActionType;
+import org.wso2.carbon.identity.action.execution.model.FlowContext;
 
 import java.util.Map;
 
@@ -63,6 +64,32 @@ public interface ActionExecutorService {
      */
     ActionExecutionStatus execute(ActionType actionType, String actionId,
                                             Map<String, Object> eventContext, String tenantDomain)
+            throws ActionExecutionException;
+
+    /**
+     * Execute the action based on the action type and the flow context.
+     *
+     * @param actionType   Action Type
+     * @param flowContext  Flow context of the corresponding flow
+     * @param tenantDomain Tenant Domain
+     * @return {@link ActionExecutionStatus} The status of the action execution and the response context
+     * @throws ActionExecutionException If an error occurs while executing the action
+     */
+    ActionExecutionStatus execute(ActionType actionType, FlowContext flowContext, String tenantDomain)
+            throws ActionExecutionException;
+
+    /**
+     * Execute the action based on the action type and the flow context.
+     *
+     * @param actionType   Action Type
+     * @param actionId     The action Id of the action that need to be executed
+     * @param flowContext  Flow context of the corresponding flow
+     * @param tenantDomain Tenant Domain
+     * @return {@link ActionExecutionStatus} The status of the action execution and the response context
+     * @throws ActionExecutionException If an error occurs while executing the action
+     */
+    ActionExecutionStatus execute(ActionType actionType, String actionId,
+                                  FlowContext flowContext, String tenantDomain)
             throws ActionExecutionException;
 
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImpl.java
@@ -160,6 +160,22 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
         }
     }
 
+    @Override
+    public ActionExecutionStatus execute(ActionType actionType,
+                                         org.wso2.carbon.identity.action.execution.model.FlowContext flowContext,
+                                         String tenantDomain) throws ActionExecutionException {
+
+        return execute(actionType, flowContext.getContextData(), tenantDomain);
+    }
+
+    @Override
+    public ActionExecutionStatus execute(ActionType actionType, String actionId,
+                                         org.wso2.carbon.identity.action.execution.model.FlowContext flowContext,
+                                         String tenantDomain) throws ActionExecutionException {
+
+        return execute(actionType, actionId, flowContext.getContextData(), tenantDomain);
+    }
+
     private ActionExecutionStatus<?> execute(Action action, Map<String, Object> eventContext, String tenantDomain)
             throws ActionExecutionException {
 
@@ -366,7 +382,7 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
                                                                   Map<String, Object> eventContext,
                                                                   ActionExecutionRequest actionRequest,
                                                                   ActionExecutionResponseProcessor
-                                                                 actionExecutionResponseProcessor)
+                                                                          actionExecutionResponseProcessor)
             throws ActionExecutionResponseProcessorException {
 
         logSuccessResponse(action, successResponse);
@@ -419,7 +435,7 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
                                                                   Map<String, Object> eventContext,
                                                                   ActionExecutionRequest actionRequest,
                                                                   ActionExecutionResponseProcessor
-                                                               actionExecutionResponseProcessor)
+                                                                          actionExecutionResponseProcessor)
             throws ActionExecutionResponseProcessorException {
 
         logFailureResponse(action, failureResponse);

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImpl.java
@@ -34,6 +34,8 @@ import org.wso2.carbon.identity.action.execution.exception.ActionExecutionRespon
 import org.wso2.carbon.identity.action.execution.exception.ActionExecutionRuntimeException;
 import org.wso2.carbon.identity.action.execution.internal.ActionExecutionServiceComponentHolder;
 import org.wso2.carbon.identity.action.execution.model.ActionExecutionRequest;
+import org.wso2.carbon.identity.action.execution.model.ActionExecutionRequestContext;
+import org.wso2.carbon.identity.action.execution.model.ActionExecutionResponseContext;
 import org.wso2.carbon.identity.action.execution.model.ActionExecutionStatus;
 import org.wso2.carbon.identity.action.execution.model.ActionInvocationErrorResponse;
 import org.wso2.carbon.identity.action.execution.model.ActionInvocationFailureResponse;
@@ -44,6 +46,7 @@ import org.wso2.carbon.identity.action.execution.model.ActionType;
 import org.wso2.carbon.identity.action.execution.model.AllowedOperation;
 import org.wso2.carbon.identity.action.execution.model.Error;
 import org.wso2.carbon.identity.action.execution.model.Failure;
+import org.wso2.carbon.identity.action.execution.model.FlowContext;
 import org.wso2.carbon.identity.action.execution.model.Incomplete;
 import org.wso2.carbon.identity.action.execution.model.PerformableOperation;
 import org.wso2.carbon.identity.action.execution.model.Request;
@@ -62,7 +65,6 @@ import org.wso2.carbon.identity.action.management.model.Authentication;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.ThreadLocalAwareExecutors;
 import org.wso2.carbon.identity.rule.evaluation.exception.RuleEvaluationException;
-import org.wso2.carbon.identity.rule.evaluation.model.FlowContext;
 import org.wso2.carbon.identity.rule.evaluation.model.FlowType;
 import org.wso2.carbon.identity.rule.evaluation.model.RuleEvaluationResult;
 
@@ -108,9 +110,9 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
     /**
      * Resolve the actions that need to be executed for the given action types and execute them.
      *
-     * @param actionType    Action Type.
-     * @param eventContext  The event context of the corresponding flow.
-     * @param tenantDomain  Tenant domain.
+     * @param actionType   Action Type.
+     * @param eventContext The event context of the corresponding flow.
+     * @param tenantDomain Tenant domain.
      * @return Action execution status.
      */
     @Override
@@ -122,8 +124,12 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
             validateActions(actions, actionType);
             // As of now only one action is allowed.
             Action action = actions.get(0);
-            eventContext.put("action", action);
-            return execute(action, eventContext, tenantDomain);
+
+            FlowContext flowContext = FlowContext.create().add("action", action);
+            if (eventContext != null) {
+                eventContext.forEach(flowContext::add);
+            }
+            return execute(action, flowContext, tenantDomain);
         } catch (ActionExecutionRuntimeException e) {
             LOG.debug("Skip executing actions for action type: " + actionType.name(), e);
             // Skip executing actions when no action available is considered as action execution being successful.
@@ -150,9 +156,12 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
         }
 
         Action action = getActionByActionId(actionType, actionId, tenantDomain);
-        eventContext.put("action", action);
         try {
-            return execute(action, eventContext, tenantDomain);
+            FlowContext flowContext = FlowContext.create().add("action", action);
+            if (eventContext != null) {
+                eventContext.forEach(flowContext::add);
+            }
+            return execute(action, flowContext, tenantDomain);
         } catch (ActionExecutionRuntimeException e) {
             LOG.debug("Skip executing action for action type: " + actionType.name(), e);
             // Skip executing actions when no action available is considered as action execution being successful.
@@ -162,7 +171,7 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
 
     @Override
     public ActionExecutionStatus execute(ActionType actionType,
-                                         org.wso2.carbon.identity.action.execution.model.FlowContext flowContext,
+                                         FlowContext flowContext,
                                          String tenantDomain) throws ActionExecutionException {
 
         return execute(actionType, flowContext.getContextData(), tenantDomain);
@@ -170,34 +179,34 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
 
     @Override
     public ActionExecutionStatus execute(ActionType actionType, String actionId,
-                                         org.wso2.carbon.identity.action.execution.model.FlowContext flowContext,
+                                         FlowContext flowContext,
                                          String tenantDomain) throws ActionExecutionException {
 
         return execute(actionType, actionId, flowContext.getContextData(), tenantDomain);
     }
 
-    private ActionExecutionStatus<?> execute(Action action, Map<String, Object> eventContext, String tenantDomain)
+    private ActionExecutionStatus<?> execute(Action action, FlowContext flowContext, String tenantDomain)
             throws ActionExecutionException {
 
         if (action.getStatus() != Action.Status.ACTIVE) {
             // If no active actions are detected, it is regarded as the action execution being successful.
-            return new SuccessStatus.Builder().setResponseContext(eventContext).build();
+            return new SuccessStatus.Builder().setResponseContext(flowContext.getContextData()).build();
         }
 
         DIAGNOSTIC_LOGGER.logActionInitiation(action);
 
-        if (!evaluateActionRule(action, eventContext, tenantDomain)) {
+        if (!evaluateActionRule(action, flowContext, tenantDomain)) {
             // If the action rule is not satisfied, it is regarded as the action execution being successful.
-            return new SuccessStatus.Builder().setResponseContext(eventContext).build();
+            return new SuccessStatus.Builder().setResponseContext(flowContext.getContextData()).build();
         }
 
         DIAGNOSTIC_LOGGER.logActionExecution(action);
 
         ActionType actionType = ActionType.valueOf(action.getType().getActionType());
-        ActionExecutionRequest actionRequest = buildActionExecutionRequest(actionType, eventContext);
+        ActionExecutionRequest actionRequest = buildActionExecutionRequest(actionType, action, flowContext);
         ActionExecutionResponseProcessor actionExecutionResponseProcessor = getResponseProcessor(actionType);
 
-        return executeAction(action, actionRequest, eventContext, actionExecutionResponseProcessor);
+        return executeAction(action, actionRequest, flowContext, actionExecutionResponseProcessor);
     }
 
     private Action getActionByActionId(ActionType actionType, String actionId, String tenantDomain)
@@ -236,7 +245,8 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
         }
     }
 
-    private ActionExecutionRequest buildActionExecutionRequest(ActionType actionType, Map<String, Object> eventContext)
+    private ActionExecutionRequest buildActionExecutionRequest(ActionType actionType, Action action,
+                                                               FlowContext flowContext)
             throws ActionExecutionException {
 
         ActionExecutionRequestBuilder requestBuilder =
@@ -245,7 +255,9 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
             throw new ActionExecutionException("No request builder found for action type: " + actionType);
         }
         try {
-            ActionExecutionRequest actionExecutionRequest = requestBuilder.buildActionExecutionRequest(eventContext);
+            ActionExecutionRequest actionExecutionRequest =
+                    requestBuilder.buildActionExecutionRequest(flowContext,
+                            ActionExecutionRequestContext.create(action));
             if (actionExecutionRequest.getEvent() == null || actionExecutionRequest.getEvent().getRequest() == null) {
                 return actionExecutionRequest;
             }
@@ -273,7 +285,7 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
 
     private ActionExecutionStatus<?> executeAction(Action action,
                                                    ActionExecutionRequest actionRequest,
-                                                   Map<String, Object> eventContext,
+                                                   FlowContext flowContext,
                                                    ActionExecutionResponseProcessor actionExecutionResponseProcessor)
             throws ActionExecutionException {
 
@@ -288,14 +300,14 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
 
             ActionInvocationResponse actionInvocationResponse =
                     executeActionAsynchronously(action, authenticationMethod, payload);
-            return processActionResponse(action, actionInvocationResponse, eventContext, actionRequest,
+            return processActionResponse(action, actionInvocationResponse, flowContext, actionRequest,
                     actionExecutionResponseProcessor);
         } catch (ActionMgtException | JsonProcessingException | ActionExecutionResponseProcessorException e) {
             throw new ActionExecutionException("Error occurred while executing action: " + action.getId(), e);
         }
     }
 
-    private boolean evaluateActionRule(Action action, Map<String, Object> eventContext, String tenantDomain)
+    private boolean evaluateActionRule(Action action, FlowContext flowContext, String tenantDomain)
             throws ActionExecutionException {
 
         if (action.getActionRule() == null || action.getActionRule().getId() == null) {
@@ -307,8 +319,9 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
             RuleEvaluationResult ruleEvaluationResult =
                     ActionExecutionServiceComponentHolder.getInstance().getRuleEvaluationService()
                             .evaluate(action.getActionRule().getId(),
-                                    new FlowContext(FlowType.valueOf(action.getType().getActionType()),
-                                            eventContext), tenantDomain);
+                                    new org.wso2.carbon.identity.rule.evaluation.model.FlowContext(
+                                            FlowType.valueOf(action.getType().getActionType()),
+                                            flowContext.getContextData()), tenantDomain);
 
             logActionRuleEvaluation(action, ruleEvaluationResult);
 
@@ -351,7 +364,7 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
 
     private ActionExecutionStatus<?> processActionResponse(Action action,
                                                            ActionInvocationResponse actionInvocationResponse,
-                                                           Map<String, Object> eventContext,
+                                                           FlowContext flowContext,
                                                            ActionExecutionRequest actionRequest,
                                                            ActionExecutionResponseProcessor
                                                                    actionExecutionResponseProcessor)
@@ -360,17 +373,17 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
         if (actionInvocationResponse.isSuccess()) {
             return processSuccessResponse(action,
                     (ActionInvocationSuccessResponse) actionInvocationResponse.getResponse(),
-                    eventContext, actionRequest, actionExecutionResponseProcessor);
+                    flowContext, actionRequest, actionExecutionResponseProcessor);
         } else if (actionInvocationResponse.isIncomplete()) {
             return processIncompleteResponse(action,
                     (ActionInvocationIncompleteResponse) actionInvocationResponse.getResponse(),
-                    eventContext, actionRequest, actionExecutionResponseProcessor);
+                    flowContext, actionRequest, actionExecutionResponseProcessor);
         } else if (actionInvocationResponse.isFailure() && actionInvocationResponse.getResponse() != null) {
             return processFailureResponse(action, (ActionInvocationFailureResponse) actionInvocationResponse
-                    .getResponse(), eventContext, actionRequest, actionExecutionResponseProcessor);
+                    .getResponse(), flowContext, actionRequest, actionExecutionResponseProcessor);
         } else if (actionInvocationResponse.isError() && actionInvocationResponse.getResponse() != null) {
             return processErrorResponse(action, (ActionInvocationErrorResponse) actionInvocationResponse.getResponse(),
-                    eventContext, actionRequest, actionExecutionResponseProcessor);
+                    flowContext, actionRequest, actionExecutionResponseProcessor);
         }
         logErrorResponse(action, actionInvocationResponse);
         throw new ActionExecutionException("Received an invalid or unexpected response for action type: "
@@ -379,7 +392,7 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
 
     private ActionExecutionStatus<Success> processSuccessResponse(Action action,
                                                                   ActionInvocationSuccessResponse successResponse,
-                                                                  Map<String, Object> eventContext,
+                                                                  FlowContext flowContext,
                                                                   ActionExecutionRequest actionRequest,
                                                                   ActionExecutionResponseProcessor
                                                                           actionExecutionResponseProcessor)
@@ -393,16 +406,16 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
                 new ActionInvocationSuccessResponse.Builder().actionStatus(ActionInvocationResponse.Status.SUCCESS)
                         .operations(allowedPerformableOperations)
                         .responseData(successResponse.getData());
-        return actionExecutionResponseProcessor.processSuccessResponse(eventContext,
-                actionRequest.getEvent(), successResponseBuilder.build());
+        return actionExecutionResponseProcessor.processSuccessResponse(flowContext,
+                ActionExecutionResponseContext.create(actionRequest.getEvent(), successResponseBuilder.build()));
     }
 
     private ActionExecutionStatus<Incomplete> processIncompleteResponse(
-                                                Action action,
-                                                ActionInvocationIncompleteResponse incompleteResponse,
-                                                Map<String, Object> eventContext,
-                                                ActionExecutionRequest actionRequest,
-                                                ActionExecutionResponseProcessor actionExecutionResponseProcessor)
+            Action action,
+            ActionInvocationIncompleteResponse incompleteResponse,
+            FlowContext flowContext,
+            ActionExecutionRequest actionRequest,
+            ActionExecutionResponseProcessor actionExecutionResponseProcessor)
             throws ActionExecutionResponseProcessorException {
 
         logIncompleteResponse(action, incompleteResponse);
@@ -413,34 +426,34 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
                 new ActionInvocationIncompleteResponse.Builder()
                         .actionStatus(ActionInvocationResponse.Status.INCOMPLETE)
                         .operations(allowedPerformableOperations);
-        return actionExecutionResponseProcessor.processIncompleteResponse(eventContext,
-                actionRequest.getEvent(), incompleteResponseBuilder.build());
+        return actionExecutionResponseProcessor.processIncompleteResponse(flowContext,
+                ActionExecutionResponseContext.create(actionRequest.getEvent(), incompleteResponseBuilder.build()));
     }
 
     private ActionExecutionStatus<Error> processErrorResponse(Action action,
                                                               ActionInvocationErrorResponse errorResponse,
-                                                              Map<String, Object> eventContext,
+                                                              FlowContext flowContext,
                                                               ActionExecutionRequest actionRequest,
                                                               ActionExecutionResponseProcessor
-                                                               actionExecutionResponseProcessor)
+                                                                      actionExecutionResponseProcessor)
             throws ActionExecutionResponseProcessorException {
 
         logErrorResponse(action, errorResponse);
-        return actionExecutionResponseProcessor.processErrorResponse(eventContext, actionRequest.getEvent(),
-                errorResponse);
+        return actionExecutionResponseProcessor.processErrorResponse(flowContext,
+                ActionExecutionResponseContext.create(actionRequest.getEvent(), errorResponse));
     }
 
     private ActionExecutionStatus<Failure> processFailureResponse(Action action,
                                                                   ActionInvocationFailureResponse failureResponse,
-                                                                  Map<String, Object> eventContext,
+                                                                  FlowContext flowContext,
                                                                   ActionExecutionRequest actionRequest,
                                                                   ActionExecutionResponseProcessor
                                                                           actionExecutionResponseProcessor)
             throws ActionExecutionResponseProcessorException {
 
         logFailureResponse(action, failureResponse);
-        return actionExecutionResponseProcessor.processFailureResponse(eventContext, actionRequest.getEvent(),
-                failureResponse);
+        return actionExecutionResponseProcessor.processFailureResponse(flowContext,
+                ActionExecutionResponseContext.create(actionRequest.getEvent(), failureResponse));
     }
 
     private void logActionRuleEvaluation(Action action, RuleEvaluationResult ruleEvaluationResult) {

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/ActionExecutionRequestContext.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/ActionExecutionRequestContext.java
@@ -21,18 +21,14 @@ package org.wso2.carbon.identity.action.execution.model;
 import org.wso2.carbon.identity.action.management.model.Action;
 
 /**
- * This class models the Action Execution Context.
- * Action Execution Context is the context of the action that is executed by the Action Executor Service.
+ * This class models the Action Execution Request Context.
+ * The context includes the action type, action and any action execution request related data.
  */
 public class ActionExecutionRequestContext {
 
     private final Action action;
 
-    protected ActionExecutionRequestContext(Action action) {
-
-        if (action == null) {
-            throw new IllegalArgumentException("Action cannot be null.");
-        }
+    private ActionExecutionRequestContext(Action action) {
 
         this.action = action;
     }
@@ -50,5 +46,13 @@ public class ActionExecutionRequestContext {
     public Action getAction() {
 
         return action;
+    }
+
+    public static ActionExecutionRequestContext create(Action action) {
+
+        if (action == null) {
+            throw new IllegalArgumentException("Action cannot be null.");
+        }
+        return new ActionExecutionRequestContext(action);
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/ActionExecutionRequestContext.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/ActionExecutionRequestContext.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.action.execution.model;
+
+import org.wso2.carbon.identity.action.management.model.Action;
+
+/**
+ * This class models the Action Execution Context.
+ * Action Execution Context is the context of the action that is executed by the Action Executor Service.
+ */
+public class ActionExecutionRequestContext {
+
+    private final Action action;
+
+    protected ActionExecutionRequestContext(Action action) {
+
+        if (action == null) {
+            throw new IllegalArgumentException("Action cannot be null.");
+        }
+
+        this.action = action;
+    }
+
+    public ActionType getActionType() {
+
+        return ActionType.valueOf(action.getType().getActionType());
+    }
+
+    public String getActionId() {
+
+        return action.getId();
+    }
+
+    public Action getAction() {
+
+        return action;
+    }
+}

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/ActionExecutionResponseContext.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/ActionExecutionResponseContext.java
@@ -20,17 +20,18 @@ package org.wso2.carbon.identity.action.execution.model;
 
 /**
  * This class models the Action Execution Response Context.
+ * The context includes the action event, action invocation response and any action response related data.
  *
  * @param <T> The type of the action invocation response.
- * {@link ActionInvocationSuccessResponse} or {@link ActionInvocationIncompleteResponse} or
- * {@link ActionInvocationErrorResponse} or {@link ActionInvocationFailureResponse}
+ *            {@link ActionInvocationSuccessResponse} or {@link ActionInvocationIncompleteResponse} or
+ *            {@link ActionInvocationErrorResponse} or {@link ActionInvocationFailureResponse}
  */
 public class ActionExecutionResponseContext<T extends ActionInvocationResponse.APIResponse> {
 
     Event actionEvent;
     T actionInvocationResponse;
 
-    protected ActionExecutionResponseContext(Event actionEvent, T actionInvocationResponse) {
+    private ActionExecutionResponseContext(Event actionEvent, T actionInvocationResponse) {
 
         this.actionEvent = actionEvent;
         this.actionInvocationResponse = actionInvocationResponse;
@@ -44,5 +45,11 @@ public class ActionExecutionResponseContext<T extends ActionInvocationResponse.A
     public T getActionInvocationResponse() {
 
         return actionInvocationResponse;
+    }
+
+    public static <T extends ActionInvocationResponse.APIResponse> ActionExecutionResponseContext<T> create(
+            Event actionEvent, T actionInvocationResponse) {
+
+        return new ActionExecutionResponseContext<>(actionEvent, actionInvocationResponse);
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/ActionExecutionResponseContext.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/ActionExecutionResponseContext.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.action.execution.model;
+
+/**
+ * This class models the Action Execution Response Context.
+ *
+ * @param <T> The type of the action invocation response.
+ * {@link ActionInvocationSuccessResponse} or {@link ActionInvocationIncompleteResponse} or
+ * {@link ActionInvocationErrorResponse} or {@link ActionInvocationFailureResponse}
+ */
+public class ActionExecutionResponseContext<T extends ActionInvocationResponse.APIResponse> {
+
+    Event actionEvent;
+    T actionInvocationResponse;
+
+    protected ActionExecutionResponseContext(Event actionEvent, T actionInvocationResponse) {
+
+        this.actionEvent = actionEvent;
+        this.actionInvocationResponse = actionInvocationResponse;
+    }
+
+    public Event getActionEvent() {
+
+        return actionEvent;
+    }
+
+    public T getActionInvocationResponse() {
+
+        return actionInvocationResponse;
+    }
+}

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/FlowContext.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/FlowContext.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.action.execution.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class FlowContext {
+
+    private final Map<String, Object> contextData = new HashMap<>();
+
+    private FlowContext() {
+
+    }
+
+    public Map<String, Object> getContextData() {
+
+        return contextData;
+    }
+
+    public <T> T getValue(String key, Class<T> type) {
+
+        return type.cast(contextData.get(key));
+    }
+
+    public FlowContext add(String key, Object value) {
+
+        contextData.put(key, value);
+        return this;
+    }
+}

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/FlowContext.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/model/FlowContext.java
@@ -21,6 +21,11 @@ package org.wso2.carbon.identity.action.execution.model;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * This class models the Flow Context.
+ * The context includes the data that is required to be shared across downstream components,
+ * implementing the actions in the flow.
+ */
 public class FlowContext {
 
     private final Map<String, Object> contextData = new HashMap<>();
@@ -43,5 +48,10 @@ public class FlowContext {
 
         contextData.put(key, value);
         return this;
+    }
+
+    public static FlowContext create() {
+
+        return new FlowContext();
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImplTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImplTest.java
@@ -48,6 +48,7 @@ import org.wso2.carbon.identity.action.execution.model.ErrorStatus;
 import org.wso2.carbon.identity.action.execution.model.Event;
 import org.wso2.carbon.identity.action.execution.model.FailedStatus;
 import org.wso2.carbon.identity.action.execution.model.Failure;
+import org.wso2.carbon.identity.action.execution.model.FlowContext;
 import org.wso2.carbon.identity.action.execution.model.Header;
 import org.wso2.carbon.identity.action.execution.model.IncompleteStatus;
 import org.wso2.carbon.identity.action.execution.model.Operation;
@@ -83,7 +84,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -157,7 +157,7 @@ public class ActionExecutorServiceImplTest {
 
         ActionExecutionStatus expectedStatus = new SuccessStatus.Builder().build();
         ActionExecutionStatus actualStatus =
-                actionExecutorService.execute(ActionType.PRE_ISSUE_ACCESS_TOKEN, any(), any());
+                actionExecutorService.execute(ActionType.PRE_ISSUE_ACCESS_TOKEN, FlowContext.create(), "tenantDomain");
 
         assertEquals(actualStatus.getStatus(), expectedStatus.getStatus());
     }
@@ -166,7 +166,6 @@ public class ActionExecutorServiceImplTest {
     public void testActionExecuteSuccessWhenNoActiveActionAvailableForActionType() throws Exception {
 
         ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
-        Map<String, Object> eventContext = new HashMap<>();
 
         Action action = mock(Action.class);
         when(action.getStatus()).thenReturn(Action.Status.INACTIVE);
@@ -180,12 +179,12 @@ public class ActionExecutorServiceImplTest {
         actionExecutionResponseProcessorFactory.when(() -> ActionExecutionResponseProcessorFactory
                         .getActionExecutionResponseProcessor(actionType))
                 .thenReturn(actionExecutionResponseProcessor);
-        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any())).thenReturn(
+        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any(), any())).thenReturn(
                 mock(ActionExecutionRequest.class));
 
         ActionExecutionStatus expectedStatus = new SuccessStatus.Builder().build();
         ActionExecutionStatus actualStatus =
-                actionExecutorService.execute(actionType, eventContext, "tenantDomain");
+                actionExecutorService.execute(actionType, FlowContext.create(), "tenantDomain");
 
         assertEquals(actualStatus.getStatus(), expectedStatus.getStatus());
     }
@@ -200,9 +199,9 @@ public class ActionExecutorServiceImplTest {
         when(ruleEvaluationService.evaluate(any(), any(), any())).thenReturn(new RuleEvaluationResult("ruleId", false));
 
         ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
-        Map<String, Object> eventContext = new HashMap<>();
 
-        ActionExecutionStatus<?> status = actionExecutorService.execute(actionType, eventContext, "tenantDomain");
+        ActionExecutionStatus<?> status =
+                actionExecutorService.execute(actionType, FlowContext.create(), "tenantDomain");
 
         assertEquals(status.getStatus(), ActionExecutionStatus.Status.SUCCESS);
     }
@@ -215,14 +214,14 @@ public class ActionExecutorServiceImplTest {
         List<Action> mockActions = Arrays.asList(mock(Action.class), mock(Action.class));
         when(actionManagementService.getActionsByActionType(any(), any())).thenReturn(mockActions);
 
-        actionExecutorService.execute(ActionType.PRE_ISSUE_ACCESS_TOKEN, any(), any());
+        actionExecutorService.execute(ActionType.PRE_ISSUE_ACCESS_TOKEN, FlowContext.create(), "tenantDomain");
     }
 
     @Test(expectedExceptions = ActionExecutionException.class,
             expectedExceptionsMessageRegExp = "Action Id cannot be blank.")
     public void testActionExecuteWithActionIdsFailureWheNullActionId() throws Exception {
 
-        actionExecutorService.execute(ActionType.PRE_ISSUE_ACCESS_TOKEN, null, new HashMap<>(),
+        actionExecutorService.execute(ActionType.PRE_ISSUE_ACCESS_TOKEN, null, FlowContext.create(),
                 "tenantDomain");
     }
 
@@ -234,7 +233,7 @@ public class ActionExecutorServiceImplTest {
         when(actionManagementService.getActionsByActionType(any(), eq("tenantDomain"))).thenReturn(
                 Collections.singletonList(action));
 
-        actionExecutorService.execute(ActionType.PRE_ISSUE_ACCESS_TOKEN, new HashMap<>(), "tenantDomain");
+        actionExecutorService.execute(ActionType.PRE_ISSUE_ACCESS_TOKEN, FlowContext.create(), "tenantDomain");
     }
 
     @Test(expectedExceptions = ActionExecutionException.class,
@@ -245,7 +244,7 @@ public class ActionExecutorServiceImplTest {
                 new ActionMgtException("Error occurred while retrieving action by action Id."));
 
         actionExecutorService.execute(
-                ActionType.PRE_ISSUE_ACCESS_TOKEN, "actionId", new HashMap<>(), "tenantDomain");
+                ActionType.PRE_ISSUE_ACCESS_TOKEN, "actionId", FlowContext.create(), "tenantDomain");
     }
 
     @Test(expectedExceptions = ActionExecutionException.class,
@@ -255,7 +254,7 @@ public class ActionExecutorServiceImplTest {
         when(actionManagementService.getActionsByActionType(any(), any())).thenThrow(
                 new ActionMgtException("Error occurred while retrieving actions."));
 
-        actionExecutorService.execute(ActionType.PRE_ISSUE_ACCESS_TOKEN, any(), any());
+        actionExecutorService.execute(ActionType.PRE_ISSUE_ACCESS_TOKEN, FlowContext.create(), "tenant1");
     }
 
     @Test(expectedExceptions = ActionExecutionException.class,
@@ -272,9 +271,9 @@ public class ActionExecutorServiceImplTest {
         when(ruleEvaluationService.evaluate(any(), any(), any())).thenThrow(new RuleEvaluationException("Error"));
 
         ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
-        Map<String, Object> eventContext = new HashMap<>();
 
-        ActionExecutionStatus<?> status = actionExecutorService.execute(actionType, eventContext, "tenantDomain");
+        ActionExecutionStatus<?> status =
+                actionExecutorService.execute(actionType, FlowContext.create(), "tenantDomain");
 
         assertEquals(status.getStatus(), ActionExecutionStatus.Status.SUCCESS);
     }
@@ -295,10 +294,10 @@ public class ActionExecutorServiceImplTest {
         actionExecutionResponseProcessorFactory.when(() -> ActionExecutionResponseProcessorFactory
                         .getActionExecutionResponseProcessor(actionType))
                 .thenReturn(actionExecutionResponseProcessor);
-        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any())).thenThrow(
+        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any(), any())).thenThrow(
                 new ActionExecutionRequestBuilderException("Error while executing request builder."));
 
-        actionExecutorService.execute(actionType, "actionId", new HashMap<>(), "tenantDomain");
+        actionExecutorService.execute(actionType, "actionId", FlowContext.create(), "tenantDomain");
     }
 
     @Test(expectedExceptions = ActionExecutionException.class)
@@ -308,7 +307,7 @@ public class ActionExecutorServiceImplTest {
         when(actionManagementService.getActionsByActionType(any(), any())).thenReturn(
                 Collections.singletonList(action));
         when(actionExecutionRequestBuilder.getSupportedActionType()).thenReturn(ActionType.PRE_ISSUE_ACCESS_TOKEN);
-        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any())).thenThrow(
+        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any(), any())).thenThrow(
                 new ActionExecutionRequestBuilderException("Error while executing request builder."));
 
         actionExecutionRequestBuilderFactory.when(
@@ -321,7 +320,7 @@ public class ActionExecutorServiceImplTest {
         assertEquals(actionExecutionStatus.getStatus(), ActionExecutionStatus.Status.FAILED);
 
         ActionExecutionStatus actionExecutionStatusWithActionIds = actionExecutorService.execute(
-                ActionType.PRE_ISSUE_ACCESS_TOKEN, any(), new HashMap<>(), "tenantDomain");
+                ActionType.PRE_ISSUE_ACCESS_TOKEN, any(), FlowContext.create(), "tenantDomain");
         assertEquals(actionExecutionStatusWithActionIds.getStatus(), ActionExecutionStatus.Status.FAILED);
     }
 
@@ -334,14 +333,14 @@ public class ActionExecutorServiceImplTest {
                 Collections.singletonList(action));
 
         when(actionExecutionRequestBuilder.getSupportedActionType()).thenReturn(ActionType.PRE_ISSUE_ACCESS_TOKEN);
-        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any())).thenReturn(
+        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any(), any())).thenReturn(
                 mock(ActionExecutionRequest.class));
 
         actionExecutionRequestBuilderFactory.when(
                         () -> ActionExecutionRequestBuilderFactory.getActionExecutionRequestBuilder(any()))
                 .thenReturn(actionExecutionRequestBuilder);
 
-        actionExecutorService.execute(ActionType.PRE_ISSUE_ACCESS_TOKEN, new HashMap<>(), "tenantDomain");
+        actionExecutorService.execute(ActionType.PRE_ISSUE_ACCESS_TOKEN, FlowContext.create(), "tenantDomain");
     }
 
     @Test(expectedExceptions = ActionExecutionException.class,
@@ -352,7 +351,7 @@ public class ActionExecutorServiceImplTest {
         when(actionManagementService.getActionByActionId(any(), any(), any())).thenReturn(action);
 
         when(actionExecutionRequestBuilder.getSupportedActionType()).thenReturn(ActionType.PRE_ISSUE_ACCESS_TOKEN);
-        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any())).thenReturn(
+        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any(), any())).thenReturn(
                 mock(ActionExecutionRequest.class));
 
         actionExecutionRequestBuilderFactory.when(
@@ -360,7 +359,7 @@ public class ActionExecutorServiceImplTest {
                 .thenReturn(actionExecutionRequestBuilder);
 
         actionExecutorService.execute(
-                ActionType.PRE_ISSUE_ACCESS_TOKEN, action.getId(), new HashMap<>(), "tenantDomain");
+                ActionType.PRE_ISSUE_ACCESS_TOKEN, action.getId(), FlowContext.create(), "tenantDomain");
     }
 
     @Test
@@ -368,9 +367,8 @@ public class ActionExecutorServiceImplTest {
             throws Exception {
 
         ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
-        Map<String, Object> eventContext = new HashMap<>();
-
         Action action = createAction();
+
         when(actionManagementService.getActionsByActionType(any(), any())).thenReturn(
                 Collections.singletonList(action));
         actionExecutionRequestBuilderFactory.when(
@@ -386,13 +384,13 @@ public class ActionExecutorServiceImplTest {
         ActionExecutionRequest actionExecutionRequest = createActionExecutionRequest(actionType);
 
         when(actionExecutionRequestBuilder.getSupportedActionType()).thenReturn(actionType);
-        when(actionExecutionRequestBuilder.buildActionExecutionRequest(eventContext)).thenReturn(
+        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any(), any())).thenReturn(
                 actionExecutionRequest);
 
         ActionInvocationResponse actionInvocationResponse = createSuccessActionInvocationResponse();
         when(apiClient.callAPI(any(), any(), any(), any())).thenReturn(actionInvocationResponse);
 
-        actionExecutorService.execute(actionType, eventContext, "tenantDomain");
+        actionExecutorService.execute(actionType, FlowContext.create(), "tenantDomain");
 
         String payload = getJSONRequestPayload(actionExecutionRequest);
         // Verify that the HTTP client was called with the expected request
@@ -403,9 +401,8 @@ public class ActionExecutorServiceImplTest {
     public void testBuildActionExecutionRequest() throws Exception {
 
         ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
-        Map<String, Object> eventContext = new HashMap<>();
-
         Action action = createAction();
+
         when(actionManagementService.getActionsByActionType(any(), any())).thenReturn(
                 Collections.singletonList(action));
         actionExecutionRequestBuilderFactory.when(
@@ -418,13 +415,13 @@ public class ActionExecutorServiceImplTest {
         ActionExecutionRequest actionExecutionRequest = createActionExecutionRequest(actionType);
 
         when(actionExecutionRequestBuilder.getSupportedActionType()).thenReturn(actionType);
-        when(actionExecutionRequestBuilder.buildActionExecutionRequest(eventContext)).thenReturn(
+        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any(), any())).thenReturn(
                 actionExecutionRequest);
 
         ActionInvocationResponse actionInvocationResponse = createSuccessActionInvocationResponse();
         when(apiClient.callAPI(any(), any(), any(), any())).thenReturn(actionInvocationResponse);
 
-        actionExecutorService.execute(actionType, eventContext, "tenantDomain");
+        actionExecutorService.execute(actionType, FlowContext.create(), "tenantDomain");
 
         String payload = getJSONRequestPayload(actionExecutionRequest);
         // Verify that the HTTP client was called with the expected request
@@ -435,9 +432,11 @@ public class ActionExecutorServiceImplTest {
     public void testActionExecuteSuccessWhenNoRuleConfiguredInAction() throws Exception {
 
         ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
-        Map<String, Object> eventContext = new HashMap<>();
-
         Action action = createAction();
+
+        when(actionManagementService.getActionsByActionType(any(), any())).thenReturn(
+                Collections.singletonList(action));
+        when(action.getActionRule()).thenReturn(null);
         when(actionManagementService.getActionsByActionType(any(), any())).thenReturn(
                 Collections.singletonList(action));
         actionExecutionRequestBuilderFactory.when(
@@ -452,7 +451,7 @@ public class ActionExecutorServiceImplTest {
 
         ActionExecutionRequest actionExecutionRequest = createActionExecutionRequest(actionType);
         when(actionExecutionRequestBuilder.getSupportedActionType()).thenReturn(actionType);
-        when(actionExecutionRequestBuilder.buildActionExecutionRequest(eventContext)).thenReturn(
+        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any(), any())).thenReturn(
                 actionExecutionRequest);
 
         ActionInvocationResponse actionInvocationResponse =
@@ -461,16 +460,16 @@ public class ActionExecutorServiceImplTest {
 
         ActionExecutionStatus expectedStatus = new SuccessStatus.Builder().build();
         when(actionExecutionResponseProcessor.getSupportedActionType()).thenReturn(actionType);
-        when(actionExecutionResponseProcessor.processSuccessResponse(any(), any(), any())).thenReturn(
+        when(actionExecutionResponseProcessor.processSuccessResponse(any(), any())).thenReturn(
                 expectedStatus);
         when(actionManagementService.getActionByActionId(any(), any(), any())).thenReturn(action);
 
         ActionExecutionStatus actualStatus =
-                actionExecutorService.execute(actionType, eventContext, "tenantDomain");
+                actionExecutorService.execute(actionType, FlowContext.create(), "tenantDomain");
         assertEquals(actualStatus.getStatus(), expectedStatus.getStatus());
 
         ActionExecutionStatus actionExecutionStatusWithActionIds = actionExecutorService.execute(
-                actionType, action.getId(), eventContext, "tenantDomain");
+                actionType, action.getId(), FlowContext.create(), "tenantDomain");
         assertEquals(actionExecutionStatusWithActionIds.getStatus(), expectedStatus.getStatus());
     }
 
@@ -478,9 +477,10 @@ public class ActionExecutorServiceImplTest {
     public void testActionExecuteSuccessWhenRuleConfiguredInActionIsSatisfied() throws Exception {
 
         ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
-        Map<String, Object> eventContext = new HashMap<>();
-
         Action action = createAction();
+
+        when(actionManagementService.getActionsByActionType(any(), any())).thenReturn(
+                Collections.singletonList(action));
         when(action.getActionRule()).thenReturn(ActionRule.create("ruleId", "tenantDomain"));
 
         when(actionManagementService.getActionsByActionType(any(), any())).thenReturn(
@@ -500,7 +500,7 @@ public class ActionExecutorServiceImplTest {
 
         ActionExecutionRequest actionExecutionRequest = createActionExecutionRequest(actionType);
         when(actionExecutionRequestBuilder.getSupportedActionType()).thenReturn(actionType);
-        when(actionExecutionRequestBuilder.buildActionExecutionRequest(eventContext)).thenReturn(
+        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any(), any())).thenReturn(
                 actionExecutionRequest);
 
         ActionInvocationResponse actionInvocationResponse = createSuccessActionInvocationResponse();
@@ -508,16 +508,16 @@ public class ActionExecutorServiceImplTest {
 
         ActionExecutionStatus expectedStatus = new SuccessStatus.Builder().build();
         when(actionExecutionResponseProcessor.getSupportedActionType()).thenReturn(actionType);
-        when(actionExecutionResponseProcessor.processSuccessResponse(any(), any(), any())).thenReturn(
+        when(actionExecutionResponseProcessor.processSuccessResponse(any(), any())).thenReturn(
                 expectedStatus);
         when(actionManagementService.getActionByActionId(any(), any(), any())).thenReturn(action);
 
         ActionExecutionStatus actualStatus =
-                actionExecutorService.execute(actionType, eventContext, "tenantDomain");
+                actionExecutorService.execute(actionType, FlowContext.create(), "tenantDomain");
         assertEquals(actualStatus.getStatus(), expectedStatus.getStatus());
 
         ActionExecutionStatus actionExecutionStatusWithActionIds = actionExecutorService.execute(
-                actionType, action.getId(), eventContext, "tenantDomain");
+                actionType, action.getId(), FlowContext.create(), "tenantDomain");
         assertEquals(actionExecutionStatusWithActionIds.getStatus(), expectedStatus.getStatus());
     }
 
@@ -525,9 +525,8 @@ public class ActionExecutorServiceImplTest {
     public void testActionExecuteFailure() throws Exception {
 
         ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
-        Map<String, Object> eventContext = new HashMap<>();
-
         Action action = createAction();
+
         when(actionManagementService.getActionsByActionType(any(), any())).thenReturn(
                 Collections.singletonList(action));
         actionExecutionRequestBuilderFactory.when(
@@ -538,7 +537,7 @@ public class ActionExecutorServiceImplTest {
                 .thenReturn(actionExecutionResponseProcessor);
 
         when(actionExecutionRequestBuilder.getSupportedActionType()).thenReturn(actionType);
-        when(actionExecutionRequestBuilder.buildActionExecutionRequest(eventContext)).thenReturn(
+        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any(), any())).thenReturn(
                 mock(ActionExecutionRequest.class));
 
         ActionInvocationResponse actionInvocationResponse = createFailureActionInvocationResponse();
@@ -547,18 +546,17 @@ public class ActionExecutorServiceImplTest {
         ActionExecutionStatus expectedStatus = new FailedStatus(new Failure("Error_reason",
                 "Error_description"));
         when(actionExecutionResponseProcessor.getSupportedActionType()).thenReturn(actionType);
-        when(actionExecutionResponseProcessor.processFailureResponse(any(), any(), any())).thenReturn(
-                expectedStatus);
+        when(actionExecutionResponseProcessor.processFailureResponse(any(), any())).thenReturn(expectedStatus);
         when(actionManagementService.getActionByActionId(any(), any(), any())).thenReturn(action);
 
         ActionExecutionStatus actualStatus =
-                actionExecutorService.execute(actionType, eventContext, "tenantDomain");
+                actionExecutorService.execute(actionType, FlowContext.create(), "tenantDomain");
         assertEquals(actualStatus.getStatus(), expectedStatus.getStatus());
         assertEquals(((FailedStatus) actualStatus).getResponse().getFailureReason(), "Error_reason");
         assertEquals(((FailedStatus) actualStatus).getResponse().getFailureDescription(), "Error_description");
 
         ActionExecutionStatus actionExecutionStatusWithActionIds = actionExecutorService.execute(
-                actionType, action.getId(), eventContext, "tenantDomain");
+                actionType, action.getId(), FlowContext.create(), "tenantDomain");
         assertEquals(actionExecutionStatusWithActionIds.getStatus(), expectedStatus.getStatus());
     }
 
@@ -566,9 +564,8 @@ public class ActionExecutorServiceImplTest {
     public void testExecuteIncomplete() throws Exception {
 
         ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
-        Map<String, Object> eventContext = new HashMap<>();
-
         Action action = createAction();
+
         when(actionManagementService.getActionsByActionType(any(), any())).thenReturn(
                 Collections.singletonList(action));
         actionExecutionRequestBuilderFactory.when(
@@ -579,7 +576,7 @@ public class ActionExecutorServiceImplTest {
                 .thenReturn(actionExecutionResponseProcessor);
 
         when(actionExecutionRequestBuilder.getSupportedActionType()).thenReturn(actionType);
-        when(actionExecutionRequestBuilder.buildActionExecutionRequest(eventContext)).thenReturn(
+        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any(), any())).thenReturn(
                 mock(ActionExecutionRequest.class));
 
         ActionInvocationResponse actionInvocationResponse = createIncompleteActionInvocationResponse();
@@ -587,16 +584,15 @@ public class ActionExecutorServiceImplTest {
 
         ActionExecutionStatus expectedStatus = new IncompleteStatus.Builder().build();
         when(actionExecutionResponseProcessor.getSupportedActionType()).thenReturn(actionType);
-        when(actionExecutionResponseProcessor.processIncompleteResponse(any(), any(), any())).thenReturn(
-                expectedStatus);
+        when(actionExecutionResponseProcessor.processIncompleteResponse(any(), any())).thenReturn(expectedStatus);
         when(actionManagementService.getActionByActionId(any(), any(), any())).thenReturn(action);
 
         ActionExecutionStatus actualStatus =
-                actionExecutorService.execute(actionType, eventContext, "tenantDomain");
+                actionExecutorService.execute(actionType, FlowContext.create(), "tenantDomain");
         assertEquals(actualStatus.getStatus(), expectedStatus.getStatus());
 
         ActionExecutionStatus actionExecutionStatusWithActionIds = actionExecutorService.execute(
-                actionType, action.getId(), eventContext, "tenantDomain");
+                actionType, action.getId(), FlowContext.create(), "tenantDomain");
         assertEquals(actionExecutionStatusWithActionIds.getStatus(), expectedStatus.getStatus());
     }
 
@@ -606,9 +602,8 @@ public class ActionExecutorServiceImplTest {
     public void testActionExecuteFailureForUnexpectedAPIResponse() throws Exception {
 
         ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
-        Map<String, Object> eventContext = new HashMap<>();
-
         Action action = createAction();
+
         when(actionManagementService.getActionsByActionType(any(), any())).thenReturn(
                 Collections.singletonList(action));
 
@@ -621,21 +616,19 @@ public class ActionExecutorServiceImplTest {
                 .thenReturn(actionExecutionResponseProcessor);
 
         when(actionExecutionRequestBuilder.getSupportedActionType()).thenReturn(actionType);
-        when(actionExecutionRequestBuilder.buildActionExecutionRequest(eventContext)).thenReturn(
+        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any(), any())).thenReturn(
                 mock(ActionExecutionRequest.class));
 
         ActionInvocationResponse actionInvocationResponse = createActionInvocationResponseWithoutAPIResponse();
         when(apiClient.callAPI(any(), any(), any(), any())).thenReturn(actionInvocationResponse);
 
-        actionExecutorService.execute(actionType, eventContext, "tenantDomain");
+        actionExecutorService.execute(actionType, FlowContext.create(), "tenantDomain");
     }
 
     @Test
     public void testExecuteError() throws Exception {
 
         ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
-        Map<String, Object> eventContext = new HashMap<>();
-
         Action action = createAction();
 
         when(actionManagementService.getActionsByActionType(any(), any())).thenReturn(
@@ -649,7 +642,7 @@ public class ActionExecutorServiceImplTest {
                 .thenReturn(actionExecutionResponseProcessor);
 
         when(actionExecutionRequestBuilder.getSupportedActionType()).thenReturn(actionType);
-        when(actionExecutionRequestBuilder.buildActionExecutionRequest(eventContext)).thenReturn(
+        when(actionExecutionRequestBuilder.buildActionExecutionRequest(any(), any())).thenReturn(
                 mock(ActionExecutionRequest.class));
 
         ActionInvocationResponse actionInvocationResponse = createErrorActionInvocationResponse();
@@ -658,18 +651,17 @@ public class ActionExecutorServiceImplTest {
         ActionExecutionStatus expectedStatus = new ErrorStatus(new Error("Error_message",
                 "Error_description"));
         when(actionExecutionResponseProcessor.getSupportedActionType()).thenReturn(actionType);
-        when(actionExecutionResponseProcessor.processErrorResponse(any(), any(), any())).thenReturn(
-                expectedStatus);
+        when(actionExecutionResponseProcessor.processErrorResponse(any(), any())).thenReturn(expectedStatus);
         when(actionManagementService.getActionByActionId(any(), any(), any())).thenReturn(action);
 
         ActionExecutionStatus actualStatus =
-                actionExecutorService.execute(actionType, eventContext, "tenantDomain");
+                actionExecutorService.execute(actionType, FlowContext.create(), "tenantDomain");
         assertEquals(actualStatus.getStatus(), expectedStatus.getStatus());
         assertEquals(((ErrorStatus) actualStatus).getResponse().getErrorMessage(), "Error_message");
         assertEquals(((ErrorStatus) actualStatus).getResponse().getErrorDescription(), "Error_description");
 
         ActionExecutionStatus actionExecutionStatusWithActionIds = actionExecutorService.execute(
-                actionType, action.getId(), eventContext, "tenantDomain");
+                actionType, action.getId(), FlowContext.create(), "tenantDomain");
         assertEquals(actionExecutionStatusWithActionIds.getStatus(), expectedStatus.getStatus());
     }
 

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/execution/UserPreUpdatePasswordActionExecutorTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/execution/UserPreUpdatePasswordActionExecutorTest.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.user.pre.update.password.action.core.execution.U
 import org.wso2.carbon.identity.user.pre.update.password.action.internal.PreUpdatePasswordActionServiceComponentHolder;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.testng.Assert.assertEquals;
@@ -72,7 +73,7 @@ public class UserPreUpdatePasswordActionExecutorTest {
     public void testExecuteSuccess() throws ActionExecutionException {
 
         ActionExecutionStatus<Success> expectedStatus = new SuccessStatus.Builder().build();
-        doReturn(expectedStatus).when(mockActionExecutorService).execute(any(), any(), anyString());
+        doReturn(expectedStatus).when(mockActionExecutorService).execute(any(), anyMap(), anyString());
 
         ActionExecutionStatus<?> resultStatus = executor.execute(mockUserActionContext, TENANT_DOMAIN);
         assertTrue(resultStatus instanceof SuccessStatus);
@@ -84,7 +85,7 @@ public class UserPreUpdatePasswordActionExecutorTest {
 
         ActionExecutionStatus<Failure> expectedStatus = new FailedStatus(new Failure("Invalid Request",
                 "Compromised Password"));
-        doReturn(expectedStatus).when(mockActionExecutorService).execute(any(), any(), anyString());
+        doReturn(expectedStatus).when(mockActionExecutorService).execute(any(), anyMap(), anyString());
 
         ActionExecutionStatus<?> resultStatus = executor.execute(mockUserActionContext, TENANT_DOMAIN);
         assertTrue(resultStatus instanceof FailedStatus);
@@ -100,7 +101,7 @@ public class UserPreUpdatePasswordActionExecutorTest {
 
         ActionExecutionStatus<Error> expectedStatus = new ErrorStatus(new Error("Internal server error",
                 "Error while validating password"));
-        doReturn(expectedStatus).when(mockActionExecutorService).execute(any(), any(), anyString());
+        doReturn(expectedStatus).when(mockActionExecutorService).execute(any(), anyMap(), anyString());
 
         ActionExecutionStatus<?> resultStatus = executor.execute(mockUserActionContext, TENANT_DOMAIN);
         assertTrue(resultStatus instanceof ErrorStatus);


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves https://github.com/wso2/product-is/issues/23108

- This defines a FlowContext to refer to flow related context data.
- ActionExecutionRequestContext to refer to action request flow related context data
- ActionExecutionResponseContext to refer to action response flow related context data
- The ActionExecutionService,  ActionExecutionRequestBuilder and  ActionExecutionResponseProcessor is updated to utilize afore mentioned context objects in the contract. New APIs will invoke the existing APIs until downstream components gets updated
