### PR TITLE
Add configurations for `dpop_signing_alg_values_supported` property in OIDC Discovery Endpoint

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1065,6 +1065,11 @@
                     <SupportedTokenEndpointSigningAlgorithm>{{algorithm}}</SupportedTokenEndpointSigningAlgorithm>
                 {% endfor %}
             </SupportedTokenEndpointSigningAlgorithms>
+            <SupportedDPoPSigningAlgorithms>
+                {% for algorithm in oauth.oidc.dpop.signing_algorithms %}
+                    <SupportedDPoPSigningAlgorithm>{{algorithm}}</SupportedDPoPSigningAlgorithm>
+                {% endfor %}
+            </SupportedDPoPSigningAlgorithms>
             <SupportedIDTokenSigningAlgorithms>
                 {% for algorithm in oauth.oidc.id_token.signing_algorithms %}
                     <SupportedIDTokenSigningAlgorithm>{{algorithm}}</SupportedIDTokenSigningAlgorithm>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -264,6 +264,7 @@
   "oauth.oidc.token_endpoint.signing_algorithms": ["PS256", "ES256", "$ref{oauth.oidc.user_info.jwt_signature_algorithm}"],
   "oauth.oidc.id_token.signing_algorithms": ["PS256", "ES256", "$ref{oauth.oidc.user_info.jwt_signature_algorithm}"],
   "oauth.oidc.request_object.signing_algorithms": ["PS256", "ES256", "$ref{oauth.oidc.user_info.jwt_signature_algorithm}"],
+  "oauth.oidc.dpop.signing_algorithms": ["ES256", "$ref{oauth.oidc.user_info.jwt_signature_algorithm}"],
   "oauth.oidc.enable_tls_certificate_bound_access_tokens_via_binding_type": true,
   "oauth.oidc.enable_hybrid_flow_app_level_validation": true,
   "oauth.oidc.enable_claims_separation_for_access_tokens": true,


### PR DESCRIPTION
### Proposed changes in this pull request

This PR adds the configurations required for getting the values for the property `dpop_signing_alg_values_supported` in the OIDC Discovery Endpoint.

### Related Issue
- https://github.com/wso2/product-is/issues/23372