### PR TITLE
Fix data resolving issues in registration flows in Pre Update Password action

### DIFF
--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
@@ -94,13 +94,13 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
             return true;
         }
 
-        return executePreUpdatePasswordAction(userID, credential, userStoreManager);
+        return executePreUpdatePasswordAction(userID, credential, userStoreManager, null);
     }
 
     /**
      * This method is responsible for handling the pre add user action execution.
      *
-     * @param userID           User id of the user.
+     * @param userName         Username of the user.
      * @param credential       Credential of the user.
      * @param roleList         List of roles to be assigned to the user.
      * @param claims           Claims to be set for the user.
@@ -110,14 +110,14 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
      * @throws UserStoreException If an error occurs while executing the action.
      */
     @Override
-    public boolean doPreAddUserWithID(String userID, Object credential, String[] roleList, Map<String, String> claims,
+    public boolean doPreAddUserWithID(String userName, Object credential, String[] roleList, Map<String, String> claims,
                                       String profile, UserStoreManager userStoreManager) throws UserStoreException {
 
         if (!isEnable() || !isEnabledInRegistrationFlows()) {
             return true;
         }
 
-        return executePreUpdatePasswordAction(userID, credential, userStoreManager);
+        return executePreUpdatePasswordAction(null, credential, userStoreManager, claims);
     }
 
     private boolean isEnabledInRegistrationFlows() {
@@ -132,21 +132,21 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
     }
 
 
-    private boolean executePreUpdatePasswordAction(String userID, Object credential,
-                                                   UserStoreManager userStoreManager) throws UserStoreException {
+    private boolean executePreUpdatePasswordAction(String userID, Object credential, UserStoreManager userStoreManager,
+                                                   Map<String, String> claims) throws UserStoreException {
 
         if (!isExecutableFlow()) {
             return true;
         }
 
         try {
-            UserActionContext userActionContext = new UserActionContext(
-                    new UserActionRequestDTO.Builder()
-                            .userId(userID)
-                            .password(getSecret(credential))
-                            .userStoreDomain(UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration()))
-                            .residentOrganization(getUserResidentOrganization(userID, userStoreManager))
-                            .build());
+            UserActionRequestDTO.Builder userActionRequestDTOBuilder = new UserActionRequestDTO.Builder()
+                    .userId(userID)
+                    .password(getSecret(credential))
+                    .userStoreDomain(UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration()))
+                    .residentOrganization(getUserResidentOrganization(userID, userStoreManager));
+            populateClaimsInUserActionRequestDTO(claims, userActionRequestDTOBuilder);
+            UserActionContext userActionContext = new UserActionContext(userActionRequestDTOBuilder.build());
 
             ActionExecutionStatus<?> executionStatus =
                     UserActionExecutorFactory.getUserActionExecutor(ActionType.PRE_UPDATE_PASSWORD)
@@ -177,11 +177,8 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
     private Organization getUserResidentOrganization(String userID, UserStoreManager userStoreManager)
             throws UserActionExecutionServerException {
 
-        org.wso2.carbon.identity.core.context.model.Organization accessingOrganization =
-                IdentityContext.getThreadLocalIdentityContext().getOrganization();
-        if (accessingOrganization == null) {
-            throw new UserActionExecutionServerException(UserActionError.PRE_UPDATE_PASSWORD_ACTION_SERVER_ERROR,
-                    "Accessing organization is not present in the identity context.");
+        if (userID == null || getCurrentFlowName() == Flow.Name.USER_REGISTRATION) {
+            return getOrganizationFromIdentityContext();
         }
 
         try {
@@ -190,22 +187,34 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
             if (managedOrgId == null) {
                 // User resident organization is the accessing organization if the managed organization claim is
                 // not set.
-               return new Organization.Builder()
-                       .id(accessingOrganization.getId())
-                       .name(accessingOrganization.getName())
-                       .orgHandle(accessingOrganization.getOrganizationHandle())
-                       .depth(accessingOrganization.getDepth())
-                       .build();
+                return getOrganizationFromIdentityContext();
             }
             // If the managed organization claim is set, retrieve the organization details.
-            return getOrganization(managedOrgId);
+            return getUserManagedOrganization(managedOrgId);
         } catch (UserStoreException e) {
             throw new UserActionExecutionServerException(UserActionError.PRE_UPDATE_PASSWORD_ACTION_SERVER_ERROR,
                     "Error while retrieving the user's managed by organization claim.", e);
         }
     }
 
-    private Organization getOrganization(String managedOrgId) throws UserActionExecutionServerException {
+    private Organization getOrganizationFromIdentityContext() throws UserActionExecutionServerException {
+
+        org.wso2.carbon.identity.core.context.model.Organization accessingOrganization =
+                IdentityContext.getThreadLocalIdentityContext().getOrganization();
+        if (accessingOrganization == null) {
+            throw new UserActionExecutionServerException(UserActionError.PRE_UPDATE_PASSWORD_ACTION_SERVER_ERROR,
+                    "Accessing organization is not present in the identity context.");
+        }
+
+        return new Organization.Builder()
+                .id(accessingOrganization.getId())
+                .name(accessingOrganization.getName())
+                .orgHandle(accessingOrganization.getOrganizationHandle())
+                .depth(accessingOrganization.getDepth())
+                .build();
+    }
+
+    private Organization getUserManagedOrganization(String managedOrgId) throws UserActionExecutionServerException {
 
         if (OrganizationManagementConstants.SUPER_ORG_ID.equals(managedOrgId)) {
             return new Organization.Builder()
@@ -239,16 +248,16 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
 
     private boolean isExecutableFlow() {
 
-        Flow flow = IdentityContext.getThreadLocalIdentityContext().getCurrentFlow();
-        if (flow == null) {
+        Flow.Name flowName = getCurrentFlowName();
+        if (flowName == null) {
             return false;
         }
 
-        return flow.getName() == Flow.Name.PASSWORD_RESET ||
-                flow.getName() == Flow.Name.INVITE ||
-                flow.getName() == Flow.Name.INVITED_USER_REGISTRATION ||
-                flow.getName() == Flow.Name.PROFILE_UPDATE ||
-                flow.getName() == Flow.Name.USER_REGISTRATION;
+        return flowName == Flow.Name.PASSWORD_RESET ||
+                flowName == Flow.Name.INVITE ||
+                flowName == Flow.Name.INVITED_USER_REGISTRATION ||
+                flowName == Flow.Name.PROFILE_UPDATE ||
+                flowName == Flow.Name.USER_REGISTRATION;
     }
 
     private char[] getSecret(Object credential) throws UserActionExecutionServerException {
@@ -260,6 +269,24 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
         } else {
             throw new UserActionExecutionServerException(UserActionError.PRE_UPDATE_PASSWORD_ACTION_UNSUPPORTED_SECRET,
                     "Credential is not in the expected format.");
+        }
+    }
+
+    private Flow.Name getCurrentFlowName() {
+
+        Flow flow = IdentityContext.getThreadLocalIdentityContext().getCurrentFlow();
+        return (flow != null) ? flow.getName() : null;
+    }
+
+    private void populateClaimsInUserActionRequestDTO(Map<String, String> userClaims,
+                                                      UserActionRequestDTO.Builder userActionRequestDTOBuilder) {
+
+        if (userClaims == null || userClaims.isEmpty()) {
+            return;
+        }
+
+        for (Map.Entry<String, String> entry : userClaims.entrySet()) {
+            userActionRequestDTOBuilder.addClaim(entry.getKey(), entry.getValue());
         }
     }
 }

--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/main/java/org/wso2/carbon/identity/user/action/internal/listener/ActionUserOperationEventListener.java
@@ -90,7 +90,7 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
     public boolean doPreUpdateCredentialByAdminWithID(String userID, Object credential,
                                                       UserStoreManager userStoreManager) throws UserStoreException {
 
-        if (!isEnable()) {
+        if (!isEnable() || !isPasswordUpdatingFlow()) {
             return true;
         }
 
@@ -113,7 +113,7 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
     public boolean doPreAddUserWithID(String userName, Object credential, String[] roleList, Map<String, String> claims,
                                       String profile, UserStoreManager userStoreManager) throws UserStoreException {
 
-        if (!isEnable() || !isEnabledInRegistrationFlows()) {
+        if (!isEnable() || !isEnabledInRegistrationFlows() || !isRegistrationFlow()) {
             return true;
         }
 
@@ -134,10 +134,6 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
 
     private boolean executePreUpdatePasswordAction(String userID, Object credential, UserStoreManager userStoreManager,
                                                    Map<String, String> claims) throws UserStoreException {
-
-        if (!isExecutableFlow()) {
-            return true;
-        }
 
         try {
             UserActionRequestDTO.Builder userActionRequestDTOBuilder = new UserActionRequestDTO.Builder()
@@ -177,7 +173,7 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
     private Organization getUserResidentOrganization(String userID, UserStoreManager userStoreManager)
             throws UserActionExecutionServerException {
 
-        if (userID == null || getCurrentFlowName() == Flow.Name.USER_REGISTRATION) {
+        if (userID == null || getCurrentFlowName() == Flow.Name.REGISTER) {
             return getOrganizationFromIdentityContext();
         }
 
@@ -246,7 +242,7 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
         }
     }
 
-    private boolean isExecutableFlow() {
+    private boolean isPasswordUpdatingFlow() {
 
         Flow.Name flowName = getCurrentFlowName();
         if (flowName == null) {
@@ -257,7 +253,19 @@ public class ActionUserOperationEventListener extends AbstractIdentityUserOperat
                 flowName == Flow.Name.INVITE ||
                 flowName == Flow.Name.INVITED_USER_REGISTRATION ||
                 flowName == Flow.Name.PROFILE_UPDATE ||
-                flowName == Flow.Name.USER_REGISTRATION;
+                flowName == Flow.Name.CREDENTIAL_UPDATE ||
+                flowName == Flow.Name.CREDENTIAL_RESET;
+    }
+
+
+    private boolean isRegistrationFlow() {
+
+        Flow.Name flowName = getCurrentFlowName();
+        if (flowName == null) {
+            return false;
+        }
+
+        return flowName == Flow.Name.REGISTER;
     }
 
     private char[] getSecret(Object credential) throws UserActionExecutionServerException {

--- a/components/user-mgt/org.wso2.carbon.identity.user.action/src/test/java/org/wso2/carbon/identity/user/action/ActionUserOperationEventListenerTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.action/src/test/java/org/wso2/carbon/identity/user/action/ActionUserOperationEventListenerTest.java
@@ -87,10 +87,6 @@ public class ActionUserOperationEventListenerTest {
         userCoreUtil = mockStatic(UserCoreUtil.class);
         listener = new ActionUserOperationEventListener();
         userCoreUtil.when(() -> UserCoreUtil.getDomainName(any())).thenReturn("PRIMARY");
-        IdentityContext.getThreadLocalIdentityContext().enterFlow(new Flow.Builder()
-                .name(Flow.Name.PASSWORD_RESET)
-                .initiatingPersona(Flow.InitiatingPersona.USER)
-                .build());
 
         organizationManager = mock(OrganizationManager.class);
         UserActionServiceComponentHolder.getInstance().setOrganizationManager(organizationManager);
@@ -139,16 +135,6 @@ public class ActionUserOperationEventListenerTest {
         }
     }
 
-    private void setOrganizationToIdentityContext() {
-
-        IdentityContext.getThreadLocalIdentityContext().setOrganization(new Organization.Builder()
-                .id(TEST_RESIDENT_ORG_ID)
-                .name(TEST_RESIDENT_ORG_NAME)
-                .organizationHandle(TEST_RESIDENT_ORG_HANDLE)
-                .depth(TEST_RESIDENT_ORG_DEPTH)
-                .build());
-    }
-
     @Test
     public void testPreUpdatePasswordActionExecutionSuccess()
             throws UserStoreException, ActionExecutionException, UnsupportedSecretTypeException {
@@ -161,14 +147,18 @@ public class ActionUserOperationEventListenerTest {
         UserActionExecutorFactory.registerUserActionExecutor(mockExecutor);
 
         // Update flow
+        enterPasswordUpdatingFlow();
         boolean result = listener.doPreUpdateCredentialByAdminWithID(USER_NAME, Secret.getSecret(PASSWORD),
                 userStoreManager);
         Assert.assertTrue(result, "The method should return true for successful execution.");
+        exitCurrentFlow();
 
         // Register flow
+        enterRegistrationFlow();
         boolean newResult = listener.doPreAddUserWithID(USER_NAME, Secret.getSecret(PASSWORD),
                 null, new HashMap<>(), null, userStoreManager);
         Assert.assertTrue(newResult, "The method should return true for successful execution.");
+        exitCurrentFlow();
     }
 
     @Test
@@ -190,14 +180,18 @@ public class ActionUserOperationEventListenerTest {
         UserActionExecutorFactory.registerUserActionExecutor(mockExecutor);
 
         // Update flow
+        enterPasswordUpdatingFlow();
         boolean result = listener.doPreUpdateCredentialByAdminWithID(USER_NAME, Secret.getSecret(PASSWORD),
                 userStoreManager);
         Assert.assertTrue(result, "The method should return true for successful execution.");
+        exitCurrentFlow();
 
         // Register flow
+        enterRegistrationFlow();
         boolean newResult = listener.doPreAddUserWithID(USER_NAME, Secret.getSecret(PASSWORD),
                 null, new HashMap<>(), null, userStoreManager);
         Assert.assertTrue(newResult, "The method should return true for successful execution.");
+        exitCurrentFlow();
     }
 
     @Test
@@ -229,15 +223,19 @@ public class ActionUserOperationEventListenerTest {
         UserActionExecutorFactory.registerUserActionExecutor(mockExecutor);
 
         // Update flow
+        enterPasswordUpdatingFlow();
         boolean result = listener.doPreUpdateCredentialByAdminWithID(USER_NAME, Secret.getSecret(PASSWORD),
                 userStoreManager);
         Assert.assertTrue(result, "The method should return true for successful execution.");
         verify(organizationManager, times(1)).getMinimalOrganization(any(), any());
+        exitCurrentFlow();
 
         // Register flow
+        enterRegistrationFlow();
         boolean newResult = listener.doPreAddUserWithID(USER_NAME, Secret.getSecret(PASSWORD),
                 null, new HashMap<>(), null, userStoreManager);
         Assert.assertTrue(newResult, "The method should return true for successful execution.");
+        exitCurrentFlow();
     }
 
     @Test
@@ -252,6 +250,7 @@ public class ActionUserOperationEventListenerTest {
 
         // Update flow
         try {
+            enterPasswordUpdatingFlow();
             listener.doPreUpdateCredentialByAdminWithID(USER_NAME, Secret.getSecret(PASSWORD), userStoreManager);
         } catch (Exception e) {
             Assert.assertTrue(e instanceof UserStoreClientException);
@@ -259,9 +258,11 @@ public class ActionUserOperationEventListenerTest {
             Assert.assertEquals(((UserStoreClientException) e).getErrorCode(),
                     PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED);
         }
+        exitCurrentFlow();
 
         // Register flow
         try {
+            enterRegistrationFlow();
             listener.doPreAddUserWithID(USER_NAME, Secret.getSecret(PASSWORD),
                     null, new HashMap<>(), null, userStoreManager);
         } catch (Exception e) {
@@ -270,6 +271,7 @@ public class ActionUserOperationEventListenerTest {
             Assert.assertEquals(((UserStoreClientException) e).getErrorCode(),
                     PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED);
         }
+        exitCurrentFlow();
     }
 
     @Test
@@ -284,6 +286,7 @@ public class ActionUserOperationEventListenerTest {
 
         // Update flow
         try {
+            enterPasswordUpdatingFlow();
             listener.doPreUpdateCredentialByAdminWithID(USER_NAME, Secret.getSecret(PASSWORD), userStoreManager);
         } catch (Exception e) {
             Assert.assertTrue(e instanceof UserStoreClientException);
@@ -291,9 +294,11 @@ public class ActionUserOperationEventListenerTest {
             Assert.assertEquals(((UserStoreClientException) e).getErrorCode(),
                     PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED);
         }
+        exitCurrentFlow();
 
         // Register flow
         try {
+            enterRegistrationFlow();
             listener.doPreAddUserWithID(USER_NAME, Secret.getSecret(PASSWORD),
                     null, new HashMap<>(), null, userStoreManager);
         } catch (Exception e) {
@@ -302,6 +307,7 @@ public class ActionUserOperationEventListenerTest {
             Assert.assertEquals(((UserStoreClientException) e).getErrorCode(),
                     PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED);
         }
+        exitCurrentFlow();
     }
 
     @Test
@@ -316,15 +322,18 @@ public class ActionUserOperationEventListenerTest {
 
         // Update flow
         try {
+            enterPasswordUpdatingFlow();
             listener.doPreUpdateCredentialByAdminWithID(USER_NAME, Secret.getSecret(PASSWORD), userStoreManager);
         } catch (Exception e) {
             Assert.assertTrue(e instanceof UserStoreException);
             Assert.assertEquals(e.getMessage(), "ErrorMessage. ErrorDescription");
             Assert.assertEquals(((UserStoreException) e).getErrorCode(), PRE_UPDATE_PASSWORD_ACTION_EXECUTION_ERROR);
         }
+        exitCurrentFlow();
 
         // Register flow
         try {
+            enterRegistrationFlow();
             listener.doPreAddUserWithID(USER_NAME, Secret.getSecret(PASSWORD),
                     null, new HashMap<>(), null, userStoreManager);
         } catch (Exception e) {
@@ -333,6 +342,7 @@ public class ActionUserOperationEventListenerTest {
             Assert.assertEquals(((UserStoreException) e).getErrorCode(),
                     PRE_UPDATE_PASSWORD_ACTION_EXECUTION_ERROR);
         }
+        exitCurrentFlow();
     }
 
     @Test
@@ -347,15 +357,18 @@ public class ActionUserOperationEventListenerTest {
 
         // Update flow
         try {
+            enterPasswordUpdatingFlow();
             listener.doPreUpdateCredentialByAdminWithID(USER_NAME, 10, userStoreManager);
         } catch (Exception e) {
             Assert.assertTrue(e instanceof UserStoreException);
             Assert.assertEquals(e.getMessage(), "Credential is not in the expected format.");
             Assert.assertEquals(((UserStoreException) e).getErrorCode(), PRE_UPDATE_PASSWORD_ACTION_UNSUPPORTED_SECRET);
         }
+        exitCurrentFlow();
 
         // Register flow
         try {
+            enterRegistrationFlow();
             listener.doPreAddUserWithID(USER_NAME, 10, null,
                     new HashMap<>(), null, userStoreManager);
         } catch (Exception e) {
@@ -364,6 +377,7 @@ public class ActionUserOperationEventListenerTest {
             Assert.assertEquals(((UserStoreException) e).getErrorCode(),
                     PRE_UPDATE_PASSWORD_ACTION_UNSUPPORTED_SECRET);
         }
+        exitCurrentFlow();
     }
 
     @Test
@@ -378,12 +392,17 @@ public class ActionUserOperationEventListenerTest {
         UserActionExecutorFactory.registerUserActionExecutor(mockExecutor);
 
         // Update flow
+        enterPasswordUpdatingFlow();
         assertFalse(listener.doPreUpdateCredentialByAdminWithID(USER_NAME, Secret.getSecret(PASSWORD),
                 userStoreManager));
+        exitCurrentFlow();
+
         // Register flow
+        enterRegistrationFlow();
         assertFalse(listener.doPreAddUserWithID(USER_NAME, Secret.getSecret(PASSWORD),
                 null, new HashMap<>(), null, userStoreManager),
                 "The method should return false for unknown status.");
+        exitCurrentFlow();
     }
 
     @Test
@@ -396,15 +415,18 @@ public class ActionUserOperationEventListenerTest {
 
         // Update flow
         try {
+            enterPasswordUpdatingFlow();
             listener.doPreUpdateCredentialByAdminWithID(USER_NAME, Secret.getSecret(PASSWORD), userStoreManager);
         } catch (Exception e) {
             Assert.assertTrue(e instanceof UserStoreException);
             Assert.assertEquals(e.getMessage(), "Error while executing pre update password action.");
             Assert.assertEquals(((UserStoreException) e).getErrorCode(), PRE_UPDATE_PASSWORD_ACTION_SERVER_ERROR);
         }
+        exitCurrentFlow();
 
         // Register flow
         try {
+            enterRegistrationFlow();
             listener.doPreAddUserWithID(USER_NAME, Secret.getSecret(PASSWORD),
                     null, new HashMap<>(), null, userStoreManager);
         } catch (Exception e) {
@@ -412,10 +434,11 @@ public class ActionUserOperationEventListenerTest {
             Assert.assertEquals(e.getMessage(), "Error while executing pre update password action.");
             Assert.assertEquals(((UserStoreException) e).getErrorCode(), PRE_UPDATE_PASSWORD_ACTION_SERVER_ERROR);
         }
+        exitCurrentFlow();
     }
 
     @Test
-    public void doPreAddUserWithIDReturnsTrueWhenPreUpdatePasswordFlowIsDisabled()
+    public void  testPreUpdatePasswordActionExecutionWithRegistrationFlowsDisabled()
             throws UserStoreException, UnsupportedSecretTypeException {
 
         try (MockedStatic<IdentityUtil> identityUtilMockedStatic = mockStatic(IdentityUtil.class)) {
@@ -429,5 +452,39 @@ public class ActionUserOperationEventListenerTest {
         } catch (ActionExecutionException e) {
             Assert.fail("Unexpected exception: " + e.getMessage());
         }
+    }
+
+    private void setOrganizationToIdentityContext() {
+
+        IdentityContext.getThreadLocalIdentityContext().setOrganization(new Organization.Builder()
+                .id(TEST_RESIDENT_ORG_ID)
+                .name(TEST_RESIDENT_ORG_NAME)
+                .organizationHandle(TEST_RESIDENT_ORG_HANDLE)
+                .depth(TEST_RESIDENT_ORG_DEPTH)
+                .build());
+    }
+
+    private void enterRegistrationFlow() {
+
+        IdentityContext.getThreadLocalIdentityContext().enterFlow(
+                new Flow.Builder()
+                        .name(Flow.Name.REGISTER)
+                        .initiatingPersona(Flow.InitiatingPersona.ADMIN)
+                        .build());
+    }
+
+    private void enterPasswordUpdatingFlow() {
+
+        IdentityContext.getThreadLocalIdentityContext().enterFlow(
+                new Flow.CredentialFlowBuilder()
+                        .name(Flow.Name.CREDENTIAL_UPDATE)
+                        .credentialType(Flow.CredentialType.PASSWORD)
+                        .initiatingPersona(Flow.InitiatingPersona.USER)
+                        .build());
+    }
+
+    private void exitCurrentFlow() {
+
+        IdentityContext.getThreadLocalIdentityContext().exitFlow();
     }
 }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/execution/PreUpdatePasswordRequestBuilder.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/execution/PreUpdatePasswordRequestBuilder.java
@@ -66,6 +66,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -289,9 +290,22 @@ public class PreUpdatePasswordRequestBuilder implements ActionExecutionRequestBu
             return;
         }
 
-        Map<String, String> claimValues = getClaimValues(userActionContext.getUserActionRequestDTO().getUserId(),
-                userClaimsToSetInEvent);
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
+        Map<String, String> claimValues = new HashMap<>();
+        if (userActionContext.getUserActionRequestDTO().getUserId() == null
+                || getCurrentFlowName() == Flow.Name.USER_REGISTRATION) {
+            // User id is not available during the user registration where the user is not yet created.
+            // In such cases, UserActionContext contains the creating user claims.
+            Map<String, Object> claimsFromUserContext = userActionContext.getUserActionRequestDTO().getClaims();
+            for (String claim : userClaimsToSetInEvent) {
+                if (claimsFromUserContext.containsKey(claim) && claimsFromUserContext.get(claim) instanceof String) {
+                    claimValues.put(claim, (String) claimsFromUserContext.get(claim));
+                }
+            }
+        } else {
+            claimValues = getClaimValues(userActionContext.getUserActionRequestDTO().getUserId(),
+                    userClaimsToSetInEvent);
+        }
 
         setClaimsInUserBuilder(userBuilder, claimValues, multiAttributeSeparator);
         setGroupsInUserBuilder(userBuilder, claimValues, multiAttributeSeparator);
@@ -400,5 +414,11 @@ public class PreUpdatePasswordRequestBuilder implements ActionExecutionRequestBu
             throw new ActionExecutionRequestBuilderException(
                     "Error while loading user store manager for tenant: " + tenantDomain, e);
         }
+    }
+
+    private Flow.Name getCurrentFlowName() {
+
+        Flow flow = IdentityContext.getThreadLocalIdentityContext().getCurrentFlow();
+        return (flow != null) ? flow.getName() : null;
     }
 }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/execution/PreUpdatePasswordRequestBuilder.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/execution/PreUpdatePasswordRequestBuilder.java
@@ -173,7 +173,7 @@ public class PreUpdatePasswordRequestBuilder implements ActionExecutionRequestBu
             case INVITE:
             case INVITED_USER_REGISTRATION:
                 return PreUpdatePasswordEvent.Action.INVITE;
-            case USER_REGISTRATION:
+            case REGISTER:
                 return PreUpdatePasswordEvent.Action.REGISTER;
             default:
                 break;
@@ -293,7 +293,7 @@ public class PreUpdatePasswordRequestBuilder implements ActionExecutionRequestBu
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
         Map<String, String> claimValues = new HashMap<>();
         if (userActionContext.getUserActionRequestDTO().getUserId() == null
-                || getCurrentFlowName() == Flow.Name.USER_REGISTRATION) {
+                || getCurrentFlowName() == Flow.Name.REGISTER) {
             // User id is not available during the user registration where the user is not yet created.
             // In such cases, UserActionContext contains the creating user claims.
             Map<String, Object> claimsFromUserContext = userActionContext.getUserActionRequestDTO().getClaims();


### PR DESCRIPTION
### Proposed changes in this pull request

Fixing few issues raised after the PR,
- https://github.com/wso2/carbon-identity-framework/pull/7036

In the registration flows, userId is null, where it leads to issues in fetching information from the DB using user id in latter parts of the flow.

Hence with this PR, when the flow is USER_REGISTRATION,
1. It skips resolving userManagedOrganization  from DB
2. Sets the creating user's claims to the User Action Context where those can be used in PreUpdatePasswordActionRequestBuilder without fecthing the claims from the user store manager.

### Related Issue
- 