### PR TITLE
Show resend button when webhook created in active mode

### DIFF
--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherSubscriberAdapterTypeHandler.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherSubscriberAdapterTypeHandler.java
@@ -106,7 +106,7 @@ public class PublisherSubscriberAdapterTypeHandler extends AdapterTypeHandler {
                         .eventProfileName(webhook.getEventProfileName())
                         .eventProfileUri(webhook.getEventProfileUri())
                         .eventProfileVersion(webhook.getEventProfileVersion())
-                        .status(webhook.getStatus())
+                        .status(WebhookStatus.PARTIALLY_ACTIVE)
                         .createdAt(webhook.getCreatedAt())
                         .updatedAt(webhook.getUpdatedAt())
                         .eventsSubscribed(subscriptions)

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/java/org/wso2/carbon/identity/webhook/management/dao/WebhookManagementDAOFacadeTest.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/java/org/wso2/carbon/identity/webhook/management/dao/WebhookManagementDAOFacadeTest.java
@@ -157,7 +157,18 @@ public class WebhookManagementDAOFacadeTest {
     @Test(priority = 1)
     public void testAddWebhook() throws Exception {
 
-        testWebhook = createTestWebhook(WEBHOOK_ENDPOINT1);
+        testWebhook = new Webhook.Builder()
+                .uuid(UUID.randomUUID().toString())
+                .endpoint(WEBHOOK_ENDPOINT1)
+                .name(WEBHOOK_NAME)
+                .secret(WEBHOOK_SECRET)
+                .eventProfileName(WEBHOOK_EVENT_PROFILE_NAME)
+                .eventProfileUri(WEBHOOK_EVENT_PROFILE_URI)
+                .status(WebhookStatus.PARTIALLY_ACTIVE)
+                .createdAt(new Timestamp(System.currentTimeMillis()))
+                .updatedAt(new Timestamp(System.currentTimeMillis()))
+                .build();
+
         daoFacade.createWebhook(testWebhook, TENANT_ID);
 
         Webhook webhookRetrieved = daoFacade.getWebhook(testWebhook.getId(), TENANT_ID);
@@ -185,7 +196,7 @@ public class WebhookManagementDAOFacadeTest {
         Assert.assertEquals(webhookRetrieved.getName(), testWebhook.getName());
         Assert.assertEquals(webhookRetrieved.getEventProfileName(), testWebhook.getEventProfileName());
         Assert.assertEquals(webhookRetrieved.getEventProfileUri(), testWebhook.getEventProfileUri());
-        Assert.assertEquals(webhookRetrieved.getStatus(), testWebhook.getStatus());
+        Assert.assertEquals(webhookRetrieved.getStatus(), WebhookStatus.PARTIALLY_ACTIVE);
 
         List<Subscription> expected = testWebhook.getEventsSubscribed();
         List<Subscription> actual = webhookRetrieved.getEventsSubscribed();


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces changes to standardize the default status of webhooks as `PARTIALLY_ACTIVE` and updates related test cases to reflect this modification. The most significant changes include updating the default status in the webhook creation logic and ensuring test cases are aligned with the new default status.

### Webhook status standardization:

* [`PublisherSubscriberAdapterTypeHandler.java`](diffhunk://#diff-83de86702b26deb322de206618f9ca375c269cd77fb2648dff7ff4cc267b1ce7L109-R109): Changed the default status of webhooks from `webhook.getStatus()` to `WebhookStatus.PARTIALLY_ACTIVE` during webhook creation.

### Test case updates:

* [`WebhookManagementDAOFacadeTest.java`](diffhunk://#diff-f9192f45d8831b047a05ab1d863fd13fdbdf028281a1b25407cec5ce7984af36L160-R171): Updated the `testAddWebhook` method to explicitly set the status of the test webhook to `WebhookStatus.PARTIALLY_ACTIVE` when creating a new webhook.
* [`WebhookManagementDAOFacadeTest.java`](diffhunk://#diff-f9192f45d8831b047a05ab1d863fd13fdbdf028281a1b25407cec5ce7984af36L188-R199): Modified the `testGetWebhook` method to assert that the retrieved webhook status is `WebhookStatus.PARTIALLY_ACTIVE` instead of relying on the `testWebhook`'s status.