### PR TITLE
Fix getflow server error and update scopes

### DIFF
--- a/components/registration-framework/org.wso2.carbon.identity.user.registration.mgt/src/main/java/org/wso2/carbon/identity/user/registration/mgt/dao/RegistrationFlowDAOImpl.java
+++ b/components/registration-framework/org.wso2.carbon.identity.user.registration.mgt/src/main/java/org/wso2/carbon/identity/user/registration/mgt/dao/RegistrationFlowDAOImpl.java
@@ -275,6 +275,7 @@ public class RegistrationFlowDAOImpl implements RegistrationFlowDAO {
             }, preparedStatement -> {
                 preparedStatement.setBoolean(1, true);
                 preparedStatement.setInt(2, tenantId);
+                preparedStatement.setString(3, REGISTRATION_FLOW);
             });
             return stepIds.isEmpty() ? null : stepIds.get(0);
         } catch (DataAccessException e) {

--- a/components/registration-framework/org.wso2.carbon.identity.user.registration.mgt/src/main/java/org/wso2/carbon/identity/user/registration/mgt/dao/SQLConstants.java
+++ b/components/registration-framework/org.wso2.carbon.identity.user.registration.mgt/src/main/java/org/wso2/carbon/identity/user/registration/mgt/dao/SQLConstants.java
@@ -61,9 +61,11 @@ public class SQLConstants {
             "SELECT n.NODE_ID, p.STEP_ID, p.PAGE_CONTENT FROM IDN_FLOW_PAGE p " +
                     "JOIN IDN_FLOW_NODE n ON p.FLOW_NODE_ID = n.ID WHERE p.FLOW_ID = ? AND p.TYPE = ?;";
 
-    public static final String GET_FIRST_STEP_ID = "SELECT fp.STEP_ID FROM IDN_FLOW_PAGE fp JOIN IDN_FLOW_NODE fn" +
-            " ON fp.FLOW_NODE_ID = fn.ID JOIN IDN_FLOW f ON fn.FLOW_ID = f.ID WHERE fn.IS_FIRST_NODE = ? AND" +
-            " f.TENANT_ID = ?;";
+    public static final String GET_FIRST_STEP_ID =
+            "SELECT fp.STEP_ID FROM IDN_FLOW_PAGE fp " +
+                    "JOIN IDN_FLOW_NODE fn ON fp.FLOW_NODE_ID = fn.ID " +
+                    "JOIN IDN_FLOW f ON fn.FLOW_ID = f.ID " +
+                    "WHERE fn.IS_FIRST_NODE = ? AND f.TENANT_ID = ? AND f.TYPE = ?;";
 
     private SQLConstants() {
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -1454,10 +1454,10 @@
 
          <!-- Flow management API -->
          <Resource context="(.*)/api/server/v1/flow(.*)" secured="true" http-method="GET">
-             <Scopes>internal_registration_flow_view</Scopes>
+             <Scopes>internal_flow_view</Scopes>
          </Resource>
          <Resource context="(.*)/api/server/v1/flow(.*)" secured="true" http-method="PUT">
-             <Scopes>internal_registration_flow_update</Scopes>
+             <Scopes>internal_flow_update</Scopes>
          </Resource>
 
           <!-- [Organization] User share API -->


### PR DESCRIPTION
This pull request introduces changes to enhance the flexibility of handling registration flows by adding support for flow types and updating access control scopes. The key changes include modifying SQL queries to incorporate flow types, updating the corresponding DAO method, and adjusting resource access control scopes.

### Enhancements to SQL Queries and DAO:

* [`SQLConstants.java`](diffhunk://#diff-50248d0ddc5ca7a68bd9aeaf385c5f70cce83bdb55882f64b3aedd635beb3539L64-R68): Updated the `GET_FIRST_STEP_ID` query to include a new condition for filtering by `f.TYPE`, enabling support for flow types.
* [`RegistrationFlowDAOImpl.java`](diffhunk://#diff-f7132cfff04984944aa81618c80271563ac0247efdea1f20b1069b715dd8cb81R278): Updated the `getFirstStepId` method to set the new `REGISTRATION_FLOW` parameter for the flow type in the SQL query.

### Updates to Access Control Scopes:

* [`resource-access-control-v2.xml.j2`](diffhunk://#diff-c1d66ea18073ea8342745dd465ae3028cc45019079d18f6c838c8d2cfb94da50L1457-R1460): Replaced `internal_registration_flow_view` and `internal_registration_flow_update` scopes with more generic `internal_flow_view` and `internal_flow_update` scopes for flow management API resources.