### PR TITLE
Implement configurable maximum webhooks per tenant validation

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -114,6 +114,9 @@ public class IdentityCoreConstants {
     // Actions constants.
     public static final String MAXIMUM_ACTIONS_PER_TYPE_PROPERTY = "Actions.MaximumActionsPerType";
 
+    // Webhook constants.
+    public static final String MAXIMUM_WEBHOOKS_PER_TENANT_PROPERTY = "Webhooks.MaximumWebhooksPerTenant";
+
     // System application constants
     public static final String CONSOLE_APPLICATION_CLIENT_ID = "CONSOLE";
     public static final String MY_ACCOUNT_APPLICATION_CLIENT_ID = "MY_ACCOUNT";
@@ -122,6 +125,8 @@ public class IdentityCoreConstants {
     public static final String IS_SYSTEM_APPLICATION = "IsSystemApplication";
 
     public static final int DEFAULT_MAXIMUM_ACTIONS_PER_TYPE = 1;
+
+    public static final int DEFAULT_MAXIMUM_WEBHOOKS_PER_TENANT = 10;
 
     // Agentic AI constants
     public static final String AGENT_IDENTITY_ENABLE = "AgentIdentity.Enabled";

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -1604,12 +1604,32 @@ public class IdentityUtil {
             try {
                 maximumActionsPerActionType = Integer.parseInt(maximumActionsPerActionTypePropertyValue);
             } catch (NumberFormatException e) {
-                maximumActionsPerActionType = IdentityCoreConstants.DEFAULT_MAXIMUM_ITEMS_PRE_PAGE;
                 log.warn("Error occurred while parsing the 'maximumActionsPerActionType' property value " +
                         "in identity.xml.", e);
             }
         }
         return maximumActionsPerActionType;
+    }
+
+    /**
+     * Get the Maximum Webhooks per Tenant to be configured.
+     *
+     * @return maximumWebhooksPerTenant which can be configured.
+     */
+    public static int getMaximumWebhooksPerTenant() {
+
+        int maximumWebhooksPerTenant = IdentityCoreConstants.DEFAULT_MAXIMUM_WEBHOOKS_PER_TENANT;
+        String maximumWebhooksPerTenantPropertyValue =
+                IdentityUtil.getProperty(IdentityCoreConstants.MAXIMUM_WEBHOOKS_PER_TENANT_PROPERTY);
+        if (StringUtils.isNotBlank(maximumWebhooksPerTenantPropertyValue)) {
+            try {
+                maximumWebhooksPerTenant = Integer.parseInt(maximumWebhooksPerTenantPropertyValue);
+            } catch (NumberFormatException e) {
+                log.warn("Error occurred while parsing the 'maximumWebhooksPerTenant' property value in " +
+                        "identity.xml.", e);
+            }
+        }
+        return maximumWebhooksPerTenant;
     }
 
     /**

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/api/constant/ErrorMessage.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/api/constant/ErrorMessage.java
@@ -50,6 +50,9 @@ public enum ErrorMessage {
             "The webhook: %s is already inactive and cannot be deactivated again."),
     ERROR_CODE_WEBHOOK_RETRY_ERROR("WEBHOOKMGT-60015", "Webhook retry error",
             "An error occurred while retrying the webhook: %s."),
+    ERROR_MAXIMUM_WEBHOOKS_PER_TENANT_REACHED("WEBHOOKMGT-60016", "Maximum number of webhooks reached.",
+            "The maximum number of webhooks allowed has been reached. Max allowed: %s. Please delete an " +
+                    "existing webhook before adding a new one."),
 
     // Server errors (65xxx range) | Remaining codes are continued in API layer.
     // Continuation of server error codes can be found in the Webhook Management API layer as well.
@@ -110,7 +113,9 @@ public enum ErrorMessage {
     ERROR_UPDATE_OPERATION_NOT_SUPPORTED("65027", "Unable to perform the update operation.",
             "Update operation is not supported for %s"),
     ERROR_RETRY_OPERATION_NOT_SUPPORTED("65028", "Unable to perform the retry operation.",
-            "Retry operation is not supported for %s");
+            "Retry operation is not supported for %s"),
+    ERROR_WHILE_RETRIEVING_WEBHOOKS_COUNT("65029", "Error while retrieving webhook count.",
+            "An error occurred while retrieving the webhook count for tenant: %s.");
 
     private final String code;
     private final String message;

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/constant/WebhookSQLConstants.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/constant/WebhookSQLConstants.java
@@ -49,6 +49,7 @@ public final class WebhookSQLConstants {
         public static final String CHANNEL_URI = "CHANNEL_URI";
         public static final String CHANNEL_SUBSCRIPTION_STATUS = "CHANNEL_SUBSCRIPTION_STATUS";
         public static final String WEBHOOK_ID = "WEBHOOK_ID";
+        public static final String WEBHOOK_COUNT = "WEBHOOK_COUNT";
 
         private Column() {
 
@@ -111,6 +112,9 @@ public final class WebhookSQLConstants {
 
         public static final String DELETE_WEBHOOK_EVENTS =
                 "DELETE FROM IDN_WEBHOOK_CHANNELS WHERE WEBHOOK_ID = :WEBHOOK_ID;";
+
+        public static final String COUNT_WEBHOOKS_BY_TENANT =
+                "SELECT COUNT(*) AS WEBHOOK_COUNT FROM IDN_WEBHOOK WHERE TENANT_ID = :TENANT_ID;";
 
         private Query() {
 

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/WebhookManagementDAO.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/WebhookManagementDAO.java
@@ -121,4 +121,13 @@ public interface WebhookManagementDAO {
      * @throws WebhookMgtException If an error occurs while retrying the webhook.
      */
     public void retryWebhook(Webhook webhook, int tenantId) throws WebhookMgtException;
+
+    /**
+     * Get the count of webhooks for a tenant.
+     *
+     * @param tenantId Tenant ID.
+     * @return Count of webhooks.
+     * @throws WebhookMgtException If an error occurs while retrieving the webhook count.
+     */
+    public int getWebhooksCount(int tenantId) throws WebhookMgtException;
 }

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/CacheBackedWebhookManagementDAO.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/CacheBackedWebhookManagementDAO.java
@@ -156,4 +156,10 @@ public class CacheBackedWebhookManagementDAO implements WebhookManagementDAO {
         LOG.debug("Webhook cache entry is cleared for webhook ID: " + webhook.getId() + " for webhook retry.");
         webhookManagementDAO.retryWebhook(webhook, tenantId);
     }
+
+    @Override
+    public int getWebhooksCount(int tenantId) throws WebhookMgtException {
+        // Count retrieval bypasses cache
+        return webhookManagementDAO.getWebhooksCount(tenantId);
+    }
 }

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/WebhookManagementDAOFacade.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/WebhookManagementDAOFacade.java
@@ -269,6 +269,17 @@ public class WebhookManagementDAOFacade implements WebhookManagementDAO {
     }
 
     @Override
+    public int getWebhooksCount(int tenantId) throws WebhookMgtException {
+
+        try {
+            return webhookManagementDAO.getWebhooksCount(tenantId);
+        } catch (WebhookMgtException e) {
+            throw WebhookManagementExceptionHandler.handleServerException(
+                    ErrorMessage.ERROR_WHILE_RETRIEVING_WEBHOOKS_COUNT, e);
+        }
+    }
+
+    @Override
     public void updateWebhook(Webhook webhook, int tenantId) throws WebhookMgtException {
 
         validateUpdateOperationSupported(WEBSUBHUB_ADAPTOR);

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.java
@@ -281,7 +281,7 @@ public class WebhookManagementServiceImpl implements WebhookManagementService {
         LOG.debug("Retrieving webhook count for tenant: " + tenantDomain);
         int webhooksCount = daoFACADE.getWebhooksCount(IdentityTenantUtil.getTenantId(tenantDomain));
         int maxWebhooksCount = IdentityUtil.getMaximumWebhooksPerTenant();
-        if (webhooksCount >= IdentityUtil.getMaximumWebhooksPerTenant()) {
+        if (webhooksCount >= maxWebhooksCount) {
             throw WebhookManagementExceptionHandler.handleClientException(
                     ErrorMessage.ERROR_MAXIMUM_WEBHOOKS_PER_TENANT_REACHED, String.valueOf(maxWebhooksCount));
         }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1274,6 +1274,10 @@
         <FailOnBlockingOutboundProvisionFailure>false</FailOnBlockingOutboundProvisionFailure>
     </OutboundProvisioning>
 
+    <Webhooks>
+        <MaximumWebhooksPerTenant>10</MaximumWebhooksPerTenant>
+    </Webhooks>
+
     <EventListeners>
         <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
                        name="org.wso2.carbon.identity.input.validation.mgt.listener.InputValidationListener"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2188,6 +2188,10 @@
         </Types>
     </Actions>
 
+    <Webhooks>
+        <MaximumWebhooksPerTenant>{{webhooks.maximum_webhooks_per_tenant}}</MaximumWebhooksPerTenant>
+    </Webhooks>
+
     <EventListeners>
         <EventListener id="input_validation"
                        type="org.wso2.carbon.user.core.listener.UserOperationEventListener"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1839,6 +1839,8 @@
   "actions.types.authentication.default_userstore": "PRIMARY",
   "actions.types.pre_update_profile.enable": true,
 
+  "webhooks.maximum_webhooks_per_tenant": "10",
+
   "oauth.authorize_all_scopes": false,
   "oauth.enable_rich_authorization_requests" : true,
   "oauth.enable_user_session_impersonation": true,


### PR DESCRIPTION
### Proposed changes in this pull request

- https://github.com/wso2-enterprise/asgardeo-product/issues/31512

This pull request introduces support for limiting the number of webhooks per tenant in the identity management system. It includes changes to define new constants, add validation logic, update SQL queries, and integrate the feature into the service layer.

### Webhook Limit Configuration:

* [`IdentityCoreConstants.java`](diffhunk://#diff-5398caecd73528910fe590141c693a88b807d6f029c2f16e61866e62515b70d3R117-R119): Added constants `MAXIMUM_WEBHOOKS_PER_TENANT_PROPERTY` and `DEFAULT_MAXIMUM_WEBHOOKS_PER_TENANT` to define the maximum number of webhooks per tenant. [[1]](diffhunk://#diff-5398caecd73528910fe590141c693a88b807d6f029c2f16e61866e62515b70d3R117-R119) [[2]](diffhunk://#diff-5398caecd73528910fe590141c693a88b807d6f029c2f16e61866e62515b70d3R129-R130)
* `identity.xml` and related configuration files: Added `<Webhooks>` section to configure the maximum webhooks per tenant. [[1]](diffhunk://#diff-682dcc48fdd68c1974091fb760d1cbfb8b2bf80e05becd70d2c55f5b887b00baR1277-R1280) [[2]](diffhunk://#diff-1ece24b053d1b4af23eb3fdd3af75e2f8816c34a5685ece650c7882061dff696R2191-R2194) [[3]](diffhunk://#diff-ccd8d78f18b752f00ba42b5384248d7b8e8c6cc965a44569e2654ca6ce5bb616R1842-R1843)

### Validation Logic:

* [`WebhookManagementServiceImpl.java`](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0R78): Added `validateMaxWebhooksCount` method to enforce the webhook limit during creation. [[1]](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0R78) [[2]](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0R278-R288)
* [`IdentityUtil.java`](diffhunk://#diff-037826944788a7b874e58ae24c3eff367d32217a4ec7a364ebeb9f05126bf073L1607-R1634): Added `getMaximumWebhooksPerTenant` method to retrieve the configured limit.

### Error Handling:

* [`ErrorMessage.java`](diffhunk://#diff-ee570b5a7b6adacb1ba0253e4f809ac35824939c735b3fba76d91c35a73a6eafR53-R55): Added error codes `ERROR_MAXIMUM_WEBHOOKS_PER_TENANT_REACHED` and `ERROR_WHILE_RETRIEVING_WEBHOOKS_COUNT` for webhook limit validation and count retrieval errors. [[1]](diffhunk://#diff-ee570b5a7b6adacb1ba0253e4f809ac35824939c735b3fba76d91c35a73a6eafR53-R55) [[2]](diffhunk://#diff-ee570b5a7b6adacb1ba0253e4f809ac35824939c735b3fba76d91c35a73a6eafL113-R118)

### SQL and DAO Updates:

* [`WebhookSQLConstants.java`](diffhunk://#diff-ad3505e02dbc1d27a09204a016bf9e2a75eed0215eb170ab7f6e226ef74a7063R52): Added `WEBHOOK_COUNT` column and `COUNT_WEBHOOKS_BY_TENANT` query for counting webhooks by tenant. [[1]](diffhunk://#diff-ad3505e02dbc1d27a09204a016bf9e2a75eed0215eb170ab7f6e226ef74a7063R52) [[2]](diffhunk://#diff-ad3505e02dbc1d27a09204a016bf9e2a75eed0215eb170ab7f6e226ef74a7063R116-R118)
* DAO classes (`WebhookManagementDAO`, `WebhookManagementDAOImpl`, `CacheBackedWebhookManagementDAO`, `WebhookManagementDAOFacade`): Added `getWebhooksCount` method to retrieve the webhook count for a tenant. [[1]](diffhunk://#diff-0251d87b2ff76c4938815c7376882d3c1e54342ba91bd025fb43086107226c40R124-R132) [[2]](diffhunk://#diff-d42a3afb651a4a10ef1804d9261221739f903e1cddb95f78a6a96051dc8101daR235-R254) [[3]](diffhunk://#diff-d390e5706d73372b0b0a92a9bf657d563cb83f9f0389ccaaefb10461c8d79afbR159-R164) [[4]](diffhunk://#diff-12e53d2f48d3bf8cb7acae93330ac30e681a94db22b9865dec070f277bb892ebR271-R281)
