### PR TITLE
Added event types

### DIFF
--- a/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
@@ -330,7 +330,16 @@ public class IdentityEventConstants {
         SESSION_EXPIRE,
         SESSION_EXTEND,
         VERIFICATION,
-        USER_SESSION_TERMINATE
+        USER_SESSION_TERMINATE,
+        POST_ADD_NEW_PASSWORD,
+        POST_UPDATE_CREDENTIAL_BY_SCIM,
+        POST_ADD_USER,
+        POST_SELF_SIGNUP_CONFIRM,
+        POST_UPDATE_USER_LIST_OF_ROLE,
+        PRE_DELETE_USER_WITH_ID,
+        POST_DELETE_USER,
+        POST_UNLOCK_ACCOUNT,
+        POST_LOCK_ACCOUNT
     }
 
     public class EventProperty {


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request adds new event types to the `EventName` enum in the `IdentityEventConstants.java` file. These changes expand the range of events that can be handled within the identity event framework, enabling more granular tracking and processing of user-related actions.

### Added event types to `EventName` enum:
* [`POST_ADD_NEW_PASSWORD`](diffhunk://#diff-8d747461bb333bc66649c04aec86df8a04c716761f92c0c3ff25c3127e274217L333-R342): Represents the event triggered after adding a new password.
* [`POST_UPDATE_CREDENTIAL_BY_SCIM`](diffhunk://#diff-8d747461bb333bc66649c04aec86df8a04c716761f92c0c3ff25c3127e274217L333-R342): Represents the event triggered after updating credentials via SCIM.
* [`POST_ADD_USER`](diffhunk://#diff-8d747461bb333bc66649c04aec86df8a04c716761f92c0c3ff25c3127e274217L333-R342): Represents the event triggered after adding a new user.
* [`POST_SELF_SIGNUP_CONFIRM`](diffhunk://#diff-8d747461bb333bc66649c04aec86df8a04c716761f92c0c3ff25c3127e274217L333-R342): Represents the event triggered after confirming self-signup.
* `POST_UPDATE_USER_LIST_OF_ROLE`, `PRE_DELETE_USER_WITH_ID`, `POST_DELETE_USER`, `POST_UNLOCK_ACCOUNT`, `POST_LOCK_ACCOUNT`: Additional events for role updates, user deletion, account unlocking, and account locking.