### PR TITLE
Add DPoP configurations.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2254,6 +2254,15 @@
                        orderId="{{event.default_listener.mutual_tls_authenticator.priority}}"
                        enable="{{event.default_listener.mutual_tls_authenticator.enable}}">
         </EventListener>
+        <EventListener id="dpop_listener"
+                       type="org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
+                       name="org.wso2.carbon.identity.oauth2.dpop.listener.OauthDPoPInterceptorHandlerProxy"
+                       orderId="{{event.default_listener.dpop.priority}}"
+                       enable="{{event.default_listener.dpop.enable}}">
+            <Property name="header_validity_period">{{event.default_listener.dpop.property.header_validity_period}}</Property>
+            <Property name="skip_dpop_validation_in_revoke">{{event.default_listener.dpop.property.skip_dpop_validation_in_revoke}}</Property>
+        </EventListener>
+
         <EventListener id="private_key_jwt_authenticator"
                        type="org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
                        name="org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.PrivateKeyJWTClientAuthenticator"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -63,6 +63,12 @@
   "remote_fetch.enable": false,
   "remote_fetch.working_directory": "${carbon.home}/tmp/",
 
+  "oauth.custom_token_validator": [
+    {
+      "type": "dpop",
+      "class": "org.wso2.carbon.identity.oauth2.dpop.validators.DPoPTokenValidator"
+    }
+  ],
   "oauth.token_cleanup.enable": true,
   "oauth.token_cleanup.retain_access_tokens_for_auditing": false,
 
@@ -585,6 +591,10 @@
   "event.default_listener.application_authentication.enable": true,
   "event.default_listener.mutual_tls_authenticator.priority": "919",
   "event.default_listener.mutual_tls_authenticator.enable": true,
+  "event.default_listener.dpop.priority": "13",
+  "event.default_listener.dpop.enable": false,
+  "event.default_listener.dpop.property.header_validity_period": "3000",
+  "event.default_listener.dpop.property.skip_dpop_validation_in_revoke": true,
   "event.default_listener.private_key_jwt_authenticator.priority": "899",
   "event.default_listener.private_key_jwt_authenticator.enable": true,
   "event.default_listener.private_key_jwt_authenticator.property.prevent_token_reuse": false,

--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/identity-event.properties
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/identity-event.properties
@@ -147,3 +147,6 @@ userOperationDataDASPublisher.subscription.3=POST_UPDATE_CREDENTIAL
 userOperationDataDASPublisher.subscription.4=POST_UPDATE_CREDENTIAL_BY_ADMIN
 userOperationDataDASPublisher.subscription.5=POST_SET_USER_CLAIMS
 userOperationDataDASPublisher.enable=false
+module.name.49=dpopEventHandler
+dpopEventHandler.subscription.1=PRE_HANDLE_PAR_REQUEST
+dpopEventHandler.subscription.2=POST_ISSUE_CODE

--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -312,5 +312,10 @@
     "POST_UPDATE_ORGANIZATION",
     "POST_PATCH_ORGANIZATION",
     "POST_DELETE_ORGANIZATION"
+  ],
+  "identity_mgt.events.schemes.dpopEventHandler.module_index": "49",
+  "identity_mgt.events.schemes.dpopEventHandler.subscriptions": [
+    "PRE_HANDLE_PAR_REQUEST",
+    "POST_ISSUE_CODE"
   ]
 }

--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.key-mappings.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.key-mappings.json
@@ -40,5 +40,7 @@
   "identity_mgt.saml_logout_handler.enable": "identity_mgt.events.schemes.SAMLLogoutHandler.properties.enable",
 
   "identity_mgt.oidc_logout_event_handler.subscriptions": "identity_mgt.events.schemes.OIDCLogoutEventHandler.subscriptions",
-  "identity_mgt.oidc_logout_event_handler.enable": "identity_mgt.events.schemes.OIDCLogoutEventHandler.properties.enable"
+  "identity_mgt.oidc_logout_event_handler.enable": "identity_mgt.events.schemes.OIDCLogoutEventHandler.properties.enable",
+
+  "identity_mgt.dpop_event_handler.subscriptions": "identity_mgt.events.schemes.dpopEventHandler.subscriptions"
 }


### PR DESCRIPTION
### Proposed changes in this pull request
This PR adds the following DPoP related Configs. 

```
[[event_listener]]
id = "dpop_listener"
type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
name = "org.wso2.carbon.identity.oauth2.dpop.listener.OauthDPoPInterceptorHandlerProxy"
order = 13
enable = true
properties.header_validity_period = 3000
properties.skip_dpop_validation_in_revoke = "true"

[[event_handler]]
name = "dpopEventHandler"
subscriptions = ["POST_ISSUE_CODE", "PRE_HANDLE_PAR_REQUEST"]

[[oauth.custom_token_validator]]
type = "dpop"
class = "org.wso2.carbon.identity.oauth2.dpop.validators.DPoPTokenValidator"
```

### Related Issue
- https://github.com/wso2/product-is/issues/20428