### PR TITLE
[next] Skip version check when removing dialects

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/UnifiedClaimMetadataManager.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/UnifiedClaimMetadataManager.java
@@ -1101,12 +1101,7 @@ public class UnifiedClaimMetadataManager implements ReadWriteClaimMetadataManage
      */
     public void removeAllClaimDialects(int tenantId) throws ClaimMetadataException {
 
-        String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
-        if (resolveWithHierarchicalMode(tenantDomain, tenantId)) {
-            this.cacheBackedDBBasedClaimMetadataManager.removeAllClaimDialects(tenantId);
-        } else {
-            this.dbBasedClaimMetadataManager.removeAllClaimDialects(tenantId);
-        }
+        this.cacheBackedDBBasedClaimMetadataManager.removeAllClaimDialects(tenantId);
     }
 
     /**


### PR DESCRIPTION
## Purpose

$subject

With v1 organizations, a new DAO level cache has been introduced and each method in the claim mgt checks the version of the organization before determining whether to directly invoke the db claim manager (v0) or the cache-backed one (v1) so that caching can be handled correctly.

For the tenant deletion flow, as the organization version is unavailable, an NPE occurs. However, this can be fixed by directly proceeding with the cache-backed invocation.