### PR TITLE
Add ThreadLocal support for User-Serving Agent and Application Client ID context

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -2547,15 +2547,15 @@ public class IdentityUtil {
         threadLocalIsUserServingAgent.remove();
     }
 
-    public static void setthreadLocalApplicationClientId(String clientId) {
+    public static void setThreadLocalApplicationClientId(String clientId) {
         threadLocalApplicationClientId.set(clientId);
     }
 
-    public static String getthreadLocalApplicationClientId() {
+    public static String getThreadLocalApplicationClientId() {
         return threadLocalApplicationClientId.get();
     }
 
-    public static void unsetthreadLocalApplicationClientId() {
+    public static void unsetThreadLocalApplicationClientId() {
         threadLocalApplicationClientId.remove();
     }
 }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -170,6 +170,8 @@ public class IdentityUtil {
     private static Map<String, Boolean> storeProcedureBasedDAOConfigurationHolder = new HashMap<>();
     private static Document importerDoc = null;
     private static ThreadLocal<IdentityErrorMsgContext> IdentityError = new ThreadLocal<IdentityErrorMsgContext>();
+    private static ThreadLocal<Boolean> threadLocalIsUserServingAgent = new ThreadLocal<>();
+    private static ThreadLocal<String> threadLocalApplicationClientId = new ThreadLocal<>();
     private static final int ENTITY_EXPANSION_LIMIT = 0;
     public static final String PEM_BEGIN_CERTFICATE = "-----BEGIN CERTIFICATE-----";
     public static final String PEM_END_CERTIFICATE = "-----END CERTIFICATE-----";
@@ -2531,5 +2533,29 @@ public class IdentityUtil {
                 jsonArray.set(i, childArray);
             }
         }
+    }
+
+    public static Boolean getThreadLocalIsUserServingAgent() {
+        return threadLocalIsUserServingAgent.get();
+    }
+
+    public static void setThreadLocalIsUserServingAgent(Boolean value) {
+        threadLocalIsUserServingAgent.set(value);
+    }
+
+    public static void unsetThreadLocalIsUserServingAgent() {
+        threadLocalIsUserServingAgent.remove();
+    }
+
+    public static void setthreadLocalApplicationClientId(String clientId) {
+        threadLocalApplicationClientId.set(clientId);
+    }
+
+    public static String getthreadLocalApplicationClientId() {
+        return threadLocalApplicationClientId.get();
+    }
+
+    public static void unsetthreadLocalApplicationClientId() {
+        threadLocalApplicationClientId.remove();
     }
 }


### PR DESCRIPTION
This PR adds a way to store agent-related information during a request execution.
Sometimes, while a request is being processed, the system needs to know:

- Is this request coming from a user-serving agent?
- What is the application client ID used by this agent?

Since this information is only needed during that request (and should not affect other requests), we store it using ThreadLocal.

**What was added**
Two new ThreadLocal variables were introduced in IdentityUtil:

- Is User Serving Agent - To track whether the current request is coming from a user-serving agent
- Application Client ID - To track which application client ID is used by the agent