### PR TITLE
Add configuration to disable double-encoding of SAML artifact binding

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -271,6 +271,8 @@ public class IdentityConstants {
         public static final String ACCEPT_OPENID_LOGIN = "SSOService.AcceptOpenIDLogin";
         public static final String SAML_RESPONSE_VALIDITY_PERIOD = "SSOService.SAMLResponseValidityPeriod";
         public static final String SAML2_ARTIFACT_VALIDITY_PERIOD = "SSOService.SAML2ArtifactValidityPeriodInMinutes";
+        public static final String SAML2_ARTIFACT_DOUBLE_ENCODING_DISABLED =
+                "SSOService.SAML2ArtifactDoubleEncodingDisabled";
         public static final String SSO_DEFAULT_SIGNING_ALGORITHM = "SSOService.SAMLDefaultSigningAlgorithmURI";
         public static final String SSO_DEFAULT_DIGEST_ALGORITHM = "SSOService.SAMLDefaultDigestAlgorithmURI";
         public static final String SSO_DEFAULT_ASSERTION_ENCRYPTION_ALGORITHM = "SSOService" +

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1483,6 +1483,7 @@
         <SLOHostNameVerificationEnabled>{{saml.slo.host_name_verification}}</SLOHostNameVerificationEnabled>
 
         <SAML2ArtifactValidityPeriodInMinutes>{{saml.artifact.validity}}</SAML2ArtifactValidityPeriodInMinutes>
+        <SAML2ArtifactDoubleEncodingDisabled>{{saml.artifact.disable_double_encoding}}</SAML2ArtifactDoubleEncodingDisabled>
         <SAMLECPEndpoint>{{saml.endpoints.ecp}}</SAMLECPEndpoint>
         <SAMLMetadataValidityPeriod>{{saml.metadata.validity_period}}</SAMLMetadataValidityPeriod>
         <SAMLMetadataSigningEnabled>{{saml.metadata.enable_signing}}</SAMLMetadataSigningEnabled>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -338,6 +338,7 @@
   "saml.slo.front_channel.post_binding.logout_request_signature_with_tenant_cert": true,
   "saml.response.validity": "5m",
   "saml.artifact.validity": "4m",
+  "saml.artifact.disable_double_encoding": true,
   "saml.use_tenant_key_of": "user",
   "saml.tenant_partitioning.enable": false,
   "saml.signing_alg": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -315,7 +315,8 @@
       "identifier_first.preserve_case_sensitivity.enabled": false,
       "application_mgt.enable_cross_tenant_authorized_api_validation": false,
       "oauth.callback.restrict_fragment_components": false,
-      "identity_mgt.challenge_questions.skip_sending_questions_in_url": false
+      "identity_mgt.challenge_questions.skip_sending_questions_in_url": false,
+      "saml.artifact.disable_double_encoding": false
     },
     "IS_7.1.0": {
       "oauth.dcrm.return_null_fields_in_response": true,
@@ -362,7 +363,8 @@
       "oauth.callback.restrict_fragment_components": false,
       "authentication.authenticator.x509_certificate.parameters.UseInternalHostnameForRedirect": true,
       "resolve_tenant_domain_from_username.enabled": true,
-      "identity_mgt.challenge_questions.skip_sending_questions_in_url": false
+      "identity_mgt.challenge_questions.skip_sending_questions_in_url": false,
+      "saml.artifact.disable_double_encoding": false
     },
     "IS_7.2.0": {
       "authenticationendpoint.authenticator_validation.enabled": false,
@@ -370,7 +372,8 @@
       "oauth.callback.restrict_fragment_components": false,
       "authentication.authenticator.x509_certificate.parameters.UseInternalHostnameForRedirect": true,
       "resolve_tenant_domain_from_username.enabled": true,
-      "identity_mgt.challenge_questions.skip_sending_questions_in_url": false
+      "identity_mgt.challenge_questions.skip_sending_questions_in_url": false,
+      "saml.artifact.disable_double_encoding": false
     }
   }
 }


### PR DESCRIPTION
### Purpose

$subject

### Related Issues
- https://github.com/wso2/product-is/issues/26211

### Related PRs
- https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to toggle SAML2 artifact double-encoding, allowing administrators to control artifact encoding behavior in SSO/SAML flows.
  * Default values for this option were added to feature defaults and versioned configuration templates so deployments have a defined initial setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->