### PR TITLE
Service component fixed

### DIFF
--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.metadata/src/main/java/org/wso2/carbon/identity/webhook/metadata/internal/component/WebhookMetadataServiceComponent.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.metadata/src/main/java/org/wso2/carbon/identity/webhook/metadata/internal/component/WebhookMetadataServiceComponent.java
@@ -52,8 +52,6 @@ public class WebhookMetadataServiceComponent {
             context.getBundleContext().registerService(WebhookMetadataService.class.getName(),
                     webhookMetadataService, null);
 
-            WebhookMetadataServiceComponentHolder.getInstance().setWebhookMetadataService(webhookMetadataService);
-
             log.info("Webhook Metadata component activated successfully");
         } catch (Throwable e) {
             log.error("Error activating Webhook Metadata component", e);

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.metadata/src/main/java/org/wso2/carbon/identity/webhook/metadata/internal/component/WebhookMetadataServiceComponentHolder.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.metadata/src/main/java/org/wso2/carbon/identity/webhook/metadata/internal/component/WebhookMetadataServiceComponentHolder.java
@@ -18,20 +18,15 @@
 
 package org.wso2.carbon.identity.webhook.metadata.internal.component;
 
-import org.wso2.carbon.identity.webhook.metadata.api.service.WebhookMetadataService;
-import org.wso2.carbon.identity.webhook.metadata.internal.service.impl.WebhookMetadataServiceImpl;
-
 /**
  * Component holder for webhook metadata services.
  */
 public class WebhookMetadataServiceComponentHolder {
 
     private static final WebhookMetadataServiceComponentHolder INSTANCE = new WebhookMetadataServiceComponentHolder();
-    private WebhookMetadataService webhookMetadataService;
 
     private WebhookMetadataServiceComponentHolder() {
 
-        this.webhookMetadataService = WebhookMetadataServiceImpl.getInstance();
     }
 
     /**
@@ -42,25 +37,5 @@ public class WebhookMetadataServiceComponentHolder {
     public static WebhookMetadataServiceComponentHolder getInstance() {
 
         return INSTANCE;
-    }
-
-    /**
-     * Get the webhook metadata service.
-     *
-     * @return WebhookMetadataService
-     */
-    public WebhookMetadataService getWebhookMetadataService() {
-
-        return webhookMetadataService;
-    }
-
-    /**
-     * Set the webhook metadata service.
-     *
-     * @param webhookMetadataService WebhookMetadataService
-     */
-    public void setWebhookMetadataService(WebhookMetadataService webhookMetadataService) {
-
-        this.webhookMetadataService = webhookMetadataService;
     }
 }

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.metadata/src/test/java/org/wso2/carbon/identity/webhook/metadata/internal/WebhookMetadataComponentServiceHolderTest.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.metadata/src/test/java/org/wso2/carbon/identity/webhook/metadata/internal/WebhookMetadataComponentServiceHolderTest.java
@@ -18,10 +18,8 @@
 
 package org.wso2.carbon.identity.webhook.metadata.internal;
 
-import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.webhook.metadata.api.service.WebhookMetadataService;
 import org.wso2.carbon.identity.webhook.metadata.internal.component.WebhookMetadataServiceComponentHolder;
 
 import static org.testng.Assert.assertEquals;
@@ -30,13 +28,11 @@ import static org.testng.Assert.assertNotNull;
 public class WebhookMetadataComponentServiceHolderTest {
 
     private WebhookMetadataServiceComponentHolder holder;
-    private WebhookMetadataService mockService;
 
     @BeforeMethod
     public void setUp() {
 
         holder = WebhookMetadataServiceComponentHolder.getInstance();
-        mockService = Mockito.mock(WebhookMetadataService.class);
     }
 
     @Test
@@ -45,13 +41,5 @@ public class WebhookMetadataComponentServiceHolderTest {
         WebhookMetadataServiceComponentHolder instance = WebhookMetadataServiceComponentHolder.getInstance();
         assertNotNull(instance);
         assertEquals(instance, holder);
-    }
-
-    @Test
-    public void testSetAndGetWebhookMetadataService() {
-
-        holder.setWebhookMetadataService(mockService);
-        WebhookMetadataService service = holder.getWebhookMetadataService();
-        assertEquals(service, mockService);
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request refactors the `WebhookMetadataServiceComponent` and its associated holder class by removing redundant code and simplifying the implementation. The changes focus on eliminating unused methods and fields, streamlining the activation process, and updating the corresponding test cases.

### Refactoring of `WebhookMetadataServiceComponent`:

* Removed the invocation of `setWebhookMetadataService` in the `activate` method, as the `WebhookMetadataServiceComponentHolder` no longer manages the service instance. (`WebhookMetadataServiceComponent.java`, [components/webhook-mgt/org.wso2.carbon.identity.webhook.metadata/src/main/java/org/wso2/carbon/identity/webhook/metadata/internal/component/WebhookMetadataServiceComponent.javaL55-L56](diffhunk://#diff-0ecb7698eec2ea198b1a5e51c359b328e5d1e523489e44113b759bc5c18c5b58L55-L56))

### Simplification of `WebhookMetadataServiceComponentHolder`:

* Removed the `webhookMetadataService` field and its associated getter and setter methods, as they are no longer necessary. (`WebhookMetadataServiceComponentHolder.java`, [[1]](diffhunk://#diff-1a33ccd4cabb5888fc2a2ecaa6cfeddd5938a0c4f9dcfec5ce9b7a405f6e08f6L21-L34) [[2]](diffhunk://#diff-1a33ccd4cabb5888fc2a2ecaa6cfeddd5938a0c4f9dcfec5ce9b7a405f6e08f6L46-L65)

### Updates to test cases:

* Removed mocking and testing of `WebhookMetadataService` in the `WebhookMetadataComponentServiceHolderTest` class, since the holder class no longer manages the service instance. (`WebhookMetadataComponentServiceHolderTest.java`, [[1]](diffhunk://#diff-95106eaf38b494c4895723b78f3b5305edf3450f0245026e9fe3ac80e4da1c0dL21-L24) [[2]](diffhunk://#diff-95106eaf38b494c4895723b78f3b5305edf3450f0245026e9fe3ac80e4da1c0dL33-L39) [[3]](diffhunk://#diff-95106eaf38b494c4895723b78f3b5305edf3450f0245026e9fe3ac80e4da1c0dL49-L56)[Copilot is generating a summary...]
