### PR TITLE
Add configs as properties to flows.

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/util/FlowExecutionEngineUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/util/FlowExecutionEngineUtils.java
@@ -63,7 +63,6 @@ import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMess
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_INVALID_FLOW_ID;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_TENANT_RESOLVE_FAILURE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_UNDEFINED_FLOW_ID;
-import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_USER_ONBOARD_FAILURE;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.EMAIL_FORMAT_VALIDATOR;
 
 /**

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
@@ -18,6 +18,12 @@
 
 package org.wso2.carbon.identity.flow.mgt;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Constants for the orchestration flow.
  */
@@ -134,20 +140,30 @@ public class Constants {
 
     public enum FlowTypes {
 
-        REGISTRATION("REGISTRATION"),
-        PASSWORD_RECOVERY("PASSWORD_RECOVERY"),
-        INVITED_USER_REGISTRATION("INVITED_USER_REGISTRATION");
+        REGISTRATION("REGISTRATION", Properties.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED,
+                Properties.IS_EMAIL_VERIFICATION_ENABLED, Properties.IS_AUTO_LOGIN_ENABLED),
+        PASSWORD_RECOVERY("PASSWORD_RECOVERY", Properties.IS_AUTO_LOGIN_ENABLED,
+                Properties.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED),
+        INVITED_USER_REGISTRATION("INVITED_USER_REGISTRATION", Properties.IS_AUTO_LOGIN_ENABLED,
+                Properties.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED);
 
         private final String type;
+        private final ArrayList<Properties> supportedProperties = new ArrayList<>();
 
-        FlowTypes(String type) {
+        FlowTypes(String type, Properties... requiredFlags) {
 
             this.type = type;
+            this.supportedProperties.addAll(Arrays.asList(requiredFlags));
         }
 
         public String getType() {
 
             return type;
+        }
+
+        public ArrayList<Properties> getSupportedProperties() {
+
+            return supportedProperties;
         }
     }
 
@@ -258,6 +274,64 @@ public class Constants {
 
         private FlowAIConstants() {
 
+        }
+    }
+
+    /**
+     * Constants for the flow properties.
+     */
+    public enum Properties {
+
+        IS_AUTO_LOGIN_ENABLED("isAutoLoginEnabled"),
+        IS_EMAIL_VERIFICATION_ENABLED("isEmailVerificationEnabled"),
+        IS_ACCOUNT_LOCK_ON_CREATION_ENABLED("isAccountLockOnCreationEnabled"),
+        IS_FLOW_COMPLETION_NOTIFICATION_ENABLED("isFlowCompletionNotificationEnabled");
+
+        private final String property;
+        private final String defaultValue;
+
+        private static final Map<String, Properties> LOOKUP = new HashMap<>();
+
+        static {
+            for (Properties constant : values()) {
+                LOOKUP.put(constant.property, constant);
+            }
+        }
+
+        Properties(String property) {
+
+            this.property = property;
+            this.defaultValue = "false";
+        }
+
+        Properties(String property, List<String> allowedValues) {
+
+            this.property = property;
+            this.defaultValue = "false";
+        }
+
+        Properties(String property, String defaultValue) {
+
+            this.property = property;
+            this.defaultValue = defaultValue;
+        }
+
+        public String getName() {
+
+            return property;
+        }
+
+        public String getDefaultValue() {
+
+            return defaultValue;
+        }
+
+        public static Properties fromProperty(String name) {
+
+            if (LOOKUP.containsKey(name)) {
+                return LOOKUP.get(name);
+            }
+            throw new IllegalArgumentException("No enum constant found for flag: " + name);
         }
     }
 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/model/FlowConfigDTO.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/model/FlowConfigDTO.java
@@ -18,6 +18,14 @@
 
 package org.wso2.carbon.identity.flow.mgt.model;
 
+import org.wso2.carbon.identity.flow.mgt.Constants;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.wso2.carbon.identity.flow.mgt.Constants.Properties.IS_AUTO_LOGIN_ENABLED;
+
 /**
  * Flow configuration model class.
  */
@@ -25,7 +33,7 @@ public class FlowConfigDTO {
 
     private String flowType;
     private Boolean isEnabled;
-    private Boolean isAutoLoginEnabled;
+    private final Map<String, String> properties = new HashMap<>();
 
     public String getFlowType() {
 
@@ -49,11 +57,51 @@ public class FlowConfigDTO {
 
     public Boolean getIsAutoLoginEnabled() {
 
-        return isAutoLoginEnabled;
+        return Boolean.parseBoolean(getProperty(IS_AUTO_LOGIN_ENABLED));
     }
 
     public void setIsAutoLoginEnabled(Boolean autoLoginEnabled) {
 
-        isAutoLoginEnabled = autoLoginEnabled;
+        addProperty(IS_AUTO_LOGIN_ENABLED, String.valueOf(autoLoginEnabled));
+    }
+
+    public void addProperty(Constants.Properties property, String value) {
+
+        if (property != null) {
+            this.properties.put(property.getName(), value);
+        }
+    }
+
+    public void addAllProperties(ArrayList<Constants.Properties> properties) {
+
+        for (Constants.Properties flag : properties) {
+            addProperty(flag, flag.getDefaultValue());
+        }
+    }
+
+    public void addAllProperties(Map<String, String> properties) {
+
+        this.properties.putAll(properties);
+    }
+
+    public Map<Constants.Properties, String> getProperties(ArrayList<Constants.Properties> propertyList) {
+
+        Map<Constants.Properties, String> selectedFlags = new HashMap<>();
+        for (Constants.Properties flag : propertyList) {
+            if (properties.containsKey(flag.getName())) {
+                selectedFlags.put(flag, properties.get(flag.getName()));
+            }
+        }
+        return selectedFlags;
+    }
+
+    public String getProperty(Constants.Properties property) {
+
+        return properties.get(property.getName());
+    }
+
+    public Map<String, String> getAllProperties() {
+
+        return properties;
     }
 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
@@ -36,11 +36,11 @@ import org.wso2.carbon.identity.flow.mgt.model.FlowConfigDTO;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowConfigConstants.FLOW_TYPE;
-import static org.wso2.carbon.identity.flow.mgt.Constants.FlowConfigConstants.IS_AUTO_LOGIN_ENABLED;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowConfigConstants.IS_ENABLED;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowConfigConstants.RESOURCE_NAME_PREFIX;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowConfigConstants.RESOURCE_TYPE;
@@ -180,10 +180,11 @@ public class FlowMgtConfigUtils {
     private static FlowConfigDTO getDefaultConfig(String flowType) {
 
         LOG.debug("Returning default flow configuration for flow type: " + flowType);
+        Constants.FlowTypes flowTypeRequested = Constants.FlowTypes.valueOf(flowType);
         FlowConfigDTO flowConfigDTO = new FlowConfigDTO();
         flowConfigDTO.setFlowType(flowType);
         flowConfigDTO.setIsEnabled(false);
-        flowConfigDTO.setIsAutoLoginEnabled(false);
+        flowConfigDTO.addAllProperties(flowTypeRequested.getSupportedProperties());
         return flowConfigDTO;
     }
 
@@ -213,10 +214,9 @@ public class FlowMgtConfigUtils {
                 case IS_ENABLED:
                     flowConfigDTO.setIsEnabled(Boolean.parseBoolean(attribute.getValue()));
                     break;
-                case IS_AUTO_LOGIN_ENABLED:
-                    flowConfigDTO.setIsAutoLoginEnabled(Boolean.parseBoolean(attribute.getValue()));
-                    break;
                 default:
+                    flowConfigDTO.addProperty(Constants.Properties.fromProperty(attribute.getKey()), attribute.getValue());
+                    break;
             }
         }
         return flowConfigDTO;
@@ -230,15 +230,23 @@ public class FlowMgtConfigUtils {
      */
     private static Resource buildResourceFromFlowConfig(FlowConfigDTO flowConfigDTO) {
 
-        Attribute flowTypeAttribute = new Attribute(FLOW_TYPE, flowConfigDTO.getFlowType());
+        String flowType = flowConfigDTO.getFlowType();
+        Attribute flowTypeAttribute = new Attribute(FLOW_TYPE, flowType);
         Attribute flowIsEnabledAttribute = new Attribute(IS_ENABLED, String.valueOf(flowConfigDTO.getIsEnabled()));
-        Attribute flowIsAutoLoginEnabledAttribute = new Attribute(IS_AUTO_LOGIN_ENABLED,
-                String.valueOf(flowConfigDTO.getIsAutoLoginEnabled()));
+        Map<Constants.Properties, String> flags = flowConfigDTO.getProperties(
+                Constants.FlowTypes.valueOf(flowType).getSupportedProperties());
 
         List<Attribute> attributes = new ArrayList<>();
         attributes.add(flowTypeAttribute);
         attributes.add(flowIsEnabledAttribute);
-        attributes.add(flowIsAutoLoginEnabledAttribute);
+
+        // Add any additional properties as attributes.
+        if (!flags.isEmpty()) {
+            flags.forEach((key, value) -> {
+                Attribute attribute = new Attribute(key.getName(), value);
+                attributes.add(attribute);
+            });
+        }
 
         Resource resource = new Resource();
         resource.setResourceType(RESOURCE_TYPE);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceTypeAdd;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resources;
+import org.wso2.carbon.identity.flow.mgt.Constants;
 import org.wso2.carbon.identity.flow.mgt.exception.FlowMgtServerException;
 import org.wso2.carbon.identity.flow.mgt.internal.FlowMgtServiceDataHolder;
 import org.wso2.carbon.identity.flow.mgt.model.FlowConfigDTO;
@@ -98,7 +99,7 @@ public class FlowMgtConfigUtilsTest {
         Assert.assertNotNull(result);
         Assert.assertEquals(result.getFlowType(), FLOW_TYPE_REGISTRATION);
         Assert.assertTrue(result.getIsEnabled());
-        Assert.assertTrue(result.getIsAutoLoginEnabled());
+        Assert.assertFalse(result.getIsAutoLoginEnabled());
         verify(configurationManager).addResource(eq(RESOURCE_TYPE), any(Resource.class));
     }
 
@@ -374,7 +375,7 @@ public class FlowMgtConfigUtilsTest {
         FlowConfigDTO flowConfigDTO = new FlowConfigDTO();
         flowConfigDTO.setFlowType(FLOW_TYPE_REGISTRATION);
         flowConfigDTO.setIsEnabled(true);
-        flowConfigDTO.setIsAutoLoginEnabled(true);
+        flowConfigDTO.addAllProperties(Constants.FlowTypes.REGISTRATION.getSupportedProperties());
         return flowConfigDTO;
     }
 
@@ -393,8 +394,10 @@ public class FlowMgtConfigUtilsTest {
         List<Attribute> attributes = new ArrayList<>();
         attributes.add(new Attribute(FLOW_TYPE, flowType));
         attributes.add(new Attribute(IS_ENABLED, "true"));
-        attributes.add(new Attribute(IS_AUTO_LOGIN_ENABLED, "true"));
-
+        for (Constants.Properties property : Constants.FlowTypes
+                .valueOf(flowType).getSupportedProperties()) {
+            attributes.add(new Attribute(property.getName(), property.getDefaultValue()));
+        }
         resource.setAttributes(attributes);
         return resource;
     }


### PR DESCRIPTION
This pull request refactors how flow configuration properties are managed and stored in the flow orchestration framework. The main change is moving from handling individual boolean flags (like `isAutoLoginEnabled`) to a more extensible, property-based approach using enums and maps. This improves flexibility for future additions and simplifies property management across flow types.