### PR TITLE
Enhance Action Audit logs to include headers parameters createdAt and updatedAt attribute values

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -79,8 +79,9 @@ public class ActionManagementServiceImpl implements ActionManagementService {
 
         DAO_FACADE.addAction(creatingActionDTO, IdentityTenantUtil.getTenantId(tenantDomain));
         Action createdAction = getActionByActionId(actionType, generatedActionId, tenantDomain);
-        ActionDTO auditActionDTO = buildAuditActionDTO(createdAction);
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.ADD, auditActionDTO);
+        ActionDTO createdActionDTO = DAO_FACADE.getActionByActionId(resolvedActionType, generatedActionId,
+                IdentityTenantUtil.getTenantId(tenantDomain));
+        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.ADD, createdActionDTO);
 
         return createdAction;
     }
@@ -158,8 +159,9 @@ public class ActionManagementServiceImpl implements ActionManagementService {
 
         DAO_FACADE.updateAction(updatingActionDTO, existingActionDTO, IdentityTenantUtil.getTenantId(tenantDomain));
         Action updatedAction = getActionByActionId(actionType, actionId, tenantDomain);
-        ActionDTO auditActionDTO = buildAuditActionDTO(updatedAction);
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.UPDATE, auditActionDTO);
+        ActionDTO updatedActionDTO = DAO_FACADE.getActionByActionId(resolvedActionType, actionId,
+                IdentityTenantUtil.getTenantId(tenantDomain));
+        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.UPDATE, updatedActionDTO);
         return updatedAction;
     }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -409,16 +409,4 @@ public class ActionManagementServiceImpl implements ActionManagementService {
                 .rule(actionDTO.getActionRule())
                 .build();
     }
-
-
-    /**
-     * Build ActionDTO from Action object for audit logging purposes.
-     *
-     * @param action The Action object containing all fields including timestamps from database.
-     * @return ActionDTO object with timestamp fields populated for audit logging.
-     */
-    private ActionDTO buildAuditActionDTO(Action action) {
-
-        return new ActionDTOBuilder(action).build();
-    }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -159,7 +159,8 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         DAO_FACADE.updateAction(updatingActionDTO, existingActionDTO, IdentityTenantUtil.getTenantId(tenantDomain));
         ActionDTO updatedActionDTO = DAO_FACADE.getActionByActionId(resolvedActionType, actionId,
                 IdentityTenantUtil.getTenantId(tenantDomain));
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.UPDATE, existingActionDTO);
+        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.UPDATE, updatingActionDTO,
+                updatedActionDTO.getUpdatedAt());
 
         return buildAction(resolvedActionType, updatedActionDTO);
     }
@@ -205,7 +206,8 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         checkIfActionExists(resolvedActionType, actionId, tenantDomain);
         ActionDTO activatedActionDTO = DAO_FACADE.activateAction(resolvedActionType, actionId,
                 IdentityTenantUtil.getTenantId(tenantDomain));
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.ACTIVATE, activatedActionDTO);
+        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.ACTIVATE, actionType, actionId,
+                activatedActionDTO.getUpdatedAt());
         return buildBasicAction(activatedActionDTO);
     }
 
@@ -229,7 +231,8 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         checkIfActionExists(resolvedActionType, actionId, tenantDomain);
         ActionDTO deactivatedActionDTO = DAO_FACADE.deactivateAction(resolvedActionType, actionId,
                 IdentityTenantUtil.getTenantId(tenantDomain));
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.DEACTIVATE, deactivatedActionDTO);
+        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.DEACTIVATE, actionType, actionId,
+                deactivatedActionDTO.getUpdatedAt());
         return buildBasicAction(deactivatedActionDTO);
     }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -80,8 +80,8 @@ public class ActionManagementServiceImpl implements ActionManagementService {
 
         DAO_FACADE.addAction(creatingActionDTO, tenantId);
         ActionDTO createdActionDTO = DAO_FACADE.getActionByActionId(resolvedActionType, generatedActionId, tenantId);
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.ADD,
-                creatingActionDTO, createdActionDTO.getCreatedAt(), true);
+        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.ADD, creatingActionDTO,
+                createdActionDTO.getCreatedAt(), createdActionDTO.getUpdatedAt());
 
         return buildAction(resolvedActionType, createdActionDTO);
     }
@@ -160,8 +160,8 @@ public class ActionManagementServiceImpl implements ActionManagementService {
 
         DAO_FACADE.updateAction(updatingActionDTO, existingActionDTO, tenantId);
         ActionDTO updatedActionDTO = DAO_FACADE.getActionByActionId(resolvedActionType, actionId, tenantId);
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.UPDATE,
-                updatingActionDTO, updatedActionDTO.getUpdatedAt(), false);
+        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.UPDATE, updatingActionDTO,
+                null, updatedActionDTO.getUpdatedAt());
 
         return buildAction(resolvedActionType, updatedActionDTO);
     }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -80,7 +80,8 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         DAO_FACADE.addAction(creatingActionDTO, IdentityTenantUtil.getTenantId(tenantDomain));
         ActionDTO createdActionDTO = DAO_FACADE.getActionByActionId(resolvedActionType, generatedActionId,
                 IdentityTenantUtil.getTenantId(tenantDomain));
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.ADD, createdActionDTO);
+        auditLogger.printCreationAuditLog(ActionManagementAuditLogger.Operation.ADD, creatingActionDTO,
+                createdActionDTO.getCreatedAt());
 
         return buildAction(resolvedActionType, createdActionDTO);
     }
@@ -159,7 +160,7 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         DAO_FACADE.updateAction(updatingActionDTO, existingActionDTO, IdentityTenantUtil.getTenantId(tenantDomain));
         ActionDTO updatedActionDTO = DAO_FACADE.getActionByActionId(resolvedActionType, actionId,
                 IdentityTenantUtil.getTenantId(tenantDomain));
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.UPDATE, updatingActionDTO,
+        auditLogger.printUpdateAuditLog(ActionManagementAuditLogger.Operation.UPDATE, updatingActionDTO,
                 updatedActionDTO.getUpdatedAt());
 
         return buildAction(resolvedActionType, updatedActionDTO);

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -185,8 +185,7 @@ public class ActionManagementServiceImpl implements ActionManagementService {
                 tenantId);
         if (existingActionDTO != null) {
             DAO_FACADE.deleteAction(existingActionDTO, tenantId);
-            auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.DELETE, actionType, actionId,
-                    existingActionDTO.getUpdatedAt());
+            auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.DELETE, actionType, actionId);
         }
     }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -78,12 +78,11 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         ActionDTO creatingActionDTO = buildActionDTO(resolvedActionType, generatedActionId, action);
 
         DAO_FACADE.addAction(creatingActionDTO, IdentityTenantUtil.getTenantId(tenantDomain));
-        Action createdAction = getActionByActionId(actionType, generatedActionId, tenantDomain);
         ActionDTO createdActionDTO = DAO_FACADE.getActionByActionId(resolvedActionType, generatedActionId,
                 IdentityTenantUtil.getTenantId(tenantDomain));
         auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.ADD, createdActionDTO);
 
-        return createdAction;
+        return buildAction(resolvedActionType, createdActionDTO);
     }
 
     /**
@@ -158,11 +157,11 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         ActionDTO updatingActionDTO = buildActionDTO(resolvedActionType, actionId, action);
 
         DAO_FACADE.updateAction(updatingActionDTO, existingActionDTO, IdentityTenantUtil.getTenantId(tenantDomain));
-        Action updatedAction = getActionByActionId(actionType, actionId, tenantDomain);
         ActionDTO updatedActionDTO = DAO_FACADE.getActionByActionId(resolvedActionType, actionId,
                 IdentityTenantUtil.getTenantId(tenantDomain));
         auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.UPDATE, updatedActionDTO);
-        return updatedAction;
+
+        return buildAction(resolvedActionType, updatedActionDTO);
     }
 
     /**

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -79,7 +79,8 @@ public class ActionManagementServiceImpl implements ActionManagementService {
 
         DAO_FACADE.addAction(creatingActionDTO, IdentityTenantUtil.getTenantId(tenantDomain));
         Action createdAction = getActionByActionId(actionType, generatedActionId, tenantDomain);
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.ADD, creatingActionDTO);
+        ActionDTO auditActionDTO = buildAuditActionDTO(createdAction);
+        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.ADD, auditActionDTO);
 
         return createdAction;
     }
@@ -156,8 +157,10 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         ActionDTO updatingActionDTO = buildActionDTO(resolvedActionType, actionId, action);
 
         DAO_FACADE.updateAction(updatingActionDTO, existingActionDTO, IdentityTenantUtil.getTenantId(tenantDomain));
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.UPDATE, updatingActionDTO);
-        return getActionByActionId(actionType, actionId, tenantDomain);
+        Action updatedAction = getActionByActionId(actionType, actionId, tenantDomain);
+        ActionDTO auditActionDTO = buildAuditActionDTO(updatedAction);
+        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.UPDATE, auditActionDTO);
+        return updatedAction;
     }
 
     /**
@@ -403,5 +406,17 @@ public class ActionManagementServiceImpl implements ActionManagementService {
                 .endpoint(actionDTO.getEndpoint())
                 .rule(actionDTO.getActionRule())
                 .build();
+    }
+
+
+    /**
+     * Build ActionDTO from Action object for audit logging purposes.
+     *
+     * @param action The Action object containing all fields including timestamps from database.
+     * @return ActionDTO object with timestamp fields populated for audit logging.
+     */
+    private ActionDTO buildAuditActionDTO(Action action) {
+
+        return new ActionDTOBuilder(action).build();
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -159,7 +159,7 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         DAO_FACADE.updateAction(updatingActionDTO, existingActionDTO, IdentityTenantUtil.getTenantId(tenantDomain));
         ActionDTO updatedActionDTO = DAO_FACADE.getActionByActionId(resolvedActionType, actionId,
                 IdentityTenantUtil.getTenantId(tenantDomain));
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.UPDATE, updatedActionDTO);
+        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.UPDATE, existingActionDTO);
 
         return buildAction(resolvedActionType, updatedActionDTO);
     }
@@ -205,7 +205,7 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         checkIfActionExists(resolvedActionType, actionId, tenantDomain);
         ActionDTO activatedActionDTO = DAO_FACADE.activateAction(resolvedActionType, actionId,
                 IdentityTenantUtil.getTenantId(tenantDomain));
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.ACTIVATE, actionType, actionId);
+        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.ACTIVATE, activatedActionDTO);
         return buildBasicAction(activatedActionDTO);
     }
 
@@ -229,7 +229,7 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         checkIfActionExists(resolvedActionType, actionId, tenantDomain);
         ActionDTO deactivatedActionDTO = DAO_FACADE.deactivateAction(resolvedActionType, actionId,
                 IdentityTenantUtil.getTenantId(tenantDomain));
-        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.DEACTIVATE, actionType, actionId);
+        auditLogger.printAuditLog(ActionManagementAuditLogger.Operation.DEACTIVATE, deactivatedActionDTO);
         return buildBasicAction(deactivatedActionDTO);
     }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementAuditLogger.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementAuditLogger.java
@@ -104,6 +104,10 @@ public class ActionManagementAuditLogger {
                 actionDTO.getDescription() != null ? actionDTO.getDescription() : JSONObject.NULL);
         data.put(LogConstants.ACTION_STATUS_FIELD, actionDTO.getStatus() != null ? actionDTO.getStatus()
                 : JSONObject.NULL);
+        data.put(LogConstants.CREATED_AT_FIELD, actionDTO.getCreatedAt() != null ?
+                actionDTO.getCreatedAt() : JSONObject.NULL);
+        data.put(LogConstants.UPDATED_AT_FIELD, actionDTO.getUpdatedAt() != null ?
+                actionDTO.getUpdatedAt() : JSONObject.NULL);
         if (actionDTO.getEndpoint() != null) {
             data.put(LogConstants.ENDPOINT_CONFIG_FIELD, getEndpointData(actionDTO.getEndpoint()));
         }
@@ -169,6 +173,10 @@ public class ActionManagementAuditLogger {
         JSONObject endpointData = new JSONObject();
         endpointData.put(LogConstants.ENDPOINT_URI_FIELD, endpointConfig.getUri() != null ? endpointConfig.getUri() :
                 JSONObject.NULL);
+        endpointData.put(LogConstants.ALLOWED_HEADERS_FIELD, endpointConfig.getAllowedHeaders() != null ?
+                endpointConfig.getAllowedHeaders() : JSONObject.NULL);
+        endpointData.put(LogConstants.ALLOWED_PARAMETERS_FIELD, endpointConfig.getAllowedParameters() != null ?
+                endpointConfig.getAllowedParameters() : JSONObject.NULL);
         if (endpointConfig.getAuthentication() != null) {
             Authentication authentication = endpointConfig.getAuthentication();
             endpointData.put(LogConstants.AUTHENTICATION_SCHEME_FIELD, authentication.getType());
@@ -277,6 +285,10 @@ public class ActionManagementAuditLogger {
         public static final String API_KEY_HEADER_FIELD = "ApiKeyHeader";
         public static final String API_KEY_VALUE_FIELD = "ApiKeyValue";
         public static final String ACTION_RULE = "Rule";
+        public static final String ALLOWED_HEADERS_FIELD = "AllowedHeaders";
+        public static final String ALLOWED_PARAMETERS_FIELD = "AllowedParameters";
+        public static final String CREATED_AT_FIELD = "CreatedAt";
+        public static final String UPDATED_AT_FIELD = "UpdatedAt";
     }
 }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementAuditLogger.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementAuditLogger.java
@@ -50,6 +50,19 @@ public class ActionManagementAuditLogger {
     private static final Log LOG = org.apache.commons.logging.LogFactory.getLog(ActionManagementAuditLogger.class);
 
     /**
+     * Print action audit log related to the operation by the action type and action ID.
+     *
+     * @param operation  Operation associated with the state change.
+     * @param actionType Type of the action to be logged.
+     * @param actionId   ID of the action to be logged.
+     */
+    public void printAuditLog(Operation operation, String actionType, String actionId) {
+
+        JSONObject data = createAuditLogEntry(actionType, actionId);
+        buildAuditLog(operation, data);
+    }
+
+    /**
      * Print action audit log related to the operation by the action type and action ID with updated time.
      *
      * @param operation  Operation associated with the state change.

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementAuditLogger.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementAuditLogger.java
@@ -90,38 +90,24 @@ public class ActionManagementAuditLogger {
     }
 
     /**
-     * Print action audit log related to the operation by the updated action DTO with updated time.
+     * Print action audit log related to the operation with created/updated time.
      *
-     * @param operation         Operation associated with the state change.
-     * @param updatingActionDTO Updated action object to be logged.
-     * @param updatedAt         Time of the update.
+     * @param operation  Operation associated with the state change.
+     * @param actionDTO  Action object to be logged.
+     * @param timestamp  Time of the creation/update.
+     * @param isCreation Whether the operation is creation or update.
      */
-    public void printUpdateAuditLog(Operation operation, ActionDTO updatingActionDTO, Timestamp updatedAt) {
+    public void printAuditLog(Operation operation, ActionDTO actionDTO,
+                              Timestamp timestamp, boolean isCreation) {
 
         try {
-            JSONObject data = createAuditLogEntry(updatingActionDTO);
-            data.put(LogConstants.UPDATED_AT_FIELD, updatedAt != null ? updatedAt : JSONObject.NULL);
+            JSONObject data = createAuditLogEntry(actionDTO);
+            String fieldName = isCreation ? LogConstants.CREATED_AT_FIELD : LogConstants.UPDATED_AT_FIELD;
+            data.put(fieldName, timestamp != null ? timestamp : JSONObject.NULL);
             buildAuditLog(operation, data);
         } catch (ActionMgtException e) {
-            LOG.warn("Failed to publish audit log for action update. Action id: " + updatingActionDTO.getId(), e);
-        }
-    }
-
-    /**
-     * Print action audit log related to the operation by the created action DTO with created time.
-     *
-     * @param operation         Operation associated with the state change.
-     * @param creatingActionDTO Created action object to be logged.
-     * @param createdAt         Time of the creation.
-     */
-    public void printCreationAuditLog(Operation operation, ActionDTO creatingActionDTO, Timestamp createdAt) {
-
-        try {
-            JSONObject data = createAuditLogEntry(creatingActionDTO);
-            data.put(LogConstants.CREATED_AT_FIELD, createdAt != null ? createdAt : JSONObject.NULL);
-            buildAuditLog(operation, data);
-        } catch (ActionMgtException e) {
-            LOG.warn("Failed to publish audit log for action creation. Action id: " + creatingActionDTO.getId(), e);
+            LOG.warn(String.format("Failed to publish audit log for %s action. Action id: %s",
+                    operation.name().toLowerCase(), actionDTO.getId()), e);
         }
     }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementAuditLogger.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementAuditLogger.java
@@ -50,6 +50,18 @@ public class ActionManagementAuditLogger {
     private static final Log LOG = org.apache.commons.logging.LogFactory.getLog(ActionManagementAuditLogger.class);
 
     /**
+     * Print action audit log related to the operation.
+     *
+     * @param operation Operation associated with the state change.
+     * @param actionDTO Action object to be logged.
+     */
+    public void printAuditLog(Operation operation, ActionDTO actionDTO) throws ActionMgtException {
+
+        JSONObject data = createAuditLogEntry(actionDTO);
+        buildAuditLog(operation, data);
+    }
+
+    /**
      * Print action audit log related to the operation by the action type and action ID.
      *
      * @param operation  Operation associated with the state change.

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementAuditLogger.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementAuditLogger.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.AuditLog;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
+import java.sql.Timestamp;
 import java.util.Map;
 
 import static org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils.jsonObjectToMap;
@@ -69,6 +70,39 @@ public class ActionManagementAuditLogger {
         JSONObject data = createAuditLogEntry(actionType, actionId);
         buildAuditLog(operation, data);
     }
+
+    /**
+     * Print action audit log related to the operation by the action type and action ID with updated time.
+     *
+     * @param operation  Operation associated with the state change.
+     * @param actionType Type of the action to be logged.
+     * @param actionId   ID of the action to be logged.
+     * @param updatedAt  Time of the update.
+     */
+    public void printAuditLog(Operation operation, String actionType, String actionId, Timestamp updatedAt) {
+        JSONObject data = createAuditLogEntry(actionType, actionId);
+        data.put(LogConstants.UPDATED_AT_FIELD, updatedAt != null ? updatedAt : JSONObject.NULL);
+        buildAuditLog(operation, data);
+    }
+
+    /**
+     * Print action audit log related to the operation by the action DTO with updated time.
+     *
+     * @param operation         Operation associated with the state change.
+     * @param updatingActionDTO Action object to be logged.
+     * @param updatedAt         Time of the update.
+     */
+    public void printAuditLog(Operation operation, ActionDTO updatingActionDTO, Timestamp updatedAt) {
+        JSONObject data = null;
+        try {
+            data = createAuditLogEntry(updatingActionDTO);
+        } catch (ActionMgtException e) {
+            data = createAuditLogEntry(String.valueOf(updatingActionDTO.getType()), updatingActionDTO.getId());
+        }
+        data.put(LogConstants.UPDATED_AT_FIELD, updatedAt != null ? updatedAt : JSONObject.NULL);
+        buildAuditLog(operation, data);
+    }
+
 
     /**
      * Build audit log using the provided data.

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementAuditLogger.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementAuditLogger.java
@@ -50,31 +50,6 @@ public class ActionManagementAuditLogger {
     private static final Log LOG = org.apache.commons.logging.LogFactory.getLog(ActionManagementAuditLogger.class);
 
     /**
-     * Print action audit log related to the operation.
-     *
-     * @param operation Operation associated with the state change.
-     * @param actionDTO Action object to be logged.
-     */
-    public void printAuditLog(Operation operation, ActionDTO actionDTO) throws ActionMgtException {
-
-        JSONObject data = createAuditLogEntry(actionDTO);
-        buildAuditLog(operation, data);
-    }
-
-    /**
-     * Print action audit log related to the operation by the action type and action ID.
-     *
-     * @param operation  Operation associated with the state change.
-     * @param actionType Type of the action to be logged.
-     * @param actionId   ID of the action to be logged.
-     */
-    public void printAuditLog(Operation operation, String actionType, String actionId) {
-
-        JSONObject data = createAuditLogEntry(actionType, actionId);
-        buildAuditLog(operation, data);
-    }
-
-    /**
      * Print action audit log related to the operation by the action type and action ID with updated time.
      *
      * @param operation  Operation associated with the state change.
@@ -94,16 +69,16 @@ public class ActionManagementAuditLogger {
      *
      * @param operation  Operation associated with the state change.
      * @param actionDTO  Action object to be logged.
-     * @param timestamp  Time of the creation/update.
-     * @param isCreation Whether the operation is creation or update.
+     * @param createdAt  Time of creation.
+     * @param updatedAt  Time of update.
      */
     public void printAuditLog(Operation operation, ActionDTO actionDTO,
-                              Timestamp timestamp, boolean isCreation) {
+                              Timestamp createdAt, Timestamp updatedAt) {
 
         try {
             JSONObject data = createAuditLogEntry(actionDTO);
-            String fieldName = isCreation ? LogConstants.CREATED_AT_FIELD : LogConstants.UPDATED_AT_FIELD;
-            data.put(fieldName, timestamp != null ? timestamp : JSONObject.NULL);
+            data.put(LogConstants.CREATED_AT_FIELD, createdAt != null ? createdAt : JSONObject.NULL);
+            data.put(LogConstants.UPDATED_AT_FIELD, updatedAt != null ? updatedAt : JSONObject.NULL);
             buildAuditLog(operation, data);
         } catch (ActionMgtException e) {
             LOG.warn(String.format("Failed to publish audit log for %s action. Action id: %s",

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementAuditLogger.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementAuditLogger.java
@@ -94,7 +94,7 @@ public class ActionManagementAuditLogger {
             data.put(LogConstants.UPDATED_AT_FIELD, updatedAt != null ? updatedAt : JSONObject.NULL);
             buildAuditLog(operation, data);
         } catch (ActionMgtException e) {
-            LOG.warn(String.format("Failed to publish audit log for %s action. Action id: %s",
+            LOG.warn(String.format("Failed to publish audit log for %s. Action id: %s",
                     operation.name().toLowerCase(), actionDTO.getId()), e);
         }
     }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
@@ -390,10 +390,10 @@ public class ActionManagementAuditLoggerTest {
     public void testPrintAddActionAuditLog(ActionManagementAuditLogger.Operation operation, ActionDTO creatingActionDTO)
             throws NoSuchFieldException, IllegalAccessException, ActionMgtException {
 
-        Assert.assertNotNull(Timestamp.valueOf(TEST_CREATED_AT), "createdAt should not be null.");
-        Assert.assertNotNull(Timestamp.valueOf(TEST_UPDATED_AT), "updatedAt should not be null.");
         auditLogger.printAuditLog(operation, creatingActionDTO,
                 Timestamp.valueOf(TEST_CREATED_AT), Timestamp.valueOf(TEST_UPDATED_AT));
+        Assert.assertNotNull(Timestamp.valueOf(TEST_CREATED_AT), "createdAt should not be null.");
+        Assert.assertNotNull(Timestamp.valueOf(TEST_UPDATED_AT), "updatedAt should not be null.");
         AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
         assertActionData(capturedArg, creatingActionDTO);
         assertAuditLoggerData(capturedArg, ADD_ACTION);
@@ -404,9 +404,9 @@ public class ActionManagementAuditLoggerTest {
                                               ActionDTO updatingActionDTO)
             throws NoSuchFieldException, IllegalAccessException, ActionMgtException {
 
-        Assert.assertNotNull(Timestamp.valueOf(TEST_UPDATED_AT), "updatedAt should not be null.");
         auditLogger.printAuditLog(operation, updatingActionDTO,
                 null, Timestamp.valueOf(TEST_UPDATED_AT));
+        Assert.assertNotNull(Timestamp.valueOf(TEST_UPDATED_AT), "updatedAt should not be null.");
         AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
         assertActionData(capturedArg, updatingActionDTO);
         assertAuditLoggerData(capturedArg, UPDATE_ACTION);
@@ -431,12 +431,11 @@ public class ActionManagementAuditLoggerTest {
                                                              Timestamp updatedAt) throws
             NoSuchFieldException, IllegalAccessException {
 
-        Assert.assertNotNull(Timestamp.valueOf(TEST_UPDATED_AT), "updatedAt should not be null.");
-
         auditLogger.printAuditLog(operation, actionDTO.getType().name(), actionDTO.getId(), updatedAt);
         AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
 
         Assert.assertNotNull(capturedArg);
+        Assert.assertNotNull(Timestamp.valueOf(TEST_UPDATED_AT), "updatedAt should not be null.");
         Assert.assertEquals(extractMapByField("ActionId", capturedArg), actionDTO.getId());
         Assert.assertEquals(extractMapByField("ActionType", capturedArg), actionDTO.getType().name());
         Assert.assertEquals(extractMapByField("UpdatedAt", capturedArg), String.valueOf(updatedAt));

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
@@ -104,6 +104,8 @@ public class ActionManagementAuditLoggerTest {
     private static final String ADD_ACTION = "add-action";
     private static final String UPDATE_ACTION = "update-action";
     private static final String DELETE_ACTION = "delete-action";
+    private static final String ACTIVATE_ACTION = "activate-action";
+    private static final String DEACTIVATE_ACTION = "deactivate-action";
 
     @BeforeMethod
     public void setUp() throws NoSuchFieldException, IllegalAccessException {
@@ -178,7 +180,7 @@ public class ActionManagementAuditLoggerTest {
                 .certificateContent(TEST_CERTIFICATE_UPDATED).build()).build());
 
         return new Object[][]{
-                // Create object with all the fields.
+                // CREATE/ADD Operations - Test cases for ADD operation
                 {ActionManagementAuditLogger.Operation.ADD,
                         new ActionDTOBuilder()
                                 .id(PRE_UPDATE_PASSWORD_ACTION_ID)
@@ -187,7 +189,7 @@ public class ActionManagementAuditLoggerTest {
                                 .type(Action.ActionTypes.PRE_UPDATE_PASSWORD)
                                 .status(Action.Status.ACTIVE)
                                 .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
+                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                                         .uri(TEST_ACTION_URI)
                                         .allowedHeaders(List.of(TEST_ACTION_ALLOWED_HEADER_1))
@@ -198,7 +200,7 @@ public class ActionManagementAuditLoggerTest {
                                 .rule(ActionRule.create(buildMockORCombinedRule()))
                                 .build()
                 },
-                // Create object without properties
+                // ADD operation without properties
                 {ActionManagementAuditLogger.Operation.ADD,
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
@@ -207,7 +209,7 @@ public class ActionManagementAuditLoggerTest {
                                 .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
                                 .status(Action.Status.ACTIVE)
                                 .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
+                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                                         .uri(TEST_ACTION_URI)
                                         .allowedHeaders(new ArrayList<>())
@@ -217,7 +219,7 @@ public class ActionManagementAuditLoggerTest {
                                         .build())
                                 .build()
                 },
-                // Update Objects
+                // UPDATE Operations - Test cases for UPDATE operation
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
@@ -226,7 +228,7 @@ public class ActionManagementAuditLoggerTest {
                                 .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
                                 .status(Action.Status.ACTIVE)
                                 .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
+                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                                         .uri(TEST_ACTION_URI_UPDATED)
                                         .allowedHeaders(List.of(TEST_ACTION_ALLOWED_HEADER_1))
@@ -243,7 +245,7 @@ public class ActionManagementAuditLoggerTest {
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
                                 .name(TEST_ACTION_NAME_UPDATED)
                                 .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
+                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .build()
                 },
                 {ActionManagementAuditLogger.Operation.UPDATE,
@@ -251,7 +253,7 @@ public class ActionManagementAuditLoggerTest {
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
                                 .description(TEST_ACTION_DESCRIPTION_UPDATED)
                                 .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
+                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .build()
                 },
                 {ActionManagementAuditLogger.Operation.UPDATE,
@@ -264,7 +266,7 @@ public class ActionManagementAuditLoggerTest {
                                         .allowedParameters(Collections.singletonList(TEST_ACTION_ALLOWED_PARAMETER_1))
                                         .build())
                                 .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
+                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .build()
                 },
                 {ActionManagementAuditLogger.Operation.UPDATE,
@@ -276,7 +278,7 @@ public class ActionManagementAuditLoggerTest {
                                         .allowedParameters(Collections.singletonList(TEST_ACTION_ALLOWED_PARAMETER_1))
                                         .build())
                                 .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
+                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .build()
                 },
                 {ActionManagementAuditLogger.Operation.UPDATE,
@@ -288,7 +290,7 @@ public class ActionManagementAuditLoggerTest {
                                         .allowedParameters(Collections.singletonList(TEST_ACTION_ALLOWED_PARAMETER_1))
                                         .build())
                                 .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
+                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .build()
                 },
                 {ActionManagementAuditLogger.Operation.UPDATE,
@@ -296,79 +298,161 @@ public class ActionManagementAuditLoggerTest {
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
                                 .properties(updatedActionProperties)
                                 .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
+                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
+                                .build()
+                },
+                // DELETE Operations - Test cases for DELETE operation
+                {ActionManagementAuditLogger.Operation.DELETE,
+                        new ActionDTOBuilder()
+                                .id(PRE_UPDATE_PASSWORD_ACTION_ID)
+                                .name(TEST_ACTION_NAME)
+                                .description(TEST_ACTION_DESCRIPTION)
+                                .type(Action.ActionTypes.PRE_UPDATE_PASSWORD)
+                                .status(Action.Status.ACTIVE)
+                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
+                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
+                                .endpoint(new EndpointConfig.EndpointConfigBuilder()
+                                        .uri(TEST_ACTION_URI)
+                                        .authentication(new Authentication.BearerAuthBuilder(TEST_ACCESS_TOKEN).build())
+                                        .build())
+                                .build()
+                },
+                // ACTIVATE Operations - Test cases for ACTIVATE operation
+                {ActionManagementAuditLogger.Operation.ACTIVATE,
+                        new ActionDTOBuilder()
+                                .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
+                                .name(TEST_ACTION_NAME)
+                                .description(TEST_ACTION_DESCRIPTION)
+                                .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
+                                .status(Action.Status.ACTIVE)
+                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
+                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
+                                .endpoint(new EndpointConfig.EndpointConfigBuilder()
+                                        .uri(TEST_ACTION_URI)
+                                        .authentication(new Authentication.BasicAuthBuilder(TEST_USERNAME,
+                                                TEST_PASSWORD).build())
+                                        .build())
+                                .build()
+                },
+                // DEACTIVATE Operations - Test cases for DEACTIVATE operation
+                {ActionManagementAuditLogger.Operation.DEACTIVATE,
+                        new ActionDTOBuilder()
+                                .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
+                                .name(TEST_ACTION_NAME)
+                                .description(TEST_ACTION_DESCRIPTION)
+                                .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
+                                .status(Action.Status.INACTIVE)
+                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
+                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
+                                .endpoint(new EndpointConfig.EndpointConfigBuilder()
+                                        .uri(TEST_ACTION_URI)
+                                        .authentication(new Authentication.APIKeyAuthBuilder(TEST_API_KEY_HEADER,
+                                                TEST_API_KEY_VALUE).build())
+                                        .build())
                                 .build()
                 }
         };
     }
 
+    @DataProvider
+    public Object[][] operationWithTimestampDataProvider() {
+
+        return new Object[][]{
+                {ActionManagementAuditLogger.Operation.DELETE, DELETE_ACTION,
+                        Timestamp.valueOf(TEST_UPDATED_AT)},
+                {ActionManagementAuditLogger.Operation.ACTIVATE, ACTIVATE_ACTION,
+                        Timestamp.valueOf(TEST_UPDATED_AT)},
+                {ActionManagementAuditLogger.Operation.DEACTIVATE, DEACTIVATE_ACTION,
+                        Timestamp.valueOf(TEST_UPDATED_AT)},
+                {ActionManagementAuditLogger.Operation.DELETE, DELETE_ACTION, null},
+                {ActionManagementAuditLogger.Operation.ACTIVATE, ACTIVATE_ACTION, null},
+                {ActionManagementAuditLogger.Operation.DEACTIVATE, DEACTIVATE_ACTION, null}
+        };
+    }
+
     @Test(dataProvider = "actionDataProvider")
-    public void testPrintAuditLogWithAction(ActionManagementAuditLogger.Operation operation, ActionDTO actionDTO)
+    public void testPrintAuditLog(ActionManagementAuditLogger.Operation operation, ActionDTO testActionDTO)
             throws NoSuchFieldException, IllegalAccessException, ActionMgtException {
 
-        auditLogger.printAuditLog(operation, actionDTO);
-        AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
-
-        Assert.assertNotNull(capturedArg);
-        assertActionData(capturedArg, actionDTO);
-        assertAuditLoggerData(capturedArg, operation.getLogAction());
-
+        if (operation == ActionManagementAuditLogger.Operation.ADD ||
+                operation == ActionManagementAuditLogger.Operation.UPDATE) {
+            auditLogger.printAuditLog(operation, testActionDTO, testActionDTO.getCreatedAt(),
+                    testActionDTO.getUpdatedAt());
+            AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
+            Assert.assertNotNull(capturedArg);
+            assertActionData(capturedArg, testActionDTO);
+        } else {
+            auditLogger.printAuditLog(operation, testActionDTO.getType().name(), testActionDTO.getId(),
+                    testActionDTO.getUpdatedAt());
+            AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
+            Assert.assertNotNull(capturedArg);
+            Assert.assertEquals(extractMapByField("ActionId", capturedArg), testActionDTO.getId());
+            Assert.assertEquals(extractMapByField("ActionType", capturedArg),
+                    testActionDTO.getType().getActionType());
+            Assert.assertEquals(extractMapByField("UpdatedAt", capturedArg),
+                    testActionDTO.getUpdatedAt().toString());
+        }
+        assertAuditLoggerData(captureTriggerAuditLogEventArgs(), operation.getLogAction());
     }
 
     @Test
-    public void testPrintAuditLogWithActionTypeAndId() throws NoSuchFieldException, IllegalAccessException {
+    public void testPrintDeleteActionAuditLog() throws NoSuchFieldException, IllegalAccessException {
 
-        ActionManagementAuditLogger.Operation operation = ActionManagementAuditLogger.Operation.DELETE;
-        auditLogger.printAuditLog(operation, actionDTO.getType().name(), actionDTO.getId());
+        assertAuditLog(ActionManagementAuditLogger.Operation.DELETE, DELETE_ACTION);
+    }
+
+    @Test
+    public void testPrintActivateAuditLog() throws NoSuchFieldException, IllegalAccessException {
+        assertAuditLog(ActionManagementAuditLogger.Operation.ACTIVATE, ACTIVATE_ACTION);
+    }
+
+    @Test
+    public void testPrintDeactivateAuditLog() throws NoSuchFieldException, IllegalAccessException {
+        assertAuditLog(ActionManagementAuditLogger.Operation.DEACTIVATE, DEACTIVATE_ACTION);
+    }
+
+    @Test(dataProvider = "operationWithTimestampDataProvider")
+    public void testPrintAuditLogWithActionTypeIdAndTimestamp(ActionManagementAuditLogger.Operation operation,
+                                                              String expectedLogAction, Timestamp updatedAt)
+            throws NoSuchFieldException, IllegalAccessException {
+
+        auditLogger.printAuditLog(operation, actionDTO.getType().name(), actionDTO.getId(), updatedAt);
         AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
 
         Assert.assertNotNull(capturedArg);
         Assert.assertEquals(extractMapByField("ActionId", capturedArg), actionDTO.getId());
         Assert.assertEquals(extractMapByField("ActionType", capturedArg),
                 Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN.getActionType());
-        assertAuditLoggerData(capturedArg, DELETE_ACTION);
 
+        if (updatedAt != null) {
+            Assert.assertEquals(extractMapByField("UpdatedAt", capturedArg), updatedAt.toString());
+        } else {
+            Assert.assertNull(extractMapByField("UpdatedAt", capturedArg));
+        }
+
+        assertAuditLoggerData(capturedArg, expectedLogAction);
     }
 
-    @Test
-    public void testPrintAuditLogWithActionDTOAndCreatedAt() throws Exception {
+    /**
+     * Helper method to assert audit log for DELETE, ACTIVATE and DEACTIVATE operations.
+     *
+     * @param operation      Operation to be logged.
+     * @param expectedAction Expected action string in the audit log.
+     * @throws NoSuchFieldException   if the provided field does not exist.
+     * @throws IllegalAccessException if the provided field is not accessible.
+     */
+    private void assertAuditLog(ActionManagementAuditLogger.Operation operation, String expectedAction)
+            throws NoSuchFieldException, IllegalAccessException {
 
-        Timestamp now = Timestamp.valueOf(TEST_CREATED_AT);
-        ActionManagementAuditLogger.Operation operation = ActionManagementAuditLogger.Operation.ADD;
-
-        auditLogger.printAuditLog(operation, actionDTO, now, true);
+        auditLogger.printAuditLog(operation, actionDTO.getType().name(),
+                actionDTO.getId(), actionDTO.getUpdatedAt());
         AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
 
         Assert.assertNotNull(capturedArg);
-        Assert.assertEquals(extractMapByField("CreatedAt", capturedArg), String.valueOf(now));
-        assertAuditLoggerData(capturedArg, ADD_ACTION);
-    }
-
-    @Test
-    public void testPrintAuditLogWithActionDTOAndUpdatedAt() throws Exception {
-
-        Timestamp now = Timestamp.valueOf(TEST_UPDATED_AT);
-        ActionManagementAuditLogger.Operation operation = ActionManagementAuditLogger.Operation.UPDATE;
-
-        auditLogger.printAuditLog(operation, actionDTO, now, false);
-        AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
-
-        Assert.assertNotNull(capturedArg);
-        Assert.assertEquals(extractMapByField("UpdatedAt", capturedArg), String.valueOf(now));
-        assertAuditLoggerData(capturedArg, UPDATE_ACTION);
-    }
-
-    @Test
-    public void testPrintAuditLogWithActionDTOAndNullTimestamp() throws Exception {
-
-        ActionManagementAuditLogger.Operation operation = ActionManagementAuditLogger.Operation.UPDATE;
-
-        auditLogger.printAuditLog(operation, actionDTO, null, false);
-        AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
-
-        Assert.assertNotNull(capturedArg);
-        Assert.assertEquals(extractMapByField("UpdatedAt", capturedArg), null);
-        assertAuditLoggerData(capturedArg, UPDATE_ACTION);
+        Assert.assertEquals(extractMapByField("ActionId", capturedArg), actionDTO.getId());
+        Assert.assertEquals(extractMapByField("ActionType", capturedArg),
+                Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN.getActionType());;
+        assertAuditLoggerData(capturedArg, expectedAction);
     }
 
     /**
@@ -558,6 +642,12 @@ public class ActionManagementAuditLoggerTest {
                 break;
             case DELETE_ACTION:
                 Assert.assertEquals(extractField("action", auditLogBuilder), "delete-action");
+                break;
+            case ACTIVATE_ACTION:
+                Assert.assertEquals(extractField("action", auditLogBuilder), "activate-action");
+                break;
+            case DEACTIVATE_ACTION:
+                Assert.assertEquals(extractField("action", auditLogBuilder), "deactivate-action");
                 break;
         }
     }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
@@ -300,6 +300,19 @@ public class ActionManagementAuditLoggerTest {
         };
     }
 
+    @Test(dataProvider = "actionDataProvider")
+    public void testPrintAuditLogWithAction(ActionManagementAuditLogger.Operation operation, ActionDTO actionDTO)
+            throws NoSuchFieldException, IllegalAccessException, ActionMgtException {
+
+        auditLogger.printAuditLog(operation, actionDTO);
+        AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
+
+        Assert.assertNotNull(capturedArg);
+        assertActionData(capturedArg, actionDTO);
+        assertAuditLoggerData(capturedArg, operation.getLogAction());
+
+    }
+
     @Test
     public void testPrintAuditLogWithActionTypeAndId() throws NoSuchFieldException, IllegalAccessException {
 
@@ -313,87 +326,6 @@ public class ActionManagementAuditLoggerTest {
                 Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN.getActionType());
         assertAuditLoggerData(capturedArg, DELETE_ACTION);
 
-    }
-
-    @Test
-    public void printsUpdateAuditLogWithActionDTOAndUpdatedAt() throws Exception {
-
-        ActionManagementAuditLogger.Operation operation = ActionManagementAuditLogger.Operation.UPDATE;
-        java.sql.Timestamp updatedAt = new java.sql.Timestamp(System.currentTimeMillis());
-
-        auditLogger.printUpdateAuditLog(operation, actionDTO, updatedAt);
-        AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
-
-        Assert.assertNotNull(capturedArg);
-        assertActionData(capturedArg, actionDTO);
-
-        Field dataField = AuditLog.AuditLogBuilder.class.getDeclaredField("data");
-        dataField.setAccessible(true);
-        Map<String, Object> dataMap = (Map<String, Object>) dataField.get(capturedArg);
-        Assert.assertEquals(dataMap.get("UpdatedAt") != null ? dataMap.get("UpdatedAt").toString() : null,
-                updatedAt.toString());
-
-        assertAuditLoggerData(capturedArg, UPDATE_ACTION);
-    }
-
-    @Test
-    public void printsCreationAuditLogWithActionDTOAndCreatedAt() throws Exception {
-
-        ActionManagementAuditLogger.Operation operation = ActionManagementAuditLogger.Operation.ADD;
-        java.sql.Timestamp createdAt = new java.sql.Timestamp(System.currentTimeMillis());
-
-        auditLogger.printCreationAuditLog(operation, actionDTO, createdAt);
-        AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
-
-        Assert.assertNotNull(capturedArg);
-        assertActionData(capturedArg, actionDTO);
-
-        Field dataField = AuditLog.AuditLogBuilder.class.getDeclaredField("data");
-        dataField.setAccessible(true);
-        Map<String, Object> dataMap = (Map<String, Object>) dataField.get(capturedArg);
-        Assert.assertEquals(dataMap.get("CreatedAt") != null ? dataMap.get("CreatedAt").toString() : null,
-                createdAt.toString());
-
-        assertAuditLoggerData(capturedArg, ADD_ACTION);
-    }
-
-    @Test
-    public void printsAuditLogWithTypeIdAndNullUpdatedAt() throws NoSuchFieldException, IllegalAccessException {
-
-        ActionManagementAuditLogger.Operation operation = ActionManagementAuditLogger.Operation.UPDATE;
-
-        auditLogger.printAuditLog(operation, actionDTO.getType().name(), actionDTO.getId(), null);
-        AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
-
-        Assert.assertNotNull(capturedArg);
-        Assert.assertEquals(extractMapByField("ActionId", capturedArg), actionDTO.getId());
-        Assert.assertEquals(extractMapByField("ActionType", capturedArg),
-                Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN.getActionType());
-
-        Field dataField = AuditLog.AuditLogBuilder.class.getDeclaredField("data");
-        dataField.setAccessible(true);
-        Map<String, Object> dataMap = (Map<String, Object>) dataField.get(capturedArg);
-        Assert.assertNull(dataMap.get("UpdatedAt"));
-
-        assertAuditLoggerData(capturedArg, UPDATE_ACTION);
-    }
-
-    @Test
-    public void printsCreationAuditLogWithNullCreatedAt() throws NoSuchFieldException, IllegalAccessException {
-
-        ActionManagementAuditLogger.Operation operation = ActionManagementAuditLogger.Operation.ADD;
-
-        auditLogger.printCreationAuditLog(operation, actionDTO, null);
-        AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
-
-        Assert.assertNotNull(capturedArg);
-
-        Field dataField = AuditLog.AuditLogBuilder.class.getDeclaredField("data");
-        dataField.setAccessible(true);
-        Map<String, Object> dataMap = (Map<String, Object>) dataField.get(capturedArg);
-        Assert.assertNull(dataMap.get("CreatedAt"));
-
-        assertAuditLoggerData(capturedArg, ADD_ACTION);
     }
 
     /**

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
@@ -81,6 +81,7 @@ import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_API_
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_CERTIFICATE;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_CERTIFICATE_UPDATED;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_CREATED_AT;
+import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_DELETED_PROPERTY;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_PASSWORD;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_PASSWORD_SHARING_TYPE;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_PASSWORD_SHARING_TYPE_UPDATED;
@@ -235,21 +236,27 @@ public class ActionManagementAuditLoggerTest {
     public Object[][] updateActionDataProvider() {
 
         Map<String, ActionProperty> updatedActionProperties = new HashMap<>();
+        Map<String, ActionProperty> deleteActionProperties = new HashMap<>();
         updatedActionProperties.put(PASSWORD_SHARING_TYPE_PROPERTY_NAME,
                 new ActionProperty.BuilderForService(TEST_PASSWORD_SHARING_TYPE_UPDATED).build());
         updatedActionProperties.put(CERTIFICATE_PROPERTY_NAME, new ActionProperty.BuilderForService(new Certificate
                 .Builder().id(CERTIFICATE_ID).name(CERTIFICATE_NAME)
                 .certificateContent(TEST_CERTIFICATE_UPDATED).build()).build());
 
+        deleteActionProperties.put(PASSWORD_SHARING_TYPE_PROPERTY_NAME,
+                new ActionProperty.BuilderForService(TEST_DELETED_PROPERTY).build());
+        deleteActionProperties.put(CERTIFICATE_PROPERTY_NAME,
+                new ActionProperty.BuilderForService(TEST_DELETED_PROPERTY).build());
+
         return new Object[][]{
                 // UPDATE Operations - Test cases for UPDATE operation
                 // full action update
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
-                                .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
+                                .id(PRE_UPDATE_PASSWORD_ACTION_ID)
                                 .name(TEST_ACTION_NAME_UPDATED)
                                 .description(TEST_ACTION_DESCRIPTION_UPDATED)
-                                .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
+                                .type(Action.ActionTypes.PRE_UPDATE_PASSWORD)
                                 .status(Action.Status.ACTIVE)
                                 .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
@@ -290,7 +297,21 @@ public class ActionManagementAuditLoggerTest {
                                         .build())
                                 .build()
                 },
-                // Update action endpoint
+                // Update action endpoint with allowed headers and parameters
+                {ActionManagementAuditLogger.Operation.UPDATE,
+                        new ActionDTOBuilder()
+                                .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
+                                .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
+                                .endpoint(new EndpointConfig.EndpointConfigBuilder()
+                                        .uri(TEST_ACTION_URI_UPDATED)
+                                        .allowedHeaders(List.of(TEST_ACTION_ALLOWED_HEADER_1))
+                                        .allowedParameters(List.of(TEST_ACTION_ALLOWED_PARAMETER_1))
+                                        .authentication(new Authentication.BasicAuthBuilder(TEST_USERNAME,
+                                                TEST_PASSWORD).build())
+                                        .build())
+                                .build()
+                },
+                // Update action endpoint uri
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
@@ -332,7 +353,7 @@ public class ActionManagementAuditLoggerTest {
                                         .build())
                                 .build()
                 },
-                // Update action properties - PRE UPDATE PASSWORD
+                // Update action properties
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
                                 .id(PRE_UPDATE_PASSWORD_ACTION_ID)
@@ -345,7 +366,7 @@ public class ActionManagementAuditLoggerTest {
                         new ActionDTOBuilder()
                                 .id(PRE_UPDATE_PASSWORD_ACTION_ID)
                                 .type(Action.ActionTypes.PRE_UPDATE_PASSWORD)
-                                .properties(new HashMap<>())
+                                .properties(deleteActionProperties)
                                 .build()
                 }
         };
@@ -357,11 +378,9 @@ public class ActionManagementAuditLoggerTest {
         return new Object[][]{
 
                 {ActionManagementAuditLogger.Operation.ACTIVATE,
-                        ACTIVATE_ACTION,
                         Timestamp.valueOf(TEST_UPDATED_AT)
                 },
                 {ActionManagementAuditLogger.Operation.DEACTIVATE,
-                        DEACTIVATE_ACTION,
                         Timestamp.valueOf(TEST_UPDATED_AT)
                 }
         };
@@ -406,7 +425,7 @@ public class ActionManagementAuditLoggerTest {
 
     @Test(dataProvider = "activateAndDeactivateActionDataProvider")
     public void testPrintActivateAndDeactivateActionAuditLog(ActionManagementAuditLogger.Operation operation,
-                                                             String actionName, Timestamp updatedAt) throws
+                                                             Timestamp updatedAt) throws
             NoSuchFieldException, IllegalAccessException {
 
         auditLogger.printAuditLog(operation, actionDTO.getType().name(), actionDTO.getId(), updatedAt);

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
@@ -390,6 +390,8 @@ public class ActionManagementAuditLoggerTest {
     public void testPrintAddActionAuditLog(ActionManagementAuditLogger.Operation operation, ActionDTO creatingActionDTO)
             throws NoSuchFieldException, IllegalAccessException, ActionMgtException {
 
+        Assert.assertNotNull(Timestamp.valueOf(TEST_CREATED_AT), "createdAt should not be null.");
+        Assert.assertNotNull(Timestamp.valueOf(TEST_UPDATED_AT), "updatedAt should not be null.");
         auditLogger.printAuditLog(operation, creatingActionDTO,
                 Timestamp.valueOf(TEST_CREATED_AT), Timestamp.valueOf(TEST_UPDATED_AT));
         AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
@@ -402,6 +404,7 @@ public class ActionManagementAuditLoggerTest {
                                               ActionDTO updatingActionDTO)
             throws NoSuchFieldException, IllegalAccessException, ActionMgtException {
 
+        Assert.assertNotNull(Timestamp.valueOf(TEST_UPDATED_AT), "updatedAt should not be null.");
         auditLogger.printAuditLog(operation, updatingActionDTO,
                 null, Timestamp.valueOf(TEST_UPDATED_AT));
         AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
@@ -427,6 +430,8 @@ public class ActionManagementAuditLoggerTest {
     public void testPrintActivateAndDeactivateActionAuditLog(ActionManagementAuditLogger.Operation operation,
                                                              Timestamp updatedAt) throws
             NoSuchFieldException, IllegalAccessException {
+
+        Assert.assertNotNull(Timestamp.valueOf(TEST_UPDATED_AT), "updatedAt should not be null.");
 
         auditLogger.printAuditLog(operation, actionDTO.getType().name(), actionDTO.getId(), updatedAt);
         AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
@@ -515,8 +520,6 @@ public class ActionManagementAuditLoggerTest {
         String description = actionDTO.getDescription();
         String type = actionDTO.getType() != null ? actionDTO.getType().name() : null;
         String status = actionDTO.getStatus() != null ? actionDTO.getStatus().name() : null;
-        String createdAt = actionDTO.getCreatedAt() != null ? String.valueOf(actionDTO.getCreatedAt()) : null;
-        String updatedAt = actionDTO.getUpdatedAt() != null ? String.valueOf(actionDTO.getUpdatedAt()) : null;
 
         String uri = actionDTO.getEndpoint() != null && actionDTO.getEndpoint().getUri() != null ?
                 actionDTO.getEndpoint().getUri() : null;

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
@@ -50,7 +50,11 @@ import org.wso2.carbon.identity.rule.management.api.util.AuditLogBuilderForRule;
 import org.wso2.carbon.utils.AuditLog;
 
 import java.lang.reflect.Field;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -64,6 +68,8 @@ import static org.wso2.carbon.identity.action.management.util.TestUtil.PASSWORD_
 import static org.wso2.carbon.identity.action.management.util.TestUtil.PRE_ISSUE_ACCESS_TOKEN_ACTION_ID;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.PRE_UPDATE_PASSWORD_ACTION_ID;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_ACCESS_TOKEN;
+import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_ACTION_ALLOWED_HEADER_1;
+import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_ACTION_ALLOWED_PARAMETER_1;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_ACTION_DESCRIPTION;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_ACTION_DESCRIPTION_UPDATED;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_ACTION_NAME;
@@ -133,6 +139,8 @@ public class ActionManagementAuditLoggerTest {
                 .status(Action.Status.ACTIVE)
                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                         .uri(TEST_ACTION_URI)
+                        .allowedHeaders(Collections.singletonList(TEST_ACTION_ALLOWED_HEADER_1))
+                        .allowedParameters(Collections.singletonList(TEST_ACTION_ALLOWED_PARAMETER_1))
                         .authentication(new Authentication.BearerAuthBuilder(TEST_ACCESS_TOKEN).build())
                         .build())
                 .properties(actionProperties)
@@ -171,61 +179,77 @@ public class ActionManagementAuditLoggerTest {
                 // Create object with all the fields.
                 {ActionManagementAuditLogger.Operation.ADD,
                         new ActionDTOBuilder()
-                        .id(PRE_UPDATE_PASSWORD_ACTION_ID)
-                        .name(TEST_ACTION_NAME)
-                        .description(TEST_ACTION_DESCRIPTION)
-                        .type(Action.ActionTypes.PRE_UPDATE_PASSWORD)
-                        .status(Action.Status.ACTIVE)
-                        .endpoint(new EndpointConfig.EndpointConfigBuilder()
-                                .uri(TEST_ACTION_URI)
-                                .authentication(new Authentication.BearerAuthBuilder(TEST_ACCESS_TOKEN).build())
-                                .build())
-                        .properties(actionProperties)
-                        .rule(ActionRule.create(buildMockORCombinedRule()))
-                        .build()
+                                .id(PRE_UPDATE_PASSWORD_ACTION_ID)
+                                .name(TEST_ACTION_NAME)
+                                .description(TEST_ACTION_DESCRIPTION)
+                                .type(Action.ActionTypes.PRE_UPDATE_PASSWORD)
+                                .status(Action.Status.ACTIVE)
+                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
+                                .endpoint(new EndpointConfig.EndpointConfigBuilder()
+                                        .uri(TEST_ACTION_URI)
+                                        .allowedHeaders(List.of(TEST_ACTION_ALLOWED_HEADER_1))
+                                        .allowedParameters(List.of(TEST_ACTION_ALLOWED_PARAMETER_1))
+                                        .authentication(new Authentication.BearerAuthBuilder(TEST_ACCESS_TOKEN).build())
+                                        .build())
+                                .properties(actionProperties)
+                                .rule(ActionRule.create(buildMockORCombinedRule()))
+                                .build()
                 },
                 // Create object without properties
                 {ActionManagementAuditLogger.Operation.ADD,
                         new ActionDTOBuilder()
-                        .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
-                        .name(TEST_ACTION_NAME)
-                        .description(TEST_ACTION_DESCRIPTION)
-                        .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
-                        .status(Action.Status.ACTIVE)
-                        .endpoint(new EndpointConfig.EndpointConfigBuilder()
-                                .uri(TEST_ACTION_URI)
-                                .authentication(new Authentication.BasicAuthBuilder(TEST_USERNAME, TEST_PASSWORD)
+                                .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
+                                .name(TEST_ACTION_NAME)
+                                .description(TEST_ACTION_DESCRIPTION)
+                                .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
+                                .status(Action.Status.ACTIVE)
+                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
+                                .endpoint(new EndpointConfig.EndpointConfigBuilder()
+                                        .uri(TEST_ACTION_URI)
+                                        .allowedHeaders(new ArrayList<>())
+                                        .allowedParameters(new ArrayList<>())
+                                        .authentication(new Authentication.BasicAuthBuilder(TEST_USERNAME,
+                                                TEST_PASSWORD).build())
                                         .build())
-                                .build())
-                        .build()
+                                .build()
                 },
                 // Update Objects
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
-                        .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
-                        .name(TEST_ACTION_NAME_UPDATED)
-                        .description(TEST_ACTION_DESCRIPTION_UPDATED)
-                        .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
-                        .status(Action.Status.ACTIVE)
-                        .endpoint(new EndpointConfig.EndpointConfigBuilder()
-                                .uri(TEST_ACTION_URI_UPDATED)
-                                .authentication(new Authentication.APIKeyAuthBuilder(TEST_API_KEY_HEADER,
-                                        TEST_API_KEY_VALUE).build())
-                                .build())
-                        .properties(updatedActionProperties)
-                        .rule(ActionRule.create(buildMockORCombinedRule()))
-                        .build()
+                                .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
+                                .name(TEST_ACTION_NAME_UPDATED)
+                                .description(TEST_ACTION_DESCRIPTION_UPDATED)
+                                .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
+                                .status(Action.Status.ACTIVE)
+                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
+                                .endpoint(new EndpointConfig.EndpointConfigBuilder()
+                                        .uri(TEST_ACTION_URI_UPDATED)
+                                        .allowedHeaders(List.of(TEST_ACTION_ALLOWED_HEADER_1))
+                                        .allowedParameters(List.of(TEST_ACTION_ALLOWED_PARAMETER_1))
+                                        .authentication(new Authentication.APIKeyAuthBuilder(TEST_API_KEY_HEADER,
+                                                TEST_API_KEY_VALUE).build())
+                                        .build())
+                                .properties(updatedActionProperties)
+                                .rule(ActionRule.create(buildMockORCombinedRule()))
+                                .build()
                 },
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
                                 .name(TEST_ACTION_NAME_UPDATED)
+                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .build()
                 },
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
                                 .description(TEST_ACTION_DESCRIPTION_UPDATED)
+                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .build()
                 },
                 {ActionManagementAuditLogger.Operation.UPDATE,
@@ -234,7 +258,11 @@ public class ActionManagementAuditLoggerTest {
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                                         .uri(TEST_ACTION_URI)
                                         .authentication(new Authentication.NoneAuthBuilder().build())
+                                        .allowedHeaders(Collections.singletonList(TEST_ACTION_ALLOWED_HEADER_1))
+                                        .allowedParameters(Collections.singletonList(TEST_ACTION_ALLOWED_PARAMETER_1))
                                         .build())
+                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .build()
                 },
                 {ActionManagementAuditLogger.Operation.UPDATE,
@@ -242,7 +270,11 @@ public class ActionManagementAuditLoggerTest {
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                                         .uri(TEST_ACTION_URI)
+                                        .allowedHeaders(Collections.singletonList(TEST_ACTION_ALLOWED_HEADER_1))
+                                        .allowedParameters(Collections.singletonList(TEST_ACTION_ALLOWED_PARAMETER_1))
                                         .build())
+                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .build()
                 },
                 {ActionManagementAuditLogger.Operation.UPDATE,
@@ -250,13 +282,19 @@ public class ActionManagementAuditLoggerTest {
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                                         .authentication(new Authentication.BearerAuthBuilder(TEST_ACCESS_TOKEN).build())
+                                        .allowedHeaders(Collections.singletonList(TEST_ACTION_ALLOWED_HEADER_1))
+                                        .allowedParameters(Collections.singletonList(TEST_ACTION_ALLOWED_PARAMETER_1))
                                         .build())
+                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .build()
                 },
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
                                 .properties(updatedActionProperties)
+                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .build()
                 }
         };
@@ -362,8 +400,16 @@ public class ActionManagementAuditLoggerTest {
         String description = actionDTO.getDescription();
         String type = actionDTO.getType() != null ? actionDTO.getType().name() : null;
         String status = actionDTO.getStatus() != null ? actionDTO.getStatus().name() : null;
+        String createdAt = actionDTO.getCreatedAt() != null ? String.valueOf(actionDTO.getCreatedAt()) : null;
+        String updatedAt = actionDTO.getUpdatedAt() != null ? String.valueOf(actionDTO.getUpdatedAt()) : null;
+
         String uri = actionDTO.getEndpoint() != null && actionDTO.getEndpoint().getUri() != null ?
                 actionDTO.getEndpoint().getUri() : null;
+        String allowedHeaders = actionDTO.getEndpoint() != null && actionDTO.getEndpoint().getAllowedHeaders() != null ?
+                actionDTO.getEndpoint().getAllowedHeaders().toString() : null;
+        String allowedParameters = actionDTO.getEndpoint() != null &&
+                actionDTO.getEndpoint().getAllowedParameters() != null ?
+                actionDTO.getEndpoint().getAllowedParameters().toString() : null;
         String authenticationScheme = actionDTO.getEndpoint() != null &&
                 actionDTO.getEndpoint().getAuthentication() != null &&
                 actionDTO.getEndpoint().getAuthentication().getType() != null ?
@@ -376,7 +422,11 @@ public class ActionManagementAuditLoggerTest {
         assertField(description != null, dataMap, "ActionDescription", description);
         assertField(type != null, dataMap, "ActionType", type);
         assertField(status != null, dataMap, "ActionStatus", status);
+        assertField(createdAt != null, dataMap, "CreatedAt", createdAt);
+        assertField(updatedAt != null, dataMap, "UpdatedAt", updatedAt);
         assertField(uri != null, endpointConfigMap, "EndpointUri", uri);
+        assertField(allowedHeaders != null, endpointConfigMap, "AllowedHeaders", allowedHeaders);
+        assertField(allowedParameters != null, endpointConfigMap, "AllowedParameters", allowedParameters);
         assertField(authenticationScheme != null, endpointConfigMap, "AuthenticationScheme",
                 authenticationScheme);
         assertField(rule != null, dataMap, "Rule", rule);

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
@@ -258,7 +258,6 @@ public class ActionManagementAuditLoggerTest {
                                 .description(TEST_ACTION_DESCRIPTION_UPDATED)
                                 .type(Action.ActionTypes.PRE_UPDATE_PASSWORD)
                                 .status(Action.Status.ACTIVE)
-                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                                         .uri(TEST_ACTION_URI_UPDATED)
                                         .allowedHeaders(List.of(TEST_ACTION_ALLOWED_HEADER_1))
@@ -390,11 +389,13 @@ public class ActionManagementAuditLoggerTest {
     public void testPrintAddActionAuditLog(ActionManagementAuditLogger.Operation operation, ActionDTO creatingActionDTO)
             throws NoSuchFieldException, IllegalAccessException, ActionMgtException {
 
-        auditLogger.printAuditLog(operation, creatingActionDTO,
-                Timestamp.valueOf(TEST_CREATED_AT), Timestamp.valueOf(TEST_UPDATED_AT));
-        Assert.assertNotNull(Timestamp.valueOf(TEST_CREATED_AT), "createdAt should not be null.");
-        Assert.assertNotNull(Timestamp.valueOf(TEST_UPDATED_AT), "updatedAt should not be null.");
+        Timestamp createdAt = Timestamp.valueOf(TestUtil.TEST_CREATED_AT);
+        Timestamp updatedAt = Timestamp.valueOf(TestUtil.TEST_UPDATED_AT);
+        auditLogger.printAuditLog(operation, creatingActionDTO, createdAt, updatedAt);
+
         AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
+        Assert.assertEquals(extractMapByField("CreatedAt", capturedArg), String.valueOf(createdAt));
+        Assert.assertEquals(extractMapByField("UpdatedAt", capturedArg), String.valueOf(updatedAt));
         assertActionData(capturedArg, creatingActionDTO);
         assertAuditLoggerData(capturedArg, ADD_ACTION);
     }
@@ -404,10 +405,12 @@ public class ActionManagementAuditLoggerTest {
                                               ActionDTO updatingActionDTO)
             throws NoSuchFieldException, IllegalAccessException, ActionMgtException {
 
-        auditLogger.printAuditLog(operation, updatingActionDTO,
-                null, Timestamp.valueOf(TEST_UPDATED_AT));
-        Assert.assertNotNull(Timestamp.valueOf(TEST_UPDATED_AT), "updatedAt should not be null.");
+        Timestamp updatedAt = Timestamp.valueOf(TEST_UPDATED_AT);
+        auditLogger.printAuditLog(operation, updatingActionDTO, null, updatedAt);
+
         AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
+        Assert.assertNotNull(capturedArg);
+        Assert.assertEquals(extractMapByField("UpdatedAt", capturedArg), String.valueOf(updatedAt));
         assertActionData(capturedArg, updatingActionDTO);
         assertAuditLoggerData(capturedArg, UPDATE_ACTION);
     }
@@ -435,7 +438,6 @@ public class ActionManagementAuditLoggerTest {
         AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
 
         Assert.assertNotNull(capturedArg);
-        Assert.assertNotNull(Timestamp.valueOf(TEST_UPDATED_AT), "updatedAt should not be null.");
         Assert.assertEquals(extractMapByField("ActionId", capturedArg), actionDTO.getId());
         Assert.assertEquals(extractMapByField("ActionType", capturedArg), actionDTO.getType().name());
         Assert.assertEquals(extractMapByField("UpdatedAt", capturedArg), String.valueOf(updatedAt));

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
@@ -163,7 +163,7 @@ public class ActionManagementAuditLoggerTest {
     }
 
     @DataProvider
-    public Object[][] actionDataProvider() {
+    public Object[][] addActionDataProvider() {
 
         Map<String, ActionProperty> actionProperties = new HashMap<>();
         actionProperties.put(PASSWORD_SHARING_TYPE_PROPERTY_NAME,
@@ -171,13 +171,6 @@ public class ActionManagementAuditLoggerTest {
         actionProperties.put(CERTIFICATE_PROPERTY_NAME, new ActionProperty.BuilderForService(new Certificate.Builder()
                 .id(CERTIFICATE_ID).name(CERTIFICATE_NAME)
                 .certificateContent(TEST_CERTIFICATE).build()).build());
-
-        Map<String, ActionProperty> updatedActionProperties = new HashMap<>();
-        updatedActionProperties.put(PASSWORD_SHARING_TYPE_PROPERTY_NAME,
-                new ActionProperty.BuilderForService(TEST_PASSWORD_SHARING_TYPE_UPDATED).build());
-        updatedActionProperties.put(CERTIFICATE_PROPERTY_NAME, new ActionProperty.BuilderForService(new Certificate
-                .Builder().id(CERTIFICATE_ID).name(CERTIFICATE_NAME)
-                .certificateContent(TEST_CERTIFICATE_UPDATED).build()).build());
 
         return new Object[][]{
                 // CREATE/ADD Operations - Test cases for ADD operation
@@ -219,7 +212,38 @@ public class ActionManagementAuditLoggerTest {
                                         .build())
                                 .build()
                 },
+                // Add operation without allowed headers and parameters
+                {ActionManagementAuditLogger.Operation.ADD,
+                        new ActionDTOBuilder()
+                                .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
+                                .name(TEST_ACTION_NAME)
+                                .description(TEST_ACTION_DESCRIPTION)
+                                .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
+                                .status(Action.Status.ACTIVE)
+                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
+                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
+                                .endpoint(new EndpointConfig.EndpointConfigBuilder()
+                                        .uri(TEST_ACTION_URI)
+                                        .authentication(new Authentication.NoneAuthBuilder().build())
+                                        .build())
+                                .build()
+                }
+        };
+    }
+
+    @DataProvider
+    public Object[][] updateActionDataProvider() {
+
+        Map<String, ActionProperty> updatedActionProperties = new HashMap<>();
+        updatedActionProperties.put(PASSWORD_SHARING_TYPE_PROPERTY_NAME,
+                new ActionProperty.BuilderForService(TEST_PASSWORD_SHARING_TYPE_UPDATED).build());
+        updatedActionProperties.put(CERTIFICATE_PROPERTY_NAME, new ActionProperty.BuilderForService(new Certificate
+                .Builder().id(CERTIFICATE_ID).name(CERTIFICATE_NAME)
+                .certificateContent(TEST_CERTIFICATE_UPDATED).build()).build());
+
+        return new Object[][]{
                 // UPDATE Operations - Test cases for UPDATE operation
+                // full action update
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
@@ -227,7 +251,6 @@ public class ActionManagementAuditLoggerTest {
                                 .description(TEST_ACTION_DESCRIPTION_UPDATED)
                                 .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
                                 .status(Action.Status.ACTIVE)
-                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
                                 .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                                         .uri(TEST_ACTION_URI_UPDATED)
@@ -240,109 +263,131 @@ public class ActionManagementAuditLoggerTest {
                                 .rule(ActionRule.create(buildMockORCombinedRule()))
                                 .build()
                 },
+                // Update action name
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
+                                .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
                                 .name(TEST_ACTION_NAME_UPDATED)
-                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .build()
                 },
+                // Update action description
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
+                                .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
                                 .description(TEST_ACTION_DESCRIPTION_UPDATED)
-                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .build()
                 },
+                // Update action endpoint
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
+                                .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                                         .uri(TEST_ACTION_URI)
                                         .authentication(new Authentication.NoneAuthBuilder().build())
-                                        .allowedHeaders(Collections.singletonList(TEST_ACTION_ALLOWED_HEADER_1))
-                                        .allowedParameters(Collections.singletonList(TEST_ACTION_ALLOWED_PARAMETER_1))
                                         .build())
-                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .build()
                 },
+                // Update action endpoint
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
+                                .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                                         .uri(TEST_ACTION_URI)
-                                        .allowedHeaders(Collections.singletonList(TEST_ACTION_ALLOWED_HEADER_1))
-                                        .allowedParameters(Collections.singletonList(TEST_ACTION_ALLOWED_PARAMETER_1))
                                         .build())
-                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .build()
                 },
+                // Update action endpoint authentication
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
+                                .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                                         .authentication(new Authentication.BearerAuthBuilder(TEST_ACCESS_TOKEN).build())
-                                        .allowedHeaders(Collections.singletonList(TEST_ACTION_ALLOWED_HEADER_1))
-                                        .allowedParameters(Collections.singletonList(TEST_ACTION_ALLOWED_PARAMETER_1))
                                         .build())
-                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
                                 .build()
                 },
+                // Update allowed headers and parameters
                 {ActionManagementAuditLogger.Operation.UPDATE,
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
+                                .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
+                                .endpoint(new EndpointConfig.EndpointConfigBuilder()
+                                        .allowedHeaders(List.of(TEST_ACTION_ALLOWED_HEADER_1))
+                                        .allowedParameters(List.of(TEST_ACTION_ALLOWED_PARAMETER_1))
+                                        .build())
+                                .build()
+                },
+                // Deleted allowed headers and parameters
+                {ActionManagementAuditLogger.Operation.UPDATE,
+                        new ActionDTOBuilder()
+                                .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
+                                .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
+                                .endpoint(new EndpointConfig.EndpointConfigBuilder()
+                                        .allowedHeaders(new ArrayList<>())
+                                        .allowedParameters(new ArrayList<>())
+                                        .build())
+                                .build()
+                },
+                // Update action properties - PRE UPDATE PASSWORD
+                {ActionManagementAuditLogger.Operation.UPDATE,
+                        new ActionDTOBuilder()
+                                .id(PRE_UPDATE_PASSWORD_ACTION_ID)
+                                .type(Action.ActionTypes.PRE_UPDATE_PASSWORD)
                                 .properties(updatedActionProperties)
-                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
-                                .updatedAt(Timestamp.valueOf(TEST_UPDATED_AT))
+                                .build()
+                },
+                // Delete action properties
+                {ActionManagementAuditLogger.Operation.UPDATE,
+                        new ActionDTOBuilder()
+                                .id(PRE_UPDATE_PASSWORD_ACTION_ID)
+                                .type(Action.ActionTypes.PRE_UPDATE_PASSWORD)
+                                .properties(new HashMap<>())
                                 .build()
                 }
         };
     }
 
     @DataProvider
-    public Object[][] operationWithTimestampDataProvider() {
+    public Object[][] activateAndDeactivateActionDataProvider() {
 
         return new Object[][]{
 
                 {ActionManagementAuditLogger.Operation.ACTIVATE,
                         ACTIVATE_ACTION,
-                        Timestamp.valueOf(TEST_UPDATED_AT)},
+                        Timestamp.valueOf(TEST_UPDATED_AT)
+                },
                 {ActionManagementAuditLogger.Operation.DEACTIVATE,
                         DEACTIVATE_ACTION,
-                        Timestamp.valueOf(TEST_UPDATED_AT)}
+                        Timestamp.valueOf(TEST_UPDATED_AT)
+                }
         };
     }
 
-    @Test(dataProvider = "actionDataProvider")
+    @Test(dataProvider = "addActionDataProvider")
     public void testPrintAddActionAuditLog(ActionManagementAuditLogger.Operation operation, ActionDTO creatingActionDTO)
             throws NoSuchFieldException, IllegalAccessException, ActionMgtException {
 
-        if (operation.equals(ActionManagementAuditLogger.Operation.ADD)) {
-            auditLogger.printAuditLog(operation, creatingActionDTO,
-                    creatingActionDTO.getCreatedAt(), creatingActionDTO.getUpdatedAt());
-            AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
-            assertActionData(capturedArg, creatingActionDTO);
-            assertAuditLoggerData(capturedArg, ADD_ACTION);
-        }
+        auditLogger.printAuditLog(operation, creatingActionDTO,
+                Timestamp.valueOf(TEST_CREATED_AT), Timestamp.valueOf(TEST_UPDATED_AT));
+        AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
+        assertActionData(capturedArg, creatingActionDTO);
+        assertAuditLoggerData(capturedArg, ADD_ACTION);
     }
 
-    @Test(dataProvider = "actionDataProvider")
+    @Test(dataProvider = "updateActionDataProvider")
     public void testPrintUpdateActionAuditLog(ActionManagementAuditLogger.Operation operation,
                                               ActionDTO updatingActionDTO)
             throws NoSuchFieldException, IllegalAccessException, ActionMgtException {
 
-        if (operation.equals(ActionManagementAuditLogger.Operation.UPDATE)) {
-            auditLogger.printAuditLog(operation, updatingActionDTO,
-                    updatingActionDTO.getCreatedAt(), updatingActionDTO.getUpdatedAt());
-            AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
-            assertActionData(capturedArg, updatingActionDTO);
-            assertAuditLoggerData(capturedArg, UPDATE_ACTION);
-        }
+        auditLogger.printAuditLog(operation, updatingActionDTO,
+                null, Timestamp.valueOf(TEST_UPDATED_AT));
+        AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
+        assertActionData(capturedArg, updatingActionDTO);
+        assertAuditLoggerData(capturedArg, UPDATE_ACTION);
     }
 
     @Test
@@ -359,36 +404,22 @@ public class ActionManagementAuditLoggerTest {
         assertAuditLoggerData(capturedArg, DELETE_ACTION);
     }
 
-    @Test(dataProvider = "operationWithTimestampDataProvider")
-    public void testPrintActivateActionAuditLog(ActionManagementAuditLogger.Operation operation, String actionName,
-                                                Timestamp updatedAt) throws
+    @Test(dataProvider = "activateAndDeactivateActionDataProvider")
+    public void testPrintActivateAndDeactivateActionAuditLog(ActionManagementAuditLogger.Operation operation,
+                                                             String actionName, Timestamp updatedAt) throws
             NoSuchFieldException, IllegalAccessException {
+
+        auditLogger.printAuditLog(operation, actionDTO.getType().name(), actionDTO.getId(), updatedAt);
+        AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
+
+        Assert.assertNotNull(capturedArg);
+        Assert.assertEquals(extractMapByField("ActionId", capturedArg), actionDTO.getId());
+        Assert.assertEquals(extractMapByField("ActionType", capturedArg), actionDTO.getType().name());
+        Assert.assertEquals(extractMapByField("UpdatedAt", capturedArg), String.valueOf(updatedAt));
 
         if (operation.equals(ActionManagementAuditLogger.Operation.ACTIVATE)) {
-            auditLogger.printAuditLog(operation, actionDTO.getType().name(), actionDTO.getId(), updatedAt);
-            AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
-
-            Assert.assertNotNull(capturedArg);
-            Assert.assertEquals(extractMapByField("ActionId", capturedArg), actionDTO.getId());
-            Assert.assertEquals(extractMapByField("ActionType", capturedArg), actionDTO.getType().name());
-            Assert.assertEquals(extractMapByField("UpdatedAt", capturedArg), String.valueOf(updatedAt));
             assertAuditLoggerData(capturedArg, ACTIVATE_ACTION);
-        }
-    }
-
-    @Test(dataProvider = "operationWithTimestampDataProvider")
-    public void testPrintDeactivateActionAuditLog(ActionManagementAuditLogger.Operation operation, String actionName,
-                                                  Timestamp updatedAt) throws
-            NoSuchFieldException, IllegalAccessException {
-
-        if (operation.equals(ActionManagementAuditLogger.Operation.DEACTIVATE)) {
-            auditLogger.printAuditLog(operation, actionDTO.getType().name(), actionDTO.getId(), updatedAt);
-            AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
-
-            Assert.assertNotNull(capturedArg);
-            Assert.assertEquals(extractMapByField("ActionId", capturedArg), actionDTO.getId());
-            Assert.assertEquals(extractMapByField("ActionType", capturedArg), actionDTO.getType().name());
-            Assert.assertEquals(extractMapByField("UpdatedAt", capturedArg), String.valueOf(updatedAt));
+        } else if (operation.equals(ActionManagementAuditLogger.Operation.DEACTIVATE)) {
             assertAuditLoggerData(capturedArg, DEACTIVATE_ACTION);
         }
     }
@@ -487,8 +518,6 @@ public class ActionManagementAuditLoggerTest {
         assertField(description != null, dataMap, "ActionDescription", description);
         assertField(type != null, dataMap, "ActionType", type);
         assertField(status != null, dataMap, "ActionStatus", status);
-        assertField(createdAt != null, dataMap, "CreatedAt", createdAt);
-        assertField(updatedAt != null, dataMap, "UpdatedAt", updatedAt);
         assertField(uri != null, endpointConfigMap, "EndpointUri", uri);
         assertField(allowedHeaders != null, endpointConfigMap, "AllowedHeaders", allowedHeaders);
         assertField(allowedParameters != null, endpointConfigMap, "AllowedParameters", allowedParameters);

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
@@ -403,11 +403,13 @@ public class ActionManagementAuditLoggerTest {
 
     @Test
     public void testPrintActivateAuditLog() throws NoSuchFieldException, IllegalAccessException {
+
         assertAuditLog(ActionManagementAuditLogger.Operation.ACTIVATE, ACTIVATE_ACTION);
     }
 
     @Test
     public void testPrintDeactivateAuditLog() throws NoSuchFieldException, IllegalAccessException {
+
         assertAuditLog(ActionManagementAuditLogger.Operation.DEACTIVATE, DEACTIVATE_ACTION);
     }
 
@@ -451,7 +453,7 @@ public class ActionManagementAuditLoggerTest {
         Assert.assertNotNull(capturedArg);
         Assert.assertEquals(extractMapByField("ActionId", capturedArg), actionDTO.getId());
         Assert.assertEquals(extractMapByField("ActionType", capturedArg),
-                Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN.getActionType());;
+                Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN.getActionType());
         assertAuditLoggerData(capturedArg, expectedAction);
     }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionManagementAuditLoggerTest.java
@@ -80,9 +80,11 @@ import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_API_
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_API_KEY_VALUE;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_CERTIFICATE;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_CERTIFICATE_UPDATED;
+import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_CREATED_AT;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_PASSWORD;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_PASSWORD_SHARING_TYPE;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_PASSWORD_SHARING_TYPE_UPDATED;
+import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_UPDATED_AT;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_USERNAME;
 
 /**
@@ -184,7 +186,7 @@ public class ActionManagementAuditLoggerTest {
                                 .description(TEST_ACTION_DESCRIPTION)
                                 .type(Action.ActionTypes.PRE_UPDATE_PASSWORD)
                                 .status(Action.Status.ACTIVE)
-                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
                                 .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                                         .uri(TEST_ACTION_URI)
@@ -204,7 +206,7 @@ public class ActionManagementAuditLoggerTest {
                                 .description(TEST_ACTION_DESCRIPTION)
                                 .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
                                 .status(Action.Status.ACTIVE)
-                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
                                 .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                                         .uri(TEST_ACTION_URI)
@@ -223,7 +225,7 @@ public class ActionManagementAuditLoggerTest {
                                 .description(TEST_ACTION_DESCRIPTION_UPDATED)
                                 .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
                                 .status(Action.Status.ACTIVE)
-                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
                                 .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .endpoint(new EndpointConfig.EndpointConfigBuilder()
                                         .uri(TEST_ACTION_URI_UPDATED)
@@ -240,7 +242,7 @@ public class ActionManagementAuditLoggerTest {
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
                                 .name(TEST_ACTION_NAME_UPDATED)
-                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
                                 .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .build()
                 },
@@ -248,7 +250,7 @@ public class ActionManagementAuditLoggerTest {
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
                                 .description(TEST_ACTION_DESCRIPTION_UPDATED)
-                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
                                 .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .build()
                 },
@@ -261,7 +263,7 @@ public class ActionManagementAuditLoggerTest {
                                         .allowedHeaders(Collections.singletonList(TEST_ACTION_ALLOWED_HEADER_1))
                                         .allowedParameters(Collections.singletonList(TEST_ACTION_ALLOWED_PARAMETER_1))
                                         .build())
-                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
                                 .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .build()
                 },
@@ -273,7 +275,7 @@ public class ActionManagementAuditLoggerTest {
                                         .allowedHeaders(Collections.singletonList(TEST_ACTION_ALLOWED_HEADER_1))
                                         .allowedParameters(Collections.singletonList(TEST_ACTION_ALLOWED_PARAMETER_1))
                                         .build())
-                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
                                 .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .build()
                 },
@@ -285,7 +287,7 @@ public class ActionManagementAuditLoggerTest {
                                         .allowedHeaders(Collections.singletonList(TEST_ACTION_ALLOWED_HEADER_1))
                                         .allowedParameters(Collections.singletonList(TEST_ACTION_ALLOWED_PARAMETER_1))
                                         .build())
-                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
                                 .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .build()
                 },
@@ -293,7 +295,7 @@ public class ActionManagementAuditLoggerTest {
                         new ActionDTOBuilder()
                                 .id(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID)
                                 .properties(updatedActionProperties)
-                                .createdAt(Timestamp.valueOf(TestUtil.TEST_CREATED_AT))
+                                .createdAt(Timestamp.valueOf(TEST_CREATED_AT))
                                 .updatedAt(Timestamp.valueOf(TestUtil.TEST_UPDATED_AT))
                                 .build()
                 }
@@ -326,6 +328,47 @@ public class ActionManagementAuditLoggerTest {
                 Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN.getActionType());
         assertAuditLoggerData(capturedArg, DELETE_ACTION);
 
+    }
+
+    @Test
+    public void testPrintAuditLogWithActionDTOAndCreatedAt() throws Exception {
+
+        Timestamp now = Timestamp.valueOf(TEST_CREATED_AT);
+        ActionManagementAuditLogger.Operation operation = ActionManagementAuditLogger.Operation.ADD;
+
+        auditLogger.printAuditLog(operation, actionDTO, now, true);
+        AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
+
+        Assert.assertNotNull(capturedArg);
+        Assert.assertEquals(extractMapByField("CreatedAt", capturedArg), String.valueOf(now));
+        assertAuditLoggerData(capturedArg, ADD_ACTION);
+    }
+
+    @Test
+    public void testPrintAuditLogWithActionDTOAndUpdatedAt() throws Exception {
+
+        Timestamp now = Timestamp.valueOf(TEST_UPDATED_AT);
+        ActionManagementAuditLogger.Operation operation = ActionManagementAuditLogger.Operation.UPDATE;
+
+        auditLogger.printAuditLog(operation, actionDTO, now, false);
+        AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
+
+        Assert.assertNotNull(capturedArg);
+        Assert.assertEquals(extractMapByField("UpdatedAt", capturedArg), String.valueOf(now));
+        assertAuditLoggerData(capturedArg, UPDATE_ACTION);
+    }
+
+    @Test
+    public void testPrintAuditLogWithActionDTOAndNullTimestamp() throws Exception {
+
+        ActionManagementAuditLogger.Operation operation = ActionManagementAuditLogger.Operation.UPDATE;
+
+        auditLogger.printAuditLog(operation, actionDTO, null, false);
+        AuditLog.AuditLogBuilder capturedArg = captureTriggerAuditLogEventArgs();
+
+        Assert.assertNotNull(capturedArg);
+        Assert.assertEquals(extractMapByField("UpdatedAt", capturedArg), null);
+        assertAuditLoggerData(capturedArg, UPDATE_ACTION);
     }
 
     /**

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/TestUtil.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/TestUtil.java
@@ -59,6 +59,8 @@ public class TestUtil {
     public static final String TEST_ACTION_DESCRIPTION_UPDATED = "Updated Test Action description";
     public static final String TEST_ACTION_URI = "https://example.com";
     public static final String TEST_ACTION_URI_UPDATED = "https://sample.com";
+    public static final String TEST_CREATED_AT = "2025-08-21 15:25:41.388";
+    public static final String TEST_UPDATED_AT = "2025-08-22 15:25:41.388";
 
     public static final String TEST_USERNAME = "sampleUsername";
     public static final String TEST_USERNAME_SECRET_REFERENCE = buildSecretName(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID,

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/TestUtil.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/TestUtil.java
@@ -91,6 +91,7 @@ public class TestUtil {
     public static final String PASSWORD_SHARING_TYPE_PROPERTY_NAME = "passwordSharingType";
     public static final String TEST_PASSWORD_SHARING_TYPE = "PLAIN_TEXT";
     public static final String TEST_PASSWORD_SHARING_TYPE_UPDATED = "SHA256_HASHED";
+    public static final String TEST_DELETED_PROPERTY = "__DELETED__";
     public static final String CERTIFICATE_PROPERTY_NAME = "certificate";
     public static final String TEST_CERTIFICATE = "sampleCertificate";
     public static final String TEST_CERTIFICATE_UPDATED = "UpdatedSampleCertificate";


### PR DESCRIPTION
This pull request enhances the audit logging functionality in the action management module by ensuring that audit logs include more complete and accurate information about actions, especially their timestamps and endpoint configuration details. The main changes involve updating how audit logs are constructed and what data is included, as well as refactoring the code to use the latest action data for logging.

### Audit Logging Improvements

* Audit logs for `addAction` and `updateAction` now use a new `buildAuditActionDTO` method to construct the `ActionDTO` from the latest `Action` object, ensuring that all fields (including timestamps) are accurately captured.
* The audit log entry now includes `CreatedAt` and `UpdatedAt` timestamp fields, providing more complete information about the action lifecycle. 

### Endpoint Configuration Logging

* Endpoint configuration in audit logs now includes `AllowedHeaders` and `AllowedParameters` fields, improving visibility into endpoint restrictions and accepted parameters.

### Related Issues:
- https://github.com/wso2/product-is/issues/25286