### PR TITLE
[Sync][`next` -> `master`][#7133]: Add "oidcScopes" to organization-enabled routes

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1299,6 +1299,7 @@
     "groups",
     "identityProviders",
     "loginAndRegistration",
+    "oidcScopes",
     "organizations",
     "password-recovery",
     "roles",


### PR DESCRIPTION
🤖 **Auto-sync from master**
This PR automatically syncs the changes from #11 to the `next` branch.

**Original PR:** https://github.com/wso2/carbon-identity-framework/pull/7133
**Author:** @AmshikaH
**Workflow:** https://github.com/brionmario/carbon-identity-framework/actions/runs/16928845140

---

### Proposed changes in this pull request

Add "oidcScopes" to organization-enabled routes

### Related Issues

- https://github.com/wso2/product-is/issues/25094