### PR TITLE
Hide v1 logs in v2 mode

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/ServerSessionManagementServiceImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/impl/ServerSessionManagementServiceImpl.java
@@ -96,6 +96,9 @@ public class ServerSessionManagementServiceImpl implements ServerSessionManageme
     private void addAuditLogs(String sessionKey, String initiator, String authenticatedUser, String userTenantDomain,
                               String traceId, Long terminatedTimestamp) {
 
+        if (LoggerUtils.isEnableV2AuditLogs()) {
+            return;
+        }
         String initiatedUser = null;
         JSONObject auditData = new JSONObject();
         auditData.put(SessionMgtConstants.SESSION_CONTEXT_ID, sessionKey);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/session/extender/processor/SessionExtenderProcessor.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/session/extender/processor/SessionExtenderProcessor.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.application.authentication.framework.session.ext
 import org.wso2.carbon.identity.application.authentication.framework.session.extender.request.SessionExtenderRequest;
 import org.wso2.carbon.identity.application.authentication.framework.session.extender.response.SessionExtenderResponse;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
@@ -199,6 +200,9 @@ public class SessionExtenderProcessor extends IdentityProcessor {
 
     private void addAuditLogs(String sessionKey, String tenantDomain, String traceId) {
 
+        if (LoggerUtils.isEnableV2AuditLogs()) {
+            return;
+        }
         JSONObject auditData = new JSONObject();
         auditData.put(SESSION_CONTEXT_ID, sessionKey);
         auditData.put(TENANT_DOMAIN, tenantDomain);

--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/listener/ClaimMetadataManagementAuditLogger.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/listener/ClaimMetadataManagementAuditLogger.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.AttributeMapping;
+import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
@@ -48,6 +49,15 @@ public class ClaimMetadataManagementAuditLogger extends AbstractEventHandler {
     private static final String SUCCESS = "Success";
 
     private static final Log log = LogFactory.getLog(ClaimMetadataManagementAuditLogger.class);
+
+    @Override
+    public boolean canHandle(MessageContext messageContext) {
+
+        if (super.canHandle(messageContext)) {
+            return !LoggerUtils.isEnableV2AuditLogs();
+        }
+        return false;
+    }
 
     /**
      * This handles the claim related operations that are subscribed and publish audit logs for those operations.

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementAdminService.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/services/UserIdentityManagementAdminService.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.mgt.ChallengeQuestionProcessor;
 import org.wso2.carbon.identity.mgt.IdentityMgtConfig;
 import org.wso2.carbon.identity.mgt.IdentityMgtServiceException;
@@ -177,8 +178,10 @@ public class UserIdentityManagementAdminService {
             String userNameWithoutDomain = UserCoreUtil.removeDomainFromName(userName);
             UserIdentityManagementUtil.disableUserAccount(userNameWithoutDomain, userStoreManager);
 
-            audit.info(String.format(AUDIT_MESSAGE, getUser(), "Disable user account", userName,
-                    "Notification type :" + notificationType, SUCCESS));
+            if (!LoggerUtils.isEnableV2AuditLogs()) {
+                audit.info(String.format(AUDIT_MESSAGE, getUser(), "Disable user account", userName,
+                        "Notification type :" + notificationType, SUCCESS));
+            }
 
             int tenantID = userStoreManager.getTenantId();
             String tenantDomain = IdentityMgtServiceComponent.getRealmService().getTenantManager().getDomain(tenantID);
@@ -228,8 +231,10 @@ public class UserIdentityManagementAdminService {
             String userNameWithoutDomain = UserCoreUtil.removeDomainFromName(userName);
             UserIdentityManagementUtil.enableUserAccount(userNameWithoutDomain, userStoreManager);
 
-            audit.info(String.format(AUDIT_MESSAGE, getUser(), "Enable user account", userName,
-                    "Notification type :" + notificationType, SUCCESS));
+            if (!LoggerUtils.isEnableV2AuditLogs()) {
+                audit.info(String.format(AUDIT_MESSAGE, getUser(), "Enable user account", userName,
+                        "Notification type :" + notificationType, SUCCESS));
+            }
 
             int tenantID = userStoreManager.getTenantId();
             String tenantDomain = IdentityMgtServiceComponent.getRealmService().getTenantManager().getDomain(tenantID);

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/listener/IDPMgtAuditLogger.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/listener/IDPMgtAuditLogger.java
@@ -49,7 +49,10 @@ public class IDPMgtAuditLogger extends AbstractIdentityProviderMgtListener {
     @Override
     public boolean isEnable() {
 
-        return super.isEnable();
+        if (super.isEnable()) {
+            return !LoggerUtils.isEnableV2AuditLogs();
+        }
+        return false;
     }
 
     @Override
@@ -62,6 +65,9 @@ public class IDPMgtAuditLogger extends AbstractIdentityProviderMgtListener {
     public boolean doPostAddIdP(IdentityProvider identityProvider, String tenantDomain) throws
             IdentityProviderManagementException {
 
+        if (!isEnable()) {
+            return true;
+        }
         String resourceId = "Undefined";
         if (identityProvider != null && StringUtils.isNotBlank(identityProvider.getResourceId())) {
             resourceId = identityProvider.getResourceId();
@@ -76,6 +82,9 @@ public class IDPMgtAuditLogger extends AbstractIdentityProviderMgtListener {
     public boolean doPostUpdateIdP(String oldIdPName, IdentityProvider identityProvider, String tenantDomain) throws
             IdentityProviderManagementException {
 
+        if (!isEnable()) {
+            return true;
+        }
         String resourceId = "Undefined";
 
         if (identityProvider != null && StringUtils.isNotEmpty(identityProvider.getResourceId())) {
@@ -98,6 +107,9 @@ public class IDPMgtAuditLogger extends AbstractIdentityProviderMgtListener {
     @Override
     public boolean doPostDeleteIdP(String idPName, String tenantDomain) throws IdentityProviderManagementException {
 
+        if (!isEnable()) {
+            return true;
+        }
         audit.info(String.format(AUDIT_MESSAGE, getUser(), "Delete-IDP", idPName, null, SUCCESS));
         return true;
     }
@@ -114,6 +126,9 @@ public class IDPMgtAuditLogger extends AbstractIdentityProviderMgtListener {
     public boolean doPostDeleteIdPByResourceId(String resourceId, IdentityProvider identityProvider, String
             tenantDomain) throws IdentityProviderManagementException {
 
+        if (!isEnable()) {
+            return true;
+        }
         if (StringUtils.isBlank(resourceId)) {
             resourceId = "Undefined";
         }
@@ -131,6 +146,9 @@ public class IDPMgtAuditLogger extends AbstractIdentityProviderMgtListener {
     @Override
     public boolean doPostDeleteIdPs(String tenantDomain) throws IdentityProviderManagementException {
 
+        if (!isEnable()) {
+            return true;
+        }
         audit.info(String.format(AUDIT_MESSAGE, getUser(), "Delete-All-IDPs", tenantDomain, null, SUCCESS));
         return true;
     }

--- a/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/internal/RoleManagementServiceImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.mgt.core/src/main/java/org/wso2/carbon/identity/role/mgt/core/internal/RoleManagementServiceImpl.java
@@ -83,8 +83,10 @@ public class RoleManagementServiceImpl implements RoleManagementService {
         if (LOG.isDebugEnabled()) {
             LOG.debug(String.format("%s add role of name : %s successfully.", getUser(tenantDomain), roleName));
         }
-        audit.info(String.format(auditMessage, getInitiator(tenantDomain), "Add Role", roleName,
-                getAuditData(tenantDomain), SUCCESS));
+        if (!LoggerUtils.isEnableV2AuditLogs()) {
+            audit.info(String.format(auditMessage, getInitiator(tenantDomain), "Add Role", roleName,
+                    getAuditData(tenantDomain), SUCCESS));
+        }
         return roleBasicInfo;
     }
 
@@ -184,8 +186,10 @@ public class RoleManagementServiceImpl implements RoleManagementService {
             LOG.debug(String.format("%s updated role name of role id : %s successfully.",
                     getUser(tenantDomain), roleID));
         }
-        audit.info(String.format(auditMessage, getInitiator(tenantDomain), "Update role name by ID", roleID,
-                getAuditData(tenantDomain, newRoleName), SUCCESS));
+        if (!LoggerUtils.isEnableV2AuditLogs()) {
+            audit.info(String.format(auditMessage, getInitiator(tenantDomain), "Update role name by ID", roleID,
+                    getAuditData(tenantDomain, newRoleName), SUCCESS));
+        }
         return roleBasicInfo;
     }
 
@@ -201,8 +205,10 @@ public class RoleManagementServiceImpl implements RoleManagementService {
             LOG.debug(String.format("%s deleted role of id : %s successfully.",
                     getUser(tenantDomain), roleID));
         }
-        audit.info(String.format(auditMessage, getInitiator(tenantDomain), "Delete role by id", roleID,
-                getAuditData(tenantDomain), SUCCESS));
+        if (!LoggerUtils.isEnableV2AuditLogs()) {
+            audit.info(String.format(auditMessage, getInitiator(tenantDomain), "Delete role by id", roleID,
+                    getAuditData(tenantDomain), SUCCESS));
+        }
     }
 
     @Override
@@ -238,8 +244,10 @@ public class RoleManagementServiceImpl implements RoleManagementService {
             LOG.debug(String.format("%s updated list of users of role of id : %s successfully.",
                     getUser(tenantDomain), roleID));
         }
-        audit.info(String.format(auditMessage, getInitiator(tenantDomain),
-                "Update users list of role by id", roleID, getAuditData(tenantDomain), SUCCESS));
+        if (!LoggerUtils.isEnableV2AuditLogs()) {
+            audit.info(String.format(auditMessage, getInitiator(tenantDomain),
+                    "Update users list of role by id", roleID, getAuditData(tenantDomain), SUCCESS));
+        }
         return roleBasicInfo;
     }
 
@@ -275,8 +283,10 @@ public class RoleManagementServiceImpl implements RoleManagementService {
             LOG.debug(String.format("%s updated list of groups of role of id : %s successfully.",
                     getUser(tenantDomain), roleID));
         }
-        audit.info(String.format(auditMessage, getInitiator(tenantDomain),
-                "Update group list of role by id", roleID, getAuditData(tenantDomain), SUCCESS));
+        if (!LoggerUtils.isEnableV2AuditLogs()) {
+            audit.info(String.format(auditMessage, getInitiator(tenantDomain),
+                    "Update group list of role by id", roleID, getAuditData(tenantDomain), SUCCESS));
+        }
         return roleBasicInfo;
     }
 
@@ -310,8 +320,10 @@ public class RoleManagementServiceImpl implements RoleManagementService {
             LOG.debug(String.format("%s set list of permissions of role of id : %s successfully.",
                     getUser(tenantDomain), roleID));
         }
-        audit.info(String.format(auditMessage, getInitiator(tenantDomain), "Set permission for role by id",
-                roleID, getAuditData(tenantDomain), SUCCESS));
+        if (!LoggerUtils.isEnableV2AuditLogs()) {
+            audit.info(String.format(auditMessage, getInitiator(tenantDomain), "Set permission for role by id",
+                    roleID, getAuditData(tenantDomain), SUCCESS));
+        }
         return roleBasicInfo;
     }
 

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/bulkimport/CSVUserBulkImport.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/bulkimport/CSVUserBulkImport.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
@@ -111,14 +112,16 @@ public class CSVUserBulkImport extends UserBulkImport {
                 line = csvReader.readNext();
             }
 
-            InputStream inputStream = config.getInStream();
-            inputStream.reset();
-            JSONConverter jsonConverter = new JSONConverter();
-            String usersImported = jsonConverter.csvToJSON(inputStream);
             String summaryLog = buildBulkImportSummary();
 
-            auditLog.info(String.format(UserMgtConstants.AUDIT_LOG_FORMAT, tenantUser,
-                    UserMgtConstants.OPERATION_NAME, userStoreDomain, usersImported, summaryLog));
+            if (!LoggerUtils.isEnableV2AuditLogs()) {
+                InputStream inputStream = config.getInStream();
+                inputStream.reset();
+                JSONConverter jsonConverter = new JSONConverter();
+                String usersImported = jsonConverter.csvToJSON(inputStream);
+                auditLog.info(String.format(UserMgtConstants.AUDIT_LOG_FORMAT, tenantUser,
+                        UserMgtConstants.OPERATION_NAME, userStoreDomain, usersImported, summaryLog));
+            }
             log.info(summaryLog);
 
             if (fail || isDuplicate) {

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/bulkimport/ExcelUserBulkImport.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/bulkimport/ExcelUserBulkImport.java
@@ -29,6 +29,7 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityIOStreamUtils;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
@@ -108,10 +109,12 @@ public class ExcelUserBulkImport extends UserBulkImport {
         String summeryLog = super.buildBulkImportSummary();
         log.info(summeryLog);
 
-        JSONConverter jsonConverter = new JSONConverter();
-        String importedUsers = jsonConverter.xlsToJSON(sheet);
-        auditLog.info(String.format(UserMgtConstants.AUDIT_LOG_FORMAT, tenantUser, UserMgtConstants.OPERATION_NAME,
-                userStoreDomain, importedUsers, summeryLog));
+        if (!LoggerUtils.isEnableV2AuditLogs()) {
+            JSONConverter jsonConverter = new JSONConverter();
+            String importedUsers = jsonConverter.xlsToJSON(sheet);
+            auditLog.info(String.format(UserMgtConstants.AUDIT_LOG_FORMAT, tenantUser, UserMgtConstants.OPERATION_NAME,
+                    userStoreDomain, importedUsers, summeryLog));
+        }
 
         if (fail || isDuplicate) {
             throw new UserAdminException(String.format(UserMgtConstants.ERROR_MESSAGE, successCount, failCount,

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserMgtAuditLogger.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserMgtAuditLogger.java
@@ -40,6 +40,15 @@ public class UserMgtAuditLogger extends AbstractIdentityUserOperationEventListen
     private static String AUDIT_MESSAGE = "Initiator : %s | Action : %s | Target : %s | Data : { %s } | Result : %s ";
 
     @Override
+    public boolean isEnable() {
+
+        if (super.isEnable()) {
+            return !LoggerUtils.isEnableV2AuditLogs();
+        }
+        return false;
+    }
+
+    @Override
     public int getExecutionOrderId() {
 
         int orderId = getOrderId();

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserMgtFailureAuditLogger.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserMgtFailureAuditLogger.java
@@ -41,9 +41,21 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     private static final Log audit = CarbonConstants.AUDIT_LOG;
 
     @Override
+    public boolean isEnable() {
+
+        if (super.isEnable()) {
+            return !LoggerUtils.isEnableV2AuditLogs();
+        }
+        return false;
+    }
+
+    @Override
     public boolean onAuthenticateFailure(String errorCode, String errorMessage, String userName, Object credential,
             UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         errorMessage = getErrorMessageWithMaskedUsername(errorMessage, userName);
         audit.warn(createAuditMessage(ListenerUtils.AUTHENTICATION_ACTION, getTargetForAuditLog
                 (LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(userName) : userName,
@@ -55,6 +67,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onAddUserFailure(String errorCode, String errorMessage, String userName, Object credential,
             String[] roleList, Map<String, String> claims, String profile, UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         JSONObject dataObject = new JSONObject();
         if (ArrayUtils.isNotEmpty(roleList)) {
             dataObject.put(ListenerUtils.ROLES_FIELD, new JSONArray(roleList));
@@ -78,6 +93,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onUpdateCredentialFailure(String errorCode, String errorMessage, String userName,
             Object newCredential, Object oldCredential, UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         errorMessage = getErrorMessageWithMaskedUsername(errorMessage, userName);
         audit.warn(createAuditMessage(ListenerUtils.CHANGE_PASSWORD_BY_USER_ACTION,
                 getTargetForAuditLog(LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(userName) : userName,
@@ -89,6 +107,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onUpdateCredentialByAdminFailure(String errorCode, String errorMessage, String userName,
             Object newCredential, UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         errorMessage = getErrorMessageWithMaskedUsername(errorMessage, userName);
         audit.warn(createAuditMessage(ListenerUtils.CHANGE_PASSWORD_BY_ADMIN_ACTION,
                 getTargetForAuditLog(LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(userName) : userName,
@@ -100,6 +121,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onDeleteUserFailure(String errorCode, String errorMessage, String userName,
             UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         errorMessage = getErrorMessageWithMaskedUsername(errorMessage, userName);
         audit.warn(createAuditMessage(ListenerUtils.DELETE_USER_ACTION,
                 getTargetForAuditLog(LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(userName) : userName,
@@ -111,6 +135,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onSetUserClaimValueFailure(String errorCode, String errorMessage, String userName, String claimURI,
             String claimValue, String profileName, UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         JSONObject dataObject = new JSONObject();
         if (LoggerUtils.isLogMaskingEnable) {
             String maskedClaimValue = LoggerUtils.getMaskedClaimValue(claimURI, claimValue);
@@ -130,6 +157,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onSetUserClaimValuesFailure(String errorCode, String errorMessage, String userName,
             Map<String, String> claims, String profileName, UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         if (LoggerUtils.isLogMaskingEnable) {
             Map<String, String> maskedClaimsMap = LoggerUtils.getMaskedClaimsMap(claims);
             errorMessage = getErrorMessageWithMaskedUsername(errorMessage, userName);
@@ -148,6 +178,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onDeleteUserClaimValuesFailure(String errorCode, String errorMessage, String userName,
             String[] claims, String profileName, UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         JSONArray data = new JSONArray();
         if (ArrayUtils.isNotEmpty(claims)) {
             data = new JSONArray(claims);
@@ -163,6 +196,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onDeleteUserClaimValueFailure(String errorCode, String errorMessage, String userName,
             String claimURI, String profileName, UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         JSONObject dataObject = new JSONObject();
         dataObject.put(ListenerUtils.CLAIM_URI_FIELD, claimURI);
         dataObject.put(ListenerUtils.PROFILE_FIELD, profileName);
@@ -177,6 +213,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onAddRoleFailure(String errorCode, String errorMessage, String roleName, String[] userList,
             Permission[] permissions, UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         JSONObject dataObject = new JSONObject();
         if (ArrayUtils.isNotEmpty(userList)) {
             if (LoggerUtils.isLogMaskingEnable) {
@@ -200,6 +239,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
                                           org.wso2.carbon.user.api.Permission[] permissions,
                                           UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         JSONObject dataObject = new JSONObject();
         if (ArrayUtils.isNotEmpty(userList)) {
             if (LoggerUtils.isLogMaskingEnable) {
@@ -222,6 +264,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onDeleteRoleFailure(String errorCode, String errorMessage, String roleName,
             UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         audit.warn(createAuditMessage(ListenerUtils.DELETE_ROLE_ACTION,
                 ListenerUtils.getEntityWithUserStoreDomain(roleName, userStoreManager), null, errorCode, errorMessage));
         return true;
@@ -231,6 +276,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onUpdateRoleNameFailure(String errorCode, String errorMessage, String roleName, String newRoleName,
             UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         audit.warn(createAuditMessage(ListenerUtils.UPDATE_ROLE_NAME_ACTION,
                 ListenerUtils.getEntityWithUserStoreDomain(roleName, userStoreManager), newRoleName, errorCode,
                 errorMessage));
@@ -241,6 +289,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onUpdateUserListOfRoleFailure(String errorCode, String errorMessage, String roleName,
             String[] deletedUsers, String[] newUsers, UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         JSONObject dataObject = new JSONObject();
         if (ArrayUtils.isNotEmpty(deletedUsers)) {
             dataObject.put(ListenerUtils.DELETED_USERS, new JSONArray(deletedUsers));
@@ -259,6 +310,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onUpdateRoleListOfUserFailure(String errorCode, String errorMessage, String userName,
             String[] deletedRoles, String[] newRoles, UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         JSONObject dataObject = new JSONObject();
         if (ArrayUtils.isNotEmpty(deletedRoles)) {
             dataObject.put(ListenerUtils.DELETED_ROLES, new JSONArray(deletedRoles));
@@ -278,6 +332,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onGetUserClaimValueFailure(String errorCode, String errorMessage, String userName, String claim,
             String profileName, UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         JSONObject dataObject = new JSONObject();
         dataObject.put(ListenerUtils.PROFILE_FIELD, profileName);
         dataObject.put(ListenerUtils.CLAIM_URI_FIELD, claim);
@@ -293,6 +350,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onGetUserClaimValuesFailure(String errorCode, String errorMessage, String userName, String[] claims,
             String profile, UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         JSONObject dataObject = new JSONObject();
         dataObject.put(ListenerUtils.PROFILE_FIELD, profile);
         if (ArrayUtils.isNotEmpty(claims)) {
@@ -310,6 +370,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onGetUserListFailure(String errorCode, String errorMessage, String claim, String claimValue,
             String profileName, UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         JSONObject dataObject = new JSONObject();
         dataObject.put(ListenerUtils.CLAIM_URI_FIELD, claim);
         if (LoggerUtils.isLogMaskingEnable) {
@@ -328,6 +391,9 @@ public class UserMgtFailureAuditLogger extends AbstractIdentityUserMgtFailureEve
     public boolean onUpdatePermissionsOfRoleFailure(String errorCode, String errorMessage, String roleName,
             Permission[] permissions, UserStoreManager userStoreManager) {
 
+        if (!isEnable()) {
+            return true;
+        }
         JSONObject dataObject = new JSONObject();
         if (ArrayUtils.isNotEmpty(permissions)) {
             JSONArray permissionsArray = new JSONArray(permissions);

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/listener/WorkflowAuditLogger.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/listener/WorkflowAuditLogger.java
@@ -41,6 +41,15 @@ public class WorkflowAuditLogger extends AbstractWorkflowListener {
     private static final String AUDIT_MESSAGE = "Initiator : %s | Action : %s | Data : { %s } | Result :  %s ";
     private static final String AUDIT_SUCCESS = "Success";
 
+    @Override
+    public boolean isEnable() {
+
+        if (super.isEnable()) {
+            return !LoggerUtils.isEnableV2AuditLogs();
+        }
+        return false;
+    }
+
     /**
      * Trigger after deleting the request.
      *
@@ -50,6 +59,9 @@ public class WorkflowAuditLogger extends AbstractWorkflowListener {
     @Override
     public void doPostDeleteWorkflowRequest(WorkflowRequest workflowRequest) throws WorkflowException {
 
+        if (!isEnable()) {
+            return;
+        }
         String loggedInUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
         if (StringUtils.isBlank(loggedInUser)) {
             loggedInUser = CarbonConstants.REGISTRY_SYSTEM_USERNAME;
@@ -72,6 +84,9 @@ public class WorkflowAuditLogger extends AbstractWorkflowListener {
     @Override
     public void doPostDeleteWorkflow(Workflow workflow) throws WorkflowException {
 
+        if (!isEnable()) {
+            return;
+        }
         String loggedInUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
         if (StringUtils.isBlank(loggedInUser)) {
             loggedInUser = CarbonConstants.REGISTRY_SYSTEM_USERNAME;
@@ -93,6 +108,9 @@ public class WorkflowAuditLogger extends AbstractWorkflowListener {
     @Override
     public void doPostDeleteWorkflows(int tenantId) throws WorkflowException {
 
+        if (!isEnable()) {
+            return;
+        }
         String loggedInUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
         if (StringUtils.isBlank(loggedInUser)) {
             loggedInUser = CarbonConstants.REGISTRY_SYSTEM_USERNAME;
@@ -118,6 +136,9 @@ public class WorkflowAuditLogger extends AbstractWorkflowListener {
     public void doPostAddWorkflow(Workflow workflowDTO, List<Parameter> parameterList, int tenantId) throws
             WorkflowException {
 
+        if (!isEnable()) {
+            return;
+        }
         String loggedInUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
         if (StringUtils.isBlank(loggedInUser)) {
             loggedInUser = CarbonConstants.REGISTRY_SYSTEM_USERNAME;
@@ -147,6 +168,9 @@ public class WorkflowAuditLogger extends AbstractWorkflowListener {
     public void doPostAddAssociation(String associationName, String workflowId, String eventId, String condition)
             throws WorkflowException {
 
+        if (!isEnable()) {
+            return;
+        }
         String loggedInUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
         if (StringUtils.isBlank(loggedInUser)) {
             loggedInUser = CarbonConstants.REGISTRY_SYSTEM_USERNAME;
@@ -171,6 +195,9 @@ public class WorkflowAuditLogger extends AbstractWorkflowListener {
     @Override
     public void doPostRemoveAssociation(int associationId) throws WorkflowException {
 
+        if (!isEnable()) {
+            return;
+        }
         String loggedInUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
         if (StringUtils.isBlank(loggedInUser)) {
             loggedInUser = CarbonConstants.REGISTRY_SYSTEM_USERNAME;
@@ -193,6 +220,9 @@ public class WorkflowAuditLogger extends AbstractWorkflowListener {
     @Override
     public void doPostChangeAssociationState(String associationId, boolean isEnable) throws WorkflowException {
 
+        if (!isEnable()) {
+            return;
+        }
         String loggedInUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
         if (StringUtils.isBlank(loggedInUser)) {
             loggedInUser = CarbonConstants.REGISTRY_SYSTEM_USERNAME;

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/listener/WorkflowExecutorAuditLogger.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/listener/WorkflowExecutorAuditLogger.java
@@ -40,6 +40,15 @@ public class WorkflowExecutorAuditLogger extends AbstractWorkflowExecutorManager
     private static final String AUDIT_MESSAGE = "Initiator : %s | Action : %s | Data : { %s } | Result :  %s ";
     private static final String AUDIT_SUCCESS = "Success";
 
+    @Override
+    public boolean isEnable() {
+
+        if (super.isEnable()) {
+            return !LoggerUtils.isEnableV2AuditLogs();
+        }
+        return false;
+    }
+
     /**
      * Trigger after executing a workflow request.
      *
@@ -50,6 +59,9 @@ public class WorkflowExecutorAuditLogger extends AbstractWorkflowExecutorManager
     public void doPostExecuteWorkflow(WorkflowRequest workFlowRequest, WorkflowExecutorResult result) throws
             WorkflowException {
 
+        if (!isEnable()) {
+            return;
+        }
         String loggedInUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
         if (StringUtils.isBlank(loggedInUser)) {
             loggedInUser = CarbonConstants.REGISTRY_SYSTEM_USERNAME;
@@ -77,6 +89,9 @@ public class WorkflowExecutorAuditLogger extends AbstractWorkflowExecutorManager
     public void doPostHandleCallback(String uuid, String status, Map<String, Object> additionalParams)
             throws WorkflowException {
 
+        if (!isEnable()) {
+            return;
+        }
         String loggedInUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
         if (StringUtils.isBlank(loggedInUser)) {
             loggedInUser = CarbonConstants.REGISTRY_SYSTEM_USERNAME;


### PR DESCRIPTION
### Proposed changes in this pull request

Related Issue https://github.com/wso2/product-is/issues/24340
Related PR https://github.com/wso2/carbon-identity-framework/pull/6851

This pull request introduces a mechanism to conditionally disable legacy audit logging across several identity management modules when the new V2 audit logging system is enabled. The main change is the addition of checks for `LoggerUtils.isEnableV2AuditLogs()` before performing audit logging actions, ensuring that only one audit logging system is active at a time. This affects audit loggers and service classes in authentication, claim management, identity management, identity provider management, role management, and user management components.

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-

### Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
