### PR TITLE
Add FlowTypes enum for supported flow types

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
@@ -183,4 +183,14 @@ public class Constants {
 
         }
     }
+
+    /**
+     * Constants for supported flow types.
+     */
+    public enum FlowTypes {
+
+        REGISTRATION,
+        PASSWORD_RECOVERY,
+        ASK_PASSWORD;
+    }
 }


### PR DESCRIPTION
This pull request adds a new `FlowTypes` enum to the `Constants` class in the `flow-orchestration-framework` module. The enum defines constants for supported flow types, improving clarity and maintainability in handling different flow scenarios.

Key change:

* Added the `FlowTypes` enum to the `Constants` class in `components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java`. This enum includes `REGISTRATION`, `PASSWORD_RECOVERY`, and `ASK_PASSWORD` as constants for supported flow types.