### PR TITLE
Return the webhook with status update

### DIFF
--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/api/service/WebhookManagementService.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/api/service/WebhookManagementService.java
@@ -103,7 +103,7 @@ public interface WebhookManagementService {
      *
      * @param webhookId    Webhook subscription ID.
      * @param tenantDomain Tenant domain.
-     * @return Activated webhook subscription.
+     * @return Deactivated webhook subscription.
      * @throws WebhookMgtException If an error occurs while disabling the webhook.
      */
     public Webhook deactivateWebhook(String webhookId, String tenantDomain) throws WebhookMgtException;

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/api/service/WebhookManagementService.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/api/service/WebhookManagementService.java
@@ -93,16 +93,18 @@ public interface WebhookManagementService {
      *
      * @param webhookId    Webhook subscription ID.
      * @param tenantDomain Tenant domain.
+     * @return Activated webhook subscription.
      * @throws WebhookMgtException If an error occurs while enabling the webhook.
      */
-    public void activateWebhook(String webhookId, String tenantDomain) throws WebhookMgtException;
+    public Webhook activateWebhook(String webhookId, String tenantDomain) throws WebhookMgtException;
 
     /**
      * Disable a webhook subscription.
      *
      * @param webhookId    Webhook subscription ID.
      * @param tenantDomain Tenant domain.
+     * @return Activated webhook subscription.
      * @throws WebhookMgtException If an error occurs while disabling the webhook.
      */
-    public void deactivateWebhook(String webhookId, String tenantDomain) throws WebhookMgtException;
+    public Webhook deactivateWebhook(String webhookId, String tenantDomain) throws WebhookMgtException;
 }

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/WebhookManagementDAO.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/WebhookManagementDAO.java
@@ -99,16 +99,18 @@ public interface WebhookManagementDAO {
      *
      * @param webhookId Webhook subscription ID.
      * @param tenantId  Tenant ID.
+     * @return Activated webhook subscription.
      * @throws WebhookMgtException If an error occurs while enabling the webhook.
      */
-    public void activateWebhook(String webhookId, int tenantId) throws WebhookMgtException;
+    public Webhook activateWebhook(String webhookId, int tenantId) throws WebhookMgtException;
 
     /**
      * Disable a webhook subscription in the database.
      *
      * @param webhookId Webhook subscription ID.
      * @param tenantId  Tenant ID.
+     * @return Activated webhook subscription.
      * @throws WebhookMgtException If an error occurs while disabling the webhook.
      */
-    public void deactivateWebhook(String webhookId, int tenantId) throws WebhookMgtException;
+    public Webhook deactivateWebhook(String webhookId, int tenantId) throws WebhookMgtException;
 }

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/WebhookManagementDAO.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/WebhookManagementDAO.java
@@ -109,7 +109,7 @@ public interface WebhookManagementDAO {
      *
      * @param webhookId Webhook subscription ID.
      * @param tenantId  Tenant ID.
-     * @return Activated webhook subscription.
+     * @return Deactivated webhook subscription.
      * @throws WebhookMgtException If an error occurs while disabling the webhook.
      */
     public Webhook deactivateWebhook(String webhookId, int tenantId) throws WebhookMgtException;

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/CacheBackedWebhookManagementDAO.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/CacheBackedWebhookManagementDAO.java
@@ -133,18 +133,18 @@ public class CacheBackedWebhookManagementDAO implements WebhookManagementDAO {
     }
 
     @Override
-    public void activateWebhook(String webhookId, int tenantId) throws WebhookMgtException {
+    public Webhook activateWebhook(String webhookId, int tenantId) throws WebhookMgtException {
 
         webhookCache.clearCacheEntry(new WebhookCacheKey(webhookId), tenantId);
         LOG.debug("Webhook cache entry is cleared for webhook ID: " + webhookId + " for webhook activate.");
-        webhookManagementDAO.activateWebhook(webhookId, tenantId);
+        return webhookManagementDAO.activateWebhook(webhookId, tenantId);
     }
 
     @Override
-    public void deactivateWebhook(String webhookId, int tenantId) throws WebhookMgtException {
+    public Webhook deactivateWebhook(String webhookId, int tenantId) throws WebhookMgtException {
 
         webhookCache.clearCacheEntry(new WebhookCacheKey(webhookId), tenantId);
         LOG.debug("Webhook cache entry is cleared for webhook ID: " + webhookId + " for webhook deactivate.");
-        webhookManagementDAO.deactivateWebhook(webhookId, tenantId);
+        return webhookManagementDAO.deactivateWebhook(webhookId, tenantId);
     }
 }

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/WebhookManagementDAOFacade.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/WebhookManagementDAOFacade.java
@@ -265,7 +265,7 @@ public class WebhookManagementDAOFacade implements WebhookManagementDAO {
      *
      * @param webhookId Webhook subscription ID.
      * @param tenantId  Tenant ID.
-     * @return Activated webhook subscription.
+     * @return Deactivated webhook subscription.
      * @throws WebhookMgtException If an error occurs while disabling the webhook.
      */
     @Override

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/WebhookManagementDAOImpl.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/WebhookManagementDAOImpl.java
@@ -202,15 +202,15 @@ public class WebhookManagementDAOImpl implements WebhookManagementDAO {
     }
 
     @Override
-    public void activateWebhook(String webhookId, int tenantId) throws WebhookMgtException {
+    public Webhook activateWebhook(String webhookId, int tenantId) throws WebhookMgtException {
 
-        updateWebhookStatus(webhookId, tenantId, WebhookStatus.ACTIVE.name());
+        return updateWebhookStatus(webhookId, tenantId, WebhookStatus.ACTIVE.name());
     }
 
     @Override
-    public void deactivateWebhook(String webhookId, int tenantId) throws WebhookMgtException {
+    public Webhook deactivateWebhook(String webhookId, int tenantId) throws WebhookMgtException {
 
-        updateWebhookStatus(webhookId, tenantId, WebhookStatus.INACTIVE.name());
+        return updateWebhookStatus(webhookId, tenantId, WebhookStatus.INACTIVE.name());
     }
 
     // --- Private helper methods ---
@@ -316,7 +316,7 @@ public class WebhookManagementDAOImpl implements WebhookManagementDAO {
         });
     }
 
-    private void updateWebhookStatus(String webhookId, int tenantId, String status) throws WebhookMgtException {
+    private Webhook updateWebhookStatus(String webhookId, int tenantId, String status) throws WebhookMgtException {
 
         NamedJdbcTemplate jdbcTemplate = new NamedJdbcTemplate(IdentityDatabaseUtil.getDataSource());
         try {
@@ -331,6 +331,7 @@ public class WebhookManagementDAOImpl implements WebhookManagementDAO {
                         });
                 return null;
             });
+            return getWebhook(webhookId, tenantId);
         } catch (TransactionException e) {
             throw WebhookManagementExceptionHandler.handleServerException(
                     ERROR_CODE_WEBHOOK_STATUS_UPDATE_ERROR, e, status);

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.java
@@ -184,7 +184,7 @@ public class WebhookManagementServiceImpl implements WebhookManagementService {
     }
 
     @Override
-    public void activateWebhook(String webhookId, String tenantDomain) throws WebhookMgtException {
+    public Webhook activateWebhook(String webhookId, String tenantDomain) throws WebhookMgtException {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug(String.format("Activating webhook with ID: %s for tenant: %s",
@@ -195,11 +195,11 @@ public class WebhookManagementServiceImpl implements WebhookManagementService {
             throw WebhookManagementExceptionHandler.handleClientException(
                     ErrorMessage.ERROR_CODE_WEBHOOK_NOT_FOUND, webhookId);
         }
-        daoFACADE.activateWebhook(webhookId, tenantId);
+        return daoFACADE.activateWebhook(webhookId, tenantId);
     }
 
     @Override
-    public void deactivateWebhook(String webhookId, String tenantDomain) throws WebhookMgtException {
+    public Webhook deactivateWebhook(String webhookId, String tenantDomain) throws WebhookMgtException {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug(String.format("Deactivating webhook with ID: %s for tenant: %s",
@@ -210,7 +210,7 @@ public class WebhookManagementServiceImpl implements WebhookManagementService {
             throw WebhookManagementExceptionHandler.handleClientException(
                     ErrorMessage.ERROR_CODE_WEBHOOK_NOT_FOUND, webhookId);
         }
-        daoFACADE.deactivateWebhook(webhookId, tenantId);
+        return daoFACADE.deactivateWebhook(webhookId, tenantId);
     }
 
     private boolean isWebhookExists(String webhookId, int tenantId) throws WebhookMgtException {


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request refactors the webhook activation and deactivation methods across multiple layers of the `webhook-mgt` component to return the updated `Webhook` object instead of using `void`. This change enhances the API by providing more feedback about the operation's result, improving usability and consistency.

### Refactoring to return `Webhook` objects:

* **Service Layer Changes**:
  - Updated `activateWebhook` and `deactivateWebhook` methods in `WebhookManagementService` to return `Webhook` objects instead of `void`.
  - Refactored corresponding methods in `WebhookManagementServiceImpl` to return the `Webhook` object retrieved from the DAO layer. [[1]](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0L187-R187) [[2]](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0L198-R202) [[3]](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0L213-R213)

* **DAO Interface Changes**:
  - Changed `activateWebhook` and `deactivateWebhook` methods in `WebhookManagementDAO` to return `Webhook` objects instead of `void`.

* **DAO Implementation Changes**:
  - Updated `CacheBackedWebhookManagementDAO`, `WebhookManagementDAOFacade`, and `WebhookManagementDAOImpl` to return the updated `Webhook` object after activation or deactivation. [[1]](diffhunk://#diff-d390e5706d73372b0b0a92a9bf657d563cb83f9f0389ccaaefb10461c8d79afbL136-R148) [[2]](diffhunk://#diff-12e53d2f48d3bf8cb7acae93330ac30e681a94db22b9865dec070f277bb892ebR254-L292) [[3]](diffhunk://#diff-d42a3afb651a4a10ef1804d9261221739f903e1cddb95f78a6a96051dc8101daL205-R213)
  - Modified the `updateWebhookStatus` method in `WebhookManagementDAOImpl` to return the updated `Webhook` object. [[1]](diffhunk://#diff-d42a3afb651a4a10ef1804d9261221739f903e1cddb95f78a6a96051dc8101daL319-R319) [[2]](diffhunk://#diff-d42a3afb651a4a10ef1804d9261221739f903e1cddb95f78a6a96051dc8101daR334)