### PR TITLE
Fix auto login issue with social sign up

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -745,6 +745,15 @@ public class DefaultStepHandler implements StepHandler {
             return;
         }
 
+        boolean isAuthenticationRequired;
+        try {
+            isAuthenticationRequired = authenticator.isAuthenticationRequired(request, response, context);
+        } catch (AuthenticationFailedException e) {
+            LOG.error("Error while checking if authentication is required for authenticator: " +
+                    authenticator.getName(), e);
+            throw new FrameworkException(e.getErrorCode(), e.getMessage(), e);
+        }
+
         String idpName = FrameworkConstants.LOCAL_IDP_NAME;
         if (context.getExternalIdP() != null && authenticator instanceof FederatedApplicationAuthenticator) {
             idpName = context.getExternalIdP().getIdPName();
@@ -768,7 +777,7 @@ public class DefaultStepHandler implements StepHandler {
         try {
             context.setAuthenticatorProperties(getAuthenticatorPropertyMap(authenticator, context));
             AuthenticatorFlowStatus status;
-            if (authenticator.isAuthenticationRequired(request, response, context)) {
+            if (isAuthenticationRequired) {
                 status = authenticator.process(request, response, context);
             } else {
                 // If the authenticator does not require authentication based on the assertion, we can skip the process.


### PR DESCRIPTION
### Issue
https://github.com/wso2/product-is/issues/25210

This pull request introduces enhancements to the authentication framework, mainly focusing on improving how user claims from assertions are handled and how external Identity Providers (IdPs) are set in the authentication context. Additionally, it refactors the authentication flow to better manage exceptions and streamline the authentication requirement check.

**Enhancements to user claim handling and external IdP assignment:**

* Refactored the `handleUserClaimsFromAssertion` method in `AbstractApplicationAuthenticator.java` to be non-static, and updated it to set the current authenticator and external IdP in the authentication context when processing user claims from assertions. This ensures the correct IdP is associated with the authentication step. [[1]](diffhunk://#diff-372dbf50a10552e442650fd7c4b7a83cb6a5fc64649518e8620018c1dc61b49cL667-R669) [[2]](diffhunk://#diff-372dbf50a10552e442650fd7c4b7a83cb6a5fc64649518e8620018c1dc61b49cR680-R715)
* Added imports for `ExternalIdPConfig` and `IdentityProvider` to support external IdP configuration assignment. [[1]](diffhunk://#diff-372dbf50a10552e442650fd7c4b7a83cb6a5fc64649518e8620018c1dc61b49cR32) [[2]](diffhunk://#diff-372dbf50a10552e442650fd7c4b7a83cb6a5fc64649518e8620018c1dc61b49cR45)

**Improvements to authentication flow and error handling:**

* Updated `DefaultStepHandler.java` to explicitly check if authentication is required by calling `isAuthenticationRequired` before processing the authenticator, and introduced exception handling for this check to improve robustness.
* Refactored the authentication flow to use the result of the explicit authentication requirement check (`isAuthenticationRequired`) instead of calling the method again, ensuring consistent logic and reducing redundant calls.