### PR TITLE
Add configurations for Dynamic Client Registration feature

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1851,6 +1851,8 @@
   "console.dynamic_client_registration.scopes.feature": [
     "console:applications"
   ],
+  "console.dynamic_client_registration.scopes.create": [],
+  "console.dynamic_client_registration.scopes.delete": [],
   "console.dynamic_client_registration.scopes.read": [
     "internal_config_view"
   ],

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1846,6 +1846,17 @@
     "internal_claim_meta_view"
   ],
   "console.console_settings.scopes.update": ["internal_application_mgt_update", "internal_user_mgt_update"],
+  "console.dynamic_client_registration.enabled": true,
+  "console.dynamic_client_registration.disabled_features": [],
+  "console.dynamic_client_registration.scopes.feature": [
+    "console:applications"
+  ],
+  "console.dynamic_client_registration.scopes.read": [
+    "internal_config_view"
+  ],
+  "console.dynamic_client_registration.scopes.update": [
+    "internal_config_update"
+  ],
   "console.guest_user.enabled": true,
   "console.guest_user.scopes.create": ["internal_guest_mgt_invite_add"],
   "console.guest_user.scopes.read": ["internal_guest_mgt_invite_list"],


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces configuration settings to enable and control dynamic client registration features in the identity core server. The main focus is on allowing dynamic client registration in the console and specifying its related scopes and disabled features.

Dynamic client registration configuration:

* Enabled dynamic client registration in the console by adding the `console.dynamic_client_registration.enabled` setting.
* Added a configuration for `console.dynamic_client_registration.disabled_features` to allow specifying features that should be disabled for dynamic client registration (currently set as an empty array).

Scope management for dynamic client registration:

* Defined the required scopes for the dynamic client registration feature (`console.dynamic_client_registration.scopes.feature`, `console.dynamic_client_registration.scopes.read`, and `console.dynamic_client_registration.scopes.update`), specifying which internal permissions are needed for feature access, reading, and updating.

### Related issue
- https://github.com/wso2/product-is/issues/25640

### Related PR
- https://github.com/wso2/identity-apps/pull/9276
