### PR TITLE
Add new config for default userStore for authentication.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2145,6 +2145,7 @@
             </PreIssueAccessToken>
             <Authentication>
                 <Enable>{{actions.types.authentication.enable}}</Enable>
+                <DefaultUserStore>{{actions.types.authentication.default.userStore}}</DefaultUserStore>
             </Authentication>
         </Types>
     </Actions>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2145,7 +2145,7 @@
             </PreIssueAccessToken>
             <Authentication>
                 <Enable>{{actions.types.authentication.enable}}</Enable>
-                <DefaultUserStore>{{actions.types.authentication.default.userStore}}</DefaultUserStore>
+                <DefaultUserStore>{{actions.types.authentication.default_userstore}}</DefaultUserStore>
             </Authentication>
         </Types>
     </Actions>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1756,7 +1756,7 @@
   "actions.maximum_actions_per_action_type": 1,
   "actions.types.pre_issue_access_token.enable": true,
   "actions.types.authentication.enable": true,
-  "actions.types.authentication.default.userStore": "PRIMARY",
+  "actions.types.authentication.default_userstore": "PRIMARY",
 
   "oauth.authorize_all_scopes": false,
   "oauth.enable_rich_authorization_requests" : true,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1756,6 +1756,7 @@
   "actions.maximum_actions_per_action_type": 1,
   "actions.types.pre_issue_access_token.enable": true,
   "actions.types.authentication.enable": true,
+  "actions.types.authentication.default.userStore": "PRIMARY",
 
   "oauth.authorize_all_scopes": false,
   "oauth.enable_rich_authorization_requests" : true,


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/23211

Add the following new configuration to set the default userstore for local users authenticating via the external service when the userstore domain is not specified in the response from the external authenticator.
```
Actions.Types.Authentication.DefaultUserStore
```