### PR TITLE
[NEXT] Register role assignments api resource by default

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -1353,7 +1353,6 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    {% if scim2.enable_scim2_roles_v3_api is sameas true %}
     <APIResourceCollection name="roleAssignments" displayName="Role Assignments" type="tenant">
         <Scopes>
             <Feature>
@@ -1380,7 +1379,6 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    {% endif %}
     <APIResourceCollection name="rolesV1" displayName="Roles" type="tenant">
         <Scopes>
             <Feature>
@@ -1733,7 +1731,6 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    {% if scim2.enable_scim2_roles_v3_api is sameas true %}
     <APIResourceCollection name="org_roleAssignments" displayName="Role Assignments" type="organization">
         <Scopes>
             <Feature>
@@ -1758,7 +1755,6 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
-    {% endif %}
     <APIResourceCollection name="org_rolesV1" displayName="Roles" type="organization">
         <Scopes>
             <Feature>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -1444,7 +1444,6 @@
                    description="Manage edits of roles in the organization from the Console"/>
         </Scopes>
     </APIResource>
-    {% if scim2.enable_scim2_roles_v3_api is sameas true %}
     <APIResource name="Role Assignments Feature" identifier="console:role_assignments"
                 requiresAuthorization="true"
                 description="Resource representation of the Role Assignments Management Feature"
@@ -1471,7 +1470,6 @@
                 description="Manage edits of Role Assignments from the Console"/>
         </Scopes>
     </APIResource>
-    {% endif %}
     <APIResource name="User Management Feature" identifier="console:users"
                  requiresAuthorization="true"
                  description="Resource representation of the User Management Feature"


### PR DESCRIPTION
### Proposed changes in this pull request
With this PR below changes will be done.

> console new permission `console:role_assignments` & `console:org:role_assignments` permissions will be available in the system. 
    - They will not be useful as the permission changes are not reflected. (Need to enable by the config)
    - This is required for the migration.

Things depend on the config:
> Roles V3 API will be available. 
> After this change, by enabling config, the console roles created with `console:roles` & `console:org:roles` will loose the assignment permission if not specifically added via migration.

The above actions are performed before as they are not affecting the backward compatibility.

Related Issues:
- https://github.com/wso2/product-is/issues/21686

Related PRs:
- https://github.com/wso2/carbon-identity-framework/pull/7253