### PR TITLE
Fix sub organization CROS configuration retrieval logic

### DIFF
--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/pom.xml
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/pom.xml
@@ -52,6 +52,10 @@
             <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.eclipse.osgi</groupId>
             <artifactId>org.eclipse.osgi.services</artifactId>
         </dependency>
@@ -111,6 +115,7 @@
                             org.wso2.carbon.identity.configuration.mgt.core.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.*;version="${carbon.identity.package.import.version.range}",
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.*;version="${org.wso2.carbon.identity.organization.management.core.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.apache.commons.logging; version="${import.package.version.commons.logging}",
                             org.wso2.carbon.identity.core.cache; version="${carbon.identity.package.import.version.range}"

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/dao/CORSOriginDAO.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/dao/CORSOriginDAO.java
@@ -44,6 +44,9 @@ public interface CORSOriginDAO {
     List<CORSOrigin> getCORSOriginsByTenantId(int tenantId)
             throws CORSManagementServiceServerException;
 
+    List<CORSOrigin> getCORSOriginsByTenantDomain(String tenantDomain)
+            throws CORSManagementServiceServerException;
+
     /**
      * Get the CORS origins of a tenant that are associated with a specific application by application ID.
      *

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/dao/CORSOriginDAO.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/dao/CORSOriginDAO.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.identity.cors.mgt.core.dao;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.wso2.carbon.identity.cors.mgt.core.exception.CORSManagementServiceServerException;
 import org.wso2.carbon.identity.cors.mgt.core.model.CORSApplication;
 import org.wso2.carbon.identity.cors.mgt.core.model.CORSOrigin;
@@ -51,8 +52,11 @@ public interface CORSOriginDAO {
      * @return List of CORS origins belonging to the tenant.
      * @throws CORSManagementServiceServerException
      */
-    List<CORSOrigin> getCORSOriginsByTenantDomain(String tenantDomain)
-            throws CORSManagementServiceServerException;
+    default List<CORSOrigin> getCORSOriginsByTenantDomain(String tenantDomain)
+            throws CORSManagementServiceServerException {
+
+        throw new NotImplementedException();
+    }
 
     /**
      * Get the CORS origins of a tenant that are associated with a specific application by application ID.

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/dao/CORSOriginDAO.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/dao/CORSOriginDAO.java
@@ -44,6 +44,13 @@ public interface CORSOriginDAO {
     List<CORSOrigin> getCORSOriginsByTenantId(int tenantId)
             throws CORSManagementServiceServerException;
 
+    /**
+     * Get the CORS origins by tenant domain.
+     *
+     * @param tenantDomain The tenant domain.
+     * @return List of CORS origins belonging to the tenant.
+     * @throws CORSManagementServiceServerException
+     */
     List<CORSOrigin> getCORSOriginsByTenantDomain(String tenantDomain)
             throws CORSManagementServiceServerException;
 

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/dao/impl/CORSOriginDAOImpl.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/dao/impl/CORSOriginDAOImpl.java
@@ -105,6 +105,17 @@ public class CORSOriginDAOImpl implements CORSOriginDAO {
      * {@inheritDoc}
      */
     @Override
+    public List<CORSOrigin> getCORSOriginsByTenantDomain(String tenantDomain)
+            throws CORSManagementServiceServerException {
+
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        return getCORSOriginsByTenantId(tenantId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public List<CORSOrigin> getCORSOriginsByApplicationId(int applicationId, int tenantId)
             throws CORSManagementServiceServerException {
 

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/dao/impl/CacheBackedCORSOriginDAO.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/dao/impl/CacheBackedCORSOriginDAO.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.cors.mgt.core.dao.impl;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.cors.mgt.core.dao.CORSOriginDAO;
 import org.wso2.carbon.identity.cors.mgt.core.exception.CORSManagementServiceServerException;
 import org.wso2.carbon.identity.cors.mgt.core.internal.cache.CORSOriginByAppIdCache;
@@ -71,6 +72,17 @@ public class CacheBackedCORSOriginDAO extends CORSOriginDAOImpl {
         List<CORSOrigin> corsOrigins = corsOriginDAO.getCORSOriginsByTenantId(tenantId);
         addCORSOriginsToCache(corsOrigins.toArray(new CORSOrigin[0]), tenantId);
         return corsOrigins;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<CORSOrigin> getCORSOriginsByTenantDomain(String tenantDomain)
+            throws CORSManagementServiceServerException {
+
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        return getCORSOriginsByTenantId(tenantId);
     }
 
     /**

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/CORSManagementServiceComponent.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/CORSManagementServiceComponent.java
@@ -31,6 +31,8 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.cors.mgt.core.CORSManagementService;
 import org.wso2.carbon.identity.cors.mgt.core.internal.impl.CORSManagementServiceImpl;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
 
 /**
  * Service component class for CORS-Service.
@@ -107,5 +109,37 @@ public class CORSManagementServiceComponent {
             log.debug("Unregistering the ConfigurationManager in CORSManagementService.");
         }
         CORSManagementServiceHolder.getInstance().setConfigurationManager(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service",
+            service = OrgResourceResolverService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrgResourceResolverService")
+    protected void setOrgResourceResolverService(OrgResourceResolverService orgResourceResolverService) {
+
+        CORSManagementServiceHolder.getInstance().setOrgResourceResolverService(orgResourceResolverService);
+    }
+
+    protected void unsetOrgResourceResolverService(OrgResourceResolverService orgResourceResolverService) {
+
+        CORSManagementServiceHolder.getInstance().setOrgResourceResolverService(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.organization.management.service",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager")
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        CORSManagementServiceHolder.getInstance().setOrganizationManager(organizationManager);
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        CORSManagementServiceHolder.getInstance().setOrganizationManager(null);
     }
 }

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/CORSManagementServiceHolder.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/CORSManagementServiceHolder.java
@@ -27,6 +27,8 @@ import org.wso2.carbon.identity.cors.mgt.core.dao.impl.CORSConfigurationDAOImpl;
 import org.wso2.carbon.identity.cors.mgt.core.dao.impl.CORSOriginDAOImpl;
 import org.wso2.carbon.identity.cors.mgt.core.dao.impl.CacheBackedCORSConfigurationDAO;
 import org.wso2.carbon.identity.cors.mgt.core.dao.impl.CacheBackedCORSOriginDAO;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
 
 /**
  * Service holder class for CORS-Service.
@@ -39,6 +41,8 @@ public class CORSManagementServiceHolder {
     private CORSConfigurationDAO corsConfigurationDAO =
             new CacheBackedCORSConfigurationDAO(new CORSConfigurationDAOImpl());
     private ConfigurationManager configurationManager;
+    private OrgResourceResolverService orgResourceResolverService;
+    private OrganizationManager organizationManager;
 
     private CORSManagementServiceHolder() {
 
@@ -105,5 +109,26 @@ public class CORSManagementServiceHolder {
     private static class SingletonHelper {
 
         private static final CORSManagementServiceHolder INSTANCE = new CORSManagementServiceHolder();
+    }
+
+    public OrgResourceResolverService getOrgResourceResolverService() {
+
+        return orgResourceResolverService;
+    }
+
+    public void setOrgResourceResolverService(
+            OrgResourceResolverService orgResourceResolverService) {
+
+        this.orgResourceResolverService = orgResourceResolverService;
+    }
+
+    public OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+
+        this.organizationManager = organizationManager;
     }
 }

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/CORSManagementServiceHolder.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/CORSManagementServiceHolder.java
@@ -116,8 +116,7 @@ public class CORSManagementServiceHolder {
         return orgResourceResolverService;
     }
 
-    public void setOrgResourceResolverService(
-            OrgResourceResolverService orgResourceResolverService) {
+    public void setOrgResourceResolverService(OrgResourceResolverService orgResourceResolverService) {
 
         this.orgResourceResolverService = orgResourceResolverService;
     }

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/impl/CORSManagementServiceImpl.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/impl/CORSManagementServiceImpl.java
@@ -339,7 +339,6 @@ public class CORSManagementServiceImpl implements CORSManagementService {
                 mergedList.add(corsOrigin);
             }
         }
-
         return mergedList;
     }
 }

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/impl/CORSManagementServiceImpl.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/internal/impl/CORSManagementServiceImpl.java
@@ -25,24 +25,35 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.LambdaExceptionUtils;
 import org.wso2.carbon.identity.cors.mgt.core.CORSManagementService;
 import org.wso2.carbon.identity.cors.mgt.core.constant.ErrorMessages;
 import org.wso2.carbon.identity.cors.mgt.core.dao.CORSConfigurationDAO;
 import org.wso2.carbon.identity.cors.mgt.core.dao.CORSOriginDAO;
 import org.wso2.carbon.identity.cors.mgt.core.exception.CORSManagementServiceClientException;
 import org.wso2.carbon.identity.cors.mgt.core.exception.CORSManagementServiceException;
+import org.wso2.carbon.identity.cors.mgt.core.exception.CORSManagementServiceServerException;
 import org.wso2.carbon.identity.cors.mgt.core.internal.CORSManagementServiceHolder;
 import org.wso2.carbon.identity.cors.mgt.core.internal.util.CORSConfigurationUtils;
 import org.wso2.carbon.identity.cors.mgt.core.model.CORSApplication;
 import org.wso2.carbon.identity.cors.mgt.core.model.CORSConfiguration;
 import org.wso2.carbon.identity.cors.mgt.core.model.CORSOrigin;
 import org.wso2.carbon.identity.cors.mgt.core.model.Origin;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception.OrgResourceHierarchyTraverseException;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.strategy.MergeAllAggregationStrategy;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.wso2.carbon.identity.cors.mgt.core.constant.ErrorMessages.ERROR_CODE_CORS_CONFIG_RETRIEVE;
 import static org.wso2.carbon.identity.cors.mgt.core.constant.ErrorMessages.ERROR_CODE_DUPLICATE_ORIGINS;
 import static org.wso2.carbon.identity.cors.mgt.core.constant.ErrorMessages.ERROR_CODE_ORIGIN_NOT_PRESENT;
 import static org.wso2.carbon.identity.cors.mgt.core.constant.ErrorMessages.ERROR_CODE_ORIGIN_PRESENT;
@@ -62,9 +73,24 @@ public class CORSManagementServiceImpl implements CORSManagementService {
     @Override
     public List<CORSOrigin> getTenantCORSOrigins(String tenantDomain) throws CORSManagementServiceException {
 
-        int tenantId = getTenantId(tenantDomain);
+        List<CORSOrigin> corsOrigins;
+        OrganizationManager organizationManager = CORSManagementServiceHolder.getInstance().getOrganizationManager();
+        try {
+            String organizationId = organizationManager.resolveOrganizationId(tenantDomain);
+            OrgResourceResolverService orgResourceManagementService =
+                    CORSManagementServiceHolder.getInstance().getOrgResourceResolverService();
+            corsOrigins = orgResourceManagementService.getResourcesFromOrgHierarchy(
+                    organizationId,
+                    LambdaExceptionUtils.rethrowFunction(this::getCorsOrigins),
+                    new MergeAllAggregationStrategy<>(this::mergeAndRemoveDuplicates)
+            );
+        } catch (OrganizationManagementException | OrgResourceHierarchyTraverseException e) {
+            throw new CORSManagementServiceException(
+                    String.format(ERROR_CODE_CORS_CONFIG_RETRIEVE.getDescription(), tenantDomain),
+                    ERROR_CODE_CORS_CONFIG_RETRIEVE.getCode(), e);
+        }
 
-        return Collections.unmodifiableList(getCORSOriginDAO().getCORSOriginsByTenantId(tenantId));
+        return Collections.unmodifiableList(corsOrigins);
     }
 
     /**
@@ -291,5 +317,29 @@ public class CORSManagementServiceImpl implements CORSManagementService {
             log.error(String.format(ERROR_CODE_VALIDATE_APP_ID.getDescription(), applicationId), e);
             throw handleClientException(ERROR_CODE_VALIDATE_APP_ID, applicationId);
         }
+    }
+
+    private Optional<List<CORSOrigin>> getCorsOrigins(String orgId)
+            throws OrganizationManagementException, CORSManagementServiceServerException {
+
+        List<CORSOrigin> corsOrigins = getCORSOriginDAO().getCORSOriginsByTenantDomain(
+                CORSManagementServiceHolder.getInstance().getOrganizationManager().resolveTenantDomain(orgId));
+        return Optional.ofNullable(corsOrigins);
+    }
+
+    private List<CORSOrigin> mergeAndRemoveDuplicates(
+            List<CORSOrigin> corsOrigins, List<CORSOrigin> newCorsOrigins) {
+
+        Set<String> existingCorsOrigins = corsOrigins.stream()
+                .map(CORSOrigin::getId)
+                .collect(Collectors.toSet());
+        List<CORSOrigin> mergedList = new ArrayList<>(corsOrigins);
+        for (CORSOrigin corsOrigin : newCorsOrigins) {
+            if (!existingCorsOrigins.contains(corsOrigin.getId())) {
+                mergedList.add(corsOrigin);
+            }
+        }
+
+        return mergedList;
     }
 }

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/model/CORSOrigin.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/main/java/org/wso2/carbon/identity/cors/mgt/core/model/CORSOrigin.java
@@ -34,6 +34,23 @@ public class CORSOrigin {
     private String origin;
 
     /**
+     * Default constructor.
+     */
+    public CORSOrigin() {
+    }
+
+    /**
+     * Constructor with all params.
+     * @param id ID of the origin.
+     * @param origin The origin of the CORSOrigin instance.
+     */
+    public CORSOrigin(String id, String origin) {
+
+        this.id = id;
+        this.origin = origin;
+    }
+
+    /**
      * Get the {@code id}.
      *
      * @return Returns the {@code id}.

--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/test/java/org/wso2/carbon/identity/cors/mgt/core/constant/TestConstants.java
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/src/test/java/org/wso2/carbon/identity/cors/mgt/core/constant/TestConstants.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.cors.mgt.core.constant;
 
+import org.wso2.carbon.identity.cors.mgt.core.model.CORSOrigin;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -30,10 +32,19 @@ public class TestConstants {
             "http://foo.com",
             "http://bar.com",
             "https://foobar.com");
+
+    public static final List<CORSOrigin> SAMPLE_CORS_ORIGIN_LIST_1 = Arrays.asList(
+            new CORSOrigin("1", "http://foo.com"),
+            new CORSOrigin("2", "http://bar.com"),
+            new CORSOrigin("3", "https://foobar.com"));
     public static final List<String> SAMPLE_ORIGIN_LIST_2 = Arrays.asList(
             "http://abc.com",
             "https://pqr.com",
             "http://xyz.com");
+    public static final List<CORSOrigin> SAMPLE_CORS_ORIGIN_LIST_2 = Arrays.asList(
+            new CORSOrigin("1", "http://abc.com"),
+            new CORSOrigin("2", "https://pqr.com"),
+            new CORSOrigin("3", "http://xyz.com"));
     public static final String INSERT_APPLICATION =
             "INSERT INTO SP_APP (ID, TENANT_ID, APP_NAME, UUID) " +
                     "VALUES (?, ?, ?, ?)";

--- a/pom.xml
+++ b/pom.xml
@@ -1220,6 +1220,18 @@
                 <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
                 <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service</artifactId>
+                <version>${identity.organization.management.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-log4j2</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
             <!--Components Dependencies Ends-->
 
             <!--Composite Feature Dependency-->
@@ -1954,6 +1966,8 @@
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>
+        <identity.organization.management.version>1.4.132</identity.organization.management.version>
+        <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0, 2.0.0)</org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
         <!--Carbon registry version-->
         <org.wso2.carbon.registry.version>4.8.37</org.wso2.carbon.registry.version>


### PR DESCRIPTION
### Description
Inherit the parent organization's CORS configurations at the runtime to sub organization. This will query the hierarchy and aggregate CORS configurations from all the ancestors since the CORS configurations are at tenant level.

### Related issue
- https://github.com/wso2/product-is/issues/23775