### PR TITLE
Support static content in execution step type

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/core/FlowExecutionEngine.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/core/FlowExecutionEngine.java
@@ -194,12 +194,22 @@ public class FlowExecutionEngine {
                                                    FlowExecutionContext context, NodeResponse nodeResponse) {
 
         DataDTO dataDTO = graph.getNodePageMappings().get(currentNode.getId()).getData();
-        handleError(dataDTO, nodeResponse);
+
+        DataDTO finalDataDTO = null;
+        if (dataDTO != null) {
+            finalDataDTO = new DataDTO.Builder()
+                    .components(dataDTO.getComponents())
+                    .requiredParams(nodeResponse.getRequiredData())
+                    .additionalData(dataDTO.getAdditionalData())
+                    .build();
+            handleError(finalDataDTO, nodeResponse);
+        }
+
         return new FlowExecutionStep.Builder()
                 .flowId(context.getContextIdentifier())
                 .flowStatus(STATUS_INCOMPLETE)
                 .stepType(VIEW)
-                .data(dataDTO)
+                .data(finalDataDTO)
                 .build();
     }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
@@ -231,6 +231,15 @@ public class InputValidationService {
             context.getCurrentRequiredInputs().put(DEFAULT_ACTION, new HashSet<>(dataDTO.getRequiredParams()));
             context.getCurrentStepInputs().put(DEFAULT_ACTION, new HashSet<>(dataDTO.getRequiredParams()));
         }
+
+        // If there are no action components, set the required params as the step inputs with the default action.
+        // This is to handle cases where the flow temporarily ends with static view and expects inputs when the flow
+        // resumes.
+        if ((dataDTO.getRequiredParams() != null && !dataDTO.getRequiredParams().isEmpty()) &&
+                context.getCurrentStepInputs().isEmpty()) {
+            context.getCurrentRequiredInputs().put(DEFAULT_ACTION, new HashSet<>(dataDTO.getRequiredParams()));
+            context.getCurrentStepInputs().put(DEFAULT_ACTION, new HashSet<>(dataDTO.getRequiredParams()));
+        }
     }
 
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/dao/FlowDAOImpl.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/dao/FlowDAOImpl.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.wso2.carbon.identity.flow.mgt.Constants.StepTypes.EXECUTION;
 import static org.wso2.carbon.identity.flow.mgt.Constants.StepTypes.VIEW;
 import static org.wso2.carbon.identity.flow.mgt.dao.SQLConstants.DELETE_FLOW;
 import static org.wso2.carbon.identity.flow.mgt.dao.SQLConstants.GET_FIRST_STEP_ID;
@@ -330,6 +331,22 @@ public class FlowDAOImpl implements FlowDAO {
         })), preparedStatement -> {
             preparedStatement.setString(1, flowId);
             preparedStatement.setString(2, VIEW);
+        });
+
+        // Fetch execution steps with page content.
+        jdbcTemplate.executeQuery(GET_VIEW_PAGES_IN_FLOW, (LambdaExceptionUtils.rethrowRowMapper((resultSet, rowNumber) -> {
+            StepDTO stepDTO = new StepDTO.Builder()
+                    .id(resultSet.getString(DB_SCHEMA_COLUMN_NAME_STEP_ID))
+                    .type(EXECUTION)
+                    .build();
+            resolvePageContent(stepDTO, resultSet.getBytes(DB_SCHEMA_COLUMN_NAME_PAGE_CONTENT), tenantId);
+            if (stepDTO.getData() != null && stepDTO.getData().getComponents() != null) {
+                nodePageMappings.put(resultSet.getString(DB_SCHEMA_COLUMN_NAME_NODE_ID), stepDTO);
+            }
+            return null;
+        })), preparedStatement -> {
+            preparedStatement.setString(1, flowId);
+            preparedStatement.setString(2, EXECUTION);
         });
         return nodePageMappings;
     }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/model/DataDTO.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/model/DataDTO.java
@@ -101,6 +101,14 @@ public class DataDTO implements Serializable {
         this.additionalData.put(key, value);
     }
 
+    public void addRequiredParam(String param) {
+
+        if (this.requiredParams == null) {
+            this.requiredParams = new ArrayList<>();
+        }
+        this.requiredParams.add(param);
+    }
+
     public Map<String, Object> getWebAuthnData() {
 
         return webAuthnData;


### PR DESCRIPTION
### Proposed changes in this pull request

This PR introduces support for displaying static content in the Execution step type. It allows the flow to be temporarily paused by showing a static message to the end user, and then cleanly resumed once the user continues the flow.

For example, in a magic link execution, an email is sent to the user while a static message is displayed prompting them to click the link. Once the user clicks the link, they are redirected back to the flow, and execution resumes from that point.

### Related Issue

https://github.com/wso2/product-is/issues/23356