### PR TITLE
Add accounts endpoint to default feature configuration

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -811,7 +811,8 @@
     "/lsp/",
     "/emailotpauthenticationendpoint/",
     "/smsotpauthenticationendpoint/",
-    "/totpauthenticationendpoint/"
+    "/totpauthenticationendpoint/",
+    "/accounts/"
   ],
   "tenant_context.rewrite.servlets": [
     "/identity/(.*)",


### PR DESCRIPTION
### Proposed changes in this pull request
This pull request makes a small update to the list of endpoints in the `org.wso2.carbon.identity.core.server.feature.default.json` configuration file. The change adds the `/accounts/` endpoint to the existing list.

* Added `/accounts/` to the endpoint list in `org.wso2.carbon.identity.core.server.feature.default.json` to support account-related features.

### Related Issues
- https://github.com/wso2/product-is/issues/25176