### PR TITLE
Upgrade json-smart version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1999,7 +1999,7 @@
         <jsr311-api.version>1.1.1</jsr311-api.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <tomcat-util.version>3.3.2</tomcat-util.version>
-        <json-smart.version>2.5.0</json-smart.version>
+        <json-smart.version>2.5.2</json-smart.version>
         <cxf-bundle.wso2.version>2.7.16.wso2v1</cxf-bundle.wso2.version>
         <org.apache.cxf.version>3.6.3</org.apache.cxf.version>
         <opencsv.wso2.version>1.8.wso2v1</opencsv.wso2.version>


### PR DESCRIPTION
### Purpose
To upgrade json-smart version from 2.5.0 to the non-vulnerable 2.5.2 version.

#### Related PRs:

Identity-inbound-auth-oauth: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2730
Identity-inbound-auth-openid: https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/109
Identity-outbound-auth-oidc: https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/199
Carbon-mediation: https://github.com/wso2/carbon-mediation/pull/1767
Carbon-analytics-common: https://github.com/wso2/carbon-analytics-common/pull/862
Carbon-apimgt: https://github.com/wso2/carbon-apimgt/pull/12953
Product-apim: https://github.com/wso2/product-apim/pull/13688
