### PR TITLE
Introduce a configuration to allow custom layout capability only for URL branded organizations

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2861,6 +2861,7 @@
     <BrandingConfiguration>
         <CustomContent>
             <MaxFileSize>1048576</MaxFileSize>
+            <AllowOnlyForUrlBrandedTenants>false</AllowOnlyForUrlBrandedTenants>
         </CustomContent>
     </BrandingConfiguration>
     <AgentIdentity>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -4795,6 +4795,7 @@
     <BrandingConfiguration>
         <CustomContent>
             <MaxFileSize>{{branding_configuration.custom_content.max_file_size}}</MaxFileSize>
+            <AllowOnlyForUrlBrandedTenants>{{branding_configuration.custom_content.allow_only_for_url_branded_tenants}}</AllowOnlyForUrlBrandedTenants>
         </CustomContent>
     </BrandingConfiguration>
     <FlowExecution>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -2086,6 +2086,7 @@
   "flow_execution.enable_legacy_flows": false,
   "flow_execution.registration.display_claim_availability": false,
   "branding_configuration.custom_content.max_file_size": "1048576",
+  "branding_configuration.custom_content.allow_only_for_url_branded_tenants": false,
   "captcha.enable_captcha_for_local_otp_authenticators": true,
 
   "console.ui.organizations.organization_display_name.enable": true,


### PR DESCRIPTION
### Proposed changes in this pull request

By default any organization can configure custom layouts for login pages of their organizations. The following configuration is introduced to restrict custom layouts only for URL branded organizations.

```toml
branding_configuration.custom_content
allow_only_for_url_branded_tenants=true
```
