### PR TITLE
Skip checking workflow association check when workflow request is about to process

### DIFF
--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/extension/AbstractWorkflowRequestHandler.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/extension/AbstractWorkflowRequestHandler.java
@@ -96,9 +96,6 @@ public abstract class AbstractWorkflowRequestHandler implements WorkflowRequestH
         if (isWorkflowCompleted()) {
             return new WorkflowExecutorResult(ExecutorResultState.COMPLETED);
         }
-        if (!isAssociated()) {
-            return new WorkflowExecutorResult(ExecutorResultState.NO_ASSOCIATION);
-        }
 
         WorkflowRequest workFlowRequest = new WorkflowRequest();
         List<RequestParameter> parameters = new ArrayList<RequestParameter>(wfParams.size() + nonWfParams.size() + 1);


### PR DESCRIPTION
### Proposed changes in this pull request

The corresponding listeners which trigger the workflow request for certain operations check whether there exist registered workflow association for the corresponding event. Hence after invoking the start workflow, it is redundant to check again.

The listeners responsible for handling workflows for certain defined operations first check the workflow is associated as it has to do some validations before starting the workflow. The recheck again could slow down the operations even a workflow is not configured.

### Related Issues

- https://github.com/wso2/product-is/issues/23374
