### PR TITLE
Provide the support to update the subject identifier externally from adaptive script

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsAuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsAuthenticatedUser.java
@@ -37,6 +37,8 @@ import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.List;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.JSAttributes.PROP_USERNAME_UPDATED_EXTERNALLY;
+
 /**
  * Abstract Javascript wrapper for Java level AuthenticatedUser.
  * This provides controlled access to AuthenticatedUser object via provided javascript native syntax.
@@ -173,6 +175,7 @@ public abstract class JsAuthenticatedUser extends AbstractJSObjectWrapper<Authen
         switch (name) {
             case FrameworkConstants.JSAttributes.JS_USERNAME:
                 getWrapped().setUserName((String) value);
+                getContext().setProperty(PROP_USERNAME_UPDATED_EXTERNALLY, "true");
                 break;
             case FrameworkConstants.JSAttributes.JS_USER_STORE_DOMAIN:
                 getWrapped().setUserStoreDomain((String) value);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
@@ -78,7 +78,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AdaptiveAuthentication.ALLOW_AUTHENTICATED_SUB_UPDATE;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Config.SEND_ONLY_LOCALLY_MAPPED_ROLES_OF_IDP;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.JSAttributes.PROP_USERNAME_UPDATED_EXTERNALLY;
 import static org.wso2.carbon.identity.core.util.IdentityUtil.getLocalGroupsClaimURI;
 
 /**
@@ -1154,6 +1156,15 @@ public class DefaultClaimHandler implements ClaimHandler {
                     log.debug("Subject claim for " + authenticatedUser.getLoggableUserId()
                             + " not found in user store");
                 }
+            }
+            if (Boolean.parseBoolean(IdentityUtil.getProperty(ALLOW_AUTHENTICATED_SUB_UPDATE)) &&
+                    Boolean.parseBoolean((String) context.getProperty(PROP_USERNAME_UPDATED_EXTERNALLY))) {
+                /*
+                 If the username is updated externally, we will update the authenticated user identifier with the
+                 username. This support is provided initially for adaptive scripts. If any other places needs to
+                 update the subject identifier externally from username, we can use the same property.
+                */
+                context.setProperty(SERVICE_PROVIDER_SUBJECT_CLAIM_VALUE, authenticatedUser.getUserName());
             }
         } catch (UserStoreException e) {
             log.error("Error occurred while retrieving " + subjectURI + " claim value for user "

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -617,6 +617,7 @@ public abstract class FrameworkConstants {
         public static final String JS_OPTIONS_USERNAME = "username";
 
         public static final String PROP_CURRENT_NODE = "Adaptive.Auth.Current.Graph.Node";
+        public static final String PROP_USERNAME_UPDATED_EXTERNALLY = "usernameUpdatedExternally";
 
         public static final String JS_FUNC_ON_LOGIN_REQUEST = "onLoginRequest";
         public static final String JS_FUNC_EXECUTE_STEP = "executeStep";
@@ -706,6 +707,8 @@ public abstract class FrameworkConstants {
                 = "AdaptiveAuthExecutionSupervisorResult";
         public static final String AUTHENTICATOR_NAME_IN_AUTH_CONFIG
                 = "AdaptiveAuth.AuthenticatorNameInAuthConfig.Enable";
+        public static final String ALLOW_AUTHENTICATED_SUB_UPDATE =
+                "AdaptiveAuth.AllowUpdatingAuthenticatedSubject";
         public static final String GRAALJS_SCRIPT_STATEMENTS_LIMIT
                 = "AdaptiveAuth.GraalJS.ScriptStatementsLimit";
         public static final int DEFAULT_GRAALJS_SCRIPT_STATEMENTS_LIMIT = 0;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthenticatedSubjectIdentifierHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthenticatedSubjectIdentifierHandlerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.handler.request.impl;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.ApplicationConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.PostAuthnHandlerFlowStatus;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AdaptiveAuthentication.ALLOW_AUTHENTICATED_SUB_UPDATE;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.JSAttributes.PROP_USERNAME_UPDATED_EXTERNALLY;
+
+/**
+ * Unit tests for PostAuthenticatedSubjectIdentifierHandler.
+ */
+public class PostAuthenticatedSubjectIdentifierHandlerTest {
+
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private HttpServletResponse response;
+    @Mock
+    private AuthenticationContext context;
+    @Mock
+    private SequenceConfig sequenceConfig;
+    @Mock
+    private ApplicationConfig applicationConfig;
+    @Mock
+    private AuthenticatedUser authenticatedUser;
+    private MockedStatic<IdentityUtil> identityUtil;
+
+    private static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
+    private static final String TEST_USER_USERNAME = "testUser";
+
+    @Before
+    public void setUp() {
+
+        MockitoAnnotations.initMocks(this);
+        when(context.getSequenceConfig()).thenReturn(sequenceConfig);
+        when(sequenceConfig.getApplicationConfig()).thenReturn(applicationConfig);
+        when(sequenceConfig.getAuthenticatedUser()).thenReturn(authenticatedUser);
+        identityUtil = Mockito.mockStatic(IdentityUtil.class);
+    }
+
+    @After
+    public void tearDown() {
+
+        identityUtil.close();
+    }
+
+    /**
+     * Test handle returns SUCCESS_COMPLETED when step-based sequence handler is not executed.
+     */
+    @Test
+    public void testHandleWhenStepBasedSequenceHandlerNotExecuted() {
+
+        when(FrameworkUtils.isStepBasedSequenceHandlerExecuted(context)).thenReturn(false);
+
+        PostAuthenticatedSubjectIdentifierHandler handler = PostAuthenticatedSubjectIdentifierHandler.getInstance();
+        PostAuthnHandlerFlowStatus status = handler.handle(request, response, context);
+
+        assertEquals(PostAuthnHandlerFlowStatus.SUCCESS_COMPLETED, status);
+    }
+
+    /**
+     * Test handle sets subject identifier when subject claim URI and value are present.
+     */
+    @Test
+    public void testHandleWhenSubjectClaimAndValueArePresent() {
+
+        when(FrameworkUtils.isStepBasedSequenceHandlerExecuted(context)).thenReturn(true);
+        when(applicationConfig.getSubjectClaimUri()).thenReturn(USERNAME_CLAIM);
+        when(context.getProperty(FrameworkConstants.SERVICE_PROVIDER_SUBJECT_CLAIM_VALUE)).
+                thenReturn(TEST_USER_USERNAME);
+
+        PostAuthenticatedSubjectIdentifierHandler handler = PostAuthenticatedSubjectIdentifierHandler.getInstance();
+        PostAuthnHandlerFlowStatus status = handler.handle(request, response, context);
+
+        assertEquals(PostAuthnHandlerFlowStatus.SUCCESS_COMPLETED, status);
+        verify(authenticatedUser, atLeastOnce()).setAuthenticatedSubjectIdentifier(TEST_USER_USERNAME);
+    }
+
+    /**
+     * Test handle sets subject identifier based on user id when subject claim is missing.
+     */
+    @Test
+    public void testHandleWhenSubjectClaimIsMissing() {
+
+        when(FrameworkUtils.isStepBasedSequenceHandlerExecuted(context)).thenReturn(true);
+        when(applicationConfig.getSubjectClaimUri()).thenReturn("");
+        when(authenticatedUser.getUserName()).thenReturn(TEST_USER_USERNAME);
+        when(context.getProperty(PROP_USERNAME_UPDATED_EXTERNALLY)).thenReturn("true");
+        identityUtil.when(() -> IdentityUtil.getProperty(ALLOW_AUTHENTICATED_SUB_UPDATE)).thenReturn("true");
+
+        PostAuthenticatedSubjectIdentifierHandler handler = spy(PostAuthenticatedSubjectIdentifierHandler.
+                getInstance());
+        PostAuthnHandlerFlowStatus status = handler.handle(request, response, context);
+
+        assertEquals(PostAuthnHandlerFlowStatus.SUCCESS_COMPLETED, status);
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/testng.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/testng.xml
@@ -33,6 +33,7 @@
             <class name="org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.JITProvisioningPostAuthenticationHandlerTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.PostAuthAssociationHandlerTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.PostAuthnMissingClaimHandlerTest"/>
+            <class name="org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.PostAuthenticatedSubjectIdentifierHandlerTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.handler.provisioning.impl.DefaultProvisioningHandlerTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl.DefaultRequestPathBasedSequenceHandlerTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl.DefaultStepBasedSequenceHandlerTest"/>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2698,6 +2698,8 @@
         <AuthenticatorNameInAuthConfig>
             <Enable>true</Enable>
         </AuthenticatorNameInAuthConfig>
+
+        <AllowUpdatingAuthenticatedSubject>{{authentication.adaptive.allow_updating_authenticated_subject}}</AllowUpdatingAuthenticatedSubject>
     </AdaptiveAuth>
 
     <!--Intermediate certificate validation for certificate based requests-->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -4173,6 +4173,8 @@
         <GraalJS>
             <ScriptStatementsLimit>{{authentication.adaptive.graaljs.script_statements_limit}}</ScriptStatementsLimit>
         </GraalJS>
+
+        <AllowUpdatingAuthenticatedSubject>{{authentication.adaptive.allow_updating_authenticated_subject}}</AllowUpdatingAuthenticatedSubject>
     </AdaptiveAuth>
 
     <!--Intermediate certificate validation for certificate based requests-->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -879,6 +879,7 @@
   "authentication.adaptive.execution_supervisor.thread_count": "1",
   "authentication.adaptive.execution_supervisor.timeout": "500ms",
   "authentication.adaptive.authenticator_name_in_auth_config.enable": true,
+  "authentication.adaptive.allow_updating_authenticated_subject": false,
   "authentication.adaptive.graaljs.script_statements_limit": "0",
   "AdaptiveAuth.ScriptEngine": "graaljs",
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Fix for : https://github.com/wso2/product-is/issues/24159
- From this implementation, when we configure the adaptive script to update the username of the authenticated object, it will be reflected in the authenticated users subject identifier without checking the subject claim set in the application configs.
- To enable this change, you need to enable the configuration from the deployment.toml file by adding the following configuration

```
[authentication.adaptive]
allow_updating_authenticated_subject=true
```