### PR TITLE
Disable Webhook Management UI

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1259,7 +1259,7 @@
   ],
   "console.actions.scopes.update": ["internal_action_mgt_update"],
   "console.actions.scopes.delete": ["internal_action_mgt_delete"],
-  "console.s.enabled": false,
+  "console.webhooks.enabled": false,
   "console.webhooks.disabled_features": [],
   "console.webhooks.scopes.feature": ["console:webhooks"],
   "console.webhooks.scopes.create": ["internal_webhook_mgt_create"],


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces a configuration update to the `org.wso2.carbon.identity.core.server.feature.default.json` file, adding new properties related to webhooks.

### Configuration Updates:
* Added a new property `console.webhooks.enabled` to enable or disable webhooks functionality. It is set to `false` by default.
* Introduced `console.webhooks.disabled_features`, an empty array to specify features that should be disabled for webhooks.
