### PR TITLE
Remove otfi from properties

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/FlowExecutionService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/FlowExecutionService.java
@@ -206,6 +206,7 @@ public class FlowExecutionService {
         if (StringUtils.isBlank(otfiToken)) {
             FlowExecutionEngineUtils.addFlowContextToCache(context);
         } else {
+            context.getProperties().remove(OTFI);
             FlowExecutionEngineUtils.addFlowContextToCache(otfiToken, context);
         }
     }


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25952

This pull request introduces a minor change to the flow execution context caching logic. Specifically, it ensures that the `OTFI` property is removed from the context before caching when an `otfiToken` is present.

* Removes the `OTFI` property from the `context` before caching it with an `otfiToken` in `cacheContext` method of `FlowExecutionService.java`.