### PR TITLE
[Config] Update default value not to return null-valued fields in DCR response

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -212,7 +212,7 @@
   "oauth.grant_type.token_exchange.allow_refresh_tokens": true,
   "oauth.grant_type.token_exchange.allow_public_client": true,
   "oauth.dcrm.application_role_permission_required_to_view": true,
-  "oauth.dcrm.return_null_fields_in_response": true,
+  "oauth.dcrm.return_null_fields_in_response": false,
   "oauth.dcr.enable_fapi_enforcement": false,
   "oauth.dcr.enable_sector_identifier_validation": false,
   "oauth.dcr.authentication_required": true,


### PR DESCRIPTION
### Purpose
Update the default configuration value not to return null-valued fields in DCR response

### Goals
Ensure that the DCR response does not include null-valued fields by setting the correct default configuration value.

### Approach
* Updated the `org.wso2.carbon.identity.core.server.feature.default.json` file
* Set `"oauth.dcrm.return_null_fields_in_response"` to `false`

### Related PRs
  - https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2800
  - https://github.com/wso2/carbon-identity-framework/pull/6817
  - Temporary preserving the earlier behaviour in Asgardeo: https://github.com/wso2-enterprise/asgardeo-deployment-helm-is/pull/1285

## Related Issues
public issue: https://github.com/wso2/product-is/issues/23989