### PR TITLE
Handle Null and Blank Callback URLs in encodeURL Utility

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
@@ -573,6 +573,10 @@ public class IdentityManagementEndpointUtil {
      */
     public static String encodeURL(String callbackUrl) throws MalformedURLException {
 
+        if (StringUtils.isBlank(callbackUrl)) {
+            return callbackUrl;
+        }
+
         URL url = new URL(callbackUrl);
         StringBuilder encodedCallbackUrl = new StringBuilder(
                 new URL(url.getProtocol(), url.getHost(), url.getPort(), url.getPath(), null).toString());

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/test/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtilTest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/test/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtilTest.java
@@ -148,6 +148,16 @@ public class IdentityManagementEndpointUtilTest {
         };
     }
 
+    @DataProvider(name = "dataForBlankOrNullCallbackUrl")
+    public Object[][] dataForBlankOrNullCallbackUrl() {
+
+        return new Object[][]{
+                {null},
+                {""},
+                {"   "}
+        };
+    }
+
     @Test(dataProvider = "getEndpointUrlTestData")
     public void testBuildEndpointUrl(String serviceContextUrl, String path, String expected) throws Exception {
 
@@ -170,6 +180,13 @@ public class IdentityManagementEndpointUtilTest {
 
         assertEquals(IdentityManagementEndpointUtil.encodeURL(callbackUrl), encodedCallbackUrl,
                 "callbackUrl is not properly encoded");
+    }
+
+    @Test(dataProvider = "dataForBlankOrNullCallbackUrl")
+    public void testEncodeURLWithBlankOrNull(String input) throws MalformedURLException {
+
+        assertEquals(IdentityManagementEndpointUtil.encodeURL(input), input,
+                "Expected the original callback URL to be returned when input is blank or null.");
     }
 
     @Test(dataProvider = "dataForQueryParamEncoding")


### PR DESCRIPTION
### Purpose
Improve the robustness of the `encodeURL()` utility method by ensuring it gracefully handles null or blank callback URLs.

### Goals
* Avoid unnecessary processing when `callbackUrl` is null, empty, or contains only whitespace.
* Prevent issues during the creation of a `URL` object with an invalid input, which can lead to failures in redirection flows.
* Ensure that when encoding is not required, the method simply returns the input as-is, maintaining expected behavior without interruption.

### Approach
* Updated `encodeURL()` in `IdentityManagementEndpointUtil` to return the original `callbackUrl` directly if it is null or blank.
* Used `StringUtils.isBlank()` to handle all forms of invalid or whitespace-only inputs uniformly.

### Related PRs

* https://github.com/wso2-extensions/identity-auth-organization-login/pull/60
* https://github.com/wso2/identity-apps/pull/8241

## Related Issue

public-issue: https://github.com/wso2/product-is/issues/23963
