### PR TITLE
Enable revamped user profile UIs in Console and My Account

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1622,6 +1622,7 @@
   "console.saml2_configuration.enabled": true,
   "console.session_management.enabled": true,
   "console.users.enabled": true,
+  "console.users.disabled_features": ["users.profile.legacy"],
   "console.users.scopes.feature": ["console:users"],
   "console.users.scopes.create": ["internal_user_mgt_create"],
   "console.users.scopes.read": [
@@ -1634,6 +1635,8 @@
       "internal_user_mgt_list",
       "internal_session_view"
   ],
+  "console.users.scopes.update": ["internal_user_mgt_update", "internal_session_delete"],
+  "console.users.scopes.delete": ["internal_user_mgt_delete"],
   "console.secrets_management.enabled": true,
   "console.secrets_management.scopes.feature": [ "console:secretsManagement" ],
   "console.secrets_management.scopes.create": [ "internal_secret_mgt_add" ],
@@ -1657,8 +1660,6 @@
   "console.tenants.scopes.read": ["internal_list_tenants"],
   "console.tenants.scopes.update": ["internal_modify_tenants"],
   "console.tenants.scopes.delete": ["internal_modify_tenants"],
-  "console.users.scopes.update": ["internal_user_mgt_update", "internal_session_delete"],
-  "console.users.scopes.delete": ["internal_user_mgt_delete"],
   "console.user_stores.enabled": true,
   "console.user_stores.disabled_features": [
     "userStores.type.remote"
@@ -1807,6 +1808,7 @@
   "myaccount.operations.enabled": true,
   "myaccount.overview.enabled": true,
   "myaccount.personal_info.enabled": true,
+  "myaccount.personal_info.disabled_features": ["profileInfo.profile.legacy"],
   "myaccount.security.enabled": true,
   "myaccount.operations.scopes.create": [],
   "myaccount.operations.scopes.read": ["internal_humantask_view"],
@@ -1816,7 +1818,6 @@
   "myaccount.session.params.userIdleWarningTimeOut": 580,
   "myaccount.session.params.sessionRefreshTimeOut": 300,
   "myaccount.session.params.checkSessionInterval": 3,
-  "myaccount.personal_info.disabled_features": [],
   "myaccount.security.disabled_features": ["security.loginVerifyData.typingDNA", "security.mfa.sms"],
   "myaccount.idp_configs.authorizeEndpointURL": "${serverOrigin}/oauth2/authorize",
   "myaccount.idp_configs.logoutEndpointURL": "${serverOrigin}/oidc/logout",


### PR DESCRIPTION
### Proposed changes in this pull request
 Add configs to disable the legacy user profile UIs, which will enable the revamped user profile UIs that adhere to the input format of claims.

### Related issues
- https://github.com/wso2/product-is/issues/24392
- Console: https://github.com/wso2/product-is/issues/24476
- My Account: https://github.com/wso2-enterprise/asgardeo-product/issues/32118

### Related PRs
- Console: https://github.com/wso2/identity-apps/pull/8509
- My Account: https://github.com/wso2/identity-apps/pull/8572
