### PR TITLE
Refactor isOrganization check to service layer when fetching API resource by ID

### DIFF
--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/constant/APIResourceManagementConstants.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/constant/APIResourceManagementConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -41,8 +41,6 @@ public class APIResourceManagementConstants {
     public static final String BEFORE = "before";
     public static final String AFTER = "after";
     public static final String PROPERTIES = "properties";
-    public static final String BUSINESS_TYPE = "BUSINESS";
-    public static final String SYSTEM_TYPE = "SYSTEM";
     public static final String EQ = "eq";
     public static final String NE = "ne";
     public static final String CO = "co";
@@ -64,6 +62,18 @@ public class APIResourceManagementConstants {
     private static final Map<String, String> authorizationDetailsTypesAttributeColumnMap = new HashMap<>();
     public static final Map<String, String> AUTHORIZATION_DETAILS_TYPES_ATTRIBUTE_COLUMN_MAP =
             Collections.unmodifiableMap(authorizationDetailsTypesAttributeColumnMap);
+
+    /**
+     * @deprecated Use {@link APIResourceTypes#BUSINESS} instead.
+     */
+    @Deprecated
+    public static final String BUSINESS_TYPE = "BUSINESS";
+
+    /**
+     * @deprecated Use {@link APIResourceTypes#SYSTEM} instead.
+     */
+    @Deprecated
+    public static final String SYSTEM_TYPE = "SYSTEM";
 
     static {
         attributeColumnMap.put(NAME, SQLConstants.NAME_COLUMN_NAME);
@@ -96,6 +106,20 @@ public class APIResourceManagementConstants {
         public static final String TENANT_ADMIN_TYPE = "TENANT_ADMIN";
         public static final String RICH_AUTHORIZATION_REQUESTS_ENABLED = "OAuth.EnableRichAuthorizationRequests";
 
+    }
+
+    /**
+     * API Resource Types.
+     */
+    public static class APIResourceTypes {
+
+        public static final String BUSINESS = "BUSINESS";
+        public static final String SYSTEM = "SYSTEM";
+        public static final String TENANT = "TENANT";
+        public static final String ORGANIZATION = "ORGANIZATION";
+        public static final String CONSOLE_FEATURE = "CONSOLE_FEATURE";
+        public static final String CONSOLE_ORG_FEATURE = "CONSOLE_ORG_FEATURE";
+        public static final String CONSOLE_ORG_LEVEL = "CONSOLE_ORG_LEVEL";
     }
 
     /**
@@ -177,7 +201,10 @@ public class APIResourceManagementConstants {
                 "Error while deleting authorization details types from the database."),
         ERROR_CODE_ERROR_WHILE_UPDATING_AUTHORIZATION_DETAILS_TYPES("65024",
                 "Error while updating authorization details types.",
-                "Error while updating authorization details types in the database.");
+                "Error while updating authorization details types in the database."),
+        ERROR_CODE_ERROR_WHILE_RETRIEVING_ROOT_ORGANIZATION_TENANT_DOMAIN("65025",
+                "Error retrieving the root organization's tenant domain.", "Failed to retrieve " +
+                "the root organization's tenant domain using the sub-organization's tenant domain: %s");
 
         private final String code;
         private final String message;

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/dao/impl/APIResourceManagementDAOImpl.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/dao/impl/APIResourceManagementDAOImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -283,19 +283,8 @@ public class APIResourceManagementDAOImpl implements APIResourceManagementDAO {
     @Override
     public APIResource getAPIResourceById(String apiId, Integer tenantId) throws APIResourceMgtException {
 
-        String query = SQLConstants.GET_API_RESOURCE_BY_ID;
-        try {
-            if (OrganizationManagementUtil.isOrganization(tenantId)) {
-                tenantId = getRootOrganizationTenantId(tenantId);
-                query = SQLConstants.GET_API_RESOURCE_BY_ID_FOR_ORGANIZATIONS;
-            }
-        } catch (OrganizationManagementException e) {
-            throw APIResourceManagementUtil.handleServerException(APIResourceManagementConstants.ErrorMessages.
-                            ERROR_CODE_ERROR_WHILE_RESOLVING_ORGANIZATION_FOR_TENANT, e,
-                    IdentityTenantUtil.getTenantDomain(tenantId));
-        }
         try (Connection dbConnection = IdentityDatabaseUtil.getDBConnection(false);
-             PreparedStatement preparedStatement = dbConnection.prepareStatement(query)) {
+             PreparedStatement preparedStatement = dbConnection.prepareStatement(SQLConstants.GET_API_RESOURCE_BY_ID)) {
             preparedStatement.setString(1, apiId);
             preparedStatement.setInt(2, tenantId);
             ResultSet resultSet = preparedStatement.executeQuery();

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/util/APIResourceManagementUtil.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/main/java/org/wso2/carbon/identity/api/resource/mgt/util/APIResourceManagementUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -195,10 +195,34 @@ public class APIResourceManagementUtil {
                         APIResourceManagementConstants.ASC, tenantDomain).getAPIResources().isEmpty();
     }
 
+    /**
+     * Checks whether a given API resource is a tenant agnostic API.
+     * This determines whether the API is an Identity Server (IS) management API that is commonly owned by all tenants.
+     * {@code APIResourceTypes.SYSTEM} indicates API resources owned only by the super tenant.
+     *
+     * @param type The API resource type to check.
+     * @return {@code true} if the API resource type is neither "BUSINESS" nor "SYSTEM".
+     */
     public static boolean isSystemAPI(String type) {
 
-        return !APIResourceManagementConstants.BUSINESS_TYPE.equalsIgnoreCase(type)
-                && !APIResourceManagementConstants.SYSTEM_TYPE.equalsIgnoreCase(type);
+        return !APIResourceManagementConstants.APIResourceTypes.BUSINESS.equalsIgnoreCase(type)
+                && !APIResourceManagementConstants.APIResourceTypes.SYSTEM.equalsIgnoreCase(type);
+    }
+
+    /**
+     * Determines whether the given API Resource Type is an allowed type for sub-organizations.
+     *
+     * @param type The API Resource Type to check.
+     * @return {@code true} if the API Resource Type is allowed for sub-organizations
+     *         ("ORGANIZATION", "BUSINESS", "CONSOLE_ORG_LEVEL", or "CONSOLE_ORG_FEATURE").
+     *         {@code false} if it is a restricted type ("TENANT", "SYSTEM", or "CONSOLE_FEATURE").
+     */
+    public static boolean isAllowedAPIResourceTypeForOrganizations(String type) {
+
+        return APIResourceManagementConstants.APIResourceTypes.ORGANIZATION.equalsIgnoreCase(type)
+                || APIResourceManagementConstants.APIResourceTypes.BUSINESS.equalsIgnoreCase(type)
+                || APIResourceManagementConstants.APIResourceTypes.CONSOLE_ORG_LEVEL.equalsIgnoreCase(type)
+                || APIResourceManagementConstants.APIResourceTypes.CONSOLE_ORG_FEATURE.equalsIgnoreCase(type);
     }
 
     public static boolean isSystemAPIByAPIId(String apiId) throws APIResourceMgtException {

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/test/java/org/wso2/carbon/identity/api/resource/mgt/APIResourceManagerTest.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/test/java/org/wso2/carbon/identity/api/resource/mgt/APIResourceManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.api.resource.mgt;
 
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -36,7 +37,9 @@ import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.common.testng.WithRegistry;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.internal.OrganizationManagementDataHolder;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,6 +48,9 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.wso2.carbon.identity.api.resource.mgt.constant.APIResourceManagementConstants.APIResourceTypes;
+import static org.wso2.carbon.identity.api.resource.mgt.constant.APIResourceManagementConstants.ErrorMessages.ERROR_CODE_ERROR_WHILE_RETRIEVING_ROOT_ORGANIZATION_TENANT_DOMAIN;
 
 @WithAxisConfiguration
 @WithCarbonHome
@@ -53,7 +59,13 @@ import static org.mockito.Mockito.mock;
 @WithH2Database(files = {"dbscripts/h2.sql"})
 public class APIResourceManagerTest {
 
+    private final String postFix1 = "test1";
+    private final String postFix2 = "test2";
+    private final String postFix3 = "test3";
+    private final String apiResourceID = "sampleAPIResourceID";
+
     private String tenantDomain;
+    private String subOrgTenantDomain;
     private APIResourceManager apiResourceManager;
     @Mock
     private IdentityEventService identityEventService;
@@ -98,17 +110,95 @@ public class APIResourceManagerTest {
     @Test
     public void testGetAPIResourceById() throws Exception {
 
-        APIResource createdAPIResource = apiResourceManager.addAPIResource(createAPIResource("test1"),
-                tenantDomain);
+        APIResource createdAPIResource = apiResourceManager.addAPIResource(
+                createAPIResource(postFix1, APIResourceTypes.BUSINESS), tenantDomain);
         APIResource apiResource = apiResourceManager.getAPIResourceById(createdAPIResource.getId(), tenantDomain);
         Assert.assertNotNull(apiResource);
         Assert.assertEquals(apiResource.getId(), createdAPIResource.getId());
     }
 
+    @DataProvider(name = "getAPIResourceByIdForSubOrgDataProvider")
+    public Object[][] getAPIResourceByIdForSubOrgDataProvider() {
+
+        return new Object[][]{
+                {APIResourceTypes.BUSINESS, true},
+                {APIResourceTypes.ORGANIZATION, true},
+                {APIResourceTypes.CONSOLE_ORG_FEATURE, true},
+                {APIResourceTypes.CONSOLE_ORG_LEVEL, true},
+                {APIResourceTypes.SYSTEM, false},
+                {APIResourceTypes.TENANT, false},
+                {APIResourceTypes.CONSOLE_FEATURE, false}
+        };
+    }
+
+    @Test(dataProvider = "getAPIResourceByIdForSubOrgDataProvider")
+    public void testGetAPIResourceByIdForSubOrg(String apiResourceType, boolean isAccessibleToSubOrg) throws Exception {
+
+        try (MockedStatic<OrganizationManagementUtil> organizationManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class)) {
+
+            organizationManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(subOrgTenantDomain))
+                    .thenReturn(true);
+            organizationManagementUtil.when(() -> OrganizationManagementUtil
+                            .getRootOrgTenantDomainBySubOrgTenantDomain(subOrgTenantDomain)).thenReturn(tenantDomain);
+
+            APIResource createdAPIResource = apiResourceManager.addAPIResource(createAPIResource(postFix1,
+                    apiResourceType), tenantDomain);
+            APIResource apiResource = apiResourceManager.getAPIResourceById(createdAPIResource.getId(),
+                    subOrgTenantDomain);
+
+            if (isAccessibleToSubOrg) {
+                Assert.assertNotNull(apiResource);
+                Assert.assertEquals(apiResource.getId(), createdAPIResource.getId());
+            } else {
+                Assert.assertNull(apiResource);
+            }
+        }
+    }
+
+    @Test
+    public void testGetAPIResourceByInvalidIdForSubOrg() throws Exception {
+
+        try (MockedStatic<OrganizationManagementUtil> organizationManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class)) {
+
+            organizationManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(subOrgTenantDomain))
+                    .thenReturn(true);
+            organizationManagementUtil.when(() -> OrganizationManagementUtil
+                    .getRootOrgTenantDomainBySubOrgTenantDomain(subOrgTenantDomain)).thenReturn(tenantDomain);
+
+            APIResource apiResource = apiResourceManager.getAPIResourceById(apiResourceID, subOrgTenantDomain);
+            Assert.assertNull(apiResource);
+        }
+    }
+
+    @Test
+    public void testGetAPIResourceByIdForSubOrgException() throws Exception {
+
+        try (MockedStatic<OrganizationManagementUtil> organizationManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class)) {
+
+            organizationManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(subOrgTenantDomain))
+                    .thenReturn(true);
+            organizationManagementUtil.when(() -> OrganizationManagementUtil
+                            .getRootOrgTenantDomainBySubOrgTenantDomain(subOrgTenantDomain))
+                    .thenThrow(new OrganizationManagementException("Test exception."));
+
+            try {
+                apiResourceManager.getAPIResourceById(apiResourceID, subOrgTenantDomain);
+                Assert.fail("Expected OrganizationManagementException to be thrown.");
+            } catch (APIResourceMgtException e) {
+                Assert.assertTrue(e.getMessage()
+                        .contains(ERROR_CODE_ERROR_WHILE_RETRIEVING_ROOT_ORGANIZATION_TENANT_DOMAIN.getMessage()));
+                Assert.assertTrue(e.getCause() instanceof OrganizationManagementException);
+            }
+        }
+    }
+
     @DataProvider(name = "addAPIResourceDataProvider")
     public Object[][] addAPIResourceDataProvider() {
 
-        APIResource apiResource1 = createAPIResource("1");
+        APIResource apiResource1 = createAPIResource("1", APIResourceTypes.BUSINESS);
         APIResource.APIResourceBuilder apiResourceBuilder = new APIResource.APIResourceBuilder()
                 .name("testAPIResource name 2")
                 .identifier("testAPIResource identifier 2")
@@ -139,7 +229,7 @@ public class APIResourceManagerTest {
     @DataProvider(name = "addAPIResourceExceptionDataProvider")
     public Object[][] addAPIResourceExceptionDataProvider() {
 
-        APIResource apiResource1 = createAPIResource("test1");
+        APIResource apiResource1 = createAPIResource(postFix1, APIResourceTypes.BUSINESS);
 
         APIResource.APIResourceBuilder apiResourceBuilder = new APIResource.APIResourceBuilder()
                 .name("testAPIResource name 2")
@@ -170,8 +260,8 @@ public class APIResourceManagerTest {
     @Test
     public void testDeleteAPIResourceById() throws Exception {
 
-        APIResource createdAPIResource = apiResourceManager.addAPIResource(createAPIResource("test1"),
-                tenantDomain);
+        APIResource createdAPIResource = apiResourceManager.addAPIResource(
+                createAPIResource(postFix1, APIResourceTypes.BUSINESS), tenantDomain);
         apiResourceManager.deleteAPIResourceById(createdAPIResource.getId(), tenantDomain);
         Assert.assertNull(apiResourceManager.getAPIResourceById(createdAPIResource.getId(), tenantDomain));
     }
@@ -179,8 +269,8 @@ public class APIResourceManagerTest {
     @DataProvider
     public Object[][] updateAPIResourceTestData() {
 
-        APIResource apiResource1 = createAPIResource("test1");
-        APIResource apiResource2 = createAPIResource("test2");
+        APIResource apiResource1 = createAPIResource(postFix1, APIResourceTypes.BUSINESS);
+        APIResource apiResource2 = createAPIResource(postFix2, APIResourceTypes.BUSINESS);
 
         return new Object[][]{
                 // Update API resource with scopes.
@@ -237,7 +327,7 @@ public class APIResourceManagerTest {
     @Test(dataProvider = "getAPIResourceByIdentifierDataProvider")
     public void testGetAPIResourceByIdentifier(String identifier) throws Exception {
 
-        apiResourceManager.addAPIResource(createAPIResource("test1"), tenantDomain);
+        apiResourceManager.addAPIResource(createAPIResource(postFix1, APIResourceTypes.BUSINESS), tenantDomain);
         APIResource apiResource = apiResourceManager.getAPIResourceByIdentifier(identifier, tenantDomain);
         Assert.assertNotNull(apiResource);
     }
@@ -245,8 +335,8 @@ public class APIResourceManagerTest {
     @Test
     public void testGetAPIScopesById() throws Exception {
 
-        APIResource createdAPIResource = apiResourceManager.addAPIResource(createAPIResource("test1"),
-                tenantDomain);
+        APIResource createdAPIResource = apiResourceManager.addAPIResource(
+                createAPIResource(postFix1, APIResourceTypes.BUSINESS), tenantDomain);
         List<Scope> scopes = apiResourceManager.getAPIScopesById(createdAPIResource.getId(), tenantDomain);
         Assert.assertNotNull(scopes);
     }
@@ -254,8 +344,8 @@ public class APIResourceManagerTest {
     @Test
     public void testDeleteAPIScopesById() throws Exception {
 
-        APIResource createdAPIResource = apiResourceManager.addAPIResource(createAPIResource("test1"),
-                tenantDomain);
+        APIResource createdAPIResource = apiResourceManager.addAPIResource(
+                createAPIResource(postFix1, APIResourceTypes.BUSINESS), tenantDomain);
         apiResourceManager.deleteAPIScopesById(createdAPIResource.getId(), tenantDomain);
         List<Scope> scopes = apiResourceManager.getAPIScopesById(createdAPIResource.getId(), tenantDomain);
         Assert.assertTrue(scopes.isEmpty());
@@ -264,8 +354,8 @@ public class APIResourceManagerTest {
     @Test
     public void testDeleteAPIScopeByScopeId() throws Exception {
 
-        APIResource createdAPIResource = apiResourceManager.addAPIResource(createAPIResource("test1"),
-                tenantDomain);
+        APIResource createdAPIResource = apiResourceManager.addAPIResource(
+                createAPIResource(postFix1, APIResourceTypes.BUSINESS), tenantDomain);
         List<Scope> scopes = createdAPIResource.getScopes();
         apiResourceManager.deleteAPIScopeByScopeName(createdAPIResource.getId(), scopes.get(0).getName(), tenantDomain);
         scopes = apiResourceManager.getAPIScopesById(createdAPIResource.getId(), tenantDomain);
@@ -275,8 +365,8 @@ public class APIResourceManagerTest {
     @DataProvider(name = "putScopesDataProvider")
     public Object[][] putScopesDataProvider() {
 
-        APIResource apiResource1 = createAPIResource("test1");
-        APIResource apiResource2 = createAPIResource("test2");
+        APIResource apiResource1 = createAPIResource(postFix1, APIResourceTypes.BUSINESS);
+        APIResource apiResource2 = createAPIResource(postFix2, APIResourceTypes.BUSINESS);
 
         return new Object[][]{
                 // Update API resource with scopes.
@@ -338,7 +428,7 @@ public class APIResourceManagerTest {
      * @param postFix Postfix to be appended to each API resource and scope information.
      * @return API resource.
      */
-    private static APIResource createAPIResource(String postFix) {
+    private static APIResource createAPIResource(String postFix, String type) {
 
         List<Scope> scopes = new ArrayList<>();
         scopes.add(createScope("testScopeOne " + postFix));
@@ -348,7 +438,7 @@ public class APIResourceManagerTest {
                 .name("testAPIResource name " + postFix)
                 .identifier("testAPIResource identifier " + postFix)
                 .description("testAPIResource description " + postFix)
-                .type("BUSINESS")
+                .type(type)
                 .requiresAuthorization(true)
                 .scopes(scopes);
         return apiResourceBuilder.build();
@@ -356,9 +446,9 @@ public class APIResourceManagerTest {
 
     private void addTestAPIResources() throws Exception {
 
-        APIResource apiResource1 = createAPIResource("test1");
-        APIResource apiResource2 = createAPIResource("test2");
-        APIResource apiResource3 = createAPIResource("test3");
+        APIResource apiResource1 = createAPIResource(postFix1, APIResourceTypes.BUSINESS);
+        APIResource apiResource2 = createAPIResource(postFix2, APIResourceTypes.BUSINESS);
+        APIResource apiResource3 = createAPIResource(postFix3, APIResourceTypes.BUSINESS);
         apiResourceManager.addAPIResource(apiResource1, tenantDomain);
         apiResourceManager.addAPIResource(apiResource2, tenantDomain);
         apiResourceManager.addAPIResource(apiResource3, tenantDomain);

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/test/java/org/wso2/carbon/identity/api/resource/mgt/dao/APIResourceManagementDAOImplTest.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt/src/test/java/org/wso2/carbon/identity/api/resource/mgt/dao/APIResourceManagementDAOImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -269,7 +269,7 @@ public class APIResourceManagementDAOImplTest {
     public Object[][] getAPIResourceByIdData() {
         return new Object[][]{
                 {"testGetAPIResourceById", TENANT_ID, TENANT_ID, false, true},
-                {"testGetOrgAPIResourceById", TENANT_ID, ORGANIZATION_TENANT_ID, true, true},
+                {"testGetOrgAPIResourceById", TENANT_ID, ORGANIZATION_TENANT_ID, true, false},
                 {"testGetAPIResourceByIdInvalidTenant", TENANT_ID, INVALID_TENANT_ID, false, false}
         };
     }
@@ -550,8 +550,8 @@ public class APIResourceManagementDAOImplTest {
     public Object[][] updateAPIResourceScopeAddition() {
 
         return new Object[][]{
-                {APIResourceManagementConstants.BUSINESS_TYPE, 2},
-                {APIResourceManagementConstants.SYSTEM_TYPE, 2},
+                {APIResourceManagementConstants.APIResourceTypes.BUSINESS, 2},
+                {APIResourceManagementConstants.APIResourceTypes.SYSTEM, 2},
                 {ORGANIZATION_TYPE, 2},
                 {TENANT_TYPE, 2},
                 {CONSOLE_ORG_LEVEL_TYPE, 2}

--- a/pom.xml
+++ b/pom.xml
@@ -1912,7 +1912,7 @@
         <carbon.identity.package.import.version.range>[5.14.0, 8.0.0)</carbon.identity.package.import.version.range>
 
         <org.bouncycastle.imp.pkg.version.range>[0.0.0,2.0.0)</org.bouncycastle.imp.pkg.version.range>
-        <org.wso2.carbon.identity.organization.management.core.version>1.0.90
+        <org.wso2.carbon.identity.organization.management.core.version>1.1.24
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request

Fixes: https://github.com/wso2/product-is/issues/23297

Refactor sub-organization logic check to the Service layer, before CacheBacked DAO layer, when fetching API resource by ID.

This ensures the cache only contains the root organization tenant domain cache entry.

### Tested outflows:
- Retrieve Organization API Resource using root organization access token (Allowed)
- Retrieve Business API Resource using root organization access token (Allowed)
- Retrieve System API Resource using root organization access token (Allowed)
- Retrieve Tenant (Management) API Resource using root organization access token (Allowed)
- Retrieve Console feature API Resource using root organization access token (Allowed)
- Retrieve Organization API using a sub-organization access token (Allowed)
- Retrieve Business API using a sub-organization access token (Allowed)
- Retrieve System API Resource using sub-organization organization access token (**Not Allowed**)
- Retrieve Tenant (Management) API Resource using sub-organization organization access token (**Not Allowed**)
- Retrieve Console feature API Resource using sub-organization organization access token (**Not Allowed**)

### Merged After

After: https://github.com/wso2/identity-organization-management-core/pull/171