### PR TITLE
Add impersonatee to the SessionContext

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/SessionContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/SessionContext.java
@@ -39,6 +39,7 @@ public class SessionContext implements Serializable {
     private SessionAuthHistory sessionAuthHistory = new SessionAuthHistory();
     // This authenticatedIdPsOfApp has the mapping of application and the map of authenticated IDPs.
     private Map<String, Map<String, AuthenticatedIdPData>> authenticatedIdPsOfApp;
+    private String impersonatedUser;
 
     public Map<String, SequenceConfig> getAuthenticatedSequences() {
         return authenticatedSequences;
@@ -72,6 +73,16 @@ public class SessionContext implements Serializable {
             this.authenticatedIdPsOfApp = new HashMap<>();
         }
         this.authenticatedIdPsOfApp.put(app, authenticatedIdPsOfApp);
+    }
+
+    public String getImpersonatedUser() {
+
+        return impersonatedUser;
+    }
+
+    public void setImpersonatedUser(String impersonatedUser) {
+
+        this.impersonatedUser = impersonatedUser;
     }
 
     public boolean isRememberMe() {


### PR DESCRIPTION
### Proposed changes in this pull request
- $subject to store impersonation information in the session context.

> Note: We will only be allowing one user get impersonated per a session. This is why we are using string type. Since impersonation is a critical operation and such a requirement will not be provided in the future as we have other ways to achieve multiple user impersonation by a single user (using different browsers.).

### Related Issues:
- https://github.com/wso2/product-is/issues/23462