### PR TITLE
Set federated authenticator property max limit

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -4255,7 +4255,6 @@
      <MaxFederatedAuthenticatorPropertiesPerIdP>{{federated.authenticator.max_property_limit}}</MaxFederatedAuthenticatorPropertiesPerIdP>
      {% endif %}
 
-
     <!--This configuration is used for X509 Certificate based authentication. -->
 
     <X509>


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

For a SAML IDP, the federated authenticator has used 33 properties. 
There will be no restriction for the number of properties.

It can be limited server wide as per the below configuration.

```toml
[federated.authenticator]
max_property_limit = 100
```
