### PR TITLE
Add config flag and display mapping for "Failed Attempt Account Lock with Admin Unlock" email template

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1772,6 +1772,12 @@
         </AutoLogin>
     </Recovery>
 
+    <AccountLock>
+        <EmailTemplate>
+            <AdminUnlockForFailedAttempts>{{account.lock.handler.enable_admin_unlock_email_template_for_failed_attempts}}</AdminUnlockForFailedAttempts>
+        </EmailTemplate>
+    </AccountLock>
+
     <Notification>
         <DefaultNotificationChannel>{{identity_mgt.notification.default_notification_channel}}</DefaultNotificationChannel>
         <ResolveNotificationChannels>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1004,6 +1004,11 @@
       "description": "This email notifies the user that the account is locked by due to too many failed login attempts"
     },
     {
+      "id": "YWNjb3VudExvY2tGYWlsZWRBdHRlbXB0VW50aWxBZG1pblVubG9jaw",
+      "displayName": "Account Locked By Failed Attempts Until Admin Unlocks",
+      "description": "This email notifies the user that the account is locked by due to too many failed login attempts until admin unlocks"
+    },
+    {
       "id": "QWNjb3VudEVuYWJsZQ",
       "displayName": "Account Enabled",
       "description": "This email notifies the user that the account is now enabled"
@@ -1846,6 +1851,8 @@
   "system_applications.system_portals": ["Console", "My Account"],
 
   "notification_templates.sms_templates.apply": true,
+
+  "account.lock.handler.enable_admin_unlock_email_template_for_failed_attempts": false,
 
   "attribute.return_previous_additional_properties.enabled": false,
 


### PR DESCRIPTION
### Purpose
To introduce a configuration flag for enabling a separate email template in account lock scenarios where the account is locked due to failed attempts and must be unlocked by an administrator. This also ensures the new template is shown correctly in the Console UI with a meaningful display name and description for the new email template type `accountLockFailedAttemptUntilAdminUnlock`.

### Goals
* Provide a configuration option to control the use of a specialized email template for admin unlock scenarios.
* Ensure the new template appears in the Console UI with proper metadata.
* Improve user experience and clarity in lock-notification emails.


### Approach

1. **Configuration Flag**
   Introduced the following config in `default.json`:

```
[account.lock.handler]
enable_admin_unlock_email_template_for_failed_attempts = false
```

   * This controls whether to use a new email template (`accountLockFailedAttemptUntilAdminUnlock`) for lock scenarios that require admin unlock.
   * It is referenced in `identity.xml.j2` under the `<EmailTemplate>` config for `<AccountLock>`.
   * Disabled by default to maintain backward compatibility.

2. **Display Mapping for Console UI**
   Added the following entry to `default.json` under `console.extensions.emailTemplates`:

   ```json
   {
     "id": "YWNjb3VudExvY2tGYWlsZWRBdHRlbXB0VW50aWxBZG1pblVubG9jaw",
     "displayName": "Account Locked By Failed Attempts Until Admin Unlocks",
     "description": "This email notifies the user that the account is locked by due to too many failed login attempts until admin unlocks"
   }
   ```

> 📝  Note: 
> * The `id` is the Base64 encoding of `accountLockFailedAttemptUntilAdminUnlock`, which maps to the `TYPE_KEY` in the `IDN_NOTIFICATION_TYPE` table in the database.
> * This mapping ensures that the template appears in the Console UI dropdown with:
>   * **Display Name**: `Account Locked By Failed Attempts Until Admin Unlocks`
>   * **Description**: `This email notifies the user that the account is locked by due to too many failed login attempts until admin unlocks`

### Related PRs
  - https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/150
  - https://github.com/wso2-extensions/identity-event-handler-notification/pull/333
  - https://github.com/wso2/carbon-identity-framework/pull/7053

## Related Issues
public issue: https://github.com/wso2/product-is/issues/24235