### PR TITLE
Add a helper method to determine if the current app is a system application

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityTenantUtil.java
@@ -479,6 +479,23 @@ public class IdentityTenantUtil {
     }
 
     /**
+     * Checks whether the current application is a system app.
+     *
+     * @param tenantDomain Tenant Domain.
+     * @param clientID Client ID.
+     * @return true if the application is a system app.
+     */
+    public static boolean isSystemApplication(String tenantDomain, String clientID) {
+
+        boolean isConsoleRequest = StringUtils.equalsIgnoreCase(clientID, "CONSOLE") ||
+                StringUtils.equalsIgnoreCase(clientID, "CONSOLE_" + tenantDomain);
+        boolean isMyAccountRequest = StringUtils.equalsIgnoreCase(clientID, "MY_ACCOUNT") ||
+                StringUtils.equalsIgnoreCase(clientID, "MY_ACCOUNT_" + tenantDomain);
+
+        return isConsoleRequest || isMyAccountRequest;
+    }
+
+    /**
      * Checks whether tenant qualified URLs should be used.
      *
      * System applications in each tenant should continue to function in a multi-tenant environment

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/util/IdentityTenantUtilTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/util/IdentityTenantUtilTest.java
@@ -33,6 +33,8 @@ public class IdentityTenantUtilTest {
 
     MockedStatic<IdentityTenantUtil> identityTenantUtil;
 
+    private static final String SUPER_TENANT = "carbon.super";
+
     @BeforeMethod
     public void setUp() throws Exception {
 
@@ -73,5 +75,25 @@ public class IdentityTenantUtilTest {
         threadLocalProperties.put(IdentityCoreConstants.IS_SYSTEM_APPLICATION, isSystemApplication);
 
         assertEquals(IdentityTenantUtil.shouldUseTenantQualifiedURLs(), expectedResult);
+    }
+
+    @DataProvider
+    public Object[][] getIsSystemApplicationConfigData() {
+
+        return new Object[][]{
+                { SUPER_TENANT, "MY_ACCOUNT", true },
+                { SUPER_TENANT, "app-1-client-id", false },
+                { "abc.com", "MY_ACCOUNT_tenant.com", false },
+                { "abc.com", "CONSOLE_abc.com", true },
+        };
+    }
+
+    @Test(dataProvider = "getIsSystemApplicationConfigData")
+    public void testIsSystemApplication(String tenantDomain, String clientID, boolean expectedResult) {
+
+        identityTenantUtil.when(() -> IdentityTenantUtil.isSystemApplication(tenantDomain, clientID)).
+                thenCallRealMethod();
+
+        assertEquals(IdentityTenantUtil.isSystemApplication(tenantDomain, clientID), expectedResult);
     }
 }


### PR DESCRIPTION
### Purpose
This PR introduces a helper method in IdentityTenantUtil to check if the application that initiated the current request is a system application.

### Related Issues
- https://github.com/wso2/product-is/issues/23710

### Related PR
- https://github.com/wso2/carbon-identity-framework/pull/6696