### PR TITLE
[Bump] ua-parser from 1.5.4.wso2v2 to 1.6.1.wso2v2 in org.wso2.carbon.identity.core.server.feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2108,7 +2108,7 @@
         <orbit.version.infinispan>5.1.2.wso2v1</orbit.version.infinispan>
         <version.org.wso2.orbit.javax.xml.bind>2.3.1.wso2v1</version.org.wso2.orbit.javax.xml.bind>
         <version.org.wso2.orbit.javax.activation>1.1.1.wso2v1</version.org.wso2.orbit.javax.activation>
-        <ua_parser.version>1.5.4.wso2v2</ua_parser.version>
+        <ua_parser.version>1.6.1.wso2v2</ua_parser.version>
         <ua_parser.version.range>[1.3.0, 2.0.0)</ua_parser.version.range>
         <apache.common.collection.version>3.2.0.wso2v1</apache.common.collection.version>
         <apache.common.collections4.version>4.4.wso2v1</apache.common.collections4.version>


### PR DESCRIPTION
Bump `ua.parser.wso2:ua-parser` to 1.6.1.wso2v2 [[1]](https://mvnrepository.com/artifact/ua.parser.wso2/ua-parser) from 1.5.4.wso2v2 
In order to support detection for Edge Chromium [[2]](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-guidance#user-agent-strings)[[3]](https://github.com/ua-parser/uap-core/issues/443). Although the current 1.5.4.wso2v2 version supports detection for Edge Chromium, this version upgrade has been done to move this to the latest release.

[1] https://mvnrepository.com/artifact/ua.parser.wso2/ua-parser
[2] https://learn.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-guidance#user-agent-strings
[3] https://github.com/ua-parser/uap-core/issues/443

## Related Issue
public issue: https://github.com/wso2/product-is/issues/24434

---

## Detected components

```
❯ grep -ri "ua-parser" --include "*.xml"

./repository/components/features/org.wso2.carbon.identity.core.server_7.8.299/feature.xml:  <plugin id="ua-parser" unpack="false" version="1.5.4.wso2v2"/>
./repository/components/artifacts.xml:    <artifact classifier='osgi.bundle' id='ua-parser' version='1.5.4.wso2v2'>
```