### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2031,8 +2031,8 @@
         <jersey-version>1.19.1</jersey-version>
 
         <!-- Pax Logging Version -->
-        <pax.logging.api.version>2.2.1-wso2v2</pax.logging.api.version>
-        <pax.logging.log4j2.version>2.2.1-wso2v2</pax.logging.log4j2.version>
+        <pax.logging.api.version>2.3.0-wso2v1</pax.logging.api.version>
+        <pax.logging.log4j2.version>2.3.0-wso2v1</pax.logging.log4j2.version>
 
         <!-- Log4j -->
         <log4j.api.version>2.17.1</log4j.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1912,7 +1912,7 @@
         <version.equinox.osgi>3.9.1.v20130814-1242</version.equinox.osgi>
         <equinox.osgi.stax-api.imp.pkg.version.range>[1.0.1,2.0.0)</equinox.osgi.stax-api.imp.pkg.version.range>
 
-        <saml.common.util.version>1.3.0</saml.common.util.version>
+        <saml.common.util.version>1.3.1</saml.common.util.version>
         <saml.common.util.version.range>[1.0.0,2.0.0)</saml.common.util.version.range>
 
         <!-- Commons -->


### PR DESCRIPTION
This PR updates several key dependencies to their latest stable versions to improve security, performance, and compatibility.

### Changes Made

**Logging Libraries:**
- **pax-logging**: `2.2.1-wso2v2` → `2.3.0-wso2v1`

**Identity Libraries:**
- **identity.saml.common.util**: `1.3.0` → `1.3.1`

Related Issue : https://github.com/wso2/api-manager/issues/3870

