### PR TITLE
Support sending multi-value user claims in the request to the extension

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/api/model/UserClaim.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/api/model/UserClaim.java
@@ -37,11 +37,13 @@ public class UserClaim {
     private final Object value;
 
     public UserClaim(String uri, String[] value) {
+
         this.uri = uri;
         this.value = value;
     }
 
     public UserClaim(String uri, String value) {
+
         this.uri = uri;
         this.value = value;
     }
@@ -52,6 +54,7 @@ public class UserClaim {
      * @return Claim value.
      */
     public Object getValue() {
+
         return value;
     }
 
@@ -61,6 +64,7 @@ public class UserClaim {
      * @return Claim URI.
      */
     public String getUri() {
+
         return uri;
     }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/api/model/UserClaim.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/api/model/UserClaim.java
@@ -18,6 +18,13 @@
 
 package org.wso2.carbon.identity.action.execution.api.model;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.io.IOException;
+
 /**
  * This class models the user claims.
  * User claim is the entity that represents the user claims of the user for whom the action is triggered for.
@@ -25,7 +32,14 @@ package org.wso2.carbon.identity.action.execution.api.model;
 public class UserClaim {
 
     private final String uri;
-    private final String value;
+
+    @JsonSerialize(using = ClaimValueSerializer.class)
+    private final Object value;
+
+    public UserClaim(String uri, String[] value) {
+        this.uri = uri;
+        this.value = value;
+    }
 
     public UserClaim(String uri, String value) {
         this.uri = uri;
@@ -37,7 +51,7 @@ public class UserClaim {
      *
      * @return Claim value.
      */
-    public String getValue() {
+    public Object getValue() {
         return value;
     }
 
@@ -48,5 +62,21 @@ public class UserClaim {
      */
     public String getUri() {
         return uri;
+    }
+
+    private static class ClaimValueSerializer extends JsonSerializer<Object> {
+
+        @Override
+        public void serialize(Object value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+            if (value instanceof String) {
+                // Serialize as string
+                gen.writeString((String) value);
+            } else if (value instanceof String[]) {
+                // Serialize as array
+                gen.writeArray((String[]) value, 0, ((String[]) value).length);
+            } else {
+                throw new IOException("Unsupported type for serialization: " + value.getClass());
+            }
+        }
     }
 }


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/23408

Improve the `UserClaim` model class to support sending multi-value user attributes in requests to the external service.

Single valued:
```
"claims": [
        {
          "uri": "http://wso2.org/claims/emailaddress",
          "value": "bob@newdomain.com"
        }
      ],
```

Multi valued:
```
"claims": [
        {
          "uri": "http://wso2.org/claims/emailaddress",
          "value": ["bob@newdomain.com", "bob.work@domain.com"]
        }
      ],
```