### PR TITLE
Add FAPI 2.0 configuration changes

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1093,6 +1093,9 @@
                         <AllowedSignatureAlgorithm>{{algorithm}}</AllowedSignatureAlgorithm>
                     {% endfor %}
                 </AllowedSignatureAlgorithms>
+                {% if oauth.oidc.fapi.version is defined %}
+                <FAPIVersion>{{oauth.oidc.fapi.version}}</FAPIVersion>
+                {% endif %}
             </FAPI>
 
             <SupportedTokenEndpointSigningAlgorithms>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -294,6 +294,7 @@
   "oauth.oidc.enable_hybrid_flow_app_level_validation": true,
   "oauth.oidc.enable_claims_separation_for_access_tokens": true,
 
+  "oauth.oidc.fapi.version": "1",
   "oauth.oidc.fapi.enable_ciba_profile": false,
   "oauth.oidc.fapi.enable_security_profile": false,
   "oauth.oidc.fapi.allowed_client_authentication_methods": ["private_key_jwt", "tls_client_auth"],


### PR DESCRIPTION
This PR adds the configuration changes required for the FAPI 2.0 compliance to the identity.xml.j2 and default.json.

Issue: https://github.com/wso2/product-is/issues/25863