### PR TITLE
Add fix for authorise internal scopes when allowed scopes are configured

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
@@ -144,6 +144,8 @@ public class ApplicationConstants {
     public static final String CONSOLE_PORTAL_PATH = "Console.AppBaseName";
     public static final String MYACCOUNT_PORTAL_PATH = "MyAccount.AppBaseName";
     public static final String AUTHORIZE_ALL_SCOPES = "OAuth.AuthorizeAllScopes";
+    public static final String AUTHORIZE_INTERNAL_SCOPES = "OAuth.AuthorizeInternalScopes";
+
     public static final String RBAC = "RBAC";
     public static final String SYSTEM_PORTALS = "SystemPortals";
     public static final String IMPERSONATE_SCOPE_NAME = "internal_user_impersonate";

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
@@ -145,7 +145,6 @@ public class ApplicationConstants {
     public static final String MYACCOUNT_PORTAL_PATH = "MyAccount.AppBaseName";
     public static final String AUTHORIZE_ALL_SCOPES = "OAuth.AuthorizeAllScopes";
     public static final String AUTHORIZE_INTERNAL_SCOPES = "OAuth.AuthorizeInternalScopes";
-
     public static final String RBAC = "RBAC";
     public static final String SYSTEM_PORTALS = "SystemPortals";
     public static final String IMPERSONATE_SCOPE_NAME = "internal_user_impersonate";

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
@@ -219,6 +219,10 @@ public class AuthorizedAPIManagementServiceImpl implements AuthorizedAPIManageme
                     authorizedScopes = new ArrayList<>(authorizedScopesMap.values());
                 } else {
                     authorizedScopes = new ArrayList<>(getScopesExcludingInternalScopes(authorizedScopesMap));
+                    List<AuthorizedScopes> appAuthorisedScopes = authorizedAPIDAO.getAuthorizedScopes(appId,
+                            IdentityTenantUtil.getTenantId(tenantDomain));
+                    // Get the scopes authorised in the application and add them too.
+                    authorizedScopes.addAll(appAuthorisedScopes);
                 }
             } else {
                 authorizedScopes = authorizedAPIDAO.getAuthorizedScopes(appId,
@@ -236,15 +240,14 @@ public class AuthorizedAPIManagementServiceImpl implements AuthorizedAPIManageme
 
     private List<AuthorizedScopes> getScopesExcludingInternalScopes(Map<String, AuthorizedScopes> authorizedScopesMap) {
 
-        // Iterate through the map and filter scopes that do not start with "internal_".
+        // Iterate and filter scopes that do not start with "internal_" and "console" scopes.
         return authorizedScopesMap.values().stream()
                 .map(authorizedScopes -> {
-                    // Filter scopes that do not start with "internal_".
+                    // Filter scopes that do not start with "internal_" and "console".
                     List<String> filteredScopes = authorizedScopes.getScopes().stream()
                             .filter(scope -> !scope.startsWith(INTERNAL_SCOPE_PREFIX))
                             .filter(scope -> !scope.startsWith(CONSOLE_SCOPE_PREFIX))
                             .collect(Collectors.toList());
-                    // Create a new AuthorizedScopes object with the filtered scopes.
                     return new AuthorizedScopes(authorizedScopes.getPolicyId(), filteredScopes);
                 })
                 .collect(Collectors.toList());

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImplTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImplTest.java
@@ -56,7 +56,6 @@ import org.wso2.carbon.identity.common.testng.realm.InMemoryRealmService;
 import org.wso2.carbon.identity.common.testng.realm.MockUserStoreManager;
 import org.wso2.carbon.identity.core.internal.component.IdentityCoreServiceDataHolder;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.organization.management.service.internal.OrganizationManagementDataHolder;
 import org.wso2.carbon.registry.core.Collection;
@@ -82,7 +81,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
-import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.AUTHORIZE_ALL_SCOPES;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_ID;
 
@@ -123,7 +121,6 @@ public class AuthorizedAPIManagementServiceImplTest {
             loggerUtils.when(() -> LoggerUtils.triggerAuditLogEvent(any())).thenAnswer(inv -> null);
 
             applicationManagementService.deleteApplication("TestApp", tenantDomain, "user 1");
-            applicationManagementService.deleteApplication("TestApp1", tenantDomain, "user 1");
         }
     }
 
@@ -396,16 +393,11 @@ public class AuthorizedAPIManagementServiceImplTest {
 
     private String addApplication() throws Exception {
 
-        return addApplication("TestApp");
-    }
-
-    private String addApplication(String appName) throws Exception {
-
         try (MockedStatic<LoggerUtils> loggerUtils = mockStatic(LoggerUtils.class)) {
             loggerUtils.when(() -> LoggerUtils.triggerAuditLogEvent(any())).thenAnswer(inv -> null);
 
             ServiceProvider serviceProvider = new ServiceProvider();
-            serviceProvider.setApplicationName(appName);
+            serviceProvider.setApplicationName("TestApp");
             return applicationManagementService.createApplication(serviceProvider, tenantDomain, "user 1");
         }
     }
@@ -553,44 +545,4 @@ public class AuthorizedAPIManagementServiceImplTest {
 
         authorizedAPIManagementService.addAuthorizedAPI(authorizedAPI.getAppId(), authorizedAPI, tenantDomain);
     }
-
-    @Test
-    public void testGetScopesExcludingInternalScopes() throws Exception {
-
-        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
-            identityUtil.when(() -> IdentityUtil.getProperty(AUTHORIZE_ALL_SCOPES)).thenReturn("true");
-
-            String appId = addApplication("TestApp1");
-            APIResource apiResource = addTestAPIResource("test-get-scopes-1");
-            APIResource apiResourceForMgtAPIs = addTestAPIResourceWithInternalScopes();
-
-            List<AuthorizedScopes> authorizedScopesList = authorizedAPIManagementService.getAuthorizedScopes(appId,
-                    tenantDomain);
-            Assert.assertFalse(authorizedScopesList.isEmpty());
-            for (AuthorizedScopes authorizedScopes : authorizedScopesList) {
-                Assert.assertEquals(authorizedScopes.getScopes().size(), 2);
-                Assert.assertFalse(authorizedScopes.getScopes().stream().anyMatch(
-                        scope -> scope.startsWith("internal_")));
-            }
-            Assert.assertTrue(authorizedScopesList.get(0).getScopes().contains("test-get-scopes"));
-
-        }
-    }
-
-    private APIResource addTestAPIResourceWithInternalScopes() throws Exception {
-
-        List<Scope> scopes = new ArrayList<>();
-        scopes.add(new Scope.ScopeBuilder().name("internal_application_mgt_create").displayName(
-                "displayName 1 ").description("description 1 ").build());
-
-        scopes.add(new Scope.ScopeBuilder().name("internal_application_mgt_view").displayName(
-                "displayName 2 ").description("description 2 ").build());
-
-        APIResource.APIResourceBuilder apiResourceBuilder =
-                new APIResource.APIResourceBuilder().name("AppMgt name ").identifier("/appmgt ").description("AppMgt "
-                ).type("BUSINESS").requiresAuthorization(true).scopes(scopes);
-
-        return apiResourceManager.addAPIResource(apiResourceBuilder.build(), tenantDomain);
-    }
-
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1366,6 +1366,7 @@
         </RestrictedQueryParameters>
 
         <AuthorizeAllScopes>{{oauth.authorize_all_scopes}}</AuthorizeAllScopes>
+        <AuthorizeInternalScopes>{{oauth.authorize_internal_scopes}}</AuthorizeInternalScopes>
 
         <!--
             When this configuration is enabled, the system supports the features defined in RFC9396,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -2024,6 +2024,7 @@
   "webhooks.maximum_webhooks_per_tenant": "10",
 
   "oauth.authorize_all_scopes": false,
+  "oauth.authorize_internal_scopes": false,
   "oauth.enable_rich_authorization_requests" : true,
 
   "system_applications.system_portals": ["Console", "My Account"],


### PR DESCRIPTION
### Proposed changes in this pull request

Related to https://github.com/wso2/carbon-identity-framework/pull/5814

**To authorise non internal scopes (Only Business scopes)**
```
[oauth]
authorize_all_scopes=true
```
Above configuration will authorise only business scopes. After wards, you can enable internal scopes registered through apps if the apps need

**To get internal scopes along with the business scopes, and to keep the backward compatibility**

```
[oauth]
authorize_all_scopes=true
authorize_internal_scopes=true
```

By default, server won't authorise internal scopes unless they are authorised in the application level. if you add the `authorize_internal_scopes` configuration explicitly, it will allow the internal scopes. 


### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-

### Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
