### PR TITLE
Fix local claim resolution in adaptive script

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsClaims.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -277,15 +278,22 @@ public abstract class JsClaims extends AbstractJSContextMemberObject implements 
                             .getApplicationAuthenticator();
             authenticatorDialect = authenticator.getClaimDialectURI();
             ExternalIdPConfig idPConfig = ConfigurationFacade.getInstance().getIdPConfigByName(idp, tenantDomain);
-            boolean useDefaultIdpDialect = idPConfig.useDefaultLocalIdpDialect();
 
-            if (authenticatorDialect != null || useDefaultIdpDialect) {
+            if (idPConfig.useDefaultLocalIdpDialect()) {
                 if (authenticatorDialect == null) {
                     authenticatorDialect = ApplicationConstants.LOCAL_IDP_DEFAULT_CLAIM_DIALECT;
                 }
                 localToIdpClaimMapping = ClaimMetadataHandler.getInstance()
                         .getMappingsMapFromOtherDialectToCarbon(authenticatorDialect, remoteClaimsMap.keySet(),
                                 tenantDomain, true);
+            } else if (authenticatorDialect != null) {
+                localToIdpClaimMapping = ClaimMetadataHandler.getInstance().getMappingsMapFromOtherDialectToCarbon
+                        (authenticatorDialect, remoteClaimsMap.keySet(), tenantDomain, true);
+                Map<String, String> customLocalToIDPClaimMapping = IdentityProviderManager.getInstance()
+                        .getMappedIdPClaimsMap(idp, tenantDomain, Collections.singletonList(localClaim));
+                if (MapUtils.isNotEmpty(customLocalToIDPClaimMapping)) {
+                    localToIdpClaimMapping.putAll(customLocalToIDPClaimMapping);
+                }
             } else {
                 localToIdpClaimMapping = IdentityProviderManager.getInstance()
                         .getMappedIdPClaimsMap(idp, tenantDomain, Collections.singletonList(localClaim));


### PR DESCRIPTION
### Purpose

Custom claims mapped in a federated IDP (e.g., abc → http://wso2.org/claims/department) are not accessible using local claim URIs in adaptive scripts. This PR updates the claim resolution logic to merge authenticator dialect mappings with explicit IDP claim mappings.

### Related Issue
- https://github.com/wso2/product-is/issues/24025