### PR TITLE
Add support for 'contain' mode in password username validation policy

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/policy/password/DefaultPasswordNamePolicy.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/policy/password/DefaultPasswordNamePolicy.java
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -18,11 +18,17 @@
 
 package org.wso2.carbon.identity.mgt.policy.password;
 
+import org.apache.commons.collections.MapUtils;
 import org.wso2.carbon.identity.mgt.policy.AbstractPasswordPolicyEnforcer;
 
 import java.util.Map;
 
 public class DefaultPasswordNamePolicy extends AbstractPasswordPolicyEnforcer {
+
+    private static final String EQUAL_MODE = "equal";
+    private static final String CONTAIN_MODE = "contain";
+
+    private String usernameCheckMode = EQUAL_MODE;
 
     @Override
     public boolean enforce(Object... args) {
@@ -32,11 +38,20 @@ public class DefaultPasswordNamePolicy extends AbstractPasswordPolicyEnforcer {
             String password = args[0].toString();
             String username = args[1].toString();
 
-            if (password.equalsIgnoreCase(username)) {
-                errorMessage = "Cannot use the username as the password";
-                return false;
+            if (CONTAIN_MODE.equalsIgnoreCase(usernameCheckMode)) {
+                if (password.toLowerCase().contains(username.toLowerCase())) {
+                    errorMessage = "Password cannot contain the username";
+                    return false;
+                } else {
+                    return true;
+                }
             } else {
-                return true;
+                if (password.equalsIgnoreCase(username)) {
+                    errorMessage = "Cannot use the username as the password";
+                    return false;
+                } else {
+                    return true;
+                }
             }
         } else {
             return true;
@@ -45,8 +60,11 @@ public class DefaultPasswordNamePolicy extends AbstractPasswordPolicyEnforcer {
 
     @Override
     public void init(Map<String, String> params) {
-        // Nothing to init
 
+        // Initialize the configuration with the parameters defined in config file.
+        if (!MapUtils.isEmpty(params)) {
+            usernameCheckMode = params.get("username.check.mode");
+        }
     }
 
 }

--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/identity-event.properties
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/identity-event.properties
@@ -1,7 +1,7 @@
 #
-# Copyright (c) 2013, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+# Copyright (c) 2013-2025, WSO2 LLC. (http://www.wso2.com).
 #
-# WSO2 Inc. licenses this file to you under the Apache License,
+# WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License.
 # You may obtain a copy of the License at
@@ -72,6 +72,7 @@ passwordPolicy.errorMsg='Password pattern policy violated. Password should conta
 passwordPolicy.class.PasswordLengthPolicy=org.wso2.carbon.identity.mgt.policy.password.DefaultPasswordLengthPolicy
 passwordPolicy.class.PasswordNamePolicy=org.wso2.carbon.identity.mgt.policy.password.DefaultPasswordNamePolicy
 passwordPolicy.class.PasswordPatternPolicy=org.wso2.carbon.identity.mgt.policy.password.DefaultPasswordPatternPolicy
+passwordPolicy.username.check.mode=equal
 passwordPolicy.enable=false
 module.name.10=suspension.notification
 suspension.notification.subscription.1=POST_AUTHENTICATION

--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -70,6 +70,7 @@
   "identity_mgt.events.schemes.passwordPolicy.properties.'class.PasswordLengthPolicy'": "org.wso2.carbon.identity.mgt.policy.password.DefaultPasswordLengthPolicy",
   "identity_mgt.events.schemes.passwordPolicy.properties.'class.PasswordNamePolicy'": "org.wso2.carbon.identity.mgt.policy.password.DefaultPasswordNamePolicy",
   "identity_mgt.events.schemes.passwordPolicy.properties.'class.PasswordPatternPolicy'": "org.wso2.carbon.identity.mgt.policy.password.DefaultPasswordPatternPolicy",
+  "identity_mgt.events.schemes.passwordPolicy.properties.'username.check.mode'": "equal",
   "identity_mgt.events.schemes.passwordPolicy.properties.enable": false,
   "identity_mgt.events.schemes.adminForcedPasswordReset.module_index": "9",
   "identity_mgt.events.schemes.adminForcedPasswordReset.subscriptions": [


### PR DESCRIPTION
### Proposed changes in this pull request

**[Please hold merging as this handler is deprecated]**

$subject

This policy can be enabled by the following config:

```
[identity_mgt.events.schemes.passwordPolicy.properties]
'username.check.mode' = "contain"
```

Related: https://github.com/wso2-extensions/identity-governance/pull/1069