### PR TITLE
Fix account linking logic to ensure secondary property is validated c…

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -3682,7 +3682,7 @@ public class IdPManagementDAO {
         List<AccountLookupAttributeMappingConfig> accountLookupAttributeMappingConfigs = new ArrayList<>();
         accountLookupAttributeMappingConfigs.add(primaryAccountLookupAttributeMappingConfig);
 
-        if (secondaryAccountLookupAttributeMappingProperty == null ||
+        if (secondaryAccountLookupAttributeMappingProperty != null &&
                 StringUtils.isNotBlank(secondaryAccountLookupAttributeMappingProperty.getValue())) {
             AccountLookupAttributeMappingConfig secondaryAccountLookupAttributeMappingConfig =
                     buildAccountLookupAttributeMappingConfig(secondaryAccountLookupAttributeMappingProperty.getValue());


### PR DESCRIPTION
**Related Issues**

- https://github.com/wso2/product-is/issues/25912

This pull request makes a small logic change in the `populateAccountLookupAttributes` method to improve the handling of secondary account lookup attribute mappings.

* Logic updated to only add the secondary account lookup attribute mapping if the property is not null and its value is not blank, instead of adding it when the property is null or the value is not blank.