### PR TITLE
Add mobile logo config to mobile view in my account

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1663,6 +1663,7 @@
   "myaccount.ui.app_title": "My Account | WSO2 Identity Server",
   "myaccount.ui.app_name": "My Account",
   "myaccount.ui.app_logo_path": "/assets/images/branding/logo.svg",
+  "myaccount.ui.app_mobile_logo_path": "/assets/images/branding/logo-mini.svg",
   "myaccount.ui.app_white_logo_path": "/assets/images/branding/logo-inverted.svg",
   "myaccount.ui.is_header_avatar_label_allowed": true,
   "myaccount.ui.product_name": "WSO2 Identity Server",


### PR DESCRIPTION
## Purpose
Introduced a new configuration field `myAccount.ui.app_mobile_logo_path` in the default JSON config to support a smaller logo (`logo-mini.svg`) specifically for mobile view.

## Goals
- Show a smaller logo (`logo-mini.svg`) on mobile devices.

## Approach
- Added `myaccount.ui.app_mobile_logo_path` to the config JSON.

## Related PRs
- https://github.com/wso2/identity-apps/pull/8136

## Related Issues
product-is issue: https://github.com/wso2/product-is/issues/23750
asgardeo issue: https://github.com/wso2-enterprise/asgardeo-product/issues/30469