### PR TITLE
[Infer-Json] Remove config to remove null values from DCR response

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -271,7 +271,6 @@
   },
   "preserve_previous_product_behaviour.version": {
     "IS_7.0.0": {
-      "oauth.dcrm.return_null_fields_in_response": true,
       "account.lock.handler.enable_admin_unlock_email_template_for_failed_attempts": false,
       "session_management.filter_by_unique_session_id_for_user": false,
       "identity_mgt.login_identifiers.enable_identifier_as_display_username": false,
@@ -280,7 +279,6 @@
       "console.identity_providers.disabled_features": []
     },
     "IS_7.1.0": {
-      "oauth.dcrm.return_null_fields_in_response": true,
       "account.lock.handler.enable_admin_unlock_email_template_for_failed_attempts": false,
       "session_management.filter_by_unique_session_id_for_user": false,
       "identity_mgt.login_identifiers.enable_identifier_as_display_username": false,


### PR DESCRIPTION
### Purpose
Remove the `oauth.dcrm.return_null_fields_in_response` configuration from the `infer.json` file, as it is no longer needed.

### Goals
* Align with the decision to exclude `null` values from DCR responses in the master branch.
* Ensure consistency with the behaviour of previous IS versions.

### Approach
* Removed the config entry `oauth.dcrm.return_null_fields_in_response` under both `IS_7.0.0` and `IS_7.1.0` in `infer.json`.

### Related PRs
  - https://github.com/wso2/carbon-identity-framework/pull/7052

## Related Issues
Product-is issue: [https://github.com/wso2/product-is/issues/23989](https://github.com/wso2/product-is/issues/23989)

---

## P.S

* This PR was originally raised to remove the `oauth.dcrm.return_null_fields_in_response` configuration from `infer.json`, based on the earlier decision to preserve the existing Identity Server behavior in the master branch.
* However, following updated discussions and alignment with the standard test suite \[1], it was decided **not** to return `null` values starting from the master branch.
* Given that this results in a behavioral change depending on the default value of the configuration, the `oauth.dcrm.return_null_fields_in_response` configuration must now be reintroduced in `infer.json` to explicitly preserve the behavior of earlier versions.

That effort is being tracked via the following PR:
  - https://github.com/wso2/carbon-identity-framework/pull/7078

[1] UK DCR Spec Test Suite
