### PR TITLE
Subscribe pre/post add events and pre authentication for ask-password OTP flow

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -87,6 +87,8 @@ public class IdentityCoreConstants {
     public static final String USER_INVALID_CREDENTIALS = "17010";
     public static final String LOGIN_FAILED_GENERIC_ERROR_CODE = "17011";
     public static final String USER_EMAIL_NOT_VERIFIED_ERROR_CODE = "17012";
+    public static final String ASK_PASSWORD_SET_PASSWORD_VIA_OTP_ERROR_CODE = "17013";
+    public static final String ASK_PASSWORD_SET_PASSWORD_VIA_OTP_MISMATCHED_ERROR_CODE = "17014";
 
     public static final String USER_ACCOUNT_STATE = "UserAccountState";
 

--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -363,5 +363,11 @@
   "identity_mgt.events.schemes.CredentialEventHook.subscriptions": [
     "POST_ADD_NEW_PASSWORD",
     "POST_UPDATE_CREDENTIAL_BY_SCIM"
+  ],
+  "identity_mgt.events.schemes.askPasswordBasedPasswordSetup.module_index": "55",
+  "identity_mgt.events.schemes.askPasswordBasedPasswordSetup.subscriptions": [
+    "PRE_ADD_USER",
+    "POST_ADD_USER",
+    "PRE_AUTHENTICATION"
   ]
 }


### PR DESCRIPTION
### Proposed changes in this pull request

The Ask-Password Based handler is separated out from the email verification handler for better manageability. Hence it is required to subscribe for pre and post add add user events.
Also subscribe to the pre-authentation event as ask password based OTP is used as temporary password for initiating the password setup flow.

### Related Issues
- https://github.com/wso2/product-is/issues/24790
