### PR TITLE
Introduce SESSION_TERMINATE_V2 event.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.L
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.LogoutRequestHandler;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
+import org.wso2.carbon.identity.application.authentication.framework.internal.util.SessionEventPublishingUtil;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationResult;
@@ -393,6 +394,9 @@ public class DefaultLogoutRequestHandler implements LogoutRequestHandler {
             FrameworkUtils.publishSessionEvent(context.getSessionIdentifier(), request, context,
                     sessionContext, authenticatedUser, FrameworkConstants.AnalyticsAttributes
                             .SESSION_TERMINATE);
+            // Publishing the session termination V2 event for improved event handling.
+            SessionEventPublishingUtil.publishSessionTerminationEvent(
+                    context.getSessionIdentifier(), authenticatedUser, request, context, sessionContext);
         }
 
         try {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/UserSessionManagementServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/UserSessionManagementServiceImpl.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.s
 import org.wso2.carbon.identity.application.authentication.framework.exception.session.mgt.SessionManagementServerException;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceComponent;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
+import org.wso2.carbon.identity.application.authentication.framework.internal.util.SessionEventPublishingUtil;
 import org.wso2.carbon.identity.application.authentication.framework.model.Application;
 import org.wso2.carbon.identity.application.authentication.framework.model.UserSession;
 import org.wso2.carbon.identity.application.authentication.framework.services.SessionManagementService;
@@ -43,6 +44,7 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
@@ -178,6 +180,28 @@ public class UserSessionManagementServiceImpl implements UserSessionManagementSe
             throw new UserSessionException("Error occurred while retrieving the userstore manager to resolve " +
                     "username for the userId: " + userId, e);
         }
+    }
+
+    private String resolveUserIdFromUser(User user) {
+
+        String username = user.getUserName();
+        String userStoreDomain = user.getUserStoreDomain();
+        String tenantDomain = user.getTenantDomain();
+
+        if (StringUtils.isBlank(username) || StringUtils.isBlank(userStoreDomain) ||
+                StringUtils.isBlank(tenantDomain)) {
+            return null;
+        }
+
+        try {
+            return resolveUserIdFromUsername(getTenantId(tenantDomain), userStoreDomain, username);
+        } catch (UserSessionException e) {
+            log.warn(String.format("Failed to resolve userId for user: %s in userstore domain: %s and tenant: %s.",
+                    (LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(username) : username),
+                    userStoreDomain, tenantDomain), e);
+        }
+
+        return null;
     }
 
     private static UserStoreManager getUserStoreManager(int tenantId, String userStoreDomain)
@@ -319,6 +343,10 @@ public class UserSessionManagementServiceImpl implements UserSessionManagementSe
             }
         }
         terminateSessionsOfUser(sessionIdList);
+        // Publish session termination event after session cleanup from session store,
+        // but before the session metadata is removed.
+        // Session publishing event may use session related metadata.
+        SessionEventPublishingUtil.publishSessionTerminationEvent(userId, sessionIdList);
         if (!sessionIdList.isEmpty()) {
             UserSessionStore.getInstance().removeTerminatedSessionRecords(sessionIdList);
         }
@@ -411,9 +439,14 @@ public class UserSessionManagementServiceImpl implements UserSessionManagementSe
             if (log.isDebugEnabled()) {
                 log.debug("Terminating the session: " + sessionId + " which belongs to the user: " + userId + ".");
             }
+
             sessionManagementService.removeSession(sessionId);
             List<String> sessionIdList = new ArrayList<>();
             sessionIdList.add(sessionId);
+            // Publish session termination event after session cleanup from session store,
+            // but before the session metadata is removed.
+            // Session publishing event may use session related metadata.
+            SessionEventPublishingUtil.publishSessionTerminationEvent(userId, sessionId);
             UserSessionStore.getInstance().removeTerminatedSessionRecords(sessionIdList);
             return true;
         } else {
@@ -502,6 +535,12 @@ public class UserSessionManagementServiceImpl implements UserSessionManagementSe
                         user.getLoggableUserId() + " of user store domain: " + user.getUserStoreDomain() + ".");
             }
             sessionManagementService.removeSession(sessionId);
+
+            // Publish session termination event after session cleanup from session store,
+            // but before the session metadata is removed.
+            // Session publishing event may use session related metadata.
+            SessionEventPublishingUtil.publishSessionTerminationEvent(resolveUserIdFromUser(user), sessionId);
+
             List<String> sessionIdList = new ArrayList<>();
             sessionIdList.add(sessionId);
             UserSessionStore.getInstance().removeTerminatedSessionRecords(sessionIdList);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/util/SessionEventPublishingUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/util/SessionEventPublishingUtil.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.internal.util;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
+import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Utility class to publish session events.
+ * This class currently publishes V2 session termination events.
+ */
+public class SessionEventPublishingUtil {
+
+    private static final Log LOG = LogFactory.getLog(SessionEventPublishingUtil.class);
+
+    private SessionEventPublishingUtil() {
+        // Prevent instantiation.
+    }
+
+    /**
+     * Publishes {@link org.wso2.carbon.identity.event.IdentityEventConstants.Event#SESSION_TERMINATE_V2}
+     * at a session termination.
+     *
+     * @param sessionId      - ID of the session to be terminated.
+     * @param request        - HTTP request associated with the session termination.
+     * @param context        - Authentication context associated with the session.
+     * @param sessionContext - Session context associated with the session.
+     */
+    public static void publishSessionTerminationEvent(String sessionId, AuthenticatedUser authenticatedUser,
+                                                      HttpServletRequest request,
+                                                      AuthenticationContext context, SessionContext sessionContext) {
+
+        if (StringUtils.isBlank(sessionId) || authenticatedUser == null || context == null) {
+            LOG.debug("Session ID, authenticated user, or authentication context is null or empty. " +
+                    "Skip publishing session termination event: " +
+                    IdentityEventConstants.Event.SESSION_TERMINATE_V2);
+            return;
+        }
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.REQUEST, request);
+        eventProperties.put(IdentityEventConstants.EventProperty.CONTEXT, context);
+        if (sessionContext != null) {
+            eventProperties.put(IdentityEventConstants.EventProperty.SESSION_CONTEXT, sessionContext);
+        }
+
+        Map<String, Object> paramMap = new HashMap<>();
+        paramMap.put(FrameworkConstants.AnalyticsAttributes.USER, authenticatedUser);
+        paramMap.put(FrameworkConstants.AnalyticsAttributes.SESSION_ID, sessionId);
+        eventProperties.put(IdentityEventConstants.EventProperty.PARAMS, paramMap);
+
+        Event event = new Event(IdentityEventConstants.Event.SESSION_TERMINATE_V2, eventProperties);
+        doPublishEvent(event);
+    }
+
+    /**
+     * Publishes {@link org.wso2.carbon.identity.event.IdentityEventConstants.Event#SESSION_TERMINATE_V2}
+     * at a session termination.
+     * This method is used when the user ID is known, but the authenticated user object is not available.
+     *
+     * @param userId    - ID of the user whose session is being terminated.
+     * @param sessionId - ID of the session to be terminated.
+     */
+    public static void publishSessionTerminationEvent(String userId, String sessionId) {
+
+        if (StringUtils.isBlank(sessionId) || StringUtils.isBlank(userId)) {
+            LOG.debug("Session ID or user ID is null or empty. " +
+                    "Skip publishing session termination event: " +
+                    IdentityEventConstants.Event.SESSION_TERMINATE_V2);
+            return;
+        }
+
+        Map<String, Object> paramMap = new HashMap<>();
+        paramMap.put(FrameworkConstants.AnalyticsAttributes.SESSION_ID, sessionId);
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.USER_ID, userId);
+        eventProperties.put(IdentityEventConstants.EventProperty.PARAMS, paramMap);
+
+        Event event = new Event(IdentityEventConstants.Event.SESSION_TERMINATE_V2, eventProperties);
+        doPublishEvent(event);
+    }
+
+    /**
+     * Publishes {@link org.wso2.carbon.identity.event.IdentityEventConstants.Event#SESSION_TERMINATE_V2}
+     * at a session termination for multiple sessions.
+     *
+     * @param userId     - ID of the user whose sessions are being terminated.
+     * @param sessionIds - List of session IDs to be terminated.
+     */
+    public static void publishSessionTerminationEvent(String userId, List<String> sessionIds) {
+
+        if (StringUtils.isBlank(userId) || sessionIds == null || sessionIds.isEmpty()) {
+            LOG.debug("User ID or session IDs are null or empty. " +
+                    "Skip publishing session termination event: " +
+                    IdentityEventConstants.Event.SESSION_TERMINATE_V2);
+            return;
+        }
+
+        Map<String, Object> paramMap = new HashMap<>();
+        paramMap.put(IdentityEventConstants.EventProperty.SESSION_IDS, sessionIds);
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.USER_ID, userId);
+        eventProperties.put(IdentityEventConstants.EventProperty.PARAMS, paramMap);
+
+        Event event = new Event(IdentityEventConstants.Event.SESSION_TERMINATE_V2, eventProperties);
+        doPublishEvent(event);
+    }
+
+    private static void doPublishEvent(Event event) {
+
+        try {
+            FrameworkServiceDataHolder.getInstance().getIdentityEventService().handleEvent(event);
+        } catch (IdentityEventException e) {
+            LOG.error("Error while publishing the event: " + event.getEventName() + ".", e);
+        }
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/internal/util/SessionEventPublishingUtilTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/internal/util/SessionEventPublishingUtilTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.internal.util;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
+import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link SessionEventPublishingUtil}.
+ */
+public class SessionEventPublishingUtilTest {
+
+    @Mock
+    private IdentityEventService identityEventService;
+    @Mock
+    FrameworkServiceDataHolder frameworkServiceDataHolder;
+    private MockedStatic<FrameworkServiceDataHolder> frameworkServiceDataHolderMockedStatic;
+
+    @BeforeMethod
+    public void setUp() {
+
+        MockitoAnnotations.openMocks(this);
+        frameworkServiceDataHolderMockedStatic = mockStatic(FrameworkServiceDataHolder.class);
+        frameworkServiceDataHolderMockedStatic.when(FrameworkServiceDataHolder::getInstance)
+                .thenReturn(frameworkServiceDataHolder);
+        when(frameworkServiceDataHolder.getIdentityEventService()).thenReturn(identityEventService);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        frameworkServiceDataHolderMockedStatic.close();
+    }
+
+    @Test
+    public void testPublishSessionTerminationEventWithValidInputs() throws IdentityEventException {
+
+        String sessionId = "session123";
+        String userId = "user123";
+
+        SessionEventPublishingUtil.publishSessionTerminationEvent(userId, sessionId);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(identityEventService, times(1)).handleEvent(eventCaptor.capture());
+
+        Event capturedEvent = eventCaptor.getValue();
+
+        // Verify event properties.
+        assertEquals(capturedEvent.getEventName(), IdentityEventConstants.Event.SESSION_TERMINATE_V2);
+        assertEquals(capturedEvent.getEventProperties().get(IdentityEventConstants.EventProperty.USER_ID),
+                userId);
+        assertTrue(
+                capturedEvent.getEventProperties().get(IdentityEventConstants.EventProperty.PARAMS) instanceof HashMap);
+        HashMap<String, Object> params = (HashMap<String, Object>) capturedEvent.getEventProperties()
+                .get(IdentityEventConstants.EventProperty.PARAMS);
+        assertEquals(params.entrySet().size(), 1);
+        assertEquals(params.get(FrameworkConstants.AnalyticsAttributes.SESSION_ID), sessionId);
+    }
+
+    @Test
+    public void testPublishSessionTerminationEventWithInvalidInputs() throws IdentityEventException {
+
+        String sessionId = "";
+        String userId = "user123";
+
+        SessionEventPublishingUtil.publishSessionTerminationEvent(userId, sessionId);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(identityEventService, never()).handleEvent(eventCaptor.capture());
+    }
+
+    @Test
+    public void testPublishSessionTerminationEventForAuthAndSessionContextsWithValidInputs()
+            throws IdentityEventException {
+
+        String sessionId = "session123";
+        AuthenticatedUser authenticatedUser = mock(AuthenticatedUser.class);
+        AuthenticationContext authenticationContext = mock(AuthenticationContext.class);
+        SessionContext sessionContext = mock(SessionContext.class);
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+
+        SessionEventPublishingUtil.publishSessionTerminationEvent(sessionId, authenticatedUser, httpServletRequest,
+                authenticationContext, sessionContext);
+
+        verify(identityEventService, times(1)).handleEvent(any(Event.class));
+    }
+
+    @Test
+    public void testPublishSessionTerminationEventForAuthAndSessionContextsWithInvalidInputs()
+            throws IdentityEventException {
+
+        String sessionId = "session123";
+        AuthenticatedUser authenticatedUser = null;
+        AuthenticationContext authenticationContext = mock(AuthenticationContext.class);
+        SessionContext sessionContext = mock(SessionContext.class);
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+
+        SessionEventPublishingUtil.publishSessionTerminationEvent(sessionId, authenticatedUser, httpServletRequest,
+                authenticationContext, sessionContext);
+
+        verify(identityEventService, never()).handleEvent(any(Event.class));
+    }
+
+    @Test
+    public void testPublishSessionTerminationEventForMultipleSessions() throws IdentityEventException {
+
+        String userId = "user123";
+        List<String> sessionIds = Arrays.asList("session1", "session2");
+
+        SessionEventPublishingUtil.publishSessionTerminationEvent(userId, sessionIds);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(identityEventService, times(1)).handleEvent(eventCaptor.capture());
+        Event capturedEvent = eventCaptor.getValue();
+
+        // Verify event properties.
+        assertEquals(capturedEvent.getEventName(), IdentityEventConstants.Event.SESSION_TERMINATE_V2);
+        assertEquals(capturedEvent.getEventProperties().get(IdentityEventConstants.EventProperty.USER_ID),
+                userId);
+        assertTrue(
+                capturedEvent.getEventProperties().get(IdentityEventConstants.EventProperty.PARAMS) instanceof HashMap);
+        HashMap<String, Object> params = (HashMap<String, Object>) capturedEvent.getEventProperties()
+                .get(IdentityEventConstants.EventProperty.PARAMS);
+        assertEquals(params.entrySet().size(), 1);
+        assertEquals(params.get(IdentityEventConstants.EventProperty.SESSION_IDS), sessionIds);
+    }
+
+    @Test
+    public void testDoPublishEventWithException() throws IdentityEventException {
+
+        doThrow(new IdentityEventException("Error")).when(identityEventService).handleEvent(any(Event.class));
+
+        String sessionId = "session123";
+        String userId = "user123";
+
+        SessionEventPublishingUtil.publishSessionTerminationEvent(userId, sessionId);
+
+        verify(identityEventService, times(1)).handleEvent(any(Event.class));
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/testng.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/testng.xml
@@ -70,6 +70,7 @@
             <class name="org.wso2.carbon.identity.application.authentication.framework.AuthenticationServiceTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.handler.approles.impl.AppAssociatedRolesResolverImplTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.internal.impl.UserSessionManagementServiceImplTest"/>
+            <class name="org.wso2.carbon.identity.application.authentication.framework.internal.util.SessionEventPublishingUtilTest"/>
         </classes>
     </test>
 

--- a/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
+++ b/components/identity-event/org.wso2.carbon.identity.event/src/main/java/org/wso2/carbon/identity/event/IdentityEventConstants.java
@@ -57,6 +57,13 @@ public class IdentityEventConstants {
         public static final String SESSION_CREATE = "SESSION_CREATE";
         public static final String SESSION_UPDATE = "SESSION_UPDATE";
         public static final String SESSION_TERMINATE = "SESSION_TERMINATE";
+        /**
+         * Session termination event version 2.
+         * This event is used to publish both single session and bulk session termination events,
+         *  consolidating multiple session terminations into a single event instead of emitting an event,
+         *  for each terminated session individually.
+         */
+        public static final String SESSION_TERMINATE_V2 = "SESSION_TERMINATE_V2";
         public static final String SESSION_EXPIRE = "SESSION_EXPIRE";
         public static final String SESSION_EXTEND = "SESSION_EXTEND";
         public static final String VERIFICATION = "VERIFICATION";
@@ -349,8 +356,6 @@ public class IdentityEventConstants {
         SESSION_TERMINATE,
         SESSION_EXPIRE,
         SESSION_EXTEND,
-        VERIFICATION,
-        USER_SESSION_TERMINATE
     }
 
     public class EventProperty {
@@ -493,6 +498,7 @@ public class IdentityEventConstants {
         public static final String USER_CLAIMS_ADDED = "USER_CLAIMS_ADDED";
         public static final String USER_CLAIMS_MODIFIED = "USER_CLAIMS_MODIFIED";
         public static final String USER_CLAIMS_DELETED = "USER_CLAIMS_DELETED";
+        public static final String SESSION_IDS = "SESSION_IDS";
 
         public class Scenario {
 


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves https://github.com/wso2/product-is/issues/24728

Introduce SESSION_TERMINATE_V2 internal event with improved behavior to emit session termination events.
This will,
- trigger an event if a single session gets terminated
- trigger one event if multiple sessions gets updated at once including terminated session info.