### PR TITLE
Introduce a constructor to the KeyStoreAdmin to avoid passing registry and deprecate the existing constructor

### DIFF
--- a/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/keystore/KeyStoreAdmin.java
+++ b/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/keystore/KeyStoreAdmin.java
@@ -68,7 +68,25 @@ public class KeyStoreAdmin {
     private final KeyStoreManager keyStoreManager;
     private boolean includeCert = false;
 
+    /**
+     * Constructor to create a KeyStoreAdmin object.
+     *
+     * @param tenantId Tenant id.
+     * @param registry Registry.
+     * @deprecated Use {@link #KeyStoreAdmin(int)} instead.
+     */
+    @Deprecated
     public KeyStoreAdmin(int tenantId, Registry registry) {
+
+        keyStoreManager = KeyStoreManager.getInstance(tenantId);
+    }
+
+    /**
+     * Constructor to create a KeyStoreAdmin object.
+     *
+     * @param tenantId Tenant id.
+     */
+    public KeyStoreAdmin(int tenantId) {
 
         keyStoreManager = KeyStoreManager.getInstance(tenantId);
     }
@@ -174,7 +192,7 @@ public class KeyStoreAdmin {
             throws SecurityConfigException {
 
         try {
-            keyStoreManager.addKeyStore(content, filename, password, provider, type, null);
+            keyStoreManager.addKeyStore(content, filename, password.toCharArray(), provider, type, null);
         } catch (SecurityException e) {
             String msg = "Error when adding a trustStore";
             log.error(msg, e);

--- a/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/keystore/KeyStoreManagementServiceImpl.java
+++ b/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/keystore/KeyStoreManagementServiceImpl.java
@@ -20,13 +20,10 @@ import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.CarbonException;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.base.ServerConfiguration;
-import org.wso2.carbon.context.CarbonContext;
-import org.wso2.carbon.context.RegistryType;
 import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.core.util.KeyStoreUtil;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.security.SecurityConfigException;
 import org.wso2.carbon.security.SecurityConstants;
 import org.wso2.carbon.security.keystore.service.CertData;
@@ -50,8 +47,8 @@ import static org.wso2.carbon.security.SecurityConstants.KeyStoreMgtConstants.Er
 import static org.wso2.carbon.security.SecurityConstants.KeyStoreMgtConstants.ErrorMessage.ERROR_CODE_CANNOT_DELETE_TENANT_CERT;
 import static org.wso2.carbon.security.SecurityConstants.KeyStoreMgtConstants.ErrorMessage.ERROR_CODE_CERTIFICATE_EXISTS;
 import static org.wso2.carbon.security.SecurityConstants.KeyStoreMgtConstants.ErrorMessage.ERROR_CODE_DELETE_CERTIFICATE;
-import static org.wso2.carbon.security.SecurityConstants.KeyStoreMgtConstants.ErrorMessage.ERROR_CODE_INITIALIZE_REGISTRY;
 import static org.wso2.carbon.security.SecurityConstants.KeyStoreMgtConstants.ErrorMessage.ERROR_CODE_EMPTY_ALIAS;
+import static org.wso2.carbon.security.SecurityConstants.KeyStoreMgtConstants.ErrorMessage.ERROR_CODE_INITIALIZE_REGISTRY;
 import static org.wso2.carbon.security.SecurityConstants.KeyStoreMgtConstants.ErrorMessage.ERROR_CODE_INVALID_CERTIFICATE;
 import static org.wso2.carbon.security.SecurityConstants.KeyStoreMgtConstants.ErrorMessage.ERROR_CODE_RETRIEVE_CLIENT_TRUSTSTORE;
 import static org.wso2.carbon.security.SecurityConstants.KeyStoreMgtConstants.ErrorMessage.ERROR_CODE_RETRIEVE_CLIENT_TRUSTSTORE_CERTIFICATE;
@@ -293,8 +290,7 @@ public class KeyStoreManagementServiceImpl implements KeyStoreManagementService 
 
     private KeyStoreAdmin getKeyStoreAdmin(String tenantDomain) {
 
-        return new KeyStoreAdmin(IdentityTenantUtil.getTenantId(tenantDomain),
-                (Registry) CarbonContext.getThreadLocalCarbonContext().getRegistry(RegistryType.SYSTEM_GOVERNANCE));
+        return new KeyStoreAdmin(IdentityTenantUtil.getTenantId(tenantDomain));
     }
 
     private KeyStoreManager getKeyStoreManager(String tenantDomain) {

--- a/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/keystore/service/KeyStoreAdminServiceImpl.java
+++ b/components/security-mgt/org.wso2.carbon.security.mgt/src/main/java/org/wso2/carbon/security/keystore/service/KeyStoreAdminServiceImpl.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.security.keystore.service;
 
 import org.apache.axiom.om.util.Base64;
-import org.wso2.carbon.CarbonException;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.core.AbstractAdmin;
@@ -31,8 +30,8 @@ public class KeyStoreAdminServiceImpl extends AbstractAdmin implements KeyStoreA
 
     @Override
     public KeyStoreData[] getKeyStores() throws SecurityConfigException {
-        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId(),
-                getGovernanceSystemRegistry());
+
+        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId());
         boolean isSuperTenant = CarbonContext.getThreadLocalCarbonContext().getTenantId() ==
                 MultitenantConstants.SUPER_TENANT_ID;
         return admin.getKeyStores(isSuperTenant);
@@ -54,8 +53,7 @@ public class KeyStoreAdminServiceImpl extends AbstractAdmin implements KeyStoreA
     @Override
     public void addTrustStore(String fileData, String filename, String password, String provider,
                               String type) throws SecurityConfigException {
-        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId(),
-                getGovernanceSystemRegistry());
+        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId());
         admin.addTrustStore(fileData, filename, password, provider, type);
     }
 
@@ -74,38 +72,33 @@ public class KeyStoreAdminServiceImpl extends AbstractAdmin implements KeyStoreA
     @Override
     public void importCertToStore(String fileName, String fileData, String keyStoreName)
             throws SecurityConfigException {
-        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId(),
-                getGovernanceSystemRegistry());
+        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId());
         admin.importCertToStore(fileName, fileData, keyStoreName);
 
     }
 
     @Override
     public String[] getStoreEntries(String keyStoreName) throws SecurityConfigException {
-        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId(),
-                getGovernanceSystemRegistry());
+        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId());
         return admin.getStoreEntries(keyStoreName);
 
     }
 
     @Override
     public KeyStoreData getKeystoreInfo(String keyStoreName) throws SecurityConfigException {
-        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId(),
-                getGovernanceSystemRegistry());
+        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId());
         return admin.getKeystoreInfo(keyStoreName);
 
     }
 
     @Override
     public void removeCertFromStore(String alias, String keyStoreName) throws SecurityConfigException {
-        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId(),
-                getGovernanceSystemRegistry());
+        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId());
         admin.removeCertFromStore(alias, keyStoreName);
     }
 
     public PaginatedKeyStoreData getPaginatedKeystoreInfo(String keyStoreName, int pageNumber) throws SecurityConfigException {
-        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId(),
-                getGovernanceSystemRegistry());
+        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId());
         return admin.getPaginatedKeystoreInfo(keyStoreName, pageNumber);
 
     }
@@ -122,8 +115,7 @@ public class KeyStoreAdminServiceImpl extends AbstractAdmin implements KeyStoreA
     public PaginatedKeyStoreData getFilteredPaginatedKeyStoreInfo(String keyStoreName, int pageNumber,
                                                                   String filter) throws SecurityConfigException {
 
-        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId(),
-                getGovernanceSystemRegistry());
+        KeyStoreAdmin admin = new KeyStoreAdmin(CarbonContext.getThreadLocalCarbonContext().getTenantId());
         return admin.getFilteredPaginatedKeyStoreInfo(keyStoreName, pageNumber, filter);
     }
 }

--- a/components/security-mgt/org.wso2.carbon.security.mgt/src/test/java/org/wso2/carbon/security/keystore/KeyStoreAdminTest.java
+++ b/components/security-mgt/org.wso2.carbon.security.mgt/src/test/java/org/wso2/carbon/security/keystore/KeyStoreAdminTest.java
@@ -103,7 +103,7 @@ public class KeyStoreAdminTest extends IdentityBaseTest {
             keyStoreUtil.when(() -> KeyStoreUtil.isPrimaryStore(any())).thenReturn(false);
             keyStoreUtil.when(() -> KeyStoreUtil.isTrustStore(any())).thenReturn(false);
 
-            keyStoreAdmin = new KeyStoreAdmin(tenantID, null);
+            keyStoreAdmin = new KeyStoreAdmin(tenantID);
             keyStoreAdmin.addKeyStore(keyStoreContent, "new_keystore.jks", KEYSTORE_PASSWORD, " ", "JKS",
                     KEYSTORE_PASSWORD);
         }
@@ -122,7 +122,7 @@ public class KeyStoreAdminTest extends IdentityBaseTest {
             keyStoreUtil.when(() -> KeyStoreUtil.isPrimaryStore(any())).thenReturn(false);
             keyStoreUtil.when(() -> KeyStoreUtil.isTrustStore(any())).thenReturn(true);
 
-            keyStoreAdmin = new KeyStoreAdmin(tenantID, null);
+            keyStoreAdmin = new KeyStoreAdmin(tenantID);
             keyStoreAdmin.addTrustStore(Base64.encode(keyStoreContent), "new_truststore.jks", KEYSTORE_PASSWORD, " ",
                     "JKS");
         }
@@ -137,7 +137,7 @@ public class KeyStoreAdminTest extends IdentityBaseTest {
             when(this.keyStoreManager.getTrustStore())
                     .thenReturn(getKeyStoreFromFile(KEYSTORE_NAME, KEYSTORE_PASSWORD));
 
-            keyStoreAdmin = new KeyStoreAdmin(tenantID, null);
+            keyStoreAdmin = new KeyStoreAdmin(tenantID);
             KeyStore result = keyStoreAdmin.getTrustStore();
 
             assertNotNull(result);
@@ -154,7 +154,7 @@ public class KeyStoreAdminTest extends IdentityBaseTest {
             when(this.keyStoreManager.getTrustStore())
                     .thenThrow(new CarbonException("Error occurred while retrieving TrustStore"));
 
-            keyStoreAdmin = new KeyStoreAdmin(tenantID, null);
+            keyStoreAdmin = new KeyStoreAdmin(tenantID);
             // Execute method under test
             assertThrows(SecurityConfigException.class, () -> {
                 keyStoreAdmin.getTrustStore();
@@ -173,7 +173,7 @@ public class KeyStoreAdminTest extends IdentityBaseTest {
             keyStoreUtil.when(() -> KeyStoreUtil.isPrimaryStore(anyString())).thenReturn(false);
             keyStoreUtil.when(() -> KeyStoreUtil.isTrustStore(anyString())).thenReturn(false);
 
-            keyStoreAdmin = new KeyStoreAdmin(tenantID, null);
+            keyStoreAdmin = new KeyStoreAdmin(tenantID);
             keyStoreAdmin.deleteStore("new_keystore.jks");
             verify(this.keyStoreManager).deleteStore("new_keystore.jks");
         }
@@ -190,7 +190,7 @@ public class KeyStoreAdminTest extends IdentityBaseTest {
             keyStoreUtil.when(() -> KeyStoreUtil.isPrimaryStore(anyString())).thenReturn(false);
             keyStoreUtil.when(() -> KeyStoreUtil.isTrustStore(anyString())).thenReturn(false);
 
-            keyStoreAdmin = new KeyStoreAdmin(tenantID, null);
+            keyStoreAdmin = new KeyStoreAdmin(tenantID);
             keyStoreAdmin.deleteStore("new_truststore.jks");
             verify(this.keyStoreManager).deleteStore("new_truststore.jks");
         }
@@ -211,7 +211,7 @@ public class KeyStoreAdminTest extends IdentityBaseTest {
             when(this.keyStoreManager.getKeyStore(anyString()))
                     .thenReturn(getKeyStoreFromFile(KEYSTORE_NAME, KEYSTORE_PASSWORD));
 
-            keyStoreAdmin = new KeyStoreAdmin(tenantID, null);
+            keyStoreAdmin = new KeyStoreAdmin(tenantID);
             PaginatedKeyStoreData result = keyStoreAdmin.getPaginatedKeystoreInfo(KEYSTORE_NAME, 10);
             int actualKeysNo = findCertDataSetSize(result.getPaginatedKeyData().getCertDataSet());
             assertEquals(actualKeysNo, 3, "Incorrect key numbers");
@@ -232,7 +232,7 @@ public class KeyStoreAdminTest extends IdentityBaseTest {
             when(keyStoreManager.getKeyStore(anyString()))
                     .thenReturn(getKeyStoreFromFile(KEYSTORE_NAME, KEYSTORE_PASSWORD));
 
-            keyStoreAdmin = new KeyStoreAdmin(tenantID, null);
+            keyStoreAdmin = new KeyStoreAdmin(tenantID);
             PaginatedKeyStoreData result =
                     keyStoreAdmin.getFilteredPaginatedKeyStoreInfo(KEYSTORE_NAME, 10, KEYSTORE_ALIAS);
             int actualKeysNo = findCertDataSetSize(result.getPaginatedKeyData().getCertDataSet());
@@ -257,7 +257,7 @@ public class KeyStoreAdminTest extends IdentityBaseTest {
             when(this.keyStoreManager.getPrivateKey(anyString(), anyString()))
                     .thenReturn(getPrivateKeyFromKeyStore(KEYSTORE_NAME, KEYSTORE_ALIAS, KEYSTORE_PASSWORD));
 
-            keyStoreAdmin = new KeyStoreAdmin(tenantID, null);
+            keyStoreAdmin = new KeyStoreAdmin(tenantID);
             KeyStoreData keystoreInfo = keyStoreAdmin.getKeystoreInfo(KEYSTORE_NAME);
             assertEquals(keystoreInfo.getKeyStoreName(), KEYSTORE_NAME, "Incorrect keystore name");
             assertEquals(keystoreInfo.getKeyStoreType(), KEYSTORE_TYPE, "Incorrect keystore type");
@@ -287,7 +287,7 @@ public class KeyStoreAdminTest extends IdentityBaseTest {
             when(keyStoreManager.getKeyStoresMetadata(anyBoolean())).thenReturn(
                     metadataList.toArray(new KeyStoreMetadata[0]));
 
-            keyStoreAdmin = new KeyStoreAdmin(tenantID, null);
+            keyStoreAdmin = new KeyStoreAdmin(tenantID);
             KeyStoreData[] keyStores = keyStoreAdmin.getKeyStores(isSuperTenant);
 
             assertEquals(keyStores.length, 1, "Incorrect number of keystores");
@@ -306,7 +306,7 @@ public class KeyStoreAdminTest extends IdentityBaseTest {
             keyStoreManager.when(() -> KeyStoreManager.getInstance(anyInt())).thenReturn(this.keyStoreManager);
             when(this.keyStoreManager.getKeyStore(KEYSTORE_NAME))
                     .thenReturn(getKeyStoreFromFile(KEYSTORE_NAME, KEYSTORE_PASSWORD));
-            keyStoreAdmin = new KeyStoreAdmin(tenantID, null);
+            keyStoreAdmin = new KeyStoreAdmin(tenantID);
             String[] names = keyStoreAdmin.getStoreEntries(KEYSTORE_NAME);
             assertEquals(names.length, 38, "Incorrect key numbers");
         }


### PR DESCRIPTION
### Proposed changes in this pull request

$subject

Part of: https://github.com/wso2/product-is/issues/21206