### PR TITLE
Add one-time-flow-id logic.

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/Constants.java
@@ -38,6 +38,7 @@ public class Constants {
     public static final String REQUIRED = "required";
     public static final String ERROR = "error";
     public static final String WEBAUTHN_DATA = "webAuthnData";
+    public static final String OTFI = "OTFI";
 
     public static final String USER_ASSERTION_EXPIRY_PROPERTY = "FlowExecution.UserAssertion.ExpiryTime";
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/FlowExecutionService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/FlowExecutionService.java
@@ -89,14 +89,14 @@ public class FlowExecutionService {
                 context = FlowExecutionEngineUtils.retrieveFlowContextFromCache(flowId);
                 String originalFlowId = context.getContextIdentifier();
 
-                // if the incoming flow id is different from the original flow id, it means this is a one time flow id.
+                // If the incoming flow id is different from the original flow id, it means this is a one time flow id.
                 if (!originalFlowId.equals(flowId)) {
                     FlowExecutionEngineUtils.removeFlowContextFromCache(flowId);
                     // Retrieve the original context and set it to the current context.
                     flowId = originalFlowId;
-                    //graphConfig will be removed from cache when adding to cache.
+                    // GraphConfig will be removed from cache when adding to cache.
                     graphConfig = context.getGraphConfig();
-                    //Cache the context against the original flowId.
+                    // Cache the context against the original flowId.
                     FlowExecutionEngineUtils.addFlowContextToCache(context);
                     context.setGraphConfig(graphConfig);
                 }
@@ -188,6 +188,14 @@ public class FlowExecutionService {
                 return false;
         }
     }
+
+    /**
+     * Cache the flow execution context.
+     *
+     * @param context Flow execution context.
+     * @param step    Current execution step.
+     * @throws FlowEngineException If something goes wrong while caching the context.
+     */
     private void cacheContext(FlowExecutionContext context, FlowExecutionStep step)
             throws FlowEngineException {
 
@@ -197,7 +205,8 @@ public class FlowExecutionService {
         String otfiToken = (String) context.getProperty(OTFI);
         if (StringUtils.isBlank(otfiToken)) {
             FlowExecutionEngineUtils.addFlowContextToCache(context);
+        } else {
+            FlowExecutionEngineUtils.addFlowContextToCache(otfiToken, context);
         }
-        FlowExecutionEngineUtils.addFlowContextToCache(otfiToken, context);
     }
 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/FlowExecutionService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/FlowExecutionService.java
@@ -36,10 +36,12 @@ import org.wso2.carbon.identity.flow.execution.engine.util.AuthenticationAsserti
 import org.wso2.carbon.identity.flow.execution.engine.util.FlowExecutionEngineUtils;
 import org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes;
 import org.wso2.carbon.identity.flow.mgt.model.DataDTO;
+import org.wso2.carbon.identity.flow.mgt.model.GraphConfig;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.OTFI;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.STATUS_COMPLETE;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION;
 import static org.wso2.carbon.identity.flow.mgt.Constants.StepTypes.REDIRECTION;
@@ -78,12 +80,26 @@ public class FlowExecutionService {
         FlowExecutionStep step;
         FlowExecutionContext context = null;
         boolean isFlowEnteredInIdentityContext = false;
+        GraphConfig graphConfig = null;
         try {
             if (StringUtils.isBlank(flowId)) {
                 // No flowId present hence initiate the flow.
                 context = FlowExecutionEngineUtils.initiateContext(tenantDomain, applicationId, flowType);
             } else {
                 context = FlowExecutionEngineUtils.retrieveFlowContextFromCache(flowId);
+                String originalFlowId = context.getContextIdentifier();
+
+                // if the incoming flow id is different from the original flow id, it means this is a one time flow id.
+                if (!originalFlowId.equals(flowId)) {
+                    FlowExecutionEngineUtils.removeFlowContextFromCache(flowId);
+                    // Retrieve the original context and set it to the current context.
+                    flowId = originalFlowId;
+                    //graphConfig will be removed from cache when adding to cache.
+                    graphConfig = context.getGraphConfig();
+                    //Cache the context against the original flowId.
+                    FlowExecutionEngineUtils.addFlowContextToCache(context);
+                    context.setGraphConfig(graphConfig);
+                }
             }
 
             isFlowEnteredInIdentityContext = enterFlowInIdentityContext(context.getFlowType());
@@ -118,7 +134,7 @@ public class FlowExecutionService {
                             AuthenticationAssertionUtils.getSignedUserAssertion(context));
                 }
             } else {
-                FlowExecutionEngineUtils.addFlowContextToCache(context);
+                cacheContext(context, step);
             }
             step.setFlowType(context.getFlowType());
             return step;
@@ -171,5 +187,17 @@ public class FlowExecutionService {
             default:
                 return false;
         }
+    }
+    private void cacheContext(FlowExecutionContext context, FlowExecutionStep step)
+            throws FlowEngineException {
+
+        if (context == null || context.getProperties() == null) {
+            return;
+        }
+        String otfiToken = (String) context.getProperty(OTFI);
+        if (StringUtils.isBlank(otfiToken)) {
+            FlowExecutionEngineUtils.addFlowContextToCache(context);
+        }
+        FlowExecutionEngineUtils.addFlowContextToCache(otfiToken, context);
     }
 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/util/FlowExecutionEngineUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/util/FlowExecutionEngineUtils.java
@@ -82,14 +82,33 @@ public class FlowExecutionEngineUtils {
      */
     public static void addFlowContextToCache(FlowExecutionContext context) throws FlowEngineException {
 
+        addFlowContextToCache(context.getContextIdentifier(), context);
+    }
+
+    /**
+     * Add flow context to cache with provided key.
+     *
+     * @param cacheKeyIdentifier Cache key identifier.
+     * @param context            Flow context.
+     * @throws FlowEngineException Flow engine exception.
+     */
+    public static void addFlowContextToCache(String cacheKeyIdentifier, FlowExecutionContext context)
+            throws FlowEngineException {
+
+        if (StringUtils.isBlank(cacheKeyIdentifier)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Cache key identifier is blank. Skipping adding flow context to cache.");
+            }
+            return;
+        }
         // Persist an optimized version of the context in the cache and flow context store.
         optimizeContext(context);
         FlowExecCtxCacheEntry cacheEntry = new FlowExecCtxCacheEntry(context);
-        FlowExecCtxCacheKey cacheKey = new FlowExecCtxCacheKey(context.getContextIdentifier());
+        FlowExecCtxCacheKey cacheKey = new FlowExecCtxCacheKey(cacheKeyIdentifier);
         FlowExecCtxCache.getInstance().clearCacheEntry(cacheKey);
         FlowExecCtxCache.getInstance().addToCache(cacheKey, cacheEntry);
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Flow context added to cache for context id: " + context.getContextIdentifier());
+            LOG.debug("Flow context added to cache for context id: " + cacheKeyIdentifier);
         }
     }
 


### PR DESCRIPTION
**Related Issues**

- https://github.com/wso2/product-is/issues/25779
This pull request introduces support for handling one-time flow identifiers (OTFI) in the flow execution engine. The main changes focus on correctly caching and retrieving flow contexts when OTFI tokens are used, ensuring robust flow execution and context management.

**OTFI support and context caching improvements:**

* Added a new constant `OTFI` to `Constants.java` to represent one-time flow identifiers.
* Enhanced the flow execution logic in `FlowExecutionService.java` to detect and handle OTFI tokens, including retrieving and re-caching the original context when an OTFI is encountered.
* Refactored context caching by introducing the `cacheContext` method, which caches the context using either the standard flow ID or the OTFI token as the cache key. [[1]](diffhunk://#diff-aeed250303d7e52dd666dedcd05dd85a61131b9db970df7df9c5ceeac58f35a0L121-R137) [[2]](diffhunk://#diff-aeed250303d7e52dd666dedcd05dd85a61131b9db970df7df9c5ceeac58f35a0R191-R202)
* Updated `FlowExecutionEngineUtils.java` to support caching flow contexts with an arbitrary cache key, allowing for flexible context retrieval using OTFI tokens.