### PR TITLE
Add Detailed error messages for retry/resend scenarios.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationService.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationService.java
@@ -482,6 +482,10 @@ public class AuthenticationService {
                 return AuthServiceConstants.ErrorMessage.ERROR_INVALID_AUTHENTICATOR;
             case FrameworkConstants.ERROR_STATUS_AUTHENTICATOR_NOT_SUPPORTED:
                 return AuthServiceConstants.ErrorMessage.ERROR_AUTHENTICATOR_NOT_SUPPORTED;
+            case FrameworkConstants.ERROR_STATUS_ALLOWED_RESEND_LIMIT_EXCEEDED:
+                return AuthServiceConstants.ErrorMessage.ERROR_RESEND_COUNT_EXCEEDED;
+            case FrameworkConstants.ERROR_STATUS_ALLOWED_RETRY_LIMIT_EXCEEDED:
+                return AuthServiceConstants.ErrorMessage.ERROR_RETRY_COUNT_EXCEEDED;
             default:
                 return null;
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -275,6 +275,10 @@ public abstract class FrameworkConstants {
     public static final String ERROR_DESCRIPTION_APP_DISABLED = "authentication.flow.app.disabled.description";
     public static final String ERROR_STATUS_AUTHENTICATOR_NOT_SUPPORTED = "authentication.api.based.unsupported" +
             ".authenticator";
+    public static final String ERROR_STATUS_ALLOWED_RETRY_LIMIT_EXCEEDED =
+            "authentication.failure.retry.limit.exceeded";
+    public static final String ERROR_STATUS_ALLOWED_RESEND_LIMIT_EXCEEDED =
+            "authentication.failure.resend.limit.exceeded";
     public static final String IS_SENT_TO_RETRY = "isSentToRetry";
     public static final String CONTEXT_IDENTIFIER = "contextIdentifier";
     public static final String REQ_ATTR_RETRY_STATUS = "retryStatus";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/auth/service/AuthServiceConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/auth/service/AuthServiceConstants.java
@@ -95,6 +95,14 @@ public class AuthServiceConstants {
                         "is restricted."),
         ERROR_INVALID_AUTHENTICATOR("60012", "Invalid authenticator.",
                 "Requested authenticator is invalid."),
+        ERROR_RETRY_COUNT_EXCEEDED("60013",
+                "Maximum retry attempts exceeded.",
+                "Authentication failed. The maximum number of retry attempts has been exceeded."
+        ),
+        ERROR_RESEND_COUNT_EXCEEDED("60014",
+                "Maximum resend attempts exceeded.",
+                "Authentication failed. The maximum number of OTP resend attempts has been exceeded."
+        ),
         // Server Error starting from 650xx.
         /* The 65001 ERROR_UNABLE_TO_PROCEED is used as the default server error
          therefor be cautious if that is being changed.*/

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
@@ -289,6 +289,82 @@ public class AuthenticationServiceTest extends AbstractFrameworkTest {
         }
     }
 
+    @DataProvider(name = "mappedErrorProvider")
+    public Object[][] mappedErrorProvider() {
+
+        // String retryStatus, AuthServiceConstants.ErrorMessage expectedError
+        return new Object[][]{
+                {FrameworkConstants.ERROR_STATUS_AUTH_FLOW_TIMEOUT,
+                        AuthServiceConstants.ErrorMessage.ERROR_AUTHENTICATION_FLOW_TIMEOUT},
+                {FrameworkConstants.ERROR_STATUS_AUTH_CONTEXT_NULL,
+                        AuthServiceConstants.ErrorMessage.ERROR_AUTHENTICATION_CONTEXT_NULL},
+                {FrameworkConstants.ERROR_STATUS_APP_DISABLED,
+                        AuthServiceConstants.ErrorMessage.ERROR_DISABLED_APPLICATION},
+                {FrameworkConstants.ERROR_STATUS_INVALID_AUTHENTICATOR,
+                        AuthServiceConstants.ErrorMessage.ERROR_INVALID_AUTHENTICATOR},
+                {FrameworkConstants.ERROR_STATUS_AUTHENTICATOR_NOT_SUPPORTED,
+                        AuthServiceConstants.ErrorMessage.ERROR_AUTHENTICATOR_NOT_SUPPORTED},
+                {FrameworkConstants.ERROR_STATUS_ALLOWED_RETRY_LIMIT_EXCEEDED,
+                        AuthServiceConstants.ErrorMessage.ERROR_RETRY_COUNT_EXCEEDED},
+                {FrameworkConstants.ERROR_STATUS_ALLOWED_RESEND_LIMIT_EXCEEDED,
+                        AuthServiceConstants.ErrorMessage.ERROR_RESEND_COUNT_EXCEEDED},
+        };
+    }
+
+    @Test(dataProvider = "mappedErrorProvider")
+    public void testGetMappedError(String retryStatus,
+                                   AuthServiceConstants.ErrorMessage expectedError) throws Exception {
+
+        AuthenticationService authenticationService = new AuthenticationService();
+        AuthServiceRequest authServiceRequest = new AuthServiceRequest(request, response);
+
+        // Simulate a concluded failed flow that was sent to retry with the given retryStatus.
+        when(request.getAttribute(FrameworkConstants.RequestParams.FLOW_STATUS))
+                .thenReturn(AuthenticatorFlowStatus.FAIL_COMPLETED);
+        when(request.getAttribute(FrameworkConstants.IS_AUTH_FLOW_CONCLUDED)).thenReturn(true);
+        when(request.getAttribute(FrameworkConstants.IS_SENT_TO_RETRY)).thenReturn(true);
+        when(request.getAttribute(FrameworkConstants.REQ_ATTR_RETRY_STATUS)).thenReturn(retryStatus);
+        when(request.getAttribute(FrameworkConstants.CONTEXT_IDENTIFIER)).thenReturn(SESSION_DATA_KEY);
+        when(response.getHeader(LOCATION_HEADER)).thenReturn(getFinalRedirectUrl(SESSION_DATA_KEY));
+
+        AuthServiceResponse authServiceResponse = authenticationService.handleAuthentication(authServiceRequest);
+
+        Assert.assertEquals(authServiceResponse.getFlowStatus(), AuthServiceConstants.FlowStatus.FAIL_COMPLETED,
+                "Expected FAIL_COMPLETED flow status.");
+        Optional<AuthServiceErrorInfo> errorInfo = authServiceResponse.getErrorInfo();
+        Assert.assertTrue(errorInfo.isPresent(), "Expected error info to be present.");
+        Assert.assertEquals(errorInfo.get().getErrorCode(), expectedError.code(),
+                "Expected error code to match for retry status: " + retryStatus);
+        Assert.assertEquals(errorInfo.get().getErrorMessage(), expectedError.message(),
+                "Expected error message to match for retry status: " + retryStatus);
+    }
+
+    @Test
+    public void testGetMappedErrorForUnknownErrorCode() throws Exception {
+
+        AuthenticationService authenticationService = new AuthenticationService();
+        AuthServiceRequest authServiceRequest = new AuthServiceRequest(request, response);
+
+        // Simulate a concluded failed flow with an unknown retryStatus — should fall to the default error.
+        when(request.getAttribute(FrameworkConstants.RequestParams.FLOW_STATUS))
+                .thenReturn(AuthenticatorFlowStatus.FAIL_COMPLETED);
+        when(request.getAttribute(FrameworkConstants.IS_AUTH_FLOW_CONCLUDED)).thenReturn(true);
+        when(request.getAttribute(FrameworkConstants.IS_SENT_TO_RETRY)).thenReturn(true);
+        when(request.getAttribute(FrameworkConstants.REQ_ATTR_RETRY_STATUS)).thenReturn("unknown.error.code");
+        when(request.getAttribute(FrameworkConstants.CONTEXT_IDENTIFIER)).thenReturn(SESSION_DATA_KEY);
+        when(response.getHeader(LOCATION_HEADER)).thenReturn(getFinalRedirectUrl(SESSION_DATA_KEY));
+
+        AuthServiceResponse authServiceResponse = authenticationService.handleAuthentication(authServiceRequest);
+
+        Assert.assertEquals(authServiceResponse.getFlowStatus(), AuthServiceConstants.FlowStatus.FAIL_COMPLETED,
+                "Expected FAIL_COMPLETED flow status.");
+        Optional<AuthServiceErrorInfo> errorInfo = authServiceResponse.getErrorInfo();
+        Assert.assertTrue(errorInfo.isPresent(), "Expected error info to be present.");
+        Assert.assertEquals(errorInfo.get().getErrorCode(),
+                AuthServiceConstants.ErrorMessage.ERROR_AUTHENTICATION_FAILURE.code(),
+                "Expected default error code for unknown error status.");
+    }
+
     @Test
     public void testHandleAuthenticationWithNonApiBasedAuthenticator() throws Exception {
 


### PR DESCRIPTION
**Related Issues**

- [x] https://github.com/wso2/product-is/issues/26743

This pull request introduces new error handling for authentication retry and resend limits, improving how the framework communicates these specific failure scenarios. The main changes include adding new error codes and messages, as well as mapping them in the authentication service.

**Error Handling Improvements:**

* Added new error status constants `ERROR_STATUS_ALLOWED_RETRY_LIMIT_EXCEEDED` and `ERROR_STATUS_ALLOWED_RESEND_LIMIT_EXCEEDED` to `FrameworkConstants`, representing exceeded retry and resend limits during authentication.
* Introduced new error messages `ERROR_RETRY_COUNT_EXCEEDED` and `ERROR_RESEND_COUNT_EXCEEDED` in `AuthServiceConstants.ErrorMessage`, providing clear descriptions for maximum retry and resend attempts exceeded.
* Updated the `getMappedError` method in `AuthenticationService.java` to map the new error status codes to their corresponding error messages, ensuring proper error reporting for these cases.