### PR TITLE
Enable both scopes for new organizations

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -1325,21 +1325,15 @@
                 <Scope name="console:roles_edit"/>
             </Feature>
             <Update>
-                {% if scim2.enable_scim2_roles_v3_api is sameas false %}
                 <Scope name="internal_role_mgt_update"/>
-                {% else %}
                 <Scope name="internal_role_mgt_meta_update"/>
-                {% endif %}
             </Update>
             <Delete>
                 <Scope name="internal_role_mgt_delete"/>
             </Delete>
             <Create>
-                {% if scim2.enable_scim2_roles_v3_api is sameas false %}
                 <Scope name="internal_role_mgt_create"/>
-                {% else %}
                 <Scope name="internal_role_mgt_meta_create"/>
-                {% endif %}
             </Create>
             <Read>
                 <Scope name="internal_user_mgt_view"/>
@@ -1704,21 +1698,15 @@
                 <Scope name="console:org:roles_edit"/>
             </Feature>
             <Update>
-                {% if scim2.enable_scim2_roles_v3_api is sameas false %}
                 <Scope name="internal_org_role_mgt_update"/>
-                {% else %}
                 <Scope name="internal_org_role_mgt_meta_update"/>
-                {% endif %}
             </Update>
             <Delete>
                 <Scope name="internal_org_role_mgt_delete"/>
             </Delete>
             <Create>
-                {% if scim2.enable_scim2_roles_v3_api is sameas false %}
                 <Scope name="internal_org_role_mgt_create"/>
-                {% else %}
                 <Scope name="internal_org_role_mgt_meta_create"/>
-                {% endif %}
             </Create>
             <Read>
                 <Scope name="internal_org_user_mgt_view"/>


### PR DESCRIPTION
### Proposed changes in this pull request
- With this change, roles permission will assign users both old and new role scopes. 
- In another effort, 
    - after migration is done 
AND
    - enabling the feature
the permissions will be set to use relevant scope on demand/use new scope only. 
- After this the unwanted scope will be removed from another migration effort.

### Related Issues:
- https://github.com/wso2/product-is/issues/24884