### PR TITLE
Add a method to check whether the user's credential are locally managed

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowUser.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowUser.java
@@ -174,8 +174,12 @@ public class FlowUser implements Serializable {
         final String userSourceId = claims.get(USER_SOURCE_ID_CLAIM_URI);
         final String localCredentialExistsStr = claims.get(LOCAL_CREDENTIAL_EXISTS_CLAIM_URI);
         // This case covers an external user source where local credentials are explicitly flagged as not existing.
-        final boolean isExternalUserWithoutLocalCreds = StringUtils.isNotEmpty(userSourceId)
-                && !Boolean.parseBoolean(localCredentialExistsStr);
+        boolean isExternalUserWithoutLocalCreds = false;
+        if (StringUtils.isNotEmpty(userSourceId)) {
+            if (!Boolean.parseBoolean(localCredentialExistsStr)) {
+                isExternalUserWithoutLocalCreds = true;
+            }
+        }
 
         final boolean isManagedExternally = isManagedByDifferentOrg || isExternalUserWithoutLocalCreds;
         return !isManagedExternally;

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowUser.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowUser.java
@@ -34,6 +34,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.core.util.CryptoException;
 import org.wso2.carbon.core.util.CryptoUtil;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
@@ -61,7 +62,6 @@ public class FlowUser implements Serializable {
     private static final long serialVersionUID = -1873658743998134877L;
     private static final Log LOG = LogFactory.getLog(FlowUser.class);
 
-    private static final String USER_SOURCE_ID_CLAIM_URI = "http://wso2.org/claims/identity/userSourceId";
     private static final String MANAGED_ORG_CLAIM_URI = "http://wso2.org/claims/identity/managedOrg";
     private static final String LOCAL_CREDENTIAL_EXISTS_CLAIM_URI = "http://wso2.org/claims/identity/localCredentialExists";
 
@@ -171,7 +171,7 @@ public class FlowUser implements Serializable {
         final String managedOrgId = claims.get(MANAGED_ORG_CLAIM_URI);
         final boolean isManagedByDifferentOrg = StringUtils.isNotBlank(managedOrgId);
 
-        final String userSourceId = claims.get(USER_SOURCE_ID_CLAIM_URI);
+        final String userSourceId = claims.get(FrameworkConstants.PROVISIONED_SOURCE_ID_CLAIM);
         final String localCredentialExistsStr = claims.get(LOCAL_CREDENTIAL_EXISTS_CLAIM_URI);
         // This case covers an external user source where local credentials are explicitly flagged as not existing.
         boolean isExternalUserWithoutLocalCreds = false;
@@ -183,6 +183,18 @@ public class FlowUser implements Serializable {
 
         final boolean isManagedExternally = isManagedByDifferentOrg || isExternalUserWithoutLocalCreds;
         return !isManagedExternally;
+    }
+
+    public boolean isAccountLocked() {
+
+        String accountLocked = claims.get(FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI);
+        return Boolean.parseBoolean(accountLocked);
+    }
+
+    public boolean isAccountDisabled() {
+
+        String accountDisabled = claims.get(FrameworkConstants.ACCOUNT_DISABLED_CLAIM_URI);
+        return Boolean.parseBoolean(accountDisabled);
     }
 
     private String resolveUsername(FlowUser user, String tenantDomain) {


### PR DESCRIPTION
### Issue 

https://github.com/wso2/product-is/issues/25636

This pull request adds logic to the `FlowUser` class to determine whether a user's credentials are managed locally or externally, based on specific user claim values. The main changes include introducing new claim URI constants and a method to encapsulate the decision logic.

**Enhancements to user credential management logic:**

* Added three new claim URI constants: `USER_SOURCE_ID_CLAIM_URI`, `MANAGED_ORG_CLAIM_URI`, and `LOCAL_CREDENTIAL_EXISTS_CLAIM_URI` to the `FlowUser` class for consistent reference to relevant user claims.
* Introduced the `isCredentialsManagedLocally()` method, which determines if credentials are managed locally by checking the above claims and applying the defined logic for external or managed organization users.