### PR TITLE
Add new AuthenticatorParamType `MULTI_VALUED`

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -819,6 +819,7 @@ public abstract class FrameworkConstants {
 
         STRING,
         INTEGER,
+        MULTI_VALUED
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

- Currently API based authentication's request body only supports `INTEGER` and `STRING` authenticator parameter types.
- However there can be multi valued parameters in the authentication request which needs to be supported (Ex: `sessionsToTerminate` parameter in Active Session Limit Handler)
- This new authenticator parameter type is added to represent such parameters.

### Related Issue
- https://github.com/wso2/product-is/issues/22979