### PR TITLE
Add support for failing authentication when no associated local user is found

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationManagementUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationManagementUtil.java
@@ -1096,4 +1096,25 @@ public class IdentityApplicationManagementUtil {
         }
         return cleanedScript.toString();
     }
+
+    /**
+     * Compare the app version with allowed minimum app version.
+     *
+     * @param appVersion App version.
+     * @return True if the app version is greater than or equal to the allowed minimum app version.
+     */
+    public static boolean isAppVersionAllowed(String appVersion, String allowedAppVersion) {
+
+        String[] appVersionDigits = appVersion.substring(1).split("\\.");
+        String[] allowedVersionDigits = allowedAppVersion.substring(1).split("\\.");
+
+        for (int i = 0; i < appVersionDigits.length; i++) {
+            if (appVersionDigits[i].equals(allowedVersionDigits[i])) {
+                continue;
+            } else {
+                return Integer.parseInt(appVersionDigits[i]) >= Integer.parseInt(allowedVersionDigits[i]);
+            }
+        }
+        return true;
+    }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
@@ -178,9 +178,10 @@ public class ApplicationConstants {
         public static final String APP_VERSION_V0 = "v0.0.0";
         public static final String APP_VERSION_V1 = "v1.0.0";
         public static final String APP_VERSION_V2 = "v2.0.0";
+        public static final String APP_VERSION_V3 = "v3.0.0";
 
         // Change the latest version when a new version is introduced.
-        public static final String LATEST_APP_VERSION = APP_VERSION_V2;
+        public static final String LATEST_APP_VERSION = APP_VERSION_V3;
         public static final String BASE_APP_VERSION = APP_VERSION_V0;
 
         /**
@@ -190,7 +191,8 @@ public class ApplicationConstants {
 
             V0(APP_VERSION_V0),
             V1(APP_VERSION_V1),
-            V2(APP_VERSION_V2);
+            V2(APP_VERSION_V2),
+            V3(APP_VERSION_V3);
 
             private final String value;
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -1335,6 +1335,7 @@ public class ApplicationMgtUtil {
                 }
                 break;
             case ApplicationConstants.ApplicationVersion.APP_VERSION_V2:
+            case ApplicationConstants.ApplicationVersion.APP_VERSION_V3:
                 break;
             default:
                 throw new IllegalStateException("Unexpected value: " + currentVersion);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/exception/ErrorToI18nCodeTranslator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/exception/ErrorToI18nCodeTranslator.java
@@ -25,6 +25,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.exce
 import static org.wso2.carbon.identity.application.authentication.framework.exception.ErrorToI18nCodeTranslator.I18NErrorMessages.ERROR_GETTING_ASSOCIATION_FOR_USER;
 import static org.wso2.carbon.identity.application.authentication.framework.exception.ErrorToI18nCodeTranslator.I18NErrorMessages.ERROR_INVALID_USER_STORE;
 import static org.wso2.carbon.identity.application.authentication.framework.exception.ErrorToI18nCodeTranslator.I18NErrorMessages.ERROR_INVALID_USER_STORE_DOMAIN;
+import static org.wso2.carbon.identity.application.authentication.framework.exception.ErrorToI18nCodeTranslator.I18NErrorMessages.ERROR_NO_ASSOCIATED_LOCAL_USER_FOUND;
 import static org.wso2.carbon.identity.application.authentication.framework.exception.ErrorToI18nCodeTranslator.I18NErrorMessages.ERROR_POST_AUTH_COOKIE_NOT_FOUND;
 import static org.wso2.carbon.identity.application.authentication.framework.exception.ErrorToI18nCodeTranslator.I18NErrorMessages.ERROR_PROCESSING_APPLICATION_CLAIM_CONFIGS;
 import static org.wso2.carbon.identity.application.authentication.framework.exception.ErrorToI18nCodeTranslator.I18NErrorMessages.ERROR_RETRIEVING_CLAIM;
@@ -139,6 +140,8 @@ public class ErrorToI18nCodeTranslator {
                 "authenticated.subject.identifier.null"),
         ERROR_WHILE_CONCLUDING_AUTHENTICATION_USER_ID_NULL("80029", "authentication.error",
                 "authenticated.user.id.null"),
+        ERROR_NO_ASSOCIATED_LOCAL_USER_FOUND("80030", "authentication.error",
+                "no.associated.local.user.found"),
         ERROR_CODE_DEFAULT("Default", "authentication.attempt.failed", "authorization.failed");
 
         private final String errorCode;
@@ -282,6 +285,9 @@ public class ErrorToI18nCodeTranslator {
         } else if (ERROR_WHILE_CONCLUDING_AUTHENTICATION_USER_ID_NULL.getErrorCode().equals(errorCode)) {
             return new I18nErrorCodeWrapper(ERROR_WHILE_CONCLUDING_AUTHENTICATION_USER_ID_NULL.getStatus(),
                     ERROR_WHILE_CONCLUDING_AUTHENTICATION_USER_ID_NULL.getStatusMsg());
+        } else if (ERROR_NO_ASSOCIATED_LOCAL_USER_FOUND.getErrorCode().equals(errorCode)) {
+            return new I18nErrorCodeWrapper(ERROR_NO_ASSOCIATED_LOCAL_USER_FOUND.getStatus(),
+                    ERROR_NO_ASSOCIATED_LOCAL_USER_FOUND.getStatusMsg());
         } else {
             return new I18nErrorCodeWrapper(ERROR_CODE_DEFAULT.getStatus(), ERROR_CODE_DEFAULT.getStatusMsg());
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -230,6 +230,8 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USE_IDP_ROLE_CLAIM_AS_IDP_GROUP_CLAIM;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_GETTING_IDP_BY_NAME;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.Error.INVALID_REQUEST;
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil.isAppVersionAllowed;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.ApplicationVersion.APP_VERSION_V3;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_ATTRIBUTE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.ORG_WISE_MULTI_ATTRIBUTE_SEPARATOR_ATTRIBUTE_NAME;
@@ -4843,4 +4845,17 @@ public class FrameworkUtils {
 
     }
 
+    /**
+     * Check whether the login should be failed if an associated user is not found for the
+     * given federated user for a service provider. This will check if the application version is
+     * greater than or equal to v3.
+     *
+     * @param serviceProvider Service Provider.
+     * @return true if enabled, false otherwise.
+     */
+    public static boolean isLoginFailureWithNoLocalAssociationEnabledForApp(ServiceProvider serviceProvider) {
+
+        String appVersion = serviceProvider.getApplicationVersion();
+        return isAppVersionAllowed(appVersion, APP_VERSION_V3);
+    }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthAssociationHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthAssociationHandlerTest.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.core.util.AdminServicesUtil;
 import org.wso2.carbon.identity.application.authentication.framework.AbstractFrameworkTest;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.FederatedApplicationAuthenticator;
+import org.wso2.carbon.identity.application.authentication.framework.MockAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.loader.UIBasedConfigurationLoader;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ApplicationConfig;
@@ -38,22 +39,28 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.PostAuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.claims.ClaimHandler;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.PostAuthnHandlerFlowStatus;
 import org.wso2.carbon.identity.application.authentication.framework.handler.sequence.StepBasedSequenceHandler;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
+import org.wso2.carbon.identity.application.authentication.framework.internal.core.ApplicationAuthenticatorManager;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.common.model.ClaimConfig;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
+import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManagerImpl;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -86,6 +93,7 @@ public class PostAuthAssociationHandlerTest extends AbstractFrameworkTest {
     private HttpServletResponse response;
     private PostAuthAssociationHandler postAuthAssociationHandler;
     private ServiceProvider sp;
+    private IdentityConfigParser mockIdentityConfigParser;
     private static final String ORI_ROLE_1 = "Internal/everyone";
     private static final String ORI_ROLE_2 = "locnomrole";
     private static final String SP_MAPPED_ROLE_1 = "everyone";
@@ -96,9 +104,12 @@ public class PostAuthAssociationHandlerTest extends AbstractFrameworkTest {
     private MockedStatic<ClaimMetadataHandler> claimMetadataHandler;
     private MockedStatic<IdentityTenantUtil> identityTenantUtil;
     private MockedStatic<AdminServicesUtil> adminServicesUtil;
+    private MockedStatic<IdentityConfigParser> identityConfigParser;
 
     @BeforeMethod
     protected void setupSuite() throws Exception {
+
+        initAuthenticators();
 
         configurationLoader = new UIBasedConfigurationLoader();
         frameworkUtils = mockStatic(FrameworkUtils.class);
@@ -106,6 +117,12 @@ public class PostAuthAssociationHandlerTest extends AbstractFrameworkTest {
         claimMetadataHandler = mockStatic(ClaimMetadataHandler.class);
         identityTenantUtil = mockStatic(IdentityTenantUtil.class);
         adminServicesUtil = mockStatic(AdminServicesUtil.class);
+
+        mockIdentityConfigParser = mock(IdentityConfigParser.class);
+        identityConfigParser = mockStatic(IdentityConfigParser.class);
+        identityConfigParser.when(IdentityConfigParser::getInstance).thenReturn(mockIdentityConfigParser);
+        setAuthenticatorActionEnableStatus(false);
+
         ConfigurationFacade mockConfigurationFacade = mock(ConfigurationFacade.class);
 
         configurationFacade.when(ConfigurationFacade::getInstance).thenReturn(mockConfigurationFacade);
@@ -149,6 +166,7 @@ public class PostAuthAssociationHandlerTest extends AbstractFrameworkTest {
         claimMetadataHandler.close();
         identityTenantUtil.close();
         adminServicesUtil.close();
+        identityConfigParser.close();
     }
 
     @Test(description = "This test case tests the Post Authentication Association handling flow with an authenticated" +
@@ -186,6 +204,53 @@ public class PostAuthAssociationHandlerTest extends AbstractFrameworkTest {
         return new Object[][]{
                 {false},
                 {true}
+        };
+    }
+
+    @Test(description = "Test resolveLocalUserLinkingStrategy method with different ClaimConfig scenarios",
+            dataProvider = "provideUserLinkStrategyTestData")
+    public void testResolveLocalUserLinkingStrategy(ClaimConfig claimConfig,
+                                                    PostAuthAssociationHandler.UserLinkStrategy expectedStrategy) {
+
+        try {
+            Method method = PostAuthAssociationHandler.class.getDeclaredMethod("resolveLocalUserLinkingStrategy",
+                    ClaimConfig.class);
+            method.setAccessible(true);
+            PostAuthAssociationHandler.UserLinkStrategy actualStrategy =
+                    (PostAuthAssociationHandler.UserLinkStrategy) method.invoke(null, claimConfig);
+
+            Assert.assertEquals(actualStrategy, expectedStrategy,
+                    "User link strategy resolution failed for the given claim config");
+        } catch (Exception e) {
+            Assert.fail("Reflection access to resolveLocalUserLinkingStrategy method failed", e);
+        }
+    }
+
+    @DataProvider(name = "provideUserLinkStrategyTestData")
+    public Object[][] provideUserLinkStrategyTestData() {
+
+        // Test case 1: null ClaimConfig should return DISABLED
+        ClaimConfig nullClaimConfig = null;
+
+        // Test case 2: ClaimConfig with mappedLocalSubjectMandatory = true should return MANDATORY
+        ClaimConfig mandatoryClaimConfig = mock(ClaimConfig.class);
+        when(mandatoryClaimConfig.isMappedLocalSubjectMandatory()).thenReturn(true);
+
+        // Test case 3: ClaimConfig with alwaysSendMappedLocalSubjectId = true should return OPTIONAL
+        ClaimConfig optionalClaimConfig = mock(ClaimConfig.class);
+        when(optionalClaimConfig.isMappedLocalSubjectMandatory()).thenReturn(false);
+        when(optionalClaimConfig.isAlwaysSendMappedLocalSubjectId()).thenReturn(true);
+
+        // Test case 4: ClaimConfig with both flags false should return DISABLED
+        ClaimConfig disabledClaimConfig = mock(ClaimConfig.class);
+        when(disabledClaimConfig.isMappedLocalSubjectMandatory()).thenReturn(false);
+        when(disabledClaimConfig.isAlwaysSendMappedLocalSubjectId()).thenReturn(false);
+
+        return new Object[][]{
+                {nullClaimConfig, PostAuthAssociationHandler.UserLinkStrategy.DISABLED},
+                {mandatoryClaimConfig, PostAuthAssociationHandler.UserLinkStrategy.MANDATORY},
+                {optionalClaimConfig, PostAuthAssociationHandler.UserLinkStrategy.OPTIONAL},
+                {disabledClaimConfig, PostAuthAssociationHandler.UserLinkStrategy.DISABLED}
         };
     }
 
@@ -252,5 +317,81 @@ public class PostAuthAssociationHandlerTest extends AbstractFrameworkTest {
 
         }
         return false;
+    }
+
+    @Test(description = "Test PostAuthAssociationHandler for MANDATORY user link strategy throws exception")
+    public void testHandleWithMandatoryUserLinkStrategyThrowsException() throws Exception {
+        // Setup ClaimConfig to return MANDATORY
+        ClaimConfig mandatoryClaimConfig = mock(ClaimConfig.class);
+        when(mandatoryClaimConfig.isMappedLocalSubjectMandatory()).thenReturn(true);
+        when(mandatoryClaimConfig.isAlwaysSendMappedLocalSubjectId()).thenReturn(false);
+
+        ServiceProvider mockSp = mock(ServiceProvider.class);
+        when(mockSp.getClaimConfig()).thenReturn(mandatoryClaimConfig);
+        String spName = "test-sp";
+        String tenantDomain = "test-tenant";
+        configurationFacade.when(() -> ConfigurationFacade.getInstance().getIdPConfigByName(anyString(), anyString()))
+                .thenReturn(null);
+        frameworkUtils.when(() -> FrameworkUtils.isStepBasedSequenceHandlerExecuted(any(AuthenticationContext.class)))
+                .thenReturn(true);
+        frameworkUtils.when(() -> FrameworkUtils.getMultiAttributeSeparator()).thenReturn(",");
+        frameworkUtils.when(() -> FrameworkUtils.getClaimHandler()).thenReturn(mock(ClaimHandler.class));
+        frameworkUtils.when(() -> FrameworkUtils.getStepBasedSequenceHandler())
+                .thenReturn(mock(StepBasedSequenceHandler.class));
+        frameworkUtils.when(() -> FrameworkUtils.isLoginFailureWithNoLocalAssociationEnabledForApp(
+                any(ServiceProvider.class))).thenReturn(true);
+        FrameworkServiceDataHolder.getInstance().setAdaptiveAuthenticationAvailable(true);
+
+        // Create minimal AuthenticationContext and SequenceConfig, avoid ApplicationConfig
+        AuthenticationContext context = new AuthenticationContext();
+        context.setTenantDomain(tenantDomain);
+        context.setServiceProviderName(spName);
+        SequenceConfig sequenceConfig = mock(SequenceConfig.class);
+        when(sequenceConfig.getApplicationConfig()).thenReturn(mock(ApplicationConfig.class));
+        context.setSequenceConfig(sequenceConfig);
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setSubjectIdentifierStep(true);
+        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
+        authenticatorConfig.setApplicationAuthenticator(mock(FederatedApplicationAuthenticator.class));
+        stepConfig.setAuthenticatedAutenticator(authenticatorConfig);
+        Map<Integer, StepConfig> stepMap = new HashMap<>();
+        stepMap.put(1, stepConfig);
+        when(sequenceConfig.getStepMap()).thenReturn(stepMap);
+
+        // Mock FrameworkServiceDataHolder and ApplicationManagementService
+        ApplicationManagementService mockAppMgtService = mock(ApplicationManagementService.class);
+        FrameworkServiceDataHolder mockDataHolder = mock(FrameworkServiceDataHolder.class);
+        when(mockAppMgtService.getServiceProvider(spName, tenantDomain)).thenReturn(mockSp);
+        when(mockDataHolder.getApplicationManagementService()).thenReturn(mockAppMgtService);
+        // Static mocking for FrameworkServiceDataHolder.getInstance()
+        try (MockedStatic<FrameworkServiceDataHolder> dataHolderStatic = mockStatic(FrameworkServiceDataHolder.class)) {
+            dataHolderStatic.when(FrameworkServiceDataHolder::getInstance).thenReturn(mockDataHolder);
+
+            // Should throw PostAuthenticationFailedException
+            try {
+                postAuthAssociationHandler.handle(request, response, context);
+                Assert.fail("Expected PostAuthenticationFailedException was not thrown");
+            } catch (PostAuthenticationFailedException e) {
+                Assert.assertEquals(e.getErrorCode(), "80030", "Error code mismatch for mandatory user link strategy");
+                Assert.assertTrue(e.getMessage().contains("Federated user is not associated with any local user."),
+                        "Error message mismatch for mandatory user link strategy");
+            }
+        }
+    }
+
+    private void setAuthenticatorActionEnableStatus(boolean isEnabled) {
+
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("Actions.Types.Authentication.Enable", Boolean.toString(isEnabled));
+        when(mockIdentityConfigParser.getConfiguration()).thenReturn(configMap);
+    }
+
+    private void initAuthenticators() {
+
+        removeAllSystemDefinedAuthenticators();
+        ApplicationAuthenticatorManager authenticatorManager = ApplicationAuthenticatorManager.getInstance();
+        authenticatorManager.addSystemDefinedAuthenticator(new MockAuthenticator("BasicMockAuthenticator"));
+        authenticatorManager.addSystemDefinedAuthenticator(new MockAuthenticator("HwkMockAuthenticator"));
+        authenticatorManager.addSystemDefinedAuthenticator(new MockAuthenticator("FptMockAuthenticator"));
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -74,6 +74,7 @@ import org.wso2.carbon.identity.application.common.model.ClaimConfig;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.model.IdentityCookieConfig;
@@ -1380,5 +1381,30 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
         for (ApplicationAuthenticator authenticator : authenticatorList) {
             ApplicationAuthenticatorManager.getInstance().removeSystemDefinedAuthenticator(authenticator);
         }
+    }
+
+    @DataProvider(name = "serviceProviderVersionProvider")
+    public Object[][] serviceProviderVersionProvider() {
+
+        return new Object[][]{
+                // appVersion, expectedResult
+                {"v3.0.0", true},           // v3 version should return true
+                {"v4.0.0", true},           // v4+ version should return true
+                {"v2.0.0", false},          // v2.x version should return false
+        };
+    }
+
+    @Test(dataProvider = "serviceProviderVersionProvider")
+    public void testIsLoginFailureWithNoLocalAssociationEnabledForApp(String appVersion, boolean expectedResult) {
+
+        // Create a mock ServiceProvider
+        ServiceProvider serviceProvider = mock(ServiceProvider.class);
+        when(serviceProvider.getApplicationVersion()).thenReturn(appVersion);
+
+        // Call the method under test
+        boolean result = FrameworkUtils.isLoginFailureWithNoLocalAssociationEnabledForApp(serviceProvider);
+
+        // Assert the result
+        assertEquals(result, expectedResult);
     }
 }


### PR DESCRIPTION
This PRs adds the changes reverted from below PR with the unit test fix

Related PR:
- https://github.com/wso2/carbon-identity-framework/pull/7111