### PR TITLE
Add config to enhance with cross-sub org access token introspection 

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1296,6 +1296,7 @@
 
         <!-- Configuration for allowing users to introspect tokens from other tenants. -->
         <AllowCrossTenantTokenIntrospection>{{oauth.introspect.allow_cross_tenant}}</AllowCrossTenantTokenIntrospection>
+        <AllowCrossTenantIntrospectionForSubOrgTokens>{{oauth.introspect.allow_cross_sub_org}}</AllowCrossTenantIntrospectionForSubOrgTokens>
 
         {% if oauth.jwt.renew_token_without_revoking_existing is defined %}
         <JWT>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -91,6 +91,7 @@
   "oauth.token_generation.include_username_in_access_token": false,
   "oauth.handle_logout_gracefully": true,
   "oauth.introspect.allow_cross_tenant": false,
+  "oauth.introspect.allow_cross_sub_org": false,
 
   "oauth.token.validation.include_validation_context_as_jwt_in_reponse": false,
   "oauth.extensions.token_context_generator": "org.wso2.carbon.identity.oauth2.authcontext.JWTTokenGenerator",


### PR DESCRIPTION
### Purpose

This PR introduces a configuration property that controls whether cross-sub-organization access token introspection is allowed. 

### Implementation

```
[oauth.introspect]  
allow_cross_sub_org = false  
```

By default, this property is set to false, which enforces strict validation and prevents cross-sub-organization access token introspection. When set to true, the behaviour reverts to the previous behavior.

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/7092