### PR TITLE
Improve Role Name Validation and Update Test Cases

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
@@ -91,15 +91,18 @@ public class RoleManagementServiceImpl implements RoleManagementService {
                         UserCoreConstants.INTERNAL_SYSTEM_ROLE_PREFIX);
                 throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
             }
+            if (roleName == null || roleName.isEmpty()) {
+                String errorMessage = "Role name cannot be empty.";
+                throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
+            }
+            if (roleName.length() > 255) {
+                String errorMessage = "Provided role name exceeds the maximum length of 255 characters.";
+                throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
+            }
             if (isDomainSeparatorPresent(roleName)) {
                 // SCIM2 API only adds roles to the internal domain.
                 throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), "Invalid character: "
                         + UserCoreConstants.DOMAIN_SEPARATOR + " contains in the role name: " + roleName + ".");
-            }
-            if (roleName.length() < 3 || roleName.length() > 255) {
-                String errorMessage = String.format("Invalid role name: %s. " +
-                        "Role names must be between 3 and 255 characters long.", roleName);
-                throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
             }
             List<RoleManagementListener> roleManagementListenerList = RoleManagementServiceComponentHolder.
                     getInstance().getRoleManagementListenerList();
@@ -351,15 +354,19 @@ public class RoleManagementServiceImpl implements RoleManagementService {
         RoleManagementEventPublisherProxy roleManagementEventPublisherProxy = RoleManagementEventPublisherProxy
                 .getInstance();
         roleManagementEventPublisherProxy.publishPreUpdateRoleNameWithException(roleId, newRoleName, tenantDomain);
+
+        if (newRoleName == null || newRoleName.isEmpty()) {
+            String errorMessage = "Role name cannot be empty.";
+            throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
+        }
+        if (newRoleName.length() > 255) {
+            String errorMessage = "Provided role name exceeds the maximum length of 255 characters.";
+            throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
+        }
         if (isDomainSeparatorPresent(newRoleName)) {
             // SCIM2 API only adds roles to the internal domain.
             throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), "Invalid character: "
                     + UserCoreConstants.DOMAIN_SEPARATOR + " contains in the role name: " + newRoleName + ".");
-        }
-        if (newRoleName.length() < 3 || newRoleName.length() > 255) {
-            String errorMessage = String.format("Invalid role name: %s. " +
-                    "Role names must be between 3 and 255 characters long.", newRoleName);
-            throw new IdentityRoleManagementClientException(INVALID_REQUEST.getCode(), errorMessage);
         }
         roleDAO.updateRoleName(roleId, newRoleName, tenantDomain);
         roleManagementEventPublisherProxy.publishPostUpdateRoleName(roleId, newRoleName, tenantDomain);


### PR DESCRIPTION
## Purpose
Improve the validation of role names and updates the corresponding test cases to reflect these changes.

## Implementation

#### Role name validation improvements:

* Added checks to ensure the role name is not null or empty and does not exceed 255 characters in the `addRole` method.
* Added similar checks in the `updateRoleName` method to ensure the new role name is valid.

#### Test case updates:

* Removed the unused `invalidRoleName` constant from `RoleManagementServiceImplTest`.
* Updated the `testAddRoleInvalidRoleName` and `testUpdateRoleInvalidRoleName` methods to use a data provider for testing various invalid role names and their expected error messages.

## Testing

### Create Roles
https://github.com/user-attachments/assets/cb15e84a-796d-4056-a2a0-2e05db8bc42d

### Update Roles
https://github.com/user-attachments/assets/13155748-66a7-4643-a43e-689b3e1b74c9

### Max length
https://github.com/user-attachments/assets/5451718b-30d9-4dc7-a68b-d500a01928d6

## Related PRs
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/627