### PR TITLE
Add userImpersonation API resource collection for console and org

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -565,6 +565,26 @@
             </Read>
         </Scopes>
     </APIResourceCollection>
+
+    <APIResourceCollection name="userImpersonation" displayName="User Impersonation" type="tenant" version="v0">
+       <Scopes>
+            <Feature>
+                <Scope name="console:userImpersonation"/>
+            </Feature>
+            <Read>
+                <Scope name="internal_userstore_view"/>
+                <Scope name="internal_role_mgt_view"/>
+                <Scope name="internal_group_mgt_view"/>
+                <Scope name="internal_governance_view"/>
+                <Scope name="internal_login"/>
+                <Scope name="internal_user_mgt_view"/>
+                <Scope name="internal_user_mgt_list"/>
+                <Scope name="internal_session_view"/>
+                <Scope name="internal_claim_meta_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+
 <!--    Legacy Organization API Resource Collections (version as v0)-->
     <APIResourceCollection name="org_consoleSettings" displayName="Console Settings" type="organization" version="v0">
        <Scopes>
@@ -2382,6 +2402,24 @@
             <Read>
                 <Scope name="internal_org_idp_view"/>
                 <Scope name="internal_org_application_mgt_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="org_userImpersonation" displayName="User Impersonation" type="organization">
+        <Scopes>
+            <Feature>
+                <Scope name="console:org:userImpersonation"/>
+            </Feature>
+            <Read>
+                <Scope name="internal_org_userstore_view"/>
+                <Scope name="internal_org_role_mgt_view"/>
+                <Scope name="internal_org_group_mgt_view"/>
+                <Scope name="internal_org_governance_view"/>
+                <Scope name="internal_org_user_mgt_view"/>
+                <Scope name="internal_org_user_mgt_list"/>
+                <Scope name="internal_org_session_view"/>
+                <Scope name="internal_org_claim_meta_view"/>
+                <Scope name="internal_org_guest_mgt_invite_list"/>
             </Read>
         </Scopes>
     </APIResourceCollection>


### PR DESCRIPTION
## Summary
   - Added `userImpersonation` API resource collection (type: `tenant`) with the `console:userImpersonation` feature scope and required read scopes for the console feature.
   - Added corresponding `org_userImpersonation` API resource collection (type: `organization`) with the `console:org:userImpersonation` feature scope and `internal_org_` read scopes for org-level access.

Console roles who has the console:userImpersonation feature scope will be able to see the Impersonate User button.
