### PR TITLE
Resolve secret for active webhooks

### DIFF
--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/api/model/Webhook.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/api/model/Webhook.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.subscription.management.api.model.Subscription;
 import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtException;
 import org.wso2.carbon.identity.webhook.management.internal.service.impl.WebhookManagementServiceImpl;
+import org.wso2.carbon.identity.webhook.management.internal.util.WebhookSecretProcessor;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -45,6 +46,7 @@ public class Webhook {
     private final Timestamp updatedAt;
     private List<Subscription> eventsSubscribed;
     private static final String EVENT_PROFILE_VERSION = "v1";
+    private final WebhookSecretProcessor webhookSecretProcessor = new WebhookSecretProcessor();
 
     private Webhook(Builder builder) {
 
@@ -80,6 +82,11 @@ public class Webhook {
     public String getSecret() {
 
         return secret;
+    }
+
+    public String getDecryptedSecret() throws WebhookMgtException {
+
+        return webhookSecretProcessor.decryptAssociatedSecrets(getId());
     }
 
     public String getEventProfileName() {

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/AdapterTypeHandler.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/AdapterTypeHandler.java
@@ -92,12 +92,7 @@ public abstract class AdapterTypeHandler implements WebhookManagementDAO {
 
     protected String getWebhookDecryptedSecretValue(String webhookId) throws WebhookMgtException {
 
-        try {
-            return webhookSecretProcessor.decryptAssociatedSecrets(webhookId);
-        } catch (SecretManagementException e) {
-            throw WebhookManagementExceptionHandler.handleServerException(
-                    ErrorMessage.ERROR_CODE_WEBHOOK_ENDPOINT_SECRET_DECRYPTION_ERROR, e, webhookId);
-        }
+        return webhookSecretProcessor.decryptAssociatedSecrets(webhookId);
     }
 
     private Webhook addSecretOrAliasToBuilder(Webhook webhook, String secretAlias) throws WebhookMgtException {

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/util/WebhookSecretProcessor.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/util/WebhookSecretProcessor.java
@@ -22,7 +22,9 @@ import org.wso2.carbon.identity.secret.mgt.core.exception.SecretManagementExcept
 import org.wso2.carbon.identity.secret.mgt.core.model.ResolvedSecret;
 import org.wso2.carbon.identity.secret.mgt.core.model.Secret;
 import org.wso2.carbon.identity.secret.mgt.core.model.SecretType;
+import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtServerException;
 import org.wso2.carbon.identity.webhook.management.internal.component.WebhookManagementComponentServiceHolder;
+import org.wso2.carbon.identity.webhook.management.internal.constant.ErrorMessage;
 
 /**
  * Webhook secrets processor service implementation.
@@ -39,10 +41,14 @@ public class WebhookSecretProcessor {
         return encryptProperty(webhookId, secret);
     }
 
-    public String decryptAssociatedSecrets(String webhookId)
-            throws SecretManagementException {
+    public String decryptAssociatedSecrets(String webhookId) throws WebhookMgtServerException {
 
-        return decryptProperty(webhookId);
+        try {
+            return decryptProperty(webhookId);
+        } catch (SecretManagementException e) {
+            throw WebhookManagementExceptionHandler.handleServerException(
+                    ErrorMessage.ERROR_CODE_WEBHOOK_ENDPOINT_SECRET_DECRYPTION_ERROR, e, webhookId);
+        }
     }
 
     public void deleteAssociatedSecrets(String webhookId)

--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/java/org/wso2/carbon/identity/webhook/management/util/WebhookSecretProcessorTest.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/test/java/org/wso2/carbon/identity/webhook/management/util/WebhookSecretProcessorTest.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.secret.mgt.core.exception.SecretManagementExcept
 import org.wso2.carbon.identity.secret.mgt.core.model.ResolvedSecret;
 import org.wso2.carbon.identity.secret.mgt.core.model.Secret;
 import org.wso2.carbon.identity.secret.mgt.core.model.SecretType;
+import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtException;
 import org.wso2.carbon.identity.webhook.management.internal.component.WebhookManagementComponentServiceHolder;
 import org.wso2.carbon.identity.webhook.management.internal.util.WebhookSecretProcessor;
 
@@ -114,7 +115,7 @@ public class WebhookSecretProcessorTest {
     }
 
     @Test
-    public void testDecryptAssociatedSecrets() throws SecretManagementException {
+    public void testDecryptAssociatedSecrets() throws SecretManagementException, WebhookMgtException {
 
         when(secretManager.isSecretExist(TEST_SECRET_TYPE_ID, SECRET_NAME)).thenReturn(true);
 
@@ -127,8 +128,8 @@ public class WebhookSecretProcessorTest {
         Assert.assertEquals(decrypted, TEST_SECRET);
     }
 
-    @Test(expectedExceptions = SecretManagementException.class)
-    public void testDecryptAssociatedSecrets_SecretNotExist() throws SecretManagementException {
+    @Test(expectedExceptions = WebhookMgtException.class)
+    public void testDecryptAssociatedSecrets_SecretNotExist() throws SecretManagementException, WebhookMgtException {
 
         when(secretManager.isSecretExist(TEST_SECRET_TYPE_ID, SECRET_NAME)).thenReturn(false);
 


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request enhances the handling of webhook secrets when retrieving active webhooks. Now, secrets are decrypted before being returned, ensuring that consumers of the API receive the decrypted values instead of the encrypted ones.

**Security and Data Handling Improvements:**

* Updated the `getActiveWebhooks` method in `PublisherAdapterTypeHandler.java` to decrypt webhook secrets before returning them to the caller, by constructing new `Webhook` objects with decrypted secrets.

**Code Quality:**

* Added import for `ArrayList` to support the creation of a new list for decrypted webhooks.
