### PR TITLE
Activate and deactivate http publisher adapter

### DIFF
--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherAdapterTypeHandler.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherAdapterTypeHandler.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.subscription.management.api.model.Subscription;
 import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtException;
 import org.wso2.carbon.identity.webhook.management.api.model.Webhook;
+import org.wso2.carbon.identity.webhook.management.api.model.WebhookStatus;
 import org.wso2.carbon.identity.webhook.management.internal.constant.ErrorMessage;
 import org.wso2.carbon.identity.webhook.management.internal.dao.WebhookManagementDAO;
 import org.wso2.carbon.identity.webhook.management.internal.util.WebhookManagementExceptionHandler;
@@ -91,13 +92,39 @@ public class PublisherAdapterTypeHandler extends AdapterTypeHandler {
     @Override
     public void activateWebhook(Webhook webhook, int tenantId) throws WebhookMgtException {
 
-        dao.activateWebhook(webhook, tenantId);
+        Webhook activatedWebhook = new Webhook.Builder()
+                .uuid(webhook.getId())
+                .endpoint(webhook.getEndpoint())
+                .name(webhook.getName())
+                .secret(webhook.getSecret())
+                .eventProfileName(webhook.getEventProfileName())
+                .eventProfileUri(webhook.getEventProfileUri())
+                .eventProfileVersion(webhook.getEventProfileVersion())
+                .status(WebhookStatus.ACTIVE)
+                .createdAt(webhook.getCreatedAt())
+                .updatedAt(webhook.getUpdatedAt())
+                .eventsSubscribed(webhook.getEventsSubscribed())
+                .build();
+        dao.activateWebhook(activatedWebhook, tenantId);
     }
 
     @Override
     public void deactivateWebhook(Webhook webhook, int tenantId) throws WebhookMgtException {
 
-        dao.deactivateWebhook(webhook, tenantId);
+        Webhook deactivatedWebhook = new Webhook.Builder()
+                .uuid(webhook.getId())
+                .endpoint(webhook.getEndpoint())
+                .name(webhook.getName())
+                .secret(webhook.getSecret())
+                .eventProfileName(webhook.getEventProfileName())
+                .eventProfileUri(webhook.getEventProfileUri())
+                .eventProfileVersion(webhook.getEventProfileVersion())
+                .status(WebhookStatus.INACTIVE)
+                .createdAt(webhook.getCreatedAt())
+                .updatedAt(webhook.getUpdatedAt())
+                .eventsSubscribed(webhook.getEventsSubscribed())
+                .build();
+        dao.deactivateWebhook(deactivatedWebhook, tenantId);
     }
 
     @Override

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/java/org/wso2/carbon/identity/webhook/management/dao/PublisherAdapterTypeHandlerTest.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/java/org/wso2/carbon/identity/webhook/management/dao/PublisherAdapterTypeHandlerTest.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.webhook.management.dao;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -166,7 +167,12 @@ public class PublisherAdapterTypeHandlerTest {
 
         doNothing().when(mockDao).activateWebhook(any(), anyInt());
         handler.activateWebhook(testWebhook, 1);
-        verify(mockDao, times(1)).activateWebhook(testWebhook, 1);
+
+        ArgumentCaptor<Webhook> captor = ArgumentCaptor.forClass(Webhook.class);
+        verify(mockDao, times(1)).activateWebhook(captor.capture(), eq(1));
+        Webhook activatedWebhook = captor.getValue();
+        Assert.assertEquals(activatedWebhook.getId(), testWebhook.getId());
+        Assert.assertEquals(activatedWebhook.getStatus(), WebhookStatus.ACTIVE);
     }
 
     @Test
@@ -174,7 +180,12 @@ public class PublisherAdapterTypeHandlerTest {
 
         doNothing().when(mockDao).deactivateWebhook(any(), anyInt());
         handler.deactivateWebhook(testWebhook, 1);
-        verify(mockDao, times(1)).deactivateWebhook(testWebhook, 1);
+
+        ArgumentCaptor<Webhook> captor = ArgumentCaptor.forClass(Webhook.class);
+        verify(mockDao, times(1)).deactivateWebhook(captor.capture(), eq(1));
+        Webhook deactivatedWebhook = captor.getValue();
+        Assert.assertEquals(deactivatedWebhook.getId(), testWebhook.getId());
+        Assert.assertEquals(deactivatedWebhook.getStatus(), WebhookStatus.INACTIVE);
     }
 
     @Test


### PR DESCRIPTION
### Proposed changes in this pull request


This pull request introduces changes to enhance the handling of webhook activation and deactivation by explicitly setting the `WebhookStatus` during these operations. Additionally, corresponding unit tests have been updated to validate the new behavior. Below are the most important changes:

### Enhancements to webhook activation and deactivation logic:

* Updated the `activateWebhook` and `deactivateWebhook` methods in `PublisherAdapterTypeHandler` to use a builder pattern for creating `Webhook` objects with an explicitly set `WebhookStatus` (`ACTIVE` for activation, `INACTIVE` for deactivation). This ensures that the status is always correctly set when these methods are called. (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherAdapterTypeHandler.javaL94-R127](diffhunk://#diff-214228f21413d3eb834194089e7451ced58a6f7c0da6784b66e4a8ba81d60dc6L94-R127)`)

### Unit test improvements:

* Modified `testActivateWebhook` and `testDeactivateWebhook` in `PublisherAdapterTypeHandlerTest` to use `ArgumentCaptor` for verifying that the `Webhook` passed to the DAO has the correct `WebhookStatus`. Added assertions to validate the `Webhook` ID and status. (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/java/org/wso2/carbon/identity/webhook/management/dao/PublisherAdapterTypeHandlerTest.javaL169-R188](diffhunk://#diff-5ec3b6f60811c0a9c950957519d0a2a4883ae0390d7ee63d9fd76dee5d11b72aL169-R188)`)
* Added the `ArgumentCaptor` import to `PublisherAdapterTypeHandlerTest` to support the new test logic. (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/java/org/wso2/carbon/identity/webhook/management/dao/PublisherAdapterTypeHandlerTest.javaR21](diffhunk://#diff-5ec3b6f60811c0a9c950957519d0a2a4883ae0390d7ee63d9fd76dee5d11b72aR21)`)