### PR TITLE
Implement logic to initialize the tenant registry for managing keystores

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityKeyStoreResolverConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityKeyStoreResolverConstants.java
@@ -124,6 +124,8 @@ public class IdentityKeyStoreResolverConstants {
                 "IKSR-10010", "Error retrieving context public certificate. Keystore doesn't exist.",
                 "Error occurred when retrieving context certificate for tenant: %s. " +
                         "Context Keystore doesn't exist."),
+        ERROR_WHILE_LOADING_REGISTRY("IKSR-10011", "Error while loading registry.",
+                "Error occurred while loading registry for tenant: %s."),
 
         // Errors occurred within the IdentityKeyStoreResolver
         ERROR_CODE_INVALID_ARGUMENT(


### PR DESCRIPTION
### Purpose
This will add code to initialize the tenant registry for retrieving tenanted keystore data. Registry initialization will be skipped for the SUPER tenant and CUSTOM keystores, as they are read directly at the file level.

### Related Issue
- https://github.com/wso2/product-is/issues/20564
