### PR TITLE
Add validation for webhook update

### DIFF
--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.java
@@ -18,12 +18,12 @@
 
 package org.wso2.carbon.identity.webhook.management.internal.service.impl;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.subscription.management.api.model.Subscription;
-import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtClientException;
 import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtException;
 import org.wso2.carbon.identity.webhook.management.api.model.Webhook;
 import org.wso2.carbon.identity.webhook.management.api.model.WebhookStatus;
@@ -74,8 +74,8 @@ public class WebhookManagementServiceImpl implements WebhookManagementService {
             throw WebhookManagementExceptionHandler.handleClientException(
                     ErrorMessage.ERROR_CODE_WEBHOOK_ENDPOINT_ALREADY_EXISTS, webhook.getEndpoint());
         }
-        doPreAddWebhookValidations(webhook);
         validateMaxWebhooksCount(tenantDomain);
+        doPreAddWebhookValidations(webhook);
         String generatedWebhookId = UUID.randomUUID().toString();
 
         WebhookStatus status = webhook.getStatus() != null ? webhook.getStatus() : WebhookStatus.INACTIVE;
@@ -135,6 +135,8 @@ public class WebhookManagementServiceImpl implements WebhookManagementService {
             throw WebhookManagementExceptionHandler.handleClientException(
                     ErrorMessage.ERROR_CODE_WEBHOOK_NOT_FOUND, webhookId);
         }
+        validateMaxWebhooksCount(tenantDomain);
+        doPreUpdateWebhookValidations(webhook);
         daoFACADE.updateWebhook(webhook, tenantId);
         return daoFACADE.getWebhook(webhookId, tenantId);
     }
@@ -233,28 +235,33 @@ public class WebhookManagementServiceImpl implements WebhookManagementService {
         return daoFACADE.getWebhook(webhookId, tenantId) != null;
     }
 
-    /**
-     * Perform pre validations on webhook model when creating an webhook.
-     *
-     * @param webhook Webhook creation model.
-     * @throws WebhookMgtClientException if webhook model is invalid.
-     */
-    private void doPreAddWebhookValidations(Webhook webhook) throws WebhookMgtException {
+    // Common validation for required fields except secret
+    private void validateCommonWebhookFields(Webhook webhook) throws WebhookMgtException {
 
         WEBHOOK_VALIDATOR.validateForBlank(WebhookMgtConstants.WEBHOOK_NAME_FIELD, webhook.getName());
         WEBHOOK_VALIDATOR.validateForBlank(WebhookMgtConstants.ENDPOINT_URI_FIELD, webhook.getEndpoint());
-        WEBHOOK_VALIDATOR.validateForBlank(WebhookMgtConstants.EVENT_PROFILE_NAME_FIELD,
-                webhook.getEventProfileName());
-        WEBHOOK_VALIDATOR.validateForBlank(WebhookMgtConstants.EVENT_PROFILE_URI_FIELD,
-                webhook.getEventProfileUri());
-        WEBHOOK_VALIDATOR.validateForBlank(WebhookMgtConstants.STATUS_FIELD,
-                String.valueOf(webhook.getStatus()));
-        WEBHOOK_VALIDATOR.validateForBlank(WebhookMgtConstants.SECRET_FIELD, webhook.getSecret());
+        WEBHOOK_VALIDATOR.validateForBlank(WebhookMgtConstants.EVENT_PROFILE_NAME_FIELD, webhook.getEventProfileName());
+        WEBHOOK_VALIDATOR.validateForBlank(WebhookMgtConstants.EVENT_PROFILE_URI_FIELD, webhook.getEventProfileUri());
+        WEBHOOK_VALIDATOR.validateForBlank(WebhookMgtConstants.STATUS_FIELD, String.valueOf(webhook.getStatus()));
         WEBHOOK_VALIDATOR.validateWebhookName(webhook.getName());
         WEBHOOK_VALIDATOR.validateEndpointUri(webhook.getEndpoint());
+        WEBHOOK_VALIDATOR.validateChannelsSubscribed(webhook.getEventProfileName(), webhook.getEventsSubscribed());
+    }
+
+    private void doPreAddWebhookValidations(Webhook webhook) throws WebhookMgtException {
+
+        validateCommonWebhookFields(webhook);
+        WEBHOOK_VALIDATOR.validateForBlank(WebhookMgtConstants.SECRET_FIELD, webhook.getSecret());
         WEBHOOK_VALIDATOR.validateWebhookSecret(webhook.getSecret());
-        WEBHOOK_VALIDATOR.validateChannelsSubscribed(webhook.getEventProfileName(),
-                webhook.getEventsSubscribed());
+    }
+
+    private void doPreUpdateWebhookValidations(Webhook webhook) throws WebhookMgtException {
+
+        validateCommonWebhookFields(webhook);
+        // Secret is optional for update
+        if (StringUtils.isNotBlank(webhook.getSecret())) {
+            WEBHOOK_VALIDATOR.validateWebhookSecret(webhook.getSecret());
+        }
     }
 
     private void validateMaxWebhooksCount(String tenantDomain) throws WebhookMgtException {

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.java
@@ -135,7 +135,6 @@ public class WebhookManagementServiceImpl implements WebhookManagementService {
             throw WebhookManagementExceptionHandler.handleClientException(
                     ErrorMessage.ERROR_CODE_WEBHOOK_NOT_FOUND, webhookId);
         }
-        validateMaxWebhooksCount(tenantDomain);
         doPreUpdateWebhookValidations(webhook);
         daoFACADE.updateWebhook(webhook, tenantId);
         return daoFACADE.getWebhook(webhookId, tenantId);


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request refactors and enhances the webhook management service implementation by improving validation logic, reordering method calls for consistency, and introducing reusable validation methods. The most important changes include the creation of a common validation method, updates to pre-validation logic for webhooks, and reordering method calls in the `createWebhook` method.

### Validation Improvements:
* Introduced a new method `validateCommonWebhookFields` to centralize and reuse common validation logic for webhook fields, reducing code duplication. This method validates fields such as `name`, `endpoint`, `eventProfileName`, and `eventProfileUri` (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.javaL236-R264](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0L236-R264)`).
* Updated `doPreAddWebhookValidations` to use `validateCommonWebhookFields` and moved the validation of the `secret` field to this method. This ensures that the `secret` field is validated only during webhook creation (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.javaL236-R264](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0L236-R264)`).
* Added a new method `doPreUpdateWebhookValidations` for webhook updates, which uses `validateCommonWebhookFields` and optionally validates the `secret` field if it is provided (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.javaL236-R264](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0L236-R264)`).

### Method Call Adjustments:
* Reordered the call to `doPreAddWebhookValidations` in the `createWebhook` method to ensure that all validations are performed after checking for existing endpoints and before generating the webhook ID (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.javaL77-R78](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0L77-R78)`).
* Added calls to `validateMaxWebhooksCount` and `doPreUpdateWebhookValidations` in the `updateWebhook` method to enforce maximum webhook limits and perform pre-update validations (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.javaR138-R139](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0R138-R139)`).

### Dependency Updates:
* Imported `StringUtils` from Apache Commons Lang to handle optional `secret` field validation in `doPreUpdateWebhookValidations` (`[components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/service/impl/WebhookManagementServiceImpl.javaR21-L26](diffhunk://#diff-a426b0aa02238c87c88a881ddc4ffa4c788b1ef2edee9d065ff1ae84d0da28d0R21-L26)`).
