### PR TITLE
Add resource access for accounts endpoint

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -1726,6 +1726,7 @@
         <Resource context="(.*)/.well-known/trusted-apps/ios" secured="false" http-method="GET"/>
         <Resource context="(.*)/push-auth/check-status(.*)" secured="false" http-method="GET"/>
         <Resource context="(.*)/push-auth/authenticate" secured="false" http-method="POST"/>
+        <Resource context="(.*)/accounts(.*)" secured="false" http-method="all"/>
 
         <!-- Wild Cards; These scopes are not avaiable in the V2 runtime, therefore any other API will be blocked. -->
         <Resource context="(.*)/api/server/v1/(?!(tenants|channel-verified-tenants))(.*)" secured="true" http-method="all">


### PR DESCRIPTION
## Purpose
This pull request introduces a newnsecured resource endpoint for account-related API paths. The change allows all HTTP methods on the `/accounts` endpoint without requiring authentication.

Access control configuration update:

* Added a new resource entry to `resource-access-control-v2.xml.j2` to permit all HTTP methods on paths matching `(.*)/accounts(.*)` without security checks.

## Related Issue
- https://github.com/wso2/product-is/issues/24937