### PR TITLE
Add sub organization api paths for webhooks

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -1483,6 +1483,29 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
+    <APIResourceCollection name="org_webhooks" displayName="Webhooks" type="organization">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:webhooks"/>
+                <Scope name="console:org:webhooks_view"/>
+                <Scope name="console:org:webhooks_edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_webhook_mgt_update"/>
+                <Scope name="internal_org_webhook_meta_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_webhook_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_webhook_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_webhook_mgt_view"/>
+                <Scope name="internal_org_webhook_meta_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
     <APIResourceCollection name="org_users" displayName="Users" type="organization">
         <Scopes>
             <Feature>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -1565,6 +1565,29 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
+    <APIResourceCollection name="org_webhooks" displayName="Webhooks" type="organization">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:webhooks"/>
+                <Scope name="console:org:webhooks_view"/>
+                <Scope name="console:org:webhooks_edit"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_org_webhook_mgt_update"/>
+                <Scope name="internal_org_webhook_meta_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_org_webhook_mgt_delete"/>
+            </Delete>
+            <Create>
+                <Scope name="internal_org_webhook_mgt_create"/>
+            </Create>
+            <Read>
+                <Scope name="internal_org_webhook_mgt_view"/>
+                <Scope name="internal_org_webhook_meta_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
     <APIResourceCollection name="org_users" displayName="Users" type="organization">
         <Scopes>
             <Feature>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -881,6 +881,20 @@
                    description="Delete webhooks in the organization (root)"/>
         </Scopes>
     </APIResource>
+    <APIResource name="Webhook Management API" identifier="/o/api/server/v1/webhooks"
+                 requiresAuthorization="true"
+                 description="API representation of the Webhook Management API" type="ORGANIZATION">
+        <Scopes>
+            <Scope displayName="View Webhooks" name="internal_org_webhook_mgt_view"
+                   description="View webhooks in the organization"/>
+            <Scope displayName="Create Webhooks" name="internal_org_webhook_mgt_create"
+                   description="Create webhooks in the organization"/>
+            <Scope displayName="Update Webhooks" name="internal_org_webhook_mgt_update"
+                   description="Update webhooks in the organization"/>
+            <Scope displayName="Delete Webhooks" name="internal_org_webhook_mgt_delete"
+                   description="Delete webhooks in the organization"/>
+        </Scopes>
+    </APIResource>
     <APIResource name="Webhook Metadata API" identifier="/api/server/v1/webhooks/metadata"
                  requiresAuthorization="true"
                  description="API representation of the Webhook Metadata API" type="TENANT">
@@ -889,6 +903,16 @@
                    description="View webhook metadata in the organization (root)"/>
             <Scope displayName="Update Webhook Metadata" name="internal_webhook_meta_update"
                    description="Update webhook metadata in the organization (root)"/>
+        </Scopes>
+    </APIResource>
+    <APIResource name="Webhook Metadata API" identifier="/o/api/server/v1/webhooks/metadata"
+                 requiresAuthorization="true"
+                 description="API representation of the Webhook Metadata API" type="ORGANIZATION">
+        <Scopes>
+            <Scope displayName="View Webhook Metadata" name="internal_org_webhook_meta_view"
+                   description="View webhook metadata in the organization"/>
+            <Scope displayName="Update Webhook Metadata" name="internal_org_webhook_meta_update"
+                   description="Update webhook metadata in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Email Template Management API v1/v2"
@@ -1034,6 +1058,19 @@
                    description="Manage views of applications in the organization from the Console"/>
             <Scope displayName="Application Edit Feature" name="console:org:applications_edit"
                    description="Manage edits of applications in the organization from the Console"/>
+        </Scopes>
+    </APIResource>
+    <APIResource name="Webhook Management Feature" identifier="console:org:webhooks"
+                 requiresAuthorization="true"
+                 description="Resource representation of the Webhook Management Feature"
+                 type="CONSOLE_ORG_FEATURE">
+        <Scopes>
+            <Scope displayName="Webhook Feature" name="console:org:webhooks"
+                   description="Manage webhooks from the Console"/>
+            <Scope displayName="Webhook View Feature" name="console:org:webhooks_view"
+                   description="Manage views of webhooks from the Console"/>
+            <Scope displayName="Webhook Edit Feature" name="console:org:webhooks_edit"
+                   description="Manage edits of webhooks from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Branding Management Feature" identifier="console:branding"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -928,6 +928,20 @@
                    description="Delete webhooks in the organization (root)"/>
         </Scopes>
     </APIResource>
+    <APIResource name="Webhook Management API" identifier="/o/api/server/v1/webhooks"
+                 requiresAuthorization="true"
+                 description="API representation of the Webhook Management API" type="ORGANIZATION">
+        <Scopes>
+            <Scope displayName="View Webhooks" name="internal_org_webhook_mgt_view"
+                   description="View webhooks in the organization"/>
+            <Scope displayName="Create Webhooks" name="internal_org_webhook_mgt_create"
+                   description="Create webhooks in the organization"/>
+            <Scope displayName="Update Webhooks" name="internal_org_webhook_mgt_update"
+                   description="Update webhooks in the organization"/>
+            <Scope displayName="Delete Webhooks" name="internal_org_webhook_mgt_delete"
+                   description="Delete webhooks in the organization"/>
+        </Scopes>
+    </APIResource>
     <APIResource name="Webhook Metadata API" identifier="/api/server/v1/webhooks/metadata"
                  requiresAuthorization="true"
                  description="API representation of the Webhook Metadata API" type="TENANT">
@@ -936,6 +950,16 @@
                    description="View webhook metadata in the organization (root)"/>
             <Scope displayName="Update Webhook Metadata" name="internal_webhook_meta_update"
                    description="Update webhook metadata in the organization (root)"/>
+        </Scopes>
+    </APIResource>
+    <APIResource name="Webhook Metadata API" identifier="/o/api/server/v1/webhooks/metadata"
+                 requiresAuthorization="true"
+                 description="API representation of the Webhook Metadata API" type="ORGANIZATION">
+        <Scopes>
+            <Scope displayName="View Webhook Metadata" name="internal_org_webhook_meta_view"
+                   description="View webhook metadata in the organization"/>
+            <Scope displayName="Update Webhook Metadata" name="internal_org_webhook_meta_update"
+                   description="Update webhook metadata in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Email Template Management API v1/v2"
@@ -1081,6 +1105,19 @@
                    description="Manage views of applications in the organization from the Console"/>
             <Scope displayName="Application Edit Feature" name="console:org:applications_edit"
                    description="Manage edits of applications in the organization from the Console"/>
+        </Scopes>
+    </APIResource>
+    <APIResource name="Webhook Management Feature" identifier="console:org:webhooks"
+                 requiresAuthorization="true"
+                 description="Resource representation of the Webhook Management Feature"
+                 type="CONSOLE_ORG_FEATURE">
+        <Scopes>
+            <Scope displayName="Webhook Feature" name="console:org:webhooks"
+                   description="Manage webhooks from the Console"/>
+            <Scope displayName="Webhook View Feature" name="console:org:webhooks_view"
+                   description="Manage views of webhooks from the Console"/>
+            <Scope displayName="Webhook Edit Feature" name="console:org:webhooks_edit"
+                   description="Manage edits of webhooks from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Branding Management Feature" identifier="console:branding"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -153,6 +153,32 @@
         <Scopes>internal_cert_validation_mgt_delete</Scopes>
     </Resource>
 
+    <!-- [Organization] Webhook Metadata API -->
+    <Resource context="(.*)/o/api/server/v1/webhooks/metadata(.*)" secured="true" http-method="GET">
+        <Scopes>internal_org_webhook_meta_view</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v1/webhooks/metadata(.*)" secured="true" http-method="PATCH">
+        <Scopes>internal_org_webhook_meta_update</Scopes>
+    </Resource>
+    <!-- The Webhook Metadata update operation using the PUT method is not supported. However, due to the shared API path structure, this method must be explicitly disallowed within the application logic. -->
+    <Resource context="(.*)/o/api/server/v1/webhooks/metadata(.*)" secured="true" http-method="PUT">
+        <Scopes>internal_org_webhook_meta_update</Scopes>
+    </Resource>
+
+    <!-- [Organization] Webhook Management API -->
+    <Resource context="(.*)/o/api/server/v1/webhooks(.*)" secured="true" http-method="POST">
+        <Scopes>internal_org_webhook_mgt_create</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v1/webhooks(.*)" secured="true" http-method="PUT">
+        <Scopes>internal_org_webhook_mgt_update</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v1/webhooks(.*)" secured="true" http-method="GET">
+        <Scopes>internal_org_webhook_mgt_view</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v1/webhooks(.*)" secured="true" http-method="DELETE">
+        <Scopes>internal_org_webhook_mgt_delete</Scopes>
+    </Resource>
+
     <!-- Webhook Metadata API -->
     <Resource context="(.*)/api/server/v1/webhooks/metadata(.*)" secured="true" http-method="GET">
         <Scopes>internal_webhook_meta_view</Scopes>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -175,6 +175,32 @@
             <Scopes>internal_cert_validation_mgt_delete</Scopes>
         </Resource>
 
+    <!-- [Organization] Webhook Metadata API -->
+    <Resource context="(.*)/o/api/server/v1/webhooks/metadata(.*)" secured="true" http-method="GET">
+        <Scopes>internal_org_webhook_meta_view</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v1/webhooks/metadata(.*)" secured="true" http-method="PATCH">
+        <Scopes>internal_org_webhook_meta_update</Scopes>
+    </Resource>
+    <!-- The Webhook Metadata update operation using the PUT method is not supported. However, due to the shared API path structure, this method must be explicitly disallowed within the application logic. -->
+    <Resource context="(.*)/o/api/server/v1/webhooks/metadata(.*)" secured="true" http-method="PUT">
+        <Scopes>internal_org_webhook_meta_update</Scopes>
+    </Resource>
+
+    <!-- [Organization] Webhook Management API -->
+    <Resource context="(.*)/o/api/server/v1/webhooks(.*)" secured="true" http-method="POST">
+        <Scopes>internal_org_webhook_mgt_create</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v1/webhooks(.*)" secured="true" http-method="PUT">
+        <Scopes>internal_org_webhook_mgt_update</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v1/webhooks(.*)" secured="true" http-method="GET">
+        <Scopes>internal_org_webhook_mgt_view</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v1/webhooks(.*)" secured="true" http-method="DELETE">
+        <Scopes>internal_org_webhook_mgt_delete</Scopes>
+    </Resource>
+
         <!-- Webhook Metadata API -->
         <Resource context="(.*)/api/server/v1/webhooks/metadata(.*)" secured="true" http-method="GET">
             <Scopes>internal_webhook_meta_view</Scopes>


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces support for managing webhooks within an organization by adding new API resources, scopes, and access control rules. The changes span multiple files to define, secure, and enable these new features.

### New Webhook Management Features:

* Added a new `APIResourceCollection` named `org_webhooks` with associated scopes for viewing, editing, creating, updating, and deleting webhooks in `api-resource-collection.xml` and its template (`api-resource-collection.xml.j2`). [[1]](diffhunk://#diff-3f84f2fc41782b93036d6233268491eda9c179f357755bd84fb13a798eb34badR1486-R1508) [[2]](diffhunk://#diff-a2db3b627822a2fef1faa05dbc072adb80137338c607f5e6c8ccfeb7295c7f33R1568-R1590)

* Introduced `Webhook Management API` and `Webhook Metadata API` as new API resources in `system-api-resource.xml` and its template (`system-api-resource.xml.j2`). These APIs include scopes for managing webhooks and their metadata at the organizational level. [[1]](diffhunk://#diff-2bb3bf5d98c3e3607e4d52f7be45a06b2e6afc0357ba58dc9bbb71a5bd8102bbR884-R897) [[2]](diffhunk://#diff-2bb3bf5d98c3e3607e4d52f7be45a06b2e6afc0357ba58dc9bbb71a5bd8102bbR908-R917) [[3]](diffhunk://#diff-a70225dc72f4100048a17b866cc1754e81c34fc31aa4128051d613ac4c64ed5bR931-R944) [[4]](diffhunk://#diff-a70225dc72f4100048a17b866cc1754e81c34fc31aa4128051d613ac4c64ed5bR955-R964)

* Added a `Webhook Management Feature` resource in `system-api-resource.xml` and its template to represent webhook-related operations in the Console. [[1]](diffhunk://#diff-2bb3bf5d98c3e3607e4d52f7be45a06b2e6afc0357ba58dc9bbb71a5bd8102bbR1063-R1075) [[2]](diffhunk://#diff-a70225dc72f4100048a17b866cc1754e81c34fc31aa4128051d613ac4c64ed5bR1110-R1122)

### Access Control Rules:

* Defined access control rules for the new webhook APIs in `resource-access-control-v2.xml` and its template. These rules secure operations like viewing, creating, updating, and deleting webhooks and webhook metadata. [[1]](diffhunk://#diff-8d3e33818f8d0a815cd470310be01f25928d196ce5ad9992cd21a2f7b81ca9aaR156-R181) [[2]](diffhunk://#diff-c1d66ea18073ea8342745dd465ae3028cc45019079d18f6c838c8d2cfb94da50R178-R203)
