### PR TITLE
Refactor uniqueness check logic in UniqueClaimUserOperationEventListener

### DIFF
--- a/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/src/main/java/org/wso2/carbon/identity/unique/claim/mgt/listener/UniqueClaimUserOperationEventListener.java
+++ b/components/multi-attribute-login/org.wso2.carbon.identity.unique.claim.mgt/src/main/java/org/wso2/carbon/identity/unique/claim/mgt/listener/UniqueClaimUserOperationEventListener.java
@@ -322,19 +322,14 @@ public class UniqueClaimUserOperationEventListener extends AbstractIdentityUserO
         String usernameWithUserStoreDomain = UserCoreUtil.addDomainToName(username, domainName);
         if (userList.length == 0) {
             return false;
-        } else {
-            if (usernameWithUserStoreDomain.equalsIgnoreCase(userList[0])) {
-                if (log.isDebugEnabled()) {
-                    if (userList.length > 1) {
-                        log.debug("Multiple users found for claim URI: " + claimUri + ". The current user is the " +
-                                "first in the list; skipping uniqueness check for this claim value.");
-                    } else {
-                        log.debug("Single user found for claim URI: " + claimUri + ". The user is the same as the " +
-                                "current user; skipping uniqueness check for this claim value.");
-                    }
-                }
-                return false;
+        }
+        if (userList.length == 1 && usernameWithUserStoreDomain.equalsIgnoreCase(userList[0])) {
+            if (log.isDebugEnabled()) {
+                log.debug("Single user found for claim URI: " + claimUri + ". The user is the same as the " +
+                        "current user; skipping uniqueness check for this claim value.");
             }
+            return false;
+        } else {
             if (log.isDebugEnabled()) {
                 log.debug("Multiple users found for claim URI: " + claimUri);
             }
@@ -506,17 +501,21 @@ public class UniqueClaimUserOperationEventListener extends AbstractIdentityUserO
                 userList = userStoreManager.getUserList(claimUri, claimValuePart, profile);
             }
             if (userList.length > 1) {
-                if (usernameWithUserStoreDomain.equalsIgnoreCase(userList[0])) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Multiple users found for claim URI: " + claimUri + ". The current user is " +
-                                "the first in the list; skipping uniqueness check for this claim value.");
-                    }
-                    continue;
+                if (log.isDebugEnabled()) {
+                    log.debug("Multiple users found for claim URI: " + claimUri);
                 }
                 return true;
             }
             if (userList.length == 1 && !usernameWithUserStoreDomain.equalsIgnoreCase(userList[0])) {
-                    return true;
+                if (log.isDebugEnabled()) {
+                    log.debug("Single user found for claim URI: " + claimUri + ". The user is different from the " +
+                            "current user.");
+                }
+                return true;
+            }
+            if (log.isDebugEnabled() && userList.length == 1) {
+                log.debug("Single user found for claim URI: " + claimUri + ". The user is the same as the " +
+                        "current user; skipping uniqueness check for this claim value.");
             }
         }
         return false;


### PR DESCRIPTION
Related PR https://github.com/wso2/carbon-identity-framework/pull/7268

This pull request refines the logic for checking claim duplication in the `UniqueClaimUserOperationEventListener.java` file, ensuring more accurate handling of edge cases and improving debug logging. The changes clarify when uniqueness checks should be skipped or enforced, especially in scenarios involving single or multiple users.

### Improvements to claim duplication logic

* Updated `isClaimDuplicated` to only skip uniqueness checks when there is exactly one user and it matches the current user, preventing incorrect skipping when multiple users are present.
* Refined `isMultiValuedClaimDuplicated` to always enforce uniqueness checks when multiple users are found, and to provide clearer debug logs distinguishing between same and different users in single-user scenarios.