### PR TITLE
Resolve tenant domain of the child orgs before getting the tenant id

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/CacheBackedIdPMgtDAO.java
@@ -878,7 +878,7 @@ public class CacheBackedIdPMgtDAO {
                 }
 
                 for (String childOrgId : childOrgIds) {
-                    int tenantId = IdentityTenantUtil.getTenantId(childOrgId);
+                    int tenantId = IdentityTenantUtil.getTenantId(organizationManager.resolveTenantDomain(childOrgId));
                     Optional<IdentityProvider> identityProvider = this.getCachedIdpByName(idPName, childOrgId);
                     identityProvider.ifPresent(
                             provider -> clearIdPCacheEntries(provider, idPName, null, childOrgId, tenantId));


### PR DESCRIPTION
### Purpose
This pr fixes a bug where the tenant id of the child organizations were not resolved correctly when trying to clear idp cache. 