### PR TITLE
Change myaccount theme to 'wso2is' to align with console theme and provide RTL support

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1677,7 +1677,7 @@
   "myaccount.ui.app_white_logo_path": "/assets/images/branding/logo-inverted.svg",
   "myaccount.ui.is_header_avatar_label_allowed": true,
   "myaccount.ui.product_name": "WSO2 Identity Server",
-  "myaccount.theme": "default",
+  "myaccount.theme": "wso2is",
   "myaccount.product_version.configs.versionOverride": "",
   "myaccount.authenticator_app_configs.enabled": true,
   "myaccount.applications.enabled": true,


### PR DESCRIPTION
### Proposed changes in this pull request

Change the myaccount theme to 'wso2is' to align with console[1] theme and provide RTL support for myaacount.

[1] https://github.com/wso2/carbon-identity-framework/blob/ff9bf4401c5c9e7011dc87d754513e77eea116f0/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json#L1227

### Related Issue
- https://github.com/wso2/product-is/issues/23986