### PR TITLE
Add log-pr-comment-analyzer github action

### DIFF
--- a/.github/workflows/log-pr-comment-analyzer.yml
+++ b/.github/workflows/log-pr-comment-analyzer.yml
@@ -41,11 +41,6 @@ jobs:
   invoke-ai-log-agent:
     name: Invoke AI Log Agent
     needs: find-pr-details
-    uses: rajithacharith/wso2-organization-templates/.github/workflows/log-pr-comment-analyzer.yml@main
+    uses: wso2/wso2-organization-templates/.github/workflows/log-pr-comment-analyzer.yml@main
     with:
-      analyzePrEndpoint: ${{ vars.AI_LOG_AGENT_URL }}/analyze-pr-merge
-      tokenUrl: ${{ vars.AI_LOG_AGENT_TOKEN_URL }}
       prUrl: ${{ needs.find-pr-details.outputs.url }}
-    secrets:
-      clientId: ${{ secrets.AI_LOG_AGENT_CLIENT_ID }}
-      clientSecret: ${{ secrets.AI_LOG_AGENT_CLIENT_SECRET }}

--- a/.github/workflows/log-pr-comment-analyzer.yml
+++ b/.github/workflows/log-pr-comment-analyzer.yml
@@ -44,3 +44,6 @@ jobs:
     uses: wso2/wso2-organization-templates/.github/workflows/log-pr-comment-analyzer.yml@main
     with:
       prUrl: ${{ needs.find-pr-details.outputs.url }}
+    secrets:
+      clientId: ${{ secrets.AI_LOG_AGENT_CLIENT_ID }}
+      clientSecret: ${{ secrets.AI_LOG_AGENT_CLIENT_SECRET }}

--- a/.github/workflows/log-pr-comment-analyzer.yml
+++ b/.github/workflows/log-pr-comment-analyzer.yml
@@ -1,0 +1,51 @@
+name: Notify Merged PR to AI Log Agent
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  find-pr-details:
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.pr.outputs.url }}
+    steps:
+      - name: Get merged PR info
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commitSha = context.sha;
+
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 10
+            });
+
+            const mergedPr = prs.data.find(pr =>
+              pr.merge_commit_sha === commitSha
+            );
+
+            if (!mergedPr) {
+              core.setFailed("No merged PR found for this commit.");
+              return;
+            }
+
+            core.info(`Found merged PR: ${mergedPr.html_url} (#${mergedPr.number})`);
+            core.setOutput("url", mergedPr.html_url);
+  invoke-ai-log-agent:
+    name: Invoke AI Log Agent
+    needs: find-pr-details
+    uses: rajithacharith/wso2-organization-templates/.github/workflows/log-pr-comment-analyzer.yml@main
+    with:
+      analyzePrEndpoint: ${{ vars.AI_LOG_AGENT_URL }}/analyze-pr-merge
+      tokenUrl: ${{ vars.AI_LOG_AGENT_TOKEN_URL }}
+      prUrl: ${{ needs.find-pr-details.outputs.url }}
+    secrets:
+      clientId: ${{ secrets.AI_LOG_AGENT_CLIENT_ID }}
+      clientSecret: ${{ secrets.AI_LOG_AGENT_CLIENT_SECRET }}

--- a/.github/workflows/pr-reviewer-for-logs.yml
+++ b/.github/workflows/pr-reviewer-for-logs.yml
@@ -8,7 +8,7 @@ jobs:
   call-template:
     uses: wso2/wso2-organization-templates/.github/workflows/pr-reviewer.yml@main
     with:
-      reviewEndpoint: ${{ vars.AI_LOG_AGENT_REVIEW_ENDPOINT }}
+      reviewEndpoint: ${{ vars.AI_LOG_AGENT_URL }}/review-pr
       tokenUrl: ${{ vars.AI_LOG_AGENT_TOKEN_URL }}
       prUrl: ${{ github.event.pull_request.html_url }}
     secrets:

--- a/.github/workflows/pr-reviewer-for-logs.yml
+++ b/.github/workflows/pr-reviewer-for-logs.yml
@@ -8,8 +8,6 @@ jobs:
   call-template:
     uses: wso2/wso2-organization-templates/.github/workflows/pr-reviewer.yml@main
     with:
-      reviewEndpoint: ${{ vars.AI_LOG_AGENT_URL }}/review-pr
-      tokenUrl: ${{ vars.AI_LOG_AGENT_TOKEN_URL }}
       prUrl: ${{ github.event.pull_request.html_url }}
     secrets:
       clientId: ${{ secrets.AI_LOG_AGENT_CLIENT_ID }}


### PR DESCRIPTION
### Proposed changes in this pull request
Add log-pr-comment-analyzer github action for analyzing the PR comment status on PR Merge

This pull request introduces a new GitHub Actions workflow to notify an AI Log Agent about merged pull requests and updates an existing workflow to adjust the endpoint for reviewing pull requests. These changes enhance the integration with the AI Log Agent service for better automation and logging.

### New GitHub Actions Workflow:

* [`.github/workflows/log-pr-comment-analyzer.yml`](diffhunk://#diff-ab8d1c48027cc34c29131aba70591bf017d962b7657dddf6c2910a7166fb1482R1-R51): Added a new workflow named "Notify Merged PR to AI Log Agent." This workflow triggers on pushes to the `master` branch, retrieves details of merged pull requests, and invokes the AI Log Agent to analyze the merged PR using a specified endpoint.

### Updates to Existing Workflow:

* [`.github/workflows/pr-reviewer-for-logs.yml`](diffhunk://#diff-293a18629002f26c7e80049a10b2ac5ff294715d69002ac614062a751e5d1dbdL11-R11): Updated the `reviewEndpoint` parameter in the `call-template` job to use a more specific endpoint (`/review-pr`) under the AI Log Agent's URL.