### PR TITLE
Update userId claim in the custom federated authenticator template to use with JIT provisioning

### DIFF
--- a/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/external-custom-authenticator/template.json
+++ b/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/external-custom-authenticator/template.json
@@ -25,7 +25,7 @@
     "idpIssuerName": "",
     "claims": {
       "userIdClaim": {
-        "uri": ""
+        "uri": "http://wso2.org/claims/username"
       },
       "roleClaim": {
         "uri": ""


### PR DESCRIPTION
### Purpose
This PR updates the userId claim of the custom federated authenticator connection template to default username claim URI. This will be utilized in JIT provisioning.