### PR TITLE
Remove config to set max jwt depth

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityCoreConstants.java
@@ -139,10 +139,8 @@ public class IdentityCoreConstants {
     public static final String AGENT_IDENTITY_USERSTORE_NAME = "AgentIdentity.Userstore";
     public static final String DEFAULT_AGENT_IDENTITY_USERSTORE_NAME = "AGENT";
 
-    // JWT related constants.
-    public static final String JWT_MAXIMUM_ALLOWED_DEPTH_PROPERTY = "OAuth.JWT.MaximumAllowedDepth";
     public static final String ENABLE_JWT_DEPTH_VALIDATION = "OAuth.JWT.EnableDepthValidation";
-    public static final int DEFAULT_JWT_MAXIMUM_ALLOWED_DEPTH = 255;
+    public static final int MAXIMUM_ALLOWED_JWT_PAYLOAD_JSON_DEPTH = 255;
 
     public static class Filter {
 

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -2296,7 +2296,7 @@ public class IdentityUtil {
         }
         String jsonPayload = new String(payloadBytes, StandardCharsets.UTF_8);
 
-        validateJsonDepth(jsonPayload, getAllowedMaxJWTDepth());
+        validateJsonDepth(jsonPayload, IdentityCoreConstants.MAXIMUM_ALLOWED_JWT_PAYLOAD_JSON_DEPTH);
     }
 
     /**
@@ -2313,7 +2313,7 @@ public class IdentityUtil {
             log.debug("JWT payload is blank, skipping depth validation");
             return;
         }
-        validateJsonDepth(payload, getAllowedMaxJWTDepth());
+        validateJsonDepth(payload, IdentityCoreConstants.MAXIMUM_ALLOWED_JWT_PAYLOAD_JSON_DEPTH);
     }
 
     /**
@@ -2354,18 +2354,4 @@ public class IdentityUtil {
         }
         log.debug("Validated JSON depth successfully.");
     }
-
-    /**
-     * Get the allowed maximum depth for JSON objects.
-     * This value defines how deeply nested a JSON structure can be before it is
-     * considered invalid.
-     * @return Maximum allowed JSON depth.
-     */
-    public static int getAllowedMaxJWTDepth() {
-
-        String depthConfig = IdentityUtil.getProperty(IdentityCoreConstants.JWT_MAXIMUM_ALLOWED_DEPTH_PROPERTY);
-        return StringUtils.isNotBlank(depthConfig) ? Integer.parseInt(depthConfig) :
-                IdentityCoreConstants.DEFAULT_JWT_MAXIMUM_ALLOWED_DEPTH;
-    }
-
 }


### PR DESCRIPTION
### Proposed changes in this pull request

As per[1] the max depth of jwt payload will be limited to 255 after a nimbus bump. Therefore it will not be possible to provide a configurable depth value. Hence removing the configurable limit.
 
[1] https://bitbucket.org/connect2id/nimbus-jose-jwt/commits/393a96f
