### PR TITLE
Rename userSelfRegistrationCompletionHandler to FlowRegistrationCompl…

### DIFF
--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -377,8 +377,8 @@
     "POST_ISSUE_ACCESS_TOKEN_V2",
     "TOKEN_REVOKED"
   ],
-  "identity_mgt.events.schemes.userSelfRegistrationCompletionHandler.module_index": "58",
-  "identity_mgt.events.schemes.userSelfRegistrationCompletionHandler.subscriptions": [
+  "identity_mgt.events.schemes.FlowRegistrationCompletionHandler.module_index": "58",
+  "identity_mgt.events.schemes.FlowRegistrationCompletionHandler.subscriptions": [
     "POST_ADD_USER"
   ],
   "identity_mgt.events.schemes.otpBasedTemporaryLoginHandler.module_index": "59",


### PR DESCRIPTION
This pull request updates the event handler configuration for user self-registration in the identity event server feature. The main change is the renaming of the handler to better reflect its functionality.

**Configuration update:**

* Renamed the event handler from `userSelfRegistrationCompletionHandler` to `FlowRegistrationCompletionHandler` in the `org.wso2.carbon.identity.event.server.feature.default.json` file, updating both the `module_index` and `subscriptions` keys.