### PR TITLE
Properly handle flow completion

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/Constants.java
@@ -235,7 +235,6 @@ public class Constants {
         public static final String STATUS_USER_INPUT_REQUIRED = "USER_INPUT_REQUIRED";
         public static final String STATUS_EXTERNAL_REDIRECTION = "EXTERNAL_REDIRECTION";
         public static final String STATUS_WEBAUTHN = "WEBAUTHN";
-        public static final String STATUS_USER_CREATED = "USER_CREATED";
         public static final String STATUS_COMPLETE = "COMPLETE";
         public static final String STATUS_RETRY = "RETRY";
         public static final String STATUS_ERROR = "ERROR";

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/FlowExecutionService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/FlowExecutionService.java
@@ -40,6 +40,7 @@ import java.util.Map;
 
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.REGISTRATION_FLOW_TYPE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.STATUS_COMPLETE;
+import static org.wso2.carbon.identity.flow.mgt.Constants.StepTypes.REDIRECTION;
 
 /**
  * Service class to handle the user flow.
@@ -118,7 +119,9 @@ public class FlowExecutionService {
                 if (step.getData() == null) {
                     step.setData(new DataDTO.Builder().additionalData(new HashMap<>()).build());
                 }
-                if (context.isGenerateAuthenticationAssertion()) {
+                // Generate authentication assertion only if the last step is a redirection. This prevents
+                // unnecessary generation of assertions when the last step is a VIEW step.
+                if (context.isGenerateAuthenticationAssertion() && REDIRECTION.equals(step.getStepType())) {
                     step.getData().addAdditionalData(FrameworkConstants.USER_ASSERTION,
                             AuthenticationAssertionUtils.getSignedUserAssertion(context));
                 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/core/FlowExecutionEngine.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/core/FlowExecutionEngine.java
@@ -168,8 +168,10 @@ public class FlowExecutionEngine {
         }
         if (Constants.NodeTypes.DECISION.equals(currentNode.getType())) {
             // If the current node is a decision node, reset the next node ID to null.
-            LOG.debug("Current node " + currentNode.getId() + " is a decision node. " +
-                    "Resetting the next node ID to null.");
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Current node " + currentNode.getId() + " is a decision node. " +
+                        "Resetting the next node ID to null.");
+            }
             currentNode.setNextNodeId(null);
         }
         return nextNode;

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/core/FlowExecutionEngine.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/core/FlowExecutionEngine.java
@@ -49,6 +49,7 @@ import static org.wso2.carbon.identity.flow.execution.engine.Constants.STATUS_IN
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.STATUS_PROMPT_ONLY;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.WEBAUTHN_DATA;
 import static org.wso2.carbon.identity.flow.execution.engine.util.FlowExecutionEngineUtils.handleServerException;
+import static org.wso2.carbon.identity.flow.mgt.Constants.END_NODE_ID;
 import static org.wso2.carbon.identity.flow.mgt.Constants.StepTypes.INTERNAL_PROMPT;
 import static org.wso2.carbon.identity.flow.mgt.Constants.StepTypes.REDIRECTION;
 import static org.wso2.carbon.identity.flow.mgt.Constants.StepTypes.VIEW;
@@ -122,6 +123,12 @@ public class FlowExecutionEngine {
             }
 
             FlowExecutionStep step = resolveStepForPrompt(graph, currentNode, context, nodeResponse);
+
+            // If the flow status is complete because the END node was reached, return the step.
+            if (STATUS_COMPLETE.equals(step.getFlowStatus())) {
+                return step;
+            }
+
             if (STATUS_INCOMPLETE.equals(nodeResponse.getStatus()) && VIEW.equals(nodeResponse.getType())) {
                 return step;
             }
@@ -193,7 +200,7 @@ public class FlowExecutionEngine {
     }
 
     private FlowExecutionStep resolveStepForPrompt(GraphConfig graph, NodeConfig currentNode,
-                                                   FlowExecutionContext context, NodeResponse nodeResponse) {
+                                                   FlowExecutionContext context, NodeResponse nodeResponse) throws FlowEngineServerException {
 
         DataDTO dataDTO = graph.getNodePageMappings().get(currentNode.getId()).getData();
 
@@ -205,6 +212,20 @@ public class FlowExecutionEngine {
                     .additionalData(dataDTO.getAdditionalData())
                     .build();
             handleError(finalDataDTO, nodeResponse);
+        }
+
+        // When the END node is reached, mark the flow status as COMPLETE, set the step type to REDIRECTION,
+        // and assign the redirect URL. Note: all END nodes are expected to be of type PROMPT_ONLY.
+        if (END_NODE_ID.equals(currentNode.getId())) {
+            if (finalDataDTO != null ) {
+                finalDataDTO.setRedirectURL(FlowExecutionEngineUtils.resolveCompletionRedirectionUrl(context));
+            }
+            return new FlowExecutionStep.Builder()
+                    .flowId(context.getContextIdentifier())
+                    .flowStatus(STATUS_COMPLETE)
+                    .stepType(REDIRECTION)
+                    .data(finalDataDTO)
+                    .build();
         }
 
         return new FlowExecutionStep.Builder()

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/core/FlowExecutionEngine.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/core/FlowExecutionEngine.java
@@ -217,6 +217,11 @@ public class FlowExecutionEngine {
         // When the END node is reached, mark the flow status as COMPLETE, set the step type to REDIRECTION,
         // and assign the redirect URL. Note: all END nodes are expected to be of type PROMPT_ONLY.
         if (END_NODE_ID.equals(currentNode.getId())) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Flow: " + context.getContextIdentifier() + " has reached the explicitly defined " +
+                        "end node. Changing the flow status to COMPLETE, step type to REDIRECTION and setting " +
+                        "the redirect URL.");
+            }
             if (finalDataDTO != null ) {
                 finalDataDTO.setRedirectURL(FlowExecutionEngineUtils.resolveCompletionRedirectionUrl(context));
             }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNode.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNode.java
@@ -39,7 +39,6 @@ import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorS
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_ERROR;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_EXTERNAL_REDIRECTION;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_RETRY;
-import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_CREATED;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_ERROR;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_WEBAUTHN;
@@ -122,7 +121,7 @@ public class TaskExecutionNode implements Node {
         if (response.getContextProperties() != null && !response.getContextProperties().isEmpty()) {
             context.addProperties(response.getContextProperties());
         }
-        if (STATUS_COMPLETE.equals(response.getResult()) || STATUS_USER_CREATED.equals(response.getResult())) {
+        if (STATUS_COMPLETE.equals(response.getResult())) {
             context.addCompletedNode(configs);
             return handleCompleteStatus(context, response, mappedFlowExecutor.getName(), configs);
         }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/UserOnboardingExecutor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/UserOnboardingExecutor.java
@@ -59,10 +59,10 @@ import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMess
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_USERNAME_ALREADY_EXISTS;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_USERSTORE_MANAGER_FAILURE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_USER_ONBOARD_FAILURE;
-import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_CREATED;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.USER_ALREADY_EXISTING_USERNAME;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.PASSWORD_KEY;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.SELF_REGISTRATION_DEFAULT_USERSTORE_CONFIG;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.STATUS_COMPLETE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.USERNAME_CLAIM_URI;
 import static org.wso2.carbon.identity.flow.execution.engine.util.FlowExecutionEngineUtils.handleClientException;
 import static org.wso2.carbon.identity.flow.execution.engine.util.FlowExecutionEngineUtils.handleServerException;
@@ -118,7 +118,7 @@ public class UserOnboardingExecutor implements Executor {
             user.setUserStoreDomain(userStoreDomainName);
             user.setUserId(userid);
             createFederatedAssociations(user, context.getTenantDomain());
-            return new ExecutorResponse(STATUS_USER_CREATED);
+            return new ExecutorResponse(STATUS_COMPLETE);
         } catch (UserStoreException e) {
             handleAndThrowClientExceptionForActionFailure(e);
             if (e.getMessage().contains(USER_ALREADY_EXISTING_USERNAME)) {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/util/FlowExecutionEngineUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/util/FlowExecutionEngineUtils.java
@@ -224,7 +224,13 @@ public class FlowExecutionEngineUtils {
                 });
             }
         } catch (FlowEngineException e) {
-            LOG.error("Error occurred while retrieving the flow context with flow id: " + contextId, e);
+            if (e instanceof FlowEngineClientException) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Client error occurred while retrieving the flow context with flow id: " + contextId, e);
+                }
+            } else {
+                LOG.error("Server error occurred while retrieving the flow context with flow id: " + contextId, e);
+            }
         }
     }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNodeTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNodeTest.java
@@ -23,7 +23,6 @@ import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.Property;
@@ -50,7 +49,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -65,7 +63,6 @@ import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMess
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_COMPLETE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_EXTERNAL_REDIRECTION;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_RETRY;
-import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_CREATED;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_ERROR;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.STATUS_INCOMPLETE;
@@ -157,7 +154,7 @@ public class TaskExecutionNodeTest {
     public void testExecutorUserCreatedStatus() throws Exception {
 
         ExecutorResponse executorResponse = new ExecutorResponse();
-        executorResponse.setResult(STATUS_USER_CREATED);
+        executorResponse.setResult(STATUS_COMPLETE);
         Map<String, Object> updatedClaims = new HashMap<>();
         updatedClaims.put("email", "test@example.com");
         executorResponse.setUpdatedUserClaims(updatedClaims);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
@@ -176,6 +176,7 @@ public class Constants {
         public static final String EXECUTION = "EXECUTION";
         public static final String WEBAUTHN = "WEBAUTHN";
         public static final String USER_ONBOARD = "USER_ONBOARD";
+        public static final String END = "END";
 
         private StepTypes() {
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/dao/FlowDAOImpl.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/dao/FlowDAOImpl.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.wso2.carbon.identity.flow.mgt.Constants.StepTypes.END;
 import static org.wso2.carbon.identity.flow.mgt.Constants.StepTypes.EXECUTION;
 import static org.wso2.carbon.identity.flow.mgt.Constants.StepTypes.VIEW;
 import static org.wso2.carbon.identity.flow.mgt.dao.SQLConstants.DELETE_FLOW;
@@ -345,6 +346,19 @@ public class FlowDAOImpl implements FlowDAO {
         })), preparedStatement -> {
             preparedStatement.setString(1, flowId);
             preparedStatement.setString(2, EXECUTION);
+        });
+
+        jdbcTemplate.executeQuery(GET_VIEW_PAGES_IN_FLOW, (LambdaExceptionUtils.rethrowRowMapper((resultSet, rowNumber) -> {
+            StepDTO stepDTO = new StepDTO.Builder()
+                    .id(resultSet.getString(DB_SCHEMA_COLUMN_NAME_STEP_ID))
+                    .type(END)
+                    .build();
+            resolvePageContent(stepDTO, resultSet.getBytes(DB_SCHEMA_COLUMN_NAME_PAGE_CONTENT), tenantId);
+            nodePageMappings.put(resultSet.getString(DB_SCHEMA_COLUMN_NAME_NODE_ID), stepDTO);
+            return null;
+        })), preparedStatement -> {
+            preparedStatement.setString(1, flowId);
+            preparedStatement.setString(2, END);
         });
         return nodePageMappings;
     }


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25415

This pull request refines the flow orchestration framework by standardizing flow completion handling, cleaning up status codes, and improving error logging. The main focus is on ensuring that when the END node is reached in a flow, the system consistently marks the flow as complete, triggers a redirection, and sets the appropriate redirect URL. It also removes the redundant `STATUS_USER_CREATED` status, consolidating completion statuses, and introduces more granular error logging.

**Flow Completion and Redirection Improvements**
* When the END node is reached, the flow status is now always set to `COMPLETE`, the step type to `REDIRECTION`, and the redirect URL is assigned. This ensures consistent handling of flow termination. [[1]](diffhunk://#diff-7e48afaa8a5a8523185c567716ed37ec669a1b35b99794dac65786f3bcc0d7c3R219-R237) [[2]](diffhunk://#diff-7e48afaa8a5a8523185c567716ed37ec669a1b35b99794dac65786f3bcc0d7c3R126-R131) [[3]](diffhunk://#diff-d6a74bf92e6fac835ade51211c40febfc18442bec372bb62bbb19c91b4c3afb7R409-R449)
* Added support for the `END` step type in the flow management constants and database layer, allowing END nodes to be properly recognized and mapped in flow definitions. [[1]](diffhunk://#diff-e9656a165eca820b5899d83bfd3ed6261b840fa35ae103e9a3eac73ca92b60a1R179) [[2]](diffhunk://#diff-83aa2d8caef5d2dd71e302555061fd38cf65627317bdabcea80ac2260485374dR50) [[3]](diffhunk://#diff-83aa2d8caef5d2dd71e302555061fd38cf65627317bdabcea80ac2260485374dR350-R362)

**Status Code Cleanup**
* Removed the `STATUS_USER_CREATED` constant and replaced its usage with `STATUS_COMPLETE` throughout the codebase, simplifying flow status management. [[1]](diffhunk://#diff-28ab79e73bb74e858270e0c19c388b5c9b1c0fe60ffb2a2d7e99dc273f2f3068L238) [[2]](diffhunk://#diff-cf0ec78259ca603b53c685150cddf0103629d353e29780326b414712ae567668L42) [[3]](diffhunk://#diff-cf0ec78259ca603b53c685150cddf0103629d353e29780326b414712ae567668L125-R124) [[4]](diffhunk://#diff-d1a264cd7c60909b37c3f18ea7b43fe236f8699441bf051cf5854da91aa74e58L62-R65) [[5]](diffhunk://#diff-d1a264cd7c60909b37c3f18ea7b43fe236f8699441bf051cf5854da91aa74e58L121-R121) [[6]](diffhunk://#diff-2e6cdd6fd70a6d88bb701c05bef9a8b7ee69bb6dfa769a9d2e8eaa5c6503343eL68) [[7]](diffhunk://#diff-2e6cdd6fd70a6d88bb701c05bef9a8b7ee69bb6dfa769a9d2e8eaa5c6503343eL160-R157)

**Error Logging Enhancements**
* Improved error logging in context rollback by distinguishing between client and server errors, and logging client errors at debug level when appropriate.

**Code and Test Maintenance**
* Updated tests to reflect the removal of `STATUS_USER_CREATED` and to verify the new flow completion logic for END nodes. [[1]](diffhunk://#diff-2e6cdd6fd70a6d88bb701c05bef9a8b7ee69bb6dfa769a9d2e8eaa5c6503343eL26) [[2]](diffhunk://#diff-2e6cdd6fd70a6d88bb701c05bef9a8b7ee69bb6dfa769a9d2e8eaa5c6503343eL53) [[3]](diffhunk://#diff-2e6cdd6fd70a6d88bb701c05bef9a8b7ee69bb6dfa769a9d2e8eaa5c6503343eL68) [[4]](diffhunk://#diff-2e6cdd6fd70a6d88bb701c05bef9a8b7ee69bb6dfa769a9d2e8eaa5c6503343eL160-R157) [[5]](diffhunk://#diff-d6a74bf92e6fac835ade51211c40febfc18442bec372bb62bbb19c91b4c3afb7R409-R449)

**Debug Logging and Minor Refactoring**
* Added debug logs for decision node transitions and END node completion, and performed minor refactoring for clarity and maintainability. [[1]](diffhunk://#diff-7e48afaa8a5a8523185c567716ed37ec669a1b35b99794dac65786f3bcc0d7c3R171-R174) [[2]](diffhunk://#diff-71f8d6293bc846375aa6180b95d53d73a7c05b0cb14ca8fe12d511bc238598baR36)

These changes collectively improve the reliability, maintainability, and clarity of the flow orchestration framework.