### PR TITLE
Disable actions `allowedHeaders` and `allowedParameters` temporarily in pre-update-profile action and pre-update-password action

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1250,7 +1250,9 @@
   "console.account_login.scopes.update": ["internal_config_mgt_update"],
   "console.actions.enabled": true,
   "console.actions.disabled_features": [
-    "actions.types.list.preRegistration"
+    "actions.types.list.preRegistration",
+    "actions.types.list.preUpdatePassword.headersAndParameters",
+    "actions.types.list.preUpdateProfile.headersAndParameters"
   ],
   "console.actions.scopes.feature": ["console:actions"],
   "console.actions.scopes.create": ["internal_action_mgt_create"],


### PR DESCRIPTION
### Purpose
This pull request updates the `org.wso2.carbon.identity.core.server.feature.default.json` configuration file to add new disabled features for console actions. These changes enhance the control over pre-registration and pre-update actions.

Console actions configuration updates:

* Added `"actions.types.list.preUpdatePassword.headersAndParameters"` and `"actions.types.list.preUpdateProfile.headersAndParameters"` to the `console.actions.disabled_features` list, expanding the scope of features that can be disabled for console actions.

### Related Issue
- https://github.com/wso2/product-is/issues/24475