### PR TITLE
Add accounts endpoint configuration and related methods

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/DefaultServiceURLBuilder.java
@@ -112,8 +112,8 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         String authenticationEndpointPath = fetchAuthenticationEndpointPath();
         String recoveryEndpointHostName = fetchRecoveryEndpointHostName();
         String recoveryEndpointPath = fetchRecoveryEndpointPath();
-        String accountsEndpointHostName = fetchAccountsEndpointHostName();
-        String accountsEndpointPath = fetchAccountsEndpointPath();
+        String accountsHostName = fetchAccountsHostName();
+        String accountsPath = fetchAccountsPath();
         int proxyPort = fetchPort();
         int transportPort = fetchTransportPort();
         String tenantDomain = StringUtils.isNotBlank(tenant) ? tenant : resolveTenantDomain();
@@ -139,10 +139,10 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
                 absolutePublicUrlWithoutURLPath = fetchAbsolutePublicUrlWithoutURLPath(protocol,
                         recoveryEndpointHostName, proxyPort);
             }
-            if (accountsEndpointHostName != null && accountsEndpointPath != null &&
-                    urlPathForPublicUrl.contains(accountsEndpointPath)) {
+            if (accountsHostName != null && accountsPath != null &&
+                    urlPathForPublicUrl.contains(accountsPath)) {
                 absolutePublicUrlWithoutURLPath = fetchAbsolutePublicUrlWithoutURLPath(protocol,
-                        accountsEndpointHostName, proxyPort);
+                        accountsHostName, proxyPort);
             }
         }
         String absolutePublicURL = fetchAbsolutePublicUrl(absolutePublicUrlWithoutURLPath, relativePublicUrl);
@@ -395,18 +395,18 @@ public class DefaultServiceURLBuilder implements ServiceURLBuilder {
         return preprocessEndpointPath(recoveryEndpointPath);
     }
 
-    protected String fetchAccountsEndpointHostName() throws URLBuilderException {
+    protected String fetchAccountsHostName() throws URLBuilderException {
 
-        String accountsEndpointHostName = IdentityUtil.
-                getProperty(IdentityCoreConstants.ACCOUNTS_ENDPOINT_HOST_NAME);
-        return resolveHostName(accountsEndpointHostName);
+        String accountsHostName = IdentityUtil.
+                getProperty(IdentityCoreConstants.ACCOUNTS_HOST_NAME);
+        return resolveHostName(accountsHostName);
     }
 
-    protected String fetchAccountsEndpointPath() {
+    protected String fetchAccountsPath() {
 
-        String accountsEndpointPath = IdentityUtil
-                .getProperty(IdentityCoreConstants.ACCOUNTS_ENDPOINT_PATH);
-        return preprocessEndpointPath(accountsEndpointPath);
+        String accountsPath = IdentityUtil
+                .getProperty(IdentityCoreConstants.ACCOUNTS_PATH);
+        return preprocessEndpointPath(accountsPath);
     }
 
     protected String preprocessEndpointPath(String endpointPath) {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -32,8 +32,8 @@ public class IdentityCoreConstants {
     public static final String AUTHENTICATION_ENDPOINT_PATH = "AuthenticationEndpoint.Path";
     public static final String RECOVERY_ENDPOINT_HOST_NAME = "RecoveryEndpoint.HostName";
     public static final String RECOVERY_ENDPOINT_PATH = "RecoveryEndpoint.Path";
-    public static final String ACCOUNTS_ENDPOINT_HOST_NAME = "AccountsEndpoint.HostName";
-    public static final String ACCOUNTS_ENDPOINT_PATH = "AccountsEndpoint.Path";
+    public static final String ACCOUNTS_HOST_NAME = "Accounts.HostName";
+    public static final String ACCOUNTS_PATH = "Accounts.Path";
     public static final String FILE_NAME_REGEX = "FileNameRegEx";
     public static final String PORTS_OFFSET = "Ports.Offset";
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -158,10 +158,10 @@
         <HostName>{{recoveryendpoint.hostname}}</HostName>
         <Path>{{recoveryendpoint.path}}</Path>
     </RecoveryEndpoint>
-    <AccountsEndpoint>
-        <HostName>{{accountsendpoint.hostname}}</HostName>
-        <Path>{{accountsendpoint.path}}</Path>
-    </AccountsEndpoint>
+    <Accounts>
+        <HostName>{{accounts.hostname}}</HostName>
+        <Path>{{accounts.path}}</Path>
+    </Accounts>
 
     <Identity>
         <IssuerPolicy>{{identity.issuer_policy}}</IssuerPolicy>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -59,8 +59,8 @@
   "authenticationendpoint.path": "/authenticationendpoint",
   "recoveryendpoint.hostname": "$ref{server.hostname}",
   "recoveryendpoint.path": "/accountrecoveryendpoint",
-  "accountsendpoint.hostname": "$ref{server.hostname}",
-  "accountsendpoint.path": "/accounts",
+  "accounts.hostname": "$ref{server.hostname}",
+  "accounts.path": "/accounts",
 
   "service_provider.sp_name_regex": "^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$",
 


### PR DESCRIPTION
## Related Issue
- https://github.com/wso2/product-is/issues/25176

## Purpose
This pull request adds support for an Accounts Endpoint to the identity core service URL builder. The main changes involve introducing new configuration properties and logic to handle the Accounts Endpoint in addition to the existing Recovery Endpoint.

**Accounts Endpoint support:**

* Added new configuration properties for `AccountsEndpoint.HostName` and `AccountsEndpoint.Path` in `IdentityCoreConstants` and updated configuration files to include these values. [[1]](diffhunk://#diff-5398caecd73528910fe590141c693a88b807d6f029c2f16e61866e62515b70d3R35-R36) [[2]](diffhunk://#diff-1ece24b053d1b4af23eb3fdd3af75e2f8816c34a5685ece650c7882061dff696R161-R164) [[3]](diffhunk://#diff-ccd8d78f18b752f00ba42b5384248d7b8e8c6cc965a44569e2654ca6ce5bb616R62-R63)
* Implemented `fetchAccountsEndpointHostName()` and `fetchAccountsEndpointPath()` methods in `DefaultServiceURLBuilder.java` to retrieve and process the Accounts Endpoint configuration.

**Service URL building logic:**

* Modified `buildServiceURL()` in `DefaultServiceURLBuilder.java` to check for the Accounts Endpoint and use its values when constructing the public service URL if the requested path matches the Accounts Endpoint path. [[1]](diffhunk://#diff-c7371fc4c3040ca46b099985e0703baa80a592a1fade3d16cde5f00ce454ccf0R115-R116) [[2]](diffhunk://#diff-c7371fc4c3040ca46b099985e0703baa80a592a1fade3d16cde5f00ce454ccf0R142-R146)