### PR TITLE
Properly resolve server url for issuer validation

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/UserAssertionUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/UserAssertionUtils.java
@@ -158,14 +158,15 @@ public class UserAssertionUtils {
             if (StringUtils.isBlank(issuer)) {
                 throw new FrameworkException("Issuer is missing in the user assertion.");
             }
-            if (!issuer.equals(IdentityUtil.getServerURL(StringUtils.EMPTY, true, true))) {
+            String serverURL = ServiceURLBuilder.create().build(IdentityUtil.getHostName()).getAbsolutePublicURL();
+            if (!issuer.equals(serverURL)) {
                 throw new FrameworkException("Invalid issuer in the user assertion.");
             }
             RSAPublicKey publicKey = (RSAPublicKey) getCertificate(tenantDomain).getPublicKey();
             if (!signedJWT.verify(new RSASSAVerifier(publicKey))) {
                 throw new FrameworkException("Signature verification failed for the user assertion.");
             }
-        } catch (JOSEException | ParseException e) {
+        } catch (JOSEException | ParseException | URLBuilderException e) {
             throw new FrameworkException("Error while verifying the user assertion signature.", e);
         }
     }


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25853

This pull request updates the logic for verifying the JWT issuer in the `verifyJWTSignature` method, ensuring the issuer is compared against the correct public server URL and improving error handling.

**Improvements to JWT verification:**

* Updated the issuer comparison to use the public server URL generated by `ServiceURLBuilder` and `IdentityUtil.getHostName()`, instead of the previous `IdentityUtil.getServerURL` method. This ensures the issuer value is accurate and consistent with public endpoints.
* Enhanced exception handling by adding `URLBuilderException` to the catch block, ensuring errors from URL building are properly managed during JWT verification.