### PR TITLE
[Infer-Json] Re-introduce config to remove null values from DCR response

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -271,6 +271,7 @@
   },
   "preserve_previous_product_behaviour.version": {
     "IS_7.0.0": {
+      "oauth.dcrm.return_null_fields_in_response": true,
       "account.lock.handler.enable_admin_unlock_email_template_for_failed_attempts": false,
       "session_management.filter_by_unique_session_id_for_user": false,
       "identity_mgt.login_identifiers.enable_identifier_as_display_username": false,
@@ -279,6 +280,7 @@
       "console.identity_providers.disabled_features": []
     },
     "IS_7.1.0": {
+      "oauth.dcrm.return_null_fields_in_response": true,
       "account.lock.handler.enable_admin_unlock_email_template_for_failed_attempts": false,
       "session_management.filter_by_unique_session_id_for_user": false,
       "identity_mgt.login_identifiers.enable_identifier_as_display_username": false,


### PR DESCRIPTION
### Purpose
Reverting the changes of [1]
* Reintroduce the `oauth.dcrm.return_null_fields_in_response` configuration in `infer.json` to preserve the previous behavior of returning `null` values in DCR responses for older IS versions.
* As described in [2], the master branch now excludes `null` values from the DCR response by default to align with standard test expectations.
* To avoid impacting environments still expecting the older behavior, this config has been reintroduced under previous versions in `infer.json`.

### Goals
* Prevent behavioral changes in existing environments that rely on the previous default behavior.
* Ensure backward compatibility for versions prior to the change introduced in the master branch.

### Approach
* Added the config entry `oauth.dcrm.return_null_fields_in_response: true` under:

  * `IS_7.0.0`
  * `IS_7.1.0`
    in `infer.json`.

### Related PRs
* [1] https://github.com/wso2/carbon-identity-framework/pull/7066

## Related Issues
* Product-is issue: https://github.com/wso2/product-is/issues/23989

[1] https://github.com/wso2/carbon-identity-framework/pull/7066
[2] UK DCR Spec Test Suite

