### PR TITLE
enable pre_session_data_cleanup

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -32,7 +32,7 @@
   "session_data.cleanup.clean_expired_session_data_every": "1d",
   "session_data.cleanup.clean_expired_session_data_in_chunks_of": "8192",
   "session_data.cleanup.clean_logged_out_sessions_at_immediate_cycle": false,
-  "session_data.cleanup.enable_pre_session_data_cleanup": false,
+  "session_data.cleanup.enable_pre_session_data_cleanup": true,
   "session_data.cleanup.enable_periodic_pre_session_data_cleanup": true,
   "session_data.session_data_persist.session_and_temp_data_separation_enabled.enable": true,
   "session_data.session_data_persist.check_existing_entry_for_delete_operation_insert": false,


### PR DESCRIPTION
### Proposed changes in this pull request

`session_data.cleanup.enable_pre_session_data_cleanup`
Setting the above configuration will fix the performance degradation in 500 concurrency.
Setting it to true enables separate cleanup for temporary authentication context data.

- https://github.com/wso2/product-is/issues/22976