### PR TITLE
Add userSelfRegistrationCompletionHandler to event subscriptions

### DIFF
--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -377,5 +377,9 @@
   "identity_mgt.events.schemes.TokenEventHook.subscriptions": [
     "POST_ISSUE_ACCESS_TOKEN_V2",
     "TOKEN_REVOKED"
+  ],
+  "identity_mgt.events.schemes.userSelfRegistrationCompletionHandler.module_index": "58",
+  "identity_mgt.events.schemes.userSelfRegistrationCompletionHandler.subscriptions": [
+    "POST_ADD_USER"
   ]
 }


### PR DESCRIPTION
This pull request updates the event subscription configuration for the identity management event server feature. The main change is the addition of a new event handler for user self-registration completion, enabling the system to react to user registration events.

**Event handler configuration updates:**

* Added `userSelfRegistrationCompletionHandler` to the configuration with a `module_index` of `58`, allowing it to be recognized and executed in the event handling pipeline.
* Subscribed `userSelfRegistrationCompletionHandler` to the `POST_ADD_USER` event, so it will handle actions after a user is added.