### PR TITLE
Add SESSION_EXPIRE to SAMLLogoutHandler subscriptions

### DIFF
--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -117,7 +117,8 @@
   "identity_mgt.events.schemes.failLoginAttemptValidator.properties.enable": true,
   "identity_mgt.events.schemes.SAMLLogoutHandler.module_index": "17",
   "identity_mgt.events.schemes.SAMLLogoutHandler.subscriptions": [
-    "SESSION_TERMINATE"
+    "SESSION_TERMINATE",
+    "SESSION_EXPIRE"
   ],
   "identity_mgt.events.schemes.SAMLLogoutHandler.properties.enable": true,
   "identity_mgt.events.schemes.confirmationCodesInvalidate.module_index": "18",


### PR DESCRIPTION
## Related Issue
- https://github.com/wso2/product-is/issues/25396

## Related PRs
- https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/448

## Implementation
This pull request makes a small configuration update to the event handling system. The change adds an additional event type to the subscriptions for the `SAMLLogoutHandler` scheme.

* The `SAMLLogoutHandler` in `org.wso2.carbon.identity.event.server.feature.default.json` now subscribes to both `SESSION_TERMINATE` and `SESSION_EXPIRE` events, instead of only `SESSION_TERMINATE`.

## Behaviour

https://github.com/user-attachments/assets/964dde69-854b-47f7-b9fe-a1c8c8bd063d


