### PR TITLE
Add USER_SESSION_TERMINATE to EventName

### DIFF
--- a/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
@@ -329,7 +329,8 @@ public class IdentityEventConstants {
         SESSION_TERMINATE,
         SESSION_EXPIRE,
         SESSION_EXTEND,
-        VERIFICATION
+        VERIFICATION,
+        USER_SESSION_TERMINATE
     }
 
     public class EventProperty {


### PR DESCRIPTION
### Proposed changes in this pull request

- We are introducing a new event named USER_SESSION_TERMINATE to use in Session Termination events.
- This PR adds initial support for it by adding it to the EventName Enum.

### Related Product IS issue:

- https://github.com/wso2/product-is/issues/24020