### PR TITLE
Add websubhub secret through secret manager

### DIFF
--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/test/resources/dbscripts/h2.sql
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/test/resources/dbscripts/h2.sql
@@ -1143,7 +1143,8 @@ INSERT INTO IDN_SECRET_TYPE (ID, NAME, DESCRIPTION) VALUES
 ('33f0a41b-569d-4ea5-a891-6c0e78a1c3b0', 'ACTION_API_ENDPOINT_AUTH_SECRETS', 'Secret type to uniquely identify secrets relevant to action endpoint authentication properties'),
 ('b411dafd-e2c4-4d2f-afba-3900d802725a', 'PUSH_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to push provider properties'),
 ('ce234fd5-3fb4-4a40-9911-818be9b4ee10', 'REMOTE_LOGGING_SECRETS', 'Secret type to uniquely identify secrets relevant to remote logging properties'),
-('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties');
+('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties'),
+('e2bc9d81-91a0-4efc-9091-c37afc46663b', 'WEBHOOK_SECRETS', 'Secret type to uniquely identify secrets relevant to webhook configurations');
 
 CREATE TABLE IF NOT EXISTS IDN_SECRET (
   ID            VARCHAR(255) NOT NULL,

--- a/components/webhook-mgt/org.wso2.carbon.identity.topic.management/src/main/java/org/wso2/carbon/identity/topic/management/api/constant/ErrorMessage.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.topic.management/src/main/java/org/wso2/carbon/identity/topic/management/api/constant/ErrorMessage.java
@@ -48,13 +48,17 @@ public enum ErrorMessage {
             "An internal server error occurred while constructing the topic from channel URI: %s."),
     ERROR_CODE_TOPIC_REGISTRATION_ERROR("TOPICMGT-65007", "Error occurred while registering topic",
             "An internal server error occurred while registering the topic: %s."),
-    ERROR_CODE_TOPIC_DEREGISTRATION_ERROR("TOPICMGT-65008", "Error occurred while deregistering topic",
+    ERROR_CODE_TOPIC_PERSISTENCE_ERROR("TOPICMGT-65008", "Error occurred while persisting topic",
+            "An internal server error occurred while persisting the topic: %s in the database."),
+    ERROR_CODE_TOPIC_DEREGISTRATION_ERROR("TOPICMGT-65009", "Error occurred while deregistering topic",
             "An internal server error occurred while deregistering the topic: %s."),
-    ERROR_CODE_TOPIC_EXISTS_CHECK_ERROR("TOPICMGT-65009", "Error occurred while checking if topic exists",
+    ERROR_CODE_TOPIC_DELETION_ERROR("TOPICMGT-650010", "Error occurred while deleting topic",
+            "An internal server error occurred while deleting the topic: %s from database."),
+    ERROR_CODE_TOPIC_EXISTS_CHECK_ERROR("TOPICMGT-65011", "Error occurred while checking if topic exists",
             "An internal server error occurred while checking if the topic exists: %s."),
-    ERROR_CODE_UNEXPECTED_ERROR("TOPICMGT-65010", "Unexpected error occurred",
+    ERROR_CODE_UNEXPECTED_ERROR("TOPICMGT-65012", "Unexpected error occurred",
             "An unexpected error occurred while processing the request."),
-    ERROR_CODE_TOPIC_MANAGER_NOT_FOUND("TOPICMGT-65011", "Topic manager not found",
+    ERROR_CODE_TOPIC_MANAGER_NOT_FOUND("TOPICMGT-65013", "Topic manager not found",
             "No suitable topic manager found in the system for tenant: %s.");
 
     private final String code;

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/component/WebhookManagementComponentServiceHolder.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/component/WebhookManagementComponentServiceHolder.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.webhook.management.internal.component;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.secret.mgt.core.SecretManager;
+import org.wso2.carbon.identity.secret.mgt.core.SecretResolveManager;
 import org.wso2.carbon.identity.topic.management.api.service.TopicManagementService;
 import org.wso2.carbon.identity.webhook.management.api.service.EventSubscriber;
 import org.wso2.carbon.identity.webhook.management.internal.service.impl.EventSubscriberService;
@@ -42,6 +43,7 @@ public class WebhookManagementComponentServiceHolder {
     private List<EventSubscriber> eventSubscribers = new ArrayList<>();
     private EventSubscriberService eventSubscriberService;
     private SecretManager secretManager;
+    private SecretResolveManager secretResolveManager;
     private TopicManagementService topicManagementService;
     private WebhookMetadataService webhookMetadataService;
 
@@ -124,6 +126,26 @@ public class WebhookManagementComponentServiceHolder {
     public void setSecretManager(SecretManager secretManager) {
 
         this.secretManager = secretManager;
+    }
+
+    /**
+     * Get the SecretResolveManager.
+     *
+     * @return SecretResolveManager instance.
+     */
+    public SecretResolveManager getSecretResolveManager() {
+
+        return secretResolveManager;
+    }
+
+    /**
+     * Set the SecretResolveManager.
+     *
+     * @param secretResolveManager SecretResolveManager instance.
+     */
+    public void setSecretResolveManager(SecretResolveManager secretResolveManager) {
+
+        this.secretResolveManager = secretResolveManager;
     }
 
     /**

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/component/WebhookManagementServiceComponent.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/component/WebhookManagementServiceComponent.java
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.secret.mgt.core.SecretManager;
+import org.wso2.carbon.identity.secret.mgt.core.SecretResolveManager;
 import org.wso2.carbon.identity.topic.management.api.service.TopicManagementService;
 import org.wso2.carbon.identity.webhook.management.api.service.EventSubscriber;
 import org.wso2.carbon.identity.webhook.management.api.service.WebhookManagementService;
@@ -116,25 +117,6 @@ public class WebhookManagementServiceComponent {
     }
 
     @Reference(
-            name = "org.wso2.carbon.identity.secret.mgt.core.SecretManager",
-            service = SecretManager.class,
-            cardinality = ReferenceCardinality.MANDATORY,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetSecretManager"
-    )
-    private void setSecretManager(SecretManager secretManager) {
-
-        WebhookManagementComponentServiceHolder.getInstance().setSecretManager(secretManager);
-        LOG.debug("SecretManager set in WebhookManagementComponentServiceHolder bundle.");
-    }
-
-    private void unsetSecretManager(SecretManager secretManager) {
-
-        WebhookManagementComponentServiceHolder.getInstance().setSecretManager(null);
-        LOG.debug("SecretManager unset in WebhookManagementComponentServiceHolder bundle.");
-    }
-
-    @Reference(
             name = "topic.management.service.component",
             service = TopicManagementService.class,
             cardinality = ReferenceCardinality.MANDATORY,
@@ -168,5 +150,43 @@ public class WebhookManagementServiceComponent {
     protected void unsetWebhookMetadataService(WebhookMetadataService webhookMetadataService) {
 
         WebhookManagementComponentServiceHolder.getInstance().setWebhookMetadataService(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.secret.mgt.core.SecretManager",
+            service = SecretManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetSecretManager"
+    )
+    private void setSecretManager(SecretManager secretManager) {
+
+        WebhookManagementComponentServiceHolder.getInstance().setSecretManager(secretManager);
+        LOG.debug("SecretManager set in WebhookManagementComponentServiceHolder bundle.");
+    }
+
+    private void unsetSecretManager(SecretManager secretManager) {
+
+        WebhookManagementComponentServiceHolder.getInstance().setSecretManager(null);
+        LOG.debug("SecretManager unset in WebhookManagementComponentServiceHolder bundle.");
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.secret.mgt.core.SecretResolveManager",
+            service = SecretResolveManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetSecretResolveManager"
+    )
+    private void setSecretResolveManager(SecretResolveManager secretResolveManager) {
+
+        WebhookManagementComponentServiceHolder.getInstance().setSecretResolveManager(secretResolveManager);
+        LOG.debug("SecretResolveManager set in WebhookManagementComponentServiceHolder bundle.");
+    }
+
+    private void unsetSecretResolveManager(SecretResolveManager secretResolveManager) {
+
+        WebhookManagementComponentServiceHolder.getInstance().setSecretResolveManager(null);
+        LOG.debug("SecretResolveManager unset in WebhookManagementComponentServiceHolder bundle.");
     }
 }

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/util/WebhookSecretProcessor.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/util/WebhookSecretProcessor.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.webhook.management.internal.util;
+
+import org.wso2.carbon.identity.secret.mgt.core.exception.SecretManagementException;
+import org.wso2.carbon.identity.secret.mgt.core.model.ResolvedSecret;
+import org.wso2.carbon.identity.secret.mgt.core.model.Secret;
+import org.wso2.carbon.identity.secret.mgt.core.model.SecretType;
+import org.wso2.carbon.identity.webhook.management.internal.component.WebhookManagementComponentServiceHolder;
+
+/**
+ * Webhook secrets processor service implementation.
+ */
+public class WebhookSecretProcessor {
+
+    private static final String IDN_SECRET_TYPE_WEBHOOK_SECRETS = "WEBHOOK_SECRETS";
+    private static final String ENDPOINT_PREFIX = "ENDPOINT";
+    private static final String SECRET_SUFFIX = "SECRET";
+
+    public String encryptAssociatedSecrets(String webhookId, String secret)
+            throws SecretManagementException {
+
+        return encryptProperty(webhookId, secret);
+    }
+
+    public String decryptAssociatedSecrets(String webhookId)
+            throws SecretManagementException {
+
+        return decryptProperty(webhookId);
+    }
+
+    public void deleteAssociatedSecrets(String webhookId)
+            throws SecretManagementException {
+
+        String secretName = buildSecretName(webhookId);
+        if (isSecretPropertyExists(secretName)) {
+            WebhookManagementComponentServiceHolder.getInstance().getSecretManager()
+                    .deleteSecret(IDN_SECRET_TYPE_WEBHOOK_SECRETS, secretName);
+        }
+    }
+
+    public String getSecretWithSecretReferences(String webhookId) throws SecretManagementException {
+
+        return buildSecretReference(buildSecretName(webhookId));
+    }
+
+    /**
+     * Encrypt secret property.
+     *
+     * @param webhookId Webhook ID.
+     * @param secret    Secret to be encrypted.
+     * @return Encrypted secret name.
+     * @throws SecretManagementException If an error occurs while encrypting the secret.
+     */
+    private String encryptProperty(String webhookId, String secret)
+            throws SecretManagementException {
+
+        String secretName = buildSecretName(webhookId);
+        if (isSecretPropertyExists(secretName)) {
+            updateExistingSecretProperty(secretName, secret);
+        } else {
+            addNewWebhookSecretProperty(secretName, secret);
+        }
+
+        return buildSecretReference(secretName);
+    }
+
+    /**
+     * Decrypt secret property.
+     *
+     * @param webhookId Webhook ID.
+     * @return Decrypted secret value.
+     * @throws SecretManagementException If an error occurs while decrypting the secret.
+     */
+    private String decryptProperty(String webhookId)
+            throws SecretManagementException {
+
+        String secretName = buildSecretName(webhookId);
+        if (!isSecretPropertyExists(secretName)) {
+            throw new SecretManagementException(String.format("Unable to find the Secret of " +
+                    "Webhook ID: %s from the system.", webhookId));
+        }
+        ResolvedSecret resolvedSecret = WebhookManagementComponentServiceHolder.getInstance().getSecretResolveManager()
+                .getResolvedSecret(IDN_SECRET_TYPE_WEBHOOK_SECRETS, secretName);
+
+        return resolvedSecret.getResolvedSecretValue();
+    }
+
+    /**
+     * Check if the secret exists.
+     *
+     * @param secretName Name of the secret.
+     * @return True if the secret exists, false otherwise.
+     * @throws SecretManagementException If an error occurs while checking the existence of the secret.
+     */
+    private boolean isSecretPropertyExists(String secretName) throws SecretManagementException {
+
+        return WebhookManagementComponentServiceHolder.getInstance().getSecretManager()
+                .isSecretExist(IDN_SECRET_TYPE_WEBHOOK_SECRETS, secretName);
+    }
+
+    /**
+     * Build secret name for the webhook.
+     *
+     * @param webhookId Webhook ID.
+     * @return Secret name.
+     */
+    private String buildSecretName(String webhookId) {
+
+        return webhookId + ":" + ENDPOINT_PREFIX + ":" + SECRET_SUFFIX;
+    }
+
+    /**
+     * Build secret reference for the webhook.
+     *
+     * @param secretName Name of the secret.
+     * @return Secret reference.
+     * @throws SecretManagementException If an error occurs while building the secret reference.
+     */
+    private String buildSecretReference(String secretName) throws SecretManagementException {
+
+        SecretType secretType = WebhookManagementComponentServiceHolder.getInstance().getSecretManager()
+                .getSecretType(IDN_SECRET_TYPE_WEBHOOK_SECRETS);
+        return secretType.getId() + ":" + secretName;
+    }
+
+    /**
+     * Add a new secret of Webhook secret type.
+     *
+     * @param secretName  Name of the secret.
+     * @param secretValue Secret value.
+     * @throws SecretManagementException If an error occurs while adding the secret.
+     */
+    private void addNewWebhookSecretProperty(String secretName, String secretValue) throws SecretManagementException {
+
+        Secret secret = new Secret();
+        secret.setSecretName(secretName);
+        secret.setSecretValue(secretValue);
+        WebhookManagementComponentServiceHolder.getInstance().getSecretManager()
+                .addSecret(IDN_SECRET_TYPE_WEBHOOK_SECRETS,
+                        secret);
+    }
+
+    /**
+     * Update an existing secret property.
+     *
+     * @param secretName  Name of the secret.
+     * @param secretValue Secret value.
+     * @throws SecretManagementException If an error occurs while updating the secret.
+     */
+    private void updateExistingSecretProperty(String secretName, String secretValue)
+            throws SecretManagementException {
+
+        ResolvedSecret resolvedSecret = WebhookManagementComponentServiceHolder.getInstance().getSecretResolveManager()
+                .getResolvedSecret(IDN_SECRET_TYPE_WEBHOOK_SECRETS, secretName);
+        if (!resolvedSecret.getResolvedSecretValue().equals(secretValue)) {
+            WebhookManagementComponentServiceHolder.getInstance().getSecretManager()
+                    .updateSecretValue(IDN_SECRET_TYPE_WEBHOOK_SECRETS, secretName, secretValue);
+        }
+    }
+}

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/java/org/wso2/carbon/identity/webhook/management/util/WebhookSecretProcessorTest.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/java/org/wso2/carbon/identity/webhook/management/util/WebhookSecretProcessorTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.webhook.management.util;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.secret.mgt.core.SecretManager;
+import org.wso2.carbon.identity.secret.mgt.core.SecretResolveManager;
+import org.wso2.carbon.identity.secret.mgt.core.exception.SecretManagementException;
+import org.wso2.carbon.identity.secret.mgt.core.model.ResolvedSecret;
+import org.wso2.carbon.identity.secret.mgt.core.model.Secret;
+import org.wso2.carbon.identity.secret.mgt.core.model.SecretType;
+import org.wso2.carbon.identity.webhook.management.internal.component.WebhookManagementComponentServiceHolder;
+import org.wso2.carbon.identity.webhook.management.internal.util.WebhookSecretProcessor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WebhookSecretProcessorTest {
+
+    private static final String TEST_WEBHOOK_ID = "webhook-123";
+    private static final String TEST_SECRET = "super-secret";
+    private static final String TEST_SECRET_TYPE_ID = "WEBHOOK_SECRETS";
+    private static final String SECRET_NAME = TEST_WEBHOOK_ID + ":ENDPOINT:SECRET";
+    private static final String SECRET_REFERENCE = TEST_SECRET_TYPE_ID + ":" + SECRET_NAME;
+
+    private SecretManager secretManager;
+    private SecretResolveManager secretResolveManager;
+    private WebhookSecretProcessor webhookSecretProcessor;
+
+    @BeforeClass
+    public void setUpClass() {
+
+        webhookSecretProcessor = new WebhookSecretProcessor();
+    }
+
+    @BeforeMethod
+    public void setUp() throws SecretManagementException {
+
+        secretManager = mock(SecretManager.class);
+        secretResolveManager = mock(SecretResolveManager.class);
+
+        WebhookManagementComponentServiceHolder.getInstance().setSecretManager(secretManager);
+        WebhookManagementComponentServiceHolder.getInstance().setSecretResolveManager(secretResolveManager);
+
+        SecretType secretType = mock(SecretType.class);
+        when(secretType.getId()).thenReturn(TEST_SECRET_TYPE_ID);
+        when(secretManager.getSecretType(any())).thenReturn(secretType);
+    }
+
+    @Test
+    public void testEncryptAssociatedSecrets_AddNewSecret() throws SecretManagementException {
+
+        when(secretManager.isSecretExist(TEST_SECRET_TYPE_ID, SECRET_NAME)).thenReturn(false);
+
+        String secretName = webhookSecretProcessor.encryptAssociatedSecrets(TEST_WEBHOOK_ID, TEST_SECRET);
+
+        Assert.assertEquals(secretName, SECRET_REFERENCE);
+        verify(secretManager, times(1)).addSecret(eq(TEST_SECRET_TYPE_ID), any(Secret.class));
+    }
+
+    @Test
+    public void testEncryptAssociatedSecrets_UpdateExistingSecret() throws SecretManagementException {
+
+        when(secretManager.isSecretExist(TEST_SECRET_TYPE_ID, SECRET_NAME)).thenReturn(true);
+
+        ResolvedSecret resolvedSecret = mock(ResolvedSecret.class);
+        when(resolvedSecret.getResolvedSecretValue()).thenReturn("old-secret");
+        when(secretResolveManager.getResolvedSecret(TEST_SECRET_TYPE_ID, SECRET_NAME)).thenReturn(resolvedSecret);
+
+        String secretName = webhookSecretProcessor.encryptAssociatedSecrets(TEST_WEBHOOK_ID, TEST_SECRET);
+
+        Assert.assertEquals(secretName, SECRET_REFERENCE);
+        verify(secretManager, times(1)).updateSecretValue(TEST_SECRET_TYPE_ID, SECRET_NAME, TEST_SECRET);
+    }
+
+    @Test
+    public void testEncryptAssociatedSecrets_NoUpdateIfSameSecret() throws SecretManagementException {
+
+        when(secretManager.isSecretExist(TEST_SECRET_TYPE_ID, SECRET_NAME)).thenReturn(true);
+
+        ResolvedSecret resolvedSecret = mock(ResolvedSecret.class);
+        when(resolvedSecret.getResolvedSecretValue()).thenReturn(TEST_SECRET);
+        when(secretResolveManager.getResolvedSecret(TEST_SECRET_TYPE_ID, SECRET_NAME)).thenReturn(resolvedSecret);
+
+        String secretName = webhookSecretProcessor.encryptAssociatedSecrets(TEST_WEBHOOK_ID, TEST_SECRET);
+
+        Assert.assertEquals(secretName, SECRET_REFERENCE);
+        verify(secretManager, never()).updateSecretValue(any(), any(), any());
+    }
+
+    @Test
+    public void testDecryptAssociatedSecrets() throws SecretManagementException {
+
+        when(secretManager.isSecretExist(TEST_SECRET_TYPE_ID, SECRET_NAME)).thenReturn(true);
+
+        ResolvedSecret resolvedSecret = mock(ResolvedSecret.class);
+        when(resolvedSecret.getResolvedSecretValue()).thenReturn(TEST_SECRET);
+        when(secretResolveManager.getResolvedSecret(TEST_SECRET_TYPE_ID, SECRET_NAME)).thenReturn(resolvedSecret);
+
+        String decrypted = webhookSecretProcessor.decryptAssociatedSecrets(TEST_WEBHOOK_ID);
+
+        Assert.assertEquals(decrypted, TEST_SECRET);
+    }
+
+    @Test(expectedExceptions = SecretManagementException.class)
+    public void testDecryptAssociatedSecrets_SecretNotExist() throws SecretManagementException {
+
+        when(secretManager.isSecretExist(TEST_SECRET_TYPE_ID, SECRET_NAME)).thenReturn(false);
+
+        webhookSecretProcessor.decryptAssociatedSecrets(TEST_WEBHOOK_ID);
+    }
+
+    @Test
+    public void testDeleteAssociatedSecrets() throws SecretManagementException {
+
+        when(secretManager.isSecretExist(TEST_SECRET_TYPE_ID, SECRET_NAME)).thenReturn(true);
+        doNothing().when(secretManager).deleteSecret(TEST_SECRET_TYPE_ID, SECRET_NAME);
+
+        webhookSecretProcessor.deleteAssociatedSecrets(TEST_WEBHOOK_ID);
+
+        verify(secretManager, times(1)).deleteSecret(TEST_SECRET_TYPE_ID, SECRET_NAME);
+    }
+
+    @Test
+    public void testDeleteAssociatedSecrets_SecretNotExist() throws SecretManagementException {
+
+        when(secretManager.isSecretExist(TEST_SECRET_TYPE_ID, SECRET_NAME)).thenReturn(false);
+
+        webhookSecretProcessor.deleteAssociatedSecrets(TEST_WEBHOOK_ID);
+
+        verify(secretManager, never()).deleteSecret(any(), any());
+    }
+
+    @Test
+    public void testGetSecretWithSecretReferences() throws SecretManagementException {
+
+        String reference = webhookSecretProcessor.getSecretWithSecretReferences(TEST_WEBHOOK_ID);
+
+        Assert.assertEquals(reference, SECRET_REFERENCE);
+    }
+}

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/resources/testng.xml
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/resources/testng.xml
@@ -40,6 +40,7 @@
     <test name="webhook-management-util-test">
         <classes>
             <class name="org.wso2.carbon.identity.webhook.management.util.WebhookValidatorTest"/>
+            <class name="org.wso2.carbon.identity.webhook.management.util.WebhookSecretProcessorTest"/>
         </classes>
     </test>
 </suite>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/db2.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/db2.sql
@@ -1745,7 +1745,8 @@ INSERT INTO IDN_SECRET_TYPE (ID, NAME, DESCRIPTION) VALUES
 ('33f0a41b-569d-4ea5-a891-6c0e78a1c3b0', 'ACTION_API_ENDPOINT_AUTH_SECRETS', 'Secret type to uniquely identify secrets relevant to action endpoint authentication properties'),
 ('b411dafd-e2c4-4d2f-afba-3900d802725a', 'PUSH_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to push provider properties'),
 ('ce234fd5-3fb4-4a40-9911-818be9b4ee10', 'REMOTE_LOGGING_SECRETS', 'Secret type to uniquely identify secrets relevant to remote logging properties'),
-('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties');
+('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties'),
+('e2bc9d81-91a0-4efc-9091-c37afc46663b', 'WEBHOOK_SECRETS', 'Secret type to uniquely identify secrets relevant to webhook configurations');
 /
 
 CREATE TABLE IDN_SECRET (

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/h2.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/h2.sql
@@ -1160,7 +1160,8 @@ INSERT INTO IDN_SECRET_TYPE (ID, NAME, DESCRIPTION) VALUES
 ('33f0a41b-569d-4ea5-a891-6c0e78a1c3b0', 'ACTION_API_ENDPOINT_AUTH_SECRETS', 'Secret type to uniquely identify secrets relevant to action endpoint authentication properties'),
 ('b411dafd-e2c4-4d2f-afba-3900d802725a', 'PUSH_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to push provider properties'),
 ('ce234fd5-3fb4-4a40-9911-818be9b4ee10', 'REMOTE_LOGGING_SECRETS', 'Secret type to uniquely identify secrets relevant to remote logging properties'),
-('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties');
+('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties'),
+('e2bc9d81-91a0-4efc-9091-c37afc46663b', 'WEBHOOK_SECRETS', 'Secret type to uniquely identify secrets relevant to webhook configurations');
 
 CREATE TABLE IF NOT EXISTS IDN_SECRET (
   ID            VARCHAR(255) NOT NULL,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/mssql.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/mssql.sql
@@ -1287,7 +1287,8 @@ INSERT INTO IDN_SECRET_TYPE (ID, NAME, DESCRIPTION) VALUES
 ('33f0a41b-569d-4ea5-a891-6c0e78a1c3b0', 'ACTION_API_ENDPOINT_AUTH_SECRETS', 'Secret type to uniquely identify secrets relevant to action endpoint authentication properties'),
 ('b411dafd-e2c4-4d2f-afba-3900d802725a', 'PUSH_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to push provider properties'),
 ('ce234fd5-3fb4-4a40-9911-818be9b4ee10', 'REMOTE_LOGGING_SECRETS', 'Secret type to uniquely identify secrets relevant to remote logging properties'),
-('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties');
+('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties'),
+('e2bc9d81-91a0-4efc-9091-c37afc46663b', 'WEBHOOK_SECRETS', 'Secret type to uniquely identify secrets relevant to webhook configurations');
 
 IF NOT EXISTS (SELECT * FROM SYS.OBJECTS WHERE OBJECT_ID = OBJECT_ID(N'[DBO].[IDN_SECRET]')
 AND TYPE IN (N'U'))

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/mysql-cluster.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/mysql-cluster.sql
@@ -1326,7 +1326,8 @@ INSERT INTO IDN_SECRET_TYPE (ID, NAME, DESCRIPTION) VALUES
 ('33f0a41b-569d-4ea5-a891-6c0e78a1c3b0', 'ACTION_API_ENDPOINT_AUTH_SECRETS', 'Secret type to uniquely identify secrets relevant to action endpoint authentication properties'),
 ('b411dafd-e2c4-4d2f-afba-3900d802725a', 'PUSH_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to push provider properties'),
 ('ce234fd5-3fb4-4a40-9911-818be9b4ee10', 'REMOTE_LOGGING_SECRETS', 'Secret type to uniquely identify secrets relevant to remote logging properties'),
-('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties');
+('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties'),
+('e2bc9d81-91a0-4efc-9091-c37afc46663b', 'WEBHOOK_SECRETS', 'Secret type to uniquely identify secrets relevant to webhook configurations');
 
 CREATE TABLE IF NOT EXISTS IDN_SECRET (
     ID VARCHAR(255) NOT NULL,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/mysql.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/mysql.sql
@@ -1187,7 +1187,8 @@ INSERT INTO IDN_SECRET_TYPE (ID, NAME, DESCRIPTION) VALUES
 ('33f0a41b-569d-4ea5-a891-6c0e78a1c3b0', 'ACTION_API_ENDPOINT_AUTH_SECRETS', 'Secret type to uniquely identify secrets relevant to action endpoint authentication properties'),
 ('b411dafd-e2c4-4d2f-afba-3900d802725a', 'PUSH_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to push provider properties'),
 ('ce234fd5-3fb4-4a40-9911-818be9b4ee10', 'REMOTE_LOGGING_SECRETS', 'Secret type to uniquely identify secrets relevant to remote logging properties'),
-('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties');
+('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties'),
+('e2bc9d81-91a0-4efc-9091-c37afc46663b', 'WEBHOOK_SECRETS', 'Secret type to uniquely identify secrets relevant to webhook configurations');
 
 CREATE TABLE IF NOT EXISTS IDN_SECRET (
     ID VARCHAR(255) NOT NULL,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/oracle.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/oracle.sql
@@ -1932,6 +1932,8 @@ INTO IDN_SECRET_TYPE (ID, NAME, DESCRIPTION) VALUES
 ('ce234fd5-3fb4-4a40-9911-818be9b4ee10', 'REMOTE_LOGGING_SECRETS', 'Secret type to uniquely identify secrets relevant to remote logging properties')
 INTO IDN_SECRET_TYPE (ID, NAME, DESCRIPTION) VALUES
 ('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties')
+INTO IDN_SECRET_TYPE (ID, NAME, DESCRIPTION) VALUES
+('e2bc9d81-91a0-4efc-9091-c37afc46663b', 'WEBHOOK_SECRETS', 'Secret type to uniquely identify secrets relevant to webhook configurations')
 SELECT 1 FROM dual
 /
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/oracle_rac.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/oracle_rac.sql
@@ -1771,6 +1771,8 @@ INTO IDN_SECRET_TYPE (ID, NAME, DESCRIPTION) VALUES
 ('ce234fd5-3fb4-4a40-9911-818be9b4ee10', 'REMOTE_LOGGING_SECRETS', 'Secret type to uniquely identify secrets relevant to remote logging properties')
 INTO IDN_SECRET_TYPE (ID, NAME, DESCRIPTION) VALUES
 ('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties')
+INTO IDN_SECRET_TYPE (ID, NAME, DESCRIPTION) VALUES
+('e2bc9d81-91a0-4efc-9091-c37afc46663b', 'WEBHOOK_SECRETS', 'Secret type to uniquely identify secrets relevant to webhook configurations')
 SELECT 1 FROM dual
 /
 CREATE TABLE IDN_SECRET (

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/postgresql.sql
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/dbscripts/postgresql.sql
@@ -1405,7 +1405,8 @@ INSERT INTO IDN_SECRET_TYPE (ID, NAME, DESCRIPTION) VALUES
 ('33f0a41b-569d-4ea5-a891-6c0e78a1c3b0', 'ACTION_API_ENDPOINT_AUTH_SECRETS', 'Secret type to uniquely identify secrets relevant to action endpoint authentication properties'),
 ('b411dafd-e2c4-4d2f-afba-3900d802725a', 'PUSH_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to push provider properties'),
 ('ce234fd5-3fb4-4a40-9911-818be9b4ee10', 'REMOTE_LOGGING_SECRETS', 'Secret type to uniquely identify secrets relevant to remote logging properties'),
-('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties');
+('a1b2c3d4-5e6f-7a89-b012-3456789ab8de', 'EMAIL_PROVIDER_SECRET_PROPERTIES', 'Secret type to uniquely identify secrets relevant to email provider properties'),
+('e2bc9d81-91a0-4efc-9091-c37afc46663b', 'WEBHOOK_SECRETS', 'Secret type to uniquely identify secrets relevant to webhook configurations');
 
 DROP TABLE IF EXISTS IDN_SECRET;
 CREATE TABLE IDN_SECRET (


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces enhancements to secret management, error handling, and webhook lifecycle operations within the webhook management module. Key changes include the addition of support for `SecretResolveManager`, improved error handling for topic operations, and integration of encryption and decryption for webhook secrets.

### Secret Management Enhancements:
* Added support for `SecretResolveManager` in `WebhookManagementComponentServiceHolder`, including getter and setter methods and OSGi references for dynamic binding. (`[[1]](diffhunk://#diff-3a15a6705ca9a49dca204084ed7314c6d599d05deb98034d15e815831e9d5608R24)`, `[[2]](diffhunk://#diff-3a15a6705ca9a49dca204084ed7314c6d599d05deb98034d15e815831e9d5608R46)`, `[[3]](diffhunk://#diff-3a15a6705ca9a49dca204084ed7314c6d599d05deb98034d15e815831e9d5608R131-R150)`, `[[4]](diffhunk://#diff-e47f1740623c6551fbaff31e319a74ea5fd9c5d042900c0ce494690939d6e01fR32)`, `[[5]](diffhunk://#diff-e47f1740623c6551fbaff31e319a74ea5fd9c5d042900c0ce494690939d6e01fR154-R191)`)
* Integrated `WebhookSecretProcessor` into `WebhookManagementDAOFacade` to handle encryption, decryption, and deletion of webhook secrets. (`[[1]](diffhunk://#diff-12e53d2f48d3bf8cb7acae93330ac30e681a94db22b9865dec070f277bb892ebR38-R46)`, `[[2]](diffhunk://#diff-12e53d2f48d3bf8cb7acae93330ac30e681a94db22b9865dec070f277bb892ebR56-R61)`, `[[3]](diffhunk://#diff-12e53d2f48d3bf8cb7acae93330ac30e681a94db22b9865dec070f277bb892ebR166-R212)`)

### Error Handling Improvements:
* Updated the `ErrorMessage` enum to include new error codes for topic persistence, deletion, and secret-related operations. (`[components/webhook-mgt/org.wso2.carbon.identity.topic.management/src/main/java/org/wso2/carbon/identity/topic/management/api/constant/ErrorMessage.javaL51-R61](diffhunk://#diff-f55d5f6306edd7003ca88f4e33cec8496c172bc730ef5cd98367284d2866ca73L51-R61)`)
* Enhanced error handling in topic registration and deregistration methods to ensure proper cleanup in case of failures. (`[[1]](diffhunk://#diff-6f9054b585164571773ce8a1699139292e4b42acb1fb1976df32030e4f36ee94L78-R96)`, `[[2]](diffhunk://#diff-6f9054b585164571773ce8a1699139292e4b42acb1fb1976df32030e4f36ee94R116-R128)`)

### Webhook Lifecycle Operations:
* Implemented encryption of webhook secrets during creation and update operations, and decryption during retrieval. (`[[1]](diffhunk://#diff-12e53d2f48d3bf8cb7acae93330ac30e681a94db22b9865dec070f277bb892ebL73-R80)`, `[[2]](diffhunk://#diff-12e53d2f48d3bf8cb7acae93330ac30e681a94db22b9865dec070f277bb892ebL106-R118)`, `[[3]](diffhunk://#diff-12e53d2f48d3bf8cb7acae93330ac30e681a94db22b9865dec070f277bb892ebR166-R212)`)
* Added logic to delete authentication secrets associated with a webhook during its deletion. (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/WebhookManagementDAOFacade.javaR143](diffhunk://#diff-12e53d2f48d3bf8cb7acae93330ac30e681a94db22b9865dec070f277bb892ebR143)`)

These changes improve security, reliability, and maintainability across the webhook management module.