### PR TITLE
Store canonical values as separate claim properties

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/pom.xml
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/pom.xml
@@ -61,6 +61,10 @@
             <artifactId>org.wso2.carbon.identity.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.json.wso2</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -111,6 +115,7 @@
                         <Import-Package>
                             javax.cache,
                             javax.xml.stream,
+                            org.json,
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.apache.commons.logging.*; version="${import.package.version.commons.logging}",

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/LocalClaimDAO.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/LocalClaimDAO.java
@@ -39,6 +39,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants.CANONICAL_VALUES_PROPERTY;
+import static org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants.CANONICAL_VALUE_PREFIX;
 import static org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants.SUB_ATTRIBUTES_PROPERTY;
 import static org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants.SUB_ATTRIBUTE_PREFIX;
 
@@ -136,6 +138,7 @@ public class LocalClaimDAO extends ClaimDAO {
 
             resultSet = preparedStatement.executeQuery();
 
+            Map<Integer, List<String>> canonicalValuesMap = new HashMap<>();
             while (resultSet.next()) {
                 String propertyName = resultSet.getString(SQLConstants.PROPERTY_NAME_COLUMN);
                 String propertyValue = resultSet.getString(SQLConstants.PROPERTY_VALUE_COLUMN);
@@ -157,6 +160,14 @@ public class LocalClaimDAO extends ClaimDAO {
                     }
                     subAttributes += propertyValue;
                     existingAttributeMap.put(SUB_ATTRIBUTES_PROPERTY, subAttributes);
+                } else if (propertyName.startsWith(CANONICAL_VALUE_PREFIX)) {
+                    List<String> canonicalValuesList = canonicalValuesMap.get(localClaimId);
+                    if (canonicalValuesList == null) {
+                        canonicalValuesList = new ArrayList<>();
+                    }
+                    canonicalValuesList.add(propertyValue);
+                    canonicalValuesMap.put(localClaimId, canonicalValuesList);
+                    existingAttributeMap.put(CANONICAL_VALUES_PROPERTY, canonicalValuesList.toString());
                 } else {
                     existingAttributeMap.put(propertyName, propertyValue);
                 }

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
@@ -65,6 +65,7 @@ public class ClaimConstants {
     public static final String MULTI_VALUED_PROPERTY = "multiValued";
     public static final String SUB_ATTRIBUTES_PROPERTY = "subAttributes";
     public static final String SUB_ATTRIBUTE_PREFIX = "subAttribute.";
+    public static final String CANONICAL_VALUE_PREFIX = "canonicalValue.";
 
     /**
      * Enum for error messages.

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/test/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementServiceImplTest.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/test/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementServiceImplTest.java
@@ -243,8 +243,8 @@ public class ClaimMetadataManagementServiceImplTest {
                 "http://wso2.org/claims/testclaim6 http://wso2.org/claims/testclaim7 http://wso2.org/claims/testclaim8 " +
                 "http://wso2.org/claims/testclaim9 http://wso2.org/claims/testclaim10 http://wso2.org/claims/testclaim11" +
                 " http://wso2.org/claims/testclaim12");
-        claimProperties.put("canonicalValues", "Current Account http://wso2.org/claims/testclaim2 " +
-                "http://wso2.org/claims/testclaim3");
+        claimProperties.put("canonicalValues", "[{\"label\":\"north\",\"value\":\"NORTHERN\"}, " +
+                "{\"label\":\"west\",\"value\":\"WEST\"}]");
         localClaimToBeAdded.setClaimProperties(claimProperties);
 
         when(unifiedClaimMetadataManager.getLocalClaims(anyInt())).thenReturn(new ArrayList<>());

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/test/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementServiceImplTest.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/test/java/org/wso2/carbon/identity/claim/metadata/mgt/ClaimMetadataManagementServiceImplTest.java
@@ -243,6 +243,8 @@ public class ClaimMetadataManagementServiceImplTest {
                 "http://wso2.org/claims/testclaim6 http://wso2.org/claims/testclaim7 http://wso2.org/claims/testclaim8 " +
                 "http://wso2.org/claims/testclaim9 http://wso2.org/claims/testclaim10 http://wso2.org/claims/testclaim11" +
                 " http://wso2.org/claims/testclaim12");
+        claimProperties.put("canonicalValues", "Current Account http://wso2.org/claims/testclaim2 " +
+                "http://wso2.org/claims/testclaim3");
         localClaimToBeAdded.setClaimProperties(claimProperties);
 
         when(unifiedClaimMetadataManager.getLocalClaims(anyInt())).thenReturn(new ArrayList<>());

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/test/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/ClaimDAOTest.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/test/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/ClaimDAOTest.java
@@ -112,9 +112,16 @@ public class ClaimDAOTest {
                         2
                 },
                 {
-                        new String[]{"Description", "subAttribute.1", "AnotherProperty"},
-                        new String[]{"desc", "http://wso2.org/claims/subattribute1", "anotherValue"},
-                        3
+                        new String[]{"DisplayName", "canonicalValue.1", "canonicalValue.2"},
+                        new String[]{"value1", "http://wso2.org/claims/canonicalValue1",
+                                "http://wso2.org/claims/canonicalValue2"},
+                        2
+                },
+                {
+                        new String[]{"subAttribute.1", "canonicalValue.1", "canonicalValue.2"},
+                        new String[]{"http://wso2.org/claims/subattribute1",
+                                "http://wso2.org/claims/canonicalValue1", "http://wso2.org/claims/canonicalValue2"},
+                        2
                 },
                 {
                         new String[]{"DisplayName", "Description", "dataType"},

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/test/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/LocalClaimDAOTest.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/test/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/LocalClaimDAOTest.java
@@ -79,6 +79,7 @@ public class LocalClaimDAOTest {
         claimProperties2 = new HashMap<>();
         claimProperties2.put("Description", "TestDescription2");
         claimProperties2.put("FriendlyName", "Nick Name");
+        // There can be canonical values without label value pairs. Those values should be safely ignored.
         claimProperties2.put("canonicalValues", "NORTHERN, WEST");
 
         claimProperties3 = new HashMap<>();

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/test/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/LocalClaimDAOTest.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/test/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/LocalClaimDAOTest.java
@@ -79,11 +79,13 @@ public class LocalClaimDAOTest {
         claimProperties2 = new HashMap<>();
         claimProperties2.put("Description", "TestDescription2");
         claimProperties2.put("FriendlyName", "Nick Name");
+        claimProperties2.put("canonicalValues", "NORTHERN, WEST");
 
         claimProperties3 = new HashMap<>();
         claimProperties3.put("Description", "TestDescription3");
         claimProperties3.put("FriendlyName", "UserName");
         claimProperties3.put("subAttributes", "http://wso2.org/claims/test http://wso2.org/claims/test2");
+        claimProperties3.put("canonicalValues", "[{\"label\":\"north\",\"value\":\"NORTHERN\"},{\"label\":\"west\",\"value\":\"WEST\"}]");
 
         mappedAttributes1 = new ArrayList<>();
         mappedAttributes1.add(attributeMapping1);


### PR DESCRIPTION
### Proposed changes in this pull request
The same approach followed for the sub-attributes storing has been followed. But sub-attribute are space separated list. But the canonical values are json array. Hence the algorithm to process the data at storing and retrieval is different.

### Related Issues
- https://github.com/wso2/product-is/issues/25359
### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/6794

The canonical values will be stored as follows.


<img width="1067" height="422" alt="Screenshot 2025-08-24 at 13 55 12" src="https://github.com/user-attachments/assets/3583020d-bc50-4a4e-a7ab-3755e29b9dba" />
