### PR TITLE
Refactore PR Reviewer for Logs pipeline name

### DIFF
--- a/.github/workflows/pr-reviewer-for-logs.yml
+++ b/.github/workflows/pr-reviewer-for-logs.yml
@@ -1,4 +1,4 @@
-name: Log PR Reviewer
+name: PR Reviewer for Logs
 
 on:
   pull_request:


### PR DESCRIPTION
### Proposed changes in this pull request

Refactore PR Reviewer for Logs pipeline name

This pull request includes a small change to the `.github/workflows/pr-reviewer-for-logs.yml` file, which was renamed from `.github/workflows/log-pr-reviewer.yml`. The workflow name was updated to "PR Reviewer for Logs" for clarity.