### PR TITLE
Add configurations to enable customisability for cookie policy privacy policy and terms of service urls in the console user dropdown

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1216,6 +1216,8 @@
   "console.ui.is_cookie_consent_banner_enabled": false,
   "console.ui.is_editing_system_roles_allowed": true,
   "console.ui.cookie_policy_url": "/authenticationendpoint/cookie_policy.do",
+  "console.ui.privacy_policy_url": "/authenticationendpoint/privacy_policy.do",
+  "console.ui.terms_of_service_url": "https://wso2.com/terms-of-use",
   "console.ui.app_title": "WSO2 Identity Server Console",
   "console.ui.app_name": "Console",
   "console.ui.app_logo_path": "/assets/images/branding/logo.svg",


### PR DESCRIPTION
### Purpose

This PR introduces configurations to enable the ability to edit or hide Privacy Policy, Cookie Policy, and Terms of Service URLs in the user dropdown menu of the Console application. Previously, these links were hardcoded and could not be customised in the Console application.

With these, if any of the above URLs are defined in the deployement.toml, they will now be directed to those defined URLs. Else it would take the default values defined by the product in the default.json. 

With this following configurations are newly introduced with the default value shown below.

```
[console.ui]
privacy_policy_url = "/authenticationendpoint/privacy_policy.do"
terms_of_service_url = "https://wso2.com/terms-of-use"
```
> The default values added for the default.json were previously hardcoded values as `https://wso2.com/cookie-policy` and `https://wso2.com/privacy-policy` are now replaced with the above URLs for consistency.

### Related Issue

- https://github.com/wso2/product-is/issues/24396

### Related PRs
- https://github.com/wso2/identity-apps/pull/8526/