### PR TITLE
Handle USER_ONBOARD step

### DIFF
--- a/components/registration-framework/org.wso2.carbon.identity.user.registration.engine/src/main/java/org/wso2/carbon/identity/user/registration/engine/Constants.java
+++ b/components/registration-framework/org.wso2.carbon.identity.user.registration.engine/src/main/java/org/wso2/carbon/identity/user/registration/engine/Constants.java
@@ -90,18 +90,20 @@ public class Constants {
         ERROR_CODE_GET_DEFAULT_REG_FLOW_FAILURE("65010",
                                                 "Error while loading the registration flow.",
                                                 "Error occurred loading the default registration flow of tenant: %s."),
+        ERROR_CODE_GET_IDP_CONFIG_FAILURE("65011",
+                                                "Error while loading identity provider configurations.",
+                                                "Error occurred loading the configurations of identity provider: %s " +
+                                                  "of tenant: %s."),
+
 
         // Client errors.
-        ERROR_CODE_UNRESOLVED_NEXT_NODE("60001",
-                                        "Unresolved next node.",
-                                        "Decision node %s cannot resolve a next node to proceed for flow id: %s"),
-        ERROR_CODE_INVALID_FLOW_ID("60002",
+         ERROR_CODE_INVALID_FLOW_ID("60001",
                                    "Invalid flow id.",
                                    "The given flow id: %s is invalid."),
-        ERROR_CODE_USERNAME_NOT_PROVIDED("60003",
+        ERROR_CODE_USERNAME_NOT_PROVIDED("60002",
                                          "Username not provided.",
                                          "Username is not provided in the registration request of flow id: %s"),
-        ERROR_CODE_UNDEFINED_FLOW_ID("60004",
+        ERROR_CODE_UNDEFINED_FLOW_ID("60003",
                                            "Flow id is not defined",
                                            "The flow id is not defined in the registration request."),;
 

--- a/components/registration-framework/org.wso2.carbon.identity.user.registration.engine/src/main/java/org/wso2/carbon/identity/user/registration/engine/graph/TaskExecutionNode.java
+++ b/components/registration-framework/org.wso2.carbon.identity.user.registration.engine/src/main/java/org/wso2/carbon/identity/user/registration/engine/graph/TaskExecutionNode.java
@@ -18,7 +18,29 @@
 
 package org.wso2.carbon.identity.user.registration.engine.graph;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.user.registration.engine.exception.RegistrationEngineException;
+import org.wso2.carbon.identity.user.registration.engine.exception.RegistrationEngineServerException;
+import org.wso2.carbon.identity.user.registration.engine.internal.RegistrationFlowEngineDataHolder;
+import org.wso2.carbon.identity.user.registration.engine.model.ExecutorResponse;
+import org.wso2.carbon.identity.user.registration.engine.model.RegisteringUser;
+import org.wso2.carbon.identity.user.registration.engine.model.RegistrationContext;
+import org.wso2.carbon.identity.user.registration.engine.model.Response;
+import org.wso2.carbon.identity.user.registration.mgt.model.ExecutorDTO;
+import org.wso2.carbon.identity.user.registration.mgt.model.NodeConfig;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.wso2.carbon.identity.user.registration.engine.Constants.ErrorMessages.ERROR_CODE_EXECUTOR_NOT_FOUND;
+import static org.wso2.carbon.identity.user.registration.engine.Constants.ErrorMessages.ERROR_CODE_GET_IDP_CONFIG_FAILURE;
 import static org.wso2.carbon.identity.user.registration.engine.Constants.ErrorMessages.ERROR_CODE_UNSUPPORTED_EXECUTOR;
 import static org.wso2.carbon.identity.user.registration.engine.Constants.ErrorMessages.ERROR_CODE_UNSUPPORTED_EXECUTOR_STATUS;
 import static org.wso2.carbon.identity.user.registration.engine.Constants.ExecutorStatus.STATUS_EXTERNAL_REDIRECTION;
@@ -30,17 +52,6 @@ import static org.wso2.carbon.identity.user.registration.engine.util.Registratio
 import static org.wso2.carbon.identity.user.registration.mgt.Constants.NodeTypes.TASK_EXECUTION;
 import static org.wso2.carbon.identity.user.registration.mgt.Constants.StepTypes.REDIRECTION;
 import static org.wso2.carbon.identity.user.registration.mgt.Constants.StepTypes.VIEW;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.identity.user.registration.engine.internal.RegistrationFlowEngineDataHolder;
-import org.wso2.carbon.identity.user.registration.engine.model.ExecutorResponse;
-import org.wso2.carbon.identity.user.registration.engine.model.RegisteringUser;
-import org.wso2.carbon.identity.user.registration.engine.model.RegistrationContext;
-import org.wso2.carbon.identity.user.registration.engine.model.Response;
-import org.wso2.carbon.identity.user.registration.engine.exception.RegistrationEngineException;
-import org.wso2.carbon.identity.user.registration.engine.exception.RegistrationEngineServerException;
-import org.wso2.carbon.identity.user.registration.mgt.model.NodeConfig;
 
 /**
  * Implementation of a node specific to executing a registration executor.
@@ -61,9 +72,9 @@ public class TaskExecutionNode implements Node {
 
         if (configs.getExecutorConfig() == null) {
             throw handleServerException(ERROR_CODE_EXECUTOR_NOT_FOUND, context.getRegGraph().getId(),
-                                        context.getTenantDomain());
+                    context.getTenantDomain());
         }
-        // TODO: 2021/4/6 Add executor configuration to the context where application
+        updateContextWithAuthenticatorProperties(context, configs.getExecutorConfig());
         return triggerExecutor(context, configs);
     }
 
@@ -123,8 +134,8 @@ public class TaskExecutionNode implements Node {
         throw handleServerException(ERROR_CODE_UNSUPPORTED_EXECUTOR_STATUS, response.getResult());
     }
 
-    private Response handleCompleteStatus(RegistrationContext context, ExecutorResponse response, String executorName
-            , NodeConfig configs) {
+    private Response handleCompleteStatus(RegistrationContext context, ExecutorResponse response, String executorName,
+                                          NodeConfig configs) {
 
         if ((response.getRequiredData() != null && !response.getRequiredData().isEmpty()) ||
                 (response.getAdditionalInfo() != null && !response.getAdditionalInfo().isEmpty())) {
@@ -145,5 +156,33 @@ public class TaskExecutionNode implements Node {
             configs.setNextNodeId(configs.getEdges().get(0).getTargetNodeId());
         }
         return new Response.Builder().status(STATUS_COMPLETE).build();
+    }
+
+    private void updateContextWithAuthenticatorProperties(RegistrationContext context, ExecutorDTO executorDTO)
+            throws RegistrationEngineServerException {
+
+        if (executorDTO == null || executorDTO.getIdpName() == null) {
+            return;
+        }
+
+        try {
+            IdentityProvider idp = IdentityProviderManager.getInstance()
+                    .getIdPByName(executorDTO.getIdpName(), context.getTenantDomain());
+
+            if (idp == null || idp.getDefaultAuthenticatorConfig() == null) {
+                throw handleServerException(ERROR_CODE_GET_IDP_CONFIG_FAILURE, executorDTO.getIdpName(),
+                        context.getTenantDomain());
+            }
+
+            Map<String, String> propertyMap = new HashMap<>();
+            FederatedAuthenticatorConfig authenticatorConfig = idp.getDefaultAuthenticatorConfig();
+            for (Property property : authenticatorConfig.getProperties()) {
+                propertyMap.put(property.getName(), property.getValue());
+            }
+            context.setAuthenticatorProperties(propertyMap);
+        } catch (IdentityProviderManagementException e) {
+            throw handleServerException(ERROR_CODE_GET_IDP_CONFIG_FAILURE, executorDTO.getIdpName(),
+                    context.getTenantDomain(), e);
+        }
     }
 }

--- a/components/registration-framework/org.wso2.carbon.identity.user.registration.engine/src/main/java/org/wso2/carbon/identity/user/registration/engine/model/RegistrationContext.java
+++ b/components/registration-framework/org.wso2.carbon.identity.user.registration.engine/src/main/java/org/wso2/carbon/identity/user/registration/engine/model/RegistrationContext.java
@@ -21,6 +21,8 @@ package org.wso2.carbon.identity.user.registration.engine.model;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import org.slf4j.MDC;
 import org.wso2.carbon.identity.user.registration.mgt.model.NodeConfig;
 import org.wso2.carbon.identity.user.registration.mgt.model.RegistrationGraphConfig;
 
@@ -30,8 +32,10 @@ import org.wso2.carbon.identity.user.registration.mgt.model.RegistrationGraphCon
 public class RegistrationContext implements Serializable {
 
     private static final long serialVersionUID = 542871476395078667L;
+    private static final String CORRELATION_ID_MDC = "Correlation-ID";
     private final Map<String, String> userInputData = new HashMap<>();
     private final Map<String, Object> properties = new HashMap<>();
+    private Map<String, String> authenticatorProperties;
     private NodeConfig currentNode;
     private RegistrationGraphConfig regGraph;
     private RegisteringUser registeringUser = new RegisteringUser();
@@ -138,5 +142,20 @@ public class RegistrationContext implements Serializable {
     public void setCurrentActionId(String currentActionId) {
 
         this.currentActionId = currentActionId;
+    }
+
+    public String getCorrelationId() {
+
+        return Optional.ofNullable(MDC.get(CORRELATION_ID_MDC)).orElse("");
+    }
+
+    public Map<String, String> getAuthenticatorProperties() {
+
+        return authenticatorProperties;
+    }
+
+    public void setAuthenticatorProperties(Map<String, String> authenticatorProperties) {
+
+        this.authenticatorProperties = authenticatorProperties;
     }
 }

--- a/components/registration-framework/org.wso2.carbon.identity.user.registration.engine/src/main/java/org/wso2/carbon/identity/user/registration/engine/util/RegistrationFlowEngine.java
+++ b/components/registration-framework/org.wso2.carbon.identity.user.registration.engine/src/main/java/org/wso2/carbon/identity/user/registration/engine/util/RegistrationFlowEngine.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.identity.user.registration.engine.util;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.wso2.carbon.identity.user.registration.engine.exception.RegistrationEngineException;
 import org.wso2.carbon.identity.user.registration.engine.graph.PagePromptNode;
 import org.wso2.carbon.identity.user.registration.engine.graph.TaskExecutionNode;
@@ -81,7 +80,7 @@ public class RegistrationFlowEngine {
         NodeConfig currentNode = context.getCurrentNode();
         if (currentNode == null) {
             LOG.debug("Current node is not set. Setting the first node as the current node and starting the " +
-                              "registration sequence.");
+                    "registration sequence.");
             currentNode = graph.getNodeConfigs().get(graph.getFirstNodeId());
         }
 
@@ -104,7 +103,14 @@ public class RegistrationFlowEngine {
                 context.setCurrentNode(currentNode);
             }
         }
-        return new RegistrationStep.Builder().flowStatus(STATUS_COMPLETE).build();
+        return new RegistrationStep.Builder()
+                .flowId(context.getContextIdentifier())
+                .flowStatus(STATUS_COMPLETE)
+                .stepType(REDIRECTION)
+                .data(new DataDTO.Builder()
+                        .url(RegistrationFlowEngineUtils.buildAccessURL(tenantDomain))
+                        .build())
+                .build();
     }
 
     /**
@@ -120,8 +126,8 @@ public class RegistrationFlowEngine {
         if (nextNode != null) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Current node " + currentNode.getId() + " is completed. "
-                                  + "Moving to the next node: " + nextNodeId
-                                  + " and setting " + currentNode.getId() + " as the previous node.");
+                        + "Moving to the next node: " + nextNodeId
+                        + " and setting " + currentNode.getId() + " as the previous node.");
             }
             nextNode.setPreviousNodeId(currentNode.getId());
         }
@@ -148,7 +154,7 @@ public class RegistrationFlowEngine {
                 return new PagePromptNode().execute(context, nodeConfig);
             default:
                 throw handleServerException(ERROR_CODE_UNSUPPORTED_NODE, nodeConfig.getType(),
-                                            context.getRegGraph().getId(), context.getTenantDomain());
+                        context.getRegGraph().getId(), context.getTenantDomain());
         }
     }
 
@@ -173,10 +179,10 @@ public class RegistrationFlowEngine {
                 .flowStatus(STATUS_INCOMPLETE)
                 .stepType(REDIRECTION)
                 .data(new DataDTO.Builder()
-                              .url(redirectUrl)
-                              .additionalData(response.getAdditionalInfo())
-                              .requiredParams(response.getRequiredData())
-                              .build())
+                        .url(redirectUrl)
+                        .additionalData(response.getAdditionalInfo())
+                        .requiredParams(response.getRequiredData())
+                        .build())
                 .build();
     }
 }

--- a/components/registration-framework/org.wso2.carbon.identity.user.registration.engine/src/main/java/org/wso2/carbon/identity/user/registration/engine/util/RegistrationFlowEngineUtils.java
+++ b/components/registration-framework/org.wso2.carbon.identity.user.registration.engine/src/main/java/org/wso2/carbon/identity/user/registration/engine/util/RegistrationFlowEngineUtils.java
@@ -27,7 +27,10 @@ import java.util.UUID;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.user.registration.engine.cache.RegistrationContextCache;
 import org.wso2.carbon.identity.user.registration.engine.cache.RegistrationContextCacheEntry;
@@ -191,5 +194,10 @@ public class RegistrationFlowEngineUtils {
             description = String.format(description, data);
         }
         return new RegistrationEngineClientException(error.getCode(), error.getMessage(), description);
+    }
+
+    public static String buildAccessURL(String tenantDomain) {
+
+        return ApplicationMgtUtil.getMyAccountAccessUrlFromServerConfig(tenantDomain);
     }
 }

--- a/components/registration-framework/org.wso2.carbon.identity.user.registration.mgt/src/main/java/org/wso2/carbon/identity/user/registration/mgt/Constants.java
+++ b/components/registration-framework/org.wso2.carbon.identity.user.registration.mgt/src/main/java/org/wso2/carbon/identity/user/registration/mgt/Constants.java
@@ -133,6 +133,7 @@ public class Constants {
 
         public static final String VIEW = "VIEW";
         public static final String REDIRECTION = "REDIRECTION";
+        public static final String USER_ONBOARD = "USER_ONBOARD";
 
         private StepTypes() {
 

--- a/components/registration-framework/org.wso2.carbon.identity.user.registration.mgt/src/test/java/org/wso2/carbon/identity/user/registration/mgt/dao/RegistrationFlowDAOImplTest.java
+++ b/components/registration-framework/org.wso2.carbon.identity.user.registration.mgt/src/test/java/org/wso2/carbon/identity/user/registration/mgt/dao/RegistrationFlowDAOImplTest.java
@@ -95,7 +95,7 @@ public class RegistrationFlowDAOImplTest {
             daoImpl.updateDefaultRegistrationFlowByTenant(regFlowConfig, tenantId, flowName);
             RegistrationFlowDTO flowDTO = daoImpl.getDefaultRegistrationFlowByTenant(tenantId);
             assertNotNull(flowDTO);
-            assertEquals(flowDTO.getSteps().size(), 3);
+            assertEquals(flowDTO.getSteps().size(), 4);
             assertEquals(flowDTO.getSteps().get(0).getId(), "step_1");
         }
     }

--- a/components/registration-framework/org.wso2.carbon.identity.user.registration.mgt/src/test/java/org/wso2/carbon/identity/user/registration/mgt/utils/GraphBuilderTest.java
+++ b/components/registration-framework/org.wso2.carbon.identity.user.registration.mgt/src/test/java/org/wso2/carbon/identity/user/registration/mgt/utils/GraphBuilderTest.java
@@ -51,6 +51,7 @@ public class GraphBuilderTest {
     public static final String STEP_1 = "step_qx3a";
     public static final String STEP_2 = "step_we12";
     public static final String STEP_3 = "step_sd21";
+    public static final String STEP_4 = "step_on12";
     public static final String GOOGLE_IDP_NAME = "Google1";
     public static final String OIDC_AUTHENTICATOR = "OIDCAuthenticator";
     public static final String OIDC_IDP = "OIDC_IDP";
@@ -140,12 +141,20 @@ public class GraphBuilderTest {
                                         .name(GOOGLE_OIDC_AUTHENTICATOR)
                                         .idpName(GOOGLE_IDP_NAME)
                                         .build())
-                                .nextId(Constants.COMPLETE)
+                                .nextId(STEP_4)
                                 .build())
                         .build())
                 .build();
 
-        flowDTO.setSteps(Arrays.asList(stepDTO1, stepDTO2, stepDTO3));
+        StepDTO stepDTO4 = new StepDTO.Builder()
+                .id(STEP_4)
+                .type(Constants.StepTypes.USER_ONBOARD)
+                .coordinateX(0)
+                .coordinateY(0)
+                .height(100.15)
+                .width(200.25)
+                .build();
+        flowDTO.setSteps(Arrays.asList(stepDTO1, stepDTO2, stepDTO3, stepDTO4));
 
         // Convert the flowDTO to a RegistrationGraphConfig.
         RegistrationGraphConfig graphConfig = GraphBuilder.convert(flowDTO);
@@ -154,7 +163,7 @@ public class GraphBuilderTest {
         assertNotNull(graphConfig);
         assertNotNull(graphConfig.getId());
         assertEquals(graphConfig.getNodeConfigs().size(), 4);
-        assertEquals(graphConfig.getNodePageMappings().size(), 3);
+        assertEquals(graphConfig.getNodePageMappings().size(), 4);
         assertEquals(graphConfig.getFirstNodeId(), STEP_1);
 
         graphConfig.getNodePageMappings().forEach((nodeId, stepDTO) -> {

--- a/components/registration-framework/org.wso2.carbon.identity.user.registration.mgt/src/test/resources/reg_flow.json
+++ b/components/registration-framework/org.wso2.carbon.identity.user.registration.mgt/src/test/resources/reg_flow.json
@@ -122,7 +122,7 @@
                 "variant": "PRIMARY",
                 "action": {
                   "type": "NEXT",
-                  "nextId": "COMPLETE"
+                  "nextId": "step_fwe3"
                 },
                 "config": {
                   "text": "Complete Registration"
@@ -147,9 +147,18 @@
             "name": "GoogleOIDCAuthenticator",
             "idp_name": "Google"
           },
-          "nextId": "COMPLETE"
+          "nextId": "step_fwe3"
         }
       }
+    },
+    {
+      "id": "step_fwe3",
+      "type": "USER_ONBOARD",
+      "width": 120,
+      "height": 240,
+      "coordinateX": 0,
+      "coordinateY": 0,
+      "data": {}
     }
   ]
 }


### PR DESCRIPTION
### Proposed changes in this pull request

This PR introduces following changes to the registration engine

- Handle the `USER_ONBOARD` step type explicitly, which was previously inferred from next step id being `COMPLETE`.
- After the flow is completed, send a redirection step as the response with my account access URL.
- Add authenticator configurations to context which will be sent in the registration portal response to initiate the authorize call in sign up using federated Idp scenarios.
- Add correlation id to context.
- Update tests to reflect the above changes

Reference PR: https://github.com/wso2/carbon-identity-framework/pull/6584