### PR TITLE
Update carbon.registry and log4j versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1808,7 +1808,7 @@
         </org.wso2.carbon.identity.organization.management.core.version.range>
 
         <!--Carbon registry version-->
-        <org.wso2.carbon.registry.version>4.8.12</org.wso2.carbon.registry.version>
+        <org.wso2.carbon.registry.version>4.8.46</org.wso2.carbon.registry.version>
         <carbon.registry.common.imp.pkg.version.range>[0.0.0,1.0.0)</carbon.registry.common.imp.pkg.version.range>
         <carbon.registry.indexing.imp.pkg.version.range>[4.7.3,5.0.0)</carbon.registry.indexing.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2035,9 +2035,9 @@
         <pax.logging.log4j2.version>2.3.0-wso2v1</pax.logging.log4j2.version>
 
         <!-- Log4j -->
-        <log4j.api.version>2.17.1</log4j.api.version>
-        <log4j.core.version>2.17.1</log4j.core.version>
-        <log4j.slf4j.version>2.19.0</log4j.slf4j.version>
+        <log4j.api.version>2.24.3</log4j.api.version>
+        <log4j.core.version>2.24.3</log4j.core.version>
+        <log4j.slf4j.version>2.24.3</log4j.slf4j.version>
 
         <!-- Unit test versions -->
         <testng.version>6.9.10</testng.version>


### PR DESCRIPTION
This PR updates critical dependencies to their latest stable versions to improve security, performance, and compatibility.

### Changes Made

**Carbon Libraries:**
- **carbon.registry**: `4.8.12` → `4.8.46`

**Logging Libraries:**
- **log4j**: `2.17.1` → `2.24.3`

Related Issue: https://github.com/wso2/api-manager/issues/3870

