### PR TITLE
Enable Pre Update Profile Action UI

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1218,7 +1218,7 @@
   "console.actions.enabled": true,
   "console.actions.disabled_features": [
     "actions.types.list.preRegistration",
-    "actions.types.list.preUpdateProfile"
+    "actions.types.preUpdateProfile.edit.rule"
   ],
   "console.actions.scopes.feature": ["console:actions"],
   "console.actions.scopes.create": ["internal_action_mgt_create"],


### PR DESCRIPTION
### Description
This PR enables the pre update profile action UI in the Identity Server. 
Please note that currently, the rule component associated with the said action is disabled.

### Related Issue
- https://github.com/wso2/product-is/issues/23487