### PR TITLE
Add workflow to comment on default.json file changes

### DIFF
--- a/.github/workflows/comment-on-config-change.yml
+++ b/.github/workflows/comment-on-config-change.yml
@@ -1,0 +1,36 @@
+name: Comment on default.json file changes
+
+on:
+  pull_request:
+    paths:
+      - 'features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json'
+
+jobs:
+  review-comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Get the latest commit SHA
+        id: get-sha
+        run: echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+
+      - name: Post inline review comment on file
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const repo = context.repo;
+            const baseUrl = `https://github.com/${repo.owner}/${repo.repo}/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources`;
+            const defaultJsonUrl = `${baseUrl}/org.wso2.carbon.identity.core.server.feature.default.json`;
+            const inferJsonUrl = `${baseUrl}/org.wso2.carbon.identity.core.server.feature.infer.json`;
+
+            await github.rest.pulls.createReviewComment({
+              owner: repo.owner,
+              repo: repo.repo,
+              pull_number: context.issue.number,
+              commit_id: '${{ steps.get-sha.outputs.sha }}',
+              path: 'features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json',
+              subject_type: 'file',
+              body: `⚠️ **Migration Configuration Check**\n\nThis PR modifies [\`org.wso2.carbon.identity.core.server.feature.default.json\`](${defaultJsonUrl}).\n\nPlease make sure that the corresponding configurations are added to [\`features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json\`](${inferJsonUrl}), where applicable, to preserve backward compatibility during migration.\n\n> [!NOTE]\n> The [\`infer.json\`](${inferJsonUrl}) file stores the default configuration values for each version in the same release line, based on the behavioral changes introduced in the upcoming release. This ensures that existing deployments continue to behave as before after upgrading.`
+            })


### PR DESCRIPTION
When developer modifies [org.wso2.carbon.identity.core.server.feature.default.json](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json) in a PR, they may missed to modify the corresponding [infer.json](https://github.com/wso2/carbon-identity-framework/blob/master/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json) which need to be updated to preserve backward compatibility during migration.
Since this is easy to overlook, there is no current mechanism to remind contributors of this requirement at the time of the PR review.
With this, add a GitHub Actions workflow that automatically posts an inline review comment on the default.json file in the Files changed tab whenever a PR modifies it.
<img width="1096" height="594" alt="Screenshot 2026-03-10 at 19 29 20" src="https://github.com/user-attachments/assets/0d7aedc1-6d32-4ff4-b344-7b665254184f" />
