### PR TITLE
Remove new line characters from the identity.xml.j2 template

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1513,12 +1513,8 @@
                 <ClaimURI>{{claimuri}}</ClaimURI>
             {% endfor %}
         </IndelibleClaims>
-        <AllowAssociatingToExistingUser>
-            {{authentication.jit_provisioning.associating_to_existing_user | default(true)}}
-        </AllowAssociatingToExistingUser>
-        <RetainEmailDomainOnProvisioning>
-            {{authentication.jit_provisioning.retain_email_domain_on_provisioning}}
-        </RetainEmailDomainOnProvisioning>
+        <AllowAssociatingToExistingUser>{{authentication.jit_provisioning.associating_to_existing_user | default(true)}}</AllowAssociatingToExistingUser>
+        <RetainEmailDomainOnProvisioning>{{authentication.jit_provisioning.retain_email_domain_on_provisioning}}</RetainEmailDomainOnProvisioning>
     </JITProvisioning>
 
     <!--Application management service configurations-->


### PR DESCRIPTION
### Purpose
When configuring SSO login for the APIM portals using APIM 4.4.0 and IS 7.0, a login failure occurs if a federated user from IS attempts to log in with a username that already exists as a local user in APIM. This is caused by improper evaluation of the JITProvisioning.AllowAssociatingToExistingUser configuration due to newline characters present in its value in the identity.xml.j2 template. Therefore, the isAssociationToExistingUserAllowed method incorrectly reads and evaluates the JITProvisioning.AllowAssociatingToExistingUser as a string value not a boolean.
Related Issue : https://github.com/wso2-enterprise/wso2-apim-internal/issues/9376

### Proposed changes in this pull request

This PR to removes unintended newline characters surrounding the JITProvisioning.AllowAssociatingToExistingUser and JITProvisioning.RetainEmailDomainOnProvisioning configuration values in the identity.xml.j2 template.