### PR TITLE
Add push device registration request cache configs

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2627,6 +2627,11 @@
                    timeout="{{cache.push_auth_status_cache_cache.timeout}}"
                    capacity="{{cache.push_auth_status_cache_cache.capacity}}"
                    isDistributed="false"/>
+            <Cache id="push_device_registration_request_cache" name="PushDeviceRegistrationRequestCache"
+                   enable="{{cache.push_device_registration_request_cache.enable}}"
+                   timeout="{{cache.push_device_registration_request_cache.timeout}}"
+                   capacity="{{cache.push_device_registration_request_cache.capacity}}"
+                   isDistributed="false"/>
             {% for cache in cache.manager %}
              <Cache name="{{cache.name}}"
                     enable="true"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -726,6 +726,9 @@
   "cache.push_auth_status_cache.enable": true,
   "cache.push_auth_status_cache.timeout": "300",
   "cache.push_auth_status_cache.capacity": "$ref{cache.default_capacity}",
+  "cache.push_device_registration_request_cache.enable": true,
+  "cache.push_device_registration_request_cache.timeout": "300",
+  "cache.push_device_registration_request_cache.capacity": "$ref{cache.default_capacity}",
 
   "resource_access_control.default_access_allow": false,
   "resource_access_control.introspect.secured": true,


### PR DESCRIPTION
With this PR, configuration required to store the pushDeviceRegistrationRequestCache into the temp session database are added.