### PR TITLE
Add Executable end node and improve error handling.

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNode.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNode.java
@@ -173,10 +173,15 @@ public class TaskExecutionNode implements Node {
                         .additionalInfo(response.getAdditionalInfo())
                         .build();
             case STATUS_USER_ERROR:
+                if (response.getErrorCode() != null){
+                    throw handleClientException(flowType, response);
+                }
                 throw handleClientException(flowType, ERROR_CODE_FLOW_FAILURE, response.getErrorMessage());
             case STATUS_ERROR:
-                throw handleClientException(flowType, ERROR_CODE_REQUEST_PROCESSING_FAILURE,
-                        response.getErrorMessage());
+                if (response.getErrorCode() != null){
+                    throw handleServerException(flowType, response);
+                }
+                throw handleServerException(flowType, ERROR_CODE_REQUEST_PROCESSING_FAILURE, response.getErrorMessage());
             default:
                 throw handleServerException(flowType, ERROR_CODE_UNSUPPORTED_EXECUTOR_STATUS, response.getResult());
         }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/UserOnboardingExecutor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/UserOnboardingExecutor.java
@@ -290,7 +290,7 @@ public class UserOnboardingExecutor implements Executor {
      * @param data     Optional data to format the error description.
      * @return Modified ExecutorResponse with error details.
      */
-    private ExecutorResponse errorResponse(ExecutorResponse response, ErrorMessages error, Throwable e ,Object... data) {
+    private ExecutorResponse errorResponse(ExecutorResponse response, ErrorMessages error, Throwable e, Object... data) {
 
         String description = error.getDescription();
         if (ArrayUtils.isNotEmpty(data)) {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/UserOnboardingExecutor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/UserOnboardingExecutor.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.flow.execution.engine.graph;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -26,6 +27,7 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.core.util.LambdaExceptionUtils;
 import org.wso2.carbon.identity.flow.execution.engine.Constants;
+import org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineClientException;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
 import org.wso2.carbon.identity.flow.execution.engine.internal.FlowExecutionEngineDataHolder;
@@ -58,6 +60,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_INVALID_USERNAME;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_USERNAME_ALREADY_EXISTS;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_USERSTORE_MANAGER_FAILURE;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_USER_ONBOARD_FAILURE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.USER_ALREADY_EXISTING_USERNAME;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.PASSWORD_KEY;
@@ -101,15 +104,17 @@ public class UserOnboardingExecutor implements Executor {
     }
 
     @Override
-    public ExecutorResponse execute(FlowExecutionContext context) throws FlowEngineException {
+    public ExecutorResponse execute(FlowExecutionContext context) {
 
-        FlowUser user = updateUserProfile(context);
-        Map<String, String> userClaims = user.getClaims();
-        Map<String, char[]> credentials = user.getUserCredentials();
-        char[] password =
-                credentials.getOrDefault(PASSWORD_KEY, new DefaultPasswordGenerator().generatePassword());
-        String flowType = context.getFlowType();
+        char[] password = null;
+        ExecutorResponse response = new ExecutorResponse();
         try {
+            FlowUser user = updateUserProfile(context);
+            Map<String, String> userClaims = user.getClaims();
+            Map<String, char[]> credentials = user.getUserCredentials();
+            password =
+                    credentials.getOrDefault(PASSWORD_KEY, new DefaultPasswordGenerator().generatePassword());
+
             String userStoreDomainName = resolveUserStoreDomain(user.getUsername());
             UserStoreManager userStoreManager = getUserStoreManager(context.getTenantDomain(), userStoreDomainName,
                     context.getContextIdentifier(), context.getFlowType());
@@ -123,21 +128,30 @@ public class UserOnboardingExecutor implements Executor {
                 LOG.debug("User: " + user.getUsername() + " successfully onboarded in user store: " +
                         userStoreDomainName + " of tenant: " + context.getTenantDomain());
             }
-            return new ExecutorResponse(STATUS_COMPLETE);
+            response.setResult(STATUS_COMPLETE);
+            return response;
         } catch (UserStoreException e) {
-            handleAndThrowClientExceptionForActionFailure(flowType, e);
-            if (e.getMessage().contains(USER_ALREADY_EXISTING_USERNAME)) {
-                throw handleClientException(flowType, ERROR_CODE_USERNAME_ALREADY_EXISTS, context.getTenantDomain());
+            response = handleAndThrowClientExceptionForActionFailure(response, e);
+            if (response.getResult() != null) {
+                return response;
             }
-            throw handleServerException(flowType, ERROR_CODE_USER_ONBOARD_FAILURE, e, user.getUsername(),
+            if (e.getMessage().contains(USER_ALREADY_EXISTING_USERNAME)) {
+                return userErrorResponse(response, ERROR_CODE_USERNAME_ALREADY_EXISTS, context.getTenantDomain());
+            }
+            return errorResponse(response, ERROR_CODE_USER_ONBOARD_FAILURE, e, context.getFlowUser().getUsername(),
                     context.getContextIdentifier());
+        } catch (FlowEngineClientException e) {
+            return userErrorResponse(response, e);
+        } catch (FlowEngineException e) {
+            return errorResponse(response, e);
         } finally {
-            Arrays.fill(password, '\0');
+            if (password != null) {
+                Arrays.fill(password, '\0');
+            }
         }
     }
 
-    private void handleAndThrowClientExceptionForActionFailure(String flowType, UserStoreException e)
-            throws FlowEngineException {
+    private ExecutorResponse handleAndThrowClientExceptionForActionFailure(ExecutorResponse response, UserStoreException e) {
 
         if (e instanceof UserStoreClientException &&
                 UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED
@@ -145,7 +159,7 @@ public class UserOnboardingExecutor implements Executor {
             Throwable cause = e.getCause();
             while (cause != null) {
                 if (cause instanceof UserActionExecutionClientException) {
-                    throw new FlowEngineClientException(flowType, Constants.ErrorMessages.
+                    return userErrorResponse(response,
                             ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE.getCode(),
                             ((UserActionExecutionClientException) cause).getError(),
                             ((UserActionExecutionClientException) cause).getDescription(), cause);
@@ -153,6 +167,7 @@ public class UserOnboardingExecutor implements Executor {
                 cause = cause.getCause();
             }
         }
+        return response;
     }
 
     private FlowUser updateUserProfile(FlowExecutionContext context) throws FlowEngineException {
@@ -265,5 +280,103 @@ public class UserOnboardingExecutor implements Executor {
                 }
             }
         }));
+    }
+
+    /**
+     * Creates an error response with the provided details.
+     *
+     * @param response ExecutorResponse to be modified with error details.
+     * @param error    Error message enum to be set in the response.
+     * @param data     Optional data to format the error description.
+     * @return Modified ExecutorResponse with error details.
+     */
+    private ExecutorResponse errorResponse(ExecutorResponse response, ErrorMessages error, Throwable e ,Object... data) {
+
+        String description = error.getDescription();
+        if (ArrayUtils.isNotEmpty(data)) {
+            description = String.format(description, data);
+        }
+        response.setErrorCode(error.getCode());
+        response.setErrorMessage(error.getMessage());
+        response.setErrorDescription(description);
+        response.setThrowable(e);
+        response.setResult(Constants.ExecutorStatus.STATUS_ERROR);
+        return response;
+    }
+
+    /**
+     * Creates an error response with the provided FlowEngineException details.
+     *
+     * @param response            ExecutorResponse to be modified with error details.
+     * @param flowEngineException FlowEngineException containing error details.
+     * @return Modified ExecutorResponse with error details.
+     */
+    private ExecutorResponse errorResponse(ExecutorResponse response, FlowEngineException flowEngineException) {
+
+        response.setErrorMessage(flowEngineException.getMessage());
+        response.setErrorCode(flowEngineException.getErrorCode());
+        response.setErrorDescription(flowEngineException.getDescription());
+        response.setThrowable(flowEngineException);
+        response.setResult(Constants.ExecutorStatus.STATUS_ERROR);
+        return response;
+    }
+
+    /**
+     * Creates an error response with the provided details.
+     *
+     * @param response ExecutorResponse to be modified with error details.
+     * @param error    Error message enum to be set in the response.
+     * @param data     Optional data to format the error description.
+     * @return Modified ExecutorResponse with error details.
+     */
+    private ExecutorResponse userErrorResponse(ExecutorResponse response, ErrorMessages error, Object... data) {
+
+        String description = error.getDescription();
+        if (ArrayUtils.isNotEmpty(data)) {
+            description = String.format(description, data);
+        }
+        response.setErrorCode(error.getCode());
+        response.setErrorMessage(error.getMessage());
+        response.setErrorDescription(description);
+        response.setResult(Constants.ExecutorStatus.STATUS_USER_ERROR);
+        return response;
+    }
+
+    /**
+     * Creates a user error response with the provided details.
+     *
+     * @param response    ExecutorResponse to be modified with user error details.
+     * @param errorCode   Error code to be set in the response.
+     * @param message     User error message to be set in the response.
+     * @param description Description of the error to be set in the response.
+     * @param throwable   Throwable associated with the error.
+     * @return Modified ExecutorResponse with user error details.
+     */
+    private ExecutorResponse userErrorResponse(ExecutorResponse response, String errorCode, String message,
+                                               String description, Throwable throwable) {
+
+        response.setErrorCode(errorCode);
+        response.setErrorMessage(message);
+        response.setErrorDescription(description);
+        response.setThrowable(throwable);
+        response.setResult(Constants.ExecutorStatus.STATUS_USER_ERROR);
+        return response;
+    }
+
+    /**
+     * Creates a user error response with the provided FlowEngineException details.
+     *
+     * @param response            ExecutorResponse to be modified with user error details.
+     * @param flowEngineException FlowEngineException containing error details.
+     * @return Modified ExecutorResponse with user error details.
+     */
+    private ExecutorResponse userErrorResponse(ExecutorResponse response, FlowEngineException flowEngineException) {
+
+        response.setErrorCode(flowEngineException.getErrorCode());
+        response.setErrorMessage(flowEngineException.getMessage());
+        response.setErrorDescription(flowEngineException.getDescription());
+        response.setThrowable(flowEngineException);
+        response.setResult(Constants.ExecutorStatus.STATUS_USER_ERROR);
+        return response;
     }
 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/ExecutorResponse.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/ExecutorResponse.java
@@ -147,7 +147,7 @@ public class ExecutorResponse {
     /**
      * Model class to represent an error object.
      */
-    public static  class ErrorObject {
+    public static class ErrorObject {
 
         private String code;
         private String message;

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/ExecutorResponse.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/ExecutorResponse.java
@@ -32,10 +32,11 @@ public class ExecutorResponse {
     private Map<String, char[]> userCredentials;
     private Map<String, Object> contextProperties;
     private Map<String, String> additionalInfo;
-    private String errorMessage;
+    private ErrorObject errorObject;
 
     public ExecutorResponse() {
 
+        this.errorObject = new ErrorObject();
     }
 
     public ExecutorResponse(String result) {
@@ -105,11 +106,88 @@ public class ExecutorResponse {
 
     public String getErrorMessage() {
 
-        return errorMessage;
+        return errorObject.getMessage();
     }
 
     public void setErrorMessage(String errorMessage) {
 
-        this.errorMessage = errorMessage;
+        this.errorObject.setMessage(errorMessage);
+    }
+
+    public String getErrorCode() {
+
+        return errorObject.getCode();
+    }
+
+    public void setErrorCode(String errorCode) {
+
+        this.errorObject.setCode(errorCode);
+    }
+
+    public String getErrorDescription() {
+
+        return errorObject.getDescription();
+    }
+
+    public void setErrorDescription(String errorDescription) {
+
+        this.errorObject.setDescription(errorDescription);
+    }
+
+    public Throwable getThrowable() {
+
+        return errorObject.getThrowable();
+    }
+
+    public void setThrowable(Throwable throwable) {
+
+        this.errorObject.setThrowable(throwable);
+    }
+
+    /**
+     * Model class to represent an error object.
+     */
+    public static  class ErrorObject {
+
+        private String code;
+        private String message;
+        private String description;
+        private Throwable throwable;
+
+        public ErrorObject() {
+
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public void setCode(String code) {
+            this.code = code;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public Throwable getThrowable() {
+            return throwable;
+        }
+
+        public void setThrowable(Throwable throwable) {
+            this.throwable = throwable;
+        }
     }
 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/ExecutorResponse.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/ExecutorResponse.java
@@ -159,34 +159,42 @@ public class ExecutorResponse {
         }
 
         public String getCode() {
+
             return code;
         }
 
         public void setCode(String code) {
+
             this.code = code;
         }
 
         public String getMessage() {
+
             return message;
         }
 
         public void setMessage(String message) {
+
             this.message = message;
         }
 
         public String getDescription() {
+
             return description;
         }
 
         public void setDescription(String description) {
+
             this.description = description;
         }
 
         public Throwable getThrowable() {
+
             return throwable;
         }
 
         public void setThrowable(Throwable throwable) {
+
             this.throwable = throwable;
         }
     }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/util/FlowExecutionEngineUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/util/FlowExecutionEngineUtils.java
@@ -310,6 +310,7 @@ public class FlowExecutionEngineUtils {
     /**
      * Handle the flow engine server exceptions.
      *
+     * @param flowType Flow type.
      * @param response Executor response.
      * @return FlowEngineServerException.
      */
@@ -394,6 +395,7 @@ public class FlowExecutionEngineUtils {
     /**
      * Handle the flow engine client exceptions.
      *
+     * @param flowType Flow type.
      * @param response Executor response.
      * @return FlowEngineClientException.
      */

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/util/FlowExecutionEngineUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/util/FlowExecutionEngineUtils.java
@@ -40,8 +40,8 @@ import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineExcept
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineServerException;
 import org.wso2.carbon.identity.flow.execution.engine.graph.TaskExecutionNode;
 import org.wso2.carbon.identity.flow.execution.engine.internal.FlowExecutionEngineDataHolder;
+import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
-import org.wso2.carbon.identity.flow.execution.engine.store.FlowContextStore;
 import org.wso2.carbon.identity.flow.mgt.Constants;
 import org.wso2.carbon.identity.flow.mgt.exception.FlowMgtFrameworkException;
 import org.wso2.carbon.identity.flow.mgt.model.FlowConfigDTO;
@@ -306,6 +306,21 @@ public class FlowExecutionEngineUtils {
         return new FlowEngineServerException(flowType, error.getCode(), error.getMessage(), description);
     }
 
+
+    /**
+     * Handle the flow engine server exceptions.
+     *
+     * @param response Executor response.
+     * @return FlowEngineServerException.
+     */
+    public static FlowEngineServerException handleServerException(String flowType, ExecutorResponse response) {
+
+        String errorMsg = response.getErrorMessage();
+        String errorCode = response.getErrorCode();
+        String errorDescription = response.getErrorDescription();
+        Throwable throwable = response.getThrowable();
+        return new FlowEngineServerException(flowType, errorCode, errorMsg, errorDescription, throwable);
+    }
     /**
      * Handle the flow engine client exceptions.
      *
@@ -374,6 +389,21 @@ public class FlowExecutionEngineUtils {
             description = String.format(description, data);
         }
         return new FlowEngineClientException(flowType, error.getCode(), error.getMessage(), description);
+    }
+
+    /**
+     * Handle the flow engine client exceptions.
+     *
+     * @param response Executor response.
+     * @return FlowEngineClientException.
+     */
+    public static FlowEngineClientException handleClientException(String flowType, ExecutorResponse response) {
+
+        String errorMsg = response.getErrorMessage();
+        String errorCode = response.getErrorCode();
+        String errorDescription = response.getErrorDescription();
+        Throwable throwable = response.getThrowable();
+        return new FlowEngineClientException(flowType, errorCode, errorMsg, errorDescription, throwable);
     }
 
     /**

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/GraphBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/GraphBuilder.java
@@ -372,7 +372,21 @@ public class GraphBuilder {
 
     private void processEndStep(StepDTO step) {
 
-        NodeConfig endNode = createPagePromptNode(step.getId());
+        ActionDTO action = step.getData().getAction();
+        NodeConfig endNode;
+
+        // if the action is not defined, consider it as a prompt only node.
+        if (action == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("No action defined for the end step. Therefore creating a prompt only node.");
+            }
+            endNode = createPagePromptNode(step.getId());
+        } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Action defined for the end step. Therefore creating a task execution node.");
+            }
+            endNode = createTaskExecutionNode(step.getId(), action.getExecutor());
+        }
         handleTempNodesInStep(Collections.singletonList(endNode), step);
     }
 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/GraphBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/GraphBuilder.java
@@ -375,7 +375,7 @@ public class GraphBuilder {
         ActionDTO action = step.getData().getAction();
         NodeConfig endNode;
 
-        // if the action is not defined, consider it as a prompt only node.
+        // If the action is not defined, consider it as a prompt only node.
         if (action == null) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("No action defined for the end step. Therefore creating a prompt only node.");

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/resources/flowWithEndNode.json
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/resources/flowWithEndNode.json
@@ -1,0 +1,121 @@
+{
+  "steps": [
+    {
+      "id": "view_5box",
+      "type": "VIEW",
+      "size": {
+        "width": 350,
+        "height": 556
+      },
+      "position": {
+        "x": 0,
+        "y": 330
+      },
+      "data": {
+        "components": [
+          {
+            "category": "DISPLAY",
+            "type": "TYPOGRAPHY",
+            "id": "typography_rled",
+            "variant": "H3",
+            "config": {
+              "text": "Register Account"
+            }
+          },
+          {
+            "category": "BLOCK",
+            "type": "FORM",
+            "config": {},
+            "id": "form_4hbb",
+            "components": [
+              {
+                "category": "FIELD",
+                "type": "INPUT",
+                "variant": "TEXT",
+                "config": {
+                  "type": "text",
+                  "hint": "",
+                  "label": "Username",
+                  "required": true,
+                  "placeholder": "Enter your username",
+                  "identifier": "http://wso2.org/claims/username"
+                },
+                "id": "input_9rvp"
+              },
+              {
+                "category": "FIELD",
+                "type": "INPUT",
+                "variant": "PASSWORD",
+                "config": {
+                  "identifier": "password",
+                  "type": "password",
+                  "hint": "",
+                  "label": "Password",
+                  "required": true,
+                  "placeholder": "Enter your password"
+                },
+                "id": "input_9fg2"
+              },
+              {
+                "category": "ACTION",
+                "type": "BUTTON",
+                "id": "button_86k2",
+                "variant": "PRIMARY",
+                "action": {
+                  "type": "NEXT",
+                  "nextId": "END"
+                },
+                "config": {
+                  "type": "submit",
+                  "text": "Continue"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "END",
+      "type": "END",
+      "data": {
+        "action": {
+          "type": "EXECUTOR",
+          "executor": {
+            "name": "UserProvisioningExecutor"
+          },
+          "nextId": "END"
+        },
+        "components": [
+          {
+            "id": "display_2v3t",
+            "category": "DISPLAY",
+            "type": "TYPOGRAPHY",
+            "variant": "H5",
+            "config": {
+              "text": "Registration Completed"
+            }
+          },
+          {
+            "id": "display_4n49",
+            "category": "DISPLAY",
+            "type": "IMAGE",
+            "variant": "IMAGE_BLOCK",
+            "config": {
+              "src": "https://www.svgrepo.com/show/428755/success-growth-successful.svg"
+            }
+          }
+        ]
+      },
+      "size": {
+        "height": 612.0,
+        "width": 350.0
+      },
+      "position": {
+        "x": 585.5320627344254,
+        "y": 444.74770515463473
+      }
+    }
+  ]
+}
+


### PR DESCRIPTION
### Proposed changes in this pull request
This pull request refactors error handling in the flow orchestration framework to improve consistency and clarity, especially in how errors are propagated and represented in executor responses. The main changes include introducing a dedicated `ErrorObject` for error details in `ExecutorResponse`, updating error handling logic in executors and utility methods, and adding helper methods for error response construction. This results in more structured error information and cleaner error management throughout the flow execution engine.

### Error handling improvements

* Introduced an `ErrorObject` inner class in `ExecutorResponse` to encapsulate error code, message, description, and throwable, replacing the previous single error message field. All error-related getters and setters now delegate to this object. (`components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/ExecutorResponse.java`) [[1]](diffhunk://#diff-783a197eda5d37f72e15f55ba3398c9180f63e75e9feb60d899540a02962dc39L35-R39) [[2]](diffhunk://#diff-783a197eda5d37f72e15f55ba3398c9180f63e75e9feb60d899540a02962dc39L108-R191)

* Refactored the `UserOnboardingExecutor` to use structured error responses, including new helper methods (`errorResponse`, `userErrorResponse`) for creating error responses with detailed information. The main execution logic now returns error responses instead of throwing exceptions directly, improving error propagation. (`components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/UserOnboardingExecutor.java`) [[1]](diffhunk://#diff-d1a264cd7c60909b37c3f18ea7b43fe236f8699441bf051cf5854da91aa74e58L104-R117) [[2]](diffhunk://#diff-d1a264cd7c60909b37c3f18ea7b43fe236f8699441bf051cf5854da91aa74e58L126-R170) [[3]](diffhunk://#diff-d1a264cd7c60909b37c3f18ea7b43fe236f8699441bf051cf5854da91aa74e58R284-R381)

* Updated imports and static references for error message enums and utility classes to support the new error handling approach. (`components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/UserOnboardingExecutor.java`) [[1]](diffhunk://#diff-d1a264cd7c60909b37c3f18ea7b43fe236f8699441bf051cf5854da91aa74e58R21) [[2]](diffhunk://#diff-d1a264cd7c60909b37c3f18ea7b43fe236f8699441bf051cf5854da91aa74e58R30) [[3]](diffhunk://#diff-d1a264cd7c60909b37c3f18ea7b43fe236f8699441bf051cf5854da91aa74e58R63)

### Utility method enhancements

* Added new overloads to `FlowExecutionEngineUtils` for handling client and server exceptions directly from an `ExecutorResponse`, extracting all relevant error details from the response's `ErrorObject`. (`components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/util/FlowExecutionEngineUtils.java`) [[1]](diffhunk://#diff-e6de876a7798cebfb9695af2ae753ed1b1c1f66eb2ea6c066242547f30d0affbR309-R323) [[2]](diffhunk://#diff-e6de876a7798cebfb9695af2ae753ed1b1c1f66eb2ea6c066242547f30d0affbR394-R408)

### Flow execution node logic

* Updated `TaskExecutionNode` to throw exceptions using the new error response structure, distinguishing between user errors and server errors based on the presence of an error code in the response. (`components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNode.java`)

### Test updates

* Updated test imports and references to accommodate the new error handling logic and status codes. (`components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNodeTest.java`) [[1]](diffhunk://#diff-2e6cdd6fd70a6d88bb701c05bef9a8b7ee69bb6dfa769a9d2e8eaa5c6503343eR31) [[2]](diffhunk://#diff-2e6cdd6fd70a6d88bb701c05bef9a8b7ee69bb6dfa769a9d2e8eaa5c6503343eR65)
