### PR TITLE
Add show_auth_failure_reason for password grant

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -423,6 +423,9 @@
              currently used by JWT token issuer for issuing access token-->
         <SkipOIDCClaimsForClientCredentialGrant>{{oauth.grant_type.client_credentials.skip_oidc_claims}}</SkipOIDCClaimsForClientCredentialGrant>
 
+        <!-- If enabled, authenitcation failure reason will be shown in the response for password grant -->
+        <ShowAuthFailureReasonForPasswordGrant>{{oauth.grant_type.password.show_auth_failure_reason}}</ShowAuthFailureReasonForPasswordGrant>
+
         <!-- If enabled, hostname will be used to build the issuer instead of entity ID -->
         <BuildIssuerWithHostname>{{oauth.build_issuer_with_hostname}}</BuildIssuerWithHostname>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -423,8 +423,12 @@
              currently used by JWT token issuer for issuing access token-->
         <SkipOIDCClaimsForClientCredentialGrant>{{oauth.grant_type.client_credentials.skip_oidc_claims}}</SkipOIDCClaimsForClientCredentialGrant>
 
-        <!-- If enabled, authenitcation failure reason will be shown in the response for password grant -->
-        <ShowAuthFailureReasonForPasswordGrant>{{oauth.grant_type.password.show_auth_failure_reason}}</ShowAuthFailureReasonForPasswordGrant>
+        <!-- If enabled, authentication failure reason will be shown in the response for password grant -->
+        {% if authentication.authenticator.basic.parameters.showAuthFailureReason is defined and oauth.password_grant.use_show_auth_failure_reason is sameas true %}
+            <ShowAuthFailureReasonForPasswordGrant>{{authentication.authenticator.basic.parameters.showAuthFailureReason}}</ShowAuthFailureReasonForPasswordGrant>
+        {% else %}
+            <ShowAuthFailureReasonForPasswordGrant>{{oauth.grant_type.password.show_auth_failure_reason}}</ShowAuthFailureReasonForPasswordGrant>
+        {% endif %}
 
         <!-- If enabled, hostname will be used to build the issuer instead of entity ID -->
         <BuildIssuerWithHostname>{{oauth.build_issuer_with_hostname}}</BuildIssuerWithHostname>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -157,6 +157,7 @@
   "oauth.grant_type.password.enable": true,
   "oauth.grant_type.password.grant_handler": "org.wso2.carbon.identity.oauth2.token.handlers.grant.PasswordGrantHandler",
   "oauth.grant_type.password.allow_public_client": true,
+  "oauth.grant_type.password.show_auth_failure_reason": false,
   "oauth.grant_type.refresh_token.enable": true,
   "oauth.grant_type.refresh_token.grant_handler": "org.wso2.carbon.identity.oauth2.token.handlers.grant.RefreshGrantHandler",
   "oauth.grant_type.refresh_token.allow_public_client": true,


### PR DESCRIPTION
### Proposed changes in this pull request

This PR adds the below configuration to show authentication failure reason in password grant

```
[oauth.grant_type.password]
show_auth_failure_reason = false
```

### Related Issue

- https://github.com/wso2/product-is/issues/23476