### PR TITLE
Preserve nested redirect parameters in /commonauth logout via configuration

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -275,6 +275,8 @@ public class FrameworkUtils {
     private static final String OPENJDK_SCRIPTER_CLASS_NAME = "org.openjdk.nashorn.api.scripting.ScriptObjectMirror";
     private static final String JDK_SCRIPTER_CLASS_NAME = "jdk.nashorn.api.scripting.ScriptObjectMirror";
     private static final String GRAALJS_SCRIPTER_CLASS_NAME = "org.graalvm.polyglot.Context";
+    private static final String ENABLE_NESTED_REDIRECT_PARAMS_IN_LOGOUT_RETURN_URL =
+            "CommonAuthCallerPath.EnableNestedRedirectParams";
 
     private FrameworkUtils() {
     }
@@ -4857,5 +4859,17 @@ public class FrameworkUtils {
 
         String appVersion = serviceProvider.getApplicationVersion();
         return isAppVersionAllowed(appVersion, APP_VERSION_V3);
+    }
+
+    /**
+     * Checks whether nested redirect parameters in the logout return URL are enabled.
+     * This method retrieves the configuration value for enabling nested redirect parameters
+     * in the logout return URL from the identity framework's configuration.
+     *
+     * @return true if nested redirect parameters in the logout return URL are enabled; false otherwise.
+     */
+    public static boolean isNestedRedirectParamsInLogoutReturnUrlEnabled() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(ENABLE_NESTED_REDIRECT_PARAMS_IN_LOGOUT_RETURN_URL));
     }
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -4411,6 +4411,7 @@
 
     <CommonAuthCallerPath>
         <EnableValidation>{{common_auth_caller_path.enable_common_auth_caller_path_validation}}</EnableValidation>
+        <EnableNestedRedirectParams>{{common_auth_caller_path.enable_nested_redirect_params}}</EnableNestedRedirectParams>
         {% if common_auth_caller_path.default_url is defined %}
         <DefaultUrl>{{common_auth_caller_path.default_url}}</DefaultUrl>
         {% endif %}

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1914,6 +1914,7 @@
   "x509.crl_download_timeout": "60000",
   "audit.log.contextual_param.params": [],
   "common_auth_caller_path.enable_common_auth_caller_path_validation": true,
+  "common_auth_caller_path.enable_nested_redirect_params": false,
   "authentication.skip_local_user_search_for_authentication_flow_handlers": true,
   "axis2.transport_sender.local.name": "local",
   "axis2.transport_sender.local.class": "org.apache.axis2.transport.local.LocalTransportSender",


### PR DESCRIPTION
### Purpose
To resolve an issue where the `redirect_uri` loses inner query parameters during `/commonauth` logout when `commonAuthCallerPath` contains a nested URL with multiple query parameters.

### Goals
* Preserve nested query parameters during `/commonauth` logout when required.
* Provide an opt-in configuration to enable the preservation without affecting existing deployments by default.
* Maintain backward compatibility for customers relying on legacy behavior.

### Approach

* Introduced the configuration in:

```toml
[common_auth_caller_path]
enable_nested_redirect_params = true 
```

* Applied the logic to preserve nested redirect parameters only when all of the following are true:

  1. The above config is enabled.
  2. The request is targeting the `/commonauth` endpoint.
  3. The `commonAuthLogout` parameter is `true`.


* **Backward compatibility:**
  * Default configuration `false` keeps the current behavior.
  * Enabling the config preserves nested query parameters in the logout return URL.

---

## Related Issues
Public issue: https://github.com/wso2/product-is/issues/24796