### PR TITLE
Clear in memory AuthenticationResultCacheEntry when pre session data expiry time hits.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/AuthenticationResultCache.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/AuthenticationResultCache.java
@@ -104,6 +104,11 @@ public class AuthenticationResultCache extends
             if (entry != null && isCacheEntryExpired(entry)) {
                 return null;
             }
+        } else {
+            if (entry != null && isCacheEntryExpired(entry)) {
+                super.clearCacheEntry(key);
+                return null;
+            }
         }
         return entry;
     }


### PR DESCRIPTION
### Proposed changes in this pull request

- Clear in memory AuthenticationResultCacheEntry when pre session data expiry time hits.

### Related PR
- https://github.com/wso2/carbon-identity-framework/pull/6330