### PR TITLE
Handle unique claim handling for concurrent user update scenario

### DIFF
--- a/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/src/main/java/org/wso2/carbon/identity/unique/claim/mgt/listener/UniqueClaimUserOperationEventListener.java
+++ b/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/src/main/java/org/wso2/carbon/identity/unique/claim/mgt/listener/UniqueClaimUserOperationEventListener.java
@@ -108,7 +108,7 @@ public class UniqueClaimUserOperationEventListener extends AbstractIdentityUserO
         }
 
         try {
-            checkClaimUniqueness(userName, claims, profile, userStoreManager, credential);
+            checkClaimUniqueness(userName, claims, profile, userStoreManager, null);
         } catch (UserStoreClientException e) {
             userStoreManager.deleteUser(userName);
         }
@@ -323,9 +323,8 @@ public class UniqueClaimUserOperationEventListener extends AbstractIdentityUserO
         } else {
             if (usernameWithUserStoreDomain.equalsIgnoreCase(userList[0])) {
                 if (userList.length > 1 && log.isDebugEnabled()) {
-                    log.debug("Multiple users found for claim URI: " + claimUri + " with value: " +
-                            claimValue + ". The current user is the first in the list; skipping uniqueness " +
-                            "check for this claim value.");
+                    log.debug("Multiple users found for claim URI: " + claimUri + ". The current user is " + 
+                    " the first in the list; skipping uniqueness check for this claim value.");
                 }
                 return false;
             }
@@ -499,9 +498,8 @@ public class UniqueClaimUserOperationEventListener extends AbstractIdentityUserO
             if (userList.length > 1) {
                 if (usernameWithUserStoreDomain.equalsIgnoreCase(userList[0])) {
                     if (log.isDebugEnabled()) {
-                        log.debug("Multiple users found for claim URI: " + claimUri + " with value: " +
-                                claimValuePart + ". The current user is the first in the list; skipping uniqueness " +
-                                "check for this claim value.");
+                        log.debug("Multiple users found for claim URI: " + claimUri + ". The current user is " + 
+                        "the first in the list; skipping uniqueness check for this claim value.");
                     }
                     continue;
                 }

--- a/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/src/main/java/org/wso2/carbon/identity/unique/claim/mgt/listener/UniqueClaimUserOperationEventListener.java
+++ b/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/src/main/java/org/wso2/carbon/identity/unique/claim/mgt/listener/UniqueClaimUserOperationEventListener.java
@@ -323,8 +323,8 @@ public class UniqueClaimUserOperationEventListener extends AbstractIdentityUserO
         } else {
             if (usernameWithUserStoreDomain.equalsIgnoreCase(userList[0])) {
                 if (userList.length > 1 && log.isDebugEnabled()) {
-                    log.debug("Multiple users found for claim URI: " + claimUri + ". The current user is " + 
-                    " the first in the list; skipping uniqueness check for this claim value.");
+                    log.debug("Multiple users found for claim URI: " + claimUri + ". The current user is the " +
+                            "first in the list; skipping uniqueness check for this claim value.");
                 }
                 return false;
             }
@@ -498,8 +498,8 @@ public class UniqueClaimUserOperationEventListener extends AbstractIdentityUserO
             if (userList.length > 1) {
                 if (usernameWithUserStoreDomain.equalsIgnoreCase(userList[0])) {
                     if (log.isDebugEnabled()) {
-                        log.debug("Multiple users found for claim URI: " + claimUri + ". The current user is " + 
-                        "the first in the list; skipping uniqueness check for this claim value.");
+                        log.debug("Multiple users found for claim URI: " + claimUri + ". The current user is " +
+                                "the first in the list; skipping uniqueness check for this claim value.");
                     }
                     continue;
                 }

--- a/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/src/main/java/org/wso2/carbon/identity/unique/claim/mgt/listener/UniqueClaimUserOperationEventListener.java
+++ b/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/src/main/java/org/wso2/carbon/identity/unique/claim/mgt/listener/UniqueClaimUserOperationEventListener.java
@@ -100,6 +100,22 @@ public class UniqueClaimUserOperationEventListener extends AbstractIdentityUserO
     }
 
     @Override
+    public boolean doPostAddUser(String userName, Object credential, String[] roleList, Map<String, String> claims,
+                                 String profile, UserStoreManager userStoreManager) throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+
+        try {
+            checkClaimUniqueness(userName, claims, profile, userStoreManager, credential);
+        } catch (UserStoreClientException e) {
+            userStoreManager.deleteUser(userName);
+        }
+        return true;
+    }
+
+    @Override
     public boolean doPreSetUserClaimValue(String userName, String claimURI, String claimValue, String profile,
                                           UserStoreManager userStoreManager) throws UserStoreException {
 
@@ -301,15 +317,20 @@ public class UniqueClaimUserOperationEventListener extends AbstractIdentityUserO
             userList = userStoreMgrFromRealm.getUserList(claimUri, claimValue, profile);
         }
 
-        if (userList.length == 1) {
-            String usernameWithUserStoreDomain = UserCoreUtil.addDomainToName(username, domainName);
+        String usernameWithUserStoreDomain = UserCoreUtil.addDomainToName(username, domainName);
+        if (userList.length == 0) {
+            return false;
+        } else {
             if (usernameWithUserStoreDomain.equalsIgnoreCase(userList[0])) {
+                if (userList.length > 1 && log.isDebugEnabled()) {
+                    log.debug("Multiple users found for claim URI: " + claimUri + " with value: " +
+                            claimValue + ". The current user is the first in the list; skipping uniqueness " +
+                            "check for this claim value.");
+                }
                 return false;
             }
-        } else if (userList.length == 0) {
-            return false;
+            return true;
         }
-        return true;
     }
 
     /**
@@ -476,6 +497,14 @@ public class UniqueClaimUserOperationEventListener extends AbstractIdentityUserO
                 userList = userStoreManager.getUserList(claimUri, claimValuePart, profile);
             }
             if (userList.length > 1) {
+                if (usernameWithUserStoreDomain.equalsIgnoreCase(userList[0])) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Multiple users found for claim URI: " + claimUri + " with value: " +
+                                claimValuePart + ". The current user is the first in the list; skipping uniqueness " +
+                                "check for this claim value.");
+                    }
+                    continue;
+                }
                 return true;
             }
             if (userList.length == 1 && !usernameWithUserStoreDomain.equalsIgnoreCase(userList[0])) {

--- a/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/src/main/java/org/wso2/carbon/identity/unique/claim/mgt/listener/UniqueClaimUserOperationEventListener.java
+++ b/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/src/main/java/org/wso2/carbon/identity/unique/claim/mgt/listener/UniqueClaimUserOperationEventListener.java
@@ -111,6 +111,7 @@ public class UniqueClaimUserOperationEventListener extends AbstractIdentityUserO
             checkClaimUniqueness(userName, claims, profile, userStoreManager, null);
         } catch (UserStoreClientException e) {
             userStoreManager.deleteUser(userName);
+            throw e;
         }
         return true;
     }


### PR DESCRIPTION
### Proposed changes in this pull request

The duplicate claim handling logic consider the scenarios where multiple users exist but the first user is the current user. In that case, there will be a relax.

To handle the concurrent user updates by violating the uniqueness constraints, the post add user handler will detect such cases and delete those records.

Note: The above validation should be done at both post add user and post claim update listeners.

Related Issue https://github.com/wso2/product-is/issues/24964