### PR TITLE
Enable DPoP

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -592,7 +592,7 @@
   "event.default_listener.mutual_tls_authenticator.priority": "919",
   "event.default_listener.mutual_tls_authenticator.enable": true,
   "event.default_listener.dpop.priority": "13",
-  "event.default_listener.dpop.enable": false,
+  "event.default_listener.dpop.enable": true,
   "event.default_listener.dpop.property.header_validity_period": "3000",
   "event.default_listener.dpop.property.skip_dpop_validation_in_revoke": true,
   "event.default_listener.private_key_jwt_authenticator.priority": "899",


### PR DESCRIPTION
### Proposed changes in this pull request

This PR will enable DPoP. 

## NOTE
 This PR will cause the `ApplicationMetadataTest` to fail and it will be fixed with the following PR.
 - https://github.com/wso2/product-is/pull/23951
 
 Below is a screenshot of the following `ApplicationMetadataTest` passing with the change. 
 
<img width="800" alt="Screenshot 2025-05-26 at 10 23 03" src="https://github.com/user-attachments/assets/65af12e5-ff5c-4dc1-adb8-5b390701ff26" />

 
<img width="800" alt="Screenshot 2025-05-26 at 10 04 15" src="https://github.com/user-attachments/assets/92ab5f1c-86ac-4d8e-b302-52113dc40c87" />

The following test `OIDCFederatedIdpInitLogoutTest` is failling regardless of the feature being enabled or not, therefore this test failure is not related to DPoP. 


 

### Related Issue 
- https://github.com/wso2/product-is/issues/20428
