### PR TITLE
Enrich Identity context with access token issuer organization

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/api/model/Organization.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/api/model/Organization.java
@@ -36,6 +36,13 @@ public class Organization {
         this.name = name;
     }
 
+    public Organization(String id, String name, String orgHandle) {
+
+        this.id = id;
+        this.name = name;
+        this.orgHandle = orgHandle;
+    }
+
     public String getId() {
 
         return id;
@@ -49,10 +56,5 @@ public class Organization {
     public String getOrgHandle() {
 
         return orgHandle;
-    }
-
-    public void setOrgHandle(String orgHandle) {
-
-        this.orgHandle = orgHandle;
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/api/model/Organization.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/api/model/Organization.java
@@ -28,6 +28,8 @@ public class Organization {
 
     private final String name;
 
+    private String orgHandle;
+
     public Organization(String id, String name) {
 
         this.id = id;
@@ -42,5 +44,15 @@ public class Organization {
     public String getName() {
 
         return name;
+    }
+
+    public String getOrgHandle() {
+
+        return orgHandle;
+    }
+
+    public void setOrgHandle(String orgHandle) {
+
+        this.orgHandle = orgHandle;
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/api/model/User.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/api/model/User.java
@@ -32,6 +32,7 @@ public class User {
     private final List<UserClaim> claims =  new ArrayList<>();
     private final List<String> groups = new ArrayList<>();
     private final List<String> roles = new ArrayList<>();
+    private Organization organization;
 
     public User(String id) {
 
@@ -44,6 +45,7 @@ public class User {
         this.claims.addAll(builder.claims);
         this.groups.addAll(builder.groups);
         this.roles.addAll(builder.roles);
+        this.organization = builder.organization;
     }
 
     public String getId() {
@@ -66,6 +68,11 @@ public class User {
         return Collections.unmodifiableList(roles);
     }
 
+    public Organization getOrganization() {
+
+        return organization;
+    }
+
     /**
      * Builder for the User.
      */
@@ -75,6 +82,7 @@ public class User {
         private final List<UserClaim> claims = new ArrayList<>();
         private final List<String> groups = new ArrayList<>();
         private final List<String> roles = new ArrayList<>();
+        private Organization organization;
 
         public Builder(String id) {
 
@@ -96,6 +104,12 @@ public class User {
         public Builder roles(List<String> roles) {
 
             this.roles.addAll(roles);
+            return this;
+        }
+
+        public Builder organization(Organization organization) {
+
+            this.organization = organization;
             return this;
         }
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/IdentityContext.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/IdentityContext.java
@@ -141,6 +141,18 @@ public class IdentityContext extends CarbonContext {
         return identityContextDataHolder.getActor() instanceof ApplicationActor;
     }
 
+    public void setAccessTokenIssuedOrganization(String accessTokenIssuedOrganization) {
+
+        if (identityContextDataHolder.getAccessTokenIssuedOrganization() == null) {
+            identityContextDataHolder.setAccessTokenIssuedOrganization(accessTokenIssuedOrganization);
+        }
+    }
+
+    public String getAccessTokenIssuedOrganization() {
+
+        return identityContextDataHolder.getAccessTokenIssuedOrganization();
+    }
+
     public static void destroyCurrentContext() {
 
         CarbonUtils.checkSecurity();

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
@@ -34,9 +34,9 @@ public class IdentityContextCreatorValve extends ValveBase {
 
     private static final Log LOG = LogFactory.getLog(IdentityContextCreatorValve.class);
     public static final String TOKEN_PATH = "/oauth2/token";
-    public static final String URL_SEPERATOR = "/";
-    public static final String TENANT_SEPERATOR = "t";
-    public static final String ORG_SEPERATOR = "o";
+    public static final String URL_SEPARATOR = "/";
+    public static final String TENANT_SEPARATOR = "t";
+    public static final String ORG_SEPARATOR = "o";
 
     public IdentityContextCreatorValve() {
         // Enable async support to handle asynchronous requests, allowing non-blocking operations
@@ -74,21 +74,21 @@ public class IdentityContextCreatorValve extends ValveBase {
          * 2. t/<tenant>/o/<org>/oauth2/token           => issuer = root
          * 3. o/<org>/oauth2/token                      => issuer = sub-org
          */
-        if (requestURI.startsWith(URL_SEPERATOR)) {
+        if (requestURI.startsWith(URL_SEPARATOR)) {
             requestURI = requestURI.substring(1);
         }
 
-        String[] parts = requestURI.split(URL_SEPERATOR);
+        String[] parts = requestURI.split(URL_SEPARATOR);
         if (parts.length < 3) {
             return;
         }
 
         String accessTokenIssuedOrganization;
-        if (TENANT_SEPERATOR.equals(parts[0])) {
+        if (TENANT_SEPARATOR.equals(parts[0])) {
             // Case 1 & 2: /t/<tenant>/oauth2/token
             // Case 3: /t/<tenant>/o/<org>/oauth2/token (virtual org)
             accessTokenIssuedOrganization = parts[1];
-        } else if (ORG_SEPERATOR.equals(parts[0])) {
+        } else if (ORG_SEPARATOR.equals(parts[0])) {
             // Case 4: /o/<org>/oauth2/token
             accessTokenIssuedOrganization = parts[1];
         } else {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
@@ -33,10 +33,10 @@ import javax.servlet.ServletException;
 public class IdentityContextCreatorValve extends ValveBase {
 
     private static final Log LOG = LogFactory.getLog(IdentityContextCreatorValve.class);
-    public static final String TOKEN_PATH = "/oauth2/token";
-    public static final String URL_SEPARATOR = "/";
-    public static final String TENANT_SEPARATOR = "t";
-    public static final String ORG_SEPARATOR = "o";
+    private static final String TOKEN_PATH = "/oauth2/token";
+    private static final String URL_SEPARATOR = "/";
+    private static final String TENANT_SEPARATOR = "t";
+    private static final String ORG_SEPARATOR = "o";
 
     public IdentityContextCreatorValve() {
         // Enable async support to handle asynchronous requests, allowing non-blocking operations

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.core.context.valve;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.core.context.IdentityContext;
@@ -32,6 +33,10 @@ import javax.servlet.ServletException;
 public class IdentityContextCreatorValve extends ValveBase {
 
     private static final Log LOG = LogFactory.getLog(IdentityContextCreatorValve.class);
+    public static final String TOKEN_PATH = "/oauth2/token";
+    public static final String URL_SEPERATOR = "/";
+    public static final String TENANT_SEPERATOR = "t";
+    public static final String ORG_SEPERATOR = "o";
 
     public IdentityContextCreatorValve() {
         // Enable async support to handle asynchronous requests, allowing non-blocking operations
@@ -40,8 +45,10 @@ public class IdentityContextCreatorValve extends ValveBase {
 
     @Override
     public void invoke(Request request, Response response) throws IOException, ServletException {
+
         try {
             initIdentityContext();
+            initAccessTokenIssuedOrganization(request.getRequestURI());
             getNext().invoke(request, response);
         } catch (Exception e) {
             LOG.error("Could not handle request: " + request.getRequestURI(), e);
@@ -49,6 +56,45 @@ public class IdentityContextCreatorValve extends ValveBase {
             // This will destroy the identity context data holder on the current thread.
             IdentityContext.destroyCurrentContext();
         }
+    }
+
+    private void initAccessTokenIssuedOrganization(String requestURI) {
+
+        if (StringUtils.isBlank(requestURI)) {
+            return;
+        }
+
+        requestURI = requestURI.trim().toLowerCase();
+        if (!requestURI.endsWith(TOKEN_PATH)) {
+            return;
+        }
+        /*
+         * Possible structures:
+         * 1. t/<tenant>/oauth2/token                    => issuer = root
+         * 2. t/<tenant>/o/<org>/oauth2/token           => issuer = root
+         * 3. o/<org>/oauth2/token                      => issuer = sub-org
+         */
+        if (requestURI.startsWith(URL_SEPERATOR)) {
+            requestURI = requestURI.substring(1);
+        }
+
+        String[] parts = requestURI.split(URL_SEPERATOR);
+        if (parts.length < 3) {
+            return;
+        }
+
+        String accessTokenIssuedOrganization;
+        if (TENANT_SEPERATOR.equals(parts[0])) {
+            // Case 1 & 2: /t/<tenant>/oauth2/token
+            // Case 3: /t/<tenant>/o/<org>/oauth2/token (virtual org)
+            accessTokenIssuedOrganization = parts[1];
+        } else if (ORG_SEPERATOR.equals(parts[0])) {
+            // Case 4: /o/<org>/oauth2/token
+            accessTokenIssuedOrganization = parts[1];
+        } else {
+            return;
+        }
+        IdentityContext.getThreadLocalIdentityContext().setAccessTokenIssuedOrganization(accessTokenIssuedOrganization);
     }
 
     public void initIdentityContext() {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/IdentityContextDataHolder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/IdentityContextDataHolder.java
@@ -29,6 +29,7 @@ public class IdentityContextDataHolder {
 
     private Flow flow;
     private Actor actor;
+    private String accessTokenIssuedOrganization;
 
     private static final ThreadLocal<IdentityContextDataHolder> currentContextHolder =
             new ThreadLocal<IdentityContextDataHolder>() {
@@ -96,6 +97,17 @@ public class IdentityContextDataHolder {
     public Actor getActor() {
 
         return actor;
+    }
+
+    public String getAccessTokenIssuedOrganization() {
+
+        return accessTokenIssuedOrganization;
+    }
+
+    public void setAccessTokenIssuedOrganization(String accessTokenIssuedOrganization) {
+
+        CarbonUtils.checkSecurity();
+        this.accessTokenIssuedOrganization = accessTokenIssuedOrganization;
     }
 
     /**


### PR DESCRIPTION
Enrich Identity context with access token issuer organization.

This PR
1. Add orgHandle to Organization data model.
2. Initialize access token issuer organization in Identity Context.

Parent issue

- https://github.com/wso2/product-is/issues/24186