### PR TITLE
Add validation for admin password reset config updates.

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2014 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -130,6 +130,17 @@ public class IdPManagementConstants {
             "Recovery.Notification.Password.OTP.SendOTPInEmail";
     public static final String SMS_OTP_PASSWORD_RECOVERY_PROPERTY
             = "Recovery.Notification.Password.smsOtp.Enable";
+
+    // Resident IDP forced password reset configs.
+    public static final String ENABLE_ADMIN_PASSWORD_RESET_OFFLINE_PROPERTY = "Recovery.AdminPasswordReset.Offline";
+    public static final String ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP_PROPERTY = "Recovery.AdminPasswordReset.OTP";
+    public static final String ENABLE_ADMIN_PASSWORD_RESET_WITH_LINK_PROPERTY = "Recovery.AdminPasswordReset" +
+            ".RecoveryLink";
+
+    // Resident IDP forced password reset options.
+    public static final String EMAIL_OTP = "Email OTP";
+    public static final String EMAIL_LINK = "Email Link";
+    public static final String OFFLINE = "Offline";
 
     // User defined federated authenticator related constants.
     public static final String USER_DEFINED_AUTHENTICATOR_NAME_REGEX = "^custom-[a-zA-Z0-9-_]{3,}$";

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
@@ -133,8 +133,8 @@ public class IdPManagementConstants {
 
     // Resident IDP forced password reset configs.
     public static final String ENABLE_ADMIN_PASSWORD_RESET_OFFLINE_PROPERTY = "Recovery.AdminPasswordReset.Offline";
-    public static final String ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP_PROPERTY = "Recovery.AdminPasswordReset.OTP";
-    public static final String ENABLE_ADMIN_PASSWORD_RESET_WITH_LINK_PROPERTY = "Recovery.AdminPasswordReset" +
+    public static final String ENABLE_ADMIN_PASSWORD_RESET_EMAIL_OTP_PROPERTY = "Recovery.AdminPasswordReset.OTP";
+    public static final String ENABLE_ADMIN_PASSWORD_RESET_EMAIL_LINK_PROPERTY = "Recovery.AdminPasswordReset" +
             ".RecoveryLink";
 
     // Resident IDP forced password reset options.

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
@@ -46,8 +46,8 @@ import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.EMAIL_LINK_PAS
 import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.EMAIL_OTP;
 import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.EMAIL_OTP_PASSWORD_RECOVERY_PROPERTY;
 import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.ENABLE_ADMIN_PASSWORD_RESET_OFFLINE_PROPERTY;
-import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP_PROPERTY;
-import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.ENABLE_ADMIN_PASSWORD_RESET_WITH_LINK_PROPERTY;
+import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.ENABLE_ADMIN_PASSWORD_RESET_EMAIL_OTP_PROPERTY;
+import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.ENABLE_ADMIN_PASSWORD_RESET_EMAIL_LINK_PROPERTY;
 import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.NOTIFICATION_PASSWORD_ENABLE_PROPERTY;
 import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.OFFLINE;
 import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.PRESERVE_LOCALLY_ADDED_CLAIMS;
@@ -447,15 +447,15 @@ public class IdPManagementUtil {
             throws IdentityProviderManagementClientException {
 
         if (configurationDetails.containsKey(ENABLE_ADMIN_PASSWORD_RESET_OFFLINE_PROPERTY) ||
-                configurationDetails.containsKey(ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP_PROPERTY) ||
-                configurationDetails.containsKey(ENABLE_ADMIN_PASSWORD_RESET_WITH_LINK_PROPERTY)) {
+                configurationDetails.containsKey(ENABLE_ADMIN_PASSWORD_RESET_EMAIL_OTP_PROPERTY) ||
+                configurationDetails.containsKey(ENABLE_ADMIN_PASSWORD_RESET_EMAIL_LINK_PROPERTY)) {
 
             String adminPasswordResetOfflineProp =
                     configurationDetails.get(ENABLE_ADMIN_PASSWORD_RESET_OFFLINE_PROPERTY);
             String adminPasswordResetEmailOtpProp =
-                    configurationDetails.get(ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP_PROPERTY);
+                    configurationDetails.get(ENABLE_ADMIN_PASSWORD_RESET_EMAIL_OTP_PROPERTY);
             String adminPasswordResetEmailLinkProp =
-                    configurationDetails.get(ENABLE_ADMIN_PASSWORD_RESET_WITH_LINK_PROPERTY);
+                    configurationDetails.get(ENABLE_ADMIN_PASSWORD_RESET_EMAIL_LINK_PROPERTY);
 
             boolean isAdminPasswordResetOfflineEnabled = Boolean.parseBoolean(adminPasswordResetOfflineProp);
             boolean isAdminPasswordResetEmailOtpEnabled = Boolean.parseBoolean(adminPasswordResetEmailOtpProp);
@@ -473,10 +473,10 @@ public class IdPManagementUtil {
                 if (ENABLE_ADMIN_PASSWORD_RESET_OFFLINE_PROPERTY.equals(identityMgtProperty.getName())) {
                     isAdminPasswordResetOfflineCurrentlyEnabled =
                             Boolean.parseBoolean(identityMgtProperty.getValue());
-                } else if (ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP_PROPERTY.equals(identityMgtProperty.getName())) {
+                } else if (ENABLE_ADMIN_PASSWORD_RESET_EMAIL_OTP_PROPERTY.equals(identityMgtProperty.getName())) {
                     isAdminPasswordResetEmailOtpCurrentlyEnabled =
                             Boolean.parseBoolean(identityMgtProperty.getValue());
-                } else if (ENABLE_ADMIN_PASSWORD_RESET_WITH_LINK_PROPERTY.equals(identityMgtProperty.getName())) {
+                } else if (ENABLE_ADMIN_PASSWORD_RESET_EMAIL_LINK_PROPERTY.equals(identityMgtProperty.getName())) {
                     isAdminPasswordResetEmailLinkCurrentlyEnabled =
                             Boolean.parseBoolean(identityMgtProperty.getValue());
                 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtilTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtilTest.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -51,6 +51,9 @@ import static org.wso2.carbon.identity.application.common.util.IdentityApplicati
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.REMEMBER_ME_TIME_OUT_DEFAULT;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.SESSION_IDLE_TIME_OUT;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.SESSION_IDLE_TIME_OUT_DEFAULT;
+import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.ENABLE_ADMIN_PASSWORD_RESET_OFFLINE_PROPERTY;
+import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.ENABLE_ADMIN_PASSWORD_RESET_WITH_LINK_PROPERTY;
+import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP_PROPERTY;
 
 /**
  * Unit tests for IdPManagementUtil.
@@ -317,6 +320,23 @@ public class IdPManagementUtilTest {
         }
     }
 
+    @Test(dataProvider = "adminPasswordResetConfigs")
+    public void testValidateAdminPasswordResetWithCurrentAndPreviousConfigs(HashMap<String, String> configs, IdentityProviderProperty[] identityProviderProperties,boolean isValid) {
+
+        try {
+            IdPManagementUtil.validateAdminPasswordResetWithCurrentAndPreviousConfigs(configs,
+                    identityProviderProperties);
+
+            if (!isValid) {
+                Assert.fail("Expected an  IdentityProviderManagementClientException but no exception was thrown.");
+            }
+        } catch (IdentityProviderManagementClientException e) {
+            if (isValid) {
+                Assert.fail("Did not expect IdentityProviderManagementClientException.", e);
+            }
+        }
+    }
+
     @Test(dataProvider = "passwordRecoveryConfigsWithIdpMgtProps")
     public void testValidatePasswordRecoveryWithCurrentAndPreviousConfigs(HashMap<String, String> configs,
                                                                           IdentityProviderProperty[] identityProviderProperties,
@@ -336,6 +356,60 @@ public class IdPManagementUtilTest {
         }
 
     }
+
+    @DataProvider(name = "adminPasswordResetConfigs")
+    public Object[][] setAdminPasswordResetConfigs() {
+
+        IdentityProviderProperty[] adminPasswordResetIdentityPropsAllFalse =
+                getAdminPasswordResetIdentityProviderProperties(false,
+                        false, false);
+
+        IdentityProviderProperty[] adminPasswordResetIdentityPropsEmailLinkEnabled =
+                getAdminPasswordResetIdentityProviderProperties(true, false, false);
+
+        IdentityProviderProperty[] adminPasswordResetIdentityPropsEmailOtpEnabled =
+                getAdminPasswordResetIdentityProviderProperties(false, true, false);
+
+        IdentityProviderProperty[] adminPasswordResetIdentityPropsOfflineEnabled =
+                getAdminPasswordResetIdentityProviderProperties(false, false, true);
+
+        HashMap<String, String> adminPasswordResetConfig1 = getAdminPasswordResetConfigs(true, null, null);
+
+        HashMap<String, String> adminPasswordResetConfig2 = getAdminPasswordResetConfigs(null, true, null);
+
+        HashMap<String, String> adminPasswordResetConfig3 = getAdminPasswordResetConfigs(null, null, true);
+
+        HashMap<String, String> adminPasswordResetConfig4 = getAdminPasswordResetConfigs(null, null, null);
+
+        HashMap<String, String> adminPasswordResetConfig5 = getAdminPasswordResetConfigs(true, true, null);
+
+        HashMap<String, String> adminPasswordResetConfig6 = getAdminPasswordResetConfigs(null, true, null);
+
+        HashMap<String, String> adminPasswordResetConfig7 = getAdminPasswordResetConfigs(null, null, true);
+
+        HashMap<String, String> adminPasswordResetConfig8 = getAdminPasswordResetConfigs(false, true, null);
+
+        HashMap<String, String> adminPasswordResetConfig9 = getAdminPasswordResetConfigs(false, null, null);
+
+        HashMap<String, String> adminPasswordResetConfig10 = getAdminPasswordResetConfigs(null, null, true);
+
+        HashMap<String, String> adminPasswordResetConfig11 = getAdminPasswordResetConfigs(true, null, null);
+
+        return new Object[][]{
+                {adminPasswordResetConfig1, adminPasswordResetIdentityPropsAllFalse, true},
+                {adminPasswordResetConfig2, adminPasswordResetIdentityPropsAllFalse, true},
+                {adminPasswordResetConfig3, adminPasswordResetIdentityPropsAllFalse, true},
+                {adminPasswordResetConfig4, adminPasswordResetIdentityPropsAllFalse, true},
+                {adminPasswordResetConfig5, adminPasswordResetIdentityPropsAllFalse, false},
+                {adminPasswordResetConfig6, adminPasswordResetIdentityPropsEmailLinkEnabled, false},
+                {adminPasswordResetConfig7, adminPasswordResetIdentityPropsEmailLinkEnabled, false},
+                {adminPasswordResetConfig8, adminPasswordResetIdentityPropsEmailLinkEnabled, true},
+                {adminPasswordResetConfig9, adminPasswordResetIdentityPropsEmailLinkEnabled, true},
+                {adminPasswordResetConfig10, adminPasswordResetIdentityPropsEmailOtpEnabled, false},
+                {adminPasswordResetConfig11, adminPasswordResetIdentityPropsOfflineEnabled, false}
+        };
+    }
+
 
     @DataProvider(name = "passwordRecoveryConfigsWithIdpMgtProps")
     public Object[][] setPasswordRecoveryConfigsWithIpdMgtProps() {
@@ -469,6 +543,47 @@ public class IdPManagementUtilTest {
                 identityProviderProperty2,
                 identityProviderProperty3,
                 identityProviderProperty4
+        };
+    }
+
+    private HashMap<String, String> getAdminPasswordResetConfigs(Boolean isEmailLinkEnabled,
+                                                                 Boolean isEmailOtpEnabled, Boolean isOffilneEnabled) {
+
+        HashMap<String, String> configs = new HashMap<>();
+        if (isEmailLinkEnabled != null) {
+            configs.put(ENABLE_ADMIN_PASSWORD_RESET_WITH_LINK_PROPERTY,
+                    isEmailLinkEnabled ? TRUE_STRING : FALSE_STRING);
+        }
+        if (isEmailOtpEnabled != null) {
+            configs.put(ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP_PROPERTY,
+                    isEmailOtpEnabled ? TRUE_STRING : FALSE_STRING);
+        }
+        if (isOffilneEnabled != null) {
+            configs.put(ENABLE_ADMIN_PASSWORD_RESET_OFFLINE_PROPERTY,
+                    isOffilneEnabled ? TRUE_STRING : FALSE_STRING);
+        }
+        return configs;
+    }
+
+    private IdentityProviderProperty[] getAdminPasswordResetIdentityProviderProperties(
+            boolean isEmailLinkEnabled, boolean isEmailOtpEnabled, boolean isOfflineEnabled) {
+
+        IdentityProviderProperty identityProviderProperty1 = new IdentityProviderProperty();
+        identityProviderProperty1.setName(ENABLE_ADMIN_PASSWORD_RESET_WITH_LINK_PROPERTY);
+        identityProviderProperty1.setValue(isEmailLinkEnabled ? TRUE_STRING : FALSE_STRING);
+
+        IdentityProviderProperty identityProviderProperty2 = new IdentityProviderProperty();
+        identityProviderProperty2.setName(ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP_PROPERTY);
+        identityProviderProperty2.setValue(isEmailOtpEnabled ? TRUE_STRING : FALSE_STRING);
+
+        IdentityProviderProperty identityProviderProperty3 = new IdentityProviderProperty();
+        identityProviderProperty3.setName(ENABLE_ADMIN_PASSWORD_RESET_OFFLINE_PROPERTY);
+        identityProviderProperty3.setValue(isOfflineEnabled ? TRUE_STRING : FALSE_STRING);
+
+        return new IdentityProviderProperty[]{
+                identityProviderProperty1,
+                identityProviderProperty2,
+                identityProviderProperty3
         };
     }
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtilTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtilTest.java
@@ -52,8 +52,8 @@ import static org.wso2.carbon.identity.application.common.util.IdentityApplicati
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.SESSION_IDLE_TIME_OUT;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.SESSION_IDLE_TIME_OUT_DEFAULT;
 import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.ENABLE_ADMIN_PASSWORD_RESET_OFFLINE_PROPERTY;
-import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.ENABLE_ADMIN_PASSWORD_RESET_WITH_LINK_PROPERTY;
-import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP_PROPERTY;
+import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.ENABLE_ADMIN_PASSWORD_RESET_EMAIL_LINK_PROPERTY;
+import static org.wso2.carbon.idp.mgt.util.IdPManagementConstants.ENABLE_ADMIN_PASSWORD_RESET_EMAIL_OTP_PROPERTY;
 
 /**
  * Unit tests for IdPManagementUtil.
@@ -551,11 +551,11 @@ public class IdPManagementUtilTest {
 
         HashMap<String, String> configs = new HashMap<>();
         if (isEmailLinkEnabled != null) {
-            configs.put(ENABLE_ADMIN_PASSWORD_RESET_WITH_LINK_PROPERTY,
+            configs.put(ENABLE_ADMIN_PASSWORD_RESET_EMAIL_LINK_PROPERTY,
                     isEmailLinkEnabled ? TRUE_STRING : FALSE_STRING);
         }
         if (isEmailOtpEnabled != null) {
-            configs.put(ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP_PROPERTY,
+            configs.put(ENABLE_ADMIN_PASSWORD_RESET_EMAIL_OTP_PROPERTY,
                     isEmailOtpEnabled ? TRUE_STRING : FALSE_STRING);
         }
         if (isOffilneEnabled != null) {
@@ -569,11 +569,11 @@ public class IdPManagementUtilTest {
             boolean isEmailLinkEnabled, boolean isEmailOtpEnabled, boolean isOfflineEnabled) {
 
         IdentityProviderProperty identityProviderProperty1 = new IdentityProviderProperty();
-        identityProviderProperty1.setName(ENABLE_ADMIN_PASSWORD_RESET_WITH_LINK_PROPERTY);
+        identityProviderProperty1.setName(ENABLE_ADMIN_PASSWORD_RESET_EMAIL_LINK_PROPERTY);
         identityProviderProperty1.setValue(isEmailLinkEnabled ? TRUE_STRING : FALSE_STRING);
 
         IdentityProviderProperty identityProviderProperty2 = new IdentityProviderProperty();
-        identityProviderProperty2.setName(ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP_PROPERTY);
+        identityProviderProperty2.setName(ENABLE_ADMIN_PASSWORD_RESET_EMAIL_OTP_PROPERTY);
         identityProviderProperty2.setValue(isEmailOtpEnabled ? TRUE_STRING : FALSE_STRING);
 
         IdentityProviderProperty identityProviderProperty3 = new IdentityProviderProperty();


### PR DESCRIPTION
### Purpose
- $subject

### Related issues
- https://github.com/wso2/product-is/issues/23660

### Approach
- With changes now only one of the below governance configs can be enabled for a given time,
  - Email Link - `Recovery.AdminPasswordReset.RecoveryLink`
  - Email OTP - `Recovery.AdminPasswordReset.OTP`
  - Offline - `Recovery.AdminPasswordReset.Offline`
- Additionally this will compare the current configuration if user not updating all configs at once.
  - For example, now user will not able enable email OTP option when email Link is already enabled.