### PR TITLE
Fixes #1257: Quote boolean values in jaas.conf for JAAS Krb5LoginModule compatibility

### DIFF
--- a/features/security-mgt/org.wso2.carbon.security.mgt.server.feature/src/main/resources/conf/jaas.conf
+++ b/features/security-mgt/org.wso2.carbon.security.mgt.server.feature/src/main/resources/conf/jaas.conf
@@ -1,11 +1,12 @@
 Server {
-com.sun.security.auth.module.Krb5LoginModule required
-useKeyTab=false
-storeKey=true
-useTicketCache=false
-isInitiator=false;
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab="false"
+    storeKey="true"
+    useTicketCache="false"
+    isInitiator="false";
 };
+
 Client {
-com.sun.security.auth.module.Krb5LoginModule required
-useTicketCache=false;
+    com.sun.security.auth.module.Krb5LoginModule required
+    useTicketCache="false";
 };


### PR DESCRIPTION
### Summary
This PR fixes issue #1257 by quoting boolean values in the `jaas.conf` file.
Some JVMs require quoted boolean strings when loading the JAAS `Krb5LoginModule`.

### Files Changed
- features/security-mgt/org.wso2.carbon.security.mgt.server.feature/src/main/resources/conf/jaas.conf