### PR TITLE
Improve the PR builder to cancel when new change added to a PR.

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -10,6 +10,10 @@ on:
     branches: [main, master]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.event.number }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Xmx4g -Xms1g
 


### PR DESCRIPTION
### Purpose
- At the moment when a user opens a PR it will automatically starts a PR builder. But when a user add a new commit to the same PR another new PR builder will be started and the previous one will not be stopped.
- With this change the we are restricting to have only a one PR builder running for a one PR. So when user pushes a new commit, previous builder will be cancelled and a new one will be started.