### PR TITLE
Use custom federated authenticator name as its display name

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/UserDefinedFederatedAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/UserDefinedFederatedAuthenticatorConfig.java
@@ -54,4 +54,19 @@ public class UserDefinedFederatedAuthenticatorConfig extends FederatedAuthentica
 
         this.endpointConfig = endpointConfig;
     }
+
+    @Override
+    public void setDisplayName(String displayName) {
+
+        /* Since the displayName must be same as the authenticator name for user defined federated authenticators,
+         we are ignoring the displayName setting here and instead setting the displayName when configuring the
+         authenticator name. */
+    }
+
+    @Override
+    public void setName(String name) {
+
+        super.setName(name);
+        displayName = name;
+    }
 }


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/23258

Improve the custom federated authenticator creation to use the authenticator name as the authenticator display name