### PR TITLE
Add configuration to enforce literal charactors in callback url validation

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -792,6 +792,9 @@
 
         <EnableRichAuthorizationRequests>false</EnableRichAuthorizationRequests>
         <ReturnSpIdToApplication>true</ReturnSpIdToApplication>
+        <Callback>
+            <EnforceLiteralCharacters>true</EnforceLiteralCharacters>
+        </Callback>
     </OAuth>
 
     <RestApiAuthentication>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1377,6 +1377,9 @@
         <EnableRichAuthorizationRequests>{{oauth.enable_rich_authorization_requests}}</EnableRichAuthorizationRequests>
         <ReturnSpIdToApplication>{{oauth.return_sp_id_to_apps}}</ReturnSpIdToApplication>
         <ReturnOnlyAppAssociatedRolesInJWTToken>{{oauth.jwt.return_only_app_associated_roles}}</ReturnOnlyAppAssociatedRolesInJWTToken>
+        <Callback>
+            <EnforceLiteralCharacters>{{oauth.callback.enforce_literal_characters}}</EnforceLiteralCharacters>
+        </Callback>
     </OAuth>
 
     <RestApiAuthentication>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -317,6 +317,8 @@
 
   "oauth.restricted_query_parameters": ["username", "password", "client_secret"],
 
+  "oauth.callback.enforce_literal_characters": true,
+
   "rest_api_authentication.add_realm_user_to_error": false,
 
   "saml.entity_id": "${carbon.host}",


### PR DESCRIPTION
### Proposed changes in this pull request

Introducing a new configuration to enforce literal characters (`.`, `?`, `+`) in the configured callback urls of an application when validating the redirect uri sent in the login requests.

### Related issue
- 