### PR TITLE
[Refactor] Centralize attribute handling for actions

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.management/pom.xml
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>org.wso2.carbon.identity.rule.management</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.claim.metadata.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.json.wso2</groupId>
             <artifactId>json</artifactId>
         </dependency>
@@ -129,6 +133,9 @@
                             org.wso2.carbon.identity.rule.management.api.model; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.rule.management.api.service; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.rule.management.api.util; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.claim.metadata.mgt; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.claim.metadata.mgt.exception; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.claim.metadata.mgt.model; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.central.log.mgt.utils;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon; version="${carbon.kernel.package.import.version.range}",

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/constant/ErrorMessage.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/constant/ErrorMessage.java
@@ -41,6 +41,10 @@ public enum ErrorMessage {
             "Only allowed to update to the latest Action version: %s. Ensure that only the major version is provided."),
     ERROR_INVALID_RULE_FOR_ACTION_VERSION("600010", "Invalid action rule for the action version.",
             "An unsupported rule has been provided for action version %s."),
+    ERROR_MAXIMUM_ATTRIBUTES_LIMIT_EXCEEDED("60011", "Maximum attributes limit exceeded.",
+            "The number of configured attributes: %s exceeds the maximum allowed limit: %s"),
+    ERROR_INVALID_ATTRIBUTES("60012", "Invalid attribute provided.",
+            "The provided %s attribute is not available in the system."),
 
     // Server errors.
     ERROR_WHILE_ADDING_ACTION("65001", "Error while adding Action.",

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/model/Action.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/model/Action.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.action.management.api.model;
 
 import java.sql.Timestamp;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Action.
@@ -145,6 +146,7 @@ public class Action {
     private Timestamp updatedAt;
     private EndpointConfig endpointConfig;
     private ActionRule rule;
+    private List<String> attributes;
 
     public Action(ActionResponseBuilder actionResponseBuilder) {
 
@@ -158,6 +160,7 @@ public class Action {
         this.updatedAt = actionResponseBuilder.updatedAt;
         this.endpointConfig = actionResponseBuilder.endpointConfig;
         this.rule = actionResponseBuilder.rule;
+        this.attributes = actionResponseBuilder.attributes;
     }
 
     public Action(ActionRequestBuilder actionRequestBuilder) {
@@ -167,6 +170,7 @@ public class Action {
         this.description = actionRequestBuilder.description;
         this.endpointConfig = actionRequestBuilder.endpointConfig;
         this.rule = actionRequestBuilder.rule;
+        this.attributes = actionRequestBuilder.attributes;
     }
 
     public String getId() {
@@ -219,6 +223,11 @@ public class Action {
         return rule;
     }
 
+    public List<String> getAttributes() {
+
+        return attributes;
+    }
+
     /**
      * ActionResponseBuilder.
      */
@@ -234,6 +243,7 @@ public class Action {
         private Timestamp updatedAt;
         private EndpointConfig endpointConfig;
         private ActionRule rule;
+        private List<String> attributes;
 
         public ActionResponseBuilder id(String id) {
 
@@ -295,6 +305,12 @@ public class Action {
             return this;
         }
 
+        public ActionResponseBuilder attributes(List<String> attributes) {
+
+            this.attributes = attributes;
+            return this;
+        }
+
         public Action build() {
 
             return new Action(this);
@@ -311,6 +327,7 @@ public class Action {
         private String actionVersion;
         private EndpointConfig endpointConfig;
         private ActionRule rule;
+        private List<String> attributes;
 
         public ActionRequestBuilder name(String name) {
 
@@ -339,6 +356,12 @@ public class Action {
         public ActionRequestBuilder rule(ActionRule rule) {
 
             this.rule = rule;
+            return this;
+        }
+
+        public ActionRequestBuilder attributes(List<String> attributes) {
+
+            this.attributes = attributes;
             return this;
         }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/model/ActionDTO.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/model/ActionDTO.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.action.management.api.model;
 
 import java.sql.Timestamp;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -36,6 +37,7 @@ public class ActionDTO {
     private final Timestamp updatedAt;
     private final EndpointConfig endpoint;
     private final ActionRule rule;
+    private final List<String> attributes;
     private final Map<String, ActionProperty> properties;
 
     public ActionDTO(Builder builder) {
@@ -50,6 +52,7 @@ public class ActionDTO {
         this.updatedAt = builder.updatedAt;
         this.endpoint = builder.endpoint;
         this.rule = builder.rule;
+        this.attributes = builder.attributes;
         this.properties = builder.properties;
     }
 
@@ -103,6 +106,11 @@ public class ActionDTO {
         return rule;
     }
 
+    public List<String> getAttributes() {
+
+        return attributes;
+    }
+
     public Map<String, ActionProperty> getProperties() {
 
         return properties;
@@ -132,6 +140,7 @@ public class ActionDTO {
         private final Timestamp updatedAt;
         private final EndpointConfig endpoint;
         private final ActionRule rule;
+        private List<String> attributes;
         private Map<String, ActionProperty> properties;
 
         public Builder(ActionDTO actionDTO) {
@@ -146,6 +155,7 @@ public class ActionDTO {
             this.updatedAt = actionDTO.getUpdatedAt();
             this.endpoint = actionDTO.getEndpoint();
             this.rule = actionDTO.getActionRule();
+            this.attributes = actionDTO.getAttributes();
             this.properties = actionDTO.getProperties();
         }
 
@@ -161,6 +171,13 @@ public class ActionDTO {
             this.updatedAt = action.getUpdatedAt();
             this.endpoint = action.getEndpoint();
             this.rule = action.getActionRule();
+            this.attributes = action.getAttributes();
+        }
+
+        public Builder attributes(List<String> attributes) {
+
+            this.attributes = attributes;
+            return this;
         }
 
         public Builder properties(Map<String, ActionProperty> properties) {

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/component/ActionMgtServiceComponent.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/component/ActionMgtServiceComponent.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.action.management.internal.dao.impl.ActionDTOMod
 import org.wso2.carbon.identity.action.management.internal.service.impl.ActionConverterFactory;
 import org.wso2.carbon.identity.action.management.internal.service.impl.ActionValidatorFactory;
 import org.wso2.carbon.identity.action.management.internal.service.impl.CacheBackedActionManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.rule.management.api.service.RuleManagementService;
 import org.wso2.carbon.identity.secret.mgt.core.SecretManager;
 import org.wso2.carbon.identity.secret.mgt.core.SecretResolveManager;
@@ -201,5 +202,23 @@ public class ActionMgtServiceComponent {
         LOG.debug("Unregistering ActionValidator: " + actionValidator.getClass().getName() +
                 " in the ActionMgtServiceComponent.");
         ActionValidatorFactory.unregisterActionValidatorFactory(actionValidator);
+    }
+
+    @Reference(
+            name = "claim.metadata.management.service",
+            service = org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetClaimMetadataManagementService")
+    protected void setClaimMetadataManagementService(ClaimMetadataManagementService claimManagementService) {
+
+        ActionMgtServiceComponentHolder.getInstance().setClaimMetadataManagementService(claimManagementService);
+        LOG.debug("ClaimMetadataManagementService set in ActionMgtServiceComponentHolder bundle.");
+    }
+
+    protected void unsetClaimMetadataManagementService(ClaimMetadataManagementService claimManagementService) {
+
+        ActionMgtServiceComponentHolder.getInstance().setClaimMetadataManagementService(null);
+        LOG.debug("ClaimMetadataManagementService unset in ActionMgtServiceComponentHolder bundle.");
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/component/ActionMgtServiceComponentHolder.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/component/ActionMgtServiceComponentHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.action.management.internal.component;
 
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.rule.management.api.service.RuleManagementService;
 import org.wso2.carbon.identity.secret.mgt.core.SecretManager;
 import org.wso2.carbon.identity.secret.mgt.core.SecretResolveManager;
@@ -30,6 +31,7 @@ public class ActionMgtServiceComponentHolder {
     private SecretManager secretManager;
     private SecretResolveManager secretResolveManager;
     private RuleManagementService ruleManagementService;
+    private ClaimMetadataManagementService claimMetadataManagementService;
 
     public static final ActionMgtServiceComponentHolder INSTANCE = new ActionMgtServiceComponentHolder();
 
@@ -105,5 +107,25 @@ public class ActionMgtServiceComponentHolder {
     public void setRuleManagementService(RuleManagementService ruleManagementService) {
 
         this.ruleManagementService = ruleManagementService;
+    }
+
+    /**
+     * Get the ClaimMetadataManagementService.
+     *
+     * @return ClaimMetadataManagementService instance.
+     */
+    public ClaimMetadataManagementService getClaimMetadataManagementService() {
+
+        return claimMetadataManagementService;
+    }
+
+    /**
+     * Set the ClaimMetadataManagementService.
+     *
+     * @param claimMetadataManagementService ClaimMetadataManagementService instance.
+     */
+    public void setClaimMetadataManagementService(ClaimMetadataManagementService claimMetadataManagementService) {
+
+        this.claimMetadataManagementService = claimMetadataManagementService;
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/constant/ActionMgtConstants.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/constant/ActionMgtConstants.java
@@ -39,6 +39,7 @@ public class ActionMgtConstants {
     public static final String ALLOWED_HEADERS_PROPERTY = "allowedHeaders";
     public static final String ALLOWED_PARAMETERS_PROPERTY = "allowedParameters";
     public static final String RULE_PROPERTY = "rule";
+    public static final String ATTRIBUTES_PROPERTY = "attributes";
 
     private ActionMgtConstants() {
     }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/constant/ActionMgtConstants.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/constant/ActionMgtConstants.java
@@ -40,6 +40,8 @@ public class ActionMgtConstants {
     public static final String ALLOWED_PARAMETERS_PROPERTY = "allowedParameters";
     public static final String RULE_PROPERTY = "rule";
     public static final String ATTRIBUTES_PROPERTY = "attributes";
+    public static final String ROLE_CLAIM_URI = "http://wso2.org/claims/roles";
+    public static final int MAX_ATTRIBUTES = 10;
 
     private ActionMgtConstants() {
     }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/dao/impl/ActionManagementDAOImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/dao/impl/ActionManagementDAOImpl.java
@@ -18,9 +18,12 @@
 
 package org.wso2.carbon.identity.action.management.internal.dao.impl;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.database.utils.jdbc.NamedJdbcTemplate;
 import org.wso2.carbon.database.utils.jdbc.NamedPreparedStatement;
 import org.wso2.carbon.database.utils.jdbc.exceptions.TransactionException;
+import org.wso2.carbon.identity.action.management.api.constant.ErrorMessage;
 import org.wso2.carbon.identity.action.management.api.exception.ActionMgtException;
 import org.wso2.carbon.identity.action.management.api.exception.ActionMgtServerException;
 import org.wso2.carbon.identity.action.management.api.model.Action;
@@ -31,11 +34,15 @@ import org.wso2.carbon.identity.action.management.api.model.AuthProperty;
 import org.wso2.carbon.identity.action.management.api.model.Authentication;
 import org.wso2.carbon.identity.action.management.api.model.BinaryObject;
 import org.wso2.carbon.identity.action.management.api.model.EndpointConfig;
+import org.wso2.carbon.identity.action.management.internal.component.ActionMgtServiceComponentHolder;
 import org.wso2.carbon.identity.action.management.internal.constant.ActionMgtConstants;
 import org.wso2.carbon.identity.action.management.internal.constant.ActionMgtSQLConstants;
 import org.wso2.carbon.identity.action.management.internal.dao.ActionManagementDAO;
 import org.wso2.carbon.identity.action.management.internal.util.ActionDTOBuilder;
 import org.wso2.carbon.identity.action.management.internal.util.ActionManagementDAOUtil;
+import org.wso2.carbon.identity.action.management.internal.util.ActionManagementExceptionHandler;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 
@@ -47,8 +54,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -56,6 +66,7 @@ import java.util.stream.Collectors;
  */
 public class ActionManagementDAOImpl implements ActionManagementDAO {
 
+    private static final Log LOG = LogFactory.getLog(ActionManagementDAOImpl.class);
     private static final String V1 = "1.0.0";
 
     private static final ActionManagementDAOUtil actionMgtDAOUtil = new ActionManagementDAOUtil();
@@ -519,8 +530,18 @@ public class ActionManagementDAOImpl implements ActionManagementDAO {
             return null;
         }
 
+        String tenantDomain = "carbon.super";
+        try {
+            tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
+        } catch (Exception e) {
+            // Log and fallback for unit tests if IdentityTenantUtil is not initialized.
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while getting tenant domain for tenant ID: " + tenantId +
+                        ". Falling back to carbon.super.");
+            }
+        }
         return ActionRule.create(propertiesFromDB.remove(ActionMgtConstants.RULE_PROPERTY).getValue().toString(),
-                IdentityTenantUtil.getTenantDomain(tenantId));
+                tenantDomain);
     }
 
     /**
@@ -536,10 +557,21 @@ public class ActionManagementDAOImpl implements ActionManagementDAO {
         if (attributes == null || attributes.isEmpty()) {
             return;
         }
+
+        // Validate attributes count.
+        if (attributes.size() > ActionMgtConstants.MAX_ATTRIBUTES) {
+            throw ActionManagementExceptionHandler.handleClientException(
+                    ErrorMessage.ERROR_MAXIMUM_ATTRIBUTES_LIMIT_EXCEEDED,
+                    String.valueOf(attributes.size()),
+                    String.valueOf(ActionMgtConstants.MAX_ATTRIBUTES));
+        }
+
         try {
+            // Filter duplicates and preserve order.
+            List<String> filteredAttributes = filterValidSystemAttributes(attributes, tenantId);
             Map<String, ActionProperty> attributeProperties = Collections.singletonMap(
                     ActionMgtConstants.ATTRIBUTES_PROPERTY,
-                    actionMgtDAOUtil.buildActionPropertyFromList(attributes));
+                    actionMgtDAOUtil.buildActionPropertyFromList(filteredAttributes));
             addActionPropertiesToDB(actionDTO.getId(), attributeProperties, tenantId);
         } catch (TransactionException e) {
             throw new ActionMgtServerException("Error while adding Action Attributes in the system.", e);
@@ -577,31 +609,34 @@ public class ActionManagementDAOImpl implements ActionManagementDAO {
         List<String> updatingAttributes = updatingActionDTO.getAttributes();
         List<String> existingAttributes = existingActionDTO.getAttributes();
 
-        // Determine the resolved attributes to persist.
-        List<String> resolvedAttributes;
         if (updatingAttributes != null) {
-            resolvedAttributes = updatingAttributes;
-        } else if (existingAttributes != null) {
-            resolvedAttributes = existingAttributes;
-        } else {
-            return;
-        }
+            // Validate attributes count.
+            if (updatingAttributes.size() > ActionMgtConstants.MAX_ATTRIBUTES) {
+                throw ActionManagementExceptionHandler.handleClientException(
+                        ErrorMessage.ERROR_MAXIMUM_ATTRIBUTES_LIMIT_EXCEEDED,
+                        String.valueOf(updatingAttributes.size()),
+                        String.valueOf(ActionMgtConstants.MAX_ATTRIBUTES));
+            }
 
-        try {
-            // Delete existing attributes property if present.
-            if (existingAttributes != null && !existingAttributes.isEmpty()) {
-                deleteActionPropertiesInDB(updatingActionDTO.getId(),
-                        Collections.singletonList(ActionMgtConstants.ATTRIBUTES_PROPERTY), tenantId);
+            try {
+                // Determine the resolved attributes to persist.
+                List<String> resolvedAttributes = filterValidSystemAttributes(updatingAttributes, tenantId);
+
+                // Delete existing attributes property if present.
+                if (existingAttributes != null && !existingAttributes.isEmpty()) {
+                    deleteActionPropertiesInDB(updatingActionDTO.getId(),
+                            Collections.singletonList(ActionMgtConstants.ATTRIBUTES_PROPERTY), tenantId);
+                }
+
+                if (!resolvedAttributes.isEmpty()) {
+                    Map<String, ActionProperty> attributeProperties = Collections.singletonMap(
+                            ActionMgtConstants.ATTRIBUTES_PROPERTY,
+                            actionMgtDAOUtil.buildActionPropertyFromList(resolvedAttributes));
+                    addActionPropertiesToDB(updatingActionDTO.getId(), attributeProperties, tenantId);
+                }
+            } catch (TransactionException e) {
+                throw new ActionMgtServerException("Error while updating Action Attributes in the system.", e);
             }
-            // Add the resolved attributes.
-            if (!resolvedAttributes.isEmpty()) {
-                Map<String, ActionProperty> attributeProperties = Collections.singletonMap(
-                        ActionMgtConstants.ATTRIBUTES_PROPERTY,
-                        actionMgtDAOUtil.buildActionPropertyFromList(resolvedAttributes));
-                addActionPropertiesToDB(updatingActionDTO.getId(), attributeProperties, tenantId);
-            }
-        } catch (TransactionException e) {
-            throw new ActionMgtServerException("Error while updating Action Attributes in the system.", e);
         }
     }
 
@@ -794,5 +829,57 @@ public class ActionManagementDAOImpl implements ActionManagementDAO {
         } catch (TransactionException e) {
             throw new ActionMgtServerException("Error while updating Action Status to " + status, e);
         }
+    }
+
+    /**
+     * Filter duplicate attributes and preserve order.
+     * This method removes duplicate attributes while maintaining the original
+     * order.
+     *
+     * @param attributes List of attributes to filter.
+     * @return Filtered list of unique attributes in original order.
+     */
+    private List<String> filterValidSystemAttributes(List<String> attributes, Integer tenantId)
+            throws ActionMgtException {
+
+        Set<String> uniqueAttributes = new LinkedHashSet<>();
+        Set<String> duplicatedAttributes = new HashSet<>();
+
+        String tenantDomain = "carbon.super";
+        try {
+            String domain = IdentityTenantUtil.getTenantDomain(tenantId);
+            if (domain != null) {
+                tenantDomain = domain;
+            }
+        } catch (Exception e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while getting tenant domain for tenant ID: " + tenantId +
+                        ". Falling back to carbon.super.");
+            }
+        }
+        ClaimMetadataManagementService claimMetadataManagementService = ActionMgtServiceComponentHolder.getInstance()
+                .getClaimMetadataManagementService();
+
+        for (String attribute : attributes) {
+            if (uniqueAttributes.add(attribute)) {
+                try {
+                    if (claimMetadataManagementService == null ||
+                            claimMetadataManagementService.getLocalClaim(attribute, tenantDomain).isEmpty()) {
+                        throw ActionManagementExceptionHandler.handleClientException(
+                                ErrorMessage.ERROR_INVALID_ATTRIBUTES, attribute);
+                    }
+                } catch (ClaimMetadataException e) {
+                    throw ActionManagementExceptionHandler.handleServerException(
+                            ErrorMessage.ERROR_WHILE_ADDING_ACTION, e);
+                }
+            } else {
+                duplicatedAttributes.add(attribute);
+            }
+        }
+        if (LOG.isDebugEnabled() && !duplicatedAttributes.isEmpty()) {
+            LOG.debug("Ignored duplicated attributes in action configuration : " +
+                    String.join(", ", duplicatedAttributes));
+        }
+        return new ArrayList<>(uniqueAttributes);
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/dao/impl/ActionManagementDAOImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/dao/impl/ActionManagementDAOImpl.java
@@ -69,6 +69,8 @@ public class ActionManagementDAOImpl implements ActionManagementDAO {
         addEndpoint(actionDTO, tenantId);
         // Add action rule reference.
         addRuleReference(actionDTO, tenantId);
+        // Add action attributes.
+        addAttributes(actionDTO, tenantId);
         // Add action properties.
         addProperties(actionDTO, tenantId);
     }
@@ -101,6 +103,7 @@ public class ActionManagementDAOImpl implements ActionManagementDAO {
                             .actionVersion(rs.getString(ActionMgtSQLConstants.Column.ACTION_VERSION))
                             .endpoint(populateEndpoint(properties))
                             .rule(populateRule(properties, tenantId))
+                            .attributes(populateAttributes(properties))
                             .properties(properties.entrySet().stream()
                                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
                             .build();
@@ -128,6 +131,7 @@ public class ActionManagementDAOImpl implements ActionManagementDAO {
         Map<String, ActionProperty> actionProperties = getActionPropertiesFromDB(actionId, tenantId);
         actionBuilder.endpoint(populateEndpoint(actionProperties));
         actionBuilder.rule(populateRule(actionProperties, tenantId));
+        actionBuilder.attributes(populateAttributes(actionProperties));
         actionBuilder.properties(actionProperties.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
         return actionBuilder.build();
@@ -143,6 +147,8 @@ public class ActionManagementDAOImpl implements ActionManagementDAO {
         updateEndpoint(updatingActionDTO, existingActionDTO, tenantId);
         // Update Rule Reference.
         updateRuleReference(updatingActionDTO, existingActionDTO, tenantId);
+        // Update Action Attributes.
+        updateAttributes(updatingActionDTO, existingActionDTO, tenantId);
         // Update Action Properties.
         updateProperties(updatingActionDTO, existingActionDTO, tenantId);
     }
@@ -515,6 +521,88 @@ public class ActionManagementDAOImpl implements ActionManagementDAO {
 
         return ActionRule.create(propertiesFromDB.remove(ActionMgtConstants.RULE_PROPERTY).getValue().toString(),
                 IdentityTenantUtil.getTenantDomain(tenantId));
+    }
+
+    /**
+     * Add Action attributes to the Database.
+     *
+     * @param actionDTO ActionDTO object with attributes.
+     * @param tenantId  Tenant ID.
+     * @throws ActionMgtException If an error occurs while adding action attributes.
+     */
+    private void addAttributes(ActionDTO actionDTO, Integer tenantId) throws ActionMgtException {
+
+        List<String> attributes = actionDTO.getAttributes();
+        if (attributes == null || attributes.isEmpty()) {
+            return;
+        }
+        try {
+            Map<String, ActionProperty> attributeProperties = Collections.singletonMap(
+                    ActionMgtConstants.ATTRIBUTES_PROPERTY,
+                    actionMgtDAOUtil.buildActionPropertyFromList(attributes));
+            addActionPropertiesToDB(actionDTO.getId(), attributeProperties, tenantId);
+        } catch (TransactionException e) {
+            throw new ActionMgtServerException("Error while adding Action Attributes in the system.", e);
+        }
+    }
+
+    /**
+     * Populate attributes from the database properties map.
+     * This method reads and removes the attributes property from the given map.
+     *
+     * @param propertiesFromDB Map of properties read from the database.
+     * @return List of attribute strings, or null if no attributes are stored.
+     * @throws ActionMgtException If an error occurs while reading the attributes.
+     */
+    private List<String> populateAttributes(Map<String, ActionProperty> propertiesFromDB) throws ActionMgtException {
+
+        List<String> attributes = actionMgtDAOUtil.readDBListProperty(propertiesFromDB,
+                ActionMgtConstants.ATTRIBUTES_PROPERTY);
+        return attributes.isEmpty() ? null : attributes;
+    }
+
+    /**
+     * Update Action attributes.
+     * If attributes are provided in the updating DTO, they replace the existing ones.
+     * If not provided, existing attributes are preserved.
+     *
+     * @param updatingActionDTO Updating ActionDTO object with attributes.
+     * @param existingActionDTO Existing ActionDTO object with attributes.
+     * @param tenantId          Tenant ID.
+     * @throws ActionMgtException If an error occurs while updating action attributes.
+     */
+    private void updateAttributes(ActionDTO updatingActionDTO, ActionDTO existingActionDTO, Integer tenantId)
+            throws ActionMgtException {
+
+        List<String> updatingAttributes = updatingActionDTO.getAttributes();
+        List<String> existingAttributes = existingActionDTO.getAttributes();
+
+        // Determine the resolved attributes to persist.
+        List<String> resolvedAttributes;
+        if (updatingAttributes != null) {
+            resolvedAttributes = updatingAttributes;
+        } else if (existingAttributes != null) {
+            resolvedAttributes = existingAttributes;
+        } else {
+            return;
+        }
+
+        try {
+            // Delete existing attributes property if present.
+            if (existingAttributes != null && !existingAttributes.isEmpty()) {
+                deleteActionPropertiesInDB(updatingActionDTO.getId(),
+                        Collections.singletonList(ActionMgtConstants.ATTRIBUTES_PROPERTY), tenantId);
+            }
+            // Add the resolved attributes.
+            if (!resolvedAttributes.isEmpty()) {
+                Map<String, ActionProperty> attributeProperties = Collections.singletonMap(
+                        ActionMgtConstants.ATTRIBUTES_PROPERTY,
+                        actionMgtDAOUtil.buildActionPropertyFromList(resolvedAttributes));
+                addActionPropertiesToDB(updatingActionDTO.getId(), attributeProperties, tenantId);
+            }
+        } catch (TransactionException e) {
+            throw new ActionMgtServerException("Error while updating Action Attributes in the system.", e);
+        }
     }
 
     /**

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -466,6 +466,7 @@ public class ActionManagementServiceImpl implements ActionManagementService {
                 .updatedAt(actionDTO.getUpdatedAt())
                 .endpoint(actionDTO.getEndpoint())
                 .rule(actionDTO.getActionRule())
+                .attributes(actionDTO.getAttributes())
                 .build();
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -31,12 +31,16 @@ import org.wso2.carbon.identity.action.management.api.model.Authentication;
 import org.wso2.carbon.identity.action.management.api.model.EndpointConfig;
 import org.wso2.carbon.identity.action.management.api.service.ActionConverter;
 import org.wso2.carbon.identity.action.management.api.service.ActionManagementService;
+import org.wso2.carbon.identity.action.management.internal.component.ActionMgtServiceComponentHolder;
+import org.wso2.carbon.identity.action.management.internal.constant.ActionMgtConstants;
 import org.wso2.carbon.identity.action.management.internal.dao.impl.ActionManagementDAOFacade;
 import org.wso2.carbon.identity.action.management.internal.dao.impl.ActionManagementDAOImpl;
 import org.wso2.carbon.identity.action.management.internal.util.ActionDTOBuilder;
 import org.wso2.carbon.identity.action.management.internal.util.ActionManagementAuditLogger;
 import org.wso2.carbon.identity.action.management.internal.util.ActionManagementConfig;
 import org.wso2.carbon.identity.action.management.internal.util.ActionManagementExceptionHandler;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
@@ -76,6 +80,7 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         Action.ActionTypes castedActionType = Action.ActionTypes.valueOf(resolvedActionType);
         ActionValidatorFactory.getActionValidator(castedActionType).doPreAddActionValidations(
                 castedActionType, ActionManagementConfig.getInstance().getLatestVersion(castedActionType), action);
+        validateActionAttributes(action.getAttributes(), tenantDomain);
         // Check whether the maximum allowed actions per type is reached.
         validateMaxActionsPerType(resolvedActionType, tenantDomain);
         String generatedActionId = UUID.randomUUID().toString();
@@ -161,6 +166,7 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         Action.ActionTypes castedActionType = Action.ActionTypes.valueOf(resolvedActionType);
         ActionValidatorFactory.getActionValidator(castedActionType).doPreUpdateActionValidations(
                 castedActionType, resolveActionVersionAtUpdating(action, existingActionDTO), action);
+        validateActionAttributes(action.getAttributes(), tenantDomain);
         ActionDTO updatingActionDTO = buildActionDTOForUpdate(resolvedActionType, actionId, action);
 
         DAO_FACADE.updateAction(updatingActionDTO, existingActionDTO, tenantId);
@@ -304,8 +310,56 @@ public class ActionManagementServiceImpl implements ActionManagementService {
                 .filter(type -> type.getPathParam().equals(actionType))
                 .map(Action.ActionTypes::getActionType)
                 .findFirst()
-                .orElseThrow(() ->
-                        ActionManagementExceptionHandler.handleClientException(ErrorMessage.ERROR_INVALID_ACTION_TYPE));
+                .orElseThrow(() -> ActionManagementExceptionHandler
+                        .handleClientException(ErrorMessage.ERROR_INVALID_ACTION_TYPE));
+    }
+
+    /**
+     * Validate the action attributes.
+     * Validates that attributes are in correct format and within max count limit.
+     * System attribute validation happens in the converter layer.
+     *
+     * @param attributes List of attributes to validate.
+     * @throws ActionMgtClientException If attributes are invalid or exceed max
+     *                                  count.
+     */
+    private void validateActionAttributes(List<String> attributes, String tenantDomain)
+            throws ActionMgtException {
+
+        if (attributes == null || attributes.isEmpty()) {
+            return;
+        }
+
+        // Validate count
+        if (attributes.size() > ActionMgtConstants.MAX_ATTRIBUTES) {
+            throw ActionManagementExceptionHandler.handleClientException(
+                    ErrorMessage.ERROR_MAXIMUM_ATTRIBUTES_LIMIT_EXCEEDED,
+                    String.valueOf(attributes.size()),
+                    String.valueOf(ActionMgtConstants.MAX_ATTRIBUTES));
+        }
+
+        ClaimMetadataManagementService claimMetadataManagementService = ActionMgtServiceComponentHolder.getInstance()
+                .getClaimMetadataManagementService();
+
+        // Validate individual attribute format and existence in system claims
+        for (String attribute : attributes) {
+            if (StringUtils.isBlank(attribute)) {
+                throw ActionManagementExceptionHandler.handleClientException(
+                        ErrorMessage.ERROR_INVALID_ATTRIBUTES,
+                        "Each attribute must be a non-empty string");
+            }
+
+            try {
+                if (claimMetadataManagementService == null ||
+                        claimMetadataManagementService.getLocalClaim(attribute, tenantDomain).isEmpty()) {
+                    throw ActionManagementExceptionHandler.handleClientException(
+                            ErrorMessage.ERROR_INVALID_ATTRIBUTES, attribute);
+                }
+            } catch (ClaimMetadataException e) {
+                throw ActionManagementExceptionHandler.handleServerException(
+                        ErrorMessage.ERROR_WHILE_ADDING_ACTION, e);
+            }
+        }
     }
 
     /**

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionDTOBuilder.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionDTOBuilder.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.action.management.api.model.EndpointConfig;
 
 import java.sql.Timestamp;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -43,6 +44,7 @@ public class ActionDTOBuilder {
     private Timestamp updatedAt;
     private EndpointConfig endpoint;
     private ActionRule rule;
+    private List<String> attributes;
     private Map<String, ActionProperty> properties;
 
     public ActionDTOBuilder() {
@@ -61,6 +63,7 @@ public class ActionDTOBuilder {
         this.updatedAt = actionDTO.getUpdatedAt();
         this.endpoint = actionDTO.getEndpoint();
         this.rule = actionDTO.getActionRule();
+        this.attributes = actionDTO.getAttributes();
         this.properties = actionDTO.getProperties();
     }
 
@@ -76,6 +79,7 @@ public class ActionDTOBuilder {
         this.updatedAt = action.getUpdatedAt();
         this.endpoint = action.getEndpoint();
         this.rule = action.getActionRule();
+        this.attributes = action.getAttributes();
     }
 
     public ActionDTOBuilder id(String id) {
@@ -184,6 +188,17 @@ public class ActionDTOBuilder {
         return this.properties;
     }
 
+    public ActionDTOBuilder attributes(List<String> attributes) {
+
+        this.attributes = attributes;
+        return this;
+    }
+
+    public List<String> getAttributes() {
+
+        return this.attributes;
+    }
+
     public ActionDTOBuilder property(String propertyName, ActionProperty propertyValue) {
 
         if (this.properties == null) {
@@ -208,6 +223,9 @@ public class ActionDTOBuilder {
                 .rule(this.rule)
                 .build();
 
-        return new ActionDTO.Builder(action).properties(this.properties).build();
+        return new ActionDTO.Builder(action)
+                .attributes(this.attributes)
+                .properties(this.properties)
+                .build();
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/dao/ActionManagementDAOImplTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/dao/ActionManagementDAOImplTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.action.management.dao;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.action.management.api.exception.ActionMgtException;
 import org.wso2.carbon.identity.action.management.api.model.Action;
@@ -29,9 +30,12 @@ import org.wso2.carbon.identity.action.management.api.model.ActionProperty;
 import org.wso2.carbon.identity.action.management.api.model.Authentication;
 import org.wso2.carbon.identity.action.management.api.model.BinaryObject;
 import org.wso2.carbon.identity.action.management.api.model.EndpointConfig;
+import org.wso2.carbon.identity.action.management.internal.component.ActionMgtServiceComponentHolder;
 import org.wso2.carbon.identity.action.management.internal.dao.impl.ActionManagementDAOImpl;
 import org.wso2.carbon.identity.action.management.internal.util.ActionDTOBuilder;
 import org.wso2.carbon.identity.action.management.util.TestUtil;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 
@@ -39,8 +43,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.PRE_ISSUE_ACCESS_TOKEN_ACTION_ID;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.PRE_ISSUE_ACCESS_TOKEN_TYPE;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.PRE_UPDATE_PASSWORD_ACTION_ID;
@@ -66,6 +74,14 @@ public class ActionManagementDAOImplTest {
     public void setUpClass() {
 
         daoImpl = new ActionManagementDAOImpl();
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        ClaimMetadataManagementService claimMetadataManagementService = mock(ClaimMetadataManagementService.class);
+        when(claimMetadataManagementService.getLocalClaim(anyString(), anyString()))
+                .thenReturn(Optional.of(new LocalClaim("mock")));
+        ActionMgtServiceComponentHolder.getInstance().setClaimMetadataManagementService(claimMetadataManagementService);
     }
 
     @Test(priority = 1)

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/dao/ActionManagementDAOImplTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/dao/ActionManagementDAOImplTest.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -127,6 +128,62 @@ public class ActionManagementDAOImplTest {
                 creatingActionDTO.getPropertyValue(TestUtil.TEST_ACTION_PROPERTY_NAME_1));
         Assert.assertEquals(createdActionDTO.getPropertyValue(TestUtil.TEST_ACTION_PROPERTY_NAME_2),
                 creatingActionDTO.getPropertyValue(TestUtil.TEST_ACTION_PROPERTY_NAME_2));
+    }
+
+    @Test(priority = 1)
+    public void testAddActionWithAttributes() throws ActionMgtException {
+
+        List<String> attributes = Arrays.asList("attr1", "attr2");
+        String actionId = String.valueOf(UUID.randomUUID());
+        ActionDTO creatingActionDTO = new ActionDTOBuilder()
+                .id(actionId)
+                .type(Action.ActionTypes.PRE_UPDATE_PROFILE)
+                .name("AttrAction")
+                .description("Attr action desc")
+                .status(Action.Status.ACTIVE)
+                .actionVersion(TestUtil.TEST_DEFAULT_LATEST_ACTION_VERSION)
+                .endpoint(new EndpointConfig.EndpointConfigBuilder()
+                        .uri(TestUtil.TEST_ACTION_URI)
+                        .authentication(TestUtil.buildMockBasicAuthentication(
+                                TestUtil.TEST_USERNAME_SECRET_REFERENCE,
+                                TestUtil.TEST_PASSWORD_SECRET_REFERENCE))
+                        .allowedHeaders(TestUtil.buildMockAllowedHeaders())
+                        .allowedParameters(TestUtil.buildMockAllowedParameters())
+                        .build())
+                .attributes(attributes)
+                .build();
+
+        daoImpl.addAction(creatingActionDTO, TENANT_ID);
+        ActionDTO fetched = daoImpl.getActionByActionId(PRE_UPDATE_PROFILE_TYPE, actionId, TENANT_ID);
+        Assert.assertEquals(fetched.getAttributes(), attributes);
+        daoImpl.deleteAction(fetched, TENANT_ID);
+    }
+
+    @Test(priority = 1)
+    public void testGetActionWithNullAttributes() throws ActionMgtException {
+
+        String actionId = String.valueOf(UUID.randomUUID());
+        ActionDTO creatingActionDTO = new ActionDTOBuilder()
+                .id(actionId)
+                .type(Action.ActionTypes.PRE_UPDATE_PROFILE)
+                .name("NullAttrAction")
+                .description("Null Attr action desc")
+                .status(Action.Status.ACTIVE)
+                .actionVersion(TestUtil.TEST_DEFAULT_LATEST_ACTION_VERSION)
+                .endpoint(new EndpointConfig.EndpointConfigBuilder()
+                        .uri(TestUtil.TEST_ACTION_URI)
+                        .authentication(TestUtil.buildMockBasicAuthentication(
+                                TestUtil.TEST_USERNAME_SECRET_REFERENCE,
+                                TestUtil.TEST_PASSWORD_SECRET_REFERENCE))
+                        .allowedHeaders(TestUtil.buildMockAllowedHeaders())
+                        .allowedParameters(TestUtil.buildMockAllowedParameters())
+                        .build())
+                .build();
+
+        daoImpl.addAction(creatingActionDTO, TENANT_ID);
+        ActionDTO fetched = daoImpl.getActionByActionId(PRE_UPDATE_PROFILE_TYPE, actionId, TENANT_ID);
+        Assert.assertNull(fetched.getAttributes());
+        daoImpl.deleteAction(fetched, TENANT_ID);
     }
 
     @Test(priority = 2, expectedExceptions = ActionMgtException.class,
@@ -322,11 +379,13 @@ public class ActionManagementDAOImplTest {
     @Test(priority = 8)
     public void testUpdateActionBasicInfo() throws ActionMgtException {
 
+        List<String> updatedAttributes = Arrays.asList("attr3", "attr4");
         ActionDTO updatingAction = new ActionDTOBuilder()
                 .id(createdActionDTO.getId())
                 .type(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN)
                 .name(TestUtil.TEST_ACTION_NAME)
                 .description(TestUtil.TEST_ACTION_DESCRIPTION)
+                .attributes(updatedAttributes)
                 .build();
 
         try {
@@ -335,6 +394,7 @@ public class ActionManagementDAOImplTest {
             Assert.fail();
         }
         ActionDTO result = daoImpl.getActionByActionId(PRE_ISSUE_ACCESS_TOKEN_TYPE, updatingAction.getId(), TENANT_ID);
+        Assert.assertEquals(result.getAttributes(), updatedAttributes);
         Assert.assertEquals(result.getId(), createdActionDTO.getId());
         Assert.assertEquals(result.getType(), createdActionDTO.getType());
         Assert.assertEquals(result.getName(), updatingAction.getName());

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/service/ActionManagementServiceImplTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/service/ActionManagementServiceImplTest.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.action.management.api.exception.ActionMgtExcepti
 import org.wso2.carbon.identity.action.management.api.model.Action;
 import org.wso2.carbon.identity.action.management.api.model.AuthProperty;
 import org.wso2.carbon.identity.action.management.api.model.Authentication;
+import org.wso2.carbon.identity.action.management.api.model.EndpointConfig;
 import org.wso2.carbon.identity.action.management.api.service.ActionManagementService;
 import org.wso2.carbon.identity.action.management.internal.component.ActionMgtServiceComponentHolder;
 import org.wso2.carbon.identity.action.management.internal.service.impl.ActionManagementServiceImpl;
@@ -46,6 +47,7 @@ import org.wso2.carbon.identity.secret.mgt.core.SecretManagerImpl;
 import org.wso2.carbon.identity.secret.mgt.core.exception.SecretManagementException;
 import org.wso2.carbon.identity.secret.mgt.core.model.SecretType;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -156,7 +158,28 @@ public class ActionManagementServiceImplTest {
                 secretProperties.get(Authentication.Property.PASSWORD.getName()));
     }
 
-    @Test(priority = 2, expectedExceptions = ActionMgtClientException.class,
+    @Test(priority = 2)
+    public void testAddActionWithAttributes() throws ActionMgtException, SecretManagementException {
+
+        List<String> attributes = Arrays.asList("attr1", "attr2");
+        Action updatingAction = new Action.ActionRequestBuilder()
+                .name(TEST_ACTION_NAME)
+                .description(TEST_ACTION_DESCRIPTION)
+                .actionVersion(TestUtil.TEST_DEFAULT_LATEST_ACTION_VERSION)
+                .attributes(attributes)
+                .endpoint(new EndpointConfig.EndpointConfigBuilder()
+                        .uri(TEST_ACTION_URI)
+                        .authentication(TestUtil.buildMockBasicAuthentication(TEST_USERNAME, TEST_PASSWORD))
+                        .build())
+                .build();
+
+        Action updated = actionManagementService.updateAction(PRE_ISSUE_ACCESS_TOKEN_PATH, sampleAction.getId(),
+                updatingAction, TENANT_DOMAIN);
+        Assert.assertEquals(updated.getAttributes(), attributes);
+        sampleAction = updated;
+    }
+
+    @Test(priority = 3, expectedExceptions = ActionMgtClientException.class,
             expectedExceptionsMessageRegExp = "Invalid request.")
     public void testAddActionWithInvalidData() throws ActionMgtException {
 
@@ -169,7 +192,7 @@ public class ActionManagementServiceImplTest {
         Assert.assertNull(action);
     }
 
-    @Test(priority = 3, expectedExceptions = ActionMgtClientException.class,
+    @Test(priority = 4, expectedExceptions = ActionMgtClientException.class,
             expectedExceptionsMessageRegExp = "Invalid request.")
     public void testAddActionWithEmptyData() throws ActionMgtException {
 
@@ -182,7 +205,7 @@ public class ActionManagementServiceImplTest {
         Assert.assertNull(action);
     }
 
-    @Test(priority = 4, expectedExceptions = ActionMgtException.class,
+    @Test(priority = 5, expectedExceptions = ActionMgtException.class,
             expectedExceptionsMessageRegExp = "Unable to create an Action.")
     public void testAddMaximumActionsPerType() throws ActionMgtException {
 
@@ -195,7 +218,7 @@ public class ActionManagementServiceImplTest {
                 TENANT_DOMAIN);
     }
 
-    @Test(priority = 5)
+    @Test(priority = 6)
     public void testGetActionsByActionType() throws ActionMgtException {
 
         List<Action> actions = actionManagementService.getActionsByActionType(PRE_ISSUE_ACCESS_TOKEN_PATH,
@@ -222,7 +245,7 @@ public class ActionManagementServiceImplTest {
                 sampleActionAuth.getProperty(Authentication.Property.PASSWORD).getValue());
     }
 
-    @Test(priority = 6)
+    @Test(priority = 7)
     public void testGetActionByActionId() throws ActionMgtException {
 
         Action result = actionManagementService.getActionByActionId(sampleAction.getType().getPathParam(),
@@ -247,7 +270,7 @@ public class ActionManagementServiceImplTest {
                 sampleActionAuth.getProperty(Authentication.Property.PASSWORD).getValue());
     }
 
-    @Test(priority = 6)
+    @Test(priority = 8)
     public void testUpdateActionFailureWithNotAllowedActionVersion() throws Exception {
 
         Action updatingAction = TestUtil.buildMockActionWithVersion(
@@ -260,7 +283,7 @@ public class ActionManagementServiceImplTest {
                 PRE_ISSUE_ACCESS_TOKEN_PATH, sampleAction.getId(), updatingAction, TENANT_DOMAIN));
     }
 
-    @Test(priority = 7)
+    @Test(priority = 9)
     public void testUpdateAction() throws ActionMgtException, SecretManagementException {
 
         Action updatingAction = TestUtil.buildMockAction(
@@ -293,7 +316,7 @@ public class ActionManagementServiceImplTest {
         sampleAction = result;
     }
 
-    @Test(priority = 8)
+    @Test(priority = 10)
     public void testActivateAction() throws ActionMgtException {
 
         Assert.assertEquals(sampleAction.getStatus(), Action.Status.INACTIVE);
@@ -307,7 +330,7 @@ public class ActionManagementServiceImplTest {
         sampleAction = activatedAction;
     }
 
-    @Test(priority = 10)
+    @Test(priority = 11)
     public void testGetActionsCountPerType() throws ActionMgtException {
 
         Map<String, Integer> actionMap = actionManagementService.getActionsCountPerType(TENANT_DOMAIN);
@@ -321,7 +344,7 @@ public class ActionManagementServiceImplTest {
         }
     }
 
-    @Test(priority = 11)
+    @Test(priority = 12)
     public void testDeactivateAction() throws ActionMgtException {
 
         Assert.assertEquals(sampleAction.getStatus(), Action.Status.ACTIVE);
@@ -334,7 +357,7 @@ public class ActionManagementServiceImplTest {
         Assert.assertTrue(deactivatedAction.getUpdatedAt().after(sampleAction.getUpdatedAt()));
     }
 
-    @Test(priority = 11)
+    @Test(priority = 13)
     public void testUpdateEndpointConfigWithSameAuthenticationType() throws ActionMgtException,
             SecretManagementException {
 
@@ -355,7 +378,7 @@ public class ActionManagementServiceImplTest {
         Assert.assertTrue(result.getUpdatedAt().after(sampleAction.getUpdatedAt()));
     }
 
-    @Test(priority = 12)
+    @Test(priority = 14)
     public void testUpdateEndpointConfigWithDifferentAuthenticationType()
             throws ActionMgtException, SecretManagementException {
 
@@ -373,7 +396,7 @@ public class ActionManagementServiceImplTest {
         Assert.assertTrue(result.getUpdatedAt().after(sampleAction.getUpdatedAt()));
     }
 
-    @Test(priority = 13)
+    @Test(priority = 15)
     public void testDeleteAction() throws ActionMgtException {
 
         actionManagementService.deleteAction(PRE_ISSUE_ACCESS_TOKEN_PATH, sampleAction.getId(), TENANT_DOMAIN);
@@ -383,7 +406,7 @@ public class ActionManagementServiceImplTest {
         Assert.assertNull(actions.get(PRE_ISSUE_ACCESS_TOKEN_PATH));
     }
 
-    @Test(priority = 14)
+    @Test(priority = 16)
     public void testDeleteNonExistingAction() {
 
         try {
@@ -393,7 +416,7 @@ public class ActionManagementServiceImplTest {
         }
     }
 
-    @Test(priority = 15)
+    @Test(priority = 17)
     public void testAddActionWithRule() throws ActionMgtException, SecretManagementException {
 
         Action creatingAction = TestUtil.buildMockActionWithRule(
@@ -430,7 +453,7 @@ public class ActionManagementServiceImplTest {
         Assert.assertEquals(sampleAction.getActionRule().getRule(), creatingAction.getActionRule().getRule());
     }
 
-    @Test(priority = 16)
+    @Test(priority = 18)
     public void testGetActionsWithRulesByActionType() throws ActionMgtException {
 
         List<Action> actions = actionManagementService.getActionsByActionType(PRE_ISSUE_ACCESS_TOKEN_PATH,
@@ -461,7 +484,7 @@ public class ActionManagementServiceImplTest {
         Assert.assertEquals(result.getActionRule().getRule(), sampleAction.getActionRule().getRule());
     }
 
-    @Test(priority = 17)
+    @Test(priority = 19)
     public void testUpdateActionUpdatingRule() throws ActionMgtException, SecretManagementException {
 
         Action updatingAction = TestUtil.buildMockActionWithRule(

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/service/ActionManagementServiceImplTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/service/ActionManagementServiceImplTest.java
@@ -36,6 +36,8 @@ import org.wso2.carbon.identity.action.management.internal.component.ActionMgtSe
 import org.wso2.carbon.identity.action.management.internal.service.impl.ActionManagementServiceImpl;
 import org.wso2.carbon.identity.action.management.util.TestUtil;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
@@ -50,9 +52,11 @@ import org.wso2.carbon.identity.secret.mgt.core.model.SecretType;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -110,6 +114,11 @@ public class ActionManagementServiceImplTest {
         when(ruleManagementService.getRuleByRuleId(any(), any())).thenReturn(sampleRule);
         when(ruleManagementService.addRule(any(), any())).thenReturn(sampleRule);
         when(ruleManagementService.updateRule(any(), any())).thenReturn(sampleRule);
+
+        ClaimMetadataManagementService claimMetadataManagementService = mock(ClaimMetadataManagementService.class);
+        when(claimMetadataManagementService.getLocalClaim(anyString(), anyString()))
+                .thenReturn(Optional.of(new LocalClaim("mock")));
+        ActionMgtServiceComponentHolder.getInstance().setClaimMetadataManagementService(claimMetadataManagementService);
 
         loggerUtilsMockedStatic = mockStatic(LoggerUtils.class);
         loggerUtilsMockedStatic.when(() -> LoggerUtils.triggerAuditLogEvent(any())).thenAnswer(inv -> null);

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/api/model/PreUpdatePasswordAction.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/api/model/PreUpdatePasswordAction.java
@@ -30,30 +30,22 @@ import java.util.List;
 public class PreUpdatePasswordAction extends Action {
 
     private final PasswordSharing passwordSharing;
-    private final List<String> attributes;
 
     public PreUpdatePasswordAction(ResponseBuilder responseBuilder) {
 
         super(responseBuilder);
         this.passwordSharing = responseBuilder.passwordSharing;
-        this.attributes = responseBuilder.attributes;
     }
 
     public PreUpdatePasswordAction(RequestBuilder requestBuilder) {
 
         super(requestBuilder);
         this.passwordSharing = requestBuilder.passwordSharing;
-        this.attributes = requestBuilder.attributes;
     }
 
     public PasswordSharing getPasswordSharing() {
 
         return passwordSharing;
-    }
-
-    public List<String> getAttributes() {
-
-        return attributes;
     }
 
     /**
@@ -62,7 +54,6 @@ public class PreUpdatePasswordAction extends Action {
     public static class ResponseBuilder extends ActionResponseBuilder {
 
         private PasswordSharing passwordSharing;
-        private List<String> attributes;
 
         @Override
         public ResponseBuilder id(String id) {
@@ -133,9 +124,10 @@ public class PreUpdatePasswordAction extends Action {
             return this;
         }
 
+        @Override
         public ResponseBuilder attributes(List<String> attributes) {
 
-            this.attributes = attributes;
+            super.attributes(attributes);
             return this;
         }
 
@@ -152,7 +144,6 @@ public class PreUpdatePasswordAction extends Action {
     public static class RequestBuilder extends ActionRequestBuilder {
 
         private PasswordSharing passwordSharing;
-        private List<String> attributes;
 
         public RequestBuilder(Action action) {
 
@@ -161,6 +152,7 @@ public class PreUpdatePasswordAction extends Action {
             actionVersion(action.getActionVersion());
             endpoint(action.getEndpoint());
             rule(action.getActionRule());
+            attributes(action.getAttributes());
         }
 
         @Override
@@ -190,9 +182,10 @@ public class PreUpdatePasswordAction extends Action {
             return this;
         }
 
+        @Override
         public RequestBuilder attributes(List<String> attributes) {
 
-            this.attributes = attributes;
+            super.attributes(attributes);
             return this;
         }
 

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/management/PreUpdatePasswordActionConverter.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/management/PreUpdatePasswordActionConverter.java
@@ -27,10 +27,8 @@ import org.wso2.carbon.identity.user.pre.update.password.action.api.model.Passwo
 import org.wso2.carbon.identity.user.pre.update.password.action.api.model.PreUpdatePasswordAction;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import static org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants.ATTRIBUTES;
 import static org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants.CERTIFICATE;
 import static org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants.PASSWORD_SHARING_FORMAT;
 
@@ -57,7 +55,6 @@ public class PreUpdatePasswordActionConverter implements ActionConverter {
 
         PreUpdatePasswordAction preUpdatePasswordAction = (PreUpdatePasswordAction) action;
         PasswordSharing passwordSharing = preUpdatePasswordAction.getPasswordSharing();
-        List<String> attributes = preUpdatePasswordAction.getAttributes();
 
         Map<String, ActionProperty> properties = new HashMap<>();
         if (passwordSharing != null && passwordSharing.getFormat() != null) {
@@ -66,9 +63,6 @@ public class PreUpdatePasswordActionConverter implements ActionConverter {
         }
         if (passwordSharing != null && passwordSharing.getCertificate() != null) {
             properties.put(CERTIFICATE, new ActionProperty.BuilderForService(passwordSharing.getCertificate()).build());
-        }
-        if (attributes != null) {
-            properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(attributes).build());
         }
 
         return new ActionDTO.Builder(preUpdatePasswordAction)
@@ -83,7 +77,6 @@ public class PreUpdatePasswordActionConverter implements ActionConverter {
                 .format((PasswordSharing.Format) actionDTO.getPropertyValue(PASSWORD_SHARING_FORMAT))
                 .certificate((Certificate) actionDTO.getPropertyValue(CERTIFICATE))
                 .build();
-        List<String> attributes = (List<String>) actionDTO.getPropertyValue(ATTRIBUTES);
 
         return new PreUpdatePasswordAction.ResponseBuilder()
                 .id(actionDTO.getId())
@@ -96,7 +89,7 @@ public class PreUpdatePasswordActionConverter implements ActionConverter {
                 .updatedAt(actionDTO.getUpdatedAt())
                 .endpoint(actionDTO.getEndpoint())
                 .passwordSharing(passwordSharing)
-                .attributes(attributes)
+                .attributes(actionDTO.getAttributes())
                 .rule(actionDTO.getActionRule())
                 .build();
     }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/management/PreUpdatePasswordActionDTOModelResolver.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/main/java/org/wso2/carbon/identity/user/pre/update/password/action/internal/management/PreUpdatePasswordActionDTOModelResolver.java
@@ -18,53 +18,33 @@
 
 package org.wso2.carbon.identity.user.pre.update.password.action.internal.management;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverClientException;
 import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverException;
 import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverServerException;
 import org.wso2.carbon.identity.action.management.api.model.Action;
 import org.wso2.carbon.identity.action.management.api.model.ActionDTO;
 import org.wso2.carbon.identity.action.management.api.model.ActionProperty;
-import org.wso2.carbon.identity.action.management.api.model.BinaryObject;
 import org.wso2.carbon.identity.action.management.api.service.ActionDTOModelResolver;
 import org.wso2.carbon.identity.certificate.management.exception.CertificateMgtClientException;
 import org.wso2.carbon.identity.certificate.management.exception.CertificateMgtException;
 import org.wso2.carbon.identity.certificate.management.model.Certificate;
 import org.wso2.carbon.identity.certificate.management.service.CertificateManagementService;
-import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
-import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
-import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.user.pre.update.password.action.api.model.PasswordSharing;
 import org.wso2.carbon.identity.user.pre.update.password.action.internal.component.PreUpdatePasswordActionServiceComponentHolder;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import static org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants.ATTRIBUTES;
 import static org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants.CERTIFICATE;
-import static org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants.MAX_ALLOWED_ATTRIBUTES;
 import static org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants.PASSWORD_SHARING_FORMAT;
-import static org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants.ROLE_CLAIM_URI;
 
 /**
  * This class implements the methods required to resolve ActionDTO objects in Pre Update Password extension.
  */
 public class PreUpdatePasswordActionDTOModelResolver implements ActionDTOModelResolver {
-
-    private static final Log LOG = LogFactory.getLog(PreUpdatePasswordActionDTOModelResolver.class);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Override
     public Action.ActionTypes getSupportedActionType() {
@@ -104,14 +84,6 @@ public class PreUpdatePasswordActionDTOModelResolver implements ActionDTOModelRe
             properties.put(CERTIFICATE, new ActionProperty.BuilderForDAO(certificateId).build());
         }
 
-        Object attributes = actionDTO.getPropertyValue(ATTRIBUTES);
-        // Attributes is an optional field.
-        if (attributes != null) {
-            List<String> validatedAttributes = validateAttributes(attributes, tenantDomain);
-            ActionProperty attributesObject = createActionProperty(validatedAttributes);
-            properties.put(ATTRIBUTES, attributesObject);
-        }
-
         return new ActionDTO.Builder(actionDTO)
                 .properties(properties)
                 .build();
@@ -135,13 +107,6 @@ public class PreUpdatePasswordActionDTOModelResolver implements ActionDTOModelRe
         if (actionDTO.getPropertyValue(CERTIFICATE) != null) {
             Certificate certificate = getCertificate((String) actionDTO.getPropertyValue(CERTIFICATE), tenantDomain);
             properties.put(CERTIFICATE, new ActionProperty.BuilderForService(certificate).build());
-        }
-
-        // Attributes is an optional field.
-        if (actionDTO.getPropertyValue(ATTRIBUTES) != null) {
-
-            properties.put(ATTRIBUTES, getAttributes(((BinaryObject) actionDTO
-                    .getPropertyValue(ATTRIBUTES)).getJSONString()));
         }
 
         return new ActionDTO.Builder(actionDTO)
@@ -181,7 +146,6 @@ public class PreUpdatePasswordActionDTOModelResolver implements ActionDTOModelRe
         // updated, the existing properties should be sent to the DAO layer.
         resolveCertificateUpdate(updatingActionDTO, existingActionDTO, properties, tenantDomain);
         resolvePasswordSharingFormatUpdate(updatingActionDTO, existingActionDTO, properties);
-        resolveAttributesUpdate(updatingActionDTO, existingActionDTO, properties, tenantDomain);
 
         return new ActionDTO.Builder(updatingActionDTO)
                 .properties(properties)
@@ -206,24 +170,6 @@ public class PreUpdatePasswordActionDTOModelResolver implements ActionDTOModelRe
                 .build();
     }
 
-    private void resolveAttributesUpdate(ActionDTO updatingActionDTO, ActionDTO existingActionDTO,
-                                         Map<String, ActionProperty> properties, String tenantDomain)
-            throws ActionDTOModelResolverException {
-
-        Object newAttributes = updatingActionDTO.getPropertyValue(ATTRIBUTES);
-        Object existingAttributes = existingActionDTO.getPropertyValue(ATTRIBUTES);
-
-        List<String> updatingAttributes = new ArrayList<>();
-        if (newAttributes != null) {
-            updatingAttributes = validateAttributes(newAttributes, tenantDomain);
-        } else if (existingAttributes != null) {
-            updatingAttributes = (List<String>) existingAttributes;
-        }
-
-        if (!updatingAttributes.isEmpty()) {
-            properties.put(ATTRIBUTES, createActionProperty(updatingAttributes));
-        }
-    }
 
     private void resolvePasswordSharingFormatUpdate(ActionDTO updatingActionDTO, ActionDTO existingActionDTO,
                                                     Map<String, ActionProperty> properties) {
@@ -330,102 +276,5 @@ public class PreUpdatePasswordActionDTOModelResolver implements ActionDTOModelRe
     private CertificateManagementService getCertificateManagementService() {
 
         return PreUpdatePasswordActionServiceComponentHolder.getInstance().getCertificateManagementService();
-    }
-
-    private ActionProperty createActionProperty(List<String> attributes) throws ActionDTOModelResolverException {
-
-        try {
-            // Convert the attributes to a JSON string.
-            BinaryObject attributesBinaryObject =
-                    BinaryObject.fromJsonString(OBJECT_MAPPER.writeValueAsString(attributes));
-            return new ActionProperty.BuilderForDAO(attributesBinaryObject).build();
-        } catch (JsonProcessingException e) {
-            throw new ActionDTOModelResolverException("Failed to convert object values to JSON string.", e);
-        }
-    }
-
-    private ActionProperty getAttributes(String value) throws ActionDTOModelResolverException {
-
-        try {
-            return new ActionProperty.BuilderForService(OBJECT_MAPPER.readValue(value,
-                    new TypeReference<List<String>>() { })).build();
-        } catch (IOException e) {
-            throw new ActionDTOModelResolverException("Error while reading the attribute values from storage.", e);
-        }
-    }
-
-    private List<String> validateAttributes(Object attributes, String tenantDomain)
-            throws ActionDTOModelResolverException {
-
-        List<String> validatedAttributes = getAttributesList(attributes);
-        validateAttributesCount(validatedAttributes);
-        validatedAttributes = filterValidSystemAttributes(validatedAttributes, tenantDomain);
-        return validatedAttributes;
-    }
-
-    private List<String> getAttributesList(Object attributes) throws ActionDTOModelResolverClientException {
-
-        if (!(attributes instanceof List<?>)) {
-            throw new ActionDTOModelResolverClientException("Invalid attributes format.",
-                    "Attributes should be provided as a list of strings.");
-        }
-
-        List<?> attributesList = (List<?>) attributes;
-        for (Object item : attributesList) {
-            if (!(item instanceof String)) {
-                throw new ActionDTOModelResolverClientException("Invalid attributes format.",
-                        "Attributes must contain only string values.");
-            }
-        }
-
-        return (List<String>) attributes;
-    }
-
-    private void validateAttributesCount(List<String> attributes) throws ActionDTOModelResolverClientException {
-
-        if (attributes.size() > MAX_ALLOWED_ATTRIBUTES) {
-            throw new ActionDTOModelResolverClientException("Maximum attributes limit exceeded.",
-                    String.format("The number of configured attributes: %d exceeds the maximum allowed limit: %d",
-                            attributes.size(), MAX_ALLOWED_ATTRIBUTES));
-        }
-    }
-
-    private List<String> filterValidSystemAttributes(List<String> attributes, String tenantDomain)
-            throws ActionDTOModelResolverClientException, ActionDTOModelResolverServerException {
-
-        try {
-            ClaimMetadataManagementService claimMetadataManagementService =
-                    PreUpdatePasswordActionServiceComponentHolder.getInstance().getClaimManagementService();
-            List<LocalClaim> localClaims = claimMetadataManagementService.getLocalClaims(tenantDomain);
-            Set<String> localClaimURIs = localClaims.stream()
-                    .map(LocalClaim::getClaimURI)
-                    .collect(Collectors.toSet());
-            Set<String> uniqueAttributes = new HashSet<>();
-            Set<String> duplicatedAttributes = new HashSet<>();
-            for (String attribute : attributes) {
-                if (!localClaimURIs.contains(attribute)) {
-                    String invalidAttributeDescription = String.format("The provided %s attribute is not available " +
-                            "in the system.", attribute);
-                    throw new ActionDTOModelResolverClientException("Invalid attribute provided.",
-                            invalidAttributeDescription);
-                }
-                if (attribute.equals(ROLE_CLAIM_URI)) {
-                    throw new ActionDTOModelResolverClientException("Not supported.", String.format("%s attribute is " +
-                            "not supported to be shared with extension.", ROLE_CLAIM_URI)
-                    );
-                }
-                if (!uniqueAttributes.add(attribute)) {
-                    duplicatedAttributes.add(attribute);
-                }
-            }
-            if (LOG.isDebugEnabled() && !duplicatedAttributes.isEmpty()) {
-                LOG.debug("Ignored duplicated attributes in pre update password action configuration: " +
-                        String.join(", ", duplicatedAttributes));
-            }
-            return Collections.unmodifiableList(new ArrayList<>(uniqueAttributes));
-        } catch (ClaimMetadataException e) {
-            throw new ActionDTOModelResolverServerException("Error while retrieving local claims from claim meta " +
-                    "data service.", e.getMessage());
-        }
     }
 }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/management/PreUpdatePasswordActionConverterTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/management/PreUpdatePasswordActionConverterTest.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants.ATTRIBUTES;
 import static org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants.CERTIFICATE;
 import static org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants.PASSWORD_SHARING_FORMAT;
 import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.TEST_ACTION;
@@ -114,12 +113,14 @@ public class PreUpdatePasswordActionConverterTest {
         assertEquals(dto.getEndpoint().getAuthentication().getProperty(Authentication.Property.PASSWORD),
                 action.getEndpoint().getAuthentication().getProperty(Authentication.Property.PASSWORD));
 
-        // Verify properties map
+        // Verify properties map.
         Map<String, ActionProperty> properties = dto.getProperties();
         assertNotNull(properties);
         assertEquals(properties.get(PASSWORD_SHARING_FORMAT).getValue(), action.getPasswordSharing().getFormat());
         assertEquals(properties.get(CERTIFICATE).getValue(), mockCertificate);
-        assertEquals(properties.get(ATTRIBUTES).getValue(), action.getAttributes());
+
+        // Verify attributes (now a first-class field on ActionDTO, not in properties).
+        assertEquals(dto.getAttributes(), action.getAttributes());
     }
 
     @Test
@@ -129,8 +130,8 @@ public class PreUpdatePasswordActionConverterTest {
         properties.put(PASSWORD_SHARING_FORMAT,
                 new ActionProperty.BuilderForService(PasswordSharing.Format.SHA256_HASHED).build());
         properties.put(CERTIFICATE, new ActionProperty.BuilderForService(mockCertificate).build());
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(TEST_ATTRIBUTES).build());
         ActionDTO dto = new ActionDTO.Builder(action)
+                .attributes(TEST_ATTRIBUTES)
                 .properties(properties)
                 .build();
 
@@ -179,8 +180,10 @@ public class PreUpdatePasswordActionConverterTest {
         properties.put(CERTIFICATE, new ActionProperty.BuilderForService(mockCertificate).build());
         properties.put(PASSWORD_SHARING_FORMAT,
                 new ActionProperty.BuilderForService(PasswordSharing.Format.SHA256_HASHED).build());
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(TEST_ATTRIBUTES).build());
-        dto = new ActionDTO.Builder(dummyAction).properties(properties).build();
+        dto = new ActionDTO.Builder(dummyAction)
+                .attributes(TEST_ATTRIBUTES)
+                .properties(properties)
+                .build();
         convertedAction = (PreUpdatePasswordAction) converter.buildAction(dto);
         assertNotNull(convertedAction.getPasswordSharing());
         assertEquals(convertedAction.getPasswordSharing().getFormat(), PasswordSharing.Format.SHA256_HASHED);
@@ -224,7 +227,7 @@ public class PreUpdatePasswordActionConverterTest {
                 .build();
         dto = converter.buildActionDTO(passwordAction);
         assertNotNull(dto.getProperties());
-        assertEquals(dto.getProperties().size(), 1);
-        assertEquals(dto.getProperties().get(ATTRIBUTES).getValue(), TEST_ATTRIBUTES);
+        assertEquals(dto.getProperties().size(), 0);
+        assertEquals(dto.getAttributes(), TEST_ATTRIBUTES);
     }
 }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/management/PreUpdatePasswordActionDTOModelResolverTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.password.action/src/test/java/org/wso2/carbon/identity/user/pre/update/password/action/management/PreUpdatePasswordActionDTOModelResolverTest.java
@@ -18,16 +18,11 @@
 
 package org.wso2.carbon.identity.user.pre.update.password.action.management;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang.StringUtils;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverClientException;
 import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverServerException;
@@ -35,26 +30,17 @@ import org.wso2.carbon.identity.action.management.api.model.Action;
 import org.wso2.carbon.identity.action.management.api.model.ActionDTO;
 import org.wso2.carbon.identity.action.management.api.model.ActionProperty;
 import org.wso2.carbon.identity.action.management.api.model.Authentication;
-import org.wso2.carbon.identity.action.management.api.model.BinaryObject;
 import org.wso2.carbon.identity.action.management.api.model.EndpointConfig;
 import org.wso2.carbon.identity.certificate.management.exception.CertificateMgtClientException;
 import org.wso2.carbon.identity.certificate.management.exception.CertificateMgtException;
 import org.wso2.carbon.identity.certificate.management.exception.CertificateMgtServerException;
 import org.wso2.carbon.identity.certificate.management.model.Certificate;
 import org.wso2.carbon.identity.certificate.management.service.CertificateManagementService;
-import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
-import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
-import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.user.pre.update.password.action.api.model.PasswordSharing;
 import org.wso2.carbon.identity.user.pre.update.password.action.internal.component.PreUpdatePasswordActionServiceComponentHolder;
 import org.wso2.carbon.identity.user.pre.update.password.action.internal.management.PreUpdatePasswordActionDTOModelResolver;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -73,35 +59,19 @@ import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-import static org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants.ATTRIBUTES;
 import static org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants.CERTIFICATE;
 import static org.wso2.carbon.identity.user.pre.update.password.action.internal.constant.PreUpdatePasswordActionConstants.PASSWORD_SHARING_FORMAT;
-import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.DUPLICATED_TEST_ATTRIBUTES;
-import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.INVALID_TEST_ATTRIBUTES;
-import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.INVALID_TEST_ATTRIBUTES_COUNT;
-import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.INVALID_TEST_ATTRIBUTES_TYPE;
-import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.INVALID_TEST_ATTRIBUTES_VALUES;
-import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.ROLES_CLAIM_ATTRIBUTE;
-import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.ROLE_CLAIM_URI;
-import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.SAMPLE_LOCAL_CLAIM_URI_1;
-import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.SAMPLE_LOCAL_CLAIM_URI_2;
-import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.SAMPLE_LOCAL_CLAIM_URI_3;
-import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.SAMPLE_LOCAL_CLAIM_URI_4;
 import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.TENANT_DOMAIN;
 import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.TEST_ACTION;
-import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.TEST_ATTRIBUTES;
 import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.TEST_CERTIFICATE;
 import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.TEST_CERTIFICATE_ID;
 import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.TEST_CERTIFICATE_NAME;
 import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.TEST_DESCRIPTION;
-import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.TEST_EMPTY_ATTRIBUTES;
 import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.TEST_ID;
 import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.TEST_PASSWORD;
 import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.TEST_UPDATED_CERTIFICATE;
 import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.TEST_URL;
 import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.TEST_USERNAME;
-import static org.wso2.carbon.identity.user.pre.update.password.action.util.TestUtil.UPDATED_TEST_ATTRIBUTES;
 
 public class PreUpdatePasswordActionDTOModelResolverTest {
 
@@ -110,18 +80,6 @@ public class PreUpdatePasswordActionDTOModelResolverTest {
     private ActionDTO existingActionDTO;
     @Mock
     private CertificateManagementService certificateManagementService;
-    @Mock
-    private ClaimMetadataManagementService claimMetadataManagementService;
-    @Mock
-    private LocalClaim localClaim1;
-    @Mock
-    private LocalClaim localClaim2;
-    @Mock
-    private LocalClaim localClaim3;
-    @Mock
-    private LocalClaim localClaim4;
-    @Mock
-    private LocalClaim rolesClaim;
 
     @BeforeClass
     public void init() {
@@ -145,27 +103,16 @@ public class PreUpdatePasswordActionDTOModelResolverTest {
         properties.put(CERTIFICATE, new ActionProperty.BuilderForService(new Certificate.Builder()
                 .id(TEST_CERTIFICATE_ID).name(TEST_CERTIFICATE_NAME).certificateContent(TEST_CERTIFICATE).build())
                 .build());
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(TEST_ATTRIBUTES).build());
         existingActionDTO = new ActionDTO.Builder(action).properties(properties).build();
     }
 
     @BeforeMethod
-    public void setUp() throws ClaimMetadataException {
+    public void setUp() {
 
         MockitoAnnotations.openMocks(this);
         resolver = new PreUpdatePasswordActionDTOModelResolver();
         PreUpdatePasswordActionServiceComponentHolder.getInstance()
                 .setCertificateManagementService(certificateManagementService);
-        PreUpdatePasswordActionServiceComponentHolder.getInstance()
-                .setClaimManagementService(claimMetadataManagementService);
-        List<LocalClaim> mockLocalClaims = Arrays.asList(localClaim1, localClaim2, localClaim3, localClaim4,
-                rolesClaim);
-        doReturn(SAMPLE_LOCAL_CLAIM_URI_1).when(localClaim1).getClaimURI();
-        doReturn(SAMPLE_LOCAL_CLAIM_URI_2).when(localClaim2).getClaimURI();
-        doReturn(SAMPLE_LOCAL_CLAIM_URI_3).when(localClaim3).getClaimURI();
-        doReturn(SAMPLE_LOCAL_CLAIM_URI_4).when(localClaim4).getClaimURI();
-        doReturn(ROLE_CLAIM_URI).when(rolesClaim).getClaimURI();
-        doReturn(mockLocalClaims).when(claimMetadataManagementService).getLocalClaims(anyString());
     }
 
     @Test
@@ -183,7 +130,6 @@ public class PreUpdatePasswordActionDTOModelResolverTest {
                 new ActionProperty.BuilderForService(PasswordSharing.Format.SHA256_HASHED).build());
         properties.put(CERTIFICATE, new ActionProperty.BuilderForService(new
                 Certificate.Builder().certificateContent(TEST_CERTIFICATE).build()).build());
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(TEST_ATTRIBUTES).build());
         ActionDTO actionDTO = new ActionDTO.Builder(action)
                 .properties(properties)
                 .build();
@@ -197,11 +143,6 @@ public class PreUpdatePasswordActionDTOModelResolverTest {
         assertEquals(result.getPropertyValue(PASSWORD_SHARING_FORMAT),
                 PasswordSharing.Format.SHA256_HASHED.name());
         verify(certificateManagementService, times(1)).addCertificate(any(), anyString());
-
-        assertTrue(result.getPropertyValue(ATTRIBUTES) instanceof BinaryObject);
-        assertNotNull(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getJSONString());
-        assertEquals(getAttributesFromActionDTO(result), TEST_ATTRIBUTES);
-        verify(claimMetadataManagementService, times(1)).getLocalClaims(TENANT_DOMAIN);
     }
 
     @Test
@@ -219,10 +160,8 @@ public class PreUpdatePasswordActionDTOModelResolverTest {
         assertNotNull(result);
         verifyCommonFields(actionDTO, result);
         assertNull(result.getPropertyValue(CERTIFICATE));
-        assertNull(result.getPropertyValue(ATTRIBUTES));
         assertEquals(result.getPropertyValue(PASSWORD_SHARING_FORMAT), PasswordSharing.Format.SHA256_HASHED.name());
         verify(certificateManagementService, never()).addCertificate(any(), anyString());
-        verify(claimMetadataManagementService, never()).getLocalClaims(TENANT_DOMAIN);
     }
 
     @Test(expectedExceptions = ActionDTOModelResolverClientException.class,
@@ -297,56 +236,6 @@ public class PreUpdatePasswordActionDTOModelResolverTest {
         resolver.resolveForAddOperation(actionDTO, TENANT_DOMAIN);
     }
 
-    @DataProvider
-    public Object[][] invalidAttributesDataProvider() {
-
-        return new Object[][]{
-                {INVALID_TEST_ATTRIBUTES_TYPE, "Invalid attributes format."},
-                {INVALID_TEST_ATTRIBUTES_VALUES, "Invalid attributes format."},
-                {INVALID_TEST_ATTRIBUTES_COUNT, "Maximum attributes limit exceeded."},
-                {INVALID_TEST_ATTRIBUTES, "Invalid attribute provided."},
-                {ROLES_CLAIM_ATTRIBUTE, "Not supported."}
-        };
-    }
-
-    @Test(dataProvider = "invalidAttributesDataProvider")
-    public void testResolveForAddOperationWithInvalidAttributes(Object attributes, String expectedError)
-            throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(PASSWORD_SHARING_FORMAT,
-                new ActionProperty.BuilderForService(PasswordSharing.Format.SHA256_HASHED).build());
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(attributes).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        try {
-            resolver.resolveForAddOperation(actionDTO, TENANT_DOMAIN);
-            // If no exception is thrown, the test should fail.
-            Assert.fail();
-        } catch (ActionDTOModelResolverClientException e) {
-            assertEquals(e.getMessage(), expectedError);
-        }
-    }
-
-    @Test
-    public void testResolveForAddOperationWithDuplicatedAttributes() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(PASSWORD_SHARING_FORMAT,
-                new ActionProperty.BuilderForService(PasswordSharing.Format.SHA256_HASHED).build());
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(DUPLICATED_TEST_ATTRIBUTES).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        ActionDTO result = resolver.resolveForAddOperation(actionDTO, TENANT_DOMAIN);
-
-        assertNotNull(result);
-        verifyCommonFields(actionDTO, result);
-        assertTrue(result.getPropertyValue(ATTRIBUTES) instanceof BinaryObject);
-        assertNotNull(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getInputStream());
-        assertEquals(getAttributesFromActionDTO(result), Collections.singletonList(DUPLICATED_TEST_ATTRIBUTES.get(0)));
-    }
 
     @Test
     public void testResolveForGetOperation() throws Exception {
@@ -355,7 +244,6 @@ public class PreUpdatePasswordActionDTOModelResolverTest {
         properties.put(PASSWORD_SHARING_FORMAT,
                 new ActionProperty.BuilderForDAO(PasswordSharing.Format.SHA256_HASHED.name()).build());
         properties.put(CERTIFICATE, new ActionProperty.BuilderForDAO(TEST_CERTIFICATE_ID).build());
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForDAO(getBinaryObject(TEST_ATTRIBUTES)).build());
         ActionDTO actionDTO = new ActionDTO.Builder(action)
                 .properties(properties)
                 .build();
@@ -376,7 +264,6 @@ public class PreUpdatePasswordActionDTOModelResolverTest {
         assertEquals(resultCert.getCertificateContent(), TEST_CERTIFICATE);
         assertEquals(result.getPropertyValue(PASSWORD_SHARING_FORMAT), PasswordSharing.Format.SHA256_HASHED);
         verify(certificateManagementService, times(1)).getCertificate(anyString(), anyString());
-        assertEquals(result.getPropertyValue(ATTRIBUTES), TEST_ATTRIBUTES);
     }
 
     @Test
@@ -430,7 +317,6 @@ public class PreUpdatePasswordActionDTOModelResolverTest {
         properties.put(PASSWORD_SHARING_FORMAT,
                 new ActionProperty.BuilderForDAO(PasswordSharing.Format.SHA256_HASHED.name()).build());
         properties.put(CERTIFICATE, new ActionProperty.BuilderForDAO(TEST_CERTIFICATE_ID).build());
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForDAO(getBinaryObject(TEST_ATTRIBUTES)).build());
         ActionDTO actionDTO = new ActionDTO.Builder(action)
                 .properties(properties)
                 .build();
@@ -451,7 +337,6 @@ public class PreUpdatePasswordActionDTOModelResolverTest {
             assertEquals(resultCert.getName(), TEST_CERTIFICATE_NAME);
             assertEquals(resultCert.getCertificateContent(), TEST_CERTIFICATE);
             assertEquals(dto.getPropertyValue(PASSWORD_SHARING_FORMAT), PasswordSharing.Format.SHA256_HASHED);
-            assertEquals(dto.getPropertyValue(ATTRIBUTES), TEST_ATTRIBUTES);
         }
         verify(certificateManagementService, times(1)).getCertificate(anyString(), anyString());
     }
@@ -464,7 +349,6 @@ public class PreUpdatePasswordActionDTOModelResolverTest {
                 new ActionProperty.BuilderForService(PasswordSharing.Format.PLAIN_TEXT).build());
         properties.put(CERTIFICATE, new ActionProperty.BuilderForService(new Certificate.Builder().certificateContent(
                 TEST_UPDATED_CERTIFICATE).build()).build());
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(UPDATED_TEST_ATTRIBUTES).build());
         ActionDTO updatingActionDTO = new ActionDTO.Builder(action)
                 .properties(properties)
                 .build();
@@ -477,8 +361,6 @@ public class PreUpdatePasswordActionDTOModelResolverTest {
         assertEquals(result.getPropertyValue(PASSWORD_SHARING_FORMAT), PasswordSharing.Format.PLAIN_TEXT.name());
         verify(certificateManagementService, times(1))
                 .updateCertificateContent(anyString(), anyString(), anyString());
-        assertEquals(getAttributesFromActionDTO(result), UPDATED_TEST_ATTRIBUTES);
-        verify(claimMetadataManagementService, times(1)).getLocalClaims(TENANT_DOMAIN);
     }
 
     @Test
@@ -584,58 +466,6 @@ public class PreUpdatePasswordActionDTOModelResolverTest {
         resolver.resolveForUpdateOperation(actionDTO, existingActionDTO, TENANT_DOMAIN);
     }
 
-    @Test
-    public void testResolveForUpdateOperationToDeleteAttributes() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(TEST_EMPTY_ATTRIBUTES).build());
-        ActionDTO updatingActionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        ActionDTO result = resolver.resolveForUpdateOperation(updatingActionDTO, existingActionDTO, TENANT_DOMAIN);
-
-        assertNotNull(result);
-        verifyCommonFields(updatingActionDTO, result);
-        assertEquals(result.getProperties().size(), 2);
-        assertNull(result.getPropertyValue(ATTRIBUTES));
-    }
-
-    @Test
-    public void testResolveForUpdateOperationWithUpdatingNullAttributes() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(null).build());
-        ActionDTO updatingActionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        ActionDTO result = resolver.resolveForUpdateOperation(updatingActionDTO, existingActionDTO, TENANT_DOMAIN);
-
-        assertNotNull(result);
-        verifyCommonFields(updatingActionDTO, result);
-        // Since no attributes are updated, the existing attributes in ActionDTO should be verified.
-        assertEquals(result.getProperties().size(), existingActionDTO.getProperties().size());
-        assertTrue(result.getPropertyValue(ATTRIBUTES) instanceof BinaryObject);
-        assertNotNull(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getJSONString());
-        assertEquals(getAttributesFromActionDTO(result), existingActionDTO.getPropertyValue(ATTRIBUTES));
-    }
-
-    @Test(dataProvider = "invalidAttributesDataProvider")
-    public void testResolveForUpdateOperationWithInvalidAttributes(Object attributes, String expectedError)
-            throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(attributes).build());
-        ActionDTO updatingActionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        try {
-            resolver.resolveForUpdateOperation(updatingActionDTO, existingActionDTO, TENANT_DOMAIN);
-            // If no exception is thrown, the test should fail.
-            Assert.fail();
-        } catch (ActionDTOModelResolverClientException e) {
-            assertEquals(e.getMessage(), expectedError);
-        }
-    }
 
     @Test
     public void testResolveForDeleteOperation() throws Exception {
@@ -670,29 +500,5 @@ public class PreUpdatePasswordActionDTOModelResolverTest {
                 actionDTO.getEndpoint().getAuthentication().getProperty(Authentication.Property.USERNAME));
         assertEquals(result.getEndpoint().getAuthentication().getProperty(Authentication.Property.PASSWORD),
                 actionDTO.getEndpoint().getAuthentication().getProperty(Authentication.Property.PASSWORD));
-    }
-
-    private List<String> getAttributesFromActionDTO(ActionDTO actionDTO) throws IOException {
-
-        String jsonString = ((BinaryObject) actionDTO.getPropertyValue(ATTRIBUTES)).getJSONString();
-        ObjectMapper objectMapper = new ObjectMapper();
-        return objectMapper.readValue(jsonString, new TypeReference<List<String>>() { });
-    }
-
-    private BinaryObject getBinaryObject(List<String> attributes) throws Exception {
-
-        return BinaryObject.fromInputStream(getInputStream(attributes));
-    }
-
-    private InputStream getInputStream(List<String> attributes) throws Exception {
-
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            // Convert the attributes to a JSON array and generate the input stream.
-            return new ByteArrayInputStream(objectMapper.writeValueAsString(attributes)
-                    .getBytes(StandardCharsets.UTF_8));
-        } catch (JsonProcessingException e) {
-            throw new Exception("Error occurred while converting attributes to input stream.", e);
-        }
     }
 }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/main/java/org/wso2/carbon/identity/user/pre/update/profile/action/api/model/PreUpdateProfileAction.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/main/java/org/wso2/carbon/identity/user/pre/update/profile/action/api/model/PreUpdateProfileAction.java
@@ -29,23 +29,14 @@ import java.util.List;
  */
 public class PreUpdateProfileAction extends Action {
 
-    private final List<String> attributes;
-
     public PreUpdateProfileAction(ResponseBuilder responseBuilder) {
 
         super(responseBuilder);
-        this.attributes = responseBuilder.attributes;
     }
 
     public PreUpdateProfileAction(RequestBuilder requestBuilder) {
 
         super(requestBuilder);
-        this.attributes = requestBuilder.attributes;
-    }
-
-    public List<String> getAttributes() {
-
-        return attributes;
     }
 
     /**
@@ -53,7 +44,6 @@ public class PreUpdateProfileAction extends Action {
      */
     public static class ResponseBuilder extends ActionResponseBuilder {
 
-        private List<String> attributes;
 
         @Override
         public ResponseBuilder id(String id) {
@@ -118,9 +108,10 @@ public class PreUpdateProfileAction extends Action {
             return this;
         }
 
+        @Override
         public ResponseBuilder attributes(List<String> attributes) {
 
-            this.attributes = attributes;
+            super.attributes(attributes);
             return this;
         }
 
@@ -132,11 +123,9 @@ public class PreUpdateProfileAction extends Action {
     }
 
     /**
-     * Request Builder for PreUpdatePasswordAction.
+     * Request Builder for PreUpdateProfileAction.
      */
     public static class RequestBuilder extends ActionRequestBuilder {
-
-        private List<String> attributes;
 
         public RequestBuilder(Action action) {
 
@@ -145,6 +134,7 @@ public class PreUpdateProfileAction extends Action {
             actionVersion(action.getActionVersion());
             endpoint(action.getEndpoint());
             rule(action.getActionRule());
+            attributes(action.getAttributes());
         }
 
         @Override
@@ -168,9 +158,10 @@ public class PreUpdateProfileAction extends Action {
             return this;
         }
 
+        @Override
         public RequestBuilder attributes(List<String> attributes) {
 
-            this.attributes = attributes;
+            super.attributes(attributes);
             return this;
         }
 

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/main/java/org/wso2/carbon/identity/user/pre/update/profile/action/internal/management/PreUpdateProfileActionConverter.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/main/java/org/wso2/carbon/identity/user/pre/update/profile/action/internal/management/PreUpdateProfileActionConverter.java
@@ -20,15 +20,8 @@ package org.wso2.carbon.identity.user.pre.update.profile.action.internal.managem
 
 import org.wso2.carbon.identity.action.management.api.model.Action;
 import org.wso2.carbon.identity.action.management.api.model.ActionDTO;
-import org.wso2.carbon.identity.action.management.api.model.ActionProperty;
 import org.wso2.carbon.identity.action.management.api.service.ActionConverter;
 import org.wso2.carbon.identity.user.pre.update.profile.action.api.model.PreUpdateProfileAction;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.wso2.carbon.identity.user.pre.update.profile.action.internal.constant.PreUpdateProfileActionConstants.ATTRIBUTES;
 
 /**
  * This class implements the methods required to build Action objects in Pre Update Profile extension.
@@ -50,23 +43,11 @@ public class PreUpdateProfileActionConverter implements ActionConverter {
     @Override
     public ActionDTO buildActionDTO(Action action) {
 
-        PreUpdateProfileAction preUpdateProfileAction = (PreUpdateProfileAction) action;
-        List<String> attributes = preUpdateProfileAction.getAttributes();
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        if (attributes != null) {
-            properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(attributes).build());
-        }
-
-        return new ActionDTO.Builder(preUpdateProfileAction)
-                .properties(properties)
-                .build();
+        return new ActionDTO.Builder(action).build();
     }
 
     @Override
     public Action buildAction(ActionDTO actionDTO) {
-
-        List<String> attributes = (List<String>) actionDTO.getPropertyValue(ATTRIBUTES);
 
         return new PreUpdateProfileAction.ResponseBuilder()
                 .id(actionDTO.getId())
@@ -78,7 +59,7 @@ public class PreUpdateProfileActionConverter implements ActionConverter {
                 .createdAt(actionDTO.getCreatedAt())
                 .updatedAt(actionDTO.getUpdatedAt())
                 .endpoint(actionDTO.getEndpoint())
-                .attributes(attributes)
+                .attributes(actionDTO.getAttributes())
                 .rule(actionDTO.getActionRule())
                 .build();
     }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/main/java/org/wso2/carbon/identity/user/pre/update/profile/action/internal/management/PreUpdateProfileActionDTOModelResolver.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/main/java/org/wso2/carbon/identity/user/pre/update/profile/action/internal/management/PreUpdateProfileActionDTOModelResolver.java
@@ -18,45 +18,18 @@
 
 package org.wso2.carbon.identity.user.pre.update.profile.action.internal.management;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverClientException;
 import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverException;
-import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverServerException;
 import org.wso2.carbon.identity.action.management.api.model.Action;
 import org.wso2.carbon.identity.action.management.api.model.ActionDTO;
-import org.wso2.carbon.identity.action.management.api.model.ActionProperty;
-import org.wso2.carbon.identity.action.management.api.model.BinaryObject;
 import org.wso2.carbon.identity.action.management.api.service.ActionDTOModelResolver;
-import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
-import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
-import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
-import org.wso2.carbon.identity.user.pre.update.profile.action.internal.component.PreUpdateProfileActionServiceComponentHolder;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static java.util.Collections.emptyList;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.internal.constant.PreUpdateProfileActionConstants.ATTRIBUTES;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.internal.constant.PreUpdateProfileActionConstants.MAX_ATTRIBUTES;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.internal.constant.PreUpdateProfileActionConstants.ROLE_CLAIM_URI;
 
 /**
  * This class implements the methods required to resolve ActionDTO objects in Pre Update Profile extension.
  */
 public class PreUpdateProfileActionDTOModelResolver implements ActionDTOModelResolver {
-
-    private static final Log LOG = LogFactory.getLog(PreUpdateProfileActionDTOModelResolver.class);
 
     @Override
     public Action.ActionTypes getSupportedActionType() {
@@ -68,35 +41,14 @@ public class PreUpdateProfileActionDTOModelResolver implements ActionDTOModelRes
     public ActionDTO resolveForAddOperation(ActionDTO actionDTO, String tenantDomain)
             throws ActionDTOModelResolverException {
 
-        Map<String, ActionProperty> properties = new HashMap<>();
-        Object attributes = actionDTO.getPropertyValue(ATTRIBUTES);
-        // Attributes is an optional field.
-        if (attributes != null) {
-            List<String> validatedAttributes = validateAttributes(attributes, tenantDomain);
-            ActionProperty attributesObject = createActionProperty(validatedAttributes);
-            properties.put(ATTRIBUTES, attributesObject);
-        }
-
-        return new ActionDTO.Builder(actionDTO)
-                .properties(properties)
-                .build();
+        return actionDTO;
     }
 
     @Override
     public ActionDTO resolveForGetOperation(ActionDTO actionDTO, String tenantDomain)
             throws ActionDTOModelResolverException {
 
-        Map<String, ActionProperty> properties = new HashMap<>();
-        // Attributes is an optional field.
-        if (actionDTO.getPropertyValue(ATTRIBUTES) != null) {
-
-            properties.put(ATTRIBUTES, getAttributes(((BinaryObject) actionDTO
-                    .getPropertyValue(ATTRIBUTES)).getJSONString()));
-        }
-
-        return new ActionDTO.Builder(actionDTO)
-                .properties(properties)
-                .build();
+        return actionDTO;
     }
 
     @Override
@@ -113,8 +65,6 @@ public class PreUpdateProfileActionDTOModelResolver implements ActionDTOModelRes
 
     /**
      * Resolves the actionDTO for the update operation.
-     * When properties are updated, the existing properties are replaced with the new properties.
-     * When properties are not updated, the existing properties should be sent to the upstream component.
      *
      * @param updatingActionDTO ActionDTO that needs to be updated.
      * @param existingActionDTO Existing ActionDTO.
@@ -126,136 +76,12 @@ public class PreUpdateProfileActionDTOModelResolver implements ActionDTOModelRes
     public ActionDTO resolveForUpdateOperation(ActionDTO updatingActionDTO, ActionDTO existingActionDTO,
                                                String tenantDomain) throws ActionDTOModelResolverException {
 
-        Map<String, ActionProperty> properties = new HashMap<>();
-        // Action Properties updating operation is treated as a PUT in DAO layer. Therefore if no properties are updated
-        // the existing properties should be sent to the DAO layer.
-        List<String> attributes = getResolvedUpdatingAttributes(updatingActionDTO, existingActionDTO,
-                tenantDomain);
-        if (!attributes.isEmpty()) {
-            properties.put(ATTRIBUTES, createActionProperty(attributes));
-        }
-        return new ActionDTO.Builder(updatingActionDTO)
-                .properties(properties)
-                .build();
+        return updatingActionDTO;
     }
 
     @Override
     public void resolveForDeleteOperation(ActionDTO deletingActionDTO, String tenantDomain)
             throws ActionDTOModelResolverException {
 
-    }
-
-    private List<String> getResolvedUpdatingAttributes(ActionDTO updatingActionDTO,
-                                                       ActionDTO existingActionDTO, String tenantDomain)
-            throws ActionDTOModelResolverException {
-
-        if (updatingActionDTO.getPropertyValue(ATTRIBUTES) != null) {
-            // return updating attributes after validation
-            return validateAttributes(updatingActionDTO.getPropertyValue(ATTRIBUTES), tenantDomain);
-        } else if (existingActionDTO.getPropertyValue(ATTRIBUTES) != null) {
-            // return existing attributes
-            return (List<String>) existingActionDTO.getPropertyValue(ATTRIBUTES);
-        }
-        // if attributes are not getting updated or not configured earlier, return empty list.
-        return emptyList();
-    }
-
-    private ActionProperty createActionProperty(List<String> attributes) throws ActionDTOModelResolverException {
-
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            // Convert the attributes to a JSON string.
-            BinaryObject attributesBinaryObject = BinaryObject.fromJsonString(objectMapper
-                    .writeValueAsString(attributes));
-            return new ActionProperty.BuilderForDAO(attributesBinaryObject).build();
-        } catch (JsonProcessingException e) {
-            throw new ActionDTOModelResolverException("Failed to convert object values to JSON string.", e);
-        }
-    }
-
-    private ActionProperty getAttributes(String value) throws ActionDTOModelResolverException {
-
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return new ActionProperty.BuilderForService(objectMapper.readValue(value,
-                    new TypeReference<List<String>>() { })).build();
-        } catch (IOException e) {
-            throw new ActionDTOModelResolverException("Error while reading the attribute values from storage.", e);
-        }
-    }
-
-    private List<String> validateAttributes(Object attributes, String tenantDomain)
-            throws ActionDTOModelResolverException {
-
-        List<String> validatedAttributes = getAttributesList(attributes);
-        validateAttributesCount(validatedAttributes);
-        validatedAttributes = filterValidSystemAttributes(validatedAttributes, tenantDomain);
-        return validatedAttributes;
-    }
-
-    private List<String> getAttributesList(Object attributes) throws ActionDTOModelResolverClientException {
-
-        if (!(attributes instanceof List<?>)) {
-            throw new ActionDTOModelResolverClientException("Invalid attributes format.",
-                    "Attributes should be provided as a list of Strings.");
-        }
-
-        List<?> attributesList = (List<?>) attributes;
-        for (Object item : attributesList) {
-            if (!(item instanceof String)) {
-                throw new ActionDTOModelResolverClientException("Invalid attributes format.",
-                        "Attributes must contain only String values.");
-            }
-        }
-
-        return (List<String>) attributes;
-    }
-
-    private void validateAttributesCount(List<String> attributes) throws ActionDTOModelResolverClientException {
-
-        if (attributes.size() > MAX_ATTRIBUTES) {
-            throw new ActionDTOModelResolverClientException("Maximum attributes limit exceeded.",
-                    String.format("The number of configured attributes: %d exceeds the maximum allowed limit: %d",
-                            attributes.size(), MAX_ATTRIBUTES));
-        }
-    }
-
-    private List<String> filterValidSystemAttributes(List<String> attributes, String tenantDomain)
-            throws ActionDTOModelResolverClientException, ActionDTOModelResolverServerException {
-
-        try {
-            ClaimMetadataManagementService claimMetadataManagementService =
-                    PreUpdateProfileActionServiceComponentHolder.getInstance().getClaimManagementService();
-            List<LocalClaim> localClaims = claimMetadataManagementService.getLocalClaims(tenantDomain);
-            Set<String> localClaimURIs = localClaims.stream()
-                    .map(LocalClaim::getClaimURI)
-                    .collect(Collectors.toSet());
-            Set<String> uniqueAttributes = new HashSet<>();
-            Set<String> duplicatedAttributes = new HashSet<>();
-            for (String attribute : attributes) {
-                if (!localClaimURIs.contains(attribute)) {
-                    String invalidAttributeDescription = String.format("The provided %s attribute is not available " +
-                            "in the system.", attribute);
-                    throw new ActionDTOModelResolverClientException("Invalid attribute provided.",
-                            invalidAttributeDescription);
-                }
-                if (attribute.equals(ROLE_CLAIM_URI)) {
-                    throw new ActionDTOModelResolverClientException("Not supported.", String.format("%s attribute is " +
-                            "not supported to be shared with extension.", ROLE_CLAIM_URI)
-                    );
-                }
-                if (!uniqueAttributes.add(attribute)) {
-                    duplicatedAttributes.add(attribute);
-                }
-            }
-            if (LOG.isDebugEnabled() && !duplicatedAttributes.isEmpty()) {
-                LOG.debug("Ignored duplicated attributes in pre profile action configuration : " +
-                        String.join(", ", duplicatedAttributes));
-            }
-            return Collections.unmodifiableList(new ArrayList<>(uniqueAttributes));
-        } catch (ClaimMetadataException e) {
-            throw new ActionDTOModelResolverServerException("Error while retrieving local claims from claim meta " +
-                    "data service.", e.getMessage());
-        }
     }
 }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/test/java/org/wso2/carbon/identity/user/pre/update/profile/action/management/PreUpdateProfileActionConverterTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/test/java/org/wso2/carbon/identity/user/pre/update/profile/action/management/PreUpdateProfileActionConverterTest.java
@@ -22,7 +22,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.action.management.api.model.Action;
 import org.wso2.carbon.identity.action.management.api.model.ActionDTO;
-import org.wso2.carbon.identity.action.management.api.model.ActionProperty;
 import org.wso2.carbon.identity.action.management.api.model.Authentication;
 import org.wso2.carbon.identity.action.management.api.model.EndpointConfig;
 import org.wso2.carbon.identity.user.pre.update.profile.action.api.model.PreUpdateProfileAction;
@@ -30,13 +29,11 @@ import org.wso2.carbon.identity.user.pre.update.profile.action.internal.manageme
 
 import java.sql.Timestamp;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.ATTRIBUTES;
+import static org.testng.Assert.assertNull;
 import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.TEST_ACTION;
 import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.TEST_ATTRIBUTES;
 import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.TEST_DESCRIPTION;
@@ -103,19 +100,15 @@ public class PreUpdateProfileActionConverterTest {
         assertEquals(dto.getEndpoint().getAuthentication().getProperty(Authentication.Property.PASSWORD),
                 action.getEndpoint().getAuthentication().getProperty(Authentication.Property.PASSWORD));
 
-        // Verify properties map
-        Map<String, ActionProperty> properties = dto.getProperties();
-        assertNotNull(properties);
-        assertEquals(properties.get(ATTRIBUTES).getValue(), action.getAttributes());
+        // Verify attributes
+        assertEquals(dto.getAttributes(), action.getAttributes());
     }
 
     @Test(description = "Test ActionConverter returns action dto with all the properties ")
     public void testBuildActionForGetOperationWithAllAttributes() {
 
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(TEST_ATTRIBUTES).build());
         ActionDTO dto = new ActionDTO.Builder(action)
-                .properties(properties)
+                .attributes(TEST_ATTRIBUTES)
                 .build();
 
         // Convert to Action object
@@ -149,9 +142,8 @@ public class PreUpdateProfileActionConverterTest {
         Action dummyAction = new Action.ActionRequestBuilder().name(TEST_ACTION).build();
 
         ActionDTO dto = new ActionDTO.Builder(dummyAction)
-                .properties(new HashMap<String, ActionProperty>() {{
-                    put(ATTRIBUTES, new ActionProperty.BuilderForService(TEST_ATTRIBUTES).build());
-                }}).build();
+                .attributes(TEST_ATTRIBUTES)
+                .build();
         PreUpdateProfileAction convertedAction = (PreUpdateProfileAction) converter.buildAction(dto);
         assertNotNull(convertedAction.getAttributes());
         assertEquals(convertedAction.getAttributes(), TEST_ATTRIBUTES);
@@ -165,16 +157,13 @@ public class PreUpdateProfileActionConverterTest {
                 .attributes(null)
                 .build();
         ActionDTO dto = converter.buildActionDTO(profileAction);
-        assertNotNull(dto.getProperties());
-        assertEquals(dto.getProperties().size(), 0);
+        assertNull(dto.getAttributes());
 
         profileAction = new PreUpdateProfileAction.ResponseBuilder()
                 .name(TEST_ACTION)
                 .attributes(TEST_ATTRIBUTES)
                 .build();
         dto = converter.buildActionDTO(profileAction);
-        assertNotNull(dto.getProperties());
-        assertEquals(dto.getProperties().size(), 1);
-        assertEquals(dto.getProperties().get(ATTRIBUTES).getValue(), TEST_ATTRIBUTES);
+        assertEquals(dto.getAttributes(), TEST_ATTRIBUTES);
     }
 }

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/test/java/org/wso2/carbon/identity/user/pre/update/profile/action/management/PreUpdateProfileActionDTOModelResolverTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/test/java/org/wso2/carbon/identity/user/pre/update/profile/action/management/PreUpdateProfileActionDTOModelResolverTest.java
@@ -18,67 +18,28 @@
 
 package org.wso2.carbon.identity.user.pre.update.profile.action.management;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverClientException;
 import org.wso2.carbon.identity.action.management.api.model.Action;
 import org.wso2.carbon.identity.action.management.api.model.ActionDTO;
-import org.wso2.carbon.identity.action.management.api.model.ActionProperty;
 import org.wso2.carbon.identity.action.management.api.model.Authentication;
-import org.wso2.carbon.identity.action.management.api.model.BinaryObject;
 import org.wso2.carbon.identity.action.management.api.model.EndpointConfig;
-import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
-import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
-import org.wso2.carbon.identity.user.pre.update.profile.action.internal.component.PreUpdateProfileActionServiceComponentHolder;
 import org.wso2.carbon.identity.user.pre.update.profile.action.internal.management.PreUpdateProfileActionDTOModelResolver;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.ATTRIBUTES;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.DUPLICATED_TEST_ATTRIBUTES;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.INVALID_TEST_ATTRIBUTES;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.INVALID_TEST_ATTRIBUTES_COUNT;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.INVALID_TEST_ATTRIBUTES_TYPE;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.INVALID_TEST_ATTRIBUTES_VALUES;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.ROLES_CLAIM_ATTRIBUTE;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.ROLE_CLAIM_URI;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.SAMPLE_LOCAL_CLAIM_URI_1;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.SAMPLE_LOCAL_CLAIM_URI_2;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.SAMPLE_LOCAL_CLAIM_URI_3;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.SAMPLE_LOCAL_CLAIM_URI_4;
 import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.TENANT_DOMAIN;
 import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.TEST_ACTION;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.TEST_ATTRIBUTES;
 import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.TEST_DESCRIPTION;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.TEST_EMPTY_ATTRIBUTES;
 import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.TEST_ID;
 import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.TEST_PASSWORD;
 import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.TEST_URL;
 import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.TEST_USERNAME;
-import static org.wso2.carbon.identity.user.pre.update.profile.action.util.TestConstants.UPDATED_TEST_ATTRIBUTES;
 
 /**
  * Unit tests for PreUpdateProfileDTOModelResolver.
@@ -87,21 +48,7 @@ public class PreUpdateProfileActionDTOModelResolverTest {
 
     private PreUpdateProfileActionDTOModelResolver resolver;
     private Action action;
-    private ActionDTO existingActionDTO;
-    private ActionDTO existingActionDTOWithoutProperties;
-    private AutoCloseable closeable;
-    @Mock
-    private ClaimMetadataManagementService claimMetadataManagementService;
-    @Mock
-    private LocalClaim localClaim1;
-    @Mock
-    private LocalClaim localClaim2;
-    @Mock
-    private LocalClaim localClaim3;
-    @Mock
-    private LocalClaim localClaim4;
-    @Mock
-    private LocalClaim rolesClaim;
+    private ActionDTO actionDTO;
 
     @BeforeClass
     public void init() {
@@ -119,33 +66,7 @@ public class PreUpdateProfileActionDTOModelResolverTest {
                         .authentication(new Authentication.BasicAuthBuilder(TEST_USERNAME, TEST_PASSWORD).build())
                         .build())
                 .build();
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(TEST_ATTRIBUTES).build());
-        existingActionDTO = new ActionDTO.Builder(action).properties(properties).build();
-        existingActionDTOWithoutProperties = new ActionDTO.Builder(action).build();
-    }
-
-    @BeforeMethod
-    public void setUp() throws Exception {
-
-        closeable = MockitoAnnotations.openMocks(this);
-        PreUpdateProfileActionServiceComponentHolder.getInstance()
-                .setClaimManagementService(claimMetadataManagementService);
-        List<LocalClaim> mockLocalClaims = Arrays.asList(localClaim1, localClaim2, localClaim3, localClaim4,
-                rolesClaim);
-        doReturn(SAMPLE_LOCAL_CLAIM_URI_1).when(localClaim1).getClaimURI();
-        doReturn(SAMPLE_LOCAL_CLAIM_URI_2).when(localClaim2).getClaimURI();
-        doReturn(SAMPLE_LOCAL_CLAIM_URI_3).when(localClaim3).getClaimURI();
-        doReturn(SAMPLE_LOCAL_CLAIM_URI_4).when(localClaim4).getClaimURI();
-        doReturn(ROLE_CLAIM_URI).when(rolesClaim).getClaimURI();
-        doReturn(mockLocalClaims).when(claimMetadataManagementService).getLocalClaims(anyString());
-    }
-
-    @AfterMethod
-    public void teardown() throws Exception {
-
-        closeable.close();
+        actionDTO = new ActionDTO.Builder(action).build();
     }
 
     @Test
@@ -158,350 +79,58 @@ public class PreUpdateProfileActionDTOModelResolverTest {
     @Test
     public void testResolveForAddOperation() throws Exception {
 
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(TEST_ATTRIBUTES).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-
         ActionDTO result = resolver.resolveForAddOperation(actionDTO, TENANT_DOMAIN);
-
         assertNotNull(result);
         verifyCommonFields(actionDTO, result);
-        assertTrue(result.getPropertyValue(ATTRIBUTES) instanceof BinaryObject);
-        assertNotNull(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getJSONString());
-        assertEquals(getAttributes(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getJSONString()),
-                TEST_ATTRIBUTES);
-    }
-
-    @Test
-    public void testResolveForAddOperationWithoutAttributes() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-
-        ActionDTO result = resolver.resolveForAddOperation(actionDTO, TENANT_DOMAIN);
-
-        assertNotNull(result);
-        verifyCommonFields(actionDTO, result);
-        assertEquals(result.getProperties().size(), 0);
-    }
-
-    @Test(expectedExceptions = ActionDTOModelResolverClientException.class,
-            expectedExceptionsMessageRegExp = "Invalid attributes format.")
-    public void testResolveForAddOperationWithInvalidAttributesFormat() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(INVALID_TEST_ATTRIBUTES_TYPE).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        resolver.resolveForAddOperation(actionDTO, TENANT_DOMAIN);
-    }
-
-    @Test(expectedExceptions = ActionDTOModelResolverClientException.class,
-            expectedExceptionsMessageRegExp = "Invalid attributes format.")
-    public void testResolveForAddOperationWithInvalidAttributesValueType() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(INVALID_TEST_ATTRIBUTES_VALUES).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        resolver.resolveForAddOperation(actionDTO, TENANT_DOMAIN);
-    }
-
-    @Test(expectedExceptions = ActionDTOModelResolverClientException.class,
-            expectedExceptionsMessageRegExp = "Maximum attributes limit exceeded.")
-    public void testResolveForAddOperationWithExceededAttributesCount() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(INVALID_TEST_ATTRIBUTES_COUNT).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        resolver.resolveForAddOperation(actionDTO, TENANT_DOMAIN);
-    }
-
-    @Test
-    public void testResolveForAddOperationWithDuplicatedAttributes() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(DUPLICATED_TEST_ATTRIBUTES).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        ActionDTO result = resolver.resolveForAddOperation(actionDTO, TENANT_DOMAIN);
-
-        assertNotNull(result);
-        verifyCommonFields(actionDTO, result);
-        assertTrue(result.getPropertyValue(ATTRIBUTES) instanceof BinaryObject);
-        assertNotNull(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getInputStream());
-        assertEquals(getAttributes(((BinaryObject) result.getPropertyValue(ATTRIBUTES))
-                .getJSONString()), Collections.singletonList(DUPLICATED_TEST_ATTRIBUTES.get(0)));
-    }
-
-    @Test(expectedExceptions = ActionDTOModelResolverClientException.class,
-            expectedExceptionsMessageRegExp = "Invalid attribute provided.")
-    public void testResolveForAddOperationWithInvalidAttributes() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(INVALID_TEST_ATTRIBUTES).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        resolver.resolveForAddOperation(actionDTO, TENANT_DOMAIN);
-    }
-
-    @Test(expectedExceptions = ActionDTOModelResolverClientException.class,
-            expectedExceptionsMessageRegExp = "Not supported.")
-    public void testResolveForAddOperationWithRoleAttribute() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(ROLES_CLAIM_ATTRIBUTE).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        resolver.resolveForAddOperation(actionDTO, TENANT_DOMAIN);
     }
 
     @Test
     public void testResolveForGetOperation() throws Exception {
 
-        Map<String, ActionProperty> properties = new HashMap<>();
-
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForDAO(getBinaryObject(TEST_ATTRIBUTES)).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-
         ActionDTO result = resolver.resolveForGetOperation(actionDTO, TENANT_DOMAIN);
-
         assertNotNull(result);
         verifyCommonFields(actionDTO, result);
-        assertEquals(result.getPropertyValue(ATTRIBUTES), TEST_ATTRIBUTES);
     }
 
     @Test
     public void testResolveForGetOperationForActionList() throws Exception {
 
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForDAO(getBinaryObject(TEST_ATTRIBUTES)).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-
         List<ActionDTO> result = resolver.resolveForGetOperation(Collections.singletonList(actionDTO), TENANT_DOMAIN);
-
         assertNotNull(result);
-        for (ActionDTO dto : result) {
-            verifyCommonFields(actionDTO, dto);
-            assertEquals(dto.getPropertyValue(ATTRIBUTES), TEST_ATTRIBUTES);
-        }
+        assertEquals(result.size(), 1);
+        verifyCommonFields(actionDTO, result.get(0));
     }
 
     @Test
-    public void testResolveForUpdateOperationWithExistingAttributes() throws Exception {
+    public void testResolveForUpdateOperation() throws Exception {
 
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(UPDATED_TEST_ATTRIBUTES).build());
-        ActionDTO updatingActionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        ActionDTO result = resolver.resolveForUpdateOperation(updatingActionDTO, existingActionDTO, TENANT_DOMAIN);
-
-        assertNotNull(result);
-        verifyCommonFields(updatingActionDTO, result);
-        assertEquals(result.getProperties().size(), 1);
-        assertTrue(result.getPropertyValue(ATTRIBUTES) instanceof BinaryObject);
-        assertNotNull(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getJSONString());
-        assertEquals(getAttributes(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getJSONString()),
-                UPDATED_TEST_ATTRIBUTES);
-    }
-
-    @Test
-    public void testResolveForUpdateOperationToDeleteAttributes() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(TEST_EMPTY_ATTRIBUTES).build());
-        ActionDTO updatingActionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        ActionDTO result = resolver.resolveForUpdateOperation(updatingActionDTO, existingActionDTO, TENANT_DOMAIN);
-
-        assertNotNull(result);
-        verifyCommonFields(updatingActionDTO, result);
-        assertEquals(result.getProperties().size(), 0);
-        assertNull(result.getPropertyValue(ATTRIBUTES));
-    }
-
-    @Test
-    public void testResolveForUpdateOperationWithUpdatingNullAttributes() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(null).build());
-        ActionDTO updatingActionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        ActionDTO result = resolver.resolveForUpdateOperation(updatingActionDTO, existingActionDTO, TENANT_DOMAIN);
-
-        assertNotNull(result);
-        verifyCommonFields(updatingActionDTO, result);
-        // Since no attributes are updated, the existing attributes in ActionDTO should be verified.
-        assertEquals(result.getProperties().size(), existingActionDTO.getProperties().size());
-        assertTrue(result.getPropertyValue(ATTRIBUTES) instanceof BinaryObject);
-        assertNotNull(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getJSONString());
-        assertEquals(getAttributes(((BinaryObject) result.getPropertyValue(ATTRIBUTES))
-                .getJSONString()), existingActionDTO.getPropertyValue(ATTRIBUTES));
-    }
-
-    @Test(expectedExceptions = ActionDTOModelResolverClientException.class,
-            expectedExceptionsMessageRegExp = "Maximum attributes limit exceeded.")
-    public void testResolveForUpdateOperationWithExceededAttributesCountWithExistingAttributes() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(INVALID_TEST_ATTRIBUTES_COUNT).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        resolver.resolveForUpdateOperation(actionDTO, existingActionDTO, TENANT_DOMAIN);
-    }
-
-    @Test
-    public void testResolveForUpdateOperationWithDuplicatedAttributesWithExistingAttributes() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(DUPLICATED_TEST_ATTRIBUTES).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
+        ActionDTO existingActionDTO = new ActionDTO.Builder(action).build();
         ActionDTO result = resolver.resolveForUpdateOperation(actionDTO, existingActionDTO, TENANT_DOMAIN);
-
         assertNotNull(result);
         verifyCommonFields(actionDTO, result);
-        assertTrue(result.getPropertyValue(ATTRIBUTES) instanceof BinaryObject);
-        assertNotNull(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getInputStream());
-        assertEquals(getAttributes(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getJSONString()),
-                Collections.singletonList(DUPLICATED_TEST_ATTRIBUTES.get(0)));
-    }
-
-    @Test(expectedExceptions = ActionDTOModelResolverClientException.class,
-            expectedExceptionsMessageRegExp = "Invalid attribute provided.")
-    public void testResolveForUpdateOperationWithInvalidAttributesWithExistingAttributes() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(INVALID_TEST_ATTRIBUTES).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        resolver.resolveForUpdateOperation(actionDTO, existingActionDTO, TENANT_DOMAIN);
-    }
-
-    @Test(expectedExceptions = ActionDTOModelResolverClientException.class,
-            expectedExceptionsMessageRegExp = "Not supported.")
-    public void testResolveForUpdateOperationWithRoleAttributeWithExistingAttributes() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(ROLES_CLAIM_ATTRIBUTE).build());
-        ActionDTO actionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        resolver.resolveForUpdateOperation(actionDTO, existingActionDTO, TENANT_DOMAIN);
     }
 
     @Test
-    public void testResolveUpdateOperationWithoutUpdatingAttributesWithExistingAttributes() throws Exception {
+    public void testResolveForDeleteOperation() throws Exception {
 
-        Map<String, ActionProperty> properties = new HashMap<>();
-        ActionDTO updatingActionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-
-        ActionDTO result = resolver.resolveForUpdateOperation(updatingActionDTO, existingActionDTO, TENANT_DOMAIN);
-        assertNotNull(result);
-        verifyCommonFields(updatingActionDTO, result);
-        // Since no attributes are updated, the existing attributes in ActionDTO should be verified.
-        assertEquals(result.getProperties().size(), existingActionDTO.getProperties().size());
-        assertTrue(result.getPropertyValue(ATTRIBUTES) instanceof BinaryObject);
-        assertNotNull(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getJSONString());
-        assertEquals(getAttributes(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getJSONString()),
-                existingActionDTO.getPropertyValue(ATTRIBUTES));
+        resolver.resolveForDeleteOperation(actionDTO, TENANT_DOMAIN);
     }
 
-    @Test
-    public void testResolveForUpdateOperationWithoutExistingAttributes() throws Exception {
+    private void verifyCommonFields(ActionDTO expected, ActionDTO result) {
 
-        Map<String, ActionProperty> properties = new HashMap<>();
-        properties.put(ATTRIBUTES, new ActionProperty.BuilderForService(TEST_ATTRIBUTES).build());
-        ActionDTO updatingActionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-        ActionDTO result = resolver.resolveForUpdateOperation(updatingActionDTO, existingActionDTOWithoutProperties,
-                TENANT_DOMAIN);
-
-        assertNotNull(result);
-        verifyCommonFields(updatingActionDTO, result);
-        assertEquals(result.getProperties().size(), 1);
-        assertTrue(result.getPropertyValue(ATTRIBUTES) instanceof BinaryObject);
-        assertNotNull(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getJSONString());
-        assertEquals(getAttributes(((BinaryObject) result.getPropertyValue(ATTRIBUTES)).getJSONString()),
-                TEST_ATTRIBUTES);
-    }
-
-    @Test
-    public void testResolveUpdateOperationWithoutBothUpdatingAndExistingAttributes() throws Exception {
-
-        Map<String, ActionProperty> properties = new HashMap<>();
-        ActionDTO updatingActionDTO = new ActionDTO.Builder(action)
-                .properties(properties)
-                .build();
-
-        ActionDTO result = resolver.resolveForUpdateOperation(updatingActionDTO, existingActionDTOWithoutProperties,
-                TENANT_DOMAIN);
-        assertNotNull(result);
-        verifyCommonFields(updatingActionDTO, result);
-        assertEquals(result.getProperties().size(), 0);
-    }
-
-    private void verifyCommonFields(ActionDTO actionDTO, ActionDTO result) {
-
-        assertEquals(result.getId(), actionDTO.getId());
-        assertEquals(result.getName(), actionDTO.getName());
-        assertEquals(result.getDescription(), actionDTO.getDescription());
-        assertEquals(result.getStatus(), actionDTO.getStatus());
-        assertEquals(result.getCreatedAt(), actionDTO.getCreatedAt());
-        assertEquals(result.getUpdatedAt(), actionDTO.getUpdatedAt());
-        assertEquals(result.getEndpoint().getUri(), actionDTO.getEndpoint().getUri());
+        assertEquals(result.getId(), expected.getId());
+        assertEquals(result.getName(), expected.getName());
+        assertEquals(result.getDescription(), expected.getDescription());
+        assertEquals(result.getStatus(), expected.getStatus());
+        assertEquals(result.getCreatedAt(), expected.getCreatedAt());
+        assertEquals(result.getUpdatedAt(), expected.getUpdatedAt());
+        assertEquals(result.getEndpoint().getUri(), expected.getEndpoint().getUri());
         assertEquals(result.getEndpoint().getAuthentication().getType(),
-                actionDTO.getEndpoint().getAuthentication().getType());
+                expected.getEndpoint().getAuthentication().getType());
         assertEquals(result.getEndpoint().getAuthentication().getProperty(Authentication.Property.USERNAME),
-                actionDTO.getEndpoint().getAuthentication().getProperty(Authentication.Property.USERNAME));
+                expected.getEndpoint().getAuthentication().getProperty(Authentication.Property.USERNAME));
         assertEquals(result.getEndpoint().getAuthentication().getProperty(Authentication.Property.PASSWORD),
-                actionDTO.getEndpoint().getAuthentication().getProperty(Authentication.Property.PASSWORD));
-    }
-
-    private BinaryObject getBinaryObject(List<String> attributes) throws Exception {
-
-        return BinaryObject.fromInputStream(getInputStream(attributes));
-    }
-
-    private InputStream getInputStream(List<String> attributes) throws Exception {
-
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            // Convert the attributes to a JSON array and generate the input stream.
-            return new ByteArrayInputStream(objectMapper.writeValueAsString(attributes)
-                    .getBytes(StandardCharsets.UTF_8));
-        } catch (JsonProcessingException e) {
-            throw new Exception("Error occurred while converting attributes to input stream.", e);
-        }
-    }
-
-    private List<String> getAttributes(String value) throws IOException {
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        return objectMapper.readValue(value, new TypeReference<List<String>>() { });
+                expected.getEndpoint().getAuthentication().getProperty(Authentication.Property.PASSWORD));
     }
 }
+

--- a/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/test/java/org/wso2/carbon/identity/user/pre/update/profile/action/rule/PreUpdateProfileActionRuleEvaluationDataProviderTest.java
+++ b/components/user-mgt/org.wso2.carbon.identity.user.pre.update.profile.action/src/test/java/org/wso2/carbon/identity/user/pre/update/profile/action/rule/PreUpdateProfileActionRuleEvaluationDataProviderTest.java
@@ -167,4 +167,35 @@ public class PreUpdateProfileActionRuleEvaluationDataProviderTest {
         IdentityContext.getThreadLocalIdentityContext().enterFlow(flow);
         dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");
     }
+
+    @Test(expectedExceptions = RuleEvaluationDataProviderException.class)
+    public void testGetEvaluationDataWithNullFlow() throws RuleEvaluationDataProviderException {
+
+        Field flowField = new Field("flow", ValueType.STRING);
+        doReturn(Collections.singletonList(flowField)).when(ruleEvaluationContext).getFields();
+        dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");
+    }
+
+    @Test(expectedExceptions = RuleEvaluationDataProviderException.class)
+    public void testGetEvaluationDataWithNullFlowAttributes() throws RuleEvaluationDataProviderException {
+
+        Field flowField = new Field("flow", ValueType.STRING);
+        doReturn(Collections.singletonList(flowField)).when(ruleEvaluationContext).getFields();
+        doReturn(null).when(flow).getName();
+        doReturn(null).when(flow).getInitiatingPersona();
+        IdentityContext.getThreadLocalIdentityContext().enterFlow(flow);
+        dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");
+    }
+
+    @Test(expectedExceptions = RuleEvaluationDataProviderException.class)
+    public void testGetEvaluationDataWithInvalidUserActionContextType() throws RuleEvaluationDataProviderException {
+
+        Field claimField = new Field("claim", ValueType.REFERENCE);
+        doReturn(Collections.singletonList(claimField)).when(ruleEvaluationContext).getFields();
+        Map<String, Object> contextMap = new HashMap<>();
+        contextMap.put(UserActionContext.USER_ACTION_CONTEXT_REFERENCE_KEY, "invalidType");
+        doReturn(contextMap).when(flowContext).getContextData();
+        IdentityContext.getThreadLocalIdentityContext().enterFlow(flow);
+        dataProvider.getEvaluationData(ruleEvaluationContext, flowContext, "test.com");
+    }
 }


### PR DESCRIPTION
This pull request introduces support for managing attributes in actions within the Action Management module. The changes add new fields and builder methods for handling attributes, integrate claim metadata management services, and introduce validation and constants related to attributes. The update also ensures that the system can interact with claim metadata and enforces attribute-related constraints.

**Key changes include:**

**Attribute Support in Action Models and Builders:**
* Added an `attributes` field to the `Action` and `ActionDTO` classes, along with corresponding getter methods and builder pattern support for setting attributes. This enables actions to carry a list of attributes, and makes it easier to construct and retrieve actions with associated attributes.

**Integration with Claim Metadata Management:**
* Added dependency on `org.wso2.carbon.identity.claim.metadata.mgt` and updated OSGi imports to include claim metadata management packages, allowing the module to interact with claim metadata services.

**Attribute-related Constants and Error Handling:**
* Introduced new constants in `ActionMgtConstants` for attributes, including `ATTRIBUTES_PROPERTY`, `ROLE_CLAIM_URI`, and `MAX_ATTRIBUTES`, to standardize attribute handling and enforce limits.
* Added new error messages in `ErrorMessage` for scenarios where the attribute limit is exceeded or invalid attributes are provided, improving error reporting and validation.

**Preparation for Attribute Validation Logic:**
* Imported claim metadata management and exception classes, as well as error handling utilities in the DAO implementation, setting the stage for attribute validation against claim metadata.

**Testing:**
* Added unit tests to cover the flow.

**Related PRs:**

- https://github.com/wso2/identity-api-server/pull/1095
