### PR TITLE
Fixed webhook audit logs

### DIFF
--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/util/WebhookManagementAuditLogger.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/util/WebhookManagementAuditLogger.java
@@ -144,7 +144,6 @@ public class WebhookManagementAuditLogger {
             return LoggerUtils.Initiator.System.name();
         }
 
-
         String initiator = null;
         if (StringUtils.isNotBlank(tenantDomain)) {
             initiator = IdentityUtil.getInitiatorId(username, tenantDomain);
@@ -162,8 +161,7 @@ public class WebhookManagementAuditLogger {
         UPDATE("update-webhook"),
         DELETE("delete-webhook"),
         ACTIVATE("activate-webhook"),
-        DEACTIVATE("deactivate-webhook"),
-        RETRY("retry-webhook");
+        DEACTIVATE("deactivate-webhook");
 
         private final String logAction;
 
@@ -183,8 +181,8 @@ public class WebhookManagementAuditLogger {
      */
     private static class LogConstants {
 
-        public static final String UUID_FIELD = "Uuid";
-        public static final String ENDPOINT_FIELD = "Endpoint";
+        public static final String UUID_FIELD = "Id";
+        public static final String ENDPOINT_FIELD = "EndpointUri";
         public static final String NAME_FIELD = "Name";
         public static final String SECRET_FIELD = "Secret";
         public static final String EVENT_PROFILE_NAME_FIELD = "EventProfileName";

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/java/org/wso2/carbon/identity/webhook/management/util/WebhookManagementAuditLoggerTest.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/java/org/wso2/carbon/identity/webhook/management/util/WebhookManagementAuditLoggerTest.java
@@ -118,9 +118,9 @@ public class WebhookManagementAuditLoggerTest {
     public void testCreateAuditLogEntryForWebhook() throws WebhookMgtException {
 
         JSONObject data = invokeCreateAuditLogEntry(webhook);
-        Assert.assertEquals(data.get("Uuid"), "webhook-123");
+        Assert.assertEquals(data.get("Id"), "webhook-123");
         Assert.assertEquals(data.get("Name"), "Test Webhook");
-        Assert.assertEquals(data.get("Endpoint"), "https://example.com/webhook");
+        Assert.assertEquals(data.get("EndpointUri"), "https://example.com/webhook");
         Assert.assertEquals(data.get("Secret"), "****");
         Assert.assertEquals(data.get("EventProfileName"), "profile");
         Assert.assertEquals(data.get("EventProfileUri"), "uri");
@@ -138,7 +138,7 @@ public class WebhookManagementAuditLoggerTest {
     public void testCreateAuditLogEntryForWebhookId() throws Exception {
 
         JSONObject data = invokeCreateAuditLogEntry();
-        Assert.assertEquals(data.get("Uuid"), "webhook-456");
+        Assert.assertEquals(data.get("Id"), "webhook-456");
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request updates the audit logging fields and actions in the webhook management module to improve consistency and clarity. The main changes include renaming audit log fields, removing an unused operation, and updating related unit tests.

**Audit log field renaming:**
* Changed audit log field names from `Uuid` to `Id` and from `Endpoint` to `EndpointUri` in `WebhookManagementAuditLogger` to standardize naming.
* Updated unit tests in `WebhookManagementAuditLoggerTest` to match the new field names (`Id` and `EndpointUri`). [[1]](diffhunk://#diff-2b9dbb6669521430d3bf408ba863b433337339cad921efc287663b741346fe85L121-R123) [[2]](diffhunk://#diff-2b9dbb6669521430d3bf408ba863b433337339cad921efc287663b741346fe85L141-R141)

**Operation enum changes:**
* Removed the `RETRY` operation from the `Operation` enum, as it is no longer used.

**Other minor cleanup:**
* Removed an unnecessary blank line in `getInitiatorId()` for code clarity.
