### PR TITLE
Add authorize_internal_scopes config to infer.json

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -311,7 +311,8 @@
       "scim2.throw_userstore_exception_on_user_creation_error": false,
       "authentication.local_authenticators.hide_user_existence": false,
       "saml.slo.front_channel.post_binding.logout_request_signature_with_tenant_cert": false,
-      "configs.endpoint.elevate_permission": false
+      "configs.endpoint.elevate_permission": false,
+      "oauth.authorize_internal_scopes": true
     },
     "IS_7.1.0": {
       "oauth.dcrm.return_null_fields_in_response": true,
@@ -352,7 +353,8 @@
       "scim2.throw_userstore_exception_on_user_creation_error": false,
       "authentication.local_authenticators.hide_user_existence": false,
       "saml.slo.front_channel.post_binding.logout_request_signature_with_tenant_cert": false,
-      "configs.endpoint.elevate_permission": false
+      "configs.endpoint.elevate_permission": false,
+      "oauth.authorize_internal_scopes": true
     }
   }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

In order to preserve the backward compatibility.