### PR TITLE
[bug-fix] Fix IdP claim mapping issue

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
@@ -692,7 +692,7 @@ public class DefaultClaimHandler implements ClaimHandler {
         localToIdPClaimMap.putAll(Arrays.stream(idPClaimMappings).filter(claimMapping -> StringUtils.
                 isNotBlank(claimMapping.getDefaultValue()) && !localToIdPClaimMap.containsKey(claimMapping.
                 getLocalClaim().getClaimUri())).collect(Collectors.toMap(claimMapping -> claimMapping.getLocalClaim().
-                getClaimUri(), claimMapping->claimMapping.getRemoteClaim().getClaimUri())));
+                getClaimUri(), claimMapping -> claimMapping.getRemoteClaim().getClaimUri())));
 
         return localToIdPClaimMap;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
@@ -692,7 +692,7 @@ public class DefaultClaimHandler implements ClaimHandler {
         localToIdPClaimMap.putAll(Arrays.stream(idPClaimMappings).filter(claimMapping -> StringUtils.
                 isNotBlank(claimMapping.getDefaultValue()) && !localToIdPClaimMap.containsKey(claimMapping.
                 getLocalClaim().getClaimUri())).collect(Collectors.toMap(claimMapping -> claimMapping.getLocalClaim().
-                getClaimUri(), ClaimMapping::getDefaultValue)));
+                getClaimUri(), claimMapping->claimMapping.getRemoteClaim().getClaimUri())));
 
         return localToIdPClaimMap;
     }


### PR DESCRIPTION
### Proposed changes in this pull request

This PR fixes the bug in custom claim mapping issue when there is a separate IdP. When adding remote claims with default values to the localToIdPClaimMap, instead of adding `<claim_uri> -> <default>` value pairs, this change adds `<claim_uri> -> <remote_claim_uri>` pairs. This way correct default values are used only if the IdP doesn't send the remote claims. 

<img width="801" height="154" alt="image" src="https://github.com/user-attachments/assets/c5b41787-43a2-466d-adc5-c6791d3b9d9c" />

### Related Issues 

https://github.com/wso2/product-is/issues/25532

