### PR TITLE
[next] Preserve backward comaptibility for pre issue access token action in allowed headers and params

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/RequestFilter.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/RequestFilter.java
@@ -67,6 +67,11 @@ public class RequestFilter {
             allowedHeaders.addAll(allowedHeadersInAction);
         } else if (hasServerAllowedHeaders) {
             allowedHeaders.addAll(allowedHeadersInServer);
+        } else if (ActionType.PRE_ISSUE_ACCESS_TOKEN.equals(actionType)) {
+            // This is to preserve backward compatibility.
+            allowedHeaders.addAll(requestHeaders.stream()
+                    .map(Header::getName)
+                    .collect(Collectors.toSet()));
         }
         // Filter out excluded headers configured at server level.
         allowedHeaders.removeAll(excludedHeadersInServer);
@@ -113,6 +118,11 @@ public class RequestFilter {
             allAllowedParamsSet.addAll(allowedParamsInAction);
         } else if (hasServerAllowedParams) {
             allAllowedParamsSet.addAll(allowedParamsInServer);
+        } else if (ActionType.PRE_ISSUE_ACCESS_TOKEN.equals(actionType)) {
+            // This is to preserve backward compatibility.
+            allAllowedParamsSet.addAll(requestParameters.stream()
+                    .map(Param::getName)
+                    .collect(Collectors.toSet()));
         }
         // Filter out excluded parameters configured at server level.
         allAllowedParamsSet.removeAll(excludedParamsInServer);

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/RequestFilterTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/RequestFilterTest.java
@@ -291,9 +291,9 @@ public class RequestFilterTest {
     public void testGetFilteredHeadersWhenNeitherAllowedOrExcludedHeadersAreConfigured() {
 
         ActionExecutorConfig config = ActionExecutorConfig.getInstance();
-        Mockito.when(config.getAllowedHeadersForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN))
+        Mockito.when(config.getAllowedHeadersForActionType(ActionType.PRE_UPDATE_PASSWORD))
                 .thenReturn(Collections.emptySet());
-        Mockito.when(config.getExcludedHeadersInActionRequestForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN))
+        Mockito.when(config.getExcludedHeadersInActionRequestForActionType(ActionType.PRE_UPDATE_PASSWORD))
                 .thenReturn(Collections.emptySet());
 
         List<Header> requestHeaders = new ArrayList<>();
@@ -302,7 +302,7 @@ public class RequestFilterTest {
         requestHeaders.add(new Header("X-Header-3", new String[]{"X-header-3-value"}));
 
         List<Header> filteredHeaders = RequestFilter.getFilteredHeaders(requestHeaders, Collections.emptyList(),
-                ActionType.PRE_ISSUE_ACCESS_TOKEN);
+                ActionType.PRE_UPDATE_PASSWORD);
         assertEquals(filteredHeaders.size(), 0);
     }
 
@@ -310,9 +310,9 @@ public class RequestFilterTest {
     public void testGetFilteredHeadersWhenNeitherAllowedOrExcludedParamsAreConfigured() {
 
         ActionExecutorConfig config = ActionExecutorConfig.getInstance();
-        Mockito.when(config.getAllowedParamsForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN))
+        Mockito.when(config.getAllowedParamsForActionType(ActionType.PRE_UPDATE_PASSWORD))
                 .thenReturn(Collections.emptySet());
-        Mockito.when(config.getExcludedParamsInActionRequestForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN))
+        Mockito.when(config.getExcludedParamsInActionRequestForActionType(ActionType.PRE_UPDATE_PASSWORD))
                 .thenReturn(Collections.emptySet());
 
         List<Header> requestParams = new ArrayList<>();
@@ -321,7 +321,7 @@ public class RequestFilterTest {
         requestParams.add(new Header("X-Param-3", new String[]{"X-param-3-value"}));
 
         List<Header> filteredParams = RequestFilter.getFilteredHeaders(requestParams, Collections.emptyList(),
-                ActionType.PRE_ISSUE_ACCESS_TOKEN);
+                ActionType.PRE_UPDATE_PASSWORD);
         assertEquals(filteredParams.size(), 0);
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
> $subject

### Related Issue
- 