### PR TITLE
Improving the registration failure event flow

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -326,7 +326,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
             } catch (UserStoreException e) {
 
                 FrameworkUtils.publishEventOnUserRegistrationFailure(e.getErrorCode(), e.getMessage(), userClaims,
-                        tenantDomain, idp);
+                        tenantDomain, userStoreDomain, idp);
                 // Add user operation will fail if a user operation workflow is already defined for the same user.
                 if (USER_WORKFLOW_ENGAGED_ERROR_CODE.equals(e.getErrorCode())) {
                     userWorkflowEngaged = true;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -1479,7 +1479,7 @@ public class FrameworkUtils {
      */
     public static void publishEventOnUserRegistrationFailure(String errorCode, String errorMessage,
                                                              Map<String, String> claims, String tenantDomain,
-                                                             String idp) {
+                                                             String userStoreDomain, String idp) {
 
         String stepId = String.valueOf(
                 IdentityUtil.threadLocalProperties.get().get(IdentityEventConstants.EventProperty.STEP_ID));
@@ -1487,6 +1487,8 @@ public class FrameworkUtils {
                 .get(IdentityEventConstants.EventProperty.CURRENT_AUTHENTICATOR));
 
         HashMap<String, Object> properties = new HashMap<>();
+        properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, userStoreDomain);
+
         properties.put(IdentityEventConstants.EventProperty.IDP, idp);
         properties.put(IdentityEventConstants.EventProperty.CURRENT_AUTHENTICATOR, authenticator);
         properties.put(IdentityEventConstants.EventProperty.STEP_ID, stepId);

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Flow.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Flow.java
@@ -59,6 +59,8 @@ public class Flow {
         FLOW_DEFINITIONS.put(Name.SESSION_REVOKE,
                 EnumSet.of(InitiatingPersona.ADMIN, InitiatingPersona.APPLICATION, InitiatingPersona.USER,
                         InitiatingPersona.SYSTEM));
+        FLOW_DEFINITIONS.put(Name.REGISTER_USER,
+                EnumSet.of(InitiatingPersona.ADMIN, InitiatingPersona.APPLICATION, InitiatingPersona.USER));
     }
 
     /**
@@ -79,7 +81,8 @@ public class Flow {
         ACCOUNT_LOCK,
         ACCOUNT_UNLOCK,
         ACCOUNT_DISABLE,
-        SESSION_REVOKE
+        SESSION_REVOKE,
+        REGISTER_USER
     }
 
     /**


### PR DESCRIPTION
This PR includes

- Adding a new REGISTER_USER event in the event flow definitions.
- Updating the publishEventOnUserRegistrationFailure method in FrameworkUtils.java to include an additional parameter (userStoreDomain).
- Adjusting the DefaultProvisioningHandler invocation to pass the new userStoreDomain parameter.


Parent issue

- https://github.com/wso2/product-is/issues/24259