### PR TITLE
Set auto_commit = true when queries are not transactions

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/persistence/JDBCPersistenceManager.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/persistence/JDBCPersistenceManager.java
@@ -203,6 +203,8 @@ public class JDBCPersistenceManager {
                         dbConnection.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
                     }
                 }
+            } else {
+                dbConnection.setAutoCommit(true);
             }
             return dbConnection;
         } catch (SQLException e) {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/persistence/JDBCPersistenceManager.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/persistence/JDBCPersistenceManager.java
@@ -204,6 +204,7 @@ public class JDBCPersistenceManager {
                     }
                 }
             } else {
+                log.debug("Transaction not applied, setting auto-commit to true for the connection.");
                 dbConnection.setAutoCommit(true);
             }
             return dbConnection;


### PR DESCRIPTION
### Proposed changes in this pull request

Set auto_commit = true when queries are not transactions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced database connection management with improved handling of transactional and non-transactional database operations, ensuring more reliable database interactions across different scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->