### PR TITLE
Add config attribute.return_previous_additional_properties.enable to preserve previous behaviour in IS 7.0 & 7.1

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -284,7 +284,8 @@
       "identity_mgt.password_reset_email.otp.send_only_otp_as_confirmation_code": false,
       "console.identity_providers.disabled_features": [],
       "scim2.enable_scim2_roles_v3_api": false,
-      "localization.prioritize_param": false
+      "localization.prioritize_param": false,
+      "attribute.return_previous_additional_properties.enable": true
     },
     "IS_7.1.0": {
       "oauth.dcrm.return_null_fields_in_response": true,
@@ -295,7 +296,8 @@
       "identity_mgt.password_reset_email.otp.send_only_otp_as_confirmation_code": false,
       "console.identity_providers.disabled_features": [],
       "scim2.enable_scim2_roles_v3_api": false,
-      "localization.prioritize_param": false
+      "localization.prioritize_param": false,
+      "attribute.return_previous_additional_properties.enable": true
     }
   }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

Add config attribute.return_previous_additional_properties.enable to preserve previous behaviour.

#### Configuration Details

| **Configuration** | **IS 7.2 Default Value** | **Value to Preserve 7.0/7.1 Behavior** | **Description** | **Owner** |
|-------------------|---------------------------|------------------------------------------|------------------|------------------|
| `attribute.return_previous_additional_properties.enable` | `false` | `true` | From IS 7.2 onwards, for claim attributes, if isMultiValued, dataType, or subAttributes are configured, they are no longer returned as additional properties in the API response. Instead, they are returned as first-class properties. This configuration allows restoring the previous behavior. | @sadilchamishka  |

-

### When should this PR be merged
- Related Issue: https://github.com/wso2/product-is/issues/24878

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-

### Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
