### PR TITLE
[5.25.x] Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -492,7 +492,7 @@
             <dependency>
                 <groupId>org.apache.ws.commons.axiom</groupId>
                 <artifactId>axiom-api</artifactId>
-                <version>${axiom.version}</version>
+                <version>${axiom.wso2.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>xerces</groupId>
@@ -1777,7 +1777,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.9.26</carbon.kernel.version>
+        <carbon.kernel.version>4.9.30</carbon.kernel.version>
         <carbon.kernel.feature.version>4.7.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>
@@ -1808,7 +1808,7 @@
         </org.wso2.carbon.identity.organization.management.core.version.range>
 
         <!--Carbon registry version-->
-        <org.wso2.carbon.registry.version>4.8.12</org.wso2.carbon.registry.version>
+        <org.wso2.carbon.registry.version>4.8.50</org.wso2.carbon.registry.version>
         <carbon.registry.common.imp.pkg.version.range>[0.0.0,1.0.0)</carbon.registry.common.imp.pkg.version.range>
         <carbon.registry.indexing.imp.pkg.version.range>[4.7.3,5.0.0)</carbon.registry.indexing.imp.pkg.version.range>
 
@@ -1817,8 +1817,8 @@
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
 
         <!-- Axis2 Version -->
-        <axis2.wso2.version>1.6.1-wso2v105</axis2.wso2.version>
-        <axis2.osgi.version.range>[1.6.1.wso2v105, 2.0.0)</axis2.osgi.version.range>
+        <axis2.wso2.version>1.6.1-wso2v108</axis2.wso2.version>
+        <axis2.osgi.version.range>[1.6.1, 2.0.0)</axis2.osgi.version.range>
         <orbit.version.wsdl4j>1.6.2.wso2v4</orbit.version.wsdl4j>
         <orbit.version.neethi>2.0.4.wso2v5</orbit.version.neethi>
         <axis2-transports.version>2.0.0-wso2v42</axis2-transports.version>
@@ -1826,13 +1826,12 @@
         <org.apache.axis2.transport.mail.version.range>[2.0.0,3.0.0)</org.apache.axis2.transport.mail.version.range>
 
         <!-- Axiom Version -->
-        <axiom.version>1.2.11-wso2v29</axiom.version>
-        <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
+        <axiom.wso2.version>1.2.11-wso2v30</axiom.wso2.version>
         <axiom.osgi.version.range>[1.2.11, 2.0.0)</axiom.osgi.version.range>
         <axiom.javax.mail.imp.pkg.version.range>[1.4.0, 2.0.0)</axiom.javax.mail.imp.pkg.version.range>
         <axiom.org.jaxen.imp.pkg.version.range>[1.1.1, 2.0.0)</axiom.org.jaxen.imp.pkg.version.range>
 
-        <!-- Servet Version -->
+        <!-- Servlet Version -->
         <servlet-api.version>2.5</servlet-api.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <javax.jsp-api.version>2.0</javax.jsp-api.version>


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request updates several dependency versions in the `pom.xml` file to ensure compatibility with newer releases and improve stability. The most important changes are grouped below:

**Dependency Version Updates:**

* Updated the `carbon.kernel.version` property from `4.9.26` to `4.9.30` to use the latest Carbon Kernel.
* Updated the `org.wso2.carbon.registry.version` property from `4.8.12` to `4.8.50` for improved registry support.
* Updated the `axis2.wso2.version` from `1.6.1-wso2v105` to `1.6.1-wso2v108` and simplified the `axis2.osgi.version.range` to `[1.6.1, 2.0.0)`.
* Updated `axiom.wso2.version` from `1.2.11-wso2v29` to `1.2.11-wso2v30` and removed the separate `axiom.version` property, now referencing only `axiom.wso2.version` for the `axiom-api` dependency. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L495-R495) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L1820-R1834)

**Minor Fixes:**

* Corrected a typo in the comment from "Servet Version" to "Servlet Version".
