### PR TITLE
Removed duplicate async impl of publisher

### DIFF
--- a/components/webhook-mgt/org.wso2.carbon.identity.event.publisher/src/main/java/org/wso2/carbon/identity/event/publisher/internal/service/impl/EventPublisherServiceImpl.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.event.publisher/src/main/java/org/wso2/carbon/identity/event/publisher/internal/service/impl/EventPublisherServiceImpl.java
@@ -30,9 +30,6 @@ import org.wso2.carbon.identity.event.publisher.internal.component.EventPublishe
 import org.wso2.carbon.identity.event.publisher.internal.util.EventPublisherExceptionHandler;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 /**
  * Implementation of the EventPublisherService interface.
@@ -42,8 +39,6 @@ public class EventPublisherServiceImpl implements EventPublisherService {
 
     private static final Log log = LogFactory.getLog(EventPublisherServiceImpl.class);
     private static final EventPublisherServiceImpl eventPublisherServiceImpl = new EventPublisherServiceImpl();
-    private static final int THREAD_POOL_SIZE = 10;
-    private static final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
     private final String webhookAdapter;
 
     private EventPublisherServiceImpl() {
@@ -68,17 +63,7 @@ public class EventPublisherServiceImpl implements EventPublisherService {
         EventPublisher adapterManager = retrieveAdapterManager(webhookAdapter);
 
         log.debug("Invoking registered event publisher: " + adapterManager.getClass().getName());
-        CompletableFuture.runAsync(() -> {
-            try {
-                adapterManager.publish(eventPayload, eventContext);
-            } catch (EventPublisherException e) {
-                log.error("Error while publishing event with publisher: " +
-                        adapterManager.getClass().getName(), e);
-            }
-        }, executorService).exceptionally(ex -> {
-            log.error("Error occurred in async event publishing: " + ex.getMessage(), ex);
-            return null;
-        });
+        adapterManager.publish(eventPayload, eventContext);
     }
 
     @Override


### PR DESCRIPTION
### Proposed changes in this pull request

Async publishing already handled in lower level.

This pull request simplifies the `EventPublisherServiceImpl` class by removing asynchronous event publishing and related threading logic. Events are now published synchronously, which reduces complexity and potential concurrency issues.

**Simplification of event publishing logic:**

* Removed use of `CompletableFuture` and `ExecutorService`, eliminating the thread pool and asynchronous execution for publishing events in `EventPublisherServiceImpl`. Events are now published synchronously. [[1]](diffhunk://#diff-76e2c0ce82941f5e525008158f069bd9d79baa8b5cc17a416f5df145ba57b4d2L33-L35) [[2]](diffhunk://#diff-76e2c0ce82941f5e525008158f069bd9d79baa8b5cc17a416f5df145ba57b4d2L45-L46) [[3]](diffhunk://#diff-76e2c0ce82941f5e525008158f069bd9d79baa8b5cc17a416f5df145ba57b4d2L71-L81)