### PR TITLE
Use correct service range for org-resource-resolver service

### DIFF
--- a/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/pom.xml
+++ b/components/cors-mgt/org.wso2.carbon.identity.cors.mgt.core/pom.xml
@@ -115,7 +115,7 @@
                             org.wso2.carbon.identity.configuration.mgt.core.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.*;version="${carbon.identity.package.import.version.range}",
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.organization.*;version="${org.wso2.carbon.identity.organization.management.core.version.range}",
+                            org.wso2.carbon.identity.organization.*;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.apache.commons.logging; version="${import.package.version.commons.logging}",
                             org.wso2.carbon.identity.core.cache; version="${carbon.identity.package.import.version.range}"


### PR DESCRIPTION
### Purpose

This range is used for org-resource-resolver service. org-mgt version range should be used instead of the org-mgt-core version range