### PR TITLE
Return workflow request timestamps as UTC timestamps

### DIFF
--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/dao/WorkflowRequestDAO.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/dao/WorkflowRequestDAO.java
@@ -736,8 +736,10 @@ public class WorkflowRequestDAO {
 
                 requestDTO.setRequestId(resultSet.getString(SQLConstants.REQUEST_UUID_COLUMN));
                 requestDTO.setOperationType(resultSet.getString(SQLConstants.REQUEST_OPERATION_TYPE_COLUMN));
-                requestDTO.setCreatedAt(resultSet.getTimestamp(SQLConstants.REQUEST_CREATED_AT_COLUMN).toString());
-                requestDTO.setUpdatedAt(resultSet.getTimestamp(SQLConstants.REQUEST_UPDATED_AT_COLUMN).toString());
+                requestDTO.setCreatedAt(
+                        resultSet.getTimestamp(SQLConstants.REQUEST_CREATED_AT_COLUMN).toInstant().toString());
+                requestDTO.setUpdatedAt(
+                        resultSet.getTimestamp(SQLConstants.REQUEST_UPDATED_AT_COLUMN).toInstant().toString());
                 requestDTO.setStatus(resultSet.getString(SQLConstants.REQUEST_STATUS_COLUMN));
                 requestDTO.setCreatedBy(resultSet.getString(SQLConstants.CREATED_BY_COLUMN));
 

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/test/java/org/wso2/carbon/identity/workflow/mgt/dao/WorkflowRequestDAOTest.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/test/java/org/wso2/carbon/identity/workflow/mgt/dao/WorkflowRequestDAOTest.java
@@ -137,9 +137,9 @@ public class WorkflowRequestDAOTest {
             assertNotNull(result, "Workflow request should not be null for ID: " + requestId);
             assertEquals(result.getRequestId(), requestId, "Request ID mismatch");
             assertEquals(result.getOperationType(), expectedOperation, "Operation type mismatch");
-            assertEquals(result.getCreatedAt(), expectedCreatedAt.toString(),
+            assertEquals(result.getCreatedAt(), expectedCreatedAt.toInstant().toString(),
                     "Created at timestamp mismatch");
-            assertEquals(result.getUpdatedAt(), expectedUpdatedAt.toString(),
+            assertEquals(result.getUpdatedAt(), expectedUpdatedAt.toInstant().toString(),
                     "Updated at timestamp mismatch");
             assertEquals(result.getStatus(), expectedStatus, "Status mismatch");
             assertEquals(result.getCreatedBy(), CREATED_BY, "Created by mismatch");


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

This pull request updates how timestamps are handled and tested in the workflow management module, ensuring consistency in formatting by converting SQL `Timestamp` objects to ISO-8601 strings using `toInstant().toString()`. This improves the accuracy and standardization of timestamp representations across the codebase.

**Timestamp handling improvements:**

* Updated `WorkflowRequestDAO.java` to use `toInstant().toString()` when setting the `createdAt` and `updatedAt` fields in `WorkflowRequest`, ensuring timestamps are stored in ISO-8601 format.

**Test consistency updates:**

* Modified `WorkflowRequestDAOTest.java` to compare expected and actual timestamps using `toInstant().toString()`, aligning test expectations with the new timestamp format.

### Related Issues
- https://github.com/wso2/product-is/issues/25902

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-

### Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
