### PR TITLE
[master] Refactor resources order to satisfy login only mode migration requirements

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -44,6 +44,84 @@
         <Resource context="(.*)" secured="false" http-method="OPTIONS"/>
         <Resource context="/" secured="false" http-method="GET"/>
 
+        <Resource context="/carbon(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/myaccount(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/console(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/commonauth(.*)" secured="false" http-method="all"/>
+        <Resource context="/t/(.*)/carbon(.*)" secured="false" http-method="all"/>
+        <Resource context="/services(.*)" secured="false" http-method="all"/>
+        <Resource context="/t/(.*)/services(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/samlsso(.*)" secured="false" http-method="all"/>
+        <Resource context="/acs(.*)" secured="false" http-method="all"/>
+        <Resource context="/openidserver(.*)" secured="false" http-method="all"/>
+        <Resource context="/openid(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/passivests(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/samlartresolve(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oauth/request-token(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oauth/authorize-url(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oauth/access-token(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oauth2/token(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oauth2/authorize(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oauth2/revoke(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oauth2/userinfo(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oauth2/jwks(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oauth2/device(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oauth2/device_authorize(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oauth2/par(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oauth2/authn(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oidc/checksession(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oidc/logout(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/oauth2/oidcdiscovery(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/wso2/scim/Users(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/wso2/scim/Groups(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/wso2/scim/Bulk(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/authenticationendpoint(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/accountrecoveryendpoint/confirmregistration.do(.*)" secured="false"
+                  http-method="GET, POST, HEAD"/>
+        <Resource context="(.*)/accountrecoveryendpoint(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/api/health-check/v1(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/emailotpauthenticationendpoint(.*)" secured="false" http-method="all"/>
+        <Resource context="/mex(.*)" secured="false" http-method="all"/>
+        <Resource context="/mexut(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/smsotpauthenticationendpoint(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/totpauthenticationendpoint(.*)" secured="false" http-method="all"/>
+        <Resource context="/x509certificateauthenticationendpoint(.*)" secured="false" http-method="all"/>
+        <Resource context="/userandrolemgtservice(.*)" secured="false" http-method="all"/>
+        <Resource context="/x509-certificate-servlet(.*)" secured="false" http-method="all"/>
+        <Resource context="/mepinauthenticationendpoint(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/identity/cas(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/identity/saml/slo(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/identity/extend-session(.*)" secured="false" http-method="all"/>
+        <Resource context="/mobileconnectauthenticationendpoint(.*)" secured="false" http-method="all"/>
+        <Resource context="/inweboauthenticationendpoint(.*)" secured="false" http-method="all"/>
+        <Resource context="/token2authenticationendpoint(.*)" secured="false" http-method="all"/>
+        <Resource context="/duoauthenticationendpoint(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/filedownload(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/logincontext(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/longwaitstatus(.*)" secured="false" http-method="GET"/>
+        <Resource context="(.*)/registry/resourceContent(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/registry/resource(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/registry/tags(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/registry/atom(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/tryit/JAXRSRequestXSSproxy_ajaxprocessor.jsp" secured="false" http-method="all"/>
+        <Resource context="(.*)/admin/jsp/WSRequestXSSproxy_ajaxprocessor.jsp" secured="false" http-method="all"/>
+        <Resource context="(.*)/iwa-kerberos(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/identity/metadata/(.*)" secured="false" http-method="all"/>
+        <Resource context="(.*)/api/identity/media/v1.0/public/(.*)" secured="false" http-method="GET"/>
+        <Resource context="(.*)/identity/oidc/slo(.*)" secured="false" http-method="POST"/>
+        <Resource context="(.*)/.well-known/trusted-apps/android" secured="false" http-method="GET"/>
+        <Resource context="(.*)/.well-known/trusted-apps/ios" secured="false" http-method="GET"/>
+        <Resource context="(.*)/push-auth/check-status(.*)" secured="false" http-method="GET"/>
+        <Resource context="(.*)/push-auth/authenticate" secured="false" http-method="POST"/>
+        <Resource context="(.*)/accounts(.*)" secured="false" http-method="all"/>
+
+        <!-- 'Login only' mode migration configuration -->
+        {% if resource_access_control.login_only_mode.enable is sameas true %}
+            <Resource context="^(?!/api/identity/user/v1.0/introspect-code|/t/.*/o/.*/oauth2/introspect|/oauth2/introspect|/o/api/server/v1/guests/invitation/introspect|/api/identity/entitlement).*" secured="true" http-method="POST, PUT, PATCH">
+                <Scopes>no_access_granted</Scopes>
+            </Resource>
+        {% endif %}
+
         <!-- [Organization] User Code Management API -->
         <Resource context="(.*)/o/api/identity/user/v1.0/validate-code(.*)" secured="true" http-method="POST">
             <Scopes>internal_org_user_code_mgt_create</Scopes>
@@ -140,6 +218,13 @@
         <Resource context="(.*)/api/identity/config-mgt/v1.0/resource/(.*)" secured="true" http-method="DELETE">
             <Scopes>internal_config_mgt_delete</Scopes>
         </Resource>
+
+        <Resource context="(.*)/api/identity/config-mgt/v1.0/resource/(.*)/(.*)" secured="true" http-method="GET"/>
+        <Resource context="(.*)/api/identity/config-mgt/v1.0/resource/(.*)/(.*)" secured="true" http-method="DELETE"/>
+        <Resource context="(.*)/api/identity/config-mgt/v1.0/resource/(.*)/(.*)" secured="true" http-method="POST"/>
+        <Resource context="(.*)/api/identity/config-mgt/v1.0/resource/(.*)/(.*)" secured="true" http-method="PUT"/>
+        <Resource context="(.*)/api/identity/config-mgt/v1.0/resource/(.*)/(.*)/(.*)" secured="true" http-method="GET"/>
+        <Resource context="(.*)/api/identity/config-mgt/v1.0/resource/(.*)/(.*)/(.*)" secured="true" http-method="DELETE"/>
 
         <!-- [Organization]  Notification Sender Management V1/V2 API -->
         <Resource context="(.*)/o/api/server/v(.*)/notification-senders/(.*)" secured="true" http-method="POST">
@@ -1782,83 +1867,6 @@
           <Resource context="(.*)/api/server/v1/workflow-instances(.*)" secured="true" http-method="DELETE">
               <Scopes>internal_workflow_instance_delete</Scopes>
           </Resource>
-
-        <Resource context="/carbon(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/myaccount(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/console(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/commonauth(.*)" secured="false" http-method="all"/>
-        <Resource context="/t/(.*)/carbon(.*)" secured="false" http-method="all"/>
-        <Resource context="/services(.*)" secured="false" http-method="all"/>
-        <Resource context="/t/(.*)/services(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/samlsso(.*)" secured="false" http-method="all"/>
-        <Resource context="/acs(.*)" secured="false" http-method="all"/>
-        <Resource context="/openidserver(.*)" secured="false" http-method="all"/>
-        <Resource context="/openid(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/passivests(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/samlartresolve(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oauth/request-token(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oauth/authorize-url(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oauth/access-token(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oauth2/token(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oauth2/authorize(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oauth2/revoke(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oauth2/userinfo(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oauth2/jwks(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oauth2/device(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oauth2/device_authorize(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oauth2/par(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oauth2/authn(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oidc/checksession(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oidc/logout(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/oauth2/oidcdiscovery(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/wso2/scim/Users(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/wso2/scim/Groups(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/wso2/scim/Bulk(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/authenticationendpoint(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/accountrecoveryendpoint/confirmregistration.do(.*)" secured="false"
-                  http-method="GET, POST, HEAD"/>
-        <Resource context="(.*)/accountrecoveryendpoint(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/api/health-check/v1(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/emailotpauthenticationendpoint(.*)" secured="false" http-method="all"/>
-        <Resource context="/mex(.*)" secured="false" http-method="all"/>
-        <Resource context="/mexut(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/smsotpauthenticationendpoint(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/totpauthenticationendpoint(.*)" secured="false" http-method="all"/>
-        <Resource context="/x509certificateauthenticationendpoint(.*)" secured="false" http-method="all"/>
-        <Resource context="/userandrolemgtservice(.*)" secured="false" http-method="all"/>
-        <Resource context="/x509-certificate-servlet(.*)" secured="false" http-method="all"/>
-        <Resource context="/mepinauthenticationendpoint(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/identity/cas(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/identity/saml/slo(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/identity/extend-session(.*)" secured="false" http-method="all"/>
-        <Resource context="/mobileconnectauthenticationendpoint(.*)" secured="false" http-method="all"/>
-        <Resource context="/inweboauthenticationendpoint(.*)" secured="false" http-method="all"/>
-        <Resource context="/token2authenticationendpoint(.*)" secured="false" http-method="all"/>
-        <Resource context="/duoauthenticationendpoint(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/filedownload(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/logincontext(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/longwaitstatus(.*)" secured="false" http-method="GET"/>
-        <Resource context="(.*)/registry/resourceContent(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/registry/resource(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/registry/tags(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/registry/atom(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/tryit/JAXRSRequestXSSproxy_ajaxprocessor.jsp" secured="false" http-method="all"/>
-        <Resource context="(.*)/admin/jsp/WSRequestXSSproxy_ajaxprocessor.jsp" secured="false" http-method="all"/>
-        <Resource context="(.*)/api/identity/config-mgt/v1.0/resource/(.*)/(.*)" secured="true" http-method="GET"/>
-        <Resource context="(.*)/api/identity/config-mgt/v1.0/resource/(.*)/(.*)" secured="true" http-method="DELETE"/>
-        <Resource context="(.*)/api/identity/config-mgt/v1.0/resource/(.*)/(.*)" secured="true" http-method="POST"/>
-        <Resource context="(.*)/api/identity/config-mgt/v1.0/resource/(.*)/(.*)" secured="true" http-method="PUT"/>
-        <Resource context="(.*)/api/identity/config-mgt/v1.0/resource/(.*)/(.*)/(.*)" secured="true" http-method="GET"/>
-        <Resource context="(.*)/api/identity/config-mgt/v1.0/resource/(.*)/(.*)/(.*)" secured="true" http-method="DELETE"/>
-        <Resource context="(.*)/iwa-kerberos(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/identity/metadata/(.*)" secured="false" http-method="all"/>
-        <Resource context="(.*)/api/identity/media/v1.0/public/(.*)" secured="false" http-method="GET"/>
-        <Resource context="(.*)/identity/oidc/slo(.*)" secured="false" http-method="POST"/>
-        <Resource context="(.*)/.well-known/trusted-apps/android" secured="false" http-method="GET"/>
-        <Resource context="(.*)/.well-known/trusted-apps/ios" secured="false" http-method="GET"/>
-        <Resource context="(.*)/push-auth/check-status(.*)" secured="false" http-method="GET"/>
-        <Resource context="(.*)/push-auth/authenticate" secured="false" http-method="POST"/>
-        <Resource context="(.*)/accounts(.*)" secured="false" http-method="all"/>
 
         <!-- Wild Cards; These scopes are not avaiable in the V2 runtime, therefore any other API will be blocked. -->
         <Resource context="(.*)/api/server/v1/(?!(tenants|channel-verified-tenants))(.*)" secured="true" http-method="all">


### PR DESCRIPTION
By adding the below config in deployment.toml file, the login only migration  mode is enabled and except for certain login related API endpoints, all other endpoint's POST, PATCH, PUT operations will be restricted.

```
[resource_access_control.login_only_mode]
enable= true
```

Related issue:
- https://github.com/wso2/product-is/issues/25284