### PR TITLE
Add json ignore to flow user object

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowUser.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowUser.java
@@ -165,6 +165,7 @@ public class FlowUser implements Serializable {
      *
      * @return true if credentials are managed locally, false otherwise.
      */
+    @JsonIgnore
     public boolean isCredentialsManagedLocally() {
 
         // Credentials are NOT managed locally if any of these conditions are true.
@@ -185,12 +186,14 @@ public class FlowUser implements Serializable {
         return !isManagedExternally;
     }
 
+    @JsonIgnore
     public boolean isAccountLocked() {
 
         String accountLocked = claims.get(FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI);
         return Boolean.parseBoolean(accountLocked);
     }
 
+    @JsonIgnore
     public boolean isAccountDisabled() {
 
         String accountDisabled = claims.get(FrameworkConstants.ACCOUNT_DISABLED_CLAIM_URI);


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25636

This pull request introduces minor improvements to the `FlowUser` model by updating method annotations to enhance JSON serialization behavior. Specifically, it adds the `@JsonIgnore` annotation to several boolean methods to ensure they are not included in JSON output.

Enhancements to JSON serialization:

* Added `@JsonIgnore` annotation to the `isCredentialsManagedLocally`, `isAccountLocked`, and `isAccountDisabled` methods in `FlowUser` to prevent these internal state methods from being serialized to JSON. [[1]](diffhunk://#diff-a08c641d960eda1d88e3281a6cc2f63ca30ce3465e929c7a6e994eeb866ead4fR168) [[2]](diffhunk://#diff-a08c641d960eda1d88e3281a6cc2f63ca30ce3465e929c7a6e994eeb866ead4fR189-R196)