### PR TITLE
[Config] Update default value to enable correct email template behavior for account lock by failed attempts when admin unlock is required

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1944,7 +1944,7 @@
 
   "notification_templates.sms_templates.apply": true,
 
-  "account.lock.handler.enable_admin_unlock_email_template_for_failed_attempts": false,
+  "account.lock.handler.enable_admin_unlock_email_template_for_failed_attempts": true,
 
   "attribute.return_previous_additional_properties.enabled": false,
 


### PR DESCRIPTION
### Purpose
Update the default configuration value for enabling the email template used when an account is locked due to failed login attempts and admin unlock is required.

### Goals
Ensure that the email notification is properly triggered in scenarios where account lock requires admin intervention, by setting the correct default configuration value.

### Approach
* Updated the `org.wso2.carbon.identity.core.server.feature.default.json` file
* Set `"account.lock.handler.enable_admin_unlock_email_template_for_failed_attempts"` to `true`

### Related PRs
  - https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/150
  - https://github.com/wso2/carbon-identity-framework/pull/6904
  - https://github.com/wso2-extensions/identity-event-handler-notification/pull/333

## Related Issues
public issue: https://github.com/wso2/product-is/issues/24235