### PR TITLE
Avoid calling shared role to main role id stored table for root org role loading

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -1711,6 +1711,11 @@ public class RoleDAOImpl implements RoleDAO {
     public boolean isSharedRole(String roleId, String tenantDomain) throws IdentityRoleManagementException {
 
         if (!isOrganization(tenantDomain)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        String.format("Tenant domain %s is not an organization. Returning false for shared role check.",
+                                tenantDomain));
+            }
             return false;
         }
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -1710,6 +1710,9 @@ public class RoleDAOImpl implements RoleDAO {
     @Override
     public boolean isSharedRole(String roleId, String tenantDomain) throws IdentityRoleManagementException {
 
+        if (!isOrganization(tenantDomain)) {
+            return false;
+        }
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
         boolean isShared = false;
         try (Connection connection = IdentityDatabaseUtil.getUserDBConnection(false);

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOTest.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOTest.java
@@ -429,7 +429,8 @@ public class RoleDAOTest {
                 L1_ORG_TENANT_ORG_ID, roleDAO);
         roleDAO.addMainRoleToSharedRoleRelationship(roleBasicInfo.getId(), sharedRoleBasicInfo.getId(),
                 SAMPLE_TENANT_DOMAIN, L1_ORG_TENANT_DOMAIN);
-
+        organizationManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(L1_ORG_TENANT_DOMAIN))
+                .thenReturn(true);
         mockRealmConfiguration();
         Role role = roleDAO.getRole(sharedRoleBasicInfo.getId(), L1_ORG_TENANT_DOMAIN);
         assertEquals(sharedRoleBasicInfo.getId(), role.getId());


### PR DESCRIPTION

This pull request introduces a small but important change to the logic for determining whether a role is shared in the `RoleDAOImpl` class. Specifically, it adds an early exit condition to the `isSharedRole` method to immediately return `false` if the tenant domain is not recognized as an organization.

* Added a check in `isSharedRole` to return `false` early if `tenantDomain` is not an organization, improving correctness and efficiency. (`RoleDAOImpl.java`, [components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.javaR1715-R1717](diffhunk://#diff-131b069dbac2f9329a833605dfd5b2da3e2ab3c6d45270f614451bb780a769f6R1715-R1717))