### PR TITLE
Add support for admin and user registration with pre update password flow

### DIFF
--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
@@ -51,8 +51,9 @@ public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEv
         APPLICATION_INITIATED_PASSWORD_UPDATE("applicationInitiatedPasswordUpdate"),
         USER_INITIATED_PASSWORD_UPDATE("userInitiatedPasswordUpdate"),
         USER_INITIATED_PASSWORD_RESET("userInitiatedPasswordReset"),
-        ADMIN_REGISTER_USER_WITH_PASSWORD("adminRegisterUserWithPassword"),
-        USER_REGISTER_WITH_PASSWORD("userRegisterWithPassword");
+        ADMIN_INITIATED_REGISTRATION_WITH_PASSWORD("adminInitiatedRegistrationWithPassword"),
+        APPLICATION_INITIATED_REGISTRATION_WITH_PASSWORD("applicationInitiatedRegistrationWithPassword"),
+        USER_INITIATED_REGISTRATION_WITH_PASSWORD("userInitiatedRegistrationWithPassword");
 
         final String flowName;
 
@@ -129,12 +130,17 @@ public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEv
 
         if (flow.getName() == Flow.Name.USER_REGISTRATION &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN) {
-            return PasswordUpdateFlowType.ADMIN_REGISTER_USER_WITH_PASSWORD.getFlowName();
+            return PasswordUpdateFlowType.ADMIN_INITIATED_REGISTRATION_WITH_PASSWORD.getFlowName();
+        }
+
+        if (flow.getName() == Flow.Name.USER_REGISTRATION &&
+                flow.getInitiatingPersona() == Flow.InitiatingPersona.APPLICATION) {
+            return PasswordUpdateFlowType.APPLICATION_INITIATED_REGISTRATION_WITH_PASSWORD.getFlowName();
         }
 
         if (flow.getName() == Flow.Name.USER_REGISTRATION &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.USER) {
-            return PasswordUpdateFlowType.USER_REGISTER_WITH_PASSWORD.getFlowName();
+            return PasswordUpdateFlowType.USER_INITIATED_REGISTRATION_WITH_PASSWORD.getFlowName();
         }
 
         throw new RuleEvaluationDataProviderException("Unsupported flow type: " + flow.getName() +

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
@@ -50,7 +50,9 @@ public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEv
         ADMIN_INITIATED_USER_INVITE_TO_SET_PASSWORD("adminInitiatedUserInviteToSetPassword"),
         APPLICATION_INITIATED_PASSWORD_UPDATE("applicationInitiatedPasswordUpdate"),
         USER_INITIATED_PASSWORD_UPDATE("userInitiatedPasswordUpdate"),
-        USER_INITIATED_PASSWORD_RESET("userInitiatedPasswordReset");
+        USER_INITIATED_PASSWORD_RESET("userInitiatedPasswordReset"),
+        ADMIN_REGISTER_USER_WITH_PASSWORD("adminRegisterUserWithPassword"),
+        USER_REGISTER_WITH_PASSWORD("userRegisterWithPassword");
 
         final String flowName;
 
@@ -123,6 +125,16 @@ public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEv
         if ((flow.getName() == Flow.Name.INVITE || flow.getName() ==
                 Flow.Name.INVITED_USER_REGISTRATION) && flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN) {
             return PasswordUpdateFlowType.ADMIN_INITIATED_USER_INVITE_TO_SET_PASSWORD.getFlowName();
+        }
+
+        if (flow.getName() == Flow.Name.USER_REGISTRATION &&
+                flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN) {
+            return PasswordUpdateFlowType.ADMIN_REGISTER_USER_WITH_PASSWORD.getFlowName();
+        }
+
+        if (flow.getName() == Flow.Name.USER_REGISTRATION &&
+                flow.getInitiatingPersona() == Flow.InitiatingPersona.USER) {
+            return PasswordUpdateFlowType.USER_REGISTER_WITH_PASSWORD.getFlowName();
         }
 
         throw new RuleEvaluationDataProviderException("Unsupported flow type: " + flow.getName() +

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
@@ -128,17 +128,17 @@ public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEv
             return PasswordUpdateFlowType.ADMIN_INITIATED_USER_INVITE_TO_SET_PASSWORD.getFlowName();
         }
 
-        if (flow.getName() == Flow.Name.USER_REGISTRATION &&
+        if (flow.getName() == Flow.Name.REGISTER &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN) {
             return PasswordUpdateFlowType.ADMIN_INITIATED_REGISTRATION.getFlowName();
         }
 
-        if (flow.getName() == Flow.Name.USER_REGISTRATION &&
+        if (flow.getName() == Flow.Name.REGISTER &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.APPLICATION) {
             return PasswordUpdateFlowType.APPLICATION_INITIATED_REGISTRATION.getFlowName();
         }
 
-        if (flow.getName() == Flow.Name.USER_REGISTRATION &&
+        if (flow.getName() == Flow.Name.REGISTER &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.USER) {
             return PasswordUpdateFlowType.USER_INITIATED_REGISTRATION.getFlowName();
         }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/rule/PreUpdatePasswordActionRuleEvaluationDataProvider.java
@@ -51,9 +51,9 @@ public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEv
         APPLICATION_INITIATED_PASSWORD_UPDATE("applicationInitiatedPasswordUpdate"),
         USER_INITIATED_PASSWORD_UPDATE("userInitiatedPasswordUpdate"),
         USER_INITIATED_PASSWORD_RESET("userInitiatedPasswordReset"),
-        ADMIN_INITIATED_REGISTRATION_WITH_PASSWORD("adminInitiatedRegistrationWithPassword"),
-        APPLICATION_INITIATED_REGISTRATION_WITH_PASSWORD("applicationInitiatedRegistrationWithPassword"),
-        USER_INITIATED_REGISTRATION_WITH_PASSWORD("userInitiatedRegistrationWithPassword");
+        ADMIN_INITIATED_REGISTRATION("adminInitiatedRegistration"),
+        APPLICATION_INITIATED_REGISTRATION("applicationInitiatedRegistration"),
+        USER_INITIATED_REGISTRATION("userInitiatedRegistration");
 
         final String flowName;
 
@@ -130,17 +130,17 @@ public class PreUpdatePasswordActionRuleEvaluationDataProvider implements RuleEv
 
         if (flow.getName() == Flow.Name.USER_REGISTRATION &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN) {
-            return PasswordUpdateFlowType.ADMIN_INITIATED_REGISTRATION_WITH_PASSWORD.getFlowName();
+            return PasswordUpdateFlowType.ADMIN_INITIATED_REGISTRATION.getFlowName();
         }
 
         if (flow.getName() == Flow.Name.USER_REGISTRATION &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.APPLICATION) {
-            return PasswordUpdateFlowType.APPLICATION_INITIATED_REGISTRATION_WITH_PASSWORD.getFlowName();
+            return PasswordUpdateFlowType.APPLICATION_INITIATED_REGISTRATION.getFlowName();
         }
 
         if (flow.getName() == Flow.Name.USER_REGISTRATION &&
                 flow.getInitiatingPersona() == Flow.InitiatingPersona.USER) {
-            return PasswordUpdateFlowType.USER_INITIATED_REGISTRATION_WITH_PASSWORD.getFlowName();
+            return PasswordUpdateFlowType.USER_INITIATED_REGISTRATION.getFlowName();
         }
 
         throw new RuleEvaluationDataProviderException("Unsupported flow type: " + flow.getName() +

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
@@ -91,11 +91,11 @@ public class PreUpdatePasswordActionRuleEvaluationDataProviderTest {
                         "adminInitiatedUserInviteToSetPassword"},
                 {Flow.Name.INVITED_USER_REGISTRATION, Flow.InitiatingPersona.ADMIN,
                         "adminInitiatedUserInviteToSetPassword"},
-                {Flow.Name.USER_REGISTRATION, Flow.InitiatingPersona.ADMIN,
+                {Flow.Name.REGISTER, Flow.InitiatingPersona.ADMIN,
                         "adminInitiatedRegistration"},
-                {Flow.Name.USER_REGISTRATION, Flow.InitiatingPersona.APPLICATION,
+                {Flow.Name.REGISTER, Flow.InitiatingPersona.APPLICATION,
                         "applicationInitiatedRegistration"},
-                {Flow.Name.USER_REGISTRATION, Flow.InitiatingPersona.USER,
+                {Flow.Name.REGISTER, Flow.InitiatingPersona.USER,
                         "userInitiatedRegistration"}
         };
     }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
@@ -92,11 +92,11 @@ public class PreUpdatePasswordActionRuleEvaluationDataProviderTest {
                 {Flow.Name.INVITED_USER_REGISTRATION, Flow.InitiatingPersona.ADMIN,
                         "adminInitiatedUserInviteToSetPassword"},
                 {Flow.Name.USER_REGISTRATION, Flow.InitiatingPersona.ADMIN,
-                        "adminInitiatedRegistrationWithPassword"},
+                        "adminInitiatedRegistration"},
                 {Flow.Name.USER_REGISTRATION, Flow.InitiatingPersona.APPLICATION,
-                        "applicationInitiatedRegistrationWithPassword"},
+                        "applicationInitiatedRegistration"},
                 {Flow.Name.USER_REGISTRATION, Flow.InitiatingPersona.USER,
-                        "userInitiatedRegistrationWithPassword"}
+                        "userInitiatedRegistration"}
         };
     }
 

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/rule/PreUpdatePasswordActionRuleEvaluationDataProviderTest.java
@@ -90,7 +90,13 @@ public class PreUpdatePasswordActionRuleEvaluationDataProviderTest {
                 {Flow.Name.INVITE, Flow.InitiatingPersona.ADMIN,
                         "adminInitiatedUserInviteToSetPassword"},
                 {Flow.Name.INVITED_USER_REGISTRATION, Flow.InitiatingPersona.ADMIN,
-                        "adminInitiatedUserInviteToSetPassword"}
+                        "adminInitiatedUserInviteToSetPassword"},
+                {Flow.Name.USER_REGISTRATION, Flow.InitiatingPersona.ADMIN,
+                        "adminInitiatedRegistrationWithPassword"},
+                {Flow.Name.USER_REGISTRATION, Flow.InitiatingPersona.APPLICATION,
+                        "applicationInitiatedRegistrationWithPassword"},
+                {Flow.Name.USER_REGISTRATION, Flow.InitiatingPersona.USER,
+                        "userInitiatedRegistrationWithPassword"}
         };
     }
 

--- a/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/flows.json
+++ b/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/flows.json
@@ -41,11 +41,15 @@
               "displayName": "User initiated password update"
             },
             {
-              "name": "adminRegisterUserWithPassword",
-              "displayName": "Admin initiated user registration with password"
+              "name": "adminInitiatedRegistrationWithPassword",
+              "displayName": "Admin initiated registration with password"
             },
             {
-              "name": "userRegisterWithPassword",
+              "name": "applicationInitiatedRegistrationWithPassword",
+              "displayName": "Application initiated registration with password"
+            },
+            {
+              "name": "userInitiatedRegistrationWithPassword",
               "displayName": "User initiated registration with password"
             }
           ]

--- a/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/flows.json
+++ b/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/flows.json
@@ -39,6 +39,14 @@
             {
               "name": "userInitiatedPasswordUpdate",
               "displayName": "User initiated password update"
+            },
+            {
+              "name": "adminRegisterUserWithPassword",
+              "displayName": "Admin initiated user registration with password"
+            },
+            {
+              "name": "userRegisterWithPassword",
+              "displayName": "User initiated registration with password"
             }
           ]
         }

--- a/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/flows.json
+++ b/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/flows.json
@@ -41,16 +41,16 @@
               "displayName": "User initiated password update"
             },
             {
-              "name": "adminInitiatedRegistrationWithPassword",
-              "displayName": "Admin initiated registration with password"
+              "name": "adminInitiatedRegistration",
+              "displayName": "Admin initiated registration"
             },
             {
-              "name": "applicationInitiatedRegistrationWithPassword",
-              "displayName": "Application initiated registration with password"
+              "name": "applicationInitiatedRegistration",
+              "displayName": "Application initiated registration"
             },
             {
-              "name": "userInitiatedRegistrationWithPassword",
-              "displayName": "User initiated registration with password"
+              "name": "userInitiatedRegistration",
+              "displayName": "User initiated registration"
             }
           ]
         }


### PR DESCRIPTION
>Related Issue: https://github.com/wso2/product-is/issues/24873

This pull request adds support for distinguishing between admin-initiated, application-initiated and user-initiated user registration flows where a password is set, both in the backend logic and the flow metadata. This allows the system to handle these new registration scenarios separately from existing password update and reset flows.

**Backend flow type enhancements:**

* Added `ADMIN_INITIATED_REGISTRATION`, `APPLICATION_INITIATED_REGISTRATION` and `USER_INITIATED_REGISTRATION` to the `PasswordUpdateFlowType` enum to represent admin-initiated and user-initiated registration flows with password, respectively.
* Updated the `getFlowFromContext` method to return the appropriate new flow type based on whether the registration was initiated by an admin or a user.

**Flow metadata updates:**

* Added new flow definitions for `adminInitiatedRegistration`, `applicationInitiatedRegistration` and `userInitiatedRegistration` in `flows.json`, including display names for each.

### Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [x] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
