### PR TITLE
Use new getResource method with inheritance support

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
@@ -76,7 +76,8 @@ public class FlowMgtConfigUtils {
         Resource newResource = buildResourceFromFlowConfig(flowConfigDTO);
 
         Resource updatedResource;
-        if (existingResource == null) {
+        if (existingResource == null ||
+                (tenantDomain != null && !tenantDomain.equals(existingResource.getTenantDomain()))) {
             LOG.debug("Adding new flow configuration for flow type: " + flowConfigDTO.getFlowType());
             updatedResource = addResource(newResource, tenantDomain);
         } else {
@@ -250,7 +251,7 @@ public class FlowMgtConfigUtils {
 
         Resource resource = null;
         try {
-            resource = getConfigurationManager().getResource(RESOURCE_TYPE, resourceName);
+            resource = getConfigurationManager().getResource(RESOURCE_TYPE, resourceName, true);
         } catch (ConfigurationManagementException e) {
             if (!ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode()) &&
                     !ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode())) {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -89,7 +90,7 @@ public class FlowMgtConfigUtilsTest {
         FlowConfigDTO flowConfigDTO = createSampleFlowConfig();
         Resource newResource = createSampleResource();
 
-        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString())).thenReturn(null);
+        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString(), anyBoolean())).thenReturn(null);
         when(configurationManager.addResource(eq(RESOURCE_TYPE), any(Resource.class))).thenReturn(newResource);
 
         FlowConfigDTO result = FlowMgtConfigUtils.addFlowConfig(flowConfigDTO, TENANT_DOMAIN);
@@ -108,7 +109,7 @@ public class FlowMgtConfigUtilsTest {
         Resource existingResource = createSampleResource();
         Resource updatedResource = createSampleResource();
 
-        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString())).thenReturn(existingResource);
+        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString(), anyBoolean())).thenReturn(existingResource);
         when(configurationManager.replaceResource(eq(RESOURCE_TYPE), any(Resource.class))).thenReturn(updatedResource);
 
         FlowConfigDTO result = FlowMgtConfigUtils.addFlowConfig(flowConfigDTO, TENANT_DOMAIN);
@@ -123,7 +124,7 @@ public class FlowMgtConfigUtilsTest {
         FlowConfigDTO flowConfigDTO = createSampleFlowConfig();
         Resource newResource = createSampleResource();
 
-        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString())).thenReturn(null);
+        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString(), anyBoolean())).thenReturn(null);
         when(configurationManager.addResource(eq(RESOURCE_TYPE), any(Resource.class)))
                 .thenThrow(new ConfigurationManagementException("Resource type does not exist",
                         ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode()))
@@ -142,7 +143,7 @@ public class FlowMgtConfigUtilsTest {
 
         Resource resource = createSampleResource();
 
-        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString())).thenReturn(resource);
+        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString(), anyBoolean())).thenReturn(resource);
 
         FlowConfigDTO result = FlowMgtConfigUtils.getFlowConfig(FLOW_TYPE_REGISTRATION, TENANT_DOMAIN);
 
@@ -155,7 +156,7 @@ public class FlowMgtConfigUtilsTest {
     @Test
     public void testGetFlowConfigReturnsDefault() throws Exception {
 
-        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString())).thenReturn(null);
+        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString(), anyBoolean())).thenReturn(null);
 
         FlowConfigDTO result = FlowMgtConfigUtils.getFlowConfig(FLOW_TYPE_REGISTRATION, TENANT_DOMAIN);
 
@@ -233,7 +234,7 @@ public class FlowMgtConfigUtilsTest {
     @Test
     public void testGetFlowConfigHandlesException() throws Exception {
 
-        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString()))
+        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString(), anyBoolean()))
                 .thenThrow(new ConfigurationManagementException("Resource type does not exist",
                         ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode()));
 
@@ -250,7 +251,7 @@ public class FlowMgtConfigUtilsTest {
 
         FlowConfigDTO flowConfigDTO = createSampleFlowConfig();
 
-        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString())).thenReturn(null);
+        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString(), anyBoolean())).thenReturn(null);
         when(configurationManager.addResource(eq(RESOURCE_TYPE), any(Resource.class)))
                 .thenThrow(new ConfigurationManagementException("Resource type does not exist",
                         ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode()));
@@ -275,7 +276,7 @@ public class FlowMgtConfigUtilsTest {
         resource.setResourceType(RESOURCE_TYPE);
         resource.setAttributes(Collections.emptyList());
 
-        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString())).thenReturn(resource);
+        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString(), anyBoolean())).thenReturn(resource);
 
         FlowConfigDTO result = FlowMgtConfigUtils.getFlowConfig(FLOW_TYPE_REGISTRATION, TENANT_DOMAIN);
 
@@ -293,7 +294,7 @@ public class FlowMgtConfigUtilsTest {
         resource.setResourceType(RESOURCE_TYPE);
         resource.setAttributes(null);
 
-        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString())).thenReturn(resource);
+        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString(), anyBoolean())).thenReturn(resource);
 
         FlowConfigDTO result = FlowMgtConfigUtils.getFlowConfig(FLOW_TYPE_REGISTRATION, TENANT_DOMAIN);
 
@@ -308,7 +309,7 @@ public class FlowMgtConfigUtilsTest {
 
         Resource resource = createCompleteResource();
 
-        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString())).thenReturn(resource);
+        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString(), anyBoolean())).thenReturn(resource);
 
         FlowConfigDTO result = FlowMgtConfigUtils.getFlowConfig(FLOW_TYPE_REGISTRATION, TENANT_DOMAIN);
 
@@ -387,6 +388,7 @@ public class FlowMgtConfigUtilsTest {
         Resource resource = new Resource();
         resource.setResourceName(RESOURCE_NAME_PREFIX + flowType);
         resource.setResourceType(RESOURCE_TYPE);
+        resource.setTenantDomain(TENANT_DOMAIN);
 
         List<Attribute> attributes = new ArrayList<>();
         attributes.add(new Attribute(FLOW_TYPE, flowType));


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25325

This pull request updates the flow configuration management logic to ensure tenant domain consistency and adapts the codebase and tests to use the correct method signature for resource retrieval. The most significant changes focus on improving multi-tenancy support and updating the unit tests for compatibility with these changes.

**Multi-tenancy and resource handling:**

* Updated the logic in `addFlowConfig` to add a new resource if the existing resource's tenant domain does not match the provided tenant domain, improving tenant domain isolation.
* Changed the resource retrieval method in `getResource` to use an additional boolean parameter, ensuring the correct method overload is called for tenant-aware resource fetching.

**Unit test updates for method signature changes:**

* Modified all mock setups in `FlowMgtConfigUtilsTest.java` to use the new method signature of `getResource` with the boolean parameter, ensuring tests reflect the updated API. [[1]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aL92-R93) [[2]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aL111-R112) [[3]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aL126-R127) [[4]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aL145-R146) [[5]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aL158-R159) [[6]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aL236-R237) [[7]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aL253-R254) [[8]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aL278-R279) [[9]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aL296-R297) [[10]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aL311-R312)
* Added the tenant domain to resources created in test helpers to better simulate real multi-tenant scenarios.
* Included `anyBoolean` in static imports for Mockito to support the new method signature in test mocks.