### PR TITLE
Fix recaptcha email

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1668,6 +1668,10 @@
         <EnableScim2RolesV3Api>{{scim2.enable_scim2_roles_v3_api}}</EnableScim2RolesV3Api>
     </SCIM2>
 
+    <Captcha>
+        <EnableCaptchaForLocalOTPAuthenticators>{{captcha.enable_captcha_for_local_otp_authenticators}}</EnableCaptchaForLocalOTPAuthenticators>
+    </Captcha>
+
       <PasswordPolicy>
           <MaxPasswordAllowedLength>{{identity_mgt.password_policy.max_password_allowed_length}}</MaxPasswordAllowedLength>
           <PasswordPolicyValidationHandler>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -2025,6 +2025,7 @@
     "REGISTRATION": "30",
     "PASSWORD_RECOVERY": "30",
     "INVITED_USER_REGISTRATION": "30"
-  }
+  },
+  "captcha.enable_captcha_for_local_otp_authenticators": true
 }
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -286,7 +286,7 @@
       "scim2.enable_scim2_roles_v3_api": false,
       "localization.prioritize_param": false,
       "attribute.return_previous_additional_properties.enable": true,
-      "captcha.enable_captcha_for_local_otp_authenticators": true
+      "captcha.enable_captcha_for_local_otp_authenticators": false
     },
     "IS_7.1.0": {
       "oauth.dcrm.return_null_fields_in_response": true,
@@ -300,7 +300,7 @@
       "localization.prioritize_param": false,
       "attribute.return_previous_additional_properties.enable": true,
       "actions.types.pre_update_password.enable_in_registration_flows": false,
-      "captcha.enable_captcha_for_local_otp_authenticators": true
+      "captcha.enable_captcha_for_local_otp_authenticators": false
     }
   }
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -285,7 +285,8 @@
       "console.identity_providers.disabled_features": [],
       "scim2.enable_scim2_roles_v3_api": false,
       "localization.prioritize_param": false,
-      "attribute.return_previous_additional_properties.enable": true
+      "attribute.return_previous_additional_properties.enable": true,
+      "captcha.enable_captcha_for_local_otp_authenticators": true
     },
     "IS_7.1.0": {
       "oauth.dcrm.return_null_fields_in_response": true,
@@ -298,7 +299,8 @@
       "scim2.enable_scim2_roles_v3_api": false,
       "localization.prioritize_param": false,
       "attribute.return_previous_additional_properties.enable": true,
-      "actions.types.pre_update_password.enable_in_registration_flows": false
+      "actions.types.pre_update_password.enable_in_registration_flows": false,
+      "captcha.enable_captcha_for_local_otp_authenticators": true
     }
   }
 }


### PR DESCRIPTION
Proposed changes in this pull request

**Related Issues**

- https://github.com/wso2/product-is/issues/24183

This pull request introduces a new configuration option to enable CAPTCHA for local OTP authenticators. The change is reflected in both the configuration files and the server feature template to support the new setting.

Configuration for CAPTCHA with OTP Authenticators:

Added the captcha.enable_captcha_for_local_otp_authenticators property to the default and inference JSON configuration files, setting its default value to true. [[1]](https://github.com/wso2/carbon-identity-framework/pull/7185/files#diff-ccd8d78f18b752f00ba42b5384248d7b8e8c6cc965a44569e2654ca6ce5bb616L2032-R2033) [[2]](https://github.com/wso2/carbon-identity-framework/pull/7185/files#diff-5a320fb31fe6943d6aca55d4c6e464e2680d1a1e5d2222d79fc6c95cd1f7033fL289-R290) [[3]](https://github.com/wso2/carbon-identity-framework/pull/7185/files#diff-5a320fb31fe6943d6aca55d4c6e464e2680d1a1e5d2222d79fc6c95cd1f7033fL304-R306)
Updated the identity.xml.j2 template to include a new <Captcha> section with an <EnableCaptchaForLocalOTPAuthenticators> element, which references the new configuration property.

