### PR TITLE
Delete only if webhook present

### DIFF
--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.java
@@ -167,11 +167,9 @@ public class WebhookManagementServiceImpl implements WebhookManagementService {
                     webhookId, tenantDomain));
         }
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-        if (!isWebhookExists(webhookId, tenantId)) {
-            throw WebhookManagementExceptionHandler.handleClientException(
-                    ErrorMessage.ERROR_CODE_WEBHOOK_NOT_FOUND, webhookId);
+        if (isWebhookExists(webhookId, tenantId)) {
+            daoFACADE.deleteWebhook(webhookId, tenantId);
         }
-        daoFACADE.deleteWebhook(webhookId, tenantId);
     }
 
     @Override


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request modifies the `deleteWebhook` method in `WebhookManagementServiceImpl.java` to change the logic for handling non-existent webhooks. The method now deletes the webhook only if it exists, removing the exception previously thrown for non-existent webhooks.

Key change:

* [`WebhookManagementServiceImpl.java`](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0L170-R173): Updated the `deleteWebhook` method to remove the exception handling for non-existent webhooks and instead conditionally delete the webhook only if it exists.