### PR TITLE
Introduce version filtering for pre-issue access token action(v2) and extend OAuth grant type support

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/service/impl/ActionExecutorServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/service/impl/ActionExecutorServiceImpl.java
@@ -239,11 +239,13 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
             request.setAdditionalHeaders(RequestFilter.getFilteredHeaders(
                     request.getAdditionalHeaders(),
                     action.getEndpoint().getAllowedHeaders(),
-                    actionType));
+                    actionType,
+                    action.getActionVersion()));
             request.setAdditionalParams(RequestFilter.getFilteredParams(
                     request.getAdditionalParams(),
                     action.getEndpoint().getAllowedParameters(),
-                    actionType));
+                    actionType,
+                    action.getActionVersion()));
             return actionExecutionRequest;
         } catch (ActionExecutionRequestBuilderException e) {
             throw new ActionExecutionException("Failed to build the request payload for action type: " + actionType, e);

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/RequestFilter.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/RequestFilter.java
@@ -53,6 +53,12 @@ public class RequestFilter {
     public static List<Header> getFilteredHeaders(List<Header> requestHeaders, List<String> allowedHeadersInAction,
                                                   ActionType actionType) {
 
+        return getFilteredHeaders(requestHeaders, allowedHeadersInAction, actionType, null);
+    }
+
+    public static List<Header> getFilteredHeaders(List<Header> requestHeaders, List<String> allowedHeadersInAction,
+                                                  ActionType actionType, String actionVersion) {
+
         Set<String> allowedHeadersInServer = Optional.ofNullable(ActionExecutorConfig.getInstance()
                 .getAllowedHeadersForActionType(actionType)).orElse(Collections.emptySet());
         Set<String> excludedHeadersInServer = Optional.ofNullable(ActionExecutorConfig.getInstance()
@@ -67,8 +73,8 @@ public class RequestFilter {
             allowedHeaders.addAll(allowedHeadersInAction);
         } else if (hasServerAllowedHeaders) {
             allowedHeaders.addAll(allowedHeadersInServer);
-        } else if (ActionType.PRE_ISSUE_ACCESS_TOKEN.equals(actionType)) {
-            // This is to preserve backward compatibility.
+        } else if (ActionType.PRE_ISSUE_ACCESS_TOKEN.equals(actionType) && !isV2OrLater(actionVersion)) {
+            // To preserve backward compatibility for v1 actions.
             allowedHeaders.addAll(requestHeaders.stream()
                     .map(Header::getName)
                     .collect(Collectors.toSet()));
@@ -92,7 +98,7 @@ public class RequestFilter {
 
     /**
      * Filters request parameters based on the allowedParameters and excludedParameters configured.
-
+     *
      * List of allowed parameters can be configured per action or globally at server level.
      * If allowed parameters per action have been configured, then the server config will be ignored.
      * List of excluded parameters can be configured only at server level. These will be filtered out from the
@@ -104,6 +110,12 @@ public class RequestFilter {
      */
     public static List<Param> getFilteredParams(List<Param> requestParameters, List<String> allowedParamsInAction,
                                                 ActionType actionType) {
+
+        return getFilteredParams(requestParameters, allowedParamsInAction, actionType, null);
+    }
+
+    public static List<Param> getFilteredParams(List<Param> requestParameters, List<String> allowedParamsInAction,
+                                                ActionType actionType, String actionVersion) {
 
         Set<String> allowedParamsInServer = ActionExecutorConfig.getInstance()
                 .getAllowedParamsForActionType(actionType);
@@ -118,8 +130,8 @@ public class RequestFilter {
             allAllowedParamsSet.addAll(allowedParamsInAction);
         } else if (hasServerAllowedParams) {
             allAllowedParamsSet.addAll(allowedParamsInServer);
-        } else if (ActionType.PRE_ISSUE_ACCESS_TOKEN.equals(actionType)) {
-            // This is to preserve backward compatibility.
+        } else if (ActionType.PRE_ISSUE_ACCESS_TOKEN.equals(actionType) && !isV2OrLater(actionVersion)) {
+            // To preserve backward compatibility for v1 actions.
             allAllowedParamsSet.addAll(requestParameters.stream()
                     .map(Param::getName)
                     .collect(Collectors.toSet()));
@@ -130,5 +142,18 @@ public class RequestFilter {
         return requestParameters.stream()
                 .filter(param -> allAllowedParamsSet.contains(param.getName()))
                 .collect(Collectors.toList());
+    }
+
+    private static boolean isV2OrLater(String actionVersion) {
+
+        if (actionVersion == null) {
+            return false;
+        }
+        try {
+            int version = Integer.parseInt(actionVersion.replace("v", ""));
+            return version >= 2;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/RequestFilterTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/RequestFilterTest.java
@@ -324,4 +324,90 @@ public class RequestFilterTest {
                 ActionType.PRE_UPDATE_PASSWORD);
         assertEquals(filteredParams.size(), 0);
     }
+
+    @Test(description = "Ensures that for pre-issue access token v2 with no allowed headers configured, " +
+            "no headers are returned by default.")
+    public void testGetFilteredHeadersForV2PreIssueAccessTokenReturnsEmptyByDefault() {
+
+        ActionExecutorConfig config = ActionExecutorConfig.getInstance();
+        Mockito.when(config.getAllowedHeadersForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN))
+                .thenReturn(Collections.emptySet());
+        Mockito.when(config.getExcludedHeadersInActionRequestForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN))
+                .thenReturn(Collections.emptySet());
+
+        List<Header> filteredHeaders = RequestFilter.getFilteredHeaders(requestHeaders, Collections.emptyList(),
+                ActionType.PRE_ISSUE_ACCESS_TOKEN, "v2");
+
+        assertEquals(filteredHeaders.size(), 0);
+    }
+
+    @Test(description = "Ensures that for pre-issue access token v2 with no allowed params configured, " +
+            "no params are returned by default.")
+    public void testGetFilteredParamsForV2PreIssueAccessTokenReturnsEmptyByDefault() {
+
+        ActionExecutorConfig config = ActionExecutorConfig.getInstance();
+        Mockito.when(config.getAllowedParamsForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN))
+                .thenReturn(Collections.emptySet());
+        Mockito.when(config.getExcludedParamsInActionRequestForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN))
+                .thenReturn(Collections.emptySet());
+
+        List<Param> filteredParams = RequestFilter.getFilteredParams(requestParams, Collections.emptyList(),
+                ActionType.PRE_ISSUE_ACCESS_TOKEN, "v2");
+
+        assertEquals(filteredParams.size(), 0);
+    }
+
+    @Test(description = "Ensures that for pre-issue access token v2 with action-level allowed headers, " +
+            "only the allowed headers are returned.")
+    public void testGetFilteredHeadersForV2PreIssueAccessTokenWithActionAllowedHeaders() {
+
+        ActionExecutorConfig config = ActionExecutorConfig.getInstance();
+        Mockito.when(config.getAllowedHeadersForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN))
+                .thenReturn(Collections.emptySet());
+        Mockito.when(config.getExcludedHeadersInActionRequestForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN))
+                .thenReturn(Collections.emptySet());
+
+        List<String> allowedHeadersInAction = new ArrayList<>();
+        allowedHeadersInAction.add("X-Header-1");
+        allowedHeadersInAction.add("X-Header-3");
+
+        List<Header> filteredHeaders = RequestFilter.getFilteredHeaders(requestHeaders, allowedHeadersInAction,
+                ActionType.PRE_ISSUE_ACCESS_TOKEN, "v2");
+
+        assertEquals(filteredHeaders.size(), 2);
+        filteredHeaders.forEach(filteredHeader -> {
+            if (filteredHeader.getName().equals("x-header-1")) {
+                assertEquals(filteredHeader.getValue(), new String[]{"X-header-1-value"});
+            } else if (filteredHeader.getName().equals("x-header-3")) {
+                assertEquals(filteredHeader.getValue(), new String[]{"X-header-3-value"});
+            }
+        });
+    }
+
+    @Test(description = "Ensures that for pre-issue access token v2 with action-level allowed params, " +
+            "only the allowed params are returned.")
+    public void testGetFilteredParamsForV2PreIssueAccessTokenWithActionAllowedParams() {
+
+        ActionExecutorConfig config = ActionExecutorConfig.getInstance();
+        Mockito.when(config.getAllowedParamsForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN))
+                .thenReturn(Collections.emptySet());
+        Mockito.when(config.getExcludedParamsInActionRequestForActionType(ActionType.PRE_ISSUE_ACCESS_TOKEN))
+                .thenReturn(Collections.emptySet());
+
+        List<String> allowedParamsInAction = new ArrayList<>();
+        allowedParamsInAction.add("x-param-1");
+        allowedParamsInAction.add("x-param-3");
+
+        List<Param> filteredParams = RequestFilter.getFilteredParams(requestParams, allowedParamsInAction,
+                ActionType.PRE_ISSUE_ACCESS_TOKEN, "v2");
+
+        assertEquals(filteredParams.size(), 2);
+        filteredParams.forEach(filteredParam -> {
+            if (filteredParam.getName().equals("x-param-1")) {
+                assertEquals(filteredParam.getValue(), new String[]{"X-param-1-value"});
+            } else if (filteredParam.getName().equals("x-param-3")) {
+                assertEquals(filteredParam.getValue(), new String[]{"X-param-3-value"});
+            }
+        });
+    }
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/repository/resources/identity/rulemeta/flows.json
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.metadata/src/test/resources/configs/repository/resources/identity/rulemeta/flows.json
@@ -23,6 +23,26 @@
             {
               "name": "client_credentials",
               "displayName": "client credentials"
+            },
+            {
+              "name": "urn:ietf:params:oauth:grant-type:token-exchange",
+              "displayName": "token exchange"
+            },
+            {
+              "name": "urn:ietf:params:oauth:grant-type:device_code",
+              "displayName": "device code"
+            },
+            {
+              "name": "organization_switch",
+              "displayName": "organization switch"
+            },
+            {
+              "name": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+              "displayName": "jwt bearer"
+            },
+            {
+              "name": "urn:ietf:params:oauth:grant-type:saml2-bearer",
+              "displayName": "saml2 bearer"
             }
           ]
         }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -2105,7 +2105,7 @@
   "actions.http_client.retry_count": "2",
   "actions.maximum_actions_per_action_type": "1",
   "actions.types.pre_issue_access_token.enable": true,
-  "actions.types.pre_issue_access_token.version.latest": "v1",
+  "actions.types.pre_issue_access_token.version.latest": "v2",
   "actions.types.pre_issue_id_token.enable": true,
   "actions.types.pre_issue_id_token.version.latest": "v1",
   "actions.types.authentication.enable": true,

--- a/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/flows.json
+++ b/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/flows.json
@@ -23,6 +23,10 @@
             {
               "name": "client_credentials",
               "displayName": "client credentials"
+            },
+            {
+              "name": "urn:ietf:params:oauth:grant-type:token-exchange",
+              "displayName": "token exchange"
             }
           ]
         }

--- a/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/flows.json
+++ b/features/rule-mgt/org.wso2.carbon.identity.rule.management.server.feature/resources/identity/rulemeta/flows.json
@@ -27,6 +27,22 @@
             {
               "name": "urn:ietf:params:oauth:grant-type:token-exchange",
               "displayName": "token exchange"
+            },
+            {
+              "name": "urn:ietf:params:oauth:grant-type:device_code",
+              "displayName": "device code"
+            },
+            {
+              "name": "organization_switch",
+              "displayName": "organization switch"
+            },
+            {
+              "name": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+              "displayName": "jwt bearer"
+            },
+            {
+              "name": "urn:ietf:params:oauth:grant-type:saml2-bearer",
+              "displayName": "saml2 bearer"
             }
           ]
         }


### PR DESCRIPTION

This pull request introduces version-aware filtering for action execution requests and updates configuration and test resources to support new OAuth grant types and action versioning. The main changes enhance backward compatibility for action types and ensure the system recognizes newer action versions and additional grant flows.

**Version-aware filtering and backward compatibility:**

* Added `actionVersion` as a parameter to `RequestFilter.getFilteredHeaders` and `getFilteredParams` methods, allowing filtering logic to distinguish between v1 and v2 (or later) actions for `PRE_ISSUE_ACCESS_TOKEN`. This preserves backward compatibility for v1 actions while enforcing stricter rules for v2 and above.
* Introduced the private helper method `isV2OrLater` in `RequestFilter.java` to determine action version and apply appropriate filtering logic.

**Configuration updates:**

* Updated the default server feature configuration to set the latest version of `pre_issue_access_token` actions to `v2`, reflecting the new versioning logic.
* Added support for new OAuth grant types (`token exchange`, `device code`, `jwt bearer`, `saml2 bearer`, `organization switch`) in both test (`rulemeta/flows.json`) and server feature resources, ensuring the system can recognize and handle these flows.