### PR TITLE
[next] Add configuration to enable inclusion of the tenant certificate in the SAML SLO logout request signature for front-channel POST binding

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1455,6 +1455,8 @@
             <SeparateMultiAttributesFromIdP>{{saml.separate_multi_attributes_from_idp}}</SeparateMultiAttributesFromIdP>
         {% endif %}
         <ReturnValidNameIDFormat>{{saml.return_valid_name_id_format}}</ReturnValidNameIDFormat>
+
+        <SAMLSLOFrontChannelPostBindingLogoutRequestSignatureWithTenantCert>{{saml.slo.front_channel.post_binding.logout_request_signature_with_tenant_cert}}</SAMLSLOFrontChannelPostBindingLogoutRequestSignatureWithTenantCert>
     </SSOService>
 
     <Consent>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -320,6 +320,7 @@
   "saml.slo.retry_attempts": "5",
   "saml.slo.retry_interval": "1m",
   "saml.slo.host_name_verification": true,
+  "saml.slo.front_channel.post_binding.logout_request_signature_with_tenant_cert": false,
   "saml.response.validity": "5m",
   "saml.artifact.validity": "4m",
   "saml.use_tenant_key_of": "user",


### PR DESCRIPTION
This PR introduces the following configuration to enable the inclusion of the tenant certificate in the SAML SLO logout request signature when using front-channel POST binding:

```
[saml.slo.front_channel.post_binding]
logout_request_signature_with_tenant_cert = true
```

Related issue: https://github.com/wso2/product-is/issues/24914.