### PR TITLE
Add method to get whether the consent redirect params config status

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtil.java
@@ -512,4 +512,14 @@ public class AuthenticationEndpointUtil {
                 !url.toLowerCase().contains("ftp:") &&
                 !url.toLowerCase().contains("data:");
     }
+
+    /**
+     * Return whether the consent page redirect parameters are allowed in the authentication endpoint.
+     *
+     * @return true if the consent page redirect parameters are allowed in the authentication endpoint.
+     */
+    public static boolean isConsentPageRedirectParamsAllowed() {
+
+        return ConfigurationFacade.getInstance().isConsentPageRedirectParamsAllowed();
+    }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/test/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtilTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/test/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtilTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.endpoint.util.bean.UserDTO;
+import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.common.testng.WithAxisConfiguration;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.internal.component.IdentityCoreServiceComponent;
@@ -54,6 +55,9 @@ public class AuthenticationEndpointUtilTest {
 
     @Mock
     private AxisConfiguration mockAxisConfiguration;
+
+    @Mock
+    private ConfigurationFacade mockedConfigurationFacade;
 
     final String USERNAME = "TestUser";
     final String USERSTORE_NAME = "WSO2.COM";
@@ -245,5 +249,25 @@ public class AuthenticationEndpointUtilTest {
 
         boolean validity = AuthenticationEndpointUtil.isSchemeSafeURL(url);
         Assert.assertEquals(validity, expectedValidity);
+    }
+
+    @DataProvider
+    public Object[][] provideIsConsentPageRedirectParamsAllowed() {
+        return new Object[][]{
+                {true},
+                {false}
+        };
+    }
+
+    @Test(dataProvider = "provideIsConsentPageRedirectParamsAllowed")
+    public void testIsConsentPageRedirectParamsAllowed(boolean allowConsentPageRedirectParams) {
+
+        try (MockedStatic<ConfigurationFacade> configFacadeMock = mockStatic(ConfigurationFacade.class)) {
+            configFacadeMock.when(ConfigurationFacade::getInstance).thenReturn(mockedConfigurationFacade);
+            when(mockedConfigurationFacade.isConsentPageRedirectParamsAllowed())
+                    .thenReturn(allowConsentPageRedirectParams);
+            Assert.assertEquals(AuthenticationEndpointUtil.isConsentPageRedirectParamsAllowed(),
+                    allowConsentPageRedirectParams);
+        }
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacade.java
@@ -311,6 +311,16 @@ public class ConfigurationFacade {
         return FileBasedConfigurationBuilder.getInstance().getMaxLoginAttemptCount();
     }
 
+    /**
+     * Return whether the consent page redirect params are allowed.
+     *
+     * @return True if the query params are allowed, false otherwise.
+     */
+    public boolean isConsentPageRedirectParamsAllowed() {
+
+        return FileBasedConfigurationBuilder.getInstance().isConsentPageRedirectParamsAllowed();
+    }
+
     private String readAccountRecoveryEndpointPath() {
 
         return preprocessEndpointPath(IdentityUtil.getProperty("RecoveryEndpoint.Path"));

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacadeTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/ConfigurationFacadeTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.application.authentication.framework.config;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -81,6 +82,27 @@ public class ConfigurationFacadeTest {
 
             String result = configurationFacade.getAuthenticationEndpointMissingClaimsURL();
             assertEquals(expectedUrl, result);
+        }
+    }
+
+    @DataProvider
+    public Object[][] provideIsConsentPageRedirectParamsAllowed() {
+        return new Object[][]{
+                {true},
+                {false}
+        };
+    }
+
+    @Test(dataProvider = "provideIsConsentPageRedirectParamsAllowed")
+    public void testIsConsentPageRedirectParamsAllowed(boolean allowConsentPageRedirectParams) {
+
+        try (MockedStatic<FileBasedConfigurationBuilder> fileBasedConfigMock =
+                     Mockito.mockStatic(FileBasedConfigurationBuilder.class)) {
+            fileBasedConfigMock.when(FileBasedConfigurationBuilder::getInstance).thenReturn(
+                    fileBasedConfigurationBuilder);
+            when(fileBasedConfigurationBuilder.isConsentPageRedirectParamsAllowed())
+                    .thenReturn(allowConsentPageRedirectParams);
+            assertEquals(configurationFacade.isConsentPageRedirectParamsAllowed(), allowConsentPageRedirectParams);
         }
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject
- This new method will be used in the authenticationendpoint webapp to decide whether to show the scopes.