### PR TITLE
Improve action diagnostic log messages in API timeouts

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/APIClient.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/APIClient.java
@@ -295,8 +295,8 @@ public class APIClient {
 
         DIAGNOSTIC_LOGGER.logAPICallRetry(request, currentAttempt, retryCount);
         if (currentAttempt < retryCount) {
-            LOG.debug("API: " + request.getURI() + " seems to be unavailable. Executing attempt " +
-                    (currentAttempt + 1) + " of " + retryCount + ".");
+            LOG.debug("API: " + request.getURI() + " seems to be unavailable. Retrying attempt " +
+                    (currentAttempt + 1) + " of " + (retryCount - 1) + ".");
         } else if (currentAttempt == retryCount) {
             LOG.debug("API: " + request.getURI() + " seems to be unavailable. Maximum retry attempts reached.");
         }
@@ -306,8 +306,8 @@ public class APIClient {
 
         DIAGNOSTIC_LOGGER.logAPICallTimeout(request, currentAttempt, retryCount);
         if (currentAttempt < retryCount) {
-            LOG.debug("Request for API: " + request.getURI() + " timed out. Executing attempt " +
-                    (currentAttempt + 1) + " of " + retryCount + ".");
+            LOG.debug("Request for API: " + request.getURI() + " timed out. Retrying attempt " +
+                    (currentAttempt + 1) + " of " + (retryCount - 1) + ".");
         } else if (currentAttempt == retryCount) {
             LOG.debug("Request for API: " + request.getURI() + " timed out. Maximum retry attempts reached.");
         }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/APIClient.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/APIClient.java
@@ -296,8 +296,8 @@ public class APIClient {
         DIAGNOSTIC_LOGGER.logAPICallRetry(request, currentAttempt, retryCount);
         if (currentAttempt < retryCount) {
             LOG.debug("API: " + request.getURI() + " seems to be unavailable. Retrying attempt " +
-                    (currentAttempt + 1) + " of " + (retryCount - 1) + ".");
-        } else if (currentAttempt == retryCount) {
+                    currentAttempt + " of " + (retryCount - 1) + ".");
+        } else {
             LOG.debug("API: " + request.getURI() + " seems to be unavailable. Maximum retry attempts reached.");
         }
     }
@@ -307,8 +307,8 @@ public class APIClient {
         DIAGNOSTIC_LOGGER.logAPICallTimeout(request, currentAttempt, retryCount);
         if (currentAttempt < retryCount) {
             LOG.debug("Request for API: " + request.getURI() + " timed out. Retrying attempt " +
-                    (currentAttempt + 1) + " of " + (retryCount - 1) + ".");
-        } else if (currentAttempt == retryCount) {
+                    currentAttempt + " of " + (retryCount - 1) + ".");
+        } else {
             LOG.debug("Request for API: " + request.getURI() + " timed out. Maximum retry attempts reached.");
         }
     }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/ActionExecutionDiagnosticLogger.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/ActionExecutionDiagnosticLogger.java
@@ -187,33 +187,34 @@ public class ActionExecutionDiagnosticLogger {
                         .configParam("notAllowedOperations", notAllowedOps.isEmpty() ? "empty" : notAllowedOps));
     }
 
-    public void logAPICallRetry(HttpPost request, int attempts, int retryCount) {
+    public void logAPICallRetry(HttpPost request, int currentAttempt, int retryCount) {
 
         if (!LoggerUtils.isDiagnosticLogsEnabled()) {
             return;
         }
 
-        triggerLogEvent(
-                initializeDiagnosticLogBuilder(
-                        ActionExecutionLogConstants.ActionIDs.SEND_ACTION_REQUEST,
-                        "External endpoint " + request.getURI() + " for action " +
-                                "execution seems to be unavailable. Retrying API call attempt " +
-                                attempts + " of " + retryCount + ".",
-                        DiagnosticLog.ResultStatus.SUCCESS));
+        String message = "External endpoint " + request.getURI() + " for action execution seems to be unavailable. " +
+                (currentAttempt < retryCount
+                        ? "Executing API call attempt " + (currentAttempt + 1) + " of " + retryCount + "."
+                        : "Maximum retry attempts reached.");
+
+        triggerLogEvent(initializeDiagnosticLogBuilder(ActionExecutionLogConstants.ActionIDs.SEND_ACTION_REQUEST,
+                message, DiagnosticLog.ResultStatus.SUCCESS));
     }
 
-    public void logAPICallTimeout(HttpPost request, int attempts, int retryCount) {
+    public void logAPICallTimeout(HttpPost request, int currentAttempt, int retryCount) {
 
         if (!LoggerUtils.isDiagnosticLogsEnabled()) {
             return;
         }
 
-        triggerLogEvent(
-                initializeDiagnosticLogBuilder(
-                        ActionExecutionLogConstants.ActionIDs.SEND_ACTION_REQUEST,
-                        "Request for external endpont " + request.getURI() + " for action is " +
-                                "timed out. Retrying API call attempt " + attempts + " of " + retryCount + ".",
-                        DiagnosticLog.ResultStatus.SUCCESS));
+        String message = "Request for external endpoint " + request.getURI() + " for action is timed out. " +
+                (currentAttempt < retryCount
+                        ? "Executing attempt " + (currentAttempt + 1) + " of " + retryCount + "."
+                        : "Maximum retry attempts reached.");
+
+        triggerLogEvent(initializeDiagnosticLogBuilder(ActionExecutionLogConstants.ActionIDs.SEND_ACTION_REQUEST,
+                message, DiagnosticLog.ResultStatus.SUCCESS));
     }
 
     public void logAPICallError(HttpPost request) {

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/ActionExecutionDiagnosticLogger.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/ActionExecutionDiagnosticLogger.java
@@ -195,7 +195,7 @@ public class ActionExecutionDiagnosticLogger {
 
         String message = "External endpoint " + request.getURI() + " for action execution seems to be unavailable. " +
                 (currentAttempt < retryCount
-                        ? "Retrying API call attempt " + (currentAttempt + 1) + " of " + (retryCount - 1) + "."
+                        ? "Retrying API call attempt " + currentAttempt + " of " + (retryCount - 1) + "."
                         : "Maximum retry attempts reached.");
 
         triggerLogEvent(initializeDiagnosticLogBuilder(ActionExecutionLogConstants.ActionIDs.SEND_ACTION_REQUEST,
@@ -210,7 +210,7 @@ public class ActionExecutionDiagnosticLogger {
 
         String message = "Request to the external endpoint " + request.getURI() + " for action execution timed out. " +
                 (currentAttempt < retryCount
-                        ? "Retrying attempt " + (currentAttempt + 1) + " of " + (retryCount - 1) + "."
+                        ? "Retrying attempt " + currentAttempt + " of " + (retryCount - 1) + "."
                         : "Maximum retry attempts reached.");
 
         triggerLogEvent(initializeDiagnosticLogBuilder(ActionExecutionLogConstants.ActionIDs.SEND_ACTION_REQUEST,

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/ActionExecutionDiagnosticLogger.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/ActionExecutionDiagnosticLogger.java
@@ -208,7 +208,7 @@ public class ActionExecutionDiagnosticLogger {
             return;
         }
 
-        String message = "Request for external endpoint " + request.getURI() + " for action is timed out. " +
+        String message = "Request to the external endpoint " + request.getURI() + " for action execution timed out. " +
                 (currentAttempt < retryCount
                         ? "Executing attempt " + (currentAttempt + 1) + " of " + retryCount + "."
                         : "Maximum retry attempts reached.");

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/ActionExecutionDiagnosticLogger.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/ActionExecutionDiagnosticLogger.java
@@ -195,7 +195,7 @@ public class ActionExecutionDiagnosticLogger {
 
         String message = "External endpoint " + request.getURI() + " for action execution seems to be unavailable. " +
                 (currentAttempt < retryCount
-                        ? "Executing API call attempt " + (currentAttempt + 1) + " of " + retryCount + "."
+                        ? "Retrying API call attempt " + (currentAttempt + 1) + " of " + (retryCount - 1) + "."
                         : "Maximum retry attempts reached.");
 
         triggerLogEvent(initializeDiagnosticLogBuilder(ActionExecutionLogConstants.ActionIDs.SEND_ACTION_REQUEST,
@@ -210,7 +210,7 @@ public class ActionExecutionDiagnosticLogger {
 
         String message = "Request to the external endpoint " + request.getURI() + " for action execution timed out. " +
                 (currentAttempt < retryCount
-                        ? "Executing attempt " + (currentAttempt + 1) + " of " + retryCount + "."
+                        ? "Retrying attempt " + (currentAttempt + 1) + " of " + (retryCount - 1) + "."
                         : "Maximum retry attempts reached.");
 
         triggerLogEvent(initializeDiagnosticLogBuilder(ActionExecutionLogConstants.ActionIDs.SEND_ACTION_REQUEST,


### PR DESCRIPTION
### Proposed changes in this pull request
> $subject

Diagnostic log for API timeout.

```
2025-06-20 14: 40: 50,156|eab6f499-c042-409d-8fae-bd40dd3a2ee1|Tenant:carbon.super|pool-4-thread-1|
{
    "logId": "380037e8-20a4-434f-8939-c643f8c9936a",
    "recordedAt": {
        "seconds": 1750410650,
        "nanos": 125311000
    },
    "requestId": "eab6f499-c042-409d-8fae-bd40dd3a2ee1",
    "resultStatus": "SUCCESS",
    "resultMessage": "Request to the external endpoint https://ashantest.free.beeceptor.com for action execution timed out. Retrying attempt 1 of 2.",
    "actionId": "send-action-request",
    "componentId": "action-execution",
    "logDetailLevel": "APPLICATION"
}
2025-06-20 14: 40: 56,420|eab6f499-c042-409d-8fae-bd40dd3a2ee1|Tenant:carbon.super|pool-4-thread-1|
{
    "logId": "79a3ddf9-bff2-4879-b3af-ea33e07ffedf",
    "recordedAt": {
        "seconds": 1750410656,
        "nanos": 416337000
    },
    "requestId": "eab6f499-c042-409d-8fae-bd40dd3a2ee1",
    "resultStatus": "SUCCESS",
    "resultMessage": "Request to the external endpoint https://ashantest.free.beeceptor.com for action execution timed out. Retrying attempt 2 of 2.",
    "actionId": "send-action-request",
    "componentId": "action-execution",
    "logDetailLevel": "APPLICATION"
}
2025-06-20 14: 41: 02,567|eab6f499-c042-409d-8fae-bd40dd3a2ee1|Tenant:carbon.super|pool-4-thread-1|
{
    "logId": "c151a00a-730f-4bba-8b9b-43f405efa817",
    "recordedAt": {
        "seconds": 1750410662,
        "nanos": 564377000
    },
    "requestId": "eab6f499-c042-409d-8fae-bd40dd3a2ee1",
    "resultStatus": "SUCCESS",
    "resultMessage": "Request to the external endpoint https://ashantest.free.beeceptor.com for action execution timed out. Maximum retry attempts reached.",
    "actionId": "send-action-request",
    "componentId": "action-execution",
    "logDetailLevel": "APPLICATION"
}
```


### Related Issue
- https://github.com/wso2/product-is/issues/24385