### PR TITLE
Introduce configs to configure b2b userstore intialization handler

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -4826,6 +4826,12 @@
         <AssociationWaitTime>{{organization.user.invitation.association.wait_time}}</AssociationWaitTime>
     </OrganizationUserInvitation>
 
+    <OrganizationUserStoreInitialization>
+        <UserStores>{{organization.userstore.initialization.user_stores}}</UserStores>
+        <WaitTime>{{organization.userstore.initialization.wait_time}}</WaitTime>
+        <WaitInterval>{{organization.userstore.initialization.wait_interval}}</WaitInterval>
+    </OrganizationUserStoreInitialization>
+
     <!-- Extension management service configurations -->
     <ExtensionManagementService>
         <ExtensionTypes>{{extension_mgt.extension_types}}</ExtensionTypes>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -4827,6 +4827,7 @@
     </OrganizationUserInvitation>
 
     <OrganizationUserStoreInitialization>
+        <Enable>{{organization.userstore.initialization.enabled}}</Enable>
         <UserStores>{{organization.userstore.initialization.user_stores}}</UserStores>
         <WaitTime>{{organization.userstore.initialization.wait_time}}</WaitTime>
         <WaitInterval>{{organization.userstore.initialization.wait_interval}}</WaitInterval>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -4826,13 +4826,6 @@
         <AssociationWaitTime>{{organization.user.invitation.association.wait_time}}</AssociationWaitTime>
     </OrganizationUserInvitation>
 
-    <OrganizationUserStoreInitialization>
-        <Enable>{{organization.userstore.initialization.enabled}}</Enable>
-        <UserStores>{{organization.userstore.initialization.user_stores}}</UserStores>
-        <WaitTime>{{organization.userstore.initialization.wait_time}}</WaitTime>
-        <WaitInterval>{{organization.userstore.initialization.wait_interval}}</WaitInterval>
-    </OrganizationUserStoreInitialization>
-
     <!-- Extension management service configurations -->
     <ExtensionManagementService>
         <ExtensionTypes>{{extension_mgt.extension_types}}</ExtensionTypes>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -2094,8 +2094,8 @@
   "organization.user.invitation.association.wait_time": "5000",
   "organization.userstore.initialization.enabled": false,
   "organization.userstore.initialization.user_stores": "",
-  "organization.userstore.initialization.wait_time": 15000,
-  "organization.userstore.initialization.wait_interval": 500,
+  "organization.userstore.initialization.wait_time": "15000",
+  "organization.userstore.initialization.wait_interval": "500",
   "extension_mgt.extension_types": "applications,connections,identity-verification-providers,notification-providers",
 
   "identity_datastore.datastore_type": "org.wso2.carbon.identity.governance.store.JDBCIdentityDataStore",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -2092,6 +2092,9 @@
   "organization.user.invitation.primary.user_domain": "PRIMARY",
   "organization.user.invitation.default.accept_url": "/accountrecoveryendpoint/acceptinvitation.do",
   "organization.user.invitation.association.wait_time": "5000",
+  "organization.userstore.initialization.user_stores": "",
+  "organization.userstore.initialization.wait_time": 15000,
+  "organization.userstore.initialization.wait_interval": 500,
   "extension_mgt.extension_types": "applications,connections,identity-verification-providers,notification-providers",
 
   "identity_datastore.datastore_type": "org.wso2.carbon.identity.governance.store.JDBCIdentityDataStore",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -2092,6 +2092,7 @@
   "organization.user.invitation.primary.user_domain": "PRIMARY",
   "organization.user.invitation.default.accept_url": "/accountrecoveryendpoint/acceptinvitation.do",
   "organization.user.invitation.association.wait_time": "5000",
+  "organization.userstore.initialization.enabled": false,
   "organization.userstore.initialization.user_stores": "",
   "organization.userstore.initialization.wait_time": 15000,
   "organization.userstore.initialization.wait_interval": 500,


### PR DESCRIPTION
### Proposed changes in this pull request

[List all changes you want to add here. If you fixed an issue, please
add a reference to that issue as well.]

$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration options for organization user store initialization: enabled flag, list of user stores, initialization wait time, and retry interval.
  * Default values provided: enabled = false, user_stores = empty, wait_time = 15000, wait_interval = 500.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->