### PR TITLE
Update role name length validation in Roles V2 API

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
@@ -96,6 +96,11 @@ public class RoleManagementServiceImpl implements RoleManagementService {
                 throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), "Invalid character: "
                         + UserCoreConstants.DOMAIN_SEPARATOR + " contains in the role name: " + roleName + ".");
             }
+            if (roleName.length() < 3 || roleName.length() > 255) {
+                String errorMessage = String.format("Invalid role name: %s. " +
+                        "Role names must be between 3 and 255 characters long.", roleName);
+                throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
+            }
             List<RoleManagementListener> roleManagementListenerList = RoleManagementServiceComponentHolder.
                     getInstance().getRoleManagementListenerList();
             for (RoleManagementListener roleManagementListener : roleManagementListenerList) {

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
@@ -356,6 +356,11 @@ public class RoleManagementServiceImpl implements RoleManagementService {
             throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), "Invalid character: "
                     + UserCoreConstants.DOMAIN_SEPARATOR + " contains in the role name: " + newRoleName + ".");
         }
+        if (newRoleName.length() < 3 || newRoleName.length() > 255) {
+            String errorMessage = String.format("Invalid role name: %s. " +
+                    "Role names must be between 3 and 255 characters long.", newRoleName);
+            throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
+        }
         roleDAO.updateRoleName(roleId, newRoleName, tenantDomain);
         roleManagementEventPublisherProxy.publishPostUpdateRoleName(roleId, newRoleName, tenantDomain);
         for (RoleManagementListener roleManagementListener : roleManagementListenerList) {

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImplTest.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImplTest.java
@@ -67,6 +67,8 @@ public class RoleManagementServiceImplTest extends IdentityBaseTest {
     private MockedStatic<PrivilegedCarbonContext> privilegedCarbonContext;
 
     private static final String USERNAME = "user";
+    private static final String invalidRoleName = "RN";
+    private static final String tenantDomain = "tenantDomain";
     private static final String audienceId = "testId";
     private static final String roleId = "testRoleId";
 
@@ -156,13 +158,22 @@ public class RoleManagementServiceImplTest extends IdentityBaseTest {
                     "Role names must be between 3 and 255 characters long\\.")
     public void testAddRoleInvalidRoleName() throws Exception {
 
-        String roleName = "RN";
         String audience = "APPLICATION";
         String audienceId = "application_id_01";
-        String tenantDomain = "tenantDomain";
-
-        roleManagementService.addRole(roleName, new ArrayList<>(), new ArrayList<>(),
+        roleManagementService.addRole(invalidRoleName, new ArrayList<>(), new ArrayList<>(),
                 new ArrayList<>(), audience, audienceId, tenantDomain);
+    }
+
+    @Test(expectedExceptions = IdentityRoleManagementClientException.class,
+            expectedExceptionsMessageRegExp = "Invalid role name: RN\\. " +
+                    "Role names must be between 3 and 255 characters long\\.")
+    public void testUpdateRoleInvalidRoleName() throws Exception {
+
+        RoleManagementEventPublisherProxy mockRoleMgtEventPublisherProxy = mock(
+                RoleManagementEventPublisherProxy.class);
+        roleManagementEventPublisherProxy.when(RoleManagementEventPublisherProxy::getInstance)
+                .thenReturn(mockRoleMgtEventPublisherProxy);
+        roleManagementService.updateRoleName(roleId, invalidRoleName, tenantDomain);
     }
 
     @Test

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImplTest.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImplTest.java
@@ -151,6 +151,20 @@ public class RoleManagementServiceImplTest extends IdentityBaseTest {
         }
     }
 
+    @Test(expectedExceptions = IdentityRoleManagementClientException.class,
+            expectedExceptionsMessageRegExp = "Invalid role name: RN\\. " +
+                    "Role names must be between 3 and 255 characters long\\.")
+    public void testAddRoleInvalidRoleName() throws Exception {
+
+        String roleName = "RN";
+        String audience = "APPLICATION";
+        String audienceId = "application_id_01";
+        String tenantDomain = "tenantDomain";
+
+        roleManagementService.addRole(roleName, new ArrayList<>(), new ArrayList<>(),
+                new ArrayList<>(), audience, audienceId, tenantDomain);
+    }
+
     @Test
     public void testAddRoleWithIsFragmentAppProperty() throws Exception {
 


### PR DESCRIPTION
## Purpose
Update the validation logic for role names to ensure role names are between 3 and 255 characters.

## Implementation
- Added checks to ensure role names are between 3 and 255 characters long and do not contain invalid characters.

## Resolved Behaviour
https://github.com/user-attachments/assets/e35e231c-f590-4b26-bf62-c0063ccb5445

## Related PRs
- https://github.com/wso2/identity-apps/pull/7876

## Related Issue
- https://github.com/wso2/product-is/issues/23265