### PR TITLE
[bug-fix] Confusion in defining a regex for multi-value attributes

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2540,6 +2540,7 @@ public class FrameworkUtils {
      * @throws UserStoreException If an error occurs while retrieving the user store manager.
      */
     private static AbstractUserStoreManager getUserStoreManager(String userStoreDomain) throws UserStoreException {
+
         if (userStoreDomain != null) {
             return (AbstractUserStoreManager) ((AbstractUserStoreManager)
                     CarbonContext.getThreadLocalCarbonContext().getUserRealm().getUserStoreManager())
@@ -2550,6 +2551,7 @@ public class FrameworkUtils {
     }
 
     public static String getPASTRCookieName (String sessionDataKey) {
+
         return FrameworkConstants.PASTR_COOKIE + "-" + sessionDataKey;
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2512,6 +2512,30 @@ public class FrameworkUtils {
         return multiAttributeSeparator;
     }
 
+    public static String getMultiAttributeSeparator(String userStoreDomain) {
+
+        try {
+            // Retrieve the user store manager of the user store domain.
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) ((AbstractUserStoreManager)
+                    CarbonContext.getThreadLocalCarbonContext().getUserRealm().getUserStoreManager())
+                    .getSecondaryUserStoreManager(userStoreDomain);
+            // Retrieve the multi attribute separator configured for the user store.
+            String multiAttributeSeparator = userStoreManager.getRealmConfiguration()
+                    .getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR);
+            // If multi attribute separator is not configured for the user store, use the higher level configuration.
+            if (StringUtils.isBlank(multiAttributeSeparator)) {
+                multiAttributeSeparator = getMultiAttributeSeparator();
+            }
+            return multiAttributeSeparator;
+        } catch (UserStoreException e) {
+            // If an error occurred while retrieving the user store manager,
+            // log and return the higher level configuration.
+            log.error("Error while retrieving UserStoreManager for user store domain: " + userStoreDomain +
+                    ". Hence defaulting to the multi attribute separator.");
+            return getMultiAttributeSeparator();
+        }
+    }
+
     public static String getPASTRCookieName (String sessionDataKey) {
         return FrameworkConstants.PASTR_COOKIE + "-" + sessionDataKey;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2514,26 +2514,27 @@ public class FrameworkUtils {
 
     public static String getMultiAttributeSeparator(String userStoreDomain) {
 
-        try {
-            // Retrieve the user store manager of the user store domain.
-            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) ((AbstractUserStoreManager)
-                    CarbonContext.getThreadLocalCarbonContext().getUserRealm().getUserStoreManager())
-                    .getSecondaryUserStoreManager(userStoreDomain);
-            // Retrieve the multi attribute separator configured for the user store.
-            String multiAttributeSeparator = userStoreManager.getRealmConfiguration()
-                    .getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR);
-            // If multi attribute separator is not configured for the user store, use the higher level configuration.
-            if (StringUtils.isBlank(multiAttributeSeparator)) {
-                multiAttributeSeparator = getMultiAttributeSeparator();
+        if (userStoreDomain != null) {
+            try {
+                // Retrieve the user store manager of the user store domain.
+                AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) ((AbstractUserStoreManager)
+                        CarbonContext.getThreadLocalCarbonContext().getUserRealm().getUserStoreManager())
+                        .getSecondaryUserStoreManager(userStoreDomain);
+                // Retrieve the multi attribute separator configured for the user store.
+                String multiAttributeSeparator = userStoreManager.getRealmConfiguration()
+                        .getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR);
+                // If multi attribute separator is not configured for the user store, use the higher level configuration.
+                if (StringUtils.isBlank(multiAttributeSeparator)) {
+                    multiAttributeSeparator = getMultiAttributeSeparator();
+                }
+                return multiAttributeSeparator;
+            } catch (UserStoreException e) {
+                // If an error occurred, log and return the higher level configuration.
+                log.error("Error while retrieving UserStoreManager for user store domain: " + userStoreDomain +
+                        ". Hence defaulting to the multi attribute separator.");
             }
-            return multiAttributeSeparator;
-        } catch (UserStoreException e) {
-            // If an error occurred while retrieving the user store manager,
-            // log and return the higher level configuration.
-            log.error("Error while retrieving UserStoreManager for user store domain: " + userStoreDomain +
-                    ". Hence defaulting to the multi attribute separator.");
-            return getMultiAttributeSeparator();
         }
+        return getMultiAttributeSeparator();
     }
 
     public static String getPASTRCookieName (String sessionDataKey) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2466,15 +2466,28 @@ public class FrameworkUtils {
         cookieBuilder.setSecure(cookieConfig.isSecure());
     }
 
+    /**
+     * Get the multi attribute separator.
+     *
+     * @return Multi attribute separator.
+     * @deprecated This method is deprecated and may be removed in future releases.
+     */
     @Deprecated
     public static String getMultiAttributeSeparator() {
 
         return getMultiAttributeSeparator(null);
     }
 
+    /**
+     * Retrieves the multi-attribute separator for a given user store domain.
+     *
+     * @param userStoreDomain The user store domain.
+     * @return The multi-attribute separator.
+     */
     public static String getMultiAttributeSeparator(String userStoreDomain) {
 
         String multiAttributeSeparator = null;
+        // Check if org-wise multi attribute separator is enabled.
         if (Boolean.parseBoolean(IdentityUtil.getProperty(ORG_WISE_MULTI_ATTRIBUTE_SEPARATOR_ENABLED))) {
             try {
                 Attribute configAttribute = FrameworkServiceDataHolder.getInstance().getConfigurationManager()
@@ -2496,31 +2509,20 @@ public class FrameworkUtils {
             }
         }
 
+        // Retrieve the multi-attribute separator from the user store configuration if not found in the org config.
         if (StringUtils.isBlank(multiAttributeSeparator)) {
             try {
-                if (userStoreDomain != null) {
-                    // Retrieve the user store manager of the user store domain.
-                    AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) ((AbstractUserStoreManager)
-                            CarbonContext.getThreadLocalCarbonContext().getUserRealm().getUserStoreManager())
-                            .getSecondaryUserStoreManager(userStoreDomain);
-                    // Retrieve the multi attribute separator configured for the user store.
+                AbstractUserStoreManager userStoreManager = getUserStoreManager(userStoreDomain);
+                if (userStoreManager != null) {
                     multiAttributeSeparator = userStoreManager.getRealmConfiguration()
                             .getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR);
-
-                } else {
-                    multiAttributeSeparator = CarbonContext.getThreadLocalCarbonContext().getUserRealm()
-                            .getRealmConfiguration().getUserStoreProperty(IdentityCoreConstants
-                                    .MULTI_ATTRIBUTE_SEPARATOR);
-
                 }
             } catch (UserStoreException e) {
-                log.error("Error while retrieving MultiAttributeSeparator from UserRealm.");
-                if (log.isDebugEnabled()) {
-                    log.debug("Error while retrieving MultiAttributeSeparator from UserRealm.", e);
-                }
+                log.error("Error while retrieving MultiAttributeSeparator from UserRealm.", e);
             }
         }
 
+        // If multi-attribute separator is not found through the above methods, use the default value.
         if (StringUtils.isBlank(multiAttributeSeparator)) {
             multiAttributeSeparator = IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT;
             if (log.isDebugEnabled()) {
@@ -2528,6 +2530,23 @@ public class FrameworkUtils {
             }
         }
         return multiAttributeSeparator;
+    }
+
+    /**
+     * Retrieves the user store manager for the given user store domain.
+     *
+     * @param userStoreDomain The user store domain.
+     * @return The user store manager, or null if not found.
+     * @throws UserStoreException If an error occurs while retrieving the user store manager.
+     */
+    private static AbstractUserStoreManager getUserStoreManager(String userStoreDomain) throws UserStoreException {
+        if (userStoreDomain != null) {
+            return (AbstractUserStoreManager) ((AbstractUserStoreManager)
+                    CarbonContext.getThreadLocalCarbonContext().getUserRealm().getUserStoreManager())
+                    .getSecondaryUserStoreManager(userStoreDomain);
+        }
+        return (AbstractUserStoreManager) CarbonContext.getThreadLocalCarbonContext().getUserRealm()
+                .getUserStoreManager();
     }
 
     public static String getPASTRCookieName (String sessionDataKey) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -1445,7 +1445,7 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
     @Test
     public void testGetMultiAttributeSeparatorFromUserRealmConfig() {
 
-        final String MULTI_ATTRIBUTE_SEPARATOR = ",";
+        final String multiAttributeSeparator = ",";
         try (MockedStatic<CarbonContext> carbonContextMockedStatic = mockStatic(CarbonContext.class)) {
             CarbonContext carbonContext = mock(CarbonContext.class);
             UserRealm userRealm = mock(UserRealm.class);
@@ -1461,10 +1461,10 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
             }
             when(primaryUserStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
             when(realmConfiguration.getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR))
-                    .thenReturn(MULTI_ATTRIBUTE_SEPARATOR);
+                    .thenReturn(multiAttributeSeparator);
 
             String separator = FrameworkUtils.getMultiAttributeSeparator();
-            assertEquals(separator, MULTI_ATTRIBUTE_SEPARATOR);
+            assertEquals(separator, multiAttributeSeparator);
         }
     }
 
@@ -1475,7 +1475,7 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
     public void testGetMultiAttributeSeparatorWithUserStoreDomain() {
 
         String userStoreDomain = "SECONDARY";
-        final String MULTI_ATTRIBUTE_SEPARATOR = ";";
+        final String multiAttributeSeparator = ";";
 
         try (MockedStatic<CarbonContext> carbonContextMockedStatic = mockStatic(CarbonContext.class)) {
             CarbonContext carbonContext = mock(CarbonContext.class);
@@ -1495,10 +1495,10 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
                     .thenReturn(secondaryUserStoreManager);
             when(secondaryUserStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
             when(realmConfiguration.getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR))
-                    .thenReturn(MULTI_ATTRIBUTE_SEPARATOR);
+                    .thenReturn(multiAttributeSeparator);
 
             String separator = FrameworkUtils.getMultiAttributeSeparator(userStoreDomain);
-            assertEquals(separator, MULTI_ATTRIBUTE_SEPARATOR);
+            assertEquals(separator, multiAttributeSeparator);
         }
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -1451,13 +1451,13 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
             RealmConfiguration realmConfiguration = mock(RealmConfiguration.class);
 
             carbonContextMockedStatic.when(CarbonContext::getThreadLocalCarbonContext).thenReturn(carbonContext);
-            when(carbonContext.getUserRealm()).thenReturn(userRealm);
+            lenient().when(carbonContext.getUserRealm()).thenReturn(userRealm);
             try {
                 lenient().when(userRealm.getRealmConfiguration()).thenReturn(realmConfiguration);
             } catch (UserStoreException e) {
                 throw new RuntimeException("Unexpected UserStoreException in test setup.", e);
             }
-            when(realmConfiguration.getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR))
+            lenient().when(realmConfiguration.getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR))
                     .thenReturn(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT);
 
             String separator = FrameworkUtils.getMultiAttributeSeparator();
@@ -1479,17 +1479,17 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
             RealmConfiguration realmConfiguration = mock(RealmConfiguration.class);
 
             carbonContextMockedStatic.when(CarbonContext::getThreadLocalCarbonContext).thenReturn(carbonContext);
-            when(carbonContext.getUserRealm()).thenReturn(userRealm);
+            lenient().when(carbonContext.getUserRealm()).thenReturn(userRealm);
             try {
-                when(userRealm.getUserStoreManager()).thenReturn(primaryUserStoreManager);
+                lenient().when(userRealm.getUserStoreManager()).thenReturn(primaryUserStoreManager);
                 lenient().when(userRealm.getRealmConfiguration()).thenReturn(realmConfiguration);
             } catch (UserStoreException e) {
                 throw new RuntimeException("Unexpected UserStoreException in test setup.", e);
             }
-            when(primaryUserStoreManager.getSecondaryUserStoreManager(userStoreDomain))
+            lenient().when(primaryUserStoreManager.getSecondaryUserStoreManager(userStoreDomain))
                     .thenReturn(secondaryUserStoreManager);
-            when(secondaryUserStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
-            when(realmConfiguration.getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR))
+            lenient().when(secondaryUserStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
+            lenient().when(realmConfiguration.getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR))
                     .thenReturn(";");
 
             String separator = FrameworkUtils.getMultiAttributeSeparator(userStoreDomain);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -1481,6 +1481,7 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
             carbonContextMockedStatic.when(CarbonContext::getThreadLocalCarbonContext).thenReturn(carbonContext);
             when(carbonContext.getUserRealm()).thenReturn(userRealm);
             try {
+                when(userRealm.getUserStoreManager()).thenReturn(primaryUserStoreManager);
                 when(userRealm.getRealmConfiguration()).thenReturn(realmConfiguration);
             } catch (UserStoreException e) {
                 throw new RuntimeException("Unexpected UserStoreException in test setup.", e);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -1482,7 +1482,7 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
             when(carbonContext.getUserRealm()).thenReturn(userRealm);
             try {
                 when(userRealm.getUserStoreManager()).thenReturn(primaryUserStoreManager);
-                when(userRealm.getRealmConfiguration()).thenReturn(realmConfiguration);
+                lenient().when(userRealm.getRealmConfiguration()).thenReturn(realmConfiguration);
             } catch (UserStoreException e) {
                 throw new RuntimeException("Unexpected UserStoreException in test setup.", e);
             }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -1453,15 +1453,15 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
             carbonContextMockedStatic.when(CarbonContext::getThreadLocalCarbonContext).thenReturn(carbonContext);
             when(carbonContext.getUserRealm()).thenReturn(userRealm);
             try {
-                when(userRealm.getRealmConfiguration()).thenReturn(realmConfiguration);
+                lenient().when(userRealm.getRealmConfiguration()).thenReturn(realmConfiguration);
             } catch (UserStoreException e) {
                 throw new RuntimeException("Unexpected UserStoreException in test setup.", e);
             }
             when(realmConfiguration.getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR))
-                    .thenReturn("|");
+                    .thenReturn(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT);
 
             String separator = FrameworkUtils.getMultiAttributeSeparator();
-            assertEquals(separator, "|");
+            assertEquals(separator, IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT);
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -217,7 +217,7 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
                 new MockAuthenticator("HwkMockAuthenticator"));
         ApplicationAuthenticatorManager.getInstance().addSystemDefinedAuthenticator(
                 new MockAuthenticator("FederatedAuthenticator", null, "sampleClaimDialectURI"));
-
+           
         authenticationContext.setTenantDomain("abc");
     }
 
@@ -413,7 +413,7 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
     public void getAddAuthenticationContextToCache() {
 
         try (MockedStatic<AuthenticationContextCache> authenticationContextCache =
-                     mockStatic(AuthenticationContextCache.class)) {
+                mockStatic(AuthenticationContextCache.class)) {
             authenticationContextCache.when(
                     AuthenticationContextCache::getInstance).thenReturn(mockedAuthenticationContextCache);
             String contextId = "CONTEXT-ID";
@@ -583,11 +583,11 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
     public void testGetAuthenticationResultFromSessionDataStoreExpired() {
 
         try (MockedStatic<SessionDataStore> sessionDataStore = mockStatic(SessionDataStore.class);
-             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
 
-            sessionDataStore.when(SessionDataStore::getInstance).thenReturn(mockedSessionDataStore);
-            identityUtil.when(() -> IdentityUtil.getProperty("JDBCPersistenceManager.SessionDataPersist.Temporary"))
-                    .thenReturn("true");
+                sessionDataStore.when(SessionDataStore::getInstance).thenReturn(mockedSessionDataStore);
+                identityUtil.when(() -> IdentityUtil.getProperty("JDBCPersistenceManager.SessionDataPersist.Temporary"))
+                        .thenReturn("true");
 
             AuthenticationResultCache authenticationCacheSpy = spy(AuthenticationResultCache.getInstance());
 
@@ -1234,13 +1234,13 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
 
         // User object.
         User user = new User(
-                "user-123",
-                "dummyUser",
-                "dummyUser",
-                "dummyUser",
-                "dummyTenantDomain",
-                "DUMMYDOMAIN",
-                null
+        "user-123",
+        "dummyUser",
+        "dummyUser",
+        "dummyUser",
+        "dummyTenantDomain",
+        "DUMMYDOMAIN",
+        null
         );
 
         RealmService realmService = mock(RealmService.class);
@@ -1313,7 +1313,7 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
                 useTenantDomainInLocalSubjectIdentifier);
 
         try (MockedStatic<IdentityUtil> identityUtilMockedStatic = mockStatic(IdentityUtil.class);
-             MockedStatic<IdentityTenantUtil> identityTenantUtilMockedStatic = mockStatic(IdentityTenantUtil.class)) {
+            MockedStatic<IdentityTenantUtil> identityTenantUtilMockedStatic = mockStatic(IdentityTenantUtil.class)) {
 
             // Mock IdentityUtil methods.
             identityUtilMockedStatic.when(() -> IdentityUtil.addDomainToName(subjectClaimUriValue, userDomain))
@@ -1449,10 +1449,17 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
         try (MockedStatic<CarbonContext> carbonContextMockedStatic = mockStatic(CarbonContext.class)) {
             CarbonContext carbonContext = mock(CarbonContext.class);
             UserRealm userRealm = mock(UserRealm.class);
+            AbstractUserStoreManager primaryUserStoreManager = mock(AbstractUserStoreManager.class);
             RealmConfiguration realmConfiguration = mock(RealmConfiguration.class);
 
             carbonContextMockedStatic.when(CarbonContext::getThreadLocalCarbonContext).thenReturn(carbonContext);
             when(carbonContext.getUserRealm()).thenReturn(userRealm);
+            try {
+                when(userRealm.getUserStoreManager()).thenReturn(primaryUserStoreManager);
+            } catch (UserStoreException e) {
+                throw new RuntimeException("Unexpected UserStoreException in test setup.", e);
+            }
+            when(primaryUserStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
             when(realmConfiguration.getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR))
                     .thenReturn(MULTI_ATTRIBUTE_SEPARATOR);
 
@@ -1486,6 +1493,7 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
             }
             when(primaryUserStoreManager.getSecondaryUserStoreManager(userStoreDomain))
                     .thenReturn(secondaryUserStoreManager);
+            when(secondaryUserStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
             when(realmConfiguration.getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR))
                     .thenReturn(MULTI_ATTRIBUTE_SEPARATOR);
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -1439,29 +1439,25 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
         assertEquals(actual, expected, note);
     }
 
-    // Java
     /**
      * Test multi attribute separator retrieval from user realm configuration.
      */
     @Test
     public void testGetMultiAttributeSeparatorFromUserRealmConfig() {
+
+        final String MULTI_ATTRIBUTE_SEPARATOR = ",";
         try (MockedStatic<CarbonContext> carbonContextMockedStatic = mockStatic(CarbonContext.class)) {
             CarbonContext carbonContext = mock(CarbonContext.class);
             UserRealm userRealm = mock(UserRealm.class);
             RealmConfiguration realmConfiguration = mock(RealmConfiguration.class);
 
             carbonContextMockedStatic.when(CarbonContext::getThreadLocalCarbonContext).thenReturn(carbonContext);
-            lenient().when(carbonContext.getUserRealm()).thenReturn(userRealm);
-            try {
-                lenient().when(userRealm.getRealmConfiguration()).thenReturn(realmConfiguration);
-            } catch (UserStoreException e) {
-                throw new RuntimeException("Unexpected UserStoreException in test setup.", e);
-            }
-            lenient().when(realmConfiguration.getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR))
-                    .thenReturn(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT);
+            when(carbonContext.getUserRealm()).thenReturn(userRealm);
+            when(realmConfiguration.getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR))
+                    .thenReturn(MULTI_ATTRIBUTE_SEPARATOR);
 
             String separator = FrameworkUtils.getMultiAttributeSeparator();
-            assertEquals(separator, IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT);
+            assertEquals(separator, MULTI_ATTRIBUTE_SEPARATOR);
         }
     }
 
@@ -1470,7 +1466,10 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
      */
     @Test
     public void testGetMultiAttributeSeparatorWithUserStoreDomain() {
+
         String userStoreDomain = "SECONDARY";
+        final String MULTI_ATTRIBUTE_SEPARATOR = ";";
+
         try (MockedStatic<CarbonContext> carbonContextMockedStatic = mockStatic(CarbonContext.class)) {
             CarbonContext carbonContext = mock(CarbonContext.class);
             UserRealm userRealm = mock(UserRealm.class);
@@ -1479,21 +1478,19 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
             RealmConfiguration realmConfiguration = mock(RealmConfiguration.class);
 
             carbonContextMockedStatic.when(CarbonContext::getThreadLocalCarbonContext).thenReturn(carbonContext);
-            lenient().when(carbonContext.getUserRealm()).thenReturn(userRealm);
+            when(carbonContext.getUserRealm()).thenReturn(userRealm);
             try {
-                lenient().when(userRealm.getUserStoreManager()).thenReturn(primaryUserStoreManager);
-                lenient().when(userRealm.getRealmConfiguration()).thenReturn(realmConfiguration);
+                when(userRealm.getUserStoreManager()).thenReturn(primaryUserStoreManager);
             } catch (UserStoreException e) {
                 throw new RuntimeException("Unexpected UserStoreException in test setup.", e);
             }
-            lenient().when(primaryUserStoreManager.getSecondaryUserStoreManager(userStoreDomain))
+            when(primaryUserStoreManager.getSecondaryUserStoreManager(userStoreDomain))
                     .thenReturn(secondaryUserStoreManager);
-            lenient().when(secondaryUserStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
-            lenient().when(realmConfiguration.getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR))
-                    .thenReturn(";");
+            when(realmConfiguration.getUserStoreProperty(IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR))
+                    .thenReturn(MULTI_ATTRIBUTE_SEPARATOR);
 
             String separator = FrameworkUtils.getMultiAttributeSeparator(userStoreDomain);
-            assertEquals(separator, ";");
+            assertEquals(separator, MULTI_ATTRIBUTE_SEPARATOR);
         }
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
The separator for multi-valued attributes can be configured at both the organization level and the user store level. Currently, `FrameworkUtils` only considers the organization-level configuration and the primary user store configuration.

This change updates the `getMultiAttributeSeparator()` method to first check whether a separator is configured for the given user store (using its domain name).

- If a user store–specific separator is found → use it.
- Otherwise → fall back to the default getMultiAttributeSeparator().

## Related Issues
- https://github.com/wso2/product-is/issues/25507

## Related PRs
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/722

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-

### Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
