### PR TITLE
Add fallback to IDN_ACTION_PROPERTIES table

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/constant/ActionMgtSQLConstants.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/constant/ActionMgtSQLConstants.java
@@ -42,6 +42,7 @@ public class ActionMgtSQLConstants {
         public static final String ACTION_PROPERTIES_UUID = "ACTION_UUID";
         public static final String ACTION_PROPERTIES_PROPERTY_NAME = "PROPERTY_NAME";
         public static final String ACTION_PROPERTIES_PROPERTY_VALUE = "PROPERTY_VALUE";
+        public static final String ACTION_PROPERTIES_PRIMITIVE_VALUE = "PRIMITIVE_VALUE";
         public static final String TENANT_ID = "TENANT_ID";
 
         private Column() {
@@ -58,11 +59,11 @@ public class ActionMgtSQLConstants {
                 "DESCRIPTION, STATUS, TENANT_ID, VERSION) VALUES (:UUID;, :TYPE;, :NAME;, :DESCRIPTION;, :STATUS;, " +
                 ":TENANT_ID;, :VERSION;)";
         public static final String ADD_ACTION_PROPERTIES = "INSERT INTO IDN_ACTION_PROPERTIES (ACTION_UUID, " +
-                "PROPERTY_NAME, PROPERTY_VALUE, TENANT_ID) VALUES (:ACTION_UUID;, :PROPERTY_NAME;, :PROPERTY_VALUE;, " +
-                ":TENANT_ID;)";
+                "PROPERTY_NAME, PRIMITIVE_VALUE, TENANT_ID) VALUES (:ACTION_UUID;, :PROPERTY_NAME;, " +
+                ":PRIMITIVE_VALUE;, :TENANT_ID;)";
         public static final String GET_ACTION_BASIC_INFO_BY_ID = "SELECT TYPE, NAME, DESCRIPTION, STATUS FROM " +
                 "IDN_ACTION WHERE TYPE = :TYPE; AND UUID = :UUID; AND TENANT_ID = :TENANT_ID;";
-        public static final String GET_ACTION_PROPERTIES_INFO_BY_ID = "SELECT PROPERTY_NAME, PROPERTY_VALUE FROM " +
+        public static final String GET_ACTION_PROPERTIES_INFO_BY_ID = "SELECT PROPERTY_NAME, PRIMITIVE_VALUE FROM " +
                 "IDN_ACTION_PROPERTIES WHERE ACTION_UUID = :ACTION_UUID; AND TENANT_ID = :TENANT_ID;";
         public static final String GET_ACTIONS_BASIC_INFO_BY_ACTION_TYPE = "SELECT UUID, TYPE, NAME, DESCRIPTION," +
                 " STATUS FROM IDN_ACTION WHERE TYPE = :TYPE; AND TENANT_ID = :TENANT_ID;";
@@ -77,9 +78,20 @@ public class ActionMgtSQLConstants {
         public static final String GET_ACTIONS_COUNT_PER_ACTION_TYPE = "SELECT TYPE, COUNT(UUID) AS COUNT" +
                 " FROM IDN_ACTION WHERE TENANT_ID = :TENANT_ID; GROUP BY TYPE";
         public static final String UPDATE_ACTION_PROPERTY = "UPDATE IDN_ACTION_PROPERTIES SET " +
-                "PROPERTY_VALUE = :PROPERTY_VALUE; WHERE ACTION_UUID = :ACTION_UUID; AND " +
+                "PRIMITIVE_VALUE = :PRIMITIVE_VALUE; WHERE ACTION_UUID = :ACTION_UUID; AND " +
                 "TENANT_ID = :TENANT_ID; AND PROPERTY_NAME = :PROPERTY_NAME;";
 
+        //TODO: Adding following queries to support existing schema. Should be removed once the PROPERTY_VALUE column
+        // name to PRIMITIVE_TYPE schema change is deployed.
+        public static final String ADD_ACTION_PROPERTIES_WITH_PROPERTY_VALUE_COLUMN = "INSERT INTO " +
+                "IDN_ACTION_PROPERTIES (ACTION_UUID, PROPERTY_NAME, PROPERTY_VALUE, TENANT_ID) VALUES " +
+                "(:ACTION_UUID;, :PROPERTY_NAME;, :PROPERTY_VALUE;, :TENANT_ID;)";
+        public static final String GET_ACTION_PROPERTIES_INFO_BY_ID_WITH_PROPERTY_VALUE_COLUMN = "SELECT " +
+                "PROPERTY_NAME, PROPERTY_VALUE FROM IDN_ACTION_PROPERTIES WHERE ACTION_UUID = :ACTION_UUID; AND " +
+                "TENANT_ID = :TENANT_ID;";
+        public static final String UPDATE_ACTION_PROPERTY_WITH_PROPERTY_VALUE_COLUMN = "UPDATE IDN_ACTION_PROPERTIES " +
+                "SET PROPERTY_VALUE = :PROPERTY_VALUE; WHERE ACTION_UUID = :ACTION_UUID; AND " +
+                "TENANT_ID = :TENANT_ID; AND PROPERTY_NAME = :PROPERTY_NAME;";
         private Query() {
 
         }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/dao/impl/ActionManagementDAOImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/dao/impl/ActionManagementDAOImpl.java
@@ -183,8 +183,7 @@ public class ActionManagementDAOImpl implements ActionManagementDAO {
                         actionTypesCountMap.put(resultSet.getString(ActionMgtSQLConstants.Column.ACTION_TYPE),
                                 resultSet.getInt(ActionMgtSQLConstants.Column.ACTION_COUNT));
                         return null;
-                    }, statement -> statement.setInt(ActionMgtSQLConstants.Column.TENANT_ID,
-                                tenantId)));
+                    }, statement -> statement.setInt(ActionMgtSQLConstants.Column.TENANT_ID, tenantId)));
             return actionTypesCountMap;
         } catch (TransactionException e) {
             throw new ActionMgtServerException("Error while retrieving Actions count per Action Type from the system.",
@@ -308,8 +307,7 @@ public class ActionManagementDAOImpl implements ActionManagementDAO {
             endpointProperties.put(URI_PROPERTY, endpoint.getUri());
             endpointProperties.put(AUTHN_TYPE_PROPERTY, endpoint.getAuthentication().getType().name());
             endpoint.getAuthentication().getProperties().forEach(
-                    authProperty -> endpointProperties.put(authProperty.getName(),
-                            authProperty.getValue()));
+                    authProperty -> endpointProperties.put(authProperty.getName(), authProperty.getValue()));
 
             addActionPropertiesToDB(actionDTO.getId(), endpointProperties, tenantId);
         } catch (TransactionException e) {
@@ -616,8 +614,7 @@ public class ActionManagementDAOImpl implements ActionManagementDAO {
      * @return A map of action properties, including any additional data based on action type.
      * @throws ActionMgtException If an error occurs while retrieving action properties from the database.
      */
-    private Map<String, String> getActionPropertiesFromDB(String actionId, Integer tenantId)
-            throws ActionMgtException {
+    private Map<String, String> getActionPropertiesFromDB(String actionId, Integer tenantId) throws ActionMgtException {
 
         NamedJdbcTemplate jdbcTemplate = new NamedJdbcTemplate(IdentityDatabaseUtil.getDataSource());
         Map<String, String> actionEndpointProperties = new HashMap<>();


### PR DESCRIPTION
### Proposed changes in this pull request

This PR adds the backward compatibilty in BE to support the future schema change to be done in IDN_ACTION_PROPERTIES table. When the PROPERTY_VALUE column is getting changed to PRIMITIVE_VALUE column this BE logic handles the CRUD operations.


### When should this PR be merged

Soon

### Follow up actions

- [ ] Todo code lines mentioned in this implementation should be removed with a new PR after the new schema change becomes stable in the PROD




