### PR TITLE
Improve getSPPropertyValueByPropertyKey DAO method.

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -6258,8 +6258,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
     public String getSPPropertyValueByPropertyKey(String applicationId, String propertyName, String tenantDomain)
             throws IdentityApplicationManagementException {
 
-        int appId = getAppIdUsingResourceId(applicationId, tenantDomain);
-        return getSPPropertyValueByPropertyKey(appId, propertyName);
+        return getSPPropertyValueByPropertyKey(applicationId, propertyName);
     }
 
     @Override
@@ -6295,14 +6294,14 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         }
     }
 
-    private String getSPPropertyValueByPropertyKey(int applicationId, String propertyName)
+    private String getSPPropertyValueByPropertyKey(String applicationId, String propertyName)
             throws IdentityApplicationManagementException {
 
         try (Connection connection = IdentityDatabaseUtil.getDBConnection(false);
              NamedPreparedStatement statement = new NamedPreparedStatement(connection,
                      isH2DB() ? ApplicationMgtDBQueries.GET_SP_PROPERTY_VALUE_BY_PROPERTY_KEY_H2 :
                              ApplicationMgtDBQueries.GET_SP_PROPERTY_VALUE_BY_PROPERTY_KEY)) {
-            statement.setInt(ApplicationMgtDBQueries.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_SP_ID, applicationId);
+            statement.setString(ApplicationMgtDBQueries.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_APP_ID, applicationId);
             statement.setString(ApplicationMgtDBQueries.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_NAME, propertyName);
             ResultSet resultSet = statement.executeQuery();
             if (resultSet.next()) {

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationMgtDBQueries.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationMgtDBQueries.java
@@ -322,12 +322,14 @@ public class ApplicationMgtDBQueries {
     public static final String GET_SP_METADATA_BY_SP_ID_H2 = "SELECT ID, NAME, `VALUE`, DISPLAY_NAME FROM " +
             "SP_METADATA WHERE SP_ID = ?";
 
-    public static final String GET_SP_PROPERTY_VALUE_BY_PROPERTY_KEY = "SELECT VALUE FROM SP_METADATA WHERE " +
-            "SP_ID=:" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_SP_ID + "; AND " +
+    public static final String GET_SP_PROPERTY_VALUE_BY_PROPERTY_KEY = "SELECT B.VALUE " +
+            "FROM SP_APP A JOIN SP_METADATA B ON A.ID = B.SP_ID WHERE " +
+            "UUID=:" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_APP_ID + "; AND " +
             "NAME=:" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_NAME + ";";
 
-    public static final String GET_SP_PROPERTY_VALUE_BY_PROPERTY_KEY_H2 = "SELECT `VALUE` FROM SP_METADATA WHERE " +
-            "SP_ID=:" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_SP_ID + "; AND " +
+    public static final String GET_SP_PROPERTY_VALUE_BY_PROPERTY_KEY_H2 = "SELECT B.`VALUE` " +
+            "FROM SP_APP A JOIN SP_METADATA B ON A.ID = B.SP_ID WHERE " +
+            "UUID=:" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_APP_ID + "; AND " +
             "NAME=:" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_NAME + ";";
 
     public static final String ADD_SP_METADATA = "INSERT INTO SP_METADATA (SP_ID, NAME, VALUE, DISPLAY_NAME, " +


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/25782

With this PR, 
Optimize the getSPPropertyValueByPropertyKey method to eliminate a database call. Currently, it performs two queries: first to get the application ID from the resource ID, and then to fetch the service provider property using that application ID. With this improvement, a single query joins the two tables to retrieve the desired result in one step.