### PR TITLE
Set basic auth showAuthFailureReason default value to false

### DIFF
--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -64,7 +64,6 @@
   "authentication.authenticator.basic.parameters.AuthMechanism": "basic",
   "authentication.authenticator.basic.parameters.Tags": "Username-Password",
   "authentication.authenticator.basic.parameters.redirectToRetryPageOnAccountLock": "false",
-  "authentication.authenticator.basic.parameters.showAuthFailureReason": "true",
 
   "authentication.authenticator.basic_request_path.name": "BasicAuthRequestPathAuthenticator",
   "authentication.authenticator.basic_request_path.enable": true,


### PR DESCRIPTION
### Proposed changes in this pull request
- Disabling this config to revert a behavioral change in Identity Server

### Related Issue
- https://github.com/wso2/product-is/issues/23476

### Related PR
- https://github.com/wso2/product-is/pull/23473