### PR TITLE
Supporting browser back button for showPrompt adaptive function

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -394,7 +394,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     }
                 }
 
-                if (isPromptRequest(request, context)) {
+                if (isPromptRequest(request)) {
                     AuthGraphNode currentNode =
                             (AuthGraphNode) context.getProperty(FrameworkConstants.JSAttributes.PROP_CURRENT_NODE);
                     // If the request is a prompt request returning from browser's back button, we need to handle it
@@ -561,7 +561,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
         }
     }
 
-    private boolean isPromptRequest(HttpServletRequest request, AuthenticationContext context) {
+    private boolean isPromptRequest(HttpServletRequest request) {
 
         return StringUtils.isNotBlank(request.getParameter(PROMPT_ID_PARAM))
                 && TRUE.equals(request.getParameter(PROMPT_RESP_PARAM));

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -574,10 +574,10 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
      */
     private AuthGraphNode moveToPreviousShowPromptNode(AuthGraphNode currentNode) {
 
-        if (currentNode == null || currentNode instanceof ShowPromptNode) {
-            return currentNode;
+        while (currentNode != null && !(currentNode instanceof ShowPromptNode)) {
+            currentNode = currentNode.getParent();
         }
-        return moveToPreviousShowPromptNode(currentNode.getParent());
+        return currentNode;
     }
 
     private boolean isIdentifierFirstRequest(HttpServletRequest request) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -566,6 +566,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
 
     private boolean isPromptRequest(HttpServletRequest request) {
 
+        // Checking for prompt request using promptId and promptResp parameters.
+        // Checking for session limit handler params since it shares same parameters with prompt request.
         return StringUtils.isNotBlank(request.getParameter(PROMPT_ID_PARAM))
                 && Boolean.parseBoolean(request.getParameter(PROMPT_RESP_PARAM))
                 && StringUtils.isBlank(request.getParameter(SESSION_LIMIT_HANDLER_PARAM));

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -361,8 +361,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                 */
                 if (isBackToFirstStepRequest(request) || (isIdentifierFirstRequest(request)
                         && (!isFlowHandlerInCurrentStepCanHandleRequest(context, request)
-                        && !FrameworkUtils.isIdfInitiatedFromAuthenticator(context)))
-                ) {
+                        && !FrameworkUtils.isIdfInitiatedFromAuthenticator(context)))) {
                     if (isCompletedStepsAreFlowHandlersOnly(context)) {
                         // If the incoming request is restart and all the completed steps have only flow handlers as the
                         // authenticated authenticator, then we reset the current step to 1.
@@ -400,8 +399,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     // If the request is a prompt request returning from browser's back button, we need to handle it
                     // by changing context to previous step.
                     if (!(currentNode instanceof ShowPromptNode)) {
-                        currentNode = moveToShowPromptNode(currentNode);
-                        context.setCurrentStep(context.getCurrentStep() - 1);
+                        currentNode = moveToPreviousNode(currentNode);
+                        context.setCurrentStep(Math.max(0, context.getCurrentStep() - 1));
                         context.setProperty(FrameworkConstants.JSAttributes.PROP_CURRENT_NODE, currentNode);
                     }
                 }
@@ -564,15 +563,21 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
     private boolean isPromptRequest(HttpServletRequest request) {
 
         return StringUtils.isNotBlank(request.getParameter(PROMPT_ID_PARAM))
-                && TRUE.equals(request.getParameter(PROMPT_RESP_PARAM));
+                && Boolean.parseBoolean(request.getParameter(PROMPT_RESP_PARAM));
     }
 
-    private AuthGraphNode moveToShowPromptNode(AuthGraphNode currentNode) {
+    /**
+     * Move to the previous node in the authentication graph.
+     *
+     * @param currentNode The current node in the authentication graph.
+     * @return The previous node in the authentication graph.
+     */
+    private AuthGraphNode moveToPreviousNode(AuthGraphNode currentNode) {
 
         if (currentNode == null || currentNode instanceof ShowPromptNode) {
             return currentNode;
         }
-        return moveToShowPromptNode(currentNode.getParent());
+        return moveToPreviousNode(currentNode.getParent());
     }
 
     private boolean isIdentifierFirstRequest(HttpServletRequest request) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -129,7 +129,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
     private static final String ACR_VALUES_ATTRIBUTE = "acr_values";
     private static final String REQUESTED_ATTRIBUTES = "requested_attributes";
     private static final String SERVICE_PROVIDER_QUERY_KEY = "serviceProvider";
-    private static final String PROMPT_ID = "promptId";
+    private static final String PROMPT_ID_PARAM = "promptId";
+    private static final String PROMPT_RESP_PARAM = "promptResp";
 
     public static DefaultRequestCoordinator getInstance() {
 
@@ -562,7 +563,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
 
     private boolean isPromptRequest(HttpServletRequest request, AuthenticationContext context) {
 
-        return StringUtils.isNotBlank(request.getParameter(PROMPT_ID));
+        return StringUtils.isNotBlank(request.getParameter(PROMPT_ID_PARAM))
+                && TRUE.equals(request.getParameter(PROMPT_RESP_PARAM));
     }
 
     private AuthGraphNode moveToShowPromptNode(AuthGraphNode currentNode) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -399,7 +399,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     // If the request is a prompt request returning from browser's back button, we need to handle it
                     // by changing context to previous step.
                     if (!(currentNode instanceof ShowPromptNode)) {
-                        currentNode = moveToPreviousNode(currentNode);
+                        currentNode = moveToPreviousShowPromptNode(currentNode);
                         context.setCurrentStep(Math.max(0, context.getCurrentStep() - 1));
                         context.setProperty(FrameworkConstants.JSAttributes.PROP_CURRENT_NODE, currentNode);
                     }
@@ -567,17 +567,17 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
     }
 
     /**
-     * Move to the previous node in the authentication graph.
+     * Move to the previous node in the authentication graph until show prompt node is reached.
      *
      * @param currentNode The current node in the authentication graph.
      * @return The previous node in the authentication graph.
      */
-    private AuthGraphNode moveToPreviousNode(AuthGraphNode currentNode) {
+    private AuthGraphNode moveToPreviousShowPromptNode(AuthGraphNode currentNode) {
 
         if (currentNode == null || currentNode instanceof ShowPromptNode) {
             return currentNode;
         }
-        return moveToPreviousNode(currentNode.getParent());
+        return moveToPreviousShowPromptNode(currentNode.getParent());
     }
 
     private boolean isIdentifierFirstRequest(HttpServletRequest request) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -131,6 +131,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
     private static final String SERVICE_PROVIDER_QUERY_KEY = "serviceProvider";
     private static final String PROMPT_ID_PARAM = "promptId";
     private static final String PROMPT_RESP_PARAM = "promptResp";
+    private static final String SESSION_LIMIT_HANDLER_PARAM = "terminateActiveSessionsAction";
 
     public static DefaultRequestCoordinator getInstance() {
 
@@ -400,8 +401,11 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     // by changing context to previous step.
                     if (!(currentNode instanceof ShowPromptNode)) {
                         currentNode = moveToPreviousShowPromptNode(currentNode);
-                        context.setCurrentStep(Math.max(0, context.getCurrentStep() - 1));
-                        context.setProperty(FrameworkConstants.JSAttributes.PROP_CURRENT_NODE, currentNode);
+                        // If ShowPromptNode is not found, current node will be null.
+                        if (currentNode != null) {
+                            context.setCurrentStep(Math.max(0, context.getCurrentStep() - 1));
+                            context.setProperty(FrameworkConstants.JSAttributes.PROP_CURRENT_NODE, currentNode);
+                        }
                     }
                 }
 
@@ -563,7 +567,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
     private boolean isPromptRequest(HttpServletRequest request) {
 
         return StringUtils.isNotBlank(request.getParameter(PROMPT_ID_PARAM))
-                && Boolean.parseBoolean(request.getParameter(PROMPT_RESP_PARAM));
+                && Boolean.parseBoolean(request.getParameter(PROMPT_RESP_PARAM))
+                && StringUtils.isBlank(request.getParameter(SESSION_LIMIT_HANDLER_PARAM));
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

If there is an adaptive authentication request with prompt function used, when browser back button is currently not working properly.

This PR addresses this issue by changing the authentication context to the previous node when back button is used.