### PR TITLE
Fix the password  recovery config correction issue.

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -1005,6 +1005,7 @@ public class IdPManagementDAO {
         List<IdentityProviderProperty> idpProperties = new ArrayList<IdentityProviderProperty>();
         boolean isRecoveryNotificationPasswordRecoveryEnabled = false;
         boolean isEmailLinkNotificationPasswordRecoveryEnabled = false;
+        boolean isEmailOTPNotificationPasswordRecoveryEnabled = false;
         boolean isSmsOtpNotificationPasswordRecoveryEnabled = false;
 
         boolean isUsernameRecoveryEnabled = false;
@@ -1028,6 +1029,10 @@ public class IdPManagementDAO {
                     isEmailLinkNotificationPasswordRecoveryEnabled =
                             Boolean.parseBoolean(rs.getString("VALUE"));
                 }
+                if (IdPManagementConstants.EMAIL_OTP_PASSWORD_RECOVERY_PROPERTY.equals(property.getName())) {
+                    isEmailOTPNotificationPasswordRecoveryEnabled =
+                            Boolean.parseBoolean(rs.getString("VALUE"));
+                }
                 if (IdPManagementConstants.SMS_OTP_PASSWORD_RECOVERY_PROPERTY.equals(property.getName())) {
                     isSmsOtpNotificationPasswordRecoveryEnabled =
                             Boolean.parseBoolean(rs.getString("VALUE"));
@@ -1046,8 +1051,8 @@ public class IdPManagementDAO {
                 idpProperties.add(property);
             }
             // If recovery notification are inconsistent, correct the configurations.
-            if (isRecoveryNotificationPasswordRecoveryEnabled && !isEmailLinkNotificationPasswordRecoveryEnabled
-                    && !isSmsOtpNotificationPasswordRecoveryEnabled) {
+            if (isRecoveryNotificationPasswordRecoveryEnabled && !isEmailLinkNotificationPasswordRecoveryEnabled &&
+                    !isEmailOTPNotificationPasswordRecoveryEnabled && !isSmsOtpNotificationPasswordRecoveryEnabled) {
                 performConfigCorrectionForPasswordRecoveryConfigs(dbConnection, tenantId, idpId, idpProperties);
             }
             // If username recovery configs are inconsistent, correct the configurations.

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
@@ -1869,7 +1869,11 @@ public class IdPManagementDAOTest {
         identityProviderProperty.setDisplayName("idpDisplayName");
         identityProviderProperty.setName("idpPropertyName");
         identityProviderProperty.setValue("idpPropertyValue");
-        idp1.setIdpProperties(new IdentityProviderProperty[]{identityProviderProperty});
+
+        IdentityProviderProperty idpProp2 = new IdentityProviderProperty();
+        idpProp2.setValue("true");
+        idpProp2.setName(IdPManagementConstants.EMAIL_OTP_PASSWORD_RECOVERY_PROPERTY);
+        idp1.setIdpProperties(new IdentityProviderProperty[]{identityProviderProperty, idpProp2});
 
         ClaimConfig claimConfig = new ClaimConfig();
         claimConfig.setLocalClaimDialect(false);


### PR DESCRIPTION
### Purpose
- $subject

### Description
- This password correction method is auto enabling the email link option when the parent password recovery config is enabled.
- But in the previous logic email OTP config hasn't consider when deciding to perform the password recovery config correction.
- With this PR we are adding that missed additional email OTP check.
