### PR TITLE
Improve password update log handling for Admin and User using IdentityContext

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLogger.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLogger.java
@@ -27,6 +27,7 @@ import org.slf4j.MDC;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
+import org.wso2.carbon.identity.core.context.IdentityContext;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.api.Permission;
@@ -51,6 +52,8 @@ public class UserManagementAuditLogger extends AbstractIdentityUserOperationEven
     private static final String SUCCESS = "Success";
     private static final String IN_PROGRESS = "In-Progress";
     private static final String USER_IDENTITY_CLAIMS_MAP = "UserIdentityClaimsMap";
+    private static final String USER = "USER";
+    private static final String ADMIN = "ADMIN";
     public static final String USER_AGENT_QUERY_KEY = "User-Agent";
     public static final String USER_AGENT_KEY = "User Agent";
     public static final String REMOTE_ADDRESS_QUERY_KEY = "remoteAddress";
@@ -223,7 +226,15 @@ public class UserManagementAuditLogger extends AbstractIdentityUserOperationEven
             UserStoreManager userStoreManager) {
 
         if (isEnable()) {
-            audit.info(createAuditMessage(ListenerUtils.CHANGE_PASSWORD_BY_ADMIN_ACTION, getTargetForAuditLog
+            IdentityContext identityContext = IdentityContext.getThreadLocalIdentityContext();
+            String initiatingPersona = String.valueOf(identityContext.getFlow().getInitiatingPersona());
+            String auditMessageAction = ListenerUtils.CHANGE_PASSWORD_ACTION;
+            if (initiatingPersona.equals(USER)) {
+                auditMessageAction = ListenerUtils.CHANGE_PASSWORD_BY_USER_ACTION;
+            } else if (initiatingPersona.equals(ADMIN)) {
+                auditMessageAction = ListenerUtils.CHANGE_PASSWORD_BY_ADMIN_ACTION;
+            }
+            audit.info(createAuditMessage(auditMessageAction, getTargetForAuditLog
                     (LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(userName) : userName,
                     userStoreManager), null, SUCCESS));
         }

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLogger.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLogger.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.user.mgt.listeners;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.MDC;
@@ -49,6 +50,7 @@ import static org.wso2.carbon.utils.CarbonUtils.isLegacyAuditLogsDisabled;
  */
 public class UserManagementAuditLogger extends AbstractIdentityUserOperationEventListener {
 
+    private static final Log LOG = LogFactory.getLog(UserManagementAuditLogger.class);
     private static final Log audit = CarbonConstants.AUDIT_LOG;
     private static final String SUCCESS = "Success";
     private static final String IN_PROGRESS = "In-Progress";
@@ -536,7 +538,8 @@ public class UserManagementAuditLogger extends AbstractIdentityUserOperationEven
 
         Flow flow = IdentityContext.getThreadLocalIdentityContext().getFlow();
         if (flow == null) {
-            return ListenerUtils.CHANGE_PASSWORD_ACTION;
+            LOG.debug("Unable to determine the initiating persona for the password update action.");
+            return null;
         }
         switch (flow.getInitiatingPersona()) {
             case USER:
@@ -545,7 +548,12 @@ public class UserManagementAuditLogger extends AbstractIdentityUserOperationEven
             case APPLICATION:
                 return ListenerUtils.CHANGE_PASSWORD_BY_ADMIN_ACTION;
             default:
-                return ListenerUtils.CHANGE_PASSWORD_ACTION;
+                // Fallback in case a new enum value is added in the future
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Unhandled initiating persona for the password update action: "
+                            + flow.getInitiatingPersona());
+                }
+                return null;
         }
     }
 }

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLogger.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLogger.java
@@ -530,9 +530,13 @@ public class UserManagementAuditLogger extends AbstractIdentityUserOperationEven
 
     /**
      * Determines the appropriate audit message action based on the initiating persona in the current flow.
+     * The action returned depends on the persona initiating the password update.
      *
-     * @return The audit message action. If the flow is not available or the persona is unrecognized,
-     *         returns {@code ListenerUtils.CHANGE_PASSWORD_ACTION} by default.
+     * @return The audit message action. If the flow is unavailable or the persona is unrecognized,
+     *         returns {@code null}. In case the flow is not available, {@code null} is returned as the default value.
+     *         If the initiating persona is a user, returns {@code ListenerUtils.CHANGE_PASSWORD_BY_USER_ACTION}.
+     *         If the initiating persona is an admin or application, returns {@code ListenerUtils.CHANGE_PASSWORD_BY_ADMIN_ACTION}.
+     *         If an unhandled persona is encountered, logs a debug message and returns {@code null}.
      */
     String getPasswordUpdateAuditMessageAction() {
 
@@ -549,10 +553,8 @@ public class UserManagementAuditLogger extends AbstractIdentityUserOperationEven
                 return ListenerUtils.CHANGE_PASSWORD_BY_ADMIN_ACTION;
             default:
                 // Fallback in case a new enum value is added in the future
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Unhandled initiating persona for the password update action: "
-                            + flow.getInitiatingPersona());
-                }
+                LOG.debug("Unhandled initiating persona for the password update action: "
+                        + flow.getInitiatingPersona());
                 return null;
         }
     }

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLogger.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLogger.java
@@ -534,7 +534,7 @@ public class UserManagementAuditLogger extends AbstractIdentityUserOperationEven
      * @return The audit message action. If the flow is not available or the persona is unrecognized,
      *         returns {@code ListenerUtils.CHANGE_PASSWORD_ACTION} by default.
      */
-    private String getPasswordUpdateAuditMessageAction() {
+    String getPasswordUpdateAuditMessageAction() {
 
         Flow flow = IdentityContext.getThreadLocalIdentityContext().getFlow();
         if (flow == null) {

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/utils/ListenerUtils.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/utils/ListenerUtils.java
@@ -41,7 +41,6 @@ public class ListenerUtils {
     public static final String SET_USER_CLAIM_VALUES_ACTION = "Set-User-Claim-Values";
     public static final String DELETE_USER_CLAIM_VALUES_ACTION = "Delete-User-Claim-Values";
     public static final String DELETE_USER_CLAIM_VALUE_ACTION = "Delete-User-Claim-Value";
-    public static final String CHANGE_PASSWORD_ACTION = "Change-Password";
     public static final String CHANGE_PASSWORD_BY_USER_ACTION = "Change-Password-by-User";
     public static final String CHANGE_PASSWORD_BY_ADMIN_ACTION = "Change-Password-by-Administrator";
     public static final String DELETE_ROLE_ACTION = "Delete-Role";

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/utils/ListenerUtils.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/utils/ListenerUtils.java
@@ -41,6 +41,7 @@ public class ListenerUtils {
     public static final String SET_USER_CLAIM_VALUES_ACTION = "Set-User-Claim-Values";
     public static final String DELETE_USER_CLAIM_VALUES_ACTION = "Delete-User-Claim-Values";
     public static final String DELETE_USER_CLAIM_VALUE_ACTION = "Delete-User-Claim-Value";
+    public static final String CHANGE_PASSWORD_ACTION = "Change-Password";
     public static final String CHANGE_PASSWORD_BY_USER_ACTION = "Change-Password-by-User";
     public static final String CHANGE_PASSWORD_BY_ADMIN_ACTION = "Change-Password-by-Administrator";
     public static final String DELETE_ROLE_ACTION = "Delete-Role";

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/test/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLoggerTest.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/test/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLoggerTest.java
@@ -25,13 +25,13 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.core.context.IdentityContext;
 import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.event.IdentityEventConfigBuilder;
+import org.wso2.carbon.user.mgt.listeners.utils.ListenerUtils;
+
 import static org.testng.Assert.assertEquals;
 
 public class UserManagementAuditLoggerTest {
 
     private UserManagementAuditLogger auditLogger;
-    public static final String CHANGE_PASSWORD_BY_USER_ACTION = "Change-Password-by-User";
-    public static final String CHANGE_PASSWORD_BY_ADMIN_ACTION = "Change-Password-by-Administrator";
 
     @BeforeMethod
     public void setUp() {
@@ -48,8 +48,9 @@ public class UserManagementAuditLoggerTest {
     @DataProvider(name = "passwordUpdateFlowData")
     public Object[][] passwordUpdateFlowData() {
         return new Object[][]{
-                {Flow.InitiatingPersona.USER, CHANGE_PASSWORD_BY_USER_ACTION},
-                {Flow.InitiatingPersona.ADMIN, CHANGE_PASSWORD_BY_ADMIN_ACTION}
+                {Flow.InitiatingPersona.USER, ListenerUtils.CHANGE_PASSWORD_BY_USER_ACTION},
+                {Flow.InitiatingPersona.ADMIN, ListenerUtils.CHANGE_PASSWORD_BY_ADMIN_ACTION},
+                {Flow.InitiatingPersona.APPLICATION, ListenerUtils.CHANGE_PASSWORD_BY_ADMIN_ACTION}
         };
     }
 

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/test/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLoggerTest.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/test/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLoggerTest.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.event.IdentityEventConfigBuilder;
 import org.wso2.carbon.user.mgt.listeners.utils.ListenerUtils;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 public class UserManagementAuditLoggerTest {
 
@@ -57,15 +58,28 @@ public class UserManagementAuditLoggerTest {
     @Test(dataProvider = "passwordUpdateFlowData")
     public void testGetPasswordUpdateAuditMessageAction(Flow.InitiatingPersona persona, String expectedAction) {
 
-        String carbonHome = IdentityEventConfigBuilder.class.getResource("/").getFile();
-        System.setProperty("carbon.home", carbonHome);
-
+        configureCarbonHome();
         IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
                 .name(Flow.Name.PASSWORD_RESET)
                 .initiatingPersona(persona)
                 .build());
-
         String action = auditLogger.getPasswordUpdateAuditMessageAction();
         assertEquals(action, expectedAction);
+    }
+
+    @Test()
+    public void testGetPasswordUpdateAuditMessageActionNull() {
+
+        configureCarbonHome();
+        String action = auditLogger.getPasswordUpdateAuditMessageAction();
+        assertNull(action);
+    }
+
+    /**
+     * Configures the carbon home system property for the test environment.
+     */
+    private void configureCarbonHome() {
+        String carbonHome = IdentityEventConfigBuilder.class.getResource("/").getFile();
+        System.setProperty("carbon.home", carbonHome);
     }
 }

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/test/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLoggerTest.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/test/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLoggerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.user.mgt.listeners;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
+import org.wso2.carbon.identity.event.IdentityEventConfigBuilder;
+import static org.testng.Assert.assertEquals;
+
+public class UserManagementAuditLoggerTest {
+
+    private UserManagementAuditLogger auditLogger;
+    public static final String CHANGE_PASSWORD_BY_USER_ACTION = "Change-Password-by-User";
+    public static final String CHANGE_PASSWORD_BY_ADMIN_ACTION = "Change-Password-by-Administrator";
+
+    @BeforeMethod
+    public void setUp() {
+        // Destroy the current identity context to avoid Flow being already set
+        auditLogger = new UserManagementAuditLogger();
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        // Destroy the current identity context after each test
+        IdentityContext.destroyCurrentContext();
+    }
+
+    @DataProvider(name = "passwordUpdateFlowData")
+    public Object[][] passwordUpdateFlowData() {
+        return new Object[][]{
+                {Flow.InitiatingPersona.USER, CHANGE_PASSWORD_BY_USER_ACTION},
+                {Flow.InitiatingPersona.ADMIN, CHANGE_PASSWORD_BY_ADMIN_ACTION}
+        };
+    }
+
+    @Test(dataProvider = "passwordUpdateFlowData")
+    public void testGetPasswordUpdateAuditMessageAction(Flow.InitiatingPersona persona, String expectedAction) {
+
+        String carbonHome = IdentityEventConfigBuilder.class.getResource("/").getFile();
+        System.setProperty("carbon.home", carbonHome);
+
+        IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
+                .name(Flow.Name.PASSWORD_RESET)
+                .initiatingPersona(persona)
+                .build());
+
+        String action = auditLogger.getPasswordUpdateAuditMessageAction();
+        assertEquals(action, expectedAction);
+    }
+}

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/test/resources/testng.xml
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/test/resources/testng.xml
@@ -27,6 +27,7 @@
             <class name="org.wso2.carbon.user.mgt.recorder.DefaultUserDeletionEventRecorderTest" />
             <class name="org.wso2.carbon.user.mgt.bulkImport.JsonConverterTest" />
             <class name="org.wso2.carbon.user.mgt.listeners.UserMgtFailureAuditLoggerTest" />
+            <class name="org.wso2.carbon.user.mgt.listeners.UserManagementAuditLoggerTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
Enhance the handling of password update differentitions between user initiated and administrator initiated password changes. This helps improve traceability and logging, ensuring that password updates are correctly attributed to the initiating party.

## Implementation
This pull request includes several changes to the `UserManagementAuditLogger` and `ListenerUtils` classes to enhance the logging and auditing capabilities of user management operations. The most important changes involve adding new constants for user roles, updating the audit message creation logic, and importing necessary classes.

Enhancements to logging and auditing:

- Added constants `USER` and `ADMIN` to differentiate between user and admin actions.
- Updated the `doPostUpdateCredentialByAdmin` method to use `IdentityContext` for determining the initiating persona and setting the appropriate audit message action.
- Added a new constant `CHANGE_PASSWORD_ACTION` for general password change actions.

## Testing
### The following flows has been tested (Demo videos)
- AdminChangingUserPassword
- ForgotPasswordFlow
- ScimMeEndpoint

## Related Issues
- https://github.com/wso2/product-is/issues/11625