### PR TITLE
Get and populate flow completion configs.

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
@@ -140,7 +140,8 @@ public class Constants {
     public enum FlowTypes {
 
         REGISTRATION("REGISTRATION", FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED,
-                FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED, FlowCompletionConfig.IS_AUTO_LOGIN_ENABLED),
+                FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED, FlowCompletionConfig.IS_AUTO_LOGIN_ENABLED,
+                FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED),
         PASSWORD_RECOVERY("PASSWORD_RECOVERY", FlowCompletionConfig.IS_AUTO_LOGIN_ENABLED,
                 FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED),
         INVITED_USER_REGISTRATION("INVITED_USER_REGISTRATION", FlowCompletionConfig.IS_AUTO_LOGIN_ENABLED,

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
@@ -420,6 +420,28 @@ public class FlowMgtConfigUtilsTest {
                 Constants.FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED)));
     }
 
+    @Test void testBuildFlowConfigFromResourceWithMissingAttributes() throws Exception {
+
+        Resource resource = createResourceWithMissingAttributes();
+
+
+        when(configurationManager.getResource(eq(RESOURCE_TYPE), anyString(), anyBoolean())).thenReturn(resource);
+
+        FlowConfigDTO result = FlowMgtConfigUtils.getFlowConfig(FLOW_TYPE_REGISTRATION, TENANT_DOMAIN);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getFlowType(), FLOW_TYPE_REGISTRATION);
+        Assert.assertTrue(result.getIsEnabled());
+
+        // Missing attributes should take default values.
+        Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
+                Constants.FlowCompletionConfig.IS_AUTO_LOGIN_ENABLED)));
+        Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
+                Constants.FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED)));
+        Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
+                Constants.FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED)));
+    }
+
     @Test
     public void testGetFlowConfigsWithEmptyResourceList() throws Exception {
 
@@ -516,6 +538,24 @@ public class FlowMgtConfigUtilsTest {
         attributes.add(new Attribute(Constants.FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED.getConfig(), "true"));
         attributes.add(new Attribute(
                 Constants.FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED.getConfig(), "true"));
+        resource.setAttributes(attributes);
+        return resource;
+    }
+
+    private Resource createResourceWithMissingAttributes() {
+
+        return createResourceWithMissingAttributes(FLOW_TYPE_REGISTRATION);
+    }
+
+    private Resource createResourceWithMissingAttributes(String flowType) {
+
+        Resource resource = new Resource();
+        resource.setResourceName(RESOURCE_NAME_PREFIX + flowType);
+        resource.setResourceType(RESOURCE_TYPE);
+
+        List<Attribute> attributes = new ArrayList<>();
+        attributes.add(new Attribute(FLOW_TYPE, flowType));
+        attributes.add(new Attribute(IS_ENABLED, "true"));
         resource.setAttributes(attributes);
         return resource;
     }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
@@ -159,9 +159,9 @@ public class FlowMgtConfigUtilsTest {
         Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
                 Constants.FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED)));
         Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
-                Constants.FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED
-                )
-        ));
+                Constants.FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED)));
+        Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
+                Constants.FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED)));
     }
 
     @Test
@@ -180,6 +180,8 @@ public class FlowMgtConfigUtilsTest {
                 Constants.FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED)));
         Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
                         Constants.FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED)));
+        Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
+                Constants.FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED)));
     }
 
     @Test
@@ -254,6 +256,8 @@ public class FlowMgtConfigUtilsTest {
                             Constants.FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED)));
                     Assert.assertFalse(Boolean.parseBoolean(config.getFlowCompletionConfig(
                             Constants.FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED)));
+                    Assert.assertFalse(Boolean.parseBoolean(config.getFlowCompletionConfig(
+                            Constants.FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED)));
                     break;
                 case FLOW_TYPE_PASSWORD_RECOVERY:
                 case FLOW_TYPE_INVITED_USER_REGISTRATION:
@@ -300,6 +304,8 @@ public class FlowMgtConfigUtilsTest {
                             Constants.FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED)));
                     Assert.assertFalse(Boolean.parseBoolean(config.getFlowCompletionConfig(
                             Constants.FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED)));
+                    Assert.assertFalse(Boolean.parseBoolean(config.getFlowCompletionConfig(
+                            Constants.FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED)));
                     break;
                 case FLOW_TYPE_PASSWORD_RECOVERY:
                 case FLOW_TYPE_INVITED_USER_REGISTRATION:
@@ -330,6 +336,8 @@ public class FlowMgtConfigUtilsTest {
                 Constants.FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED)));
         Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
                 Constants.FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED)));
+        Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
+                Constants.FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED)));
     }
 
     @Test
@@ -375,6 +383,8 @@ public class FlowMgtConfigUtilsTest {
                 Constants.FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED)));
         Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
                 Constants.FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED)));
+        Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
+                Constants.FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED)));
     }
 
     @Test
@@ -398,6 +408,8 @@ public class FlowMgtConfigUtilsTest {
                 Constants.FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED)));
         Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
                 Constants.FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED)));
+        Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
+                Constants.FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED)));
     }
 
     @Test
@@ -418,6 +430,8 @@ public class FlowMgtConfigUtilsTest {
                 Constants.FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED)));
         Assert.assertTrue(Boolean.parseBoolean(result.getFlowCompletionConfig(
                 Constants.FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED)));
+        Assert.assertTrue(Boolean.parseBoolean(result.getFlowCompletionConfig(
+                Constants.FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED)));
     }
 
     @Test void testBuildFlowConfigFromResourceWithMissingAttributes() throws Exception {
@@ -440,6 +454,8 @@ public class FlowMgtConfigUtilsTest {
                 Constants.FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED)));
         Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
                 Constants.FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED)));
+        Assert.assertFalse(Boolean.parseBoolean(result.getFlowCompletionConfig(
+                Constants.FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED)));
     }
 
     @Test
@@ -538,6 +554,8 @@ public class FlowMgtConfigUtilsTest {
         attributes.add(new Attribute(Constants.FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED.getConfig(), "true"));
         attributes.add(new Attribute(
                 Constants.FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED.getConfig(), "true"));
+        attributes.add(new Attribute(
+                Constants.FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED.getConfig(), "true"));
         resource.setAttributes(attributes);
         return resource;
     }


### PR DESCRIPTION
This pull request enhances the flow configuration management by ensuring that all supported flow completion configs are present in each flow configuration, defaulting missing ones to their standard values. It also introduces the `IS_FLOW_COMPLETION_NOTIFICATION_ENABLED` config to the registration flow and updates relevant methods and tests to reflect these improvements.

### Flow configuration logic improvements

* Updated the logic in `FlowMgtConfigUtils.java` so that any missing supported flow completion configs for a flow are automatically populated with their default values when building a `FlowConfigDTO`. This ensures completeness and consistency of flow configurations. [[1]](diffhunk://#diff-c3e7fdcbeaa8fe65ff8b81d9c0da8a035161ea6629e08c7745a75d7019de822fL88-R88) [[2]](diffhunk://#diff-c3e7fdcbeaa8fe65ff8b81d9c0da8a035161ea6629e08c7745a75d7019de822fL101-R101) [[3]](diffhunk://#diff-c3e7fdcbeaa8fe65ff8b81d9c0da8a035161ea6629e08c7745a75d7019de822fL121-R121) [[4]](diffhunk://#diff-c3e7fdcbeaa8fe65ff8b81d9c0da8a035161ea6629e08c7745a75d7019de822fL166-R171) [[5]](diffhunk://#diff-c3e7fdcbeaa8fe65ff8b81d9c0da8a035161ea6629e08c7745a75d7019de822fL197-R214) [[6]](diffhunk://#diff-c3e7fdcbeaa8fe65ff8b81d9c0da8a035161ea6629e08c7745a75d7019de822fR225-R233)
* Renamed `buildFlowConfigFromResource` methods to `buildAndPopulateFlowConfigFromResource` to reflect the new behavior of populating missing configs. [[1]](diffhunk://#diff-c3e7fdcbeaa8fe65ff8b81d9c0da8a035161ea6629e08c7745a75d7019de822fL166-R171) [[2]](diffhunk://#diff-c3e7fdcbeaa8fe65ff8b81d9c0da8a035161ea6629e08c7745a75d7019de822fL197-R214)

### Flow types and supported configs

* Added `IS_FLOW_COMPLETION_NOTIFICATION_ENABLED` as a supported config for the registration flow type in the `FlowTypes` enum in `Constants.java`.

### Test coverage improvements

* Updated and added tests in `FlowMgtConfigUtilsTest.java` to verify that missing attributes are correctly populated with default values and that the new config is handled properly. This includes new scenarios for missing attributes and updates to existing assertions. [[1]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aL162-R164) [[2]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aR183-R184) [[3]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aR259-R260) [[4]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aR307-R308) [[5]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aR339-R340) [[6]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aR386-R387) [[7]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aR411-R412) [[8]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aR433-R458) [[9]](diffhunk://#diff-c789be9d04485b85379803b175a84024c21af43e64d23977a4e18ae7d4dfd04aR557-R576)