### PR TITLE
Skip addition of claim properties with secondary user store claim mappings

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/UnifiedClaimMetadataManager.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/UnifiedClaimMetadataManager.java
@@ -772,13 +772,13 @@ public class UnifiedClaimMetadataManager implements ReadWriteClaimMetadataManage
                                 !mappedAttribute.getUserStoreDomain().equals(primaryUserStoreDomain);
             } else {
                 filterCondition = mappedAttribute -> !mappedAttribute.getUserStoreDomain().equals(userStoreDomain);
+                localClaim.setClaimProperties(localClaimMap.get(localClaim.getClaimURI()).getClaimProperties());
             }
             List<AttributeMapping> missingMappedAttributes = localClaimMap.get(localClaim.getClaimURI())
                     .getMappedAttributes().stream()
                     .filter(filterCondition)
                     .collect(Collectors.toList());
             localClaim.getMappedAttributes().addAll(missingMappedAttributes);
-            localClaim.setClaimProperties(localClaimMap.get(localClaim.getClaimURI()).getClaimProperties());
         }
         if (isHierarchicalMode) {
             this.cacheBackedDBBasedClaimMetadataManager


### PR DESCRIPTION
## Purpose

Updates the updateLocalClaimMappings method used in the User Store API to skip the addition of claim properties with secondary user store claim mappings for v1 sub-organizations.

## Related Issues

- https://github.com/wso2/product-is/issues/24283