### PR TITLE
Refactor organization resolving logic in identity context with the new getMinimalOrganization() in org manager

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Organization.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Organization.java
@@ -27,6 +27,7 @@ public class Organization {
     private final String id;
     private final String name;
     private final String organizationHandle;
+    private final String parentOrganizationId;
     private final int depth;
 
     private Organization(Builder builder) {
@@ -34,6 +35,7 @@ public class Organization {
         this.id = builder.id;
         this.name = builder.name;
         this.organizationHandle = builder.organizationHandle;
+        this.parentOrganizationId = builder.parentOrganizationId;
         this.depth = builder.depth;
     }
 
@@ -68,6 +70,16 @@ public class Organization {
     }
 
     /**
+     * Returns the ID of the parent organization.
+     *
+     * @return ID of the parent organization.
+     */
+    public String getParentOrganizationId() {
+
+        return parentOrganizationId;
+    }
+
+    /**
      * Returns the depth of the organization in the organization hierarchy.
      *
      * @return Depth of the organization.
@@ -85,6 +97,7 @@ public class Organization {
         private String id;
         private String name;
         private String organizationHandle;
+        private String parentOrganizationId;
         private int depth;
 
         public Builder id(String id) {
@@ -102,6 +115,12 @@ public class Organization {
         public Builder organizationHandle(String organizationHandle) {
 
             this.organizationHandle = organizationHandle;
+            return this;
+        }
+
+        public Builder parentOrganizationId(String parentOrganizationId) {
+
+            this.parentOrganizationId = parentOrganizationId;
             return this;
         }
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/context/OrganizationResolver.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/context/OrganizationResolver.java
@@ -96,9 +96,7 @@ public class OrganizationResolver {
                 // Resolve root organization with tenant information in the CarbonContext.
                 resolveRootOrganization(IdentityContext.getThreadLocalIdentityContext().getTenantId());
                 // Resolve root organization information to the Organization object in tenanted paths.
-                RootOrganization rootOrganization = IdentityContext.getThreadLocalIdentityContext().getRootOrganization();
-                resolveRootOrganizationToOrganization(rootOrganization.getOrganizationId(),
-                        rootOrganization.getAssociatedTenantDomain());
+                resolveRootOrganizationToOrganization();
             }
         } catch (OrganizationManagementException | UserStoreException e) {
             LOG.error("Error while initializing organization information.", e);
@@ -137,9 +135,16 @@ public class OrganizationResolver {
                 .build());
     }
 
-    private void resolveRootOrganizationToOrganization(String organizationId, String associatedTenantDomain)
-            throws OrganizationManagementException {
+    private void resolveRootOrganizationToOrganization() throws OrganizationManagementException {
 
+        RootOrganization rootOrganization = IdentityContext.getThreadLocalIdentityContext().getRootOrganization();
+        if (rootOrganization == null) {
+            LOG.debug("Root organization is not set in the IdentityContext. Cannot initialize organization.");
+            return;
+        }
+
+        String organizationId = rootOrganization.getOrganizationId();
+        String associatedTenantDomain = rootOrganization.getAssociatedTenantDomain();
         MinimalOrganization minimalOrganization = getMinimalOrganization(organizationId, associatedTenantDomain);
         if (minimalOrganization == null) {
             LOG.debug("Unable to find an organization for the root organization id: " + organizationId +

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/context/OrganizationResolver.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/context/OrganizationResolver.java
@@ -95,7 +95,8 @@ public class OrganizationResolver {
                 resolveRootOrganization(IdentityContext.getThreadLocalIdentityContext().getTenantId());
                 // Resolve root organization information to the Organization object in tenanted paths.
                 RootOrganization rootOrganization = IdentityContext.getThreadLocalIdentityContext().getRootOrganization();
-                resolveOrganization(rootOrganization.getOrganizationId(), rootOrganization.getAssociatedTenantDomain());
+                resolveRootOrganizationToOrganization(rootOrganization.getOrganizationId(),
+                        rootOrganization.getAssociatedTenantDomain());
             }
         } catch (OrganizationManagementException | UserStoreException e) {
             LOG.error("Error while initializing organization information.", e);
@@ -122,6 +123,25 @@ public class OrganizationResolver {
                 org.wso2.carbon.identity.organization.management.service.util.Utils.getSubOrgStartLevel()) {
             LOG.debug("Organization with id: " + organizationId + " is not a sub organization. " +
                     "Skipping initialization of organization.");
+            return;
+        }
+
+        IdentityContext.getThreadLocalIdentityContext().setOrganization(new Organization.Builder()
+                .id(minimalOrganization.getId())
+                .name(minimalOrganization.getName())
+                .organizationHandle(minimalOrganization.getOrganizationHandle())
+                .parentOrganizationId(minimalOrganization.getParentOrganizationId())
+                .depth(minimalOrganization.getDepth())
+                .build());
+    }
+
+    private void resolveRootOrganizationToOrganization(String organizationId, String associatedTenantDomain)
+            throws OrganizationManagementException {
+
+        MinimalOrganization minimalOrganization = getMinimalOrganization(organizationId, associatedTenantDomain);
+        if (minimalOrganization == null) {
+            LOG.debug("Unable to find an organization for the root organization id: " + organizationId +
+                    ". Cannot initialize organization.");
             return;
         }
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/context/OrganizationResolver.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/context/OrganizationResolver.java
@@ -45,8 +45,10 @@ public class OrganizationResolver {
     private static final Log LOG = LogFactory.getLog(OrganizationResolver.class);
     private static final String TENANT_SEPARATOR = "/t/";
     private static final String ORG_SEPARATOR = "/o/";
-    private static final Pattern PATTERN_ORG_QUALIFIED_ONLY = Pattern.compile("^/o/[a-f0-9\\-]+?");
-    private static final Pattern PATTERN_TENANT_AND_ORG_QUALIFIED = Pattern.compile("^/t/[^/]+/o/[a-f0-9\\-]+?");
+    private static final Pattern PATTERN_ORG_QUALIFIED_ONLY =
+            Pattern.compile("^/o/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$");
+    private static final Pattern PATTERN_TENANT_AND_ORG_QUALIFIED =
+            Pattern.compile("^/t/[^/]+/o/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$");
 
     private OrganizationResolver() {
         // Private constructor to prevent instantiation.

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/context/OrganizationResolver.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/context/OrganizationResolver.java
@@ -29,13 +29,11 @@ import org.wso2.carbon.identity.core.internal.component.IdentityCoreServiceDataH
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
-import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
+import org.wso2.carbon.identity.organization.management.service.model.MinimalOrganization;
 import org.wso2.carbon.user.api.Tenant;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
-import java.util.Collections;
-import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
@@ -80,44 +78,59 @@ public class OrganizationResolver {
 
                 // Request URI has an organization ID -> Resolve sub-organization info.
                 String organizationId = extractResourceFromURI(requestURI, ORG_SEPARATOR);
-                resolveSubOrganization(organizationId);
+                resolveOrganization(organizationId);
             } else if (PATTERN_ORG_QUALIFIED_ONLY.matcher(requestURI).find()) {
                 // Handle the requests starts with /o/<org_id>/
                 // Request URI has an organization ID -> Resolve both root and sub-organization info.
                 resolveRootAndSubOrganization(requestURI);
-            } else {
-                // Handle the requests starts with /t/<tenant>/, /o/ or /t/<tenant>/o/
-                // /o/ -> Resolves to /t/carbon.super/o/
+            } else if (requestURI.contains(ORG_SEPARATOR)) {
+                // Handle the requests starts with /o/ or /t/<tenant>/o/
+                // /o/ -> Act as /t/carbon.super/o/
                 // Resolve root organization with tenant information in the CarbonContext.
                 // Resolving sub organization is handled in org.wso2.carbon.identity.authz.valve.AuthorizationValve.
                 resolveRootOrganization(IdentityContext.getThreadLocalIdentityContext().getTenantId());
+            } else {
+                // Handle the requests starts with /t/<tenant>/ and the super tenant requests without /t/carbon.super/.
+                // Resolve root organization with tenant information in the CarbonContext.
+                resolveRootOrganization(IdentityContext.getThreadLocalIdentityContext().getTenantId());
+                // Resolve root organization information to the Organization object in tenanted paths.
+                RootOrganization rootOrganization = IdentityContext.getThreadLocalIdentityContext().getRootOrganization();
+                resolveOrganization(rootOrganization.getOrganizationId(), rootOrganization.getAssociatedTenantDomain());
             }
         } catch (OrganizationManagementException | UserStoreException e) {
             LOG.error("Error while initializing organization information.", e);
         }
     }
 
-    private void resolveSubOrganization(String organizationId) throws OrganizationManagementException {
+    private void resolveOrganization(String organizationId) throws OrganizationManagementException {
 
-        int organizationDepth = getOrganizationDepthInHierarchy(organizationId);
-        if (organizationDepth <
+        // When tenant domain is not provided, it will be resolved from the organization ID inside the
+        // organization manager service.
+        resolveOrganization(organizationId, null);
+    }
+
+    private void resolveOrganization(String organizationId, String associatedTenantDomain)
+            throws OrganizationManagementException {
+
+        MinimalOrganization minimalOrganization = getMinimalOrganization(organizationId, associatedTenantDomain);
+        if (minimalOrganization == null) {
+            LOG.debug("Unable to find an organization for the id: " + organizationId +
+                    ". Cannot initialize organization.");
+            return;
+        }
+        if (minimalOrganization.getDepth() <
                 org.wso2.carbon.identity.organization.management.service.util.Utils.getSubOrgStartLevel()) {
             LOG.debug("Organization with id: " + organizationId + " is not a sub organization. " +
                     "Skipping initialization of organization.");
             return;
         }
 
-        BasicOrganization basicOrganizationInfo = getBasicOrganization(organizationId);
-        if (basicOrganizationInfo == null) {
-            LOG.debug("Unable to find an organization for the id: " + organizationId +
-                    ". Cannot initialize organization.");
-            return;
-        }
         IdentityContext.getThreadLocalIdentityContext().setOrganization(new Organization.Builder()
-                .id(basicOrganizationInfo.getId())
-                .name(basicOrganizationInfo.getName())
-                .organizationHandle(basicOrganizationInfo.getOrganizationHandle())
-                .depth(organizationDepth)
+                .id(minimalOrganization.getId())
+                .name(minimalOrganization.getName())
+                .organizationHandle(minimalOrganization.getOrganizationHandle())
+                .parentOrganizationId(minimalOrganization.getParentOrganizationId())
+                .depth(minimalOrganization.getDepth())
                 .build());
     }
 
@@ -142,7 +155,7 @@ public class OrganizationResolver {
                     .build());
         }
 
-        resolveSubOrganization(organizationId);
+        resolveOrganization(organizationId);
     }
 
     private void resolveRootOrganization(int tenantId) throws UserStoreException {
@@ -170,17 +183,11 @@ public class OrganizationResolver {
                 .build());
     }
 
-    private int getOrganizationDepthInHierarchy(String organizationId) throws OrganizationManagementException {
+    private MinimalOrganization getMinimalOrganization(String organizationId, String associatedTenantDomain)
+            throws OrganizationManagementException {
 
         return IdentityCoreServiceDataHolder.getInstance().getOrganizationManager()
-                .getOrganizationDepthInHierarchy(organizationId);
-    }
-
-    private BasicOrganization getBasicOrganization(String organizationId) throws OrganizationManagementException {
-
-        Map<String, BasicOrganization> orgsMap = IdentityCoreServiceDataHolder.getInstance().getOrganizationManager()
-                .getBasicOrganizationDetailsByOrgIDs(Collections.singletonList(organizationId));
-        return orgsMap.get(organizationId);
+                .getMinimalOrganization(organizationId, associatedTenantDomain);
     }
 
     private String getRootOrganizationId(String organizationId) throws OrganizationManagementException {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/context/OrganizationResolver.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/internal/context/OrganizationResolver.java
@@ -46,9 +46,9 @@ public class OrganizationResolver {
     private static final String TENANT_SEPARATOR = "/t/";
     private static final String ORG_SEPARATOR = "/o/";
     private static final Pattern PATTERN_ORG_QUALIFIED_ONLY =
-            Pattern.compile("^/o/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$");
+            Pattern.compile("^/o/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/?");
     private static final Pattern PATTERN_TENANT_AND_ORG_QUALIFIED =
-            Pattern.compile("^/t/[^/]+/o/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$");
+            Pattern.compile("^/t/[^/]+/o/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/?");
 
     private OrganizationResolver() {
         // Private constructor to prevent instantiation.

--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
@@ -30,7 +30,7 @@ import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
-import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
+import org.wso2.carbon.identity.organization.management.service.model.MinimalOrganization;
 import org.wso2.carbon.identity.user.action.api.constant.UserActionError;
 import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionClientException;
 import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionServerException;
@@ -46,9 +46,6 @@ import org.wso2.carbon.user.core.listener.SecretHandleableListener;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.Secret;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
-
-import java.util.Collections;
-import java.util.Map;
 
 /**
  * This class is responsible for handling the action invocation related to user flows.
@@ -128,15 +125,13 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
     }
 
     private Organization getUserResidentOrganization(String userID, UserStoreManager userStoreManager)
-            throws ActionExecutionException {
-
+            throws UserActionExecutionServerException {
 
         org.wso2.carbon.identity.core.context.model.Organization accessingOrganization =
                 IdentityContext.getThreadLocalIdentityContext().getOrganization();
         if (accessingOrganization == null) {
-            // If the accessing organization is null, it means the user is not accessing from an organization context.
-            // Hence, return null.
-            return null;
+            throw new UserActionExecutionServerException(UserActionError.PRE_UPDATE_PASSWORD_ACTION_SERVER_ERROR,
+                    "Accessing organization is not present in the identity context.");
         }
 
         try {
@@ -155,11 +150,12 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
             // If the managed organization claim is set, retrieve the organization details.
             return getOrganization(managedOrgId);
         } catch (UserStoreException e) {
-            throw new ActionExecutionException("Error while retrieving the user's managed by organization claim.", e);
+            throw new UserActionExecutionServerException(UserActionError.PRE_UPDATE_PASSWORD_ACTION_SERVER_ERROR,
+                    "Error while retrieving the user's managed by organization claim.", e);
         }
     }
 
-    private Organization getOrganization(String managedOrgId) throws ActionExecutionException {
+    private Organization getOrganization(String managedOrgId) throws UserActionExecutionServerException {
 
         if (OrganizationManagementConstants.SUPER_ORG_ID.equals(managedOrgId)) {
             return new Organization.Builder()
@@ -171,26 +167,23 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
         }
 
         try {
-            Map<String, BasicOrganization> orgsMap = UserActionServiceComponentHolder.getInstance().
-                    getOrganizationManager()
-                    .getBasicOrganizationDetailsByOrgIDs(Collections.singletonList(managedOrgId));
-            BasicOrganization basicOrganization = orgsMap.get(managedOrgId);
-            if (basicOrganization == null) {
-                throw new ActionExecutionException("No organization found for the user's managed organization id: "
-                        + managedOrgId);
+            MinimalOrganization minimalOrganization = UserActionServiceComponentHolder.getInstance().
+                    getOrganizationManager().getMinimalOrganization(managedOrgId, null);
+            if (minimalOrganization == null) {
+                throw new UserActionExecutionServerException(UserActionError.PRE_UPDATE_PASSWORD_ACTION_SERVER_ERROR,
+                        "No organization found for the user's managed organization id: " + managedOrgId);
             }
 
-            int depth = UserActionServiceComponentHolder.getInstance().getOrganizationManager()
-                    .getOrganizationDepthInHierarchy(managedOrgId);
             return new Organization.Builder()
-                    .id(basicOrganization.getId())
-                    .name(basicOrganization.getName())
-                    .orgHandle(basicOrganization.getOrganizationHandle())
-                    .depth(depth)
+                    .id(minimalOrganization.getId())
+                    .name(minimalOrganization.getName())
+                    .orgHandle(minimalOrganization.getOrganizationHandle())
+                    .depth(minimalOrganization.getDepth())
                     .build();
         } catch (OrganizationManagementException e) {
-            throw new ActionExecutionException("Error while retrieving organization details for the user's " +
-                    "managed organization id: " + managedOrgId, e);
+            throw new UserActionExecutionServerException(UserActionError.PRE_UPDATE_PASSWORD_ACTION_SERVER_ERROR,
+                    "Error while retrieving organization details for the user's managed organization id: "
+                            + managedOrgId, e);
         }
     }
 

--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/test/java/org/wso2/carbon/identity/user/action/ActionUserOperationEventListenerTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/test/java/org/wso2/carbon/identity/user/action/ActionUserOperationEventListenerTest.java
@@ -23,7 +23,7 @@ import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
-import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
+import org.wso2.carbon.identity.organization.management.service.model.MinimalOrganization;
 import org.wso2.carbon.identity.user.action.api.service.UserActionExecutor;
 import org.wso2.carbon.identity.user.action.internal.component.UserActionServiceComponentHolder;
 import org.wso2.carbon.identity.user.action.internal.factory.UserActionExecutorFactory;
@@ -42,6 +42,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertFalse;
 import static org.wso2.carbon.identity.user.action.api.constant.UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_ERROR;
 import static org.wso2.carbon.identity.user.action.api.constant.UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED;
@@ -117,6 +119,7 @@ public class ActionUserOperationEventListenerTest {
     public void testPreUpdatePasswordActionExecutionWithDisabledListener()
             throws UserStoreException, UnsupportedSecretTypeException {
 
+        setOrganizationToIdentityContext();
         IdentityEventListenerConfig mockConfig = mock(IdentityEventListenerConfig.class);
         try (MockedStatic<IdentityUtil> identityUtilMockedStatic = mockStatic(IdentityUtil.class)) {
             identityUtilMockedStatic.when(() -> IdentityUtil.readEventListenerProperty(any(), any()))
@@ -127,10 +130,21 @@ public class ActionUserOperationEventListenerTest {
         }
     }
 
+    private void setOrganizationToIdentityContext() {
+
+        IdentityContext.getThreadLocalIdentityContext().setOrganization(new Organization.Builder()
+                .id(TEST_RESIDENT_ORG_ID)
+                .name(TEST_RESIDENT_ORG_NAME)
+                .organizationHandle(TEST_RESIDENT_ORG_HANDLE)
+                .depth(TEST_RESIDENT_ORG_DEPTH)
+                .build());
+    }
+
     @Test
     public void testPreUpdatePasswordActionExecutionSuccess()
             throws UserStoreException, ActionExecutionException, UnsupportedSecretTypeException {
 
+        setOrganizationToIdentityContext();
         ActionExecutionStatus<Success> successStatus =
                 new SuccessStatus.Builder().setResponseContext(Collections.emptyMap()).build();
         doReturn(successStatus).when(mockExecutor).execute(any(), any());
@@ -178,13 +192,14 @@ public class ActionUserOperationEventListenerTest {
                 .build());
         doReturn(TEST_MANAGED_BY_ORG_ID).when(userStoreManager).getUserClaimValueWithID(any(), any(), any());
 
-        BasicOrganization managedByOrg = new BasicOrganization();
-        managedByOrg.setId(TEST_MANAGED_BY_ORG_ID);
-        managedByOrg.setName(TEST_MANAGED_BY_ORG_NAME);
-        managedByOrg.setOrganizationHandle(TEST_MANAGED_BY_ORG_HANDLE);
-        doReturn(Collections.singletonMap(TEST_MANAGED_BY_ORG_ID, managedByOrg)).when(organizationManager)
-                .getBasicOrganizationDetailsByOrgIDs(any());
-        doReturn(TEST_MANAGED_BY_ORG_DEPTH).when(organizationManager).getOrganizationDepthInHierarchy(any());
+        MinimalOrganization managedByOrg = new MinimalOrganization.Builder()
+                .id(TEST_MANAGED_BY_ORG_ID)
+                .name(TEST_MANAGED_BY_ORG_NAME)
+                .organizationHandle(TEST_MANAGED_BY_ORG_HANDLE)
+                .parentOrganizationId(TEST_RESIDENT_ORG_ID)
+                .depth(TEST_MANAGED_BY_ORG_DEPTH)
+                .build();
+        doReturn(managedByOrg).when(organizationManager).getMinimalOrganization(any(), any());
 
         ActionExecutionStatus<Success> successStatus =
                 new SuccessStatus.Builder().setResponseContext(Collections.emptyMap()).build();
@@ -195,11 +210,13 @@ public class ActionUserOperationEventListenerTest {
         boolean result = listener.doPreUpdateCredentialByAdminWithID(USER_NAME, Secret.getSecret(PASSWORD),
                 userStoreManager);
         Assert.assertTrue(result, "The method should return true for successful execution.");
+        verify(organizationManager, times(1)).getMinimalOrganization(any(), any());
     }
 
     @Test
     public void testPreUpdatePasswordActionExecutionFailure() throws ActionExecutionException {
 
+        setOrganizationToIdentityContext();
         Failure failureResponse = new Failure("FailureReason", "FailureDescription");
         ActionExecutionStatus<Failure> failedStatus = new FailedStatus(failureResponse);
         doReturn(failedStatus).when(mockExecutor).execute(any(), any());
@@ -219,6 +236,7 @@ public class ActionUserOperationEventListenerTest {
     @Test
     public void testPreUpdatePasswordActionExecutionFailureWithoutDescription() throws ActionExecutionException {
 
+        setOrganizationToIdentityContext();
         Failure failureResponse = new Failure("FailureReason", null);
         ActionExecutionStatus<Failure> failedStatus = new FailedStatus(failureResponse);
         doReturn(failedStatus).when(mockExecutor).execute(any(), any());
@@ -238,6 +256,7 @@ public class ActionUserOperationEventListenerTest {
     @Test
     public void testPreUpdatePasswordActionExecutionError() throws ActionExecutionException {
 
+        setOrganizationToIdentityContext();
         Error errorResponse = new Error("ErrorMessage", "ErrorDescription");
         ActionExecutionStatus<Error> errorStatus = new ErrorStatus(errorResponse);
         doReturn(errorStatus).when(mockExecutor).execute(any(), any());
@@ -256,6 +275,7 @@ public class ActionUserOperationEventListenerTest {
     @Test
     public void testPreUpdatePasswordActionExecutionWithUnsupportedSecret() throws ActionExecutionException {
 
+        setOrganizationToIdentityContext();
         Error errorResponse = new Error("ErrorMessage", "ErrorDescription");
         ActionExecutionStatus<Error> errorStatus = new ErrorStatus(errorResponse);
         doReturn(errorStatus).when(mockExecutor).execute(any(), any());
@@ -275,6 +295,7 @@ public class ActionUserOperationEventListenerTest {
     public void testPreUpdatePasswordActionExecutionWithUnknownStatus()
             throws UserStoreException, ActionExecutionException, UnsupportedSecretTypeException {
 
+        setOrganizationToIdentityContext();
         ActionExecutionStatus<?> unknownStatus = mock(ActionExecutionStatus.class);
         doReturn(null).when(unknownStatus).getStatus();
         doReturn(unknownStatus).when(mockExecutor).execute(any(), any());
@@ -288,6 +309,7 @@ public class ActionUserOperationEventListenerTest {
     @Test
     public void testPreUpdatePasswordActionExecutionWithActionExecutionException() throws ActionExecutionException {
 
+        setOrganizationToIdentityContext();
         doThrow(new ActionExecutionException("Execution error")).when(mockExecutor).execute(any(), any());
         doReturn(ActionType.PRE_UPDATE_PASSWORD).when(mockExecutor).getSupportedActionType();
         UserActionExecutorFactory.registerUserActionExecutor(mockExecutor);

--- a/pom.xml
+++ b/pom.xml
@@ -2032,7 +2032,7 @@
         <carbon.identity.package.import.version.range>[5.14.0, 8.0.0)</carbon.identity.package.import.version.range>
 
         <org.bouncycastle.imp.pkg.version.range>[0.0.0,2.0.0)</org.bouncycastle.imp.pkg.version.range>
-        <org.wso2.carbon.identity.organization.management.core.version>1.1.44
+        <org.wso2.carbon.identity.organization.management.core.version>1.1.45
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.version>2.0.8</org.wso2.carbon.identity.organization.management.version>
         <org.wso2.carbon.identity.organization.management.version.range>[2.0.0, 3.0.0)</org.wso2.carbon.identity.organization.management.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -2032,7 +2032,7 @@
         <carbon.identity.package.import.version.range>[5.14.0, 8.0.0)</carbon.identity.package.import.version.range>
 
         <org.bouncycastle.imp.pkg.version.range>[0.0.0,2.0.0)</org.bouncycastle.imp.pkg.version.range>
-        <org.wso2.carbon.identity.organization.management.core.version>1.1.40
+        <org.wso2.carbon.identity.organization.management.core.version>1.1.44
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.version>2.0.8</org.wso2.carbon.identity.organization.management.version>
         <org.wso2.carbon.identity.organization.management.version.range>[2.0.0, 3.0.0)</org.wso2.carbon.identity.organization.management.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request
- Add new `parentOrganizationId ` attribute to the Organization object in the identity context.
- Refactor Organization Resolver in identity context to utillize the new ` getMinimalOrganization(String orgId, String tenantDomain)` method from Organization Manager.

### Depends on
- https://github.com/wso2/identity-organization-management-core/pull/194
- https://github.com/wso2/product-is/pull/24893

### Related Issue
- https://github.com/wso2/product-is/issues/24855
