### PR TITLE
Remove tenant creation check

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/pom.xml
@@ -95,10 +95,6 @@
             <groupId>org.wso2.carbon.identity.organization.management</groupId>
             <artifactId>org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.multitenancy</groupId>
-            <artifactId>org.wso2.carbon.tenant.mgt</artifactId>
-        </dependency>
     </dependencies>
 
     <build>
@@ -156,7 +152,6 @@
                             version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service;
                             version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
-                            org.wso2.carbon.tenant.mgt.util.*;version="${carbon.multitenancy.imp.pkg.version.range}",
                             org.wso2.carbon; version="${carbon.kernel.package.import.version.range}",
                             org.apache.axiom.om; version="${axiom.osgi.version.range}",
                             org.apache.axiom.om.impl.builder; version="${axiom.osgi.version.range}"

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/CacheBackedUnifiedClaimMetadataManager.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/CacheBackedUnifiedClaimMetadataManager.java
@@ -34,7 +34,6 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
 import org.wso2.carbon.identity.organization.management.service.util.Utils;
-import org.wso2.carbon.tenant.mgt.util.TenantMgtUtil;
 import org.wso2.carbon.user.api.UserStoreException;
 
 import java.util.ArrayList;
@@ -401,11 +400,7 @@ public class CacheBackedUnifiedClaimMetadataManager extends UnifiedClaimMetadata
         tenantIdsToBeInvalidated.add(tenantId);
         String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
         try {
-            /*
-             * During tenant creation, there will naturally be no child organizations for the tenant being created,
-             * therefore, there is no need to resolve child organizations.
-             */
-             if (!TenantMgtUtil.isTenantCreation() && Utils.isClaimAndOIDCScopeInheritanceEnabled(tenantDomain)) {
+             if (Utils.isClaimAndOIDCScopeInheritanceEnabled(tenantDomain)) {
                 String organizationId = IdentityClaimManagementServiceDataHolder.getInstance().getOrganizationManager()
                         .resolveOrganizationId(tenantDomain);
                 List<BasicOrganization> childOrganizations = IdentityClaimManagementServiceDataHolder.getInstance()

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/UnifiedClaimMetadataManager.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/UnifiedClaimMetadataManager.java
@@ -42,7 +42,6 @@ import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception.OrgResourceHierarchyTraverseException;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.strategy.FirstFoundAggregationStrategy;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.strategy.MergeAllAggregationStrategy;
-import org.wso2.carbon.tenant.mgt.util.TenantMgtUtil;
 import org.wso2.carbon.user.api.UserStoreException;
 
 import java.util.ArrayList;


### PR DESCRIPTION
### Proposed changes in this pull request

Removes the tenant creation check prior to checking whether claim inheritance is enabled as the limitation of not being able to check the org version is no longer present with the fix in [1].

[1] https://github.com/wso2/identity-organization-management-core/pull/197

## Related Issues

- https://github.com/wso2/product-is/issues/24283