### PR TITLE
Publisher test update

### DIFF
--- a/components/webhook-mgt/org.wso2.carbon.identity.event.publisher/src/test/java/org/wso2/carbon/identity/event/publisher/service/EventPublisherServiceImplTest.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.event.publisher/src/test/java/org/wso2/carbon/identity/event/publisher/service/EventPublisherServiceImplTest.java
@@ -99,7 +99,7 @@ public class EventPublisherServiceImplTest {
         EventPublisherComponentServiceHolder.getInstance().setEventPublishers(null);
     }
 
-    @Test
+    @Test(expectedExceptions = EventPublisherException.class)
     public void testPublishWithException() throws Exception {
 
         when(mockEventPublisher1.getAssociatedAdapter()).thenReturn("webSubHubAdapter");
@@ -110,7 +110,7 @@ public class EventPublisherServiceImplTest {
 
         eventPublisherService.publish(mockEventPayload, mockEventContext);
 
-        // Wait for async execution
+        // Wait for async execution.
         TimeUnit.MILLISECONDS.sleep(200);
         verify(mockEventPublisher1, times(1)).publish(mockEventPayload, mockEventContext);
         verify(mockEventPublisher2, never()).publish(any(), any());

--- a/components/webhook-mgt/org.wso2.carbon.identity.event.publisher/src/test/java/org/wso2/carbon/identity/event/publisher/service/EventPublisherServiceImplTest.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.event.publisher/src/test/java/org/wso2/carbon/identity/event/publisher/service/EventPublisherServiceImplTest.java
@@ -109,11 +109,6 @@ public class EventPublisherServiceImplTest {
                 .when(mockEventPublisher1).publish(mockEventPayload, mockEventContext);
 
         eventPublisherService.publish(mockEventPayload, mockEventContext);
-
-        // Wait for async execution.
-        TimeUnit.MILLISECONDS.sleep(200);
-        verify(mockEventPublisher1, times(1)).publish(mockEventPayload, mockEventContext);
-        verify(mockEventPublisher2, never()).publish(any(), any());
     }
 
     @Test


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request makes a minor update to the `EventPublisherServiceImplTest` unit test to improve test reliability and correctness. The most notable change is the explicit expectation of an exception in the `testPublishWithException` test method.

Test improvements:

* Updated the `testPublishWithException` method to expect an `EventPublisherException`, ensuring the test correctly validates that the exception is thrown when appropriate.
* Added a period to the comment about waiting for async execution for clarity.