### PR TITLE
Improve password update log handling for Admin and User 

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/java/org/wso2/carbon/user/mgt/ui/UserAdminClient.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/java/org/wso2/carbon/user/mgt/ui/UserAdminClient.java
@@ -24,6 +24,7 @@ import org.apache.axis2.client.ServiceClient;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.mgt.stub.UserAdminStub;
 import org.wso2.carbon.user.mgt.stub.UserAdminUserAdminException;
 import org.wso2.carbon.user.mgt.stub.types.carbon.ClaimValue;
@@ -39,6 +40,7 @@ public class UserAdminClient  {
 
     protected UserAdminStub stub = null;
 
+    private static final String CHANGE_PASSWORD_BY_ADMIN = "changePasswordByAdmin";
     protected static final Log log = LogFactory.getLog(UserAdminClient.class);
 
     public UserAdminClient(String cookie, String url, String serviceName,
@@ -99,9 +101,12 @@ public class UserAdminClient  {
 
     public void changePassword(String userName, String newPassword) throws AxisFault {
         try {
+            IdentityUtil.threadLocalProperties.get().put(CHANGE_PASSWORD_BY_ADMIN, true);
             stub.changePassword(userName, newPassword);
         } catch (Exception e) {
             handleException(e);
+        } finally {
+            IdentityUtil.threadLocalProperties.get().remove(CHANGE_PASSWORD_BY_ADMIN);
         }
 
     }

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLogger.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLogger.java
@@ -59,6 +59,7 @@ public class UserManagementAuditLogger extends AbstractIdentityUserOperationEven
     public static final String SERVICE_PROVIDER_QUERY_KEY = "serviceProvider";
     private final String USER_NAME_KEY = "UserName";
     private final String USER_NAME_QUERY_KEY = "userName";
+    private final String CHANGE_PASSWORD_BY_ADMIN = "changePasswordByAdmin";
 
     @Override
     public boolean isEnable() {
@@ -223,7 +224,11 @@ public class UserManagementAuditLogger extends AbstractIdentityUserOperationEven
             UserStoreManager userStoreManager) {
 
         if (isEnable()) {
-            audit.info(createAuditMessage(ListenerUtils.CHANGE_PASSWORD_BY_ADMIN_ACTION, getTargetForAuditLog
+            String auditMessageAction = ListenerUtils.CHANGE_PASSWORD_BY_USER_ACTION;
+            if (IdentityUtil.threadLocalProperties.get().get(CHANGE_PASSWORD_BY_ADMIN) != null) {
+                auditMessageAction = ListenerUtils.CHANGE_PASSWORD_BY_ADMIN_ACTION;
+            }
+            audit.info(createAuditMessage(auditMessageAction, getTargetForAuditLog
                     (LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(userName) : userName,
                     userStoreManager), null, SUCCESS));
         }


### PR DESCRIPTION
## Purpose
Enhance the handling of password update differentitions between user initiated and administrator initiated password changes. This helps improve traceability and logging, ensuring that password updates are correctly attributed to the initiating party.

## Implementation
This PR includes changes to enhance the logging and handling of password changes by administrators in the user management module. The main updates involve using a thread-local property to track password changes initiated by administrators and adjusting the audit logging accordingly.

- Added a thread-local property `CHANGE_PASSWORD_BY_ADMIN` to track when an admin changes a user's password and ensure it is properly logged. 

- Modified the audit logging to differentiate between password changes made by users and those made by administrators using the `CHANGE_PASSWORD_BY_ADMIN` property. 

## Testing
### The following flows has been tested (Demo videos)
- AdminChangingUserPassword
https://drive.google.com/file/d/1L3yc-qWgoS-nZiHPBfuy_GWRVVQNk6AY/view?usp=sharing

- ForgotPasswordFlow
https://drive.google.com/file/d/1I8oi7YTUrL5r4p7BVW46S7938M-t47kh/view?usp=sharing

- ScimMeEndpoint
https://drive.google.com/file/d/1JncVxtiUyZd_WZFgfsz5ozB_gtv5MoS0/view?usp=sharing

## Related Issues
- https://github.com/wso2/product-is/issues/11625

## Related PRs
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/623