### PR TITLE
Enable refresh token for impersonation flows by default

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -318,7 +318,7 @@
   "oauth.allowed_scopes": ["^device_.*"],
   "oauth.restricted_query_parameters": ["username", "password", "client_secret"],
   "oauth.callback.enforce_literal_characters": true,
-  "oauth.impersonated_refresh_token.enable": false,
+  "oauth.impersonated_refresh_token.enable": true,
 
   "rest_api_authentication.add_realm_user_to_error": false,
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -272,7 +272,6 @@
   "preserve_previous_product_behaviour.version": {
     "IS_7.0.0": {
       "oauth.dcrm.return_null_fields_in_response": true,
-      "oauth.impersonated_refresh_token.enable": true,
       "oauth.oidc.user_info.return_only_app_associated_roles": false,
       "oauth.oidc.user_info.remove_internal_prefix_from_roles": false,
       "scim2.enable_group_based_user_filter_improvements": false,
@@ -317,7 +316,6 @@
     },
     "IS_7.1.0": {
       "oauth.dcrm.return_null_fields_in_response": true,
-      "oauth.impersonated_refresh_token.enable": true,
       "oauth.return_sp_id_to_apps": true,
       "oauth.jwt.return_only_app_associated_roles": false,
       "oauth.oidc.user_info.return_only_app_associated_roles": false,


### PR DESCRIPTION
### Proposed changes in this pull request
Issue: https://github.com/wso2/product-is/issues/25778
Scenario tests can be found [here](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2950#issuecomment-3371482435).


This pull request updates the configuration for OAuth impersonated refresh tokens by enabling the feature in the default configuration and removing its explicit enablement from version-specific overrides. 
**OAuth impersonated refresh token configuration:**

* Enabled `oauth.impersonated_refresh_token.enable` in the default configuration file `org.wso2.carbon.identity.core.server.feature.default.json`, allowing the feature by default.

**Version-specific configuration cleanup:**

* Removed the explicit enablement of `oauth.impersonated_refresh_token.enable` for `IS_7.0.0` and `IS_7.1.0` in `org.wso2.carbon.identity.core.server.feature.infer.json`, relying on the default configuration instead. [[1]](diffhunk://#diff-5a320fb31fe6943d6aca55d4c6e464e2680d1a1e5d2222d79fc6c95cd1f7033fL275) [[2]](diffhunk://#diff-5a320fb31fe6943d6aca55d4c6e464e2680d1a1e5d2222d79fc6c95cd1f7033fL320)