### PR TITLE
Hide MS 365 v1 SSO template in Console

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1302,7 +1302,9 @@
   "console.ui.hiddenConnectionTemplates": [
     "swe-idp"
   ],
-  "console.ui.hiddenApplicationTemplates": [],
+  "console.ui.hiddenApplicationTemplates": [
+    "microsoft-365"
+  ],
   "console.ui.system_reserved_user_stores": ["AGENT"],
   "console.ui.google_one_tap_enabled_tenants": [],
   "console.ui.show_app_switch_button": true,


### PR DESCRIPTION
### Proposed changes in this pull request

[List all changes you want to add here. If you fixed an issue, please
add a reference to that issue as well.]

- Hide the Microsoft 365 (v1) template in the application creation wizard in console.

