### PR TITLE
Fix additional data being populated from dataDTO instead of nodeResponse

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/core/FlowExecutionEngine.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/core/FlowExecutionEngine.java
@@ -214,7 +214,7 @@ public class FlowExecutionEngine {
             finalDataDTO = new DataDTO.Builder()
                     .components(dataDTO.getComponents())
                     .requiredParams(nodeResponse.getRequiredData())
-                    .additionalData(dataDTO.getAdditionalData())
+                    .additionalData(nodeResponse.getAdditionalInfo())
                     .build();
             handleError(finalDataDTO, nodeResponse);
         }


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25583

This pull request makes a targeted update to how additional data is handled when resolving steps for prompts in the flow execution engine. The change ensures that the `additionalData` field in the `DataDTO` object now uses the more contextually relevant `additionalInfo` from the node response, rather than the previous value from the incoming data DTO.

* The `additionalData` field in the `DataDTO` builder within `FlowExecutionEngine.java` is now set to `nodeResponse.getAdditionalInfo()` instead of `dataDTO.getAdditionalData()`, ensuring that the latest node-specific information is used when building the DTO.