### PR TITLE
Add flow initiator claim property 

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/UnifiedClaimMetadataManager.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/UnifiedClaimMetadataManager.java
@@ -173,13 +173,9 @@ public class UnifiedClaimMetadataManager implements ReadWriteClaimMetadataManage
             });
         });
 
-        //If Transactional claim property is missing in localClaimsInDB, set it to default value.
+        // If SharedProfileValueResolvingMethod, FlowInitiator claim property are missing in localClaimsInDB, set it to default value.
         for (LocalClaim localClaim : localClaimMap.values()) {
-            setTransactionalAttributeProperty(localClaim.getClaimURI(), tenantId, localClaim);
-        }
-
-        // If SharedProfileValueResolvingMethod is missing in localClaimsInDB, set it to default value.
-        for (LocalClaim localClaim : localClaimMap.values()) {
+            setFlowInitiatorClaimProperty(localClaim.getClaimURI(), tenantId, localClaim);
             setDefaultSharedProfileValueResolvingMethod(localClaim.getClaimURI(), tenantId, localClaim);
         }
 
@@ -245,28 +241,17 @@ public class UnifiedClaimMetadataManager implements ReadWriteClaimMetadataManage
         }
     }
 
-    private void setTransactionalAttributeProperty(String localClaimURI, int tenantId,
-                                                   LocalClaim localClaimInDB) throws ClaimMetadataException {
+    private void setFlowInitiatorClaimProperty(String localClaimURI, int tenantId,
+                                               LocalClaim localClaimInDB) throws ClaimMetadataException {
 
-        String transactionalAttribute = localClaimInDB.getClaimProperty(ClaimConstants.TRANSACTIONAL);
-        if (StringUtils.isNotBlank(transactionalAttribute)) {
-            return;
-        }
         // If the claim is a system claim, get the default value set in the system default claim metadata.
         if (isSystemDefaultLocalClaim(localClaimURI, tenantId)) {
             Optional<LocalClaim> localClaimInSystem = this.systemDefaultClaimMetadataManager.getLocalClaim(
                     localClaimURI, tenantId);
             if (localClaimInSystem.isPresent()) {
-                String systemDefaultTransactionalAttribute = localClaimInSystem.get()
-                        .getClaimProperty(ClaimConstants.TRANSACTIONAL);
-                if (StringUtils.isNotBlank(systemDefaultTransactionalAttribute)) {
-                    localClaimInDB.setClaimProperty(ClaimConstants.TRANSACTIONAL,
-                            systemDefaultTransactionalAttribute);
-                } else {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(String.format("Transactional property is not defined for the system " +
-                                "claim: %s", localClaimURI));
-                    }
+                String flowInitiatorProperty = localClaimInSystem.get().getClaimProperty(ClaimConstants.FLOW_INITIATOR);
+                if (StringUtils.isNotBlank(flowInitiatorProperty)) {
+                    localClaimInDB.setClaimProperty(ClaimConstants.FLOW_INITIATOR, flowInitiatorProperty);
                 }
             }
         }
@@ -281,7 +266,6 @@ public class UnifiedClaimMetadataManager implements ReadWriteClaimMetadataManage
      */
     public void addLocalClaim(LocalClaim localClaim, int tenantId) throws ClaimMetadataException {
 
-        localClaim.getClaimProperties().remove(ClaimConstants.IS_SYSTEM_CLAIM);
         validateNonModifiableClaimProperties(localClaim);
         if (!isClaimDialectInDB(ClaimConstants.LOCAL_CLAIM_DIALECT_URI, tenantId)) {
             addSystemDefaultDialectToDB(ClaimConstants.LOCAL_CLAIM_DIALECT_URI, tenantId);
@@ -298,7 +282,6 @@ public class UnifiedClaimMetadataManager implements ReadWriteClaimMetadataManage
      */
     public void updateLocalClaim(LocalClaim localClaim, int tenantId) throws ClaimMetadataException {
 
-        localClaim.getClaimProperties().remove(ClaimConstants.IS_SYSTEM_CLAIM);
         validateNonModifiableClaimProperties(localClaim);
         if (isLocalClaimInDB(localClaim.getClaimURI(), tenantId)) {
             this.dbBasedClaimMetadataManager.updateLocalClaim(localClaim, tenantId);
@@ -672,10 +655,12 @@ public class UnifiedClaimMetadataManager implements ReadWriteClaimMetadataManage
 
     private void validateNonModifiableClaimProperties(LocalClaim localClaim) throws ClaimMetadataClientException {
 
-        if (localClaim.getClaimProperty(ClaimConstants.TRANSACTIONAL) != null) {
+        //isSystemClaim is removed without throwing an exception to make it non-modifiable to preserve backward compatibility.
+        localClaim.getClaimProperties().remove(ClaimConstants.IS_SYSTEM_CLAIM);
+        if (localClaim.getClaimProperty(ClaimConstants.FLOW_INITIATOR) != null) {
             throw new ClaimMetadataClientException(
-                    ClaimConstants.ErrorMessage.ERROR_CODE_CANNOT_MODIFY_TRANSACTIONAL_CLAIM_PROPERTY.getCode(),
-                    String.format(ClaimConstants.ErrorMessage.ERROR_CODE_CANNOT_MODIFY_TRANSACTIONAL_CLAIM_PROPERTY
+                    ClaimConstants.ErrorMessage.ERROR_CODE_CANNOT_MODIFY_FLOW_INITIATOR_CLAIM_PROPERTY.getCode(),
+                    String.format(ClaimConstants.ErrorMessage.ERROR_CODE_CANNOT_MODIFY_FLOW_INITIATOR_CLAIM_PROPERTY
                                     .getMessage(), localClaim.getClaimURI()));
         }
 

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/UnifiedClaimMetadataManager.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/UnifiedClaimMetadataManager.java
@@ -173,9 +173,10 @@ public class UnifiedClaimMetadataManager implements ReadWriteClaimMetadataManage
             });
         });
 
-        // If SharedProfileValueResolvingMethod, FlowInitiator claim property are missing in localClaimsInDB, set it to default value.
         for (LocalClaim localClaim : localClaimMap.values()) {
+            // If FlowInitiator claim property is present in localClaimsInDB, set it to system value.
             setFlowInitiatorClaimProperty(localClaim.getClaimURI(), tenantId, localClaim);
+            // If SharedProfileValueResolvingMethod is missing in localClaimsInDB, set it to default value.
             setDefaultSharedProfileValueResolvingMethod(localClaim.getClaimURI(), tenantId, localClaim);
         }
 
@@ -244,15 +245,17 @@ public class UnifiedClaimMetadataManager implements ReadWriteClaimMetadataManage
     private void setFlowInitiatorClaimProperty(String localClaimURI, int tenantId,
                                                LocalClaim localClaimInDB) throws ClaimMetadataException {
 
+        if (!isSystemDefaultLocalClaim(localClaimURI, tenantId)) {
+            return;
+        }
+
         // If the claim is a system claim, get the default value set in the system default claim metadata.
-        if (isSystemDefaultLocalClaim(localClaimURI, tenantId)) {
-            Optional<LocalClaim> localClaimInSystem = this.systemDefaultClaimMetadataManager.getLocalClaim(
-                    localClaimURI, tenantId);
-            if (localClaimInSystem.isPresent()) {
-                String flowInitiatorProperty = localClaimInSystem.get().getClaimProperty(ClaimConstants.FLOW_INITIATOR);
-                if (StringUtils.isNotBlank(flowInitiatorProperty)) {
-                    localClaimInDB.setClaimProperty(ClaimConstants.FLOW_INITIATOR, flowInitiatorProperty);
-                }
+        Optional<LocalClaim> localClaimInSystem = this.systemDefaultClaimMetadataManager.getLocalClaim(
+                localClaimURI, tenantId);
+        if (localClaimInSystem.isPresent()) {
+            String flowInitiatorProperty = localClaimInSystem.get().getClaimProperty(ClaimConstants.FLOW_INITIATOR);
+            if (StringUtils.isNotBlank(flowInitiatorProperty)) {
+                localClaimInDB.setClaimProperty(ClaimConstants.FLOW_INITIATOR, flowInitiatorProperty);
             }
         }
     }

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/model/Claim.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/model/Claim.java
@@ -16,6 +16,8 @@
 
 package org.wso2.carbon.identity.claim.metadata.mgt.model;
 
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -64,6 +66,10 @@ public class Claim implements Serializable {
             return this.getClaimProperties().get(propertyName);
         }
         return null;
+    }
+
+    public boolean getFlowInitiator() {
+        return Boolean.parseBoolean(this.getClaimProperties().get(ClaimConstants.FLOW_INITIATOR));
     }
 
     public void setClaimProperties(Map<String, String> claimProperties) {

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/model/Claim.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/model/Claim.java
@@ -69,6 +69,7 @@ public class Claim implements Serializable {
     }
 
     public boolean getFlowInitiator() {
+
         return Boolean.parseBoolean(this.getClaimProperties().get(ClaimConstants.FLOW_INITIATOR));
     }
 

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
@@ -54,6 +54,7 @@ public class ClaimConstants {
     public static final String MAX_LENGTH = "maxLength";
     public static final String IS_SYSTEM_CLAIM = "isSystemClaim";
     public static final String SHARED_PROFILE_VALUE_RESOLVING_METHOD = "SharedProfileValueResolvingMethod";
+    public static final String TRANSACTIONAL = "Transactional";
     public static final String EXTERNAL_CLAIM_ADDITION_NOT_ALLOWED_FOR_DIALECT =
             "ExternalClaimAdditionNotAllowedForDialect";
     public static final String MULTI_VALUED_PROPERTY = "multiValued";
@@ -117,6 +118,8 @@ public class ClaimConstants {
         ERROR_CODE_INVALID_ATTRIBUTE_PROFILE("CMT-600015", "Invalid attribute profile name."),
         ERROR_CODE_CANNOT_ADD_TO_EXTERNAL_DIALECT("CMT-60016",
                 "Adding claims to dialect %s is not allowed"),
+        ERROR_CODE_CANNOT_MODIFY_TRANSACTIONAL_CLAIM_PROPERTY("CMT-60017",
+                "Cannot change transactional property of the system claim: %s"),
 
         // Server Errors
         ERROR_CODE_DELETE_IDN_CLAIM_MAPPED_ATTRIBUTE("65001", "Error occurred while deleting claim " +

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
@@ -54,7 +54,7 @@ public class ClaimConstants {
     public static final String MAX_LENGTH = "maxLength";
     public static final String IS_SYSTEM_CLAIM = "isSystemClaim";
     public static final String SHARED_PROFILE_VALUE_RESOLVING_METHOD = "SharedProfileValueResolvingMethod";
-    public static final String TRANSACTIONAL = "Transactional";
+    public static final String FLOW_INITIATOR = "FlowInitiator";
     public static final String EXTERNAL_CLAIM_ADDITION_NOT_ALLOWED_FOR_DIALECT =
             "ExternalClaimAdditionNotAllowedForDialect";
     public static final String MULTI_VALUED_PROPERTY = "multiValued";
@@ -118,8 +118,8 @@ public class ClaimConstants {
         ERROR_CODE_INVALID_ATTRIBUTE_PROFILE("CMT-600015", "Invalid attribute profile name."),
         ERROR_CODE_CANNOT_ADD_TO_EXTERNAL_DIALECT("CMT-60016",
                 "Adding claims to dialect %s is not allowed"),
-        ERROR_CODE_CANNOT_MODIFY_TRANSACTIONAL_CLAIM_PROPERTY("CMT-60017",
-                "Cannot change transactional property of the system claim: %s"),
+        ERROR_CODE_CANNOT_MODIFY_FLOW_INITIATOR_CLAIM_PROPERTY("CMT-60017",
+                "Cannot change flow initiator property of the system claim: %s"),
 
         // Server Errors
         ERROR_CODE_DELETE_IDN_CLAIM_MAPPED_ATTRIBUTE("65001", "Error occurred while deleting claim " +

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -479,7 +479,7 @@
 				<AttributeID>verifyEmail</AttributeID>
 				<Description>Temporary claim to invoke email verified feature</Description>
 				<SharedProfileValueResolvingMethod>FromOrigin</SharedProfileValueResolvingMethod>
-				<Transactional>True</Transactional>
+				<FlowInitiator>True</FlowInitiator>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/identity/askPassword</ClaimURI>
@@ -489,7 +489,7 @@
 				<AttributeID>askPassword</AttributeID>
 				<Description>Temporary claim to invoke email ask Password feature</Description>
 				<SharedProfileValueResolvingMethod>FromOrigin</SharedProfileValueResolvingMethod>
-				<Transactional>True</Transactional>
+				<FlowInitiator>True</FlowInitiator>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/identity/tenantAdminAskPassword</ClaimURI>
@@ -508,7 +508,7 @@
 				<AttributeID>forcePasswordReset</AttributeID>
 				<Description>Temporary claim to invoke email force password feature</Description>
 				<SharedProfileValueResolvingMethod>FromOrigin</SharedProfileValueResolvingMethod>
-				<Transactional>True</Transactional>
+				<FlowInitiator>True</FlowInitiator>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/entitlements</ClaimURI>
@@ -832,7 +832,7 @@
 				<AttributeID>verifyMobile</AttributeID>
 				<Description>Temporary claim to invoke mobile verification feature</Description>
 				<SharedProfileValueResolvingMethod>FromOrigin</SharedProfileValueResolvingMethod>
-				<Transactional>True</Transactional>
+				<FlowInitiator>True</FlowInitiator>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/identity/userSourceId</ClaimURI>

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -479,6 +479,7 @@
 				<AttributeID>verifyEmail</AttributeID>
 				<Description>Temporary claim to invoke email verified feature</Description>
 				<SharedProfileValueResolvingMethod>FromOrigin</SharedProfileValueResolvingMethod>
+				<Transactional>True</Transactional>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/identity/askPassword</ClaimURI>
@@ -488,6 +489,7 @@
 				<AttributeID>askPassword</AttributeID>
 				<Description>Temporary claim to invoke email ask Password feature</Description>
 				<SharedProfileValueResolvingMethod>FromOrigin</SharedProfileValueResolvingMethod>
+				<Transactional>True</Transactional>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/identity/tenantAdminAskPassword</ClaimURI>
@@ -506,6 +508,7 @@
 				<AttributeID>forcePasswordReset</AttributeID>
 				<Description>Temporary claim to invoke email force password feature</Description>
 				<SharedProfileValueResolvingMethod>FromOrigin</SharedProfileValueResolvingMethod>
+				<Transactional>True</Transactional>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/entitlements</ClaimURI>
@@ -829,6 +832,7 @@
 				<AttributeID>verifyMobile</AttributeID>
 				<Description>Temporary claim to invoke mobile verification feature</Description>
 				<SharedProfileValueResolvingMethod>FromOrigin</SharedProfileValueResolvingMethod>
+				<Transactional>True</Transactional>
 			</Claim>
 			<Claim>
 				<ClaimURI>http://wso2.org/claims/identity/userSourceId</ClaimURI>


### PR DESCRIPTION
### Description

This PR introduces the flow initiator claim property for system claims.

Below system claims are identified as flow initiator claims where all the other system claims are not treated as flow initiator  claims.
- claims/identity/verifyEmail
- claims/identity/verifyMobile
- claims/identity/askPassword
- claims/identity/adminForcedPasswordReset

#### Proposed change

- The claim property is added from the claim-config.xml and overwrite the db value from the in memory value read from the config file
- The claim property is not modifiable through the claim metadata api instead throws a clientException

#### Related Issues
- https://github.com/wso2/product-is/issues/23798
