### PR TITLE
Add get active webhooks service method

### DIFF
--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/api/service/WebhookManagementService.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/api/service/WebhookManagementService.java
@@ -118,4 +118,17 @@ public interface WebhookManagementService {
      * @throws WebhookMgtException If an error occurs while retrying the webhook.
      */
     Webhook retryWebhook(String webhookId, String tenantDomain) throws WebhookMgtException;
+
+    /**
+     * Get active webhooks for a specific channel URI and tenant ID.
+     *
+     * @param eventProfileName    Name of the event profile.
+     * @param eventProfileVersion Version of the event profile.
+     * @param channelUri          Channel URI to filter webhooks.
+     * @param tenantDomain        Tenant domain.
+     * @return List of active webhooks for the specified channel URI and tenant ID.
+     * @throws WebhookMgtException If an error occurs while retrieving the active webhooks.
+     */
+    List<Webhook> getActiveWebhooks(String eventProfileName, String eventProfileVersion, String channelUri,
+                                    String tenantDomain) throws WebhookMgtException;
 }

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/constant/ErrorMessage.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/constant/ErrorMessage.java
@@ -113,7 +113,7 @@ public enum ErrorMessage {
     ERROR_UPDATE_OPERATION_NOT_SUPPORTED("65027", "Unable to perform the update operation.",
             "Update operation is not supported for %s"),
     ERROR_OPERATION_NOT_SUPPORTED("65028", "Unable to perform the operation.",
-            "Operation is not supported for %s"),
+            "Operation is not supported for %s adapter type."),
     ERROR_WHILE_RETRIEVING_WEBHOOKS_COUNT("65029", "Error while retrieving webhook count.",
             "An error occurred while retrieving the webhook count for tenant: %s."),
     ERROR_CODE_WEBHOOK_ACTIVATION_ADAPTER_ERROR("65030", "Webhook activation error",
@@ -121,7 +121,9 @@ public enum ErrorMessage {
     ERROR_CODE_WEBHOOK_DEACTIVATION_ADAPTER_ERROR("65031", "Webhook deactivation error",
             "An error occurred while deactivating the webhook: %s."),
     ERROR_CODE_WEBHOOK_RETRY_ADAPTER_ERROR("65032", "Webhook retry error",
-            "An error occurred while retrying the webhook: %s.");
+            "An error occurred while retrying the webhook: %s."),
+    ERROR_CODE_ACTIVE_WEBHOOKS_BY_PROFILE_CHANNEL_ERROR("65033", "Error occurred while retrieving active webhooks by channel",
+            "An error occurred while retrieving active webhooks for channel: %s and tenant: %s.");
 
     private final String code;
     private final String message;
@@ -154,4 +156,4 @@ public enum ErrorMessage {
 
         return code + " : " + message;
     }
-    }
+}

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/constant/ErrorMessage.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/constant/ErrorMessage.java
@@ -122,7 +122,8 @@ public enum ErrorMessage {
             "An error occurred while deactivating the webhook: %s."),
     ERROR_CODE_WEBHOOK_RETRY_ADAPTER_ERROR("65032", "Webhook retry error",
             "An error occurred while retrying the webhook: %s."),
-    ERROR_CODE_ACTIVE_WEBHOOKS_BY_PROFILE_CHANNEL_ERROR("65033", "Error occurred while retrieving active webhooks by channel",
+    ERROR_CODE_ACTIVE_WEBHOOKS_BY_PROFILE_CHANNEL_ERROR("65033",
+            "Error occurred while retrieving active webhooks by channel",
             "An error occurred while retrieving active webhooks for channel: %s and tenant: %s.");
 
     private final String code;

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/constant/WebhookSQLConstants.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/constant/WebhookSQLConstants.java
@@ -115,13 +115,13 @@ public final class WebhookSQLConstants {
                 "SELECT COUNT(*) AS WEBHOOK_COUNT FROM IDN_WEBHOOK WHERE TENANT_ID = :TENANT_ID;";
 
         public static final String GET_ACTIVE_WEBHOOKS_BY_PROFILE_CHANNEL =
-                "SELECT W.* FROM IDN_WEBHOOK W " +
-                        "INNER JOIN IDN_WEBHOOK_CHANNELS C ON W.ID = C.WEBHOOK_ID " +
-                        "WHERE C.CHANNEL_URI = :CHANNEL_URI; " +
-                        "AND W.TENANT_ID = :TENANT_ID; " +
-                        "AND W.STATUS = :STATUS; " +
-                        "AND W.EVENT_PROFILE_NAME = :EVENT_PROFILE_NAME; " +
-                        "AND W.EVENT_PROFILE_VERSION = :EVENT_PROFILE_VERSION;";
+                "SELECT WEBHOOK.* FROM IDN_WEBHOOK WEBHOOK " +
+                        "INNER JOIN IDN_WEBHOOK_CHANNELS CHANNEL ON WEBHOOK.ID = CHANNEL.WEBHOOK_ID " +
+                        "WHERE CHANNEL.CHANNEL_URI = :CHANNEL_URI; " +
+                        "AND WEBHOOK.TENANT_ID = :TENANT_ID; " +
+                        "AND WEBHOOK.STATUS = :STATUS; " +
+                        "AND WEBHOOK.EVENT_PROFILE_NAME = :EVENT_PROFILE_NAME; " +
+                        "AND WEBHOOK.EVENT_PROFILE_VERSION = :EVENT_PROFILE_VERSION;";
 
         private Query() {
 

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/constant/WebhookSQLConstants.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/constant/WebhookSQLConstants.java
@@ -95,12 +95,6 @@ public final class WebhookSQLConstants {
         public static final String CHECK_WEBHOOK_ENDPOINT_EXISTS =
                 "SELECT 1 FROM IDN_WEBHOOK WHERE ENDPOINT = :ENDPOINT; AND TENANT_ID = :TENANT_ID;";
 
-        public static final String ACTIVATE_WEBHOOK =
-                "UPDATE IDN_WEBHOOK SET STATUS = 'ACTIVE' WHERE UUID = :UUID; AND TENANT_ID = :TENANT_ID;";
-
-        public static final String DEACTIVATE_WEBHOOK =
-                "UPDATE IDN_WEBHOOK SET STATUS = 'INACTIVE' WHERE UUID = :UUID; AND TENANT_ID = :TENANT_ID;";
-
         public static final String ADD_WEBHOOK_EVENT =
                 "INSERT INTO IDN_WEBHOOK_CHANNELS (WEBHOOK_ID, CHANNEL_URI, CHANNEL_SUBSCRIPTION_STATUS) VALUES " +
                         "(:WEBHOOK_ID;, :CHANNEL_URI;, :CHANNEL_SUBSCRIPTION_STATUS;)";
@@ -119,6 +113,15 @@ public final class WebhookSQLConstants {
 
         public static final String COUNT_WEBHOOKS_BY_TENANT =
                 "SELECT COUNT(*) AS WEBHOOK_COUNT FROM IDN_WEBHOOK WHERE TENANT_ID = :TENANT_ID;";
+
+        public static final String GET_ACTIVE_WEBHOOKS_BY_PROFILE_CHANNEL =
+                "SELECT W.* FROM IDN_WEBHOOK W " +
+                        "INNER JOIN IDN_WEBHOOK_CHANNELS C ON W.ID = C.WEBHOOK_ID " +
+                        "WHERE C.CHANNEL_URI = :CHANNEL_URI; " +
+                        "AND W.TENANT_ID = :TENANT_ID; " +
+                        "AND W.STATUS = :STATUS; " +
+                        "AND W.EVENT_PROFILE_NAME = :EVENT_PROFILE_NAME; " +
+                        "AND W.EVENT_PROFILE_VERSION = :EVENT_PROFILE_VERSION;";
 
         private Query() {
 

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/WebhookManagementDAO.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/WebhookManagementDAO.java
@@ -130,4 +130,17 @@ public interface WebhookManagementDAO {
      * @throws WebhookMgtException If an error occurs while retrieving the webhook count.
      */
     int getWebhooksCount(int tenantId) throws WebhookMgtException;
+
+    /**
+     * Get active webhooks for a specific channel URI and tenant ID.
+     *
+     * @param eventProfileName    Event profile name to filter webhooks.
+     * @param eventProfileVersion Event profile version to filter webhooks.
+     * @param channelUri          Channel URI to filter webhooks.
+     * @param tenantId            Tenant ID.
+     * @return List of active webhooks for the specified channel URI and tenant ID.
+     * @throws WebhookMgtException If an error occurs while retrieving the active webhooks.
+     */
+    List<Webhook> getActiveWebhooks(String eventProfileName, String eventProfileVersion, String channelUri,
+                                    int tenantId) throws WebhookMgtException;
 }

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/CacheBackedWebhookManagementDAO.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/CacheBackedWebhookManagementDAO.java
@@ -162,4 +162,11 @@ public class CacheBackedWebhookManagementDAO implements WebhookManagementDAO {
         // Count retrieval bypasses cache
         return webhookManagementDAO.getWebhooksCount(tenantId);
     }
+
+    @Override
+    public List<Webhook> getActiveWebhooks(String eventProfileName, String eventProfileVersion, String channelUri,
+                                           int tenantId) throws WebhookMgtException {
+        // Active webhooks retrieval bypasses cache
+        return webhookManagementDAO.getActiveWebhooks(eventProfileName, eventProfileVersion, channelUri, tenantId);
+    }
 }

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/WebhookManagementDAOFacade.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/WebhookManagementDAOFacade.java
@@ -117,4 +117,11 @@ public class WebhookManagementDAOFacade implements WebhookManagementDAO {
 
         getHandler().updateWebhook(webhook, tenantId);
     }
+
+    @Override
+    public List<Webhook> getActiveWebhooks(String eventProfileName, String eventProfileVersion, String channelUri,
+                                           int tenantId) throws WebhookMgtException {
+
+        return getHandler().getActiveWebhooks(eventProfileName, eventProfileVersion, channelUri, tenantId);
+    }
 }

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherAdapterTypeHandler.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherAdapterTypeHandler.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.webhook.management.api.model.Webhook;
 import org.wso2.carbon.identity.webhook.management.internal.constant.ErrorMessage;
 import org.wso2.carbon.identity.webhook.management.internal.dao.WebhookManagementDAO;
 import org.wso2.carbon.identity.webhook.management.internal.util.WebhookManagementExceptionHandler;
+import org.wso2.carbon.identity.webhook.metadata.api.model.AdapterType;
 
 import java.util.List;
 
@@ -103,7 +104,7 @@ public class PublisherAdapterTypeHandler extends AdapterTypeHandler {
     public void retryWebhook(Webhook webhook, int tenantId) throws WebhookMgtException {
 
         throw WebhookManagementExceptionHandler.handleClientException(
-                ErrorMessage.ERROR_OPERATION_NOT_SUPPORTED, webhook.getId());
+                ErrorMessage.ERROR_OPERATION_NOT_SUPPORTED, String.valueOf(AdapterType.Publisher));
     }
 
     @Override
@@ -116,5 +117,12 @@ public class PublisherAdapterTypeHandler extends AdapterTypeHandler {
     public void updateWebhook(Webhook webhook, int tenantId) throws WebhookMgtException {
 
         dao.updateWebhook(webhook, tenantId);
+    }
+
+    @Override
+    public List<Webhook> getActiveWebhooks(String eventProfileName, String eventProfileVersion, String channelUri,
+                                           int tenantId) throws WebhookMgtException {
+
+        return dao.getActiveWebhooks(eventProfileName, eventProfileVersion, channelUri, tenantId);
     }
 }

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherSubscriberAdapterTypeHandler.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherSubscriberAdapterTypeHandler.java
@@ -266,6 +266,15 @@ public class PublisherSubscriberAdapterTypeHandler extends AdapterTypeHandler {
     @Override
     public void retryWebhook(Webhook webhook, int tenantId) throws WebhookMgtException {
 
+
+        if (webhook.getStatus() == WebhookStatus.ACTIVE) {
+            throw WebhookManagementExceptionHandler.handleClientException(
+                    ErrorMessage.ERROR_CODE_WEBHOOK_ALREADY_ACTIVE, webhook.getName());
+        }
+        if (webhook.getStatus() == WebhookStatus.INACTIVE) {
+            throw WebhookManagementExceptionHandler.handleClientException(
+                    ErrorMessage.ERROR_CODE_WEBHOOK_ALREADY_INACTIVE, webhook.getName());
+        }
         if (webhook.getStatus() == WebhookStatus.PARTIALLY_ACTIVE ||
                 webhook.getStatus() == WebhookStatus.PARTIALLY_INACTIVE) {
             SubscriptionManagementService subscriptionManagementService =
@@ -361,6 +370,13 @@ public class PublisherSubscriberAdapterTypeHandler extends AdapterTypeHandler {
         throw WebhookManagementExceptionHandler.handleClientException(
                 ErrorMessage.ERROR_UPDATE_OPERATION_NOT_SUPPORTED,
                 "updateWebhook not supported for PublisherSubscriber");
+    }
+
+    @Override
+    public List<Webhook> getActiveWebhooks(String eventProfileName, String eventProfileVersion, String channelUri,
+                                           int tenantId) throws WebhookMgtException {
+
+        return dao.getActiveWebhooks(eventProfileName, eventProfileVersion, channelUri, tenantId);
     }
 
     // --- Helper methods below ---

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.java
@@ -208,16 +208,20 @@ public class WebhookManagementServiceImpl implements WebhookManagementService {
             throw WebhookManagementExceptionHandler.handleClientException(
                     ErrorMessage.ERROR_CODE_WEBHOOK_NOT_FOUND, webhookId);
         }
-        if (existingWebhook.getStatus() == WebhookStatus.ACTIVE) {
-            throw WebhookManagementExceptionHandler.handleClientException(
-                    ErrorMessage.ERROR_CODE_WEBHOOK_ALREADY_ACTIVE, existingWebhook.getName());
-        }
-        if (existingWebhook.getStatus() == WebhookStatus.INACTIVE) {
-            throw WebhookManagementExceptionHandler.handleClientException(
-                    ErrorMessage.ERROR_CODE_WEBHOOK_ALREADY_INACTIVE, existingWebhook.getName());
-        }
         daoFACADE.retryWebhook(existingWebhook, tenantId);
         return daoFACADE.getWebhook(webhookId, tenantId);
+    }
+
+    @Override
+    public List<Webhook> getActiveWebhooks(String eventProfileName, String eventProfileVersion, String channelUri,
+                                           String tenantDomain) throws WebhookMgtException {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Retrieving active webhooks for channel URI: %s in tenant: %s",
+                    channelUri, tenantDomain));
+        }
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        return daoFACADE.getActiveWebhooks(eventProfileName, eventProfileVersion, channelUri, tenantId);
     }
 
     private boolean isWebhookExists(String webhookId, int tenantId) throws WebhookMgtException {

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/java/org/wso2/carbon/identity/webhook/management/service/WebhookManagementServiceImplTest.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/java/org/wso2/carbon/identity/webhook/management/service/WebhookManagementServiceImplTest.java
@@ -293,35 +293,36 @@ public class WebhookManagementServiceImplTest {
         assertEquals(result, updatedWebhook);
     }
 
-    @Test(expectedExceptions = WebhookMgtClientException.class,
-            expectedExceptionsMessageRegExp = "Webhook already active")
-    public void testRetryWebhook_AlreadyActive() throws WebhookMgtException {
-
-        Webhook webhook = mock(Webhook.class);
-        when(webhook.getStatus()).thenReturn(WebhookStatus.ACTIVE);
-        when(webhook.getName()).thenReturn("activeWebhook");
-        when(webhookManagementDAO.getWebhook(WEBHOOK_ID, TENANT_ID)).thenReturn(webhook);
-
-        webhookManagementService.retryWebhook(WEBHOOK_ID, TENANT_DOMAIN);
-    }
-
-    @Test(expectedExceptions = WebhookMgtClientException.class,
-            expectedExceptionsMessageRegExp = "Webhook already inactive")
-    public void testRetryWebhook_AlreadyInactive() throws WebhookMgtException {
-
-        Webhook webhook = mock(Webhook.class);
-        when(webhook.getStatus()).thenReturn(WebhookStatus.INACTIVE);
-        when(webhook.getName()).thenReturn("inactiveWebhook");
-        when(webhookManagementDAO.getWebhook(WEBHOOK_ID, TENANT_ID)).thenReturn(webhook);
-
-        webhookManagementService.retryWebhook(WEBHOOK_ID, TENANT_DOMAIN);
-    }
-
     @Test(expectedExceptions = WebhookMgtClientException.class, expectedExceptionsMessageRegExp = "Webhook not found")
     public void testRetryWebhook_NotFound() throws WebhookMgtException {
 
         when(webhookManagementDAO.getWebhook(WEBHOOK_ID, TENANT_ID)).thenReturn(null);
 
         webhookManagementService.retryWebhook(WEBHOOK_ID, TENANT_DOMAIN);
+    }
+
+    @Test
+    public void testGetActiveWebhooks() throws WebhookMgtException {
+
+        String eventProfileName = "profile";
+        String eventProfileVersion = "v1";
+        String channelUri = "schemas.identity.wso2.org/events/logins";
+
+        List<Webhook> activeWebhooks = new ArrayList<>();
+        Webhook webhook1 = mock(Webhook.class);
+        Webhook webhook2 = mock(Webhook.class);
+        activeWebhooks.add(webhook1);
+        activeWebhooks.add(webhook2);
+
+        when(webhookManagementDAO.getActiveWebhooks(eventProfileName, eventProfileVersion, channelUri, TENANT_ID))
+                .thenReturn(activeWebhooks);
+
+        List<Webhook> result = webhookManagementService.getActiveWebhooks(
+                eventProfileName, eventProfileVersion, channelUri, TENANT_DOMAIN);
+
+        verify(webhookManagementDAO).getActiveWebhooks(eventProfileName, eventProfileVersion, channelUri, TENANT_ID);
+        assertEquals(result.size(), 2);
+        assertEquals(result.get(0), webhook1);
+        assertEquals(result.get(1), webhook2);
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces functionality to retrieve active webhooks filtered by channel URI, event profile, and tenant. It includes updates to the service, DAO, SQL queries, and error handling to support this feature. Additionally, some redundant SQL queries have been removed, and error messages have been refined.

### New Functionality: Retrieve Active Webhooks
* Added a new method `getActiveWebhooks` in `WebhookManagementService`, `WebhookManagementDAO`, and their respective implementations (`WebhookManagementDAOImpl`, `CacheBackedWebhookManagementDAO`, `WebhookManagementDAOFacade`, and handler classes). This method retrieves active webhooks based on event profile name, version, channel URI, and tenant ID. (`[[1]](diffhunk://#diff-a1f22311dc6f1cee83a38d89b00109254886eeebbcab2921b2a245d9b9f54fd3R121-R133)`, `[[2]](diffhunk://#diff-0251d87b2ff76c4938815c7376882d3c1e54342ba91bd025fb43086107226c40R133-R145)`, `[[3]](diffhunk://#diff-d390e5706d73372b0b0a92a9bf657d563cb83f9f0389ccaaefb10461c8d79afbR165-R171)`, `[[4]](diffhunk://#diff-12e53d2f48d3bf8cb7acae93330ac30e681a94db22b9865dec070f277bb892ebR120-R126)`, `[[5]](diffhunk://#diff-d42a3afb651a4a10ef1804d9261221739f903e1cddb95f78a6a96051dc8101daR259-R286)`, `[[6]](diffhunk://#diff-214228f21413d3eb834194089e7451ced58a6f7c0da6784b66e4a8ba81d60dc6R121-R127)`, `[[7]](diffhunk://#diff-83de86702b26deb322de206618f9ca375c269cd77fb2648dff7ff4cc267b1ce7R375-R381)`, `[[8]](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0L211-R226)`)

* Introduced a new SQL query `GET_ACTIVE_WEBHOOKS_BY_PROFILE_CHANNEL` in `WebhookSQLConstants` to fetch active webhooks matching the specified criteria. (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/constant/WebhookSQLConstants.javaR117-R125](diffhunk://#diff-ad3505e02dbc1d27a09204a016bf9e2a75eed0215eb170ab7f6e226ef74a7063R117-R125)`)

* Added a new error message `ERROR_CODE_ACTIVE_WEBHOOKS_BY_PROFILE_CHANNEL_ERROR` to handle exceptions during the retrieval of active webhooks. (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/constant/ErrorMessage.javaL116-R126](diffhunk://#diff-e85309b823c45494084d4e5d4936726c7e20ae9a443d36bdb4d72ce7198506adL116-R126)`)

### Code Cleanup and Refinement
* Removed redundant SQL queries `ACTIVATE_WEBHOOK` and `DEACTIVATE_WEBHOOK` from `WebhookSQLConstants`, as they are no longer in use. (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/constant/WebhookSQLConstants.javaL98-L103](diffhunk://#diff-ad3505e02dbc1d27a09204a016bf9e2a75eed0215eb170ab7f6e226ef74a7063L98-L103)`)

* Updated the error message `ERROR_OPERATION_NOT_SUPPORTED` to include the adapter type for better clarity. (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/constant/ErrorMessage.javaL116-R126](diffhunk://#diff-e85309b823c45494084d4e5d4936726c7e20ae9a443d36bdb4d72ce7198506adL116-R126)`)

### Additional Enhancements
* Added validation in `PublisherSubscriberAdapterTypeHandler` to throw specific exceptions if a webhook is already active or inactive during retry operations. (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherSubscriberAdapterTypeHandler.javaR269-R277](diffhunk://#diff-83de86702b26deb322de206618f9ca375c269cd77fb2648dff7ff4cc267b1ce7R269-R277)`)

* Imported the `AdapterType` class in `PublisherAdapterTypeHandler` to improve error handling when retrying webhooks. (`[[1]](diffhunk://#diff-214228f21413d3eb834194089e7451ced58a6f7c0da6784b66e4a8ba81d60dc6R29)`, `[[2]](diffhunk://#diff-214228f21413d3eb834194089e7451ced58a6f7c0da6784b66e4a8ba81d60dc6L106-R107)`)