### PR TITLE
Use updated timestamp to validate the cache expiry time during SSO flows

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/AuthenticationResultCache.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/AuthenticationResultCache.java
@@ -110,14 +110,18 @@ public class AuthenticationResultCache extends
 
     private boolean isCacheEntryExpired(AuthenticationResultCacheEntry entry) {
 
-        if (entry.getResult().getProperty(FrameworkConstants.CREATED_TIMESTAMP) == null) {
-            log.warn("Cache entry does not have a created timestamp.");
+        String cacheCreatedTimestamp;
+        if (entry.getResult().getProperty(FrameworkConstants.UPDATED_TIMESTAMP) != null) {
+            cacheCreatedTimestamp = entry.getResult().getProperty(FrameworkConstants.UPDATED_TIMESTAMP).toString();
+        } else if (entry.getResult().getProperty(FrameworkConstants.CREATED_TIMESTAMP) != null) {
+            cacheCreatedTimestamp = entry.getResult().getProperty(FrameworkConstants.CREATED_TIMESTAMP).toString();
+        } else {
+            log.warn("Cache entry does not have a created or updated timestamp.");
             return false;
         }
-        String createdTimestamp = entry.getResult().getProperty(FrameworkConstants.CREATED_TIMESTAMP).toString();
-        if (StringUtils.isNotBlank(createdTimestamp) &&
+        if (StringUtils.isNotBlank(cacheCreatedTimestamp) &&
                 (FrameworkUtils.getCurrentStandardNano() >
-                    entry.getValidityPeriod() + Long.parseLong(createdTimestamp) * 1000000)) {
+                    entry.getValidityPeriod() + Long.parseLong(cacheCreatedTimestamp) * 1000000)) {
             log.warn("Authentication result cache is expired");
             return true;
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -527,6 +527,11 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                     authenticationResult.addProperty(FrameworkConstants.CREATED_TIMESTAMP, createdTime);
                 }
 
+                Long updatedTime = (Long) sessionContext.getProperty(FrameworkConstants.UPDATED_TIMESTAMP);
+                if (updatedTime != null) {
+                    authenticationResult.addProperty(FrameworkConstants.UPDATED_TIMESTAMP, updatedTime);
+                }
+
                 // Authentication context properties received from newly authenticated IdPs
                 if (context.getProperty(FrameworkConstants.AUTHENTICATION_CONTEXT_PROPERTIES) != null) {
                     authenticationContextProperties.addAll((List<AuthenticationContextProperty>) context


### PR DESCRIPTION
With https://github.com/wso2/product-is/issues/22194, we introduced the logic to honor the cache expiry configuration for AuthenticationResultCache. In order to validate, we used the CREATED_TIMESTAMP from the session context as the authenticationResultCache created time and compared it against the configuration from the deployment.toml.

In SSO flows, since it uses the same sessionContext, the createdTime of the new authenticationResultCache is set to the CREATED_TIMESTAMP of the same session context, which could be the old and expired time. Hence, when logging in into the same application after the configured expiry period, the user fails to login.

The UPDATED_TIMESTAMP property is set to the sessionContext during the SSO flows. To fix the above issue, we add the UPDATED_TIMESTAMP to the authenticationResultCache, and when validating the expiry period, we first consider the UPDATED_TIMESTAMP and then the CREATED_TIMESTAMP.

Related issue:
- https://github.com/wso2/product-is/issues/24127