### PR TITLE
Add config to switch between Challenge Questions storage type

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -81,6 +81,7 @@
         <CertificateValidation>database</CertificateValidation>
         <AdminAdvisoryBanner>database</AdminAdvisoryBanner>
         <RemoteLoggingConfig>database</RemoteLoggingConfig>
+        <ChallengeQuestions>database</ChallengeQuestions>
     </DataStorageType>
 
     <!-- Time configurations are in minutes -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -92,6 +92,7 @@
         <CertificateValidation>{{data_storage_type.certificate_validation}}</CertificateValidation>
         <AdminAdvisoryBanner>{{data_storage_type.admin_advisory_banner}}</AdminAdvisoryBanner>
         <RemoteLoggingConfig>{{data_storage_type.remote_logging_config}}</RemoteLoggingConfig>
+        <ChallengeQuestions>{{data_storage_type.challenge_questions}}</ChallengeQuestions>
     </DataStorageType>
 
     <NotificationTemplates>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -15,6 +15,7 @@
   "data_storage_type.certificate_validation": "database",
   "data_storage_type.admin_advisory_banner": "database",
   "data_storage_type.remote_logging_config": "database",
+  "data_storage_type.challenge_questions": "database",
   "database.identity_db.pool_options.maxActive": "50",
   "database.identity_db.pool_options.maxWait": "60000",
   "database.identity_db.pool_options.testOnBorrow": "true",


### PR DESCRIPTION
### Proposed changes in this pull request

- Add config to switch between Challenge Questions storage type
Related to, 
* https://github.com/wso2/product-is/issues/23354