### PR TITLE
Provide inheritance for login & registration related configurations

### DIFF
--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/pom.xml
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/pom.xml
@@ -61,6 +61,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.core</artifactId>
             <exclusions>
@@ -137,6 +145,15 @@
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.package.import.version.range}",
 
                             org.wso2.carbon.identity.application.common.*; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.organization.management.service; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.exception; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.util; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
+                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service;
+                            version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception;
+                            version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.strategy;
+                            version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.configuration.mgt.core.internal,

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManagerImpl.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2018-2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationCon
 import org.wso2.carbon.identity.configuration.mgt.core.dao.ConfigurationDAO;
 import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementClientException;
 import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
+import org.wso2.carbon.identity.configuration.mgt.core.internal.ConfigurationManagerComponentDataHolder;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ConfigurationManagerConfigurationHolder;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
@@ -38,10 +39,21 @@ import org.wso2.carbon.identity.configuration.mgt.core.search.ComplexCondition;
 import org.wso2.carbon.identity.configuration.mgt.core.search.Condition;
 import org.wso2.carbon.identity.configuration.mgt.core.search.PrimitiveCondition;
 import org.wso2.carbon.identity.configuration.mgt.core.search.constant.ConditionType;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.LambdaExceptionUtils;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception.OrgResourceHierarchyTraverseException;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.strategy.MergeAllAggregationStrategy;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages
         .ERROR_CODE_ATTRIBUTE_ALREADY_EXISTS;
@@ -178,7 +190,18 @@ public class ConfigurationManagerImpl implements ConfigurationManager {
 
         validateResourcesRetrieveRequest(resourceTypeName);
         ResourceType resourceType = getResourceType(resourceTypeName);
-        List<Resource> resourceList = this.getConfigurationDAO().getResourcesByType(tenantId, resourceType.getId());
+        List<Resource> resourceList;
+        try {
+            if (OrganizationManagementUtil.isOrganization(tenantId) &&
+                    ConfigurationConstants.INHERITED_RESOURCE_TYPES.contains(resourceType.getName())) {
+                    resourceList = getInheritedResourcesByType(tenantId, resourceType.getId());
+            } else {
+                resourceList = this.getConfigurationDAO().getResourcesByType(tenantId, resourceType.getId());
+            }
+        } catch (OrganizationManagementException | OrgResourceHierarchyTraverseException e) {
+            throw handleServerException(ErrorMessages.ERROR_CODE_RETRIEVE_RESOURCE_TYPE, resourceTypeName, e);
+        }
+
         if (resourceList == null) {
             if (log.isDebugEnabled()) {
                 log.debug("No resource found for the resourceTypeName: " + resourceTypeName);
@@ -187,6 +210,56 @@ public class ConfigurationManagerImpl implements ConfigurationManager {
                     ErrorMessages.ERROR_CODE_RESOURCES_DOES_NOT_EXISTS, resourceTypeName, null);
         }
         return new Resources(resourceList);
+    }
+
+    /**
+     * Method to get inherited resources by type.
+     *
+     * @param tenantId  Tenant ID.
+     * @param resourceTypeId Resource type ID.
+     * @return List of resources of the given type inherited from the organization hierarchy.
+     * @throws OrganizationManagementException If an error occurred when getting organization manager.
+     * @throws OrgResourceHierarchyTraverseException If an error occurred when traversing the resource hierarchy.
+     */
+    private List<Resource> getInheritedResourcesByType(int tenantId, String resourceTypeId)
+            throws OrganizationManagementException, OrgResourceHierarchyTraverseException {
+
+        OrganizationManager organizationManager =
+                ConfigurationManagerComponentDataHolder.getInstance().getOrganizationManager();
+        OrgResourceResolverService orgResourceResolverService =
+                ConfigurationManagerComponentDataHolder.getInstance().getOrgResourceResolverService();
+        String orgId = organizationManager.resolveOrganizationId(IdentityTenantUtil.getTenantDomain(tenantId));
+
+        return orgResourceResolverService.getResourcesFromOrgHierarchy(
+                orgId,
+                LambdaExceptionUtils.rethrowFunction(orgID ->
+                        Optional.of(this.getConfigurationDAO().getResourcesByType(
+                                IdentityTenantUtil.getTenantId(organizationManager.resolveTenantDomain(orgID)),
+                                resourceTypeId))),
+                new MergeAllAggregationStrategy<>(this::mergeResourceLists));
+    }
+
+    /**
+     * Merge two Resources objects by combining the resources from both giving priority to the current resources.
+     *
+     * @param currentResourceList Current resources.
+     * @param parentResourceList  Parent resources.
+     * @return  Merged resources object.
+     */
+    private List<Resource> mergeResourceLists (List<Resource> currentResourceList, List<Resource> parentResourceList) {
+
+        Map<String, Resource> resourceMap = new HashMap<>();
+        for (Resource resource : currentResourceList) {
+            resourceMap.put(resource.getResourceName(), resource);
+        }
+
+        for (Resource resource : parentResourceList) {
+            if (!resourceMap.containsKey(resource.getResourceName())) {
+                currentResourceList.add(resource);
+            }
+        }
+
+        return currentResourceList;
     }
 
     /**

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/constant/ConfigurationConstants.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/constant/ConfigurationConstants.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2018-2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.wso2.carbon.identity.configuration.mgt.core.constant;
+
+import java.util.List;
 
 /**
  * Constants related to configuration management.
@@ -70,6 +72,7 @@ public class ConfigurationConstants {
     public static final String TENANT_NAME_FROM_CONTEXT = "TenantNameFromContext";
     public static final String PATH_SEPARATOR = "/";
     public static final String CORRELATION_ID_MDC = "Correlation-ID";
+    public static final List<String> INHERITED_RESOURCE_TYPES = List.of("input-validation-configurations");
 
 
     public enum ErrorMessages {

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/internal/ConfigurationManagerComponent.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/internal/ConfigurationManagerComponent.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2018-2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -34,6 +34,8 @@ import org.wso2.carbon.identity.configuration.mgt.core.dao.impl.CachedBackedConf
 import org.wso2.carbon.identity.configuration.mgt.core.dao.impl.ConfigurationDAOImpl;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ConfigurationManagerConfigurationHolder;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
@@ -81,15 +83,15 @@ public class ConfigurationManagerComponent {
             bundleContext.registerService(ConfigurationDAO.class.getName(),
                     new CachedBackedConfigurationDAO(configurationDAO), null);
 
+            ConfigurationManagerComponentDataHolder.getInstance().setConfigurationManagementEnabled
+                    (isConfigurationManagementEnabled());
+            setUseCreatedTime();
             ConfigurationManagerConfigurationHolder configurationManagerConfigurationHolder =
                     new ConfigurationManagerConfigurationHolder();
             configurationManagerConfigurationHolder.setConfigurationDAOS(configurationDAOs);
 
             bundleContext.registerService(ConfigurationManager.class.getName(),
                     new ConfigurationManagerImpl(configurationManagerConfigurationHolder), null);
-            ConfigurationManagerComponentDataHolder.getInstance().setConfigurationManagementEnabled
-                    (isConfigurationManagementEnabled());
-            setUseCreatedTime();
         } catch (Throwable e) {
             log.error("Error while activating ConfigurationManagerComponent.", e);
         }
@@ -164,6 +166,40 @@ public class ConfigurationManagerComponent {
             log.debug("Unsetting the Realm Service");
         }
         ConfigurationManagerComponentDataHolder.getInstance().setRealmService(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.organization.management.service",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager"
+    )
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        ConfigurationManagerComponentDataHolder.getInstance().setOrganizationManager(organizationManager);
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        ConfigurationManagerComponentDataHolder.getInstance().setOrganizationManager(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service",
+            service = OrgResourceResolverService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrgResourceResolverService"
+    )
+    protected void setOrgResourceResolverService(OrgResourceResolverService orgResourceResolverService) {
+
+        ConfigurationManagerComponentDataHolder.getInstance().setOrgResourceResolverService(orgResourceResolverService);
+    }
+
+    protected void unsetOrgResourceResolverService(OrgResourceResolverService orgResourceResolverService) {
+
+        ConfigurationManagerComponentDataHolder.getInstance().setOrgResourceResolverService(null);
     }
 
     private void setUseCreatedTime() throws DataAccessException {

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/internal/ConfigurationManagerComponentDataHolder.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/internal/ConfigurationManagerComponentDataHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019-2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.wso2.carbon.identity.configuration.mgt.core.internal;
 
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -28,6 +30,8 @@ public class ConfigurationManagerComponentDataHolder {
 
     private boolean configurationManagementEnabled;
     private RealmService realmService;
+    private OrganizationManager organizationManager;
+    private OrgResourceResolverService orgResourceResolverService;
 
     public static ConfigurationManagerComponentDataHolder getInstance() {
 
@@ -62,5 +66,45 @@ public class ConfigurationManagerComponentDataHolder {
     public void setRealmService(RealmService realmService) {
 
         this.realmService = realmService;
+    }
+
+    /**
+     * Get the OrganizationManager.
+     *
+     * @return OrganizationManager instance.
+     */
+    public OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    /**
+     * Set the OrganizationManager.
+     *
+     * @param organizationManager OrganizationManager instance.
+     */
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+
+        this.organizationManager = organizationManager;
+    }
+
+    /**
+     * Get the OrgResourceResolverService.
+     *
+     * @return OrgResourceResolverService instance.
+     */
+    public OrgResourceResolverService getOrgResourceResolverService() {
+
+        return orgResourceResolverService;
+    }
+
+    /**
+     * Set the OrgResourceResolverService.
+     *
+     * @param orgResourceResolverService OrgResourceResolverService instance.
+     */
+    public void setOrgResourceResolverService(OrgResourceResolverService orgResourceResolverService) {
+
+        this.orgResourceResolverService = orgResourceResolverService;
     }
 }

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/test/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManagerTest.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/test/java/org/wso2/carbon/identity/configuration/mgt/core/ConfigurationManagerTest.java
@@ -44,6 +44,9 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.core.util.JdbcUtils;
 import org.apache.commons.io.FileUtils;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
 
 import java.io.File;
 import java.io.InputStream;
@@ -60,19 +63,27 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_ID;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.TestConstants.INHERITABLE_SAMPLE_RESOURCE_TYPE_NAME;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.TestConstants.SAMPLE_ATTRIBUTE_NAME1;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.TestConstants.SAMPLE_ATTRIBUTE_VALUE3_UPDATED;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.TestConstants.SAMPLE_RESOURCE_NAME1;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.TestConstants.SAMPLE_RESOURCE_TYPE_NAME1;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.TestConstants.SAMPLE_TENANT_DOMAIN_ABC;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.TestConstants.SAMPLE_TENANT_ID_ABC;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.TestConstants.TEST_ORG_ID;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.TestSQLConstants.REMOVE_CREATED_TIME_COLUMN_H2;
 import static org.wso2.carbon.identity.configuration.mgt.core.util.TestUtils.closeH2Base;
+import static org.wso2.carbon.identity.configuration.mgt.core.util.TestUtils.getInheritableSampleResourceTypeAdd;
 import static org.wso2.carbon.identity.configuration.mgt.core.util.TestUtils.getSampleAttribute1;
 import static org.wso2.carbon.identity.configuration.mgt.core.util.TestUtils.getSampleAttribute3;
 import static org.wso2.carbon.identity.configuration.mgt.core.util.TestUtils.getSampleResource1Add;
@@ -88,11 +99,15 @@ public class ConfigurationManagerTest {
 
     private ConfigurationManager configurationManager;
     private Connection connection;
+    private OrganizationManager organizationManager;
+    private OrgResourceResolverService orgResourceResolverService;
 
     private MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil;
     private MockedStatic<PrivilegedCarbonContext> privilegedCarbonContext;
     private MockedStatic<IdentityTenantUtil> identityTenantUtil;
     private MockedStatic<IdentityUtil> identityUtil;
+    private MockedStatic<OrganizationManagementUtil> organizationManagementUtilMockedStatic;
+
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -116,6 +131,13 @@ public class ConfigurationManagerTest {
         identityUtil = mockStatic(IdentityUtil.class);
         prepareConfigs(privilegedCarbonContext, identityTenantUtil, identityUtil);
 
+        organizationManager = mock(OrganizationManager.class);
+        ConfigurationManagerComponentDataHolder.getInstance().setOrganizationManager(organizationManager);
+        organizationManagementUtilMockedStatic = mockStatic(OrganizationManagementUtil.class);
+
+        orgResourceResolverService = mock(OrgResourceResolverService.class);
+        ConfigurationManagerComponentDataHolder.getInstance().setOrgResourceResolverService(orgResourceResolverService);
+
         ConfigurationManagerComponentDataHolder.getInstance().setConfigurationManagementEnabled(true);
     }
 
@@ -129,6 +151,7 @@ public class ConfigurationManagerTest {
         privilegedCarbonContext.close();
         identityTenantUtil.close();
         identityUtil.close();
+        organizationManagementUtilMockedStatic.close();
     }
 
     @Test(priority = 1)
@@ -609,6 +632,24 @@ public class ConfigurationManagerTest {
         resourcesByType = configurationManager.getResourcesByType(resourceType.getName());
         Assert.assertTrue("Retrieved resource count should be equal to the 0",
                 resourcesByType.getResources().size() == 0);
+    }
+
+    @Test (priority = 34)
+    public void testGetInheritedResourcesByType() throws Exception {
+
+        organizationManagementUtilMockedStatic.when(() -> OrganizationManagementUtil.isOrganization(anyInt()))
+                .thenReturn(true);
+        when(organizationManager.resolveOrganizationId(anyString())).thenReturn(TEST_ORG_ID);
+
+        ResourceType resourceType = configurationManager.addResourceType(getInheritableSampleResourceTypeAdd());
+        Resource resource1 = configurationManager.addResource(resourceType.getName(), getSampleResource1Add());
+        when(orgResourceResolverService.getResourcesFromOrgHierarchy(
+                eq(TEST_ORG_ID), any(), any())).thenReturn(List.of(resource1));
+
+        Resources returnedResources = configurationManager.getResourcesByType(INHERITABLE_SAMPLE_RESOURCE_TYPE_NAME);
+        verify(orgResourceResolverService, times(1)).getResourcesFromOrgHierarchy(
+                eq(TEST_ORG_ID), any(), any());
+        org.testng.Assert.assertFalse(returnedResources.getResources().isEmpty());
     }
 
     private void removeCreatedTimeColumn() throws DataAccessException {

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/test/java/org/wso2/carbon/identity/configuration/mgt/core/constant/TestConstants.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/test/java/org/wso2/carbon/identity/configuration/mgt/core/constant/TestConstants.java
@@ -20,8 +20,10 @@ public class TestConstants {
 
     public static final int SAMPLE_TENANT_ID_ABC = 1;
     public static final String SAMPLE_TENANT_DOMAIN_ABC = "abc.com";
+    public static final String TEST_ORG_ID = "24584a8d-163f-4g11-hjd5-efedfgu82211";
     public static final String SAMPLE_RESOURCE_TYPE_NAME1 = "email";
     public static final String SAMPLE_RESOURCE_TYPE_NAME2 = "publisher";
+    public static final String INHERITABLE_SAMPLE_RESOURCE_TYPE_NAME = "input-validation-configurations";
     public static final String SAMPLE_RESOURCE_TYPE_DESCRIPTION = "Sample resource type description";
     public static final String SAMPLE_RESOURCE_NAME1 = "email-resource";
     public static final String SAMPLE_RESOURCE_NAME2 = "publisher-resource";

--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/test/java/org/wso2/carbon/identity/configuration/mgt/core/util/TestUtils.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/test/java/org/wso2/carbon/identity/configuration/mgt/core/util/TestUtils.java
@@ -19,8 +19,10 @@ package org.wso2.carbon.identity.configuration.mgt.core.util;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceAdd;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceTypeAdd;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resources;
 import org.wso2.carbon.identity.configuration.mgt.core.search.ComplexCondition;
 import org.wso2.carbon.identity.configuration.mgt.core.search.Condition;
 import org.wso2.carbon.identity.configuration.mgt.core.search.PrimitiveCondition;
@@ -43,6 +45,7 @@ import static org.mockito.Mockito.spy;
 import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.RESOURCE_SEARCH_BEAN_FIELD_ATTRIBUTE_KEY;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.RESOURCE_SEARCH_BEAN_FIELD_TENANT_DOMAIN;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.TestConstants.INHERITABLE_SAMPLE_RESOURCE_TYPE_NAME;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.TestConstants.SAMPLE_ATTRIBUTE_NAME1;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.TestConstants.SAMPLE_ATTRIBUTE_NAME2;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.TestConstants.SAMPLE_ATTRIBUTE_NAME3;
@@ -119,6 +122,14 @@ public class TestUtils {
 
         ResourceTypeAdd resourceTypeAdd = new ResourceTypeAdd();
         resourceTypeAdd.setName(SAMPLE_RESOURCE_TYPE_NAME2);
+        resourceTypeAdd.setDescription(SAMPLE_RESOURCE_TYPE_DESCRIPTION);
+        return resourceTypeAdd;
+    }
+
+    public static ResourceTypeAdd getInheritableSampleResourceTypeAdd() {
+
+        ResourceTypeAdd resourceTypeAdd = new ResourceTypeAdd();
+        resourceTypeAdd.setName(INHERITABLE_SAMPLE_RESOURCE_TYPE_NAME);
         resourceTypeAdd.setDescription(SAMPLE_RESOURCE_TYPE_DESCRIPTION);
         return resourceTypeAdd;
     }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/pom.xml
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2015-2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~  WSO2 Inc. licenses this file to you under the Apache License,
   ~  Version 2.0 (the "License"); you may not use this file except
@@ -81,6 +81,14 @@
         <dependency>
             <groupId>org.wso2.carbon.utils</groupId>
             <artifactId>org.wso2.carbon.database.utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
@@ -169,6 +177,15 @@
                             org.wso2.carbon.identity.claim.metadata.mgt.*;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.secret.mgt.core.*;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.central.log.mgt.utils;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.organization.management.service; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.exception; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.util; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
+                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service;
+                            version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception;
+                            version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.strategy;
+                            version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon;version="${carbon.kernel.package.import.version.range}",
                             org.apache.commons.codec.binary; version="${commons-codec.wso2.osgi.version.range}",
                             org.json;version="${json.wso2.version.range}",

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -447,6 +447,34 @@ public class IdentityProviderManager implements IdpManager {
     }
 
     /**
+     * Delete properties of the resident IDP in the given tenant.
+     * @param tenantDomain Tenant domain whose resident IdP propperties should be deleted.
+     * @param propertyNames List of property names to be deleted.
+     * @throws IdentityProviderManagementException
+     */
+    @Override
+    public void deleteResidentIdpProperties(String tenantDomain, List<String> propertyNames)
+            throws IdentityProviderManagementException {
+
+        IdentityProvider residentIdp = dao.getIdPByName(null, IdentityApplicationConstants.RESIDENT_IDP_RESERVED_NAME,
+                IdentityTenantUtil.getTenantId(tenantDomain), tenantDomain);
+
+        Collection<IdentityProviderMgtListener> listeners = IdPManagementServiceComponent.getIdpMgtListeners();
+        for (IdentityProviderMgtListener listener : listeners) {
+            if (listener.isEnable() && !listener.doPreDeleteResidentIdpProperties(tenantDomain, propertyNames)) {
+                return;
+            }
+        }
+
+        dao.deleteIdpProperties(tenantDomain, residentIdp, propertyNames);
+        for (IdentityProviderMgtListener listener : listeners) {
+            if (listener.isEnable() && !listener.doPostDeleteResidentIdpProperties(tenantDomain, propertyNames)) {
+                return;
+            }
+        }
+    }
+
+    /**
      * Retrieves registered Identity finally {
      * break;
      * }providers for a given tenant

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdpManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdpManager.java
@@ -67,6 +67,17 @@ public interface IdpManager {
             IdentityProviderManagementException;
 
     /**
+     * Delete properties of the resident Identity Provider for a given tenant.
+     * @param tenantDomain Tenant domain whose resident IdP properties should be deleted.
+     * @param propertyNames List of property names to be deleted.
+     * @throws IdentityProviderManagementException
+     */
+    default void deleteResidentIdpProperties(String tenantDomain, List<String> propertyNames)
+            throws IdentityProviderManagementException {
+
+    }
+
+    /**
      * Retrieves registered Identity providers for a given tenant
      *
      * @param tenantDomain Tenant domain whose IdP names are requested

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAO.java
@@ -619,6 +619,27 @@ public class CacheBackedIdPMgtDAO {
     }
 
     /**
+     * Delete the properties of the given Identity Provider.
+     *
+     * @param tenantDomain       Tenant domain of the Identity Provider.
+     * @param identityProvider   Identity provider whose properties need to be deleted.
+     * @param propertyNames      List of property names to be deleted.
+     */
+    public void deleteIdpProperties(String tenantDomain, IdentityProvider identityProvider, List<String> propertyNames)
+            throws IdentityProviderManagementException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Updating the resident IDP properties for tenant: " + tenantDomain +
+                    "Following properties will be deleted: " + propertyNames.toString());
+        }
+
+        clearIdpCache(identityProvider.getIdentityProviderName(), identityProvider.getResourceId(),
+                IdentityTenantUtil.getTenantId(tenantDomain), tenantDomain);
+        idPManagementFacade.deleteIdpProperties(
+                tenantDomain, Integer.parseInt(identityProvider.getId()), propertyNames);
+    }
+
+    /**
      * @param idPName
      * @param tenantId
      * @param tenantDomain

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -3506,6 +3506,12 @@ public class IdPManagementDAO {
     private List<IdentityProviderProperty> mergePropertyLists(List<IdentityProviderProperty> list1,
                                                               List<IdentityProviderProperty> list2) {
 
+        // Filter properties that should not be inherited.
+        list2 = list2.stream()
+                .filter(property -> !IdPManagementConstants.INHERITANCE_DISABLED_GOVERNANCE_PROPERTIES
+                        .contains(property.getName()))
+                .collect(Collectors.toList());
+
         for (IdentityProviderProperty property : list2) {
             if (list1.stream().noneMatch(p -> p.getName().equals(property.getName()))) {
                 list1.add(property);

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -6364,6 +6364,36 @@ public class IdPManagementDAO {
         }
     }
 
+    /**
+     * Deletes the specified properties of an identity provider.
+     *
+     * @param tenantDomain  Tenant domain of the identity provider.
+     * @param idpId         ID of the identity provider.
+     * @param propertyNames List of property names to be deleted.
+     * @throws IdentityProviderManagementException If an error occurred while deleting properties.
+     */
+    public void deleteIdpProperties(String tenantDomain, int idpId, List<String> propertyNames)
+            throws IdentityProviderManagementException {
+
+        String query = IdPManagementConstants.SQLQueries.DELETE_IDP_METADATA_BY_PROPERTY_NAME;
+        query = query.replace(
+                IdPManagementConstants.IDP_METADATA_PROPERTY_LIST_PLACEHOLDER,
+                String.join(",", Collections.nCopies(propertyNames.size(), "?")));
+
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false);
+             PreparedStatement preparedStatement = connection.prepareStatement(query)) {
+            preparedStatement.setInt(1, idpId);
+            for (int i = 0; i < propertyNames.size(); i++) {
+                preparedStatement.setString(i + 2, propertyNames.get(i));
+            }
+
+            preparedStatement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IdentityProviderManagementException("Error occured while deleting properties of IDP:" + idpId +
+                    " in tenant:" + tenantDomain, e);
+        }
+    }
+
     private void getFederatedProperties(Connection connection, int authnId,
             FederatedAuthenticatorConfig federatedAuthenticatorConfig) throws SQLException{
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementFacade.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementFacade.java
@@ -323,6 +323,12 @@ public class IdPManagementFacade {
         return configList;
     }
 
+    public void deleteIdpProperties(String tenantDomain, int idpId, List<String> propertyNames)
+            throws IdentityProviderManagementException {
+
+        dao.deleteIdpProperties(tenantDomain, idpId, propertyNames);
+    }
+
     private IdentityProvider populateEndpointConfig(IdentityProvider identityProvider, String tenantDomain)
             throws IdentityProviderManagementException {
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/internal/IdPManagementServiceComponent.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/internal/IdPManagementServiceComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014-2025 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -42,6 +42,8 @@ import org.wso2.carbon.identity.core.ConnectorConfig;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
 import org.wso2.carbon.identity.role.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.secret.mgt.core.SecretManager;
 import org.wso2.carbon.identity.secret.mgt.core.SecretResolveManager;
@@ -525,5 +527,39 @@ public class IdPManagementServiceComponent {
     protected void unsetActionManagementService(ActionManagementService actionManagementService) {
 
         IdpMgtServiceComponentHolder.getInstance().setActionManagementService(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.organization.management.service",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager"
+    )
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        IdpMgtServiceComponentHolder.getInstance().setOrganizationManager(organizationManager);
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        IdpMgtServiceComponentHolder.getInstance().setOrganizationManager(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service",
+            service = OrgResourceResolverService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrgResourceResolverService"
+    )
+    protected void setOrgResourceResolverService(OrgResourceResolverService orgResourceResolverService) {
+
+        IdpMgtServiceComponentHolder.getInstance().setOrgResourceResolverService(orgResourceResolverService);
+    }
+
+    protected void unsetOrgResourceResolverService(OrgResourceResolverService orgResourceResolverService) {
+
+        IdpMgtServiceComponentHolder.getInstance().setOrgResourceResolverService(null);
     }
 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/internal/IdpMgtServiceComponentHolder.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/internal/IdpMgtServiceComponentHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -24,6 +24,8 @@ import org.wso2.carbon.identity.application.common.util.IdentityApplicationConst
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.core.ConnectorConfig;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
 import org.wso2.carbon.identity.role.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.secret.mgt.core.SecretManager;
 import org.wso2.carbon.identity.secret.mgt.core.SecretResolveManager;
@@ -57,6 +59,8 @@ public class IdpMgtServiceComponentHolder {
     private SecretManager secretManager;
     private SecretResolveManager  secretResolveManager;
     private ActionManagementService actionManagementService;
+    private OrganizationManager organizationManager;
+    private OrgResourceResolverService orgResourceResolverService;
 
     private List<MetadataConverter> metadataConverters = new ArrayList<>();
 
@@ -207,5 +211,45 @@ public class IdpMgtServiceComponentHolder {
     public void setActionManagementService(ActionManagementService actionManagementService) {
 
         this.actionManagementService = actionManagementService;
+    }
+
+    /**
+     * Get the OrganizationManager.
+     *
+     * @return OrganizationManager instance.
+     */
+    public OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    /**
+     * Set the OrganizationManager.
+     *
+     * @param organizationManager OrganizationManager instance.
+     */
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+
+        this.organizationManager = organizationManager;
+    }
+
+    /**
+     * Get the OrgResourceResolverService.
+     *
+     * @return OrgResourceResolverService instance.
+     */
+    public OrgResourceResolverService getOrgResourceResolverService() {
+
+        return orgResourceResolverService;
+    }
+
+    /**
+     * Set the OrgResourceResolverService.
+     *
+     * @param orgResourceResolverService OrgResourceResolverService instance.
+     */
+    public void setOrgResourceResolverService(OrgResourceResolverService orgResourceResolverService) {
+
+        this.orgResourceResolverService = orgResourceResolverService;
     }
 }

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/listener/IdentityProviderMgtListener.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/listener/IdentityProviderMgtListener.java
@@ -1,25 +1,27 @@
 /*
- *  Copyright (c) 2005-2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2005-2025, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
- *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 package org.wso2.carbon.idp.mgt.listener;
 
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+
+import java.util.List;
 
 /**
  * Listener interface for Identity Provider Managements tasks.
@@ -86,6 +88,32 @@ public interface IdentityProviderMgtListener {
      */
     public boolean doPostUpdateResidentIdP(IdentityProvider identityProvider, String tenantDomain) throws
             IdentityProviderManagementException;
+
+    /**
+     * Define any additional actions before deleting resident idp properties.
+     * @param tenantDomain Tenant domain of the resident idp.
+     * @param propertyNames List of property names to be deleted.
+     * @return Whether execution of this method of the underlying UserStoreManager must happen.
+     * @throws IdentityProviderManagementException
+     */
+    public default boolean doPreDeleteResidentIdpProperties(String tenantDomain,  List<String> propertyNames) throws
+            IdentityProviderManagementException {
+
+        return true;
+    }
+
+    /**
+     * Define any additional actions after deleting resident idp properties.
+     * @param tenantDomain Tenant domain of the resident idp.
+     * @param propertyNames List of property names deleted.
+     * @return Whether execution of this method of the underlying UserStoreManager must happen.
+     * @throws IdentityProviderManagementException
+     */
+    public default boolean doPostDeleteResidentIdpProperties(String tenantDomain, List<String> propertyNames) throws
+            IdentityProviderManagementException {
+
+        return true;
+    }
 
     /**
      * Define any additional actions before adding idp

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
@@ -30,6 +30,7 @@ public class IdPManagementConstants {
     public static final String SHARED_IDP_PREFIX = "SHARED_";
     public static final String SCOPE_LIST_PLACEHOLDER = "_SCOPE_LIST_";
     public static final String IDP_GROUP_LIST_PLACEHOLDER = "_IDP_GROUP_LIST_";
+    public static final String IDP_METADATA_PROPERTY_LIST_PLACEHOLDER = "_IDP_METADATA_PROPERTY_LIST_";
     public static final String MULTI_VALUED_PROPERTY_CHARACTER = ".";
     public static final String IS_TRUE_VALUE = "1";
     public static final String IS_FALSE_VALUE = "0";
@@ -528,6 +529,8 @@ public class IdPManagementConstants {
         public static final String ADD_IDP_METADATA_H2 = "INSERT INTO IDP_METADATA (IDP_ID, NAME, `VALUE`, DISPLAY_NAME, " +
                 "TENANT_ID) VALUES (?, ?, ?, ?, ?)";
         public static final String DELETE_IDP_METADATA = "DELETE FROM IDP_METADATA WHERE IDP_ID = ?";
+        public static final String DELETE_IDP_METADATA_BY_PROPERTY_NAME = "DELETE FROM IDP_METADATA WHERE IDP_ID = ?" +
+                " AND NAME IN (" + IDP_METADATA_PROPERTY_LIST_PLACEHOLDER + ")";
 
         public static final String GET_CONNECTED_APPS_MYSQL = "SELECT UUID FROM (SP_AUTH_STEP INNER JOIN " +
                 "SP_FEDERATED_IDP ON SP_AUTH_STEP.ID=SP_FEDERATED_IDP.ID) INNER JOIN SP_APP ON SP_AUTH_STEP" +

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
@@ -18,6 +18,10 @@
 
 package org.wso2.carbon.idp.mgt.util;
 
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+
+import java.util.List;
+
 /**
  * This class is used to keep the identity provider management related constants.
  */
@@ -145,6 +149,15 @@ public class IdPManagementConstants {
     public static final String USERNAME_RECOVERY_PROPERTY = "Recovery.Notification.Username.Enable";
     public static final String EMAIL_USERNAME_RECOVERY_PROPERTY = "Recovery.Notification.Username.Email.Enable";
     public static final String SMS_USERNAME_RECOVERY_PROPERTY = "Recovery.Notification.Username.SMS.Enable";
+
+    public static final List<String> INHERITED_FEDERATED_AUTHENTICATORS = List.of(
+            IdentityApplicationConstants.Authenticator.SAML2SSO.NAME,
+            IdentityApplicationConstants.Authenticator.WSTrust.NAME);
+
+    public static final List<String> INHERITED_FEDERATED_AUTHENTICATOR_PROPERTIES = List.of(
+            IdentityApplicationConstants.Authenticator.SAML2SSO.SAML_METADATA_SIGNING_ENABLED,
+            IdentityApplicationConstants.Authenticator.SAML2SSO.SAML_METADATA_VALIDITY_PERIOD,
+            IdentityApplicationConstants.Authenticator.SAML2SSO.SAML_METADATA_AUTHN_REQUESTS_SIGNING_ENABLED);
 
     public static class SQLConstants {
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
@@ -160,6 +160,13 @@ public class IdPManagementConstants {
             IdentityApplicationConstants.Authenticator.SAML2SSO.SAML_METADATA_VALIDITY_PERIOD,
             IdentityApplicationConstants.Authenticator.SAML2SSO.SAML_METADATA_AUTHN_REQUESTS_SIGNING_ENABLED);
 
+    public static final List<String> INHERITANCE_DISABLED_GOVERNANCE_PROPERTIES = List.of(
+            "Organization.SelfService.Enable",
+            "Organization.SelfService.AdminEmailVerification",
+            "Organization.SelfService.OnboardAdminToOrg",
+            "Organization.SelfService.EnableAutoLogin");
+
+
     public static class SQLConstants {
 
         public static final String DEFINED_BY_COLUMN = "DEFINED_BY";

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagementServiceTest.java
@@ -1287,6 +1287,16 @@ public class IdentityProviderManagementServiceTest {
         verify(actionManagementService, times(1)).addAction(anyString(), any(), anyString());
     }
 
+    @Test
+    public void testDeleteResidentIdpProperties() throws Exception {
+
+        addResidentIdp();
+        List<String> propertiesToDelete = new ArrayList<>();
+        propertiesToDelete.add(IdentityApplicationConstants.SESSION_IDLE_TIME_OUT);
+        IdentityProviderManager.getInstance().deleteResidentIdpProperties(ROOT_TENANT_DOMAIN, propertiesToDelete);
+        Assert.assertNotNull(identityProviderManagementService.getResidentIdP());
+    }
+
     private void addTestIdps() throws IdentityProviderManagementException {
 
         // Initialize Test Identity Provider 1.

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021-2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -50,6 +50,7 @@ import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.identity.secret.mgt.core.SecretManagerImpl;
 import org.wso2.carbon.identity.secret.mgt.core.model.SecretType;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementClientException;
@@ -114,6 +115,7 @@ public class IdPManagementDAOTest {
 
     MockedStatic<IdentityTenantUtil> identityTenantUtil;
     MockedStatic<CryptoUtil> cryptoUtil;
+    MockedStatic<OrganizationManagementUtil> organizationManagementUtilMockedStatic;
     private SecretManagerImpl secretManager;
     private CryptoUtil mockCryptoUtil;
 
@@ -169,10 +171,12 @@ public class IdPManagementDAOTest {
 
         cryptoUtil = mockStatic(CryptoUtil.class);
         mockCryptoUtil = mock(CryptoUtil.class);
+        organizationManagementUtilMockedStatic = mockStatic(OrganizationManagementUtil.class);
         cryptoUtil.when(CryptoUtil::getDefaultCryptoUtil).thenReturn(mockCryptoUtil);
         when(mockCryptoUtil.encryptAndBase64Encode(any())).thenReturn("ENCRYPTED_VALUE2");
         when(mockCryptoUtil.base64DecodeAndDecrypt(anyString())).thenReturn("ENCRYPTED_VALUE2".getBytes());
-
+        organizationManagementUtilMockedStatic.when(() -> OrganizationManagementUtil.isOrganization(TENANT_DOMAIN))
+                .thenReturn(false);
         endpointConfig = ActionMgtTestUtil.createEndpointConfig("http://localhost", "admin", "admin");
         endpointConfigToBeUpdated = ActionMgtTestUtil.createEndpointConfig("http://localhost1", "admin1", "admin1");
         userDefinedIdP = ActionMgtTestUtil.createIdPWithUserDefinedFederatedAuthenticatorConfig(CUSTOM_IDP_NAME, endpointConfig);
@@ -184,6 +188,7 @@ public class IdPManagementDAOTest {
     public void tearDownClass() {
 
         cryptoUtil.close();
+        organizationManagementUtilMockedStatic.close();
     }
 
     @BeforeMethod

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementService.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementService.java
@@ -125,4 +125,16 @@ public interface InputValidationManagementService {
 
         return new ValidationConfiguration();
     }
+
+    /**
+     * Method to delete input validation configurations for provided fields.
+     *
+     * @param fields        List of fields that configurations need to be deleted.
+     * @param tenantDomain  Tenant domain name.
+     * @throws InputValidationMgtServerException If an error occurred when deleting configurations.
+     */
+    default void revertInputValidationConfiguration(List<String> fields, String tenantDomain)
+            throws InputValidationMgtServerException {
+
+    }
 }

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementServiceImpl.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/services/InputValidationManagementServiceImpl.java
@@ -62,6 +62,7 @@ import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Conf
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_GETTING_EXISTING_CONFIGURATIONS;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_NO_CONFIGURATIONS_FOUND;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_WHILE_ADDING_CONFIGURATIONS;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_WHILE_DELETING_CONFIGURATIONS;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_WHILE_UPDATING_CONFIGURATIONS;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.FIELD_VALIDATION_CONFIG_HANDLER_MAP;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.INPUT_VAL_CONFIG_RESOURCE_NAME_PREFIX;
@@ -272,6 +273,31 @@ public class InputValidationManagementServiceImpl implements InputValidationMana
         }
 
         return buildValidationConfigFromResource(updatedResource);
+    }
+
+    /**
+     * Method to delete input validation configurations for provided fields.
+     *
+     * @param fields        List of fields that configurations need to be deleted.
+     * @param tenantDomain  Tenant domain name.
+     * @throws InputValidationMgtServerException If an error occurred when deleting configurations.
+     */
+    @Override
+    public void revertInputValidationConfiguration(List<String> fields, String tenantDomain)
+            throws InputValidationMgtServerException {
+
+        for (String field : fields) {
+            String resourceName = INPUT_VAL_CONFIG_RESOURCE_NAME_PREFIX + field;
+            Resource resource = getResource(resourceName, tenantDomain);
+            if (resource != null) {
+                try {
+                    getConfigurationManager().deleteResource(INPUT_VAL_CONFIG_RESOURCE_TYPE_NAME, resourceName);
+                } catch (ConfigurationManagementException e) {
+                    throw new InputValidationMgtServerException(ERROR_WHILE_DELETING_CONFIGURATIONS.getCode(),
+                            String.format(ERROR_WHILE_DELETING_CONFIGURATIONS.getMessage(), tenantDomain), e);
+                }
+            }
+        }
     }
 
     /**

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/main/java/org/wso2/carbon/identity/input/validation/mgt/utils/Constants.java
@@ -202,7 +202,10 @@ public class Constants {
                 "Error occurred while adding the input validation configurations for the tenant: %s"),
         ERROR_WHILE_UPDATING_CONFIGURATIONS("65003",
                 "Unable to update configurations.",
-                "Error occurred while updating the input validation configurations for the tenant: %s");
+                "Error occurred while updating the input validation configurations for the tenant: %s"),
+        ERROR_WHILE_DELETING_CONFIGURATIONS("65004",
+                "Unable to delete configurations.",
+                "Error occurred while deleting the input validation configurations for the tenant: %s");
 
 
         private final String code;

--- a/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/test/java/org/wso2/carbon/identity/input/validation/mgt/test/InputValidationManagementServiceTest.java
+++ b/components/input-validation-mgt/org.wso2.carbon.identity.input.validation.mgt/src/test/java/org/wso2/carbon/identity/input/validation/mgt/test/InputValidationManagementServiceTest.java
@@ -47,6 +47,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.INPUT_VAL_CONFIG_RESOURCE_NAME_PREFIX;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.INPUT_VAL_CONFIG_RESOURCE_TYPE_NAME;
@@ -122,6 +125,54 @@ public class InputValidationManagementServiceTest {
         } catch (ConfigurationManagementException | InputValidationMgtException e) {
             Assert.fail();
         }
+    }
+
+    @Test
+    public void testRevertInputValidationConfiguration() throws Exception {
+
+        ConfigurationManager configurationManager = mock(ConfigurationManager.class);
+        when(InputValidationDataHolder.getConfigurationManager()).thenReturn(configurationManager);
+
+        // Case 1: Resource exists and should be deleted.
+        String existingField = "existingField";
+        List<String> fieldsToRevert = new ArrayList<>();
+        fieldsToRevert.add(existingField);
+        String resourceName = INPUT_VAL_CONFIG_RESOURCE_NAME_PREFIX + existingField;
+        Resource mockResource = new Resource();
+        mockResource.setResourceName(resourceName);
+
+        when(configurationManager.getResource(INPUT_VAL_CONFIG_RESOURCE_TYPE_NAME, resourceName))
+                .thenReturn(mockResource);
+        service.revertInputValidationConfiguration(fieldsToRevert, tenantName);
+        verify(configurationManager, times(1)).deleteResource(INPUT_VAL_CONFIG_RESOURCE_TYPE_NAME, resourceName);
+
+        // Case 2: Resource does not exist, delete should not be called.
+        String nonExistingField = "nonExistingField";
+        fieldsToRevert.clear();
+        fieldsToRevert.add(nonExistingField);
+        String nonExistingResourceName = INPUT_VAL_CONFIG_RESOURCE_NAME_PREFIX + nonExistingField;
+        when(configurationManager.getResource(INPUT_VAL_CONFIG_RESOURCE_TYPE_NAME, nonExistingResourceName))
+                .thenReturn(null);
+        service.revertInputValidationConfiguration(fieldsToRevert, tenantName);
+        // Verify deleteResource was not called again for this case (still 1 from previous case).
+        verify(configurationManager, times(1)).deleteResource(anyString(), anyString());
+
+        // Case 3: Multiple fields, one exists, one doesn't.
+        fieldsToRevert.clear();
+        fieldsToRevert.add(existingField);
+        fieldsToRevert.add(nonExistingField);
+
+        when(configurationManager.getResource(INPUT_VAL_CONFIG_RESOURCE_TYPE_NAME, resourceName))
+                .thenReturn(mockResource);
+        when(configurationManager.getResource(INPUT_VAL_CONFIG_RESOURCE_TYPE_NAME, nonExistingResourceName))
+                .thenReturn(null);
+
+        service.revertInputValidationConfiguration(fieldsToRevert, tenantName);
+        // existingField's resource should be deleted (called once more, total 2 times)
+        verify(configurationManager, times(2)).deleteResource(INPUT_VAL_CONFIG_RESOURCE_TYPE_NAME, resourceName);
+         // nonExistingField's resource should not be deleted (still 0 times for this specific resource)
+        verify(configurationManager, never()).deleteResource(
+                INPUT_VAL_CONFIG_RESOURCE_TYPE_NAME, nonExistingResourceName);
     }
 
     private Resources getResources() {


### PR DESCRIPTION
## Purpose

This pr introduces the following changes.

### Inheritance

- Introduces inheritance for resident IDP properties
- Introduce inheritance for federated authenticator properties of the resident IDP
- Introduce inheritance for validation rules resources

### Reverting configurations

- Add capability to delete resident IDP properties and properties of the federated authenticators of the resident IDP
- Add capability to delete input validation configurations

## Related issue
- https://github.com/wso2/product-is/issues/24318