### PR TITLE
Fix the issue referring to MDC for request correlation id.

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/pom.xml
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/pom.xml
@@ -124,6 +124,7 @@
                             version="${com.fasterxml.jackson.annotation.version.range}",
                             com.fasterxml.jackson.annotation.*;
                             version="${com.fasterxml.jackson.annotation.version.range}",
+                            org.slf4j; version="${org.slf4j.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
### Proposed changes in this pull request

Resolve https://github.com/wso2/product-is/issues/24637

This PR adds the proper wiring for the slf4j that holds the MDC used to resolve the request correlation id when correlation logs is enabled.

Once this is merged service extension request payloads will include `requestId` property, if the server starts with correlation logs passing argument `-DenableCorrelationLogs=true`
