### PR TITLE
Disable webhook settings temporarily

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1306,7 +1306,9 @@
   "console.actions.scopes.update": ["internal_action_mgt_update"],
   "console.actions.scopes.delete": ["internal_action_mgt_delete"],
   "console.webhooks.enabled": true,
-  "console.webhooks.disabled_features": [],
+  "console.webhooks.disabled_features": [
+    "webhooks.settings"
+  ],
   "console.agents.enabled": true,
   "console.agents.disabled_features": [],
   "console.agents.scopes.feature": ["console:users"],


### PR DESCRIPTION
### Purpose
This PR disables the webhook settings from the console UI.

### Related Issue
- https://github.com/wso2/product-is/issues/24923