### PR TITLE
Introduce a new method to preprocess usernames using the context tenant domain

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -4035,6 +4035,39 @@ public class FrameworkUtils {
     }
 
     /**
+     * Pre-process user's username considering authentication context.
+     * This version uses context.getTenantDomain() instead of context.getUserTenantDomain() which is used in
+     * public static String preprocessUsername(String username, AuthenticationContext context) method.
+     *
+     * @param username Username of the user.
+     * @param context  Authentication context.
+     * @return preprocessed username with context tenant domain.
+     */
+    public static String preprocessUsernameWithContextTenantDomain(String username, AuthenticationContext context) {
+
+        boolean isSaaSApp = context.getSequenceConfig().getApplicationConfig().isSaaSApp();
+
+        if (isLegacySaaSAuthenticationEnabled() && isSaaSApp) {
+            return username;
+        }
+
+        if (IdentityUtil.isEmailUsernameEnabled()) {
+            if (StringUtils.countMatches(username, "@") == 1) {
+                return username + "@" + context.getUserTenantDomain();
+            }
+        } else if (!username.endsWith(context.getUserTenantDomain())) {
+
+            // If the username is email-type (without enabling email username option) or belongs to a tenant which is
+            // not the app owner.
+            if (isSaaSApp && StringUtils.countMatches(username, "@") >= 1) {
+                return username;
+            }
+            return username + "@" + context.getTenantDomain();
+        }
+        return username;
+    }
+
+    /**
      * Pre-process user's username considering the service provider.
      *
      * @param username Username of the user.


### PR DESCRIPTION
### Purpose
Currently, the existing `preprocessUsername` method appends the tenant domain from `context.getUserTenantDomain()`. However, this becomes limiting in cases where the effective tenant domain for username resolution should come from the **authentication context** rather than the **user tenant**.

This PR addresses that limitation by introducing a new method that uses the **context tenant domain** to preprocess usernames.

### Goals
* Allow username preprocessing to respect the tenant domain derived from the authentication context.
* Preserve the existing method for backward compatibility.
* Improve flexibility in multi-tenant authentication scenarios.

### Approach
* Added a new method that follows the same logic as the existing `preprocessUsername`, but uses `context.getTenantDomain()` instead of `context.getUserTenantDomain()`.
* Ensures consistent handling for SaaS applications and email-based usernames.

## Related Issues
  - public issue: https://github.com/wso2/product-is/issues/25964
