### PR TITLE
Process JsGraalParameters recursively to support nested arrays

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/js-sp-longwait-1.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/js-sp-longwait-1.xml
@@ -84,8 +84,19 @@ var onLoginRequest = function(context) {
     //TODO remove this executeStep and make it to work.
     executeStep(1);
     testLongWaitCall('a', 'b', 'c', {}, {
-            "onSuccess" : function(){Log.info('OK Called');
-        }
+            "onSuccess" : function(context, data)
+                {
+                    Log.info('OK Called');
+                    if (data.arrayKey[0].key1 !== 'value1') {
+                        fail();
+                    }
+                    if (data.listKey[0].key3 !== 'value3') {
+                        fail();
+                    }
+                    if (context.request.params.stringAttribute !== 'stringAttributeValue' || context.request.params.arrayAttribute[0] !== 'arrayValue1') {
+                        fail();
+                    }
+                }
     });
 };
 ]]></AuthenticationScript>


### PR DESCRIPTION
### Purpose
- When JSON Object members are returned to Javascript runtime, they need to be explicitly checked and converted to Proxy Arrays to be properly handled in the JS runtime.
- This PR adds the handling.

### Related Issue
- https://github.com/wso2-enterprise/asgardeo-product/issues/29677