### PR TITLE
Add Custom schema support for Postegre DB.

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/persistence/JDBCPersistenceManager.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/persistence/JDBCPersistenceManager.java
@@ -56,6 +56,7 @@ public class JDBCPersistenceManager {
     private static final String PG_ACTIVE_SQL_TRANSACTION_STATE = "25001";
     private static final String POSTGRESQL_DATABASE = "PostgreSQL";
     public static final String PARENT_SCHEMA = "parentSchema";
+    public static final String POSTGRES_SCHEMA = "postgresSchema";
 
     private JDBCPersistenceManager() {
 
@@ -176,6 +177,27 @@ public class JDBCPersistenceManager {
             parentSchema = properties.getProperty(PARENT_SCHEMA);
         }
         return parentSchema;
+    }
+
+    /**
+     * This method extracts the custom schema from PostgreSQL db configurations.
+     * This is used when a schema other than the user's default schema is used in PostgreSQL.
+     * In such cases, the custom schema name should be specified in db configuration with the property name
+     * "postgresSchema".
+     *
+     * @return postgres Schema.
+     */
+    public String getPostgresSchema() {
+
+        String customSchema = null;
+        if (!(dataSource instanceof DataSourceProxy)) {
+            return null;
+        }
+        Properties properties = ((DataSourceProxy) dataSource).getDbProperties();
+        if (properties != null) {
+            customSchema = properties.getProperty(POSTGRES_SCHEMA);
+        }
+        return customSchema;
     }
 
     /**

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityDatabaseUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityDatabaseUtil.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.core.util;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
@@ -33,6 +34,7 @@ import javax.sql.DataSource;
 
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.DB2;
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.ORACLE;
+import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.POSTGRE_SQL;
 
 /**
  * Utility class for database operations.
@@ -55,6 +57,17 @@ public class IdentityDatabaseUtil {
     public static String getParentSchema() {
 
         return JDBCPersistenceManager.getInstance().getParentSchema();
+    }
+
+    /**
+     * This method returns the custom schema from the configurations for PostgreSQL database.
+     * Custom schema is used when the tables are not created in the first schema of the search path of the db user.
+     *
+     * @return postgres Schema.
+     */
+    public static String getPostgresSchema() {
+
+        return JDBCPersistenceManager.getInstance().getPostgresSchema();
     }
 
     /**
@@ -228,6 +241,15 @@ public class IdentityDatabaseUtil {
                 String parentSchema = getParentSchema();
                 if (parentSchema != null) {
                     schemaName = parentSchema;
+                }
+            }
+
+            // For PostgreSQL, use the configured schema if available. This handles cases where tables reside in a
+            // non-default schema that differs from the first entry in the database user's search path.
+            if (POSTGRE_SQL.equalsIgnoreCase(connection.getMetaData().getDatabaseProductName())) {
+                String postgresSchema = getPostgresSchema();
+                if (StringUtils.isNotBlank(postgresSchema)) {
+                    schemaName = postgresSchema.trim();
                 }
             }
             try (ResultSet resultSet = metaData.getTables(catalogName, schemaName, tableName, new String[]{"TABLE"})) {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/util/IdentityDatabaseUtilTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/util/IdentityDatabaseUtilTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.core.util;
+
+import org.mockito.MockedStatic;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.persistence.JDBCPersistenceManager;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link IdentityDatabaseUtil}.
+ */
+@Listeners(MockitoTestNGListener.class)
+public class IdentityDatabaseUtilTest {
+
+    private static final String CUSTOM_SCHEMA_VALUE = "custom_schema";
+    private static final String PARENT_SCHEMA_VALUE = "oracle_parent_schema";
+    private static final String TEST_TABLE = "IDN_TEST_TABLE";
+    private static final String CONNECTION_SCHEMA = "public";
+    private static final String CONNECTION_CATALOG = "testdb";
+
+    @Test(description = "Test isTableExists() for PostgreSQL when a custom schema is configured, " +
+            "verifying that the custom schema is used in the metadata query")
+    public void testIsTableExists_postgresWithCustomSchema_usesCustomSchema() throws Exception {
+
+        Connection mockConnection = buildMockConnection(IdentityCoreConstants.POSTGRE_SQL);
+        DatabaseMetaData metaData = mockConnection.getMetaData();
+        ResultSet mockResultSet = resultSetWithRow(true);
+        when(metaData.getTables(eq(CONNECTION_CATALOG), eq(CUSTOM_SCHEMA_VALUE),
+                eq(TEST_TABLE), any())).thenReturn(mockResultSet);
+
+        JDBCPersistenceManager mockManager = mock(JDBCPersistenceManager.class);
+        when(mockManager.getDBConnection(anyBoolean())).thenReturn(mockConnection);
+        when(mockManager.getPostgresSchema()).thenReturn(CUSTOM_SCHEMA_VALUE);
+
+        try (MockedStatic<JDBCPersistenceManager> staticMock = mockStatic(JDBCPersistenceManager.class)) {
+            staticMock.when(JDBCPersistenceManager::getInstance).thenReturn(mockManager);
+            assertTrue(IdentityDatabaseUtil.isTableExists(TEST_TABLE),
+                    "isTableExists() should return true when the table is found under the custom PostgreSQL schema");
+        }
+
+        verify(metaData).getTables(CONNECTION_CATALOG, CUSTOM_SCHEMA_VALUE, TEST_TABLE, new String[]{"TABLE"});
+    }
+
+    @Test(description = "Test isTableExists() for PostgreSQL when a custom schema is not configured, " +
+            "verifying that the connection schema is used in the metadata query")
+    public void testIsTableExists_postgresWithoutCustomSchema_usesConnectionSchema() throws Exception {
+
+        Connection mockConnection = buildMockConnection(IdentityCoreConstants.POSTGRE_SQL);
+        DatabaseMetaData metaData = mockConnection.getMetaData();
+        ResultSet mockResultSet = resultSetWithRow(true);
+        when(metaData.getTables(eq(CONNECTION_CATALOG), eq(CONNECTION_SCHEMA),
+                eq(TEST_TABLE), any())).thenReturn(mockResultSet);
+
+        JDBCPersistenceManager mockManager = mock(JDBCPersistenceManager.class);
+        when(mockManager.getDBConnection(anyBoolean())).thenReturn(mockConnection);
+        when(mockManager.getPostgresSchema()).thenReturn(null);
+
+        try (MockedStatic<JDBCPersistenceManager> staticMock = mockStatic(JDBCPersistenceManager.class)) {
+            staticMock.when(JDBCPersistenceManager::getInstance).thenReturn(mockManager);
+            assertTrue(IdentityDatabaseUtil.isTableExists(TEST_TABLE),
+                    "isTableExists() should fall back to the connection schema when no custom schema is configured");
+        }
+
+        verify(metaData).getTables(CONNECTION_CATALOG, CONNECTION_SCHEMA, TEST_TABLE, new String[]{"TABLE"});
+    }
+
+    @Test(description = "Test isTableExists() for PostgreSQL when a blank custom schema is configured, " +
+            "verifying that the blank custom schema is treated as absent and the connection schema is used")
+    public void testIsTableExists_postgresWithBlankCustomSchema_usesConnectionSchema() throws Exception {
+
+        Connection mockConnection = buildMockConnection(IdentityCoreConstants.POSTGRE_SQL);
+        DatabaseMetaData metaData = mockConnection.getMetaData();
+        ResultSet mockResultSet = resultSetWithRow(true);
+        when(metaData.getTables(eq(CONNECTION_CATALOG), eq(CONNECTION_SCHEMA),
+                eq(TEST_TABLE), any())).thenReturn(mockResultSet);
+
+        JDBCPersistenceManager mockManager = mock(JDBCPersistenceManager.class);
+        when(mockManager.getDBConnection(anyBoolean())).thenReturn(mockConnection);
+        when(mockManager.getPostgresSchema()).thenReturn("   ");
+
+        try (MockedStatic<JDBCPersistenceManager> staticMock = mockStatic(JDBCPersistenceManager.class)) {
+            staticMock.when(JDBCPersistenceManager::getInstance).thenReturn(mockManager);
+            assertTrue(IdentityDatabaseUtil.isTableExists(TEST_TABLE),
+                    "isTableExists() should treat a blank custom schema as absent and use the connection schema");
+        }
+
+        verify(metaData).getTables(CONNECTION_CATALOG, CONNECTION_SCHEMA, TEST_TABLE, new String[]{"TABLE"});
+    }
+
+    @Test(description = "Test isTableExists() for PostgreSQL when a custom schema is configured but the table is " +
+            "not found, verifying that the method returns false")
+    public void testIsTableExists_postgresTableNotFound_returnsFalse() throws Exception {
+
+        Connection mockConnection = buildMockConnection(IdentityCoreConstants.POSTGRE_SQL);
+        DatabaseMetaData metaData = mockConnection.getMetaData();
+        ResultSet mockResultSet = resultSetWithRow(false);
+        when(metaData.getTables(any(), any(), eq(TEST_TABLE), any())).thenReturn(mockResultSet);
+
+        JDBCPersistenceManager mockManager = mock(JDBCPersistenceManager.class);
+        when(mockManager.getDBConnection(anyBoolean())).thenReturn(mockConnection);
+        when(mockManager.getPostgresSchema()).thenReturn(CUSTOM_SCHEMA_VALUE);
+
+        try (MockedStatic<JDBCPersistenceManager> staticMock = mockStatic(JDBCPersistenceManager.class)) {
+            staticMock.when(JDBCPersistenceManager::getInstance).thenReturn(mockManager);
+            assertFalse(IdentityDatabaseUtil.isTableExists(TEST_TABLE),
+                    "isTableExists() should return false when the table is not found under the custom schema");
+        }
+    }
+
+    @Test(description = "Test isTableExists() for Oracle when a parent schema is configured, " +
+            "verifying that the parent schema is used in the metadata query")
+    public void testIsTableExists_oracleWithParentSchema_usesParentSchema() throws Exception {
+
+        Connection mockConnection = buildMockConnection(IdentityCoreConstants.ORACLE);
+        DatabaseMetaData metaData = mockConnection.getMetaData();
+        ResultSet mockResultSet = resultSetWithRow(true);
+        when(metaData.getTables(eq(CONNECTION_CATALOG), eq(PARENT_SCHEMA_VALUE),
+                eq(TEST_TABLE), any())).thenReturn(mockResultSet);
+
+        JDBCPersistenceManager mockManager = mock(JDBCPersistenceManager.class);
+        when(mockManager.getDBConnection(anyBoolean())).thenReturn(mockConnection);
+        when(mockManager.getParentSchema()).thenReturn(PARENT_SCHEMA_VALUE);
+
+        try (MockedStatic<JDBCPersistenceManager> staticMock = mockStatic(JDBCPersistenceManager.class)) {
+            staticMock.when(JDBCPersistenceManager::getInstance).thenReturn(mockManager);
+            assertTrue(IdentityDatabaseUtil.isTableExists(TEST_TABLE),
+                    "isTableExists() should use the Oracle parentSchema override (regression)");
+        }
+
+        verify(metaData).getTables(CONNECTION_CATALOG, PARENT_SCHEMA_VALUE, TEST_TABLE, new String[]{"TABLE"});
+    }
+
+    /**
+     * Builds a mock {@link Connection} whose metadata reports the given {@code dbProductName}.
+     * Schema and catalog return the test constants; {@code storesLowerCaseIdentifiers()} is false.
+     */
+    private Connection buildMockConnection(String dbProductName) throws Exception {
+
+        Connection connection = mock(Connection.class);
+        DatabaseMetaData metaData = mock(DatabaseMetaData.class);
+        when(connection.getMetaData()).thenReturn(metaData);
+        when(metaData.getDatabaseProductName()).thenReturn(dbProductName);
+        when(metaData.storesLowerCaseIdentifiers()).thenReturn(false);
+        when(connection.getSchema()).thenReturn(CONNECTION_SCHEMA);
+        when(connection.getCatalog()).thenReturn(CONNECTION_CATALOG);
+        return connection;
+    }
+
+    private ResultSet resultSetWithRow(boolean hasRow) throws Exception {
+
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.next()).thenReturn(hasRow);
+        return rs;
+    }
+}

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/resources/testng.xml
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/resources/testng.xml
@@ -36,6 +36,7 @@
             <class name="org.wso2.carbon.identity.core.model.FilterTreeBuilderTest"/>
             <class name="org.wso2.carbon.identity.core.util.IdentityTenantUtilTest"/>
             <class name="org.wso2.carbon.identity.core.util.JWTDepthValidationTest"/>
+            <class name="org.wso2.carbon.identity.core.util.IdentityDatabaseUtilTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
**Related Issues**

- [x] https://github.com/wso2/product-is/issues/27332

In Order to apply a custom schema for following db prop should be added to db configs in deployement.toml

```
[database.identity_db]
type = "postgresql"
url = <url>
username = <db_user_username>
password = <db_user_password>
driver = <driver>
db_props.postgresSchema = <custom_schema>

[database.shared_db]
type = "postgresql"
url = <url>
username = <db_user_username>
password = <db_user_password>
driver = <driver>
db_props.postgresSchema = <custom_schema>
```

See the following example

```
type = "postgresql"
url = "jdbc:postgresql://localhost:5432/is_db_72_patch"
username = "IS_DB_72_PATCH"
password = "123"
driver = "org.postgresql.Driver"
db_props.postgresSchema = "IS_DB_72_PATCH"
```

This pull request adds support for configuring and using a custom PostgreSQL schema when checking for table existence in the identity core database utilities. It introduces a new mechanism to specify a custom schema for PostgreSQL databases, updates the logic to use this schema when present, and adds comprehensive unit tests to ensure correct behavior across different scenarios.

**PostgreSQL Custom Schema Support:**

* Added a new constant `CUSTOM_SCHEMA` and a corresponding `getCustomSchema()` method in `JDBCPersistenceManager` to retrieve the custom schema property from the database configuration. [[1]](diffhunk://#diff-99ce25278845d8c8d6437ad91cab722d0aa93cb22652684b6cc6f22172f5bf54R59) [[2]](diffhunk://#diff-99ce25278845d8c8d6437ad91cab722d0aa93cb22652684b6cc6f22172f5bf54R182-R196)
* Updated `IdentityDatabaseUtil.isTableExists()` to use the custom schema for PostgreSQL if configured and non-blank; otherwise, it falls back to the connection schema.

**Utility and API Enhancements:**

* Added a static `getCustomSchema()` method in `IdentityDatabaseUtil` to expose the custom schema retrieval.
* Imported `StringUtils` and updated static imports to support the new schema logic. [[1]](diffhunk://#diff-3e76780293989f9b85f7e2aafe1108c5cc137803454623a6f586f5cbb841bedaR21) [[2]](diffhunk://#diff-3e76780293989f9b85f7e2aafe1108c5cc137803454623a6f586f5cbb841bedaR37)

**Testing Improvements:**

* Introduced a new test class `IdentityDatabaseUtilTest` with comprehensive unit tests covering PostgreSQL custom schema scenarios, fallback logic, and regression tests for Oracle parent schema handling.