### PR TITLE
Add rule support for pre update profile action

### DIFF
--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/api/model/FlowType.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/api/model/FlowType.java
@@ -24,5 +24,6 @@ package org.wso2.carbon.identity.rule.evaluation.api.model;
 public enum FlowType {
 
     PRE_ISSUE_ACCESS_TOKEN,
-    PRE_UPDATE_PASSWORD
+    PRE_UPDATE_PASSWORD,
+    PRE_UPDATE_PROFILE
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.management/src/main/java/org/wso2/carbon/identity/rule/management/api/model/FlowType.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.management/src/main/java/org/wso2/carbon/identity/rule/management/api/model/FlowType.java
@@ -25,4 +25,5 @@ public enum FlowType {
 
     PRE_ISSUE_ACCESS_TOKEN,
     PRE_UPDATE_PASSWORD,
+    PRE_UPDATE_PROFILE
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/main/java/org/wso2/carbon/identity/rule/metadata/api/model/FlowType.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/main/java/org/wso2/carbon/identity/rule/metadata/api/model/FlowType.java
@@ -26,7 +26,8 @@ import org.wso2.carbon.identity.rule.metadata.internal.util.RuleMetadataExceptio
  */
 public enum FlowType {
     PRE_ISSUE_ACCESS_TOKEN("preIssueAccessToken"),
-    PRE_UPDATE_PASSWORD("preUpdatePassword");
+    PRE_UPDATE_PASSWORD("preUpdatePassword"),
+    PRE_UPDATE_PROFILE("preUpdateProfile");
 
     private final String flowAlias;
 

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/pom.xml
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/pom.xml
@@ -133,6 +133,9 @@
                             org.wso2.carbon.identity.action.execution.api.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.user.action.api.model; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt.*; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.rule.evaluation.api.model; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.rule.evaluation.api.exception; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.rule.evaluation.api.provider; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.util; version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
                     </instructions>

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/main/java/org/wso2/carbon/identity/user/pre/update/profile/action/internal/component/PreUpdateProfileActionServiceComponent.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/main/java/org/wso2/carbon/identity/user/pre/update/profile/action/internal/component/PreUpdateProfileActionServiceComponent.java
@@ -34,10 +34,12 @@ import org.wso2.carbon.identity.action.execution.api.service.ActionExecutorServi
 import org.wso2.carbon.identity.action.management.api.service.ActionConverter;
 import org.wso2.carbon.identity.action.management.api.service.ActionDTOModelResolver;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.rule.evaluation.api.provider.RuleEvaluationDataProvider;
 import org.wso2.carbon.identity.user.pre.update.profile.action.internal.execution.PreUpdateProfileRequestBuilder;
 import org.wso2.carbon.identity.user.pre.update.profile.action.internal.execution.PreUpdateProfileResponseProcessor;
 import org.wso2.carbon.identity.user.pre.update.profile.action.internal.management.PreUpdateProfileActionConverter;
 import org.wso2.carbon.identity.user.pre.update.profile.action.internal.management.PreUpdateProfileActionDTOModelResolver;
+import org.wso2.carbon.identity.user.pre.update.profile.action.internal.rule.PreUpdateProfileActionRuleEvaluationDataProvider;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -69,6 +71,10 @@ public class PreUpdateProfileActionServiceComponent {
             bundleCtx.registerService(
                     ActionExecutionResponseProcessor.class, new PreUpdateProfileResponseProcessor(), null);
             LOG.debug("Pre Update Profile Action Response Processor is registered");
+
+            bundleCtx.registerService(RuleEvaluationDataProvider.class,
+                    new PreUpdateProfileActionRuleEvaluationDataProvider(), null);
+            LOG.debug("User Pre Update Profile Action Rule Evaluation Data Provider is enabled");
 
             LOG.debug("Pre Update Profile Action bundle is activated");
         } catch (Throwable e) {

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/main/java/org/wso2/carbon/identity/user/pre/update/profile/action/internal/rule/PreUpdateProfileActionRuleEvaluationDataProvider.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/main/java/org/wso2/carbon/identity/user/pre/update/profile/action/internal/rule/PreUpdateProfileActionRuleEvaluationDataProvider.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.user.pre.update.profile.action.internal.rule;
+
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
+import org.wso2.carbon.identity.rule.evaluation.api.exception.RuleEvaluationDataProviderException;
+import org.wso2.carbon.identity.rule.evaluation.api.model.Field;
+import org.wso2.carbon.identity.rule.evaluation.api.model.FieldValue;
+import org.wso2.carbon.identity.rule.evaluation.api.model.FlowContext;
+import org.wso2.carbon.identity.rule.evaluation.api.model.FlowType;
+import org.wso2.carbon.identity.rule.evaluation.api.model.RuleEvaluationContext;
+import org.wso2.carbon.identity.rule.evaluation.api.model.ValueType;
+import org.wso2.carbon.identity.rule.evaluation.api.provider.RuleEvaluationDataProvider;
+import org.wso2.carbon.identity.user.action.api.model.UserActionContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Rule evaluation data provider for pre update profile flow.
+ * This class provides the data required for rule evaluation in pre update profile flow.
+ */
+public class PreUpdateProfileActionRuleEvaluationDataProvider implements RuleEvaluationDataProvider {
+
+    private enum RuleField {
+        FLOW_FIELD("flow"),
+        CLAIM_FIELD("claim");
+
+        final String fieldName;
+
+        RuleField(String fieldName) {
+
+            this.fieldName = fieldName;
+        }
+
+        public String getFieldName() {
+
+            return fieldName;
+        }
+
+        public static RuleField valueOfFieldName(String fieldName) throws RuleEvaluationDataProviderException {
+
+            for (RuleField ruleField : RuleField.values()) {
+                if (ruleField.getFieldName().equals(fieldName)) {
+                    return ruleField;
+                }
+            }
+
+            throw new RuleEvaluationDataProviderException("Unsupported field: " + fieldName);
+        }
+    }
+
+    /**
+     * Supported flows for pre update profile action.
+     */
+    private enum ProfileUpdateFlowType {
+        ADMIN_INITIATED_PROFILE_UPDATE("adminInitiatedProfileUpdate"),
+        APPLICATION_INITIATED_PROFILE_UPDATE("applicationInitiatedProfileUpdate"),
+        USER_INITIATED_PROFILE_UPDATE("userInitiatedProfileUpdate");
+
+        final String flowName;
+
+        ProfileUpdateFlowType(String flowName) {
+
+            this.flowName = flowName;
+        }
+
+        public String getFlowName() {
+
+            return flowName;
+        }
+    }
+
+    @Override
+    public FlowType getSupportedFlowType() {
+
+        return FlowType.PRE_UPDATE_PROFILE;
+    }
+
+    @Override
+    public List<FieldValue> getEvaluationData(RuleEvaluationContext ruleEvaluationContext,
+                                              FlowContext flowContext, String tenantDomain)
+            throws RuleEvaluationDataProviderException {
+
+        List<FieldValue> fieldValueList = new ArrayList<>();
+
+        for (Field field : ruleEvaluationContext.getFields()) {
+            switch (RuleField.valueOfFieldName(field.getName())) {
+                case FLOW_FIELD:
+                    fieldValueList.add(new FieldValue(field.getName(), getFlowFromContext(), ValueType.STRING));
+                    break;
+                case CLAIM_FIELD:
+                    addClaimFieldValue(fieldValueList, field, flowContext);
+                    break;
+                default:
+                    throw new RuleEvaluationDataProviderException("Unsupported field: " + field.getName());
+            }
+        }
+
+        return fieldValueList;
+    }
+
+    private String getFlowFromContext() throws RuleEvaluationDataProviderException {
+
+        Flow flow = IdentityContext.getThreadLocalIdentityContext().getFlow();
+        if (flow.getName() == Flow.Name.PROFILE_UPDATE &&
+                flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN) {
+            return ProfileUpdateFlowType.ADMIN_INITIATED_PROFILE_UPDATE.getFlowName();
+        }
+
+        if (flow.getName() == Flow.Name.PROFILE_UPDATE &&
+                flow.getInitiatingPersona() == Flow.InitiatingPersona.APPLICATION) {
+            return ProfileUpdateFlowType.APPLICATION_INITIATED_PROFILE_UPDATE.getFlowName();
+        }
+
+        if (flow.getName() == Flow.Name.PROFILE_UPDATE &&
+                flow.getInitiatingPersona() == Flow.InitiatingPersona.USER) {
+            return ProfileUpdateFlowType.USER_INITIATED_PROFILE_UPDATE.getFlowName();
+        }
+
+        throw new RuleEvaluationDataProviderException("Unsupported flow type: " + flow.getName() +
+                " for Pre Update Profile Action.");
+    }
+
+    private void addClaimFieldValue(List<FieldValue> fieldValueList, Field field, FlowContext flowContext)
+            throws RuleEvaluationDataProviderException {
+
+        UserActionContext userActionContext = resolveUserActionContext(flowContext);
+        Set<String> claims = userActionContext.getUserActionRequestDTO().getClaims().keySet();
+        if (claims != null) {
+            fieldValueList.add(new FieldValue(field.getName(), new ArrayList<>(claims)));
+        }
+    }
+
+    private UserActionContext resolveUserActionContext(FlowContext flowContext)
+            throws RuleEvaluationDataProviderException {
+
+        Object userActionContext = flowContext.getContextData()
+                .get(UserActionContext.USER_ACTION_CONTEXT_REFERENCE_KEY);
+        if (!(userActionContext instanceof UserActionContext)) {
+            throw new RuleEvaluationDataProviderException("Invalid context data type: " + userActionContext);
+        }
+        return (UserActionContext) userActionContext;
+    }
+}

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/main/java/org/wso2/carbon/identity/user/pre/update/profile/action/internal/rule/PreUpdateProfileActionRuleEvaluationDataProvider.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/main/java/org/wso2/carbon/identity/user/pre/update/profile/action/internal/rule/PreUpdateProfileActionRuleEvaluationDataProvider.java
@@ -121,23 +121,27 @@ public class PreUpdateProfileActionRuleEvaluationDataProvider implements RuleEva
     private String getFlowFromContext() throws RuleEvaluationDataProviderException {
 
         Flow flow = IdentityContext.getThreadLocalIdentityContext().getFlow();
-        if (flow.getName() == Flow.Name.PROFILE_UPDATE &&
-                flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN) {
-            return ProfileUpdateFlowType.ADMIN_INITIATED_PROFILE_UPDATE.getFlowName();
+
+        if (flow == null || flow.getName() == null || flow.getInitiatingPersona() == null) {
+            throw new RuleEvaluationDataProviderException("Flow or required attributes are null.");
         }
 
-        if (flow.getName() == Flow.Name.PROFILE_UPDATE &&
-                flow.getInitiatingPersona() == Flow.InitiatingPersona.APPLICATION) {
-            return ProfileUpdateFlowType.APPLICATION_INITIATED_PROFILE_UPDATE.getFlowName();
+        if (flow.getName() != Flow.Name.PROFILE_UPDATE) {
+            throw new RuleEvaluationDataProviderException("Unsupported flow type: " + flow.getName() +
+                    " for Pre Update Profile Action.");
         }
 
-        if (flow.getName() == Flow.Name.PROFILE_UPDATE &&
-                flow.getInitiatingPersona() == Flow.InitiatingPersona.USER) {
-            return ProfileUpdateFlowType.USER_INITIATED_PROFILE_UPDATE.getFlowName();
+        switch (flow.getInitiatingPersona()) {
+            case ADMIN:
+                return ProfileUpdateFlowType.ADMIN_INITIATED_PROFILE_UPDATE.getFlowName();
+            case APPLICATION:
+                return ProfileUpdateFlowType.APPLICATION_INITIATED_PROFILE_UPDATE.getFlowName();
+            case USER:
+                return ProfileUpdateFlowType.USER_INITIATED_PROFILE_UPDATE.getFlowName();
+            default:
+                throw new RuleEvaluationDataProviderException("Unsupported initiating persona: "
+                        + flow.getInitiatingPersona());
         }
-
-        throw new RuleEvaluationDataProviderException("Unsupported flow type: " + flow.getName() +
-                " for Pre Update Profile Action.");
     }
 
     private void addClaimFieldValue(List<FieldValue> fieldValueList, Field field, FlowContext flowContext)

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/test/java/org/wso2/carbon/identity/user/pre/update/profile/action/rule/PreUpdateProfileActionRuleEvaluationDataProviderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/test/java/org/wso2/carbon/identity/user/pre/update/profile/action/rule/PreUpdateProfileActionRuleEvaluationDataProviderTest.java
@@ -96,12 +96,21 @@ public class PreUpdateProfileActionRuleEvaluationDataProviderTest {
         };
     }
 
-    @DataProvider(name = "claim")
+    @DataProvider(name = "claimData")
     public Object[][] claimData() {
 
         return new Object[][]{
                 {new ArrayList<>(Arrays.asList("http://wso2.org/claims/country", "http://wso2.org/claims/givenname"))}
         };
+    }
+
+    @DataProvider(name = "unsupportedFlowData")
+    public Object[][] unsupportedFlowData() {
+
+        return Arrays.stream(Flow.Name.values())
+                .filter(name -> name != Flow.Name.PROFILE_UPDATE) //Remove the supported flow
+                .map(name -> new Object[]{name})
+                .toArray(Object[][]::new);
     }
 
     @Test(dataProvider = "flowData")
@@ -118,7 +127,7 @@ public class PreUpdateProfileActionRuleEvaluationDataProviderTest {
         assertEquals(fieldValues.get(0).getValue(), fieldValue);
     }
 
-    @Test(dataProvider = "claim")
+    @Test(dataProvider = "claimData")
     public void testGetEvaluationDataForClaim(ArrayList<String> claims)
             throws RuleEvaluationDataProviderException {
 
@@ -147,12 +156,13 @@ public class PreUpdateProfileActionRuleEvaluationDataProviderTest {
         dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");
     }
 
-    @Test(expectedExceptions = RuleEvaluationDataProviderException.class)
-    public void testGetEvaluationDataWithUnsupportedFlow() throws RuleEvaluationDataProviderException {
+    @Test(dataProvider = "unsupportedFlowData", expectedExceptions = RuleEvaluationDataProviderException.class)
+    public void testGetEvaluationDataWithUnsupportedFlows(Flow.Name flowName)
+            throws RuleEvaluationDataProviderException {
 
         Field flowField = new Field("flow", ValueType.STRING);
         doReturn(Collections.singletonList(flowField)).when(ruleEvaluationContext).getFields();
-        doReturn(Flow.Name.PASSWORD_RESET).when(flow).getName();
+        doReturn(flowName).when(flow).getName();
         doReturn(Flow.InitiatingPersona.APPLICATION).when(flow).getInitiatingPersona();
         IdentityContext.getThreadLocalIdentityContext().setFlow(flow);
         dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/test/java/org/wso2/carbon/identity/user/pre/update/profile/action/rule/PreUpdateProfileActionRuleEvaluationDataProviderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/test/java/org/wso2/carbon/identity/user/pre/update/profile/action/rule/PreUpdateProfileActionRuleEvaluationDataProviderTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.user.pre.update.profile.action.rule;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
+import org.wso2.carbon.identity.rule.evaluation.api.exception.RuleEvaluationDataProviderException;
+import org.wso2.carbon.identity.rule.evaluation.api.model.Field;
+import org.wso2.carbon.identity.rule.evaluation.api.model.FieldValue;
+import org.wso2.carbon.identity.rule.evaluation.api.model.FlowContext;
+import org.wso2.carbon.identity.rule.evaluation.api.model.FlowType;
+import org.wso2.carbon.identity.rule.evaluation.api.model.RuleEvaluationContext;
+import org.wso2.carbon.identity.rule.evaluation.api.model.ValueType;
+import org.wso2.carbon.identity.user.action.api.model.UserActionContext;
+import org.wso2.carbon.identity.user.action.api.model.UserActionRequestDTO;
+import org.wso2.carbon.identity.user.pre.update.profile.action.internal.rule.PreUpdateProfileActionRuleEvaluationDataProvider;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.doReturn;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test class for PreUpdateProfileActionRuleEvaluationDataProvider.
+ */
+@WithCarbonHome
+public class PreUpdateProfileActionRuleEvaluationDataProviderTest {
+
+    @Mock
+    private RuleEvaluationContext ruleEvaluationContext;
+    @Mock
+    private FlowContext flowContext;
+    @Mock
+    private Flow flow;
+    @Mock
+    private UserActionContext userActionContext;
+    @Mock
+    private UserActionRequestDTO userActionRequestDTO;
+
+    private PreUpdateProfileActionRuleEvaluationDataProvider dataProvider;
+
+    @BeforeMethod
+    public void setUp() {
+
+        MockitoAnnotations.openMocks(this);
+        dataProvider = new PreUpdateProfileActionRuleEvaluationDataProvider();
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        IdentityContext.destroyCurrentContext();
+    }
+
+    @Test
+    public void testGetSupportedFlowType() {
+
+        assertEquals(dataProvider.getSupportedFlowType(), FlowType.PRE_UPDATE_PROFILE);
+    }
+
+    @DataProvider(name = "flowData")
+    public Object[][] flowData() {
+
+        return new Object[][]{
+                {Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.ADMIN, "adminInitiatedProfileUpdate"},
+                {Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.USER, "userInitiatedProfileUpdate"},
+                {Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.APPLICATION, "applicationInitiatedProfileUpdate"}
+        };
+    }
+
+    @DataProvider(name = "claim")
+    public Object[][] claimData() {
+
+        return new Object[][]{
+                {new ArrayList<>(Arrays.asList("http://wso2.org/claims/country", "http://wso2.org/claims/givenname"))}
+        };
+    }
+
+    @Test(dataProvider = "flowData")
+    public void testGetEvaluationDataForFlow(Flow.Name flowName, Flow.InitiatingPersona initiatingPersona,
+                                             String fieldValue) throws RuleEvaluationDataProviderException {
+
+        Field flowField = new Field("flow", ValueType.STRING);
+        doReturn(Collections.singletonList(flowField)).when(ruleEvaluationContext).getFields();
+        doReturn(flowName).when(flow).getName();
+        doReturn(initiatingPersona).when(flow).getInitiatingPersona();
+        IdentityContext.getThreadLocalIdentityContext().setFlow(flow);
+        List<FieldValue> fieldValues = dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");
+        assertEquals(fieldValues.size(), 1);
+        assertEquals(fieldValues.get(0).getValue(), fieldValue);
+    }
+
+    @Test(dataProvider = "claim")
+    public void testGetEvaluationDataForClaim(ArrayList<String> claims)
+            throws RuleEvaluationDataProviderException {
+
+        Field claimField = new Field("claim", ValueType.REFERENCE);
+        doReturn(Collections.singletonList(claimField)).when(ruleEvaluationContext).getFields();
+        Map<String, Object> contextMap = new HashMap<>();
+        contextMap.put(UserActionContext.USER_ACTION_CONTEXT_REFERENCE_KEY, userActionContext);
+        doReturn(contextMap).when(flowContext).getContextData();
+        doReturn(userActionRequestDTO).when(userActionContext).getUserActionRequestDTO();
+        Map<String, Object> claimMap = new HashMap<>();
+        claimMap.put(claims.get(0), "testValue1");
+        claimMap.put(claims.get(1), "testValue2");
+        doReturn(claimMap).when(userActionRequestDTO).getClaims();
+        IdentityContext.getThreadLocalIdentityContext().setFlow(flow);
+
+        List<FieldValue> fieldValues = dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");
+        assertEquals(fieldValues.size(), 1);
+        assertEquals(fieldValues.get(0).getValue(), claims);
+    }
+
+    @Test(expectedExceptions = RuleEvaluationDataProviderException.class)
+    public void testGetEvaluationDataWithUnsupportedField() throws RuleEvaluationDataProviderException {
+
+        Field field = new Field("unsupported_field", ValueType.STRING);
+        doReturn(Collections.singletonList(field)).when(ruleEvaluationContext).getFields();
+        dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");
+    }
+
+    @Test(expectedExceptions = RuleEvaluationDataProviderException.class)
+    public void testGetEvaluationDataWithUnsupportedFlow() throws RuleEvaluationDataProviderException {
+
+        Field flowField = new Field("flow", ValueType.STRING);
+        doReturn(Collections.singletonList(flowField)).when(ruleEvaluationContext).getFields();
+        doReturn(Flow.Name.PASSWORD_RESET).when(flow).getName();
+        doReturn(Flow.InitiatingPersona.APPLICATION).when(flow).getInitiatingPersona();
+        IdentityContext.getThreadLocalIdentityContext().setFlow(flow);
+        dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");
+    }
+}

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/test/resources/testng.xml
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/test/resources/testng.xml
@@ -24,6 +24,7 @@
             <class name="org.wso2.carbon.identity.user.pre.update.profile.action.management.PreUpdateProfileActionConverterTest"></class>
             <class name="org.wso2.carbon.identity.user.pre.update.profile.action.management.PreUpdateProfileActionDTOModelResolverTest"></class>
             <class name="org.wso2.carbon.identity.user.pre.update.profile.action.model.PreUpdateProfileActionBuilderTest"></class>
+            <class name="org.wso2.carbon.identity.user.pre.update.profile.action.rule.PreUpdateProfileActionRuleEvaluationDataProviderTest"></class>
         </classes>
     </test>
     <test name="pre-update-profile-action-execution-tests" preserve-order="true" parallel="false">

--- a/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/fields.json
+++ b/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/fields.json
@@ -73,5 +73,28 @@
       "valueType": "string",
       "values": []
     }
+  },
+  "claim": {
+    "field": {
+      "name": "claim",
+      "displayName": "claim"
+    },
+    "operators": [
+      "equals",
+      "notEquals"
+    ],
+    "value": {
+      "inputType": "options",
+      "valueType": "reference",
+      "valueReferenceAttribute": "uri",
+      "valueDisplayAttribute": "name",
+      "links": [
+        {
+          "href": "/claim-dialects/local/claims?exclude-hidden-claims=true",
+          "method": "GET",
+          "rel": "values"
+        }
+      ]
+    }
   }
 }

--- a/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/flows.json
+++ b/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/flows.json
@@ -44,5 +44,34 @@
         }
       }
     }
+  ],
+  "preUpdateProfile": [
+    {
+      "fieldName": "flow",
+      "overrides": {
+        "field": {
+          "displayName": "flow"
+        },
+        "value": {
+          "values": [
+            {
+              "name": "adminInitiatedProfileUpdate",
+              "displayName": "Admin initiated profile update"
+            },
+            {
+              "name": "applicationInitiatedProfileUpdate",
+              "displayName": "Application initiated profile update"
+            },
+            {
+              "name": "userInitiatedProfileUpdate",
+              "displayName": "User initiated profile update"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fieldName": "claim"
+    }
   ]
 }


### PR DESCRIPTION
#### Description

- This PR adds the rule support for pre update profile action
- Introduces rule meta data for the flow PRE_UPDATE_PROFILE 
- Adds relevant unit tests 

#### Related issue
- https://github.com/wso2/product-is/issues/23983

#### Follow up tasks
-  Merge https://github.com/wso2/identity-api-server/pull/877