### PR TITLE
Onboarding new flow definition for the password reset flow

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Flow.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Flow.java
@@ -44,9 +44,6 @@ public class Flow {
                 EnumSet.of(InitiatingPersona.ADMIN, InitiatingPersona.APPLICATION));
 
         // Deprecated: To be removed when migration is complete.
-        FLOW_DEFINITIONS.put(Name.USER_REGISTRATION_INVITE_WITH_PASSWORD,
-                EnumSet.of(InitiatingPersona.ADMIN, InitiatingPersona.APPLICATION));
-        // Deprecated: To be removed when migration is complete.
         FLOW_DEFINITIONS.put(Name.INVITED_USER_REGISTRATION,
                 EnumSet.of(InitiatingPersona.ADMIN, InitiatingPersona.APPLICATION));
         // -----------------------------------------------------------------------------------------------
@@ -54,17 +51,10 @@ public class Flow {
         // -------------------------------- Direct and self-registration flows ---------------------------
         FLOW_DEFINITIONS.put(Name.REGISTER,
                 EnumSet.of(InitiatingPersona.ADMIN, InitiatingPersona.APPLICATION, InitiatingPersona.USER));
-
-        // Deprecated: To be removed when migration is complete.
-        FLOW_DEFINITIONS.put(Name.USER_REGISTRATION,
-                EnumSet.of(InitiatingPersona.ADMIN, InitiatingPersona.APPLICATION, InitiatingPersona.USER));
         // -----------------------------------------------------------------------------------------------
 
         // -------------------------------- JIT Provisioning flows ----------------------------------------
         FLOW_DEFINITIONS.put(Name.JUST_IN_TIME_PROVISION, EnumSet.of(InitiatingPersona.USER));
-
-        // Deprecated: To be removed when migration is complete.
-        FLOW_DEFINITIONS.put(Name.JIT_PROVISION, EnumSet.of(InitiatingPersona.USER));
         // -----------------------------------------------------------------------------------------------
 
         // -------------------------------- Authentication flows -----------------------------------------
@@ -145,21 +135,15 @@ public class Flow {
         // ------------ Invited registration flows ----------
         INVITE,
         @Deprecated // Use INVITE instead.
-        USER_REGISTRATION_INVITE_WITH_PASSWORD,
-        @Deprecated // Use INVITE instead.
         INVITED_USER_REGISTRATION,
         // --------------------------------------------------
 
         // --------Direct and self-registration flows--------
         REGISTER,
-        @Deprecated // Use REGISTER instead.
-        USER_REGISTRATION,
         // --------------------------------------------------
 
         // -------------JIT Provisioning flows---------------
         JUST_IN_TIME_PROVISION,
-        @Deprecated // Use JUST_IN_TIME_PROVISION instead.
-        JIT_PROVISION,
         // --------------------------------------------------
 
         // -------------Authentication flows-----------------

--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
@@ -201,7 +201,7 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
             return false;
         }
 
-        return flow.getName() == Flow.Name.PASSWORD_RESET ||
+        return flow.getName() == Flow.Name.CREDENTIAL_RESET ||
                 flow.getName() == Flow.Name.INVITE ||
                 flow.getName() == Flow.Name.INVITED_USER_REGISTRATION ||
                 flow.getName() == Flow.Name.PROFILE_UPDATE;

--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/test/java/org/wso2/carbon/identity/user/action/ActionUserOperationEventListenerTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/test/java/org/wso2/carbon/identity/user/action/ActionUserOperationEventListenerTest.java
@@ -81,9 +81,10 @@ public class ActionUserOperationEventListenerTest {
         userCoreUtil = mockStatic(UserCoreUtil.class);
         listener = new ActionUserOperationEventListener();
         userCoreUtil.when(() -> UserCoreUtil.getDomainName(any())).thenReturn("PRIMARY");
-        IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.PASSWORD_RESET)
+        IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.CredentialFlowBuilder()
+                .name(Flow.Name.CREDENTIAL_RESET)
                 .initiatingPersona(Flow.InitiatingPersona.USER)
+                .credentialType(Flow.CredentialType.PASSWORD)
                 .build());
 
         organizationManager = mock(OrganizationManager.class);

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/execution/PreUpdatePasswordRequestBuilder.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/execution/PreUpdatePasswordRequestBuilder.java
@@ -167,7 +167,7 @@ public class PreUpdatePasswordRequestBuilder implements ActionExecutionRequestBu
             case PROFILE_UPDATE:
                 // Password update is a sub-flow of profile update.
                 return PreUpdatePasswordEvent.Action.UPDATE;
-            case PASSWORD_RESET:
+            case CREDENTIAL_RESET:
                 return PreUpdatePasswordEvent.Action.RESET;
             case INVITE:
             case INVITED_USER_REGISTRATION:

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
@@ -110,12 +110,12 @@ public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEv
             return PasswordUpdateFlowType.USER_INITIATED_PASSWORD_UPDATE.getFlowName();
         }
 
-        if (flow.getName() == Flow.Name.PASSWORD_RESET &&
+        if (flow.getName() == Flow.Name.CREDENTIAL_RESET &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN) {
             return PasswordUpdateFlowType.ADMIN_INITIATED_PASSWORD_RESET.getFlowName();
         }
 
-        if (flow.getName() == Flow.Name.PASSWORD_RESET &&
+        if (flow.getName() == Flow.Name.CREDENTIAL_RESET &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.USER) {
             return PasswordUpdateFlowType.USER_INITIATED_PASSWORD_RESET.getFlowName();
         }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/execution/PreUpdatePasswordActionRequestBuilderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/execution/PreUpdatePasswordActionRequestBuilderTest.java
@@ -255,9 +255,9 @@ public class PreUpdatePasswordActionRequestBuilderTest {
                         PreUpdatePasswordEvent.Action.UPDATE, PreUpdatePasswordEvent.FlowInitiatorType.APPLICATION},
                 {false, buildMockedFlow(Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.ADMIN),
                         PreUpdatePasswordEvent.Action.UPDATE, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN},
-                {false, buildMockedFlow(Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.USER),
+                {false, buildMockedFlow(Flow.Name.CREDENTIAL_RESET, Flow.InitiatingPersona.USER),
                         PreUpdatePasswordEvent.Action.RESET, PreUpdatePasswordEvent.FlowInitiatorType.USER},
-                {false, buildMockedFlow(Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.ADMIN),
+                {false, buildMockedFlow(Flow.Name.CREDENTIAL_RESET, Flow.InitiatingPersona.ADMIN),
                         PreUpdatePasswordEvent.Action.RESET, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN},
                 {false, buildMockedFlow(Flow.Name.INVITE, Flow.InitiatingPersona.ADMIN),
                         PreUpdatePasswordEvent.Action.INVITE, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN},
@@ -269,9 +269,9 @@ public class PreUpdatePasswordActionRequestBuilderTest {
                         PreUpdatePasswordEvent.Action.UPDATE, PreUpdatePasswordEvent.FlowInitiatorType.APPLICATION},
                 {true, buildMockedFlow(Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.ADMIN),
                         PreUpdatePasswordEvent.Action.UPDATE, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN},
-                {true, buildMockedFlow(Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.USER),
+                {true, buildMockedFlow(Flow.Name.CREDENTIAL_RESET, Flow.InitiatingPersona.USER),
                         PreUpdatePasswordEvent.Action.RESET, PreUpdatePasswordEvent.FlowInitiatorType.USER},
-                {true, buildMockedFlow(Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.ADMIN),
+                {true, buildMockedFlow(Flow.Name.CREDENTIAL_RESET, Flow.InitiatingPersona.ADMIN),
                         PreUpdatePasswordEvent.Action.RESET, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN},
                 {true, buildMockedFlow(Flow.Name.INVITE, Flow.InitiatingPersona.ADMIN),
                         PreUpdatePasswordEvent.Action.INVITE, PreUpdatePasswordEvent.FlowInitiatorType.ADMIN},
@@ -509,10 +509,18 @@ public class PreUpdatePasswordActionRequestBuilderTest {
 
     private static Flow buildMockedFlow(Flow.Name flowName, Flow.InitiatingPersona initiatingPersona) {
 
-        return new Flow.Builder()
-                .name(flowName)
-                .initiatingPersona(initiatingPersona)
-                .build();
+        if (Flow.Name.CREDENTIAL_RESET.equals(flowName)) {
+            return new Flow.CredentialFlowBuilder()
+                    .name(flowName)
+                    .initiatingPersona(initiatingPersona)
+                    .credentialType(Flow.CredentialType.PASSWORD)
+                    .build();
+        } else {
+            return new Flow.Builder()
+                    .name(flowName)
+                    .initiatingPersona(initiatingPersona)
+                    .build();
+        }
     }
 
     private static UserStoreModel createUserStoreModel() {

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
@@ -85,8 +85,8 @@ public class PreUpdatePasswordActionRuleEvaluationDataProviderTest {
                 {Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.ADMIN, "adminInitiatedPasswordUpdate"},
                 {Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.USER, "userInitiatedPasswordUpdate"},
                 {Flow.Name.PROFILE_UPDATE, Flow.InitiatingPersona.APPLICATION, "applicationInitiatedPasswordUpdate"},
-                {Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.ADMIN, "adminInitiatedPasswordReset"},
-                {Flow.Name.PASSWORD_RESET, Flow.InitiatingPersona.USER, "userInitiatedPasswordReset"},
+                {Flow.Name.CREDENTIAL_RESET, Flow.InitiatingPersona.ADMIN, "adminInitiatedPasswordReset"},
+                {Flow.Name.CREDENTIAL_RESET, Flow.InitiatingPersona.USER, "userInitiatedPasswordReset"},
                 {Flow.Name.INVITE, Flow.InitiatingPersona.ADMIN,
                         "adminInitiatedUserInviteToSetPassword"},
                 {Flow.Name.INVITED_USER_REGISTRATION, Flow.InitiatingPersona.ADMIN,
@@ -118,7 +118,7 @@ public class PreUpdatePasswordActionRuleEvaluationDataProviderTest {
     @Test(expectedExceptions = RuleEvaluationDataProviderException.class)
     public void testGetEvaluationDataWithUnsupportedFlow() throws RuleEvaluationDataProviderException {
 
-        doReturn(Flow.Name.PASSWORD_RESET).when(flow).getName();
+        doReturn(Flow.Name.CREDENTIAL_RESET).when(flow).getName();
         doReturn(Flow.InitiatingPersona.APPLICATION).when(flow).getInitiatingPersona();
         IdentityContext.getThreadLocalIdentityContext().setFlow(flow);
         dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/test/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLoggerTest.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/test/java/org/wso2/carbon/user/mgt/listeners/UserManagementAuditLoggerTest.java
@@ -59,9 +59,10 @@ public class UserManagementAuditLoggerTest {
     public void testGetPasswordUpdateAuditMessageAction(Flow.InitiatingPersona persona, String expectedAction) {
 
         configureCarbonHome();
-        IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.PASSWORD_RESET)
+        IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.CredentialFlowBuilder()
+                .name(Flow.Name.CREDENTIAL_RESET)
                 .initiatingPersona(persona)
+                .credentialType(Flow.CredentialType.PASSWORD)
                 .build());
         String action = auditLogger.getPasswordUpdateAuditMessageAction();
         assertEquals(action, expectedAction);


### PR DESCRIPTION
This update adopts the latest flow names for password-reset-related functionality, which impacts the following areas:
- Actions
- Newly introduced webhook events

This is a breaking change and should only be merged once all related pull requests are ready and tested together in a WSO2 Identity Server pack(Integration tests locally) that includes all required modifications.

Possible repositories of the PRs

- SCIM2
- Identity Governance
- Webhook Event Handlers

Parent issue
- https://github.com/wso2/product-is/issues/24869