### PR TITLE
Update default value for new organization version.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1947,7 +1947,7 @@
   "organization_management.self_service.default_token_expiry_time": "7200",
   "organization_management.self_service.internal_role_name": "B2B-SS-System-Role",
   "organization_management.self_service.user_store_name_for_system_user": "PRIMARY",
-  "organization_management.organization_versioning.new_organization_version": "v0.0.0",
+  "organization_management.organization_versioning.new_organization_version": "v1.0.0",
   "organization_discovery.default_param": "orgName",
   "client_attestation.allowed_window": "60000",
   "client_attestation.apple_attestation_root_certificate_path": "${carbon.home}/repository/resources/identity/apple/attestation/apple_attestation_root_ca.pem",


### PR DESCRIPTION
### Purpose
$subject.

This will be updated to make sure new deployments have the default version of new root organization as v1.0.0. Migrating customers will be handled via the infer.json introduced with configuration versioning.

### Related issue
- https://github.com/wso2/product-is/issues/24463