### PR TITLE
Return if user assertion is not available

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java
@@ -612,6 +612,9 @@ public abstract class AbstractApplicationAuthenticator implements ApplicationAut
         String userAssertion = (String) context.getProperty(FrameworkConstants.USER_ASSERTION);
         if (userAssertion == null) {
             userAssertion = request.getParameter(FrameworkConstants.USER_ASSERTION);
+            if (userAssertion == null) {
+                return false;
+            }
             context.setProperty(FrameworkConstants.USER_ASSERTION, userAssertion);
         }
         try {


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/24768

This pull request introduces a small but important change to the `canHandleWithUserAssertion` method in `AbstractApplicationAuthenticator.java`. The update ensures that if the `userAssertion` parameter is missing from both the context and the request, the method will immediately return `false` instead of proceeding further.

* Improved input validation: The method now returns `false` early if `userAssertion` is not found in the request, preventing unnecessary processing.