### PR TITLE
Unexpose internal model classes in Pre Update Password action component

### DIFF
--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/execution/PreUpdatePasswordActionRequestBuilder.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/execution/PreUpdatePasswordActionRequestBuilder.java
@@ -36,12 +36,12 @@ import org.wso2.carbon.identity.core.context.IdentityContext;
 import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.user.action.api.model.UserActionContext;
-import org.wso2.carbon.identity.user.pre.update.password.action.api.model.Credential;
 import org.wso2.carbon.identity.user.pre.update.password.action.api.model.PasswordSharing;
-import org.wso2.carbon.identity.user.pre.update.password.action.api.model.PasswordUpdatingUser;
 import org.wso2.carbon.identity.user.pre.update.password.action.api.model.PreUpdatePasswordAction;
-import org.wso2.carbon.identity.user.pre.update.password.action.api.model.PreUpdatePasswordEvent;
 import org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants;
+import org.wso2.carbon.identity.user.pre.update.password.action.internal.model.Credential;
+import org.wso2.carbon.identity.user.pre.update.password.action.internal.model.PasswordUpdatingUser;
+import org.wso2.carbon.identity.user.pre.update.password.action.internal.model.PreUpdatePasswordEvent;
 import org.wso2.carbon.utils.Secret;
 import org.wso2.carbon.utils.UnsupportedSecretTypeException;
 

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/model/Credential.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/model/Credential.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.wso2.carbon.identity.user.pre.update.password.action.api.model;
+package org.wso2.carbon.identity.user.pre.update.password.action.internal.model;
 
 /**
  * Represents an unencrypted credential.

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/model/PasswordUpdatingUser.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/model/PasswordUpdatingUser.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.wso2.carbon.identity.user.pre.update.password.action.api.model;
+package org.wso2.carbon.identity.user.pre.update.password.action.internal.model;
 
 import com.google.gson.Gson;
 import com.nimbusds.jose.EncryptionMethod;

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/model/PreUpdatePasswordEvent.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/model/PreUpdatePasswordEvent.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.wso2.carbon.identity.user.pre.update.password.action.api.model;
+package org.wso2.carbon.identity.user.pre.update.password.action.internal.model;
 
 import org.wso2.carbon.identity.action.execution.api.model.ActionExecutionRequest;
 import org.wso2.carbon.identity.action.execution.api.model.Event;

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/execution/PreUpdatePasswordActionRequestBuilderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/execution/PreUpdatePasswordActionRequestBuilderTest.java
@@ -35,13 +35,13 @@ import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.context.IdentityContext;
 import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.user.action.api.model.UserActionContext;
-import org.wso2.carbon.identity.user.pre.update.password.action.api.model.Credential;
 import org.wso2.carbon.identity.user.pre.update.password.action.api.model.PasswordSharing;
-import org.wso2.carbon.identity.user.pre.update.password.action.api.model.PasswordUpdatingUser;
 import org.wso2.carbon.identity.user.pre.update.password.action.api.model.PreUpdatePasswordAction;
-import org.wso2.carbon.identity.user.pre.update.password.action.api.model.PreUpdatePasswordEvent;
 import org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants;
 import org.wso2.carbon.identity.user.pre.update.password.action.internal.execution.PreUpdatePasswordActionRequestBuilder;
+import org.wso2.carbon.identity.user.pre.update.password.action.internal.model.Credential;
+import org.wso2.carbon.identity.user.pre.update.password.action.internal.model.PasswordUpdatingUser;
+import org.wso2.carbon.identity.user.pre.update.password.action.internal.model.PreUpdatePasswordEvent;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;


### PR DESCRIPTION
### Proposed changes in this pull request
- Since few classes are used internally we don't need to expose them. Hence moving them to the internal package.

