### PR TITLE
Fix auto login not working for federated sign up

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -745,6 +745,15 @@ public class DefaultStepHandler implements StepHandler {
             return;
         }
 
+        boolean isAuthenticationRequired;
+        try {
+            isAuthenticationRequired = authenticator.isAuthenticationRequired(request, response, context);
+        } catch (AuthenticationFailedException e) {
+            LOG.error("Error while checking if authentication is required for authenticator: " +
+                    authenticator.getName(), e);
+            throw new FrameworkException(e.getErrorCode(), e.getMessage(), e);
+        }
+
         String idpName = FrameworkConstants.LOCAL_IDP_NAME;
         if (context.getExternalIdP() != null && authenticator instanceof FederatedApplicationAuthenticator) {
             idpName = context.getExternalIdP().getIdPName();
@@ -768,7 +777,7 @@ public class DefaultStepHandler implements StepHandler {
         try {
             context.setAuthenticatorProperties(getAuthenticatorPropertyMap(authenticator, context));
             AuthenticatorFlowStatus status;
-            if (authenticator.isAuthenticationRequired(request, response, context)) {
+            if (isAuthenticationRequired) {
                 status = authenticator.process(request, response, context);
             } else {
                 // If the authenticator does not require authentication based on the assertion, we can skip the process.


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25210

This pull request introduces enhancements to the authentication framework, primarily focused on improving the handling of user claims from assertions and the authentication flow. The most significant changes include better management of external identity provider (IdP) information during authentication, improved error handling, and refactoring for maintainability.

**Enhancements to assertion handling and external IdP management:**

* Refactored `handleUserClaimsFromAssertion` to be an instance method, allowing access to authenticator-specific context and enabling the method to set the current authenticator and external IdP in the `AuthenticationContext` based on the current authentication step and IdP configuration. [[1]](diffhunk://#diff-372dbf50a10552e442650fd7c4b7a83cb6a5fc64649518e8620018c1dc61b49cL667-R669) [[2]](diffhunk://#diff-372dbf50a10552e442650fd7c4b7a83cb6a5fc64649518e8620018c1dc61b49cR680-R715)
* Added imports for `ExternalIdPConfig` and `IdentityProvider` to support the new external IdP handling logic. [[1]](diffhunk://#diff-372dbf50a10552e442650fd7c4b7a83cb6a5fc64649518e8620018c1dc61b49cR32) [[2]](diffhunk://#diff-372dbf50a10552e442650fd7c4b7a83cb6a5fc64649518e8620018c1dc61b49cR45)

**Authentication flow improvements:**

* In `DefaultStepHandler`, added a pre-check for whether authentication is required using the authenticator's `isAuthenticationRequired` method, with robust error handling to catch and log exceptions, ensuring the authentication flow is resilient.
* Updated the authentication flow to use the result of the pre-check (`isAuthenticationRequired`) to determine if the authenticator's `process` method should be invoked, streamlining the decision logic.