### PR TITLE
[Next] Fix not trigerring session terminate event for logouts associated with IdP logout urls

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
@@ -228,6 +228,35 @@ public class DefaultLogoutRequestHandler implements LogoutRequestHandler {
         } else {
             FrameworkUtils.removeAuthCookie(request, response);
         }
+
+        if (FrameworkServiceDataHolder.getInstance().getAuthnDataPublisherProxy() != null &&
+                FrameworkServiceDataHolder.getInstance().getAuthnDataPublisherProxy().isEnabled(context) &&
+                sessionContext != null) {
+            Object authenticatedUserObj = sessionContext.getProperty(FrameworkConstants.AUTHENTICATED_USER);
+            AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+            if (authenticatedUserObj instanceof AuthenticatedUser) {
+                authenticatedUser = (AuthenticatedUser) authenticatedUserObj;
+                if (LoggerUtils.isDiagnosticLogsEnabled() && diagnosticLogBuilder != null) {
+                    diagnosticLogBuilder.inputParam(LogConstants.InputKeys.USER, LoggerUtils.isLogMaskingEnable ?
+                                    LoggerUtils.getMaskedContent(authenticatedUser.getUserName()) :
+                                    authenticatedUser.getUserName())
+                            .inputParam(LogConstants.InputKeys.USER_ID, authenticatedUser.getLoggableUserId());
+                }
+            }
+            // Setting the authenticated user's object to the request to get the relevant details to log out the user.
+            context.setProperty(FrameworkConstants.AUTHENTICATED_USER, authenticatedUser);
+
+            if (log.isDebugEnabled()) {
+                log.debug("Publishing session termination event for the session: " + context.getSessionIdentifier());
+            }
+            FrameworkUtils.publishSessionEvent(context.getSessionIdentifier(), request, context,
+                    sessionContext, authenticatedUser, FrameworkConstants.AnalyticsAttributes
+                            .SESSION_TERMINATE);
+            // Publishing the session termination V2 event for improved event handling.
+            SessionEventPublishingUtil.publishSessionTerminationEvent(
+                    context.getSessionIdentifier(), authenticatedUser, request, context, sessionContext);
+        }
+
         if (context.isPreviousSessionFound()) {
             // if this is the start of the logout sequence
             if (context.getCurrentStep() == 0) {
@@ -373,30 +402,6 @@ public class DefaultLogoutRequestHandler implements LogoutRequestHandler {
                     }
                 }
             }
-        }
-
-        if (FrameworkServiceDataHolder.getInstance().getAuthnDataPublisherProxy() != null &&
-                FrameworkServiceDataHolder.getInstance().getAuthnDataPublisherProxy().isEnabled(context) &&
-                sessionContext != null) {
-            Object authenticatedUserObj = sessionContext.getProperty(FrameworkConstants.AUTHENTICATED_USER);
-            AuthenticatedUser authenticatedUser = new AuthenticatedUser();
-            if (authenticatedUserObj instanceof AuthenticatedUser) {
-                authenticatedUser = (AuthenticatedUser) authenticatedUserObj;
-                if (LoggerUtils.isDiagnosticLogsEnabled() && diagnosticLogBuilder != null) {
-                    diagnosticLogBuilder.inputParam(LogConstants.InputKeys.USER, LoggerUtils.isLogMaskingEnable ?
-                                    LoggerUtils.getMaskedContent(authenticatedUser.getUserName()) :
-                                    authenticatedUser.getUserName())
-                            .inputParam(LogConstants.InputKeys.USER_ID, authenticatedUser.getLoggableUserId());
-                }
-            }
-            // Setting the authenticated user's object to the request to get the relevant details to log out the user.
-            context.setProperty(FrameworkConstants.AUTHENTICATED_USER, authenticatedUser);
-            FrameworkUtils.publishSessionEvent(context.getSessionIdentifier(), request, context,
-                    sessionContext, authenticatedUser, FrameworkConstants.AnalyticsAttributes
-                            .SESSION_TERMINATE);
-            // Publishing the session termination V2 event for improved event handling.
-            SessionEventPublishingUtil.publishSessionTerminationEvent(
-                    context.getSessionIdentifier(), authenticatedUser, request, context, sessionContext);
         }
 
         try {


### PR DESCRIPTION
### Proposed changes in this pull request
Currently, if the user is authenticated from an IdP with a logout url, redirection to that logout url is initiated. However after logout from the IdP when it returns to logout handler again, session context is not available. As a result, session termination events are not getting triggered. Here, we are moving the session termination event triggering block before authenticator execution.

Initially this block for publishing session termination event is executed before removing session context from the cache. However, with the improvements in https://github.com/wso2/carbon-identity-framework/pull/6666, we have moved the block for publishing session termination event after authenticator execution for updated logic related to active session count. However, it is not needed to move that logic after authenticator execution and having it after the removing session context logic before authenticator execution is enough.

Issue - https://github.com/wso2/product-is/issues/25131