### PR TITLE
Improve failure handling for pre password update action.

### DIFF
--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
@@ -28,9 +28,9 @@ import org.wso2.carbon.identity.core.context.IdentityContext;
 import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.user.action.api.constant.UserActionError;
+import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionClientException;
 import org.wso2.carbon.identity.user.action.api.model.UserActionContext;
 import org.wso2.carbon.identity.user.action.internal.factory.UserActionExecutorFactory;
-import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.listener.SecretHandleableListener;
@@ -93,9 +93,9 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
                 return true;
             } else if (executionStatus.getStatus() == ActionExecutionStatus.Status.FAILED) {
                 Failure failure = (Failure) executionStatus.getResponse();
-                String errorMsg = buildErrorMessage(failure.getFailureReason(), failure.getFailureDescription());
-                throw new UserStoreClientException(errorMsg,
-                        UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED);
+                throw new UserActionExecutionClientException(
+                        UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED,
+                        failure.getFailureReason(), failure.getFailureDescription());
             } else if (executionStatus.getStatus() == ActionExecutionStatus.Status.ERROR) {
                 Error error = (Error) executionStatus.getResponse();
                 String errorMsg = buildErrorMessage(error.getErrorMessage(), error.getErrorDescription());

--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
@@ -134,13 +134,4 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
                     "Credential is not in the expected format.");
         }
     }
-
-    private String buildErrorMessage(String message, String description) {
-
-        if (description == null) {
-            return message;
-        }
-
-        return message + ". " + description;
-    }
 }

--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.user.action.api.constant.UserActionError;
 import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionClientException;
+import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionServerException;
 import org.wso2.carbon.identity.user.action.api.model.UserActionContext;
 import org.wso2.carbon.identity.user.action.internal.factory.UserActionExecutorFactory;
 import org.wso2.carbon.user.core.UserStoreException;
@@ -98,14 +99,15 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
                         failure.getFailureReason(), failure.getFailureDescription());
             } else if (executionStatus.getStatus() == ActionExecutionStatus.Status.ERROR) {
                 Error error = (Error) executionStatus.getResponse();
-                String errorMsg = buildErrorMessage(error.getErrorMessage(), error.getErrorDescription());
-                throw new UserStoreException(errorMsg, UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_ERROR);
+                throw new UserActionExecutionServerException(
+                        UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_ERROR,
+                        error.getErrorMessage(), error.getErrorDescription());
             } else {
                 return false;
             }
         } catch (ActionExecutionException e) {
-            throw new UserStoreException("Error while executing pre update password action.",
-                    UserActionError.PRE_UPDATE_PASSWORD_ACTION_SERVER_ERROR, e);
+            throw new UserActionExecutionServerException(UserActionError.PRE_UPDATE_PASSWORD_ACTION_SERVER_ERROR,
+                    "Error while executing pre update password action.");
         }
     }
 
@@ -121,15 +123,15 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
                 flow.getName() == Flow.Name.PROFILE_UPDATE;
     }
 
-    private char[] getSecret(Object credential) throws UserStoreException {
+    private char[] getSecret(Object credential) throws UserActionExecutionServerException {
 
         if (credential instanceof Secret) {
             return ((Secret) credential).getChars();
         } else if (credential instanceof StringBuffer) {
             return ((StringBuffer) credential).toString().toCharArray();
         } else {
-            throw new UserStoreException("Credential is not in the expected format.",
-                    UserActionError.PRE_UPDATE_PASSWORD_ACTION_UNSUPPORTED_SECRET);
+            throw new UserActionExecutionServerException(UserActionError.PRE_UPDATE_PASSWORD_ACTION_UNSUPPORTED_SECRET,
+                    "Credential is not in the expected format.");
         }
     }
 


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/23568

To map `failureReason` and `failureDescription` from the external authentication service response to `scimType` and `detail` respectively, this PR updates to throw`UserActionExecutionClientException` instead of `UserStoreClientException`.

Related PR:
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/625