### PR TITLE
Skip for invalid authenticator ids

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -3130,6 +3130,9 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
                 }
 
                 int authenticatorId = stepInfoResultSet.getInt(2);
+                if (authenticatorId < 0) {
+                    continue;
+                }
                 Map<String, String> authenticatorInfo = getAuthenticatorInfo(connection, tenantId,
                         authenticatorId);
 


### PR DESCRIPTION
### Proposed changes in this pull request
> There are some authenticator ids added as -1 in `SP_FEDERATED_IDP` table. When these rows are getting processed Application retrieval fails for these tenants.

As the fix, skip processing these rows.