### PR TITLE
Update the password recovery config validations.

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -330,7 +330,7 @@ public class IdentityProviderManager implements IdpManager {
         IdentityProviderProperty[] identityMgtProperties = residentIdp.getIdpProperties();
         List<IdentityProviderProperty> newProperties = new ArrayList<>();
 
-        IdPManagementUtil.validatePasswordRecoveryPropertyValues(configurationDetails, identityMgtProperties);
+        IdPManagementUtil.validatePasswordRecoveryPropertyValues(configurationDetails);
         IdPManagementUtil.validateUsernameRecoveryPropertyValues(configurationDetails);
 
         for (IdentityProviderProperty identityMgtProperty : identityMgtProperties) {

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -330,7 +330,7 @@ public class IdentityProviderManager implements IdpManager {
         IdentityProviderProperty[] identityMgtProperties = residentIdp.getIdpProperties();
         List<IdentityProviderProperty> newProperties = new ArrayList<>();
 
-        IdPManagementUtil.validatePasswordRecoveryPropertyValues(configurationDetails);
+        IdPManagementUtil.validatePasswordRecoveryPropertyValues(configurationDetails, identityMgtProperties);
         IdPManagementUtil.validateUsernameRecoveryPropertyValues(configurationDetails);
 
         for (IdentityProviderProperty identityMgtProperty : identityMgtProperties) {

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
@@ -348,13 +348,13 @@ public class IdPManagementUtil {
                     isEmailLinkPasswordRecoveryEnabled) && isEmailOtpPasswordRecoveryEnabled) {
                 throw IdPManagementUtil.handleClientException(
                         IdPManagementConstants.ErrorMessage.ERROR_CODE_INVALID_CONNECTOR_CONFIGURATION,
-                        "Enabling email otp and when email link is enabled is not allowed.");
+                        "Enabling email OTP and when email link is enabled is not allowed.");
             }
             if (((isEmailOtpCurrentlyEnabled && StringUtils.isBlank(emailOtpForPasswordRecoveryProp)) ||
                     isEmailOtpPasswordRecoveryEnabled) && isEmailLinkPasswordRecoveryEnabled) {
                 throw IdPManagementUtil.handleClientException(
                         IdPManagementConstants.ErrorMessage.ERROR_CODE_INVALID_CONNECTOR_CONFIGURATION,
-                        "Enabling email link and when email otp is enabled is not allowed.");
+                        "Enabling email link and when email OTP is enabled is not allowed.");
             }
         }
     }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
@@ -285,8 +285,7 @@ public class IdPManagementUtil {
      *
      * @param configurationDetails Configuration updates for governance configuration.
      */
-    public static void validatePasswordRecoveryPropertyValues(Map<String, String> configurationDetails,
-                                                              IdentityProviderProperty[] identityMgtProperties)
+    public static void validatePasswordRecoveryPropertyValues(Map<String, String> configurationDetails)
             throws IdentityProviderManagementClientException {
 
         if (configurationDetails.containsKey(NOTIFICATION_PASSWORD_ENABLE_PROPERTY) ||
@@ -332,6 +331,27 @@ public class IdPManagementUtil {
                         IdPManagementConstants.ErrorMessage.ERROR_CODE_INVALID_CONNECTOR_CONFIGURATION,
                         "Enabling both email link and email otp options are not allowed.");
             }
+        }
+    }
+
+    public static void validatePasswordRecoveryWithCurrentAndPreviousConfigs(Map<String, String> configurationDetails,
+                                                                   IdentityProviderProperty[] identityMgtProperties)
+            throws IdentityProviderManagementClientException {
+
+        // Validate updating configs.
+        validatePasswordRecoveryPropertyValues(configurationDetails);
+
+
+        // Check weather current configurations include email OTP or Link since enabling both at same time is not
+        // allowed.
+        if (configurationDetails.containsKey(EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY) ||
+                configurationDetails.containsKey(EMAIL_OTP_PASSWORD_RECOVERY_PROPERTY)) {
+
+            String emailLinkForPasswordRecoveryProp = configurationDetails.get(EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY);
+            String emailOtpForPasswordRecoveryProp = configurationDetails.get(EMAIL_OTP_PASSWORD_RECOVERY_PROPERTY);
+
+            boolean isEmailLinkPasswordRecoveryEnabled = Boolean.parseBoolean(emailLinkForPasswordRecoveryProp);
+            boolean isEmailOtpPasswordRecoveryEnabled = Boolean.parseBoolean(emailOtpForPasswordRecoveryProp);
 
             // Checks for already existing configurations.
             boolean isEmailLinkCurrentlyEnabled = false;
@@ -344,6 +364,7 @@ public class IdPManagementUtil {
                     isEmailOtpCurrentlyEnabled = Boolean.parseBoolean(identityMgtProperty.getValue());
                 }
             }
+
             if (((isEmailLinkCurrentlyEnabled && StringUtils.isBlank(emailLinkForPasswordRecoveryProp)) ||
                     isEmailLinkPasswordRecoveryEnabled) && isEmailOtpPasswordRecoveryEnabled) {
                 throw IdPManagementUtil.handleClientException(
@@ -358,6 +379,7 @@ public class IdPManagementUtil {
             }
         }
     }
+
 
     /**
      * This method is used to validate the username recovery property values.

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
@@ -348,13 +348,13 @@ public class IdPManagementUtil {
                     isEmailLinkPasswordRecoveryEnabled) && isEmailOtpPasswordRecoveryEnabled) {
                 throw IdPManagementUtil.handleClientException(
                         IdPManagementConstants.ErrorMessage.ERROR_CODE_INVALID_CONNECTOR_CONFIGURATION,
-                        "Enabling email OTP and when email link is enabled is not allowed.");
+                        "Enabling email OTP while email link is enabled is not allowed.");
             }
             if (((isEmailOtpCurrentlyEnabled && StringUtils.isBlank(emailOtpForPasswordRecoveryProp)) ||
                     isEmailOtpPasswordRecoveryEnabled) && isEmailLinkPasswordRecoveryEnabled) {
                 throw IdPManagementUtil.handleClientException(
                         IdPManagementConstants.ErrorMessage.ERROR_CODE_INVALID_CONNECTOR_CONFIGURATION,
-                        "Enabling email link and when email OTP is enabled is not allowed.");
+                        "Enabling email link while email OTP is enabled is not allowed.");
             }
         }
     }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
@@ -41,7 +41,11 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.Map;
 
+import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY;
+import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.EMAIL_OTP_PASSWORD_RECOVERY_PROPERTY;
+import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.NOTIFICATION_PASSWORD_ENABLE_PROPERTY;
 import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.PRESERVE_LOCALLY_ADDED_CLAIMS;
+import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.SMS_OTP_PASSWORD_RECOVERY_PROPERTY;
 
 public class IdPManagementUtil {
 
@@ -281,22 +285,19 @@ public class IdPManagementUtil {
      *
      * @param configurationDetails Configuration updates for governance configuration.
      */
-    public static void validatePasswordRecoveryPropertyValues(Map<String, String> configurationDetails)
+    public static void validatePasswordRecoveryPropertyValues(Map<String, String> configurationDetails,
+                                                              IdentityProviderProperty[] identityMgtProperties)
             throws IdentityProviderManagementClientException {
 
-        if (configurationDetails.containsKey(IdPManagementConstants.NOTIFICATION_PASSWORD_ENABLE_PROPERTY) ||
-                configurationDetails.containsKey(IdPManagementConstants.EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY) ||
-                configurationDetails.containsKey(IdPManagementConstants.EMAIL_OTP_PASSWORD_RECOVERY_PROPERTY) ||
-                configurationDetails.containsKey(IdPManagementConstants.SMS_OTP_PASSWORD_RECOVERY_PROPERTY)) {
+        if (configurationDetails.containsKey(NOTIFICATION_PASSWORD_ENABLE_PROPERTY) ||
+                configurationDetails.containsKey(EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY) ||
+                configurationDetails.containsKey(EMAIL_OTP_PASSWORD_RECOVERY_PROPERTY) ||
+                configurationDetails.containsKey(SMS_OTP_PASSWORD_RECOVERY_PROPERTY)) {
             // Perform process only if notification based password recovery connector or options are updated.
-            String recoveryNotificationPasswordProp =
-                    configurationDetails.get(IdPManagementConstants.NOTIFICATION_PASSWORD_ENABLE_PROPERTY);
-            String emailLinkForPasswordRecoveryProp =
-                    configurationDetails.get(IdPManagementConstants.EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY);
-            String emailOtpForPasswordRecoveryProp =
-                    configurationDetails.get(IdPManagementConstants.EMAIL_OTP_PASSWORD_RECOVERY_PROPERTY);
-            String smsOtpForPasswordRecoveryProp =
-                    configurationDetails.get(IdPManagementConstants.SMS_OTP_PASSWORD_RECOVERY_PROPERTY);
+            String recoveryNotificationPasswordProp = configurationDetails.get(NOTIFICATION_PASSWORD_ENABLE_PROPERTY);
+            String emailLinkForPasswordRecoveryProp = configurationDetails.get(EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY);
+            String emailOtpForPasswordRecoveryProp = configurationDetails.get(EMAIL_OTP_PASSWORD_RECOVERY_PROPERTY);
+            String smsOtpForPasswordRecoveryProp = configurationDetails.get(SMS_OTP_PASSWORD_RECOVERY_PROPERTY);
 
             boolean isRecoveryNotificationPasswordEnabled = Boolean.parseBoolean(recoveryNotificationPasswordProp);
             boolean isEmailLinkPasswordRecoveryEnabled = Boolean.parseBoolean(emailLinkForPasswordRecoveryProp);
@@ -325,6 +326,35 @@ public class IdPManagementUtil {
                         .handleClientException(
                                 IdPManagementConstants.ErrorMessage.ERROR_CODE_INVALID_CONNECTOR_CONFIGURATION,
                                 "Enabling recovery options when connector is disabled, is not allowed.");
+            }
+            if (isEmailLinkPasswordRecoveryEnabled && isEmailOtpPasswordRecoveryEnabled) {
+                throw IdPManagementUtil.handleClientException(
+                        IdPManagementConstants.ErrorMessage.ERROR_CODE_INVALID_CONNECTOR_CONFIGURATION,
+                        "Enabling both email link and email otp options are not allowed.");
+            }
+
+            // Checks for already existing configurations.
+            boolean isEmailLinkCurrentlyEnabled = false;
+            boolean isEmailOtpCurrentlyEnabled = false;
+
+            for (IdentityProviderProperty identityMgtProperty : identityMgtProperties) {
+                if (EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY.equals(identityMgtProperty.getName())) {
+                    isEmailLinkCurrentlyEnabled = Boolean.parseBoolean(identityMgtProperty.getValue());
+                } else if (EMAIL_OTP_PASSWORD_RECOVERY_PROPERTY.equals(identityMgtProperty.getName())) {
+                    isEmailOtpCurrentlyEnabled = Boolean.parseBoolean(identityMgtProperty.getValue());
+                }
+            }
+            if (((isEmailLinkCurrentlyEnabled && StringUtils.isBlank(emailLinkForPasswordRecoveryProp)) ||
+                    isEmailLinkPasswordRecoveryEnabled) && isEmailOtpPasswordRecoveryEnabled) {
+                throw IdPManagementUtil.handleClientException(
+                        IdPManagementConstants.ErrorMessage.ERROR_CODE_INVALID_CONNECTOR_CONFIGURATION,
+                        "Enabling email otp and when email link is enabled is not allowed.");
+            }
+            if (((isEmailOtpCurrentlyEnabled && StringUtils.isBlank(emailOtpForPasswordRecoveryProp)) ||
+                    isEmailOtpPasswordRecoveryEnabled) && isEmailLinkPasswordRecoveryEnabled) {
+                throw IdPManagementUtil.handleClientException(
+                        IdPManagementConstants.ErrorMessage.ERROR_CODE_INVALID_CONNECTOR_CONFIGURATION,
+                        "Enabling email link and when email otp is enabled is not allowed.");
             }
         }
     }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtilTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtilTest.java
@@ -61,6 +61,13 @@ public class IdPManagementUtilTest {
 
     private static final String TRUE_STRING = "true";
     private static final String FALSE_STRING = "false";
+    private static final String PASSWORD_RECOVERY_ENABLE = "Recovery.Notification.Password.Enable";
+    private static final String PASSWORD_RECOVERY_EMAIL_LINK_ENABLE
+            = "Recovery.Notification.Password.emailLink.Enable";
+    private static final String PASSWORD_RECOVERY_EMAIL_OTP_ENABLE =
+            "Recovery.Notification.Password.OTP.SendOTPInEmail";
+    private static final String PASSWORD_RECOVERY_SMS_OTP_ENABLE = "Recovery.Notification.Password.smsOtp.Enable";
+
 
     @Mock
     private IdentityProviderManager mockedIdentityProviderManager;
@@ -295,10 +302,12 @@ public class IdPManagementUtilTest {
     }
 
     @Test(dataProvider = "passwordRecoveryConfigs")
-    public void testValidatePasswordRecoveryPropertyValues(HashMap<String, String> configs, boolean isValid) {
+    public void testValidatePasswordRecoveryPropertyValues(HashMap<String, String> configs,
+                                                           IdentityProviderProperty[] identityMgtProperties,
+                                                           boolean isValid) {
 
         try {
-            IdPManagementUtil.validatePasswordRecoveryPropertyValues(configs);
+            IdPManagementUtil.validatePasswordRecoveryPropertyValues(configs, identityMgtProperties);
 
             if (!isValid) {
                 Assert.fail("Expected an  IdentityProviderManagementClientException but no exception was thrown.");
@@ -313,20 +322,52 @@ public class IdPManagementUtilTest {
     @DataProvider(name = "passwordRecoveryConfigs")
     public Object[][] setPasswordRecoveryConfigs() {
 
+        IdentityProviderProperty[] passwordIdentityPropsAllFalse = getPasswordRecoveryIdentityProviderProperties(false,
+                false, false, false);
+
+        IdentityProviderProperty[] passwordIdentityPropsEmailLinkEnabled =
+                getPasswordRecoveryIdentityProviderProperties(false, true, false, false);
+
+        IdentityProviderProperty[] passwordIdentityPropsEmailOtpEnabled =
+                getPasswordRecoveryIdentityProviderProperties(false, false, true, false);
+
+        HashMap<String, String> recoveryConfig1 = getPasswordRecoveryConfigs(true, true, null, null);
+
+        HashMap<String, String> recoveryConfig2 = getPasswordRecoveryConfigs(true, false, false, false);
+
+        HashMap<String, String> recoveryConfig3 = getPasswordRecoveryConfigs(false, true, false, false);
+
+        HashMap<String, String> recoveryConfig4 = getPasswordRecoveryConfigs(false, false, true, false);
+
+        HashMap<String, String> recoveryConfig5 = getPasswordRecoveryConfigs(false, false, false, true);
+
+        HashMap<String, String> recoveryConfig6 = getPasswordRecoveryConfigs(null, true, true, false);
+
+        HashMap<String, String> recoveryConfig7 = getPasswordRecoveryConfigs(null, null, true, null);
+
+        HashMap<String, String> recoveryConfig8 = getPasswordRecoveryConfigs(null, true, null, null);
+
+        HashMap<String, String> recoveryConfig9 = getPasswordRecoveryConfigs(null, null, null, true);
+
+        HashMap<String, String> recoveryConfig10 = getPasswordRecoveryConfigs(null, false, null, null);
+
+        HashMap<String, String> recoveryConfig11 = getPasswordRecoveryConfigs(null, true, false, null);
+
+        HashMap<String, String> recoveryConfig12 = getPasswordRecoveryConfigs(null, false, true, null);
+
         return new Object[][]{
-                {getPasswordRecoveryConfigs(true, true, null, null), true},
-                {getPasswordRecoveryConfigs(null, true, null, null), true},
-                {getPasswordRecoveryConfigs(null, null, true, null), true},
-                {getPasswordRecoveryConfigs(null, null, null, true), true},
-                {getPasswordRecoveryConfigs(true, null, null, null), true},
-                {getPasswordRecoveryConfigs(true, false, true, null), true},
-                {getPasswordRecoveryConfigs(true, false, null, null), true},
-                {getPasswordRecoveryConfigs(true, false, false, null), true},
-                {getPasswordRecoveryConfigs(true, false, false, true), true},
-                {getPasswordRecoveryConfigs(true, false, false, false), false},
-                {getPasswordRecoveryConfigs(false, true, null, null), false},
-                {getPasswordRecoveryConfigs(false, false, true, false), false},
-                {getPasswordRecoveryConfigs(false, false, false, true), false}
+                {recoveryConfig1, passwordIdentityPropsAllFalse, true},
+                {recoveryConfig2, passwordIdentityPropsAllFalse, false},
+                {recoveryConfig3, passwordIdentityPropsAllFalse, false},
+                {recoveryConfig4, passwordIdentityPropsAllFalse, false},
+                {recoveryConfig5, passwordIdentityPropsAllFalse, false},
+                {recoveryConfig6, passwordIdentityPropsAllFalse, false},
+                {recoveryConfig7, passwordIdentityPropsEmailLinkEnabled, false},
+                {recoveryConfig8, passwordIdentityPropsEmailOtpEnabled, false},
+                {recoveryConfig9, passwordIdentityPropsAllFalse, true},
+                {recoveryConfig10, passwordIdentityPropsEmailLinkEnabled, true},
+                {recoveryConfig11, passwordIdentityPropsEmailOtpEnabled, true},
+                {recoveryConfig12, passwordIdentityPropsEmailLinkEnabled, true}
         };
     }
 
@@ -358,6 +399,36 @@ public class IdPManagementUtilTest {
         }
 
         return configs;
+    }
+
+    private IdentityProviderProperty[] getPasswordRecoveryIdentityProviderProperties(
+            boolean passwordRecoveryEnable,
+            boolean passwordRecoveryEmailLinkEnable,
+            boolean passwordRecoveryEmailOtpEnable,
+            boolean passwordRecoverySmsOtpEnable) {
+
+        IdentityProviderProperty identityProviderProperty1 = new IdentityProviderProperty();
+        identityProviderProperty1.setName(PASSWORD_RECOVERY_ENABLE);
+        identityProviderProperty1.setValue(passwordRecoveryEnable ? TRUE_STRING : FALSE_STRING);
+
+        IdentityProviderProperty identityProviderProperty2 = new IdentityProviderProperty();
+        identityProviderProperty2.setName(PASSWORD_RECOVERY_EMAIL_LINK_ENABLE);
+        identityProviderProperty2.setValue(passwordRecoveryEmailLinkEnable ? TRUE_STRING : FALSE_STRING);
+
+        IdentityProviderProperty identityProviderProperty3 = new IdentityProviderProperty();
+        identityProviderProperty3.setName(PASSWORD_RECOVERY_EMAIL_OTP_ENABLE);
+        identityProviderProperty3.setValue(passwordRecoveryEmailOtpEnable ? TRUE_STRING : FALSE_STRING);
+
+        IdentityProviderProperty identityProviderProperty4 = new IdentityProviderProperty();
+        identityProviderProperty4.setName(PASSWORD_RECOVERY_SMS_OTP_ENABLE);
+        identityProviderProperty4.setValue(passwordRecoverySmsOtpEnable ? TRUE_STRING : FALSE_STRING);
+
+        return new IdentityProviderProperty[]{
+                identityProviderProperty1,
+                identityProviderProperty2,
+                identityProviderProperty3,
+                identityProviderProperty4
+        };
     }
 
     @Test(dataProvider = "setSuccessConfigDetails")

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtilTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtilTest.java
@@ -302,12 +302,10 @@ public class IdPManagementUtilTest {
     }
 
     @Test(dataProvider = "passwordRecoveryConfigs")
-    public void testValidatePasswordRecoveryPropertyValues(HashMap<String, String> configs,
-                                                           IdentityProviderProperty[] identityMgtProperties,
-                                                           boolean isValid) {
+    public void testValidatePasswordRecoveryPropertyValues(HashMap<String, String> configs, boolean isValid) {
 
         try {
-            IdPManagementUtil.validatePasswordRecoveryPropertyValues(configs, identityMgtProperties);
+            IdPManagementUtil.validatePasswordRecoveryPropertyValues(configs);
 
             if (!isValid) {
                 Assert.fail("Expected an  IdentityProviderManagementClientException but no exception was thrown.");
@@ -319,8 +317,28 @@ public class IdPManagementUtilTest {
         }
     }
 
-    @DataProvider(name = "passwordRecoveryConfigs")
-    public Object[][] setPasswordRecoveryConfigs() {
+    @Test(dataProvider = "passwordRecoveryConfigsWithIdpMgtProps")
+    public void testValidatePasswordRecoveryWithCurrentAndPreviousConfigs(HashMap<String, String> configs,
+                                                                          IdentityProviderProperty[] identityProviderProperties,
+                                                                          boolean isValid) {
+
+        try {
+            IdPManagementUtil.validatePasswordRecoveryWithCurrentAndPreviousConfigs(configs,
+                    identityProviderProperties);
+
+            if (!isValid) {
+                Assert.fail("Expected an  IdentityProviderManagementClientException but no exception was thrown.");
+            }
+        } catch (IdentityProviderManagementClientException e) {
+            if (isValid) {
+                Assert.fail("Did not expect IdentityProviderManagementClientException.", e);
+            }
+        }
+
+    }
+
+    @DataProvider(name = "passwordRecoveryConfigsWithIdpMgtProps")
+    public Object[][] setPasswordRecoveryConfigsWithIpdMgtProps() {
 
         IdentityProviderProperty[] passwordIdentityPropsAllFalse = getPasswordRecoveryIdentityProviderProperties(false,
                 false, false, false);
@@ -330,6 +348,29 @@ public class IdPManagementUtilTest {
 
         IdentityProviderProperty[] passwordIdentityPropsEmailOtpEnabled =
                 getPasswordRecoveryIdentityProviderProperties(false, false, true, false);
+
+        HashMap<String, String> recoveryConfig1 = getPasswordRecoveryConfigs(null, true, null, null);
+
+        HashMap<String, String> recoveryConfig2 = getPasswordRecoveryConfigs(null, null, true, null);
+
+        HashMap<String, String> recoveryConfig3 = getPasswordRecoveryConfigs(true, null, null, null);
+
+        HashMap<String, String> recoveryConfig4 = getPasswordRecoveryConfigs(null, true, false, null);
+
+        HashMap<String, String> recoveryConfig5 = getPasswordRecoveryConfigs(null, false, true, null);
+        return new Object[][]{
+                {recoveryConfig1, passwordIdentityPropsEmailOtpEnabled, false},
+                {recoveryConfig1, passwordIdentityPropsAllFalse, true},
+                {recoveryConfig2, passwordIdentityPropsEmailLinkEnabled, false},
+                {recoveryConfig2, passwordIdentityPropsAllFalse, true},
+                {recoveryConfig3, passwordIdentityPropsAllFalse, true},
+                {recoveryConfig4, passwordIdentityPropsEmailOtpEnabled, true},
+                {recoveryConfig5, passwordIdentityPropsEmailLinkEnabled, true}
+        };
+    }
+
+    @DataProvider(name = "passwordRecoveryConfigs")
+    public Object[][] setPasswordRecoveryConfigs() {
 
         HashMap<String, String> recoveryConfig1 = getPasswordRecoveryConfigs(true, true, null, null);
 
@@ -341,33 +382,33 @@ public class IdPManagementUtilTest {
 
         HashMap<String, String> recoveryConfig5 = getPasswordRecoveryConfigs(false, false, false, true);
 
-        HashMap<String, String> recoveryConfig6 = getPasswordRecoveryConfigs(null, true, true, false);
+        HashMap<String, String> recoveryConfig6 = getPasswordRecoveryConfigs(null, true, null, null);
 
-        HashMap<String, String> recoveryConfig7 = getPasswordRecoveryConfigs(null, null, true, null);
+        HashMap<String, String> recoveryConfig7 = getPasswordRecoveryConfigs(null, null, null, true);
 
-        HashMap<String, String> recoveryConfig8 = getPasswordRecoveryConfigs(null, true, null, null);
+        HashMap<String, String> recoveryConfig8 = getPasswordRecoveryConfigs(null, false, null, null);
 
-        HashMap<String, String> recoveryConfig9 = getPasswordRecoveryConfigs(null, null, null, true);
+        HashMap<String, String> recoveryConfig9 = getPasswordRecoveryConfigs(null, true, false, null);
 
-        HashMap<String, String> recoveryConfig10 = getPasswordRecoveryConfigs(null, false, null, null);
+        HashMap<String, String> recoveryConfig10 = getPasswordRecoveryConfigs(null, false, true, null);
 
-        HashMap<String, String> recoveryConfig11 = getPasswordRecoveryConfigs(null, true, false, null);
+        HashMap<String, String> recoveryConfig11 = getPasswordRecoveryConfigs(null, true, true, false);
 
-        HashMap<String, String> recoveryConfig12 = getPasswordRecoveryConfigs(null, false, true, null);
+        HashMap<String, String> recoveryConfig12 = getPasswordRecoveryConfigs(null, null, true, null);
 
         return new Object[][]{
-                {recoveryConfig1, passwordIdentityPropsAllFalse, true},
-                {recoveryConfig2, passwordIdentityPropsAllFalse, false},
-                {recoveryConfig3, passwordIdentityPropsAllFalse, false},
-                {recoveryConfig4, passwordIdentityPropsAllFalse, false},
-                {recoveryConfig5, passwordIdentityPropsAllFalse, false},
-                {recoveryConfig6, passwordIdentityPropsAllFalse, false},
-                {recoveryConfig7, passwordIdentityPropsEmailLinkEnabled, false},
-                {recoveryConfig8, passwordIdentityPropsEmailOtpEnabled, false},
-                {recoveryConfig9, passwordIdentityPropsAllFalse, true},
-                {recoveryConfig10, passwordIdentityPropsEmailLinkEnabled, true},
-                {recoveryConfig11, passwordIdentityPropsEmailOtpEnabled, true},
-                {recoveryConfig12, passwordIdentityPropsEmailLinkEnabled, true}
+                {recoveryConfig1, true},
+                {recoveryConfig2, false},
+                {recoveryConfig3, false},
+                {recoveryConfig4, false},
+                {recoveryConfig5, false},
+                {recoveryConfig6, true},
+                {recoveryConfig7, true},
+                {recoveryConfig8, true},
+                {recoveryConfig9, true},
+                {recoveryConfig10, true},
+                {recoveryConfig11, false},
+                {recoveryConfig12, true}
         };
     }
 


### PR DESCRIPTION
### Purpose
- $subject

### Implementation details
- Additional validations have been introduced by not allowing following configuration updates,
  - Enabling both email OTP and email link at once.
  - Enabling email link when email OTP is already enabled.
  - Enabling email OTP when email link is already enabled.

### After merging
- please update the [governance validation call](https://github.com/wso2-extensions/identity-governance/blob/381c5fffa0d694db0fdecdb1ec17aab40a1adb42/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java#L76) when bumping the version in governance repo to include this additional validations.

### Related issues
- https://github.com/wso2/product-is/issues/23444
