### PR TITLE
Handle update webhook without secret

### DIFF
--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherAdapterTypeHandler.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherAdapterTypeHandler.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.webhook.management.internal.dao.impl.handler;
 
+import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.database.utils.jdbc.NamedJdbcTemplate;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.subscription.management.api.model.Subscription;
@@ -143,7 +144,25 @@ public class PublisherAdapterTypeHandler extends AdapterTypeHandler {
     @Override
     public void updateWebhook(Webhook webhook, int tenantId) throws WebhookMgtException {
 
-        dao.updateWebhook(webhook, tenantId);
+        Webhook existingWebhook = dao.getWebhook(webhook.getId(), tenantId);
+        String secret = webhook.getSecret();
+        if (StringUtils.isEmpty(secret)) {
+            secret = existingWebhook.getSecret() != null ? existingWebhook.getSecret() : null;
+        }
+        Webhook updatedWebhook = new Webhook.Builder()
+                .uuid(webhook.getId())
+                .endpoint(webhook.getEndpoint())
+                .name(webhook.getName())
+                .secret(secret)
+                .eventProfileName(webhook.getEventProfileName())
+                .eventProfileUri(webhook.getEventProfileUri())
+                .eventProfileVersion(webhook.getEventProfileVersion())
+                .status(webhook.getStatus())
+                .createdAt(webhook.getCreatedAt())
+                .updatedAt(webhook.getUpdatedAt())
+                .eventsSubscribed(webhook.getEventsSubscribed())
+                .build();
+        dao.updateWebhook(updatedWebhook, tenantId);
     }
 
     @Override

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.java
@@ -131,6 +131,10 @@ public class WebhookManagementServiceImpl implements WebhookManagementService {
             throws WebhookMgtException {
 
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        if (!isWebhookExists(webhookId, tenantId)) {
+            throw WebhookManagementExceptionHandler.handleClientException(
+                    ErrorMessage.ERROR_CODE_WEBHOOK_NOT_FOUND, webhookId);
+        }
         daoFACADE.updateWebhook(webhook, tenantId);
         return daoFACADE.getWebhook(webhookId, tenantId);
     }


### PR DESCRIPTION
### Proposed changes in this pull request


This pull request introduces updates to the webhook management module to improve data integrity and error handling during webhook updates. The changes ensure that missing secrets are handled gracefully and that update operations validate the existence of the webhook before proceeding.

### Enhancements to webhook update logic:

* **Graceful handling of missing secrets in `updateWebhook` method**:
  - Updated the `updateWebhook` method in `PublisherAdapterTypeHandler` to fetch the existing webhook's secret if the new webhook's secret is empty. This ensures that secrets are not unintentionally cleared during updates. (`PublisherAdapterTypeHandler.java`, [components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherAdapterTypeHandler.javaL146-R165](diffhunk://#diff-214228f21413d3eb834194089e7451ced58a6f7c0da6784b66e4a8ba81d60dc6L146-R165))
  - Introduced the use of `StringUtils.isEmpty` for null and empty string checks. (`PublisherAdapterTypeHandler.java`, [components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherAdapterTypeHandler.javaR21](diffhunk://#diff-214228f21413d3eb834194089e7451ced58a6f7c0da6784b66e4a8ba81d60dc6R21))

### Improved error handling:

* **Validation of webhook existence before updates**:
  - Added a check in `WebhookManagementServiceImpl` to verify if the webhook exists before attempting an update. If the webhook is not found, a client exception is thrown with an appropriate error message. (`WebhookManagementServiceImpl.java`, [components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.javaR134-R137](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0R134-R137))