### PR TITLE
Enable flows in organizations

### DIFF
--- a/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/constant/ConfigurationConstants.java
+++ b/components/configuration-mgt/org.wso2.carbon.identity.configuration.mgt.core/src/main/java/org/wso2/carbon/identity/configuration/mgt/core/constant/ConfigurationConstants.java
@@ -72,7 +72,8 @@ public class ConfigurationConstants {
     public static final String TENANT_NAME_FROM_CONTEXT = "TenantNameFromContext";
     public static final String PATH_SEPARATOR = "/";
     public static final String CORRELATION_ID_MDC = "Correlation-ID";
-    public static final List<String> INHERITED_RESOURCE_TYPES = List.of("input-validation-configurations");
+    public static final List<String> INHERITED_RESOURCE_TYPES = List.of("input-validation-configurations",
+            "flow-mgt-config");
 
 
     public enum ErrorMessages {

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -1893,4 +1893,21 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
+    <APIResourceCollection name="flows" displayName="Flows" type="organization">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:flows"/>
+                <Scope name="console:org:flows_view"/>
+                <Scope name="console:org:flows_edit"/>
+            </Feature>
+            <Update>
+            </Update>
+            <Delete>
+            </Delete>
+            <Create>
+            </Create>
+            <Read>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
 </APIResourceCollections>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -2009,4 +2009,21 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
+    <APIResourceCollection name="flows" displayName="Flows" type="organization">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:flows"/>
+                <Scope name="console:org:flows_view"/>
+                <Scope name="console:org:flows_edit"/>
+            </Feature>
+            <Update>
+            </Update>
+            <Delete>
+            </Delete>
+            <Create>
+            </Create>
+            <Read>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
 </APIResourceCollections>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -1723,6 +1723,19 @@
                    description="Manage edits of flows from the Console"/>
         </Scopes>
     </APIResource>
+    <APIResource name="Flows Feature" identifier="console:org:flows"
+                 requiresAuthorization="true"
+                 description="Resource representation of the Flows Feature"
+                 type="CONSOLE_ORG_FEATURE">
+        <Scopes>
+            <Scope displayName="Flows Feature" name="console:org:flows"
+                   description="Manage flows from the Console"/>
+            <Scope displayName="Flows View Feature" name="console:org:flows_view"
+                   description="Manage views of flows from the Console"/>
+            <Scope displayName="Flows Edit Feature" name="console:org:flows_edit"
+                   description="Manage edits of flows from the Console"/>
+        </Scopes>
+    </APIResource>
     <APIResource name="Offline User Onboard API" identifier="/o/api/users/v1/offline-invite-link/"
                  requiresAuthorization="true"
                  description="API to generate user onboard offline invite link" type="ORGANIZATION">
@@ -1787,6 +1800,16 @@
                    description="View flow in the organization (root)"/>
             <Scope displayName="Update Flow" name="internal_flow_update"
                    description="Update flow in the organization (root)"/>
+        </Scopes>
+    </APIResource>
+    <APIResource name="Flow Management API" identifier="/o/api/server/v1/flow"
+                 requiresAuthorization="true"
+                 description="API representation of the Flow Management API" type="ORGANIZATION">
+        <Scopes>
+            <Scope displayName="View Flow" name="internal_org_flow_view"
+                   description="View flow in the organization"/>
+            <Scope displayName="Update Flow" name="internal_org_flow_update"
+                   description="Update flow in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Asynchronous Operation Status API" identifier="/api/server/v1/async-operations"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -1798,6 +1798,19 @@
                    description="Manage edits of flows from the Console"/>
         </Scopes>
     </APIResource>
+    <APIResource name="Flows Feature" identifier="console:org:flows"
+                 requiresAuthorization="true"
+                 description="Resource representation of the Flows Feature"
+                 type="CONSOLE_ORG_FEATURE">
+        <Scopes>
+            <Scope displayName="Flows Feature" name="console:org:flows"
+                   description="Manage flows from the Console"/>
+            <Scope displayName="Flows View Feature" name="console:org:flows_view"
+                   description="Manage views of flows from the Console"/>
+            <Scope displayName="Flows Edit Feature" name="console:org:flows_edit"
+                   description="Manage edits of flows from the Console"/>
+        </Scopes>
+    </APIResource>
     <APIResource name="Offline User Onboard API" identifier="/o/api/users/v1/offline-invite-link/"
                  requiresAuthorization="true"
                  description="API to generate user onboard offline invite link" type="ORGANIZATION">
@@ -1888,6 +1901,16 @@
                    description="View flow in the organization (root)"/>
             <Scope displayName="Update Flow" name="internal_flow_update"
                    description="Update flow in the organization (root)"/>
+        </Scopes>
+    </APIResource>
+    <APIResource name="Flow Management API" identifier="/o/api/server/v1/flow"
+                 requiresAuthorization="true"
+                 description="API representation of the Flow Management API" type="ORGANIZATION">
+        <Scopes>
+            <Scope displayName="View Flow" name="internal_org_flow_view"
+                   description="View flow in the organization"/>
+            <Scope displayName="Update Flow" name="internal_org_flow_update"
+                   description="Update flow in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Asynchronous Operation Status API" identifier="/o/api/server/v1/async-operations"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3986,6 +3986,7 @@
                     <Path>/api/users/v1/offline-invite-link</Path>
                     <Path>/api/server/v1/validation-rules</Path>
                     <Path>/api/users/v1/me/push/devices</Path>
+                    <Path>/api/server/v1/flow/execute</Path>
                 </SubPaths>
             </Context>
             <Context>
@@ -3996,6 +3997,9 @@
             </Context>
             <Context>
                 <BasePath>/accountrecoveryendpoint/</BasePath>
+            </Context>
+            <Context>
+                <BasePath>/accounts/</BasePath>
             </Context>
         </WebApp>
         <Servlet>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1296,6 +1296,7 @@
     "branding",
     "consoleSettings",
     "emailTemplates",
+    "flows",
     "gettingStarted",
     "governanceConnectors",
     "groups",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -1573,6 +1573,14 @@
     <!-- Flow execution API -->
     <Resource context="(.*)/api/server/v1/flow/(.*)" secured="false" http-method="POST" />
 
+    <!-- Organization Flow management API -->
+    <Resource context="(.*)/o/api/server/v1/flow(.*)" secured="true" http-method="GET">
+        <Scopes>internal_org_flow_view</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/server/v1/flow(.*)" secured="true" http-method="PUT, PATCH">
+        <Scopes>internal_org_flow_update</Scopes>
+    </Resource>
+
     <!-- Flow management API -->
     <Resource context="(.*)/api/server/v1/flow(.*)" secured="true" http-method="GET">
         <Scopes>internal_flow_view</Scopes>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -1645,6 +1645,14 @@
          <!-- Flow execution API -->
           <Resource context="(.*)/api/server/v1/flow/(.*)" secured="false" http-method="POST" />
 
+        <!-- [Organization] Flow management API -->
+        <Resource context="(.*)/o/api/server/v1/flow(.*)" secured="true" http-method="GET">
+            <Scopes>internal_org_flow_view</Scopes>
+        </Resource>
+        <Resource context="(.*)/o/api/server/v1/flow(.*)" secured="true" http-method="PUT, PATCH">
+            <Scopes>internal_org_flow_update</Scopes>
+        </Resource>
+
          <!-- Flow management API -->
          <Resource context="(.*)/api/server/v1/flow(.*)" secured="true" http-method="GET">
              <Scopes>internal_flow_view</Scopes>


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25212

This pull request introduces new API resources and access control rules to support flow management features for organizations, including both Console and API endpoints. It adds the necessary scopes, resource definitions, and configuration updates to enable and secure flow management and execution functionality.

**API Resource and Scope Definitions**

* Added a new `Flows Feature` resource under `CONSOLE_ORG_FEATURE` with scopes for managing, viewing, and editing flows from the Console in `system-api-resource.xml` and its template file. [[1]](diffhunk://#diff-2bb3bf5d98c3e3607e4d52f7be45a06b2e6afc0357ba58dc9bbb71a5bd8102bbR1726-R1738) [[2]](diffhunk://#diff-a70225dc72f4100048a17b866cc1754e81c34fc31aa4128051d613ac4c64ed5bR1801-R1813)
* Introduced a new `Flow Management API` resource for organization-level flow management, including scopes for viewing and updating flows, in both XML and Jinja template files. [[1]](diffhunk://#diff-2bb3bf5d98c3e3607e4d52f7be45a06b2e6afc0357ba58dc9bbb71a5bd8102bbR1805-R1814) [[2]](diffhunk://#diff-a70225dc72f4100048a17b866cc1754e81c34fc31aa4128051d613ac4c64ed5bR1906-R1915)

**Access Control Updates**

* Updated `resource-access-control-v2.xml` and its template to secure the new organization flow management API endpoints, mapping HTTP methods to the appropriate scopes for viewing and updating flows. [[1]](diffhunk://#diff-8d3e33818f8d0a815cd470310be01f25928d196ce5ad9992cd21a2f7b81ca9aaR1576-R1583) [[2]](diffhunk://#diff-c1d66ea18073ea8342745dd465ae3028cc45019079d18f6c838c8d2cfb94da50R1648-R1655)

**Core Feature Configuration**

* Registered `flows` as a new feature in `org.wso2.carbon.identity.core.server.feature.default.json` to enable it in the core feature set.

**Web Application and API Path Configuration**

* Added `/api/server/v1/flow/execute` to the list of recognized API sub-paths and introduced a new `/accounts/` context in the web application configuration. [[1]](diffhunk://#diff-1ece24b053d1b4af23eb3fdd3af75e2f8816c34a5685ece650c7882061dff696R3989) [[2]](diffhunk://#diff-1ece24b053d1b4af23eb3fdd3af75e2f8816c34a5685ece650c7882061dff696R4001-R4003)