### PR TITLE
Add capability to revert flows in sub orgs

### DIFF
--- a/components/central-logger/org.wso2.carbon.identity.central.log.mgt/src/main/java/org/wso2/carbon/identity/central/log/mgt/utils/LogConstants.java
+++ b/components/central-logger/org.wso2.carbon.identity.central.log.mgt/src/main/java/org/wso2/carbon/identity/central/log/mgt/utils/LogConstants.java
@@ -169,6 +169,7 @@ public class LogConstants {
 
         public static final String UPDATE_FLOW = "update-flow-";
         public static final String UPDATE_FLOW_CONFIG = "update-flow-config-";
+        public static final String DELETE_FLOW = "delete-flow-";
 
         private FlowManagement() {
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
@@ -71,6 +71,8 @@ public class Constants {
                 "Unexpected server error while updating the flow config for tenant, %s"),
         ERROR_CODE_INVOKING_AI_SERVICE("65012", "Error while invoking the AI service.",
                 "Unexpected server error while invoking the AI service for tenant, %s"),
+        ERROR_CODE_DELETE_FLOW("65013", "Error while deleting the flow.",
+                "Unexpected server error while deleting the flow for tenant, %s"),
 
         // Client errors.
         ERROR_CODE_UNSUPPORTED_STEP_TYPE("60001", "Unsupported step type.",

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/FlowMgtService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/FlowMgtService.java
@@ -104,6 +104,13 @@ public class FlowMgtService {
         return FLOW_DAO.getFlow(flowType, tenantIdWithResource);
     }
 
+    /**
+     * Delete the specific flow of the given non-root organization.
+     *
+     * @param flowType The flow type.
+     * @param tenantID The tenant ID.
+     * @throws FlowMgtFrameworkException If an error occurs while deleting the flow.
+     */
     public void deleteFlow(String flowType, int tenantID) throws FlowMgtFrameworkException {
 
         try {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/dao/CacheBackedFlowDAOImpl.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/dao/CacheBackedFlowDAOImpl.java
@@ -73,6 +73,15 @@ public class CacheBackedFlowDAOImpl implements FlowDAO {
     }
 
     @Override
+    public void deleteFlow(String flowType, int tenantId) throws FlowMgtFrameworkException {
+
+        FlowMgtCacheKey flowMgtCacheKey = new FlowMgtCacheKey(flowType, DEFAULT_FLOW_NAME);
+        FlowMgtCache.getInstance().clearCacheEntry(flowMgtCacheKey, tenantId);
+        GraphConfigCache.getInstance().clearCacheEntry(flowMgtCacheKey, tenantId);
+        FLOW_DAO.deleteFlow(flowType, tenantId);
+    }
+
+    @Override
     public GraphConfig getGraphConfig(String flowType, int tenantId) throws FlowMgtFrameworkException {
 
         FlowMgtCacheKey flowMgtCacheKey = new FlowMgtCacheKey(flowType, DEFAULT_FLOW_NAME);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/dao/FlowDAO.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/dao/FlowDAO.java
@@ -51,6 +51,15 @@ public interface FlowDAO {
     FlowDTO getFlow(String flowType, int tenantId) throws FlowMgtServerException;
 
     /**
+     * Delete the specific flow of the given tenant.
+     *
+     * @param flowType The flow type.
+     * @param tenantId The tenant ID.
+     * @throws FlowMgtServerException If an error occurs while deleting the flow.
+     */
+    void deleteFlow(String flowType, int tenantId) throws FlowMgtFrameworkException;
+
+    /**
      * Get the specific graph of the given tenant.
      *
      * @param flowType The flow type.

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/dao/FlowDAO.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/dao/FlowDAO.java
@@ -55,7 +55,7 @@ public interface FlowDAO {
      *
      * @param flowType The flow type.
      * @param tenantId The tenant ID.
-     * @throws FlowMgtServerException If an error occurs while deleting the flow.
+     * @throws FlowMgtFrameworkException If an error occurs while deleting the flow.
      */
     void deleteFlow(String flowType, int tenantId) throws FlowMgtFrameworkException;
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/dao/FlowDAOImpl.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/dao/FlowDAOImpl.java
@@ -255,6 +255,22 @@ public class FlowDAOImpl implements FlowDAO {
     }
 
     @Override
+    public void deleteFlow(String flowType, int tenantId) throws FlowMgtFrameworkException {
+
+        JdbcTemplate jdbcTemplate = JdbcUtils.getNewTemplate();
+        try {
+            jdbcTemplate.executeUpdate(DELETE_FLOW,
+                    preparedStatement -> {
+                        preparedStatement.setInt(1, tenantId);
+                        preparedStatement.setBoolean(2, true);
+                        preparedStatement.setString(3, flowType);
+                    });
+        } catch (DataAccessException e) {
+            throw handleServerException(Constants.ErrorMessages.ERROR_CODE_DELETE_FLOW, e, tenantId);
+        }
+    }
+
+    @Override
     public GraphConfig getGraphConfig(String flowType, int tenantId) throws FlowMgtFrameworkException {
 
         JdbcTemplate jdbcTemplate = JdbcUtils.getNewTemplate();

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -1949,6 +1949,7 @@
                 <Scope name="internal_org_governance_update"/>
             </Update>
             <Delete>
+                <Scope name="internal_org_flow_delete"/>
             </Delete>
             <Create>
             </Create>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -2080,6 +2080,7 @@
                 <Scope name="internal_org_governance_update"/>
             </Update>
             <Delete>
+                <Scope name="internal_org_flow_delete"/>
             </Delete>
             <Create>
             </Create>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -1846,6 +1846,8 @@
                    description="View flow in the organization"/>
             <Scope displayName="Update Flow" name="internal_org_flow_update"
                    description="Update flow in the organization"/>
+            <Scope displayName="Delete Flow" name="internal_org_flow_delete"
+                   description="Delete flow in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Asynchronous Operation Status API" identifier="/api/server/v1/async-operations"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -1941,6 +1941,8 @@
                    description="View flow in the organization"/>
             <Scope displayName="Update Flow" name="internal_org_flow_update"
                    description="Update flow in the organization"/>
+            <Scope displayName="Delete Flow" name="internal_org_flow_delete"
+                   description="Delete flow in the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Asynchronous Operation Status API" identifier="/o/api/server/v1/async-operations"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -1663,6 +1663,9 @@
     <Resource context="(.*)/o/api/server/v1/flow(.*)" secured="true" http-method="PUT, PATCH">
         <Scopes>internal_org_flow_update</Scopes>
     </Resource>
+    <Resource context="(.*)/o/api/server/v1/flow(.*)" secured="true" http-method="DELETE">
+        <Scopes>internal_org_flow_delete</Scopes>
+    </Resource>
 
     <!-- Flow management API -->
     <Resource context="(.*)/api/server/v1/flow(.*)" secured="true" http-method="GET">

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -1832,6 +1832,9 @@
         <Resource context="(.*)/o/api/server/v1/flow(.*)" secured="true" http-method="PUT, PATCH">
             <Scopes>internal_org_flow_update</Scopes>
         </Resource>
+        <Resource context="(.*)/o/api/server/v1/flow(.*)" secured="true" http-method="DELETE">
+            <Scopes>internal_org_flow_delete</Scopes>
+        </Resource>
 
          <!-- Flow management API -->
          <Resource context="(.*)/api/server/v1/flow(.*)" secured="true" http-method="GET">


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25328

This pull request introduces support for deleting flows within the flow orchestration framework, including the necessary backend logic, error handling, audit logging, and access control updates. The changes ensure that only non-root organizations can delete flows and that the operation is properly secured and auditable.

**Backend support for flow deletion:**

* Added a new `deleteFlow` method to the `FlowMgtService` class, which checks organization eligibility, clears caches, deletes the flow, and triggers an audit log event.
* Implemented the `deleteFlow` method in the DAO layer (`FlowDAO`, `FlowDAOImpl`, and `CacheBackedFlowDAOImpl`) to handle database and cache operations for flow deletion. [[1]](diffhunk://#diff-22defaaadaa97ce5c7bc7d1d334ab50dfc47ff537ff7b10d6dc46d30b82fe1f8R53-R61) [[2]](diffhunk://#diff-83aa2d8caef5d2dd71e302555061fd38cf65627317bdabcea80ac2260485374dR257-R272) [[3]](diffhunk://#diff-4f621b71e9a2cf8af0fa02be8aad90fe6be0743a8b2cec3a351170b6457a1419R75-R83)
* Introduced a new error code and message for flow deletion failures in the `ErrorMessages` enum.
* Added a new log constant for flow deletion operations in `LogConstants`.

**Access control and API resource updates:**

* Defined a new scope (`internal_org_flow_delete`) for flow deletion in system API resource and resource access control configuration files, and updated the DELETE HTTP method to require this scope. [[1]](diffhunk://#diff-2bb3bf5d98c3e3607e4d52f7be45a06b2e6afc0357ba58dc9bbb71a5bd8102bbR1849-R1850) [[2]](diffhunk://#diff-a70225dc72f4100048a17b866cc1754e81c34fc31aa4128051d613ac4c64ed5bR1944-R1945) [[3]](diffhunk://#diff-8d3e33818f8d0a815cd470310be01f25928d196ce5ad9992cd21a2f7b81ca9aaR1666-R1668) [[4]](diffhunk://#diff-c1d66ea18073ea8342745dd465ae3028cc45019079d18f6c838c8d2cfb94da50R1835-R1837)
* Updated API resource collections to include the new delete flow scope. [[1]](diffhunk://#diff-3f84f2fc41782b93036d6233268491eda9c179f357755bd84fb13a798eb34badR1952) [[2]](diffhunk://#diff-a2db3b627822a2fef1faa05dbc072adb80137338c607f5e6c8ccfeb7295c7f33R2083)