### PR TITLE
Skip adding the previous session to the context when Forced Authentication is enabled

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -107,6 +107,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.REDIRECT_URL;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.REQUEST_PARAM_SP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.AUTH_TYPE;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.FORCE_AUTHENTICATE;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.IDENTIFIER_CONSENT;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.IDF;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.RESTART_FLOW;
@@ -938,7 +939,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
             }
         }
         // if a value for the sessionContextKey exists user has previously authenticated
-        if (sessionContextKey != null) {
+        if (sessionContextKey != null && !isForceAuthEnabled(request)) {
 
             SessionContext sessionContext = null;
             // get the authentication details from the cache
@@ -1351,5 +1352,10 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
             // for branding purposes.
             log.debug("Error while adding spId to redirect URL.");
         }
+    }
+
+    private boolean isForceAuthEnabled(HttpServletRequest request) {
+
+        return Boolean.parseBoolean(request.getParameter(FORCE_AUTHENTICATE));
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

The Magic Link authenticator incorrectly picks the username from the previous session, even when forced authentication (prompt=login) is enabled. This happens because, despite triggering forced authentication, the authentication flow still checks the previous session and sets the existing user in the context [1]. As a result, the username is retrieved from the previous session [2] instead of requiring a fresh login.

To solve this when forceAuth=true, we should skip adding the previous session to the context.


[1] https://github.com/wso2-support/carbon-identity-framework/blob/80e9a4e080760645160ef65d6de5fc35c7bf3d2c/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java#L927

Tested Flows:

- Steps mentioned in the issue: https://github.com/wso2/product-is/issues/22621
- Single sign-on
- Single Logout
- Admin initiated SLO and SSO. 


Related issue:

- https://github.com/wso2/product-is/issues/22621

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
