### PR TITLE
Enable flows UI in v1 sub-orgs

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1327,7 +1327,7 @@
   "console.ui.routes.organizationEnabledRoutes.branding": "v0.0.0",
   "console.ui.routes.organizationEnabledRoutes.consoleSettings": "v0.0.0",
   "console.ui.routes.organizationEnabledRoutes.emailTemplates": "v0.0.0",
-  "console.ui.routes.organizationEnabledRoutes.flows": "v0.0.0",
+  "console.ui.routes.organizationEnabledRoutes.flows": "v1.0.0",
   "console.ui.routes.organizationEnabledRoutes.gettingStarted": "v0.0.0",
   "console.ui.routes.organizationEnabledRoutes.governanceConnectors": "v0.0.0",
   "console.ui.routes.organizationEnabledRoutes.groups": "v0.0.0",


### PR DESCRIPTION
### Purpose
Since inheritance is disabled in v0 organizations, side panel item related to flows should be disabled in sub-organizations

### Related issue
- https://github.com/wso2/product-is/issues/25580