### PR TITLE
Allow impersonation API resource for my account by default

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
@@ -152,6 +152,7 @@ public class ApplicationConstants {
             IMPERSONATE_SCOPE_NAME, IMPERSONATE_ORG_SCOPE_NAME));
     public static final String IMPERSONATE_ROLE_NAME = "Impersonator";
     public static final String IMPERSONATION_API_RESOURCE = "system:impersonation";
+    public static final String IMPERSONATION_ORG_API_RESOURCE = "org:impersonation";
     public static final String APPLICATION_ROLE_AUDIENCE = "application";
 
     /**

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/MyAccountAuthorizedAPIListener.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/listener/MyAccountAuthorizedAPIListener.java
@@ -37,6 +37,11 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.IMPERSONATE_ORG_SCOPE_NAME;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.IMPERSONATE_SCOPE_NAME;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.IMPERSONATION_API_RESOURCE;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.IMPERSONATION_ORG_API_RESOURCE;
+
 /**
  * MyAccount authorized API listener.
  */
@@ -44,12 +49,14 @@ public class MyAccountAuthorizedAPIListener extends AbstractAuthorizedAPIManagem
 
     private static final List<String> authorizedNoPolicyAPIIdentifiers = Arrays.asList(
             "/api/users/v1/me/approval-tasks",
-            "/o/api/users/v1/me/approval-tasks");
+            "/o/api/users/v1/me/approval-tasks",
+            IMPERSONATION_API_RESOURCE, IMPERSONATION_ORG_API_RESOURCE);
     private static final List<String> authorizedNoPolicyScopes = Arrays.asList(
             "internal_approval_task_view",
             "internal_approval_task_update",
             "internal_org_approval_task_view",
-            "internal_org_approval_task_update");
+            "internal_org_approval_task_update",
+            IMPERSONATE_SCOPE_NAME, IMPERSONATE_ORG_SCOPE_NAME);
 
     private static final Log log = LogFactory.getLog(MyAccountAuthorizedAPIListener.class);
 


### PR DESCRIPTION
### Proposed changes in this pull request
$subject so that the migrating customers doesn't have to register this API resource manually. This feature was introduced by https://github.com/wso2/carbon-identity-framework/pull/7189. 


Related Issues:
- https://github.com/wso2/product-is/issues/24474