### PR TITLE
Update Email regex pattern

### DIFF
--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -89,11 +89,11 @@ public class Constants {
                 "^(?=.*[a-zA-Z])[a-zA-Z0-9!@#$&'+\\\\=^_.{|}~-]+$";
         public static final String DEFAULT_EMAIL_JAVA_REGEX_PATTERN =
             "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![!#$'+=^_.{|}~\\-&]{2})[\\u00C0-\\u00FF\\w!#$'+=^_.{|}~\\-&]" +
-                    "){0,63}(?<=[\\u00C0-\\u00FFA-Za-z0-9_])@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}" +
+                    "){0,63}(?<=[\\u00C0-\\u00FFa-zA-Z0-9_])@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}" +
                     "(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";
         public static final String DEFAULT_EMAIL_JS_REGEX_PATTERN =
             "(^[\\u00C0-\\u00FFa-zA-Z0-9](?:(?![!#$'+=^_.{|}~\\-&]{2})[\\u00C0-\\u00FF\\w!#$'+=^_.{|}~\\-&]" +
-                    "){0,63}(?<=[\\u00C0-\\u00FFA-Za-z0-9_])@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}" +
+                    "){0,63}(?<=[\\u00C0-\\u00FFa-zA-Z0-9_])@(?![+.\\-_])(?:(?![.+\\-_]{2})[\\w.+\\-]){0,245}" +
                     "(?=[\\u00C0-\\u00FFa-zA-Z0-9]).\\.[a-zA-Z]{2,10})";
 
         public static final String INPUT_VALIDATION_DEFAULT_VALIDATOR = "InputValidation.DefaultUserNameValidator";


### PR DESCRIPTION
### Proposed changes in this pull request

- Updates the Email address regex pattern, which is used in EmailFormatValidator.
- This enables having 1 character or more in the email address local part. Ex: a@example.com, 1@example.com
- This does not change any other behaviors restricted by the existing pattern.
