### PR TITLE
Cache empty action list when no action is configured

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/CacheBackedActionManagementService.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/CacheBackedActionManagementService.java
@@ -78,7 +78,7 @@ public class CacheBackedActionManagementService implements ActionManagementServi
 
         List<Action> actions = ACTION_MGT_SERVICE.getActionsByActionType(actionType, tenantDomain);
 
-        if (actions != null && !actions.isEmpty()) {
+        if (actions != null) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Entry fetched from DB for Action Type " + actionType + ". Updating cache.");
             }


### PR DESCRIPTION
### Proposed changes in this pull request

- Previously when no actions are configured it didn't cache the empty action list in the cache.
- Due to that reason, it requires i/o operations to fetch actions from the DB everytime.
- Caching the empty list will prevent above overhead.

### Related Issue
- https://github.com/wso2/product-is/issues/23276