### PR TITLE
Introducing new registration flow names for actions and events

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -301,7 +301,7 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
                 }
             }
         } else {
-            FrameworkUtils.updateIdentityContextFlow(Flow.Name.JIT_PROVISION);
+            FrameworkUtils.updateIdentityContextFlow(Flow.Name.JUST_IN_TIME_PROVISION);
             password = resolvePassword(userClaims);
             // Check for inconsistencies in username attribute and the username claim.
             if (userClaims.containsKey(USERNAME_CLAIM) && !userClaims.get(USERNAME_CLAIM).equals(username)) {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/FlowExecutionService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/FlowExecutionService.java
@@ -82,7 +82,7 @@ public class FlowExecutionService {
             }
 
             if (REGISTRATION_FLOW_TYPE.equals(context.getFlowType())) {
-                FrameworkUtils.updateIdentityContextFlow(Flow.Name.USER_REGISTRATION);
+                FrameworkUtils.updateIdentityContextFlow(Flow.Name.REGISTER);
             }
 
             if (inputs != null) {

--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
@@ -202,7 +202,7 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
         }
 
         return flow.getName() == Flow.Name.PASSWORD_RESET ||
-                flow.getName() == Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD ||
+                flow.getName() == Flow.Name.INVITE ||
                 flow.getName() == Flow.Name.INVITED_USER_REGISTRATION ||
                 flow.getName() == Flow.Name.PROFILE_UPDATE;
     }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/execution/PreUpdatePasswordRequestBuilder.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/execution/PreUpdatePasswordRequestBuilder.java
@@ -169,7 +169,7 @@ public class PreUpdatePasswordRequestBuilder implements ActionExecutionRequestBu
                 return PreUpdatePasswordEvent.Action.UPDATE;
             case PASSWORD_RESET:
                 return PreUpdatePasswordEvent.Action.RESET;
-            case USER_REGISTRATION_INVITE_WITH_PASSWORD:
+            case INVITE:
             case INVITED_USER_REGISTRATION:
                 return PreUpdatePasswordEvent.Action.INVITE;
             default:

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
@@ -120,7 +120,7 @@ public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEv
             return PasswordUpdateFlowType.USER_INITIATED_PASSWORD_RESET.getFlowName();
         }
 
-        if ((flow.getName() == Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD || flow.getName() ==
+        if ((flow.getName() == Flow.Name.INVITE || flow.getName() ==
                 Flow.Name.INVITED_USER_REGISTRATION) && flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN) {
             return PasswordUpdateFlowType.ADMIN_INITIATED_USER_INVITE_TO_SET_PASSWORD.getFlowName();
         }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/execution/PreUpdatePasswordActionRequestBuilderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/execution/PreUpdatePasswordActionRequestBuilderTest.java
@@ -259,7 +259,7 @@ public class PreUpdatePasswordActionRequestBuilderTest {
                         PreUpdatePasswordEvent.Action.RESET, PreUpdatePasswordEvent.FlowInitiatorType.USER},
                 {false, buildMockedFlow(Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.ADMIN),
                         PreUpdatePasswordEvent.Action.RESET, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN},
-                {false, buildMockedFlow(Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD, Flow.InitiatingPersona.ADMIN),
+                {false, buildMockedFlow(Flow.Name.INVITE, Flow.InitiatingPersona.ADMIN),
                         PreUpdatePasswordEvent.Action.INVITE, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN},
                 {false, buildMockedFlow(Flow.Name.INVITED_USER_REGISTRATION, Flow.InitiatingPersona.ADMIN),
                         PreUpdatePasswordEvent.Action.INVITE, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN},
@@ -273,7 +273,7 @@ public class PreUpdatePasswordActionRequestBuilderTest {
                         PreUpdatePasswordEvent.Action.RESET, PreUpdatePasswordEvent.FlowInitiatorType.USER},
                 {true, buildMockedFlow(Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.ADMIN),
                         PreUpdatePasswordEvent.Action.RESET, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN},
-                {true, buildMockedFlow(Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD, Flow.InitiatingPersona.ADMIN),
+                {true, buildMockedFlow(Flow.Name.INVITE, Flow.InitiatingPersona.ADMIN),
                         PreUpdatePasswordEvent.Action.INVITE, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN},
                 {true, buildMockedFlow(Flow.Name.INVITED_USER_REGISTRATION, Flow.InitiatingPersona.ADMIN),
                         PreUpdatePasswordEvent.Action.INVITE, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN}

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
@@ -87,7 +87,7 @@ public class PreUpdatePasswordActionRuleEvaluationDataProviderTest {
                 {Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.APPLICATION, "applicationInitiatedPasswordUpdate"},
                 {Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.ADMIN, "adminInitiatedPasswordReset"},
                 {Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.USER, "userInitiatedPasswordReset"},
-                {Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD, Flow.InitiatingPersona.ADMIN,
+                {Flow.Name.INVITE, Flow.InitiatingPersona.ADMIN,
                         "adminInitiatedUserInviteToSetPassword"},
                 {Flow.Name.INVITED_USER_REGISTRATION, Flow.InitiatingPersona.ADMIN,
                         "adminInitiatedUserInviteToSetPassword"}


### PR DESCRIPTION
This update adopts the latest flow names for registration-related functionality, which impacts the following areas:
- Actions
- Newly introduced webhook events

This is a breaking change and should only be merged once all related pull requests are ready and tested together in a WSO2 Identity Server pack(Integration tests locally) that includes all required modifications.

Possible repositories of the PRs

- SCIM2
- Identity Governance
- Webhook Event Handlers

Parent issue
- https://github.com/wso2/product-is/issues/24847