### PR TITLE
Provided support for custom keystores through keystore resolver

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/IdentityKeyStoreResolver.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/IdentityKeyStoreResolver.java
@@ -553,6 +553,67 @@ public class IdentityKeyStoreResolver {
 
     }
 
+    /**
+     * Return custom key store.
+     *
+     * @param tenantDomain Tenant domain.
+     * @param keyStoreName Name of the custom key store.
+     * @return Custom key store.
+     * @throws IdentityKeyStoreResolverException the exception in the IdentityKeyStoreResolver class.
+     */
+    public KeyStore getCustomKeyStore(String tenantDomain, String keyStoreName)
+            throws IdentityKeyStoreResolverException {
+
+        if (StringUtils.isEmpty(tenantDomain)) {
+            throw new IdentityKeyStoreResolverException(
+                    ErrorMessages.ERROR_CODE_INVALID_ARGUMENT.getCode(),
+                    String.format(ErrorMessages.ERROR_CODE_INVALID_ARGUMENT.getDescription(), "Tenant domain"));
+        }
+        if (StringUtils.isEmpty(keyStoreName)) {
+            throw new IdentityKeyStoreResolverException(
+                    ErrorMessages.ERROR_CODE_INVALID_ARGUMENT.getCode(),
+                    String.format(ErrorMessages.ERROR_CODE_INVALID_ARGUMENT.getDescription(), "Key store name"));
+        }
+
+        String customKeyStoreName = IdentityKeyStoreResolverUtil.buildCustomKeyStoreName(keyStoreName);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Custom key store configuration available. " +
+                    "Retrieving keystore " + customKeyStoreName);
+        }
+
+        try {
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            KeyStoreManager keyStoreManager = KeyStoreManager.getInstance(tenantId);
+            return keyStoreManager.getKeyStore(customKeyStoreName);
+        } catch (Exception e) {
+            throw new IdentityKeyStoreResolverException(
+                    ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_CUSTOM_KEYSTORE.getCode(),
+                    String.format(ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_CUSTOM_KEYSTORE.getDescription(),
+                            customKeyStoreName), e);
+        }
+    }
+
+    /**
+     * Returns the trust store.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return Trust store.
+     * @throws IdentityKeyStoreResolverException if an error occurs while retrieving the trust store.
+     */
+    public KeyStore getTrustStore(String tenantDomain) throws IdentityKeyStoreResolverException {
+
+        try {
+            KeyStoreManager keyStoreManager = KeyStoreManager.getInstance(IdentityTenantUtil.getTenantId(tenantDomain));
+            return keyStoreManager.getTrustStore();
+        } catch (CarbonException e) {
+            throw new IdentityKeyStoreResolverException(
+                    ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_TRUSTSTORE.getCode(),
+                    String.format(ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_TRUSTSTORE.getDescription(), tenantDomain),
+                    e);
+        }
+    }
+
     private String getPrimaryKeyStoreConfig(String configName) throws IdentityKeyStoreResolverException {
 
         try {
@@ -605,7 +666,7 @@ public class IdentityKeyStoreResolver {
         }
     }
 
-    private String getCustomKeyStoreConfig(String keyStoreName, String configName)
+    public String getCustomKeyStoreConfig(String keyStoreName, String configName)
             throws IdentityKeyStoreResolverException {
 
         try {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityKeyStoreResolverConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityKeyStoreResolverConstants.java
@@ -126,6 +126,9 @@ public class IdentityKeyStoreResolverConstants {
                         "Context Keystore doesn't exist."),
         ERROR_WHILE_LOADING_REGISTRY("IKSR-10011", "Error while loading registry.",
                 "Error occurred while loading registry for tenant: %s."),
+        ERROR_CODE_ERROR_RETRIEVING_TRUSTSTORE(
+                "IKSR-10012", "Error retrieving trust store.",
+                "Error occurred when retrieving trust store for tenant: %s."),
 
         // Errors occurred within the IdentityKeyStoreResolver
         ERROR_CODE_INVALID_ARGUMENT(

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/IdentityKeyStoreResolverTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/IdentityKeyStoreResolverTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
+import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.security.KeystoreUtils;
@@ -44,7 +45,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
-import static org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants.*;
+import static org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants.InboundProtocol;
 
 /**
  * Test cases for IdentityKeyStoreResolver.
@@ -256,6 +257,34 @@ public class IdentityKeyStoreResolverTest extends TestCase {
 
         keystoreUtils.when(() -> KeystoreUtils.getKeyStoreFileExtension(tenantDomain)).thenReturn(".jks");
         assertEquals(expectedCert, identityKeyStoreResolver.getCertificate(tenantDomain, inboundProtocol));
+    }
+
+    @Test
+    public void testGetCustomKeyStore_Success() throws Exception {
+
+        keystoreUtils.when(() -> KeystoreUtils.getKeyStoreFileExtension(TENANT_DOMAIN)).thenReturn(".jks");
+        KeyStore result = identityKeyStoreResolver.getCustomKeyStore(TENANT_DOMAIN, CUSTOM_KEY_STORE);
+        assertEquals(customKeyStore, result);
+    }
+
+    @Test(expectedExceptions = IdentityKeyStoreResolverException.class)
+    public void testGetCustomKeyStore_InvalidTenantDomain() throws Exception {
+
+        identityKeyStoreResolver.getCustomKeyStore("", CUSTOM_KEY_STORE);
+    }
+
+    @Test(expectedExceptions = IdentityKeyStoreResolverException.class)
+    public void testGetCustomKeyStore_InvalidKeyStoreName() throws Exception {
+
+        identityKeyStoreResolver.getCustomKeyStore(TENANT_DOMAIN, "");
+    }
+
+    @Test(expectedExceptions = IdentityKeyStoreResolverException.class)
+    public void testGetTrustStore_Exception() throws Exception {
+
+        KeyStoreManager keyStoreManager = KeyStoreManager.getInstance(Integer.valueOf(TENANT_ID));
+        when(keyStoreManager.getTrustStore()).thenThrow(new org.wso2.carbon.CarbonException("error"));
+        identityKeyStoreResolver.getTrustStore(TENANT_DOMAIN);
     }
 
     private KeyStore getKeyStoreFromFile(String keystoreName, String password, String home) throws Exception {


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces enhancements to the `IdentityKeyStoreResolver` class, adding new methods to retrieve custom key stores and trust stores while improving error handling. Additionally, it includes updates to error codes to support these new functionalities.

### Enhancements to `IdentityKeyStoreResolver`:

* Added `getCustomKeyStore` method to retrieve a custom key store for a given tenant domain and key store name, with validation checks and detailed error handling.
* Added `getTrustStore` method to retrieve the trust store for a specific tenant domain, with appropriate error handling for retrieval failures.

### API Visibility Changes:

* Changed the visibility of `getCustomKeyStoreConfig` from private to public, allowing external access to custom key store configurations.

### Error Handling Improvements:

* Added a new error code `ERROR_CODE_ERROR_RETRIEVING_TRUSTSTORE` to handle trust store retrieval failures, along with an appropriate error message.