### PR TITLE
[next] Remove version check in service layer call

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/CacheBackedUnifiedClaimMetadataManager.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/CacheBackedUnifiedClaimMetadataManager.java
@@ -308,13 +308,10 @@ public class CacheBackedUnifiedClaimMetadataManager extends UnifiedClaimMetadata
     public void removeAllClaimDialects(int tenantId) throws ClaimMetadataException {
 
         super.removeAllClaimDialects(tenantId);
-        List<Integer> tenantIdsToBeInvalidated = getOrganizationsToBeInvalidated(tenantId);
-        for (Integer tenantIdToBeInvalidated: tenantIdsToBeInvalidated) {
-            claimDialectCache.clearClaimDialects(tenantIdToBeInvalidated);
-            localClaimCache.clear(tenantIdToBeInvalidated);
-            externalClaimCache.clear(tenantIdToBeInvalidated);
-            associatedClaimCache.clear(tenantIdToBeInvalidated);
-        }
+        claimDialectCache.clearClaimDialects(tenantId);
+        localClaimCache.clear(tenantId);
+        externalClaimCache.clear(tenantId);
+        associatedClaimCache.clear(tenantId);
         if (log.isDebugEnabled()) {
             log.debug("All claim dialects are removed for tenant: " + tenantId +
                     ". Invalidated ClaimDialectCache, LocalClaimCache and ExternalClaimCache.");


### PR DESCRIPTION
## Purpose

The version check in the removeAllDialects relevant to the DAO cache has been removed in a previous PR [1]. This removes it from the service layer call as well.

[1] https://github.com/wso2/carbon-identity-framework/pull/7172
