### PR TITLE
Added webhook id to the error message

### DIFF
--- a/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherSubscriberAdapterTypeHandler.java
+++ b/components/webhook-mgt/org.wso2.carbon.identity.webhook.management/src/main/java/org/wso2/carbon/identity/webhook/management/internal/dao/impl/handler/PublisherSubscriberAdapterTypeHandler.java
@@ -205,7 +205,7 @@ public class PublisherSubscriberAdapterTypeHandler extends AdapterTypeHandler {
                     .allMatch(r -> r.getStatus() == SubscriptionStatus.SUBSCRIPTION_ERROR);
             if (allError) {
                 throw WebhookManagementExceptionHandler.handleClientException(
-                        ErrorMessage.ERROR_CODE_WEBHOOK_ACTIVATION_ERROR);
+                        ErrorMessage.ERROR_CODE_WEBHOOK_ACTIVATION_ERROR, webhook.getId());
             }
             List<Subscription> updatedSubscriptions =
                     mergeSubscriptions(webhook.getEventsSubscribed(), allResults);
@@ -253,7 +253,7 @@ public class PublisherSubscriberAdapterTypeHandler extends AdapterTypeHandler {
                     .allMatch(r -> r.getStatus() == SubscriptionStatus.UNSUBSCRIPTION_ERROR);
             if (allError) {
                 throw WebhookManagementExceptionHandler.handleClientException(
-                        ErrorMessage.ERROR_CODE_WEBHOOK_DEACTIVATION_ERROR);
+                        ErrorMessage.ERROR_CODE_WEBHOOK_DEACTIVATION_ERROR, webhook.getId());
             }
             List<Subscription> updatedUnsubscriptions =
                     mergeSubscriptions(webhook.getEventsSubscribed(), allResults);


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request makes a small but important improvement to error handling in the webhook activation and deactivation flows. Specifically, it enhances the exceptions thrown when all subscription or unsubscription operations fail by including the webhook ID in the error details. This will make it easier to debug issues related to specific webhooks.

Error handling improvements:

* In `PublisherSubscriberAdapterTypeHandler.java`, both `activateWebhook` and `deactivateWebhook` methods now include the webhook ID when throwing exceptions for activation or deactivation errors. [[1]](diffhunk://#diff-83de86702b26deb322de206618f9ca375c269cd77fb2648dff7ff4cc267b1ce7L208-R208) [[2]](diffhunk://#diff-83de86702b26deb322de206618f9ca375c269cd77fb2648dff7ff4cc267b1ce7L256-R256)