### PR TITLE
Enable invited user registration flow by default

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/pom.xml
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/pom.xml
@@ -176,6 +176,7 @@
                             org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
                             org.wso2.carbon.identity.ai.service.mgt.*; version="${carbon.identity.package.import.version.range}",
                             org.apache.http.client.methods; version="${httpcomponents-httpclient.imp.pkg.version.range}",
+                            org.apache.axiom.om; version="${axiom.osgi.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.flow.mgt.internal,

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
@@ -73,6 +73,8 @@ public class Constants {
                 "Unexpected server error while invoking the AI service for tenant, %s"),
         ERROR_CODE_DELETE_FLOW("65013", "Error while deleting the flow.",
                 "Unexpected server error while deleting the flow for tenant, %s"),
+        ERROR_CODE_LOAD_SYSTEM_DEFAULT_FLOW("65014", "Error while loading system default flow.",
+                "Unexpected error while loading system default flow for flow type, %s"),
 
         // Client errors.
         ERROR_CODE_UNSUPPORTED_STEP_TYPE("60001", "Unsupported step type.",
@@ -249,6 +251,9 @@ public class Constants {
         public static final String FLOW_TYPE = "flowType";
         public static final String IS_ENABLED = "isEnabled";
         public static final String IS_AUTO_LOGIN_ENABLED = "isAutoLoginEnabled";
+        public static final String FLOW_EXECUTION_CONFIG = "FlowExecution";
+        public static final String DEFAULT_ENABLED_FLOWS_CONFIG = "DefaultEnabledFlows";
+        public static final String FLOW_TYPE_ELEMENT = "FlowType";
 
         private FlowConfigConstants() {
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/FlowMgtService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/FlowMgtService.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.flow.mgt;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.osgi.annotation.bundle.Capability;
 import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
@@ -67,6 +69,7 @@ public class FlowMgtService {
 
     private static final FlowMgtService INSTANCE = new FlowMgtService();
     private static final FlowDAO FLOW_DAO = CacheBackedFlowDAOImpl.getInstance();
+    private static final Log LOG = LogFactory.getLog(FlowMgtService.class);
 
     private FlowMgtService() {
 
@@ -86,7 +89,7 @@ public class FlowMgtService {
     public void updateFlow(FlowDTO flowDTO, int tenantID)
             throws FlowMgtFrameworkException {
 
-        clearFlowResolveCache(tenantID);
+        clearFlowResolveCache(flowDTO.getFlowType(), tenantID);
         GraphConfig flowConfig = new GraphBuilder().withSteps(flowDTO.getSteps()).build();
         FLOW_DAO.updateFlow(flowDTO.getFlowType(), flowConfig, tenantID, DEFAULT_FLOW_NAME);
         AuditLog.AuditLogBuilder auditLogBuilder =
@@ -108,6 +111,9 @@ public class FlowMgtService {
 
         Integer tenantIdWithResource = getFirstTenantWithFlow(flowType, tenantID);
         if (tenantIdWithResource == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("No flow found for type: " + flowType + " in tenant hierarchy. Returning system default.");
+            }
             return SystemDefaultFlowProvider.getInstance().getSystemDefaultFlow(flowType);
         }
         return FLOW_DAO.getFlow(flowType, tenantIdWithResource);
@@ -134,7 +140,7 @@ public class FlowMgtService {
             throw handleServerException(Constants.ErrorMessages.ERROR_CODE_DELETE_FLOW, e,
                     IdentityTenantUtil.getTenantDomain(tenantID));
         }
-        clearFlowResolveCache(tenantID);
+        clearFlowResolveCache(flowType, tenantID);
         FLOW_DAO.deleteFlow(flowType, tenantID);
         AuditLog.AuditLogBuilder auditLogBuilder =
                 new AuditLog.AuditLogBuilder(getInitiatorId(), LoggerUtils.getInitiatorType(getInitiatorId()),
@@ -154,6 +160,10 @@ public class FlowMgtService {
         // Since graph config is built from the flow, we can reuse the logic to get the first tenant with the flow.
         Integer tenantIdWithResource = getFirstTenantWithFlow(flowType, tenantID);
         if (tenantIdWithResource == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("No graph config found for flow type: " + flowType + " in tenant hierarchy. Returning " +
+                        "system default.");
+            }
             return SystemDefaultFlowProvider.getInstance().getSystemDefaultGraphConfig(flowType);
         }
         return FLOW_DAO.getGraphConfig(flowType, tenantIdWithResource);
@@ -214,7 +224,7 @@ public class FlowMgtService {
             OrganizationManager orgManager = FlowMgtServiceDataHolder.getInstance().getOrganizationManager();
             String currentOrgId = orgManager.resolveOrganizationId(tenantDomain);
 
-            FlowResolveCacheKey cacheKey = new FlowResolveCacheKey(currentOrgId);
+            FlowResolveCacheKey cacheKey = new FlowResolveCacheKey(currentOrgId, flowType);
             FlowResolveCacheEntry cacheEntry = FlowResolveCache.getInstance().getValueFromCache(cacheKey, tenantID);
             if (cacheEntry != null) {
                 return cacheEntry.getResolvedTenantId();
@@ -246,13 +256,13 @@ public class FlowMgtService {
         return (flowDTO == null || flowDTO.getSteps().isEmpty()) ? Optional.empty() : Optional.of(tenantId);
     }
 
-    private void clearFlowResolveCache(int tenantId) throws FlowMgtServerException {
+    private void clearFlowResolveCache(String flowType, int tenantId) throws FlowMgtServerException {
 
         String currentTenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
         try {
             OrganizationManager organizationManager = FlowMgtServiceDataHolder.getInstance().getOrganizationManager();
             String orgId = organizationManager.resolveOrganizationId(currentTenantDomain);
-            FlowResolveCacheKey cacheKey = new FlowResolveCacheKey(orgId);
+            FlowResolveCacheKey cacheKey = new FlowResolveCacheKey(orgId, flowType);
             FlowMgtUtils.clearCache(cacheKey, FlowResolveCache.getInstance(), tenantId);
         } catch (OrganizationManagementException e) {
             throw handleServerException(Constants.ErrorMessages.ERROR_CODE_CLEAR_CACHE_FAILED, e, currentTenantDomain);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/FlowMgtService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/FlowMgtService.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.flow.mgt.model.GraphConfig;
 import org.wso2.carbon.identity.flow.mgt.utils.FlowMgtConfigUtils;
 import org.wso2.carbon.identity.flow.mgt.utils.FlowMgtUtils;
 import org.wso2.carbon.identity.flow.mgt.utils.GraphBuilder;
+import org.wso2.carbon.identity.flow.mgt.utils.SystemDefaultFlowProvider;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
@@ -107,7 +108,7 @@ public class FlowMgtService {
 
         Integer tenantIdWithResource = getFirstTenantWithFlow(flowType, tenantID);
         if (tenantIdWithResource == null) {
-            return null;
+            return SystemDefaultFlowProvider.getInstance().getSystemDefaultFlow(flowType);
         }
         return FLOW_DAO.getFlow(flowType, tenantIdWithResource);
     }
@@ -153,7 +154,7 @@ public class FlowMgtService {
         // Since graph config is built from the flow, we can reuse the logic to get the first tenant with the flow.
         Integer tenantIdWithResource = getFirstTenantWithFlow(flowType, tenantID);
         if (tenantIdWithResource == null) {
-            return null;
+            return SystemDefaultFlowProvider.getInstance().getSystemDefaultGraphConfig(flowType);
         }
         return FLOW_DAO.getGraphConfig(flowType, tenantIdWithResource);
     }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/cache/FlowResolveCacheKey.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/cache/FlowResolveCacheKey.java
@@ -28,10 +28,12 @@ public class FlowResolveCacheKey extends CacheKey {
 
     private static final long serialVersionUID = 1L;
     private final String tenantId;
+    private final String flowType;
 
-    public FlowResolveCacheKey(String tenantId) {
+    public FlowResolveCacheKey(String tenantId, String flowType) {
 
         this.tenantId = tenantId;
+        this.flowType = flowType;
     }
 
     @Override
@@ -40,12 +42,12 @@ public class FlowResolveCacheKey extends CacheKey {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         FlowResolveCacheKey that = (FlowResolveCacheKey) o;
-        return tenantId.equals(that.tenantId);
+        return tenantId.equals(that.tenantId) && flowType.equals(that.flowType);
     }
 
     @Override
     public int hashCode() {
 
-        return tenantId.hashCode();
+        return 31 * tenantId.hashCode() + flowType.hashCode();
     }
 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/model/DataDTO.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/model/DataDTO.java
@@ -57,6 +57,11 @@ public class DataDTO implements Serializable {
         return components;
     }
 
+    public void setComponents(List<ComponentDTO> components) {
+
+        this.components = components;
+    }
+
     public void addComponent(ComponentDTO component) {
 
         if (this.components == null) {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
@@ -18,10 +18,13 @@
 
 package org.wso2.carbon.identity.flow.mgt.utils;
 
+import org.apache.axiom.om.OMElement;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants;
 import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
@@ -35,8 +38,12 @@ import org.wso2.carbon.identity.flow.mgt.model.FlowConfigDTO;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS;
@@ -51,6 +58,7 @@ import static org.wso2.carbon.identity.flow.mgt.Constants.FlowConfigConstants.RE
 public class FlowMgtConfigUtils {
 
     private static final Log LOG = LogFactory.getLog(FlowMgtConfigUtils.class);
+    private static final Set<String> SERVER_DEFAULT_ENABLED_FLOWS = loadServerDefaultEnabledFlows();
 
     private FlowMgtConfigUtils() {
 
@@ -59,6 +67,31 @@ public class FlowMgtConfigUtils {
     private static ConfigurationManager getConfigurationManager() {
 
         return FlowMgtServiceDataHolder.getInstance().getConfigurationManager();
+    }
+
+    private static Set<String> loadServerDefaultEnabledFlows() {
+
+        Set<String> defaultEnabledFlows = new HashSet<>();
+        OMElement flowExecutionElement = IdentityConfigParser.getInstance()
+                .getConfigElement(Constants.FlowConfigConstants.FLOW_EXECUTION_CONFIG);
+        if (flowExecutionElement == null) {
+            return defaultEnabledFlows;
+        }
+        Iterator<OMElement> defaultEnabledFlowsIt = flowExecutionElement
+                .getChildrenWithLocalName(Constants.FlowConfigConstants.DEFAULT_ENABLED_FLOWS_CONFIG);
+        if (!defaultEnabledFlowsIt.hasNext()) {
+            return defaultEnabledFlows;
+        }
+        OMElement defaultEnabledFlowsElement = defaultEnabledFlowsIt.next();
+        Iterator<OMElement> flowTypeElements = defaultEnabledFlowsElement
+                .getChildrenWithLocalName(Constants.FlowConfigConstants.FLOW_TYPE_ELEMENT);
+        while (flowTypeElements.hasNext()) {
+            String flowType = flowTypeElements.next().getText();
+            if (StringUtils.isNotBlank(flowType)) {
+                defaultEnabledFlows.add(flowType.trim());
+            }
+        }
+        return Collections.unmodifiableSet(defaultEnabledFlows);
     }
 
     /**
@@ -183,7 +216,7 @@ public class FlowMgtConfigUtils {
         Constants.FlowTypes requestedFlowType = Constants.FlowTypes.valueOf(flowType);
         FlowConfigDTO flowConfigDTO = new FlowConfigDTO();
         flowConfigDTO.setFlowType(flowType);
-        flowConfigDTO.setIsEnabled(false);
+        flowConfigDTO.setIsEnabled(SERVER_DEFAULT_ENABLED_FLOWS.contains(flowType));
         flowConfigDTO.addAllFlowCompletionConfigs(requestedFlowType.getSupportedFlowCompletionConfigs());
         return flowConfigDTO;
     }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
@@ -75,6 +75,7 @@ public class FlowMgtConfigUtils {
         OMElement flowExecutionElement = IdentityConfigParser.getInstance()
                 .getConfigElement(Constants.FlowConfigConstants.FLOW_EXECUTION_CONFIG);
         if (flowExecutionElement == null) {
+            LOG.debug("No flow execution configuration found in identity.xml");
             return defaultEnabledFlows;
         }
         Iterator<OMElement> defaultEnabledFlowsIt = flowExecutionElement
@@ -90,6 +91,9 @@ public class FlowMgtConfigUtils {
             if (StringUtils.isNotBlank(flowType)) {
                 defaultEnabledFlows.add(flowType.trim());
             }
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Loaded server default enabled flows: " + defaultEnabledFlows);
         }
         return Collections.unmodifiableSet(defaultEnabledFlows);
     }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/SystemDefaultFlowProvider.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/SystemDefaultFlowProvider.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.flow.mgt.Constants;
 import org.wso2.carbon.identity.flow.mgt.exception.FlowMgtFrameworkException;
 import org.wso2.carbon.identity.flow.mgt.exception.FlowMgtServerException;
 import org.wso2.carbon.identity.flow.mgt.model.FlowDTO;
@@ -54,15 +55,10 @@ public class SystemDefaultFlowProvider {
     private static final String FLOW_DEFAULTS_DIR = "flow-defaults";
 
     /**
-     * Cache for loaded FlowDTOs per flow type. Optional.empty() is stored when no default exists,
-     * preventing repeated file system lookups for unsupported flow types.
+     * Cache for loaded FlowDTOs per flow type.
+     * Optional.empty() is stored when no default exists, preventing repeated file system lookups.
      */
     private final Map<String, Optional<FlowDTO>> flowDTOCache = new ConcurrentHashMap<>();
-
-    /**
-     * Cache for built GraphConfigs per flow type. Optional.empty() is stored when no default exists.
-     */
-    private final Map<String, Optional<GraphConfig>> graphConfigCache = new ConcurrentHashMap<>();
 
     private SystemDefaultFlowProvider() {
 
@@ -76,43 +72,48 @@ public class SystemDefaultFlowProvider {
     /**
      * Get the system default FlowDTO for the given flow type.
      * Returns {@code null} if no system default is configured for this flow type.
+     * Each call returns a deep copy of the cached instance so callers cannot mutate shared state.
      *
      * @param flowType The flow type identifier (e.g. "INVITED_USER_REGISTRATION").
-     * @return The system default FlowDTO, or {@code null} if not found.
-     * @throws FlowMgtServerException If an error occurs while loading or parsing the default flow.
+     * @return A deep copy of the cached FlowDTO, or {@code null} if not found.
+     * @throws FlowMgtServerException If an error occurs while loading or copying the default flow.
      */
     public FlowDTO getSystemDefaultFlow(String flowType) throws FlowMgtServerException {
 
-        if (flowDTOCache.containsKey(flowType)) {
-            return flowDTOCache.get(flowType).orElse(null);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Retrieving system default flow for flow type: " + flowType);
         }
-        FlowDTO flowDTO = loadFlowFromResource(flowType);
-        flowDTOCache.put(flowType, Optional.ofNullable(flowDTO));
-        return flowDTO;
+        if (!flowDTOCache.containsKey(flowType)) {
+            flowDTOCache.put(flowType, Optional.ofNullable(loadFlowFromResource(flowType)));
+        }
+        FlowDTO cached = flowDTOCache.get(flowType).orElse(null);
+        if (cached == null) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.readValue(OBJECT_MAPPER.writeValueAsBytes(cached), FlowDTO.class);
+        } catch (IOException e) {
+            throw handleServerException(ERROR_CODE_LOAD_SYSTEM_DEFAULT_FLOW, e, flowType);
+        }
     }
 
     /**
      * Get the system default GraphConfig for the given flow type.
      * Returns {@code null} if no system default is configured for this flow type.
+     * The GraphConfig is built fresh on each call from a newly deserialized FlowDTO.
      *
      * @param flowType The flow type identifier (e.g. "INVITED_USER_REGISTRATION").
-     * @return The system default GraphConfig, or {@code null} if not found.
+     * @return A new GraphConfig instance, or {@code null} if not found.
      * @throws FlowMgtServerException If an error occurs while loading or building the default flow graph.
      */
     public GraphConfig getSystemDefaultGraphConfig(String flowType) throws FlowMgtServerException {
 
-        if (graphConfigCache.containsKey(flowType)) {
-            return graphConfigCache.get(flowType).orElse(null);
-        }
         FlowDTO flowDTO = getSystemDefaultFlow(flowType);
         if (flowDTO == null) {
-            graphConfigCache.put(flowType, Optional.empty());
             return null;
         }
         try {
-            GraphConfig graphConfig = new GraphBuilder().withSteps(flowDTO.getSteps()).build();
-            graphConfigCache.put(flowType, Optional.of(graphConfig));
-            return graphConfig;
+            return new GraphBuilder().withSteps(flowDTO.getSteps()).build();
         } catch (FlowMgtFrameworkException e) {
             throw handleServerException(ERROR_CODE_LOAD_SYSTEM_DEFAULT_FLOW, e, flowType);
         }
@@ -120,6 +121,17 @@ public class SystemDefaultFlowProvider {
 
     private FlowDTO loadFlowFromResource(String flowType) throws FlowMgtServerException {
 
+        boolean isKnownFlowType = false;
+        for (Constants.FlowTypes knownType : Constants.FlowTypes.values()) {
+            if (knownType.getType().equals(flowType)) {
+                isKnownFlowType = true;
+                break;
+            }
+        }
+        if (!isKnownFlowType) {
+            LOG.warn("Rejected unknown flow type for system default flow lookup: " + flowType);
+            return null;
+        }
         File configFile = new File(CarbonUtils.getCarbonConfigDirPath(), FLOW_DEFAULTS_DIR + File.separator
                 + flowType + ".json");
         if (!configFile.exists()) {
@@ -132,6 +144,7 @@ public class SystemDefaultFlowProvider {
         try (InputStream inputStream = new FileInputStream(configFile)) {
             FlowDTO flowDTO = OBJECT_MAPPER.readValue(inputStream, FlowDTO.class);
             flowDTO.setFlowType(flowType);
+            LOG.info("Successfully loaded system default flow for flow type: " + flowType);
             return flowDTO;
         } catch (IOException e) {
             throw handleServerException(ERROR_CODE_LOAD_SYSTEM_DEFAULT_FLOW, e, flowType);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/SystemDefaultFlowProvider.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/SystemDefaultFlowProvider.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.mgt.utils;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.flow.mgt.exception.FlowMgtFrameworkException;
+import org.wso2.carbon.identity.flow.mgt.exception.FlowMgtServerException;
+import org.wso2.carbon.identity.flow.mgt.model.FlowDTO;
+import org.wso2.carbon.identity.flow.mgt.model.GraphConfig;
+import org.wso2.carbon.utils.CarbonUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.wso2.carbon.identity.flow.mgt.Constants.ErrorMessages.ERROR_CODE_LOAD_SYSTEM_DEFAULT_FLOW;
+import static org.wso2.carbon.identity.flow.mgt.utils.FlowMgtUtils.handleServerException;
+
+/**
+ * Provider for system default flows loaded from JSON configuration files located in the Carbon conf directory
+ * under {@code <carbon-home>/repository/conf/flow-defaults/{flowType}.json}. System default flows serve as
+ * fallbacks when no tenant-specific or org-hierarchy-inherited flow exists for a given flow type.
+ */
+public class SystemDefaultFlowProvider {
+
+    private static final Log LOG = LogFactory.getLog(SystemDefaultFlowProvider.class);
+
+    private static final SystemDefaultFlowProvider INSTANCE = new SystemDefaultFlowProvider();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    private static final String FLOW_DEFAULTS_DIR = "flow-defaults";
+
+    /**
+     * Cache for loaded FlowDTOs per flow type. Optional.empty() is stored when no default exists,
+     * preventing repeated file system lookups for unsupported flow types.
+     */
+    private final Map<String, Optional<FlowDTO>> flowDTOCache = new ConcurrentHashMap<>();
+
+    /**
+     * Cache for built GraphConfigs per flow type. Optional.empty() is stored when no default exists.
+     */
+    private final Map<String, Optional<GraphConfig>> graphConfigCache = new ConcurrentHashMap<>();
+
+    private SystemDefaultFlowProvider() {
+
+    }
+
+    public static SystemDefaultFlowProvider getInstance() {
+
+        return INSTANCE;
+    }
+
+    /**
+     * Get the system default FlowDTO for the given flow type.
+     * Returns {@code null} if no system default is configured for this flow type.
+     *
+     * @param flowType The flow type identifier (e.g. "INVITED_USER_REGISTRATION").
+     * @return The system default FlowDTO, or {@code null} if not found.
+     * @throws FlowMgtServerException If an error occurs while loading or parsing the default flow.
+     */
+    public FlowDTO getSystemDefaultFlow(String flowType) throws FlowMgtServerException {
+
+        if (flowDTOCache.containsKey(flowType)) {
+            return flowDTOCache.get(flowType).orElse(null);
+        }
+        FlowDTO flowDTO = loadFlowFromResource(flowType);
+        flowDTOCache.put(flowType, Optional.ofNullable(flowDTO));
+        return flowDTO;
+    }
+
+    /**
+     * Get the system default GraphConfig for the given flow type.
+     * Returns {@code null} if no system default is configured for this flow type.
+     *
+     * @param flowType The flow type identifier (e.g. "INVITED_USER_REGISTRATION").
+     * @return The system default GraphConfig, or {@code null} if not found.
+     * @throws FlowMgtServerException If an error occurs while loading or building the default flow graph.
+     */
+    public GraphConfig getSystemDefaultGraphConfig(String flowType) throws FlowMgtServerException {
+
+        if (graphConfigCache.containsKey(flowType)) {
+            return graphConfigCache.get(flowType).orElse(null);
+        }
+        FlowDTO flowDTO = getSystemDefaultFlow(flowType);
+        if (flowDTO == null) {
+            graphConfigCache.put(flowType, Optional.empty());
+            return null;
+        }
+        try {
+            GraphConfig graphConfig = new GraphBuilder().withSteps(flowDTO.getSteps()).build();
+            graphConfigCache.put(flowType, Optional.of(graphConfig));
+            return graphConfig;
+        } catch (FlowMgtFrameworkException e) {
+            throw handleServerException(ERROR_CODE_LOAD_SYSTEM_DEFAULT_FLOW, e, flowType);
+        }
+    }
+
+    private FlowDTO loadFlowFromResource(String flowType) throws FlowMgtServerException {
+
+        File configFile = new File(CarbonUtils.getCarbonConfigDirPath(), FLOW_DEFAULTS_DIR + File.separator
+                + flowType + ".json");
+        if (!configFile.exists()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("No system default flow configuration found for flow type: " + flowType
+                        + " at path: " + configFile.getAbsolutePath());
+            }
+            return null;
+        }
+        try (InputStream inputStream = new FileInputStream(configFile)) {
+            FlowDTO flowDTO = OBJECT_MAPPER.readValue(inputStream, FlowDTO.class);
+            flowDTO.setFlowType(flowType);
+            return flowDTO;
+        } catch (IOException e) {
+            throw handleServerException(ERROR_CODE_LOAD_SYSTEM_DEFAULT_FLOW, e, flowType);
+        }
+    }
+}

--- a/features/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt.server.feature/pom.xml
+++ b/features/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt.server.feature/pom.xml
@@ -42,6 +42,31 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prefilter-resources</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>src/main/resources</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>resources</directory>
+                                    <includes>
+                                        <include>INVITED_USER_REGISTRATION.json</include>
+                                        <include>p2.inf</include>
+                                        <include>build.properties</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.wso2.maven</groupId>
                 <artifactId>carbon-p2-plugin</artifactId>
                 <version>${carbon.p2.plugin.version}</version>
@@ -66,6 +91,27 @@
                                 </bundleDef>
                             </bundles>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.1</version>
+                <executions>
+                    <execution>
+                        <id>clean_target</id>
+                        <phase>install</phase>
+                        <configuration>
+                            <tasks>
+                                <delete dir="src/main/resources" />
+                                <delete dir="src/main" />
+                                <delete dir="src" />
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/features/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt.server.feature/resources/INVITED_USER_REGISTRATION.json
+++ b/features/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt.server.feature/resources/INVITED_USER_REGISTRATION.json
@@ -46,7 +46,7 @@
                   "type": "password",
                   "hint": "",
                   "label": "Password",
-                  "required": false,
+                  "required": true,
                   "placeholder": "Enter your password"
                 }
               },

--- a/features/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt.server.feature/resources/INVITED_USER_REGISTRATION.json
+++ b/features/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt.server.feature/resources/INVITED_USER_REGISTRATION.json
@@ -1,0 +1,115 @@
+{
+  "steps": [
+    {
+      "id": "execution_aa41",
+      "type": "EXECUTION",
+      "data": {
+        "action": {
+          "type": "EXECUTOR",
+          "executor": {
+            "name": "ConfirmationCodeValidationExecutor"
+          },
+          "nextId": "ID_1ybm"
+        }
+      },
+      "height": 99.0,
+      "width": 205.0,
+      "coordinateX": 157.0,
+      "coordinateY": 495.0
+    },
+    {
+      "id": "ID_1ybm",
+      "type": "VIEW",
+      "data": {
+        "components": [
+          {
+            "id": "typography_5ptq",
+            "category": "DISPLAY",
+            "type": "TYPOGRAPHY",
+            "variant": "H3",
+            "configs": {
+              "text": "Set Password"
+            }
+          },
+          {
+            "id": "form_5w11",
+            "category": "BLOCK",
+            "type": "FORM",
+            "components": [
+              {
+                "id": "input_2yk7",
+                "category": "FIELD",
+                "type": "INPUT",
+                "variant": "PASSWORD",
+                "configs": {
+                  "identifier": "password",
+                  "type": "password",
+                  "hint": "",
+                  "label": "Password",
+                  "required": false,
+                  "placeholder": "Enter your password"
+                }
+              },
+              {
+                "id": "button_ycsc",
+                "category": "ACTION",
+                "type": "BUTTON",
+                "variant": "PRIMARY",
+                "action": {
+                  "type": "EXECUTOR",
+                  "executor": {
+                    "name": "PasswordProvisioningExecutor"
+                  },
+                  "nextId": "END"
+                },
+                "configs": {
+                  "type": "submit",
+                  "text": "Continue"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "height": 453.0,
+      "width": 350.0,
+      "coordinateX": 500.0,
+      "coordinateY": 319.0
+    },
+    {
+      "id": "END",
+      "type": "END",
+      "data": {
+        "components": [
+          {
+            "id": "typography_u2oz",
+            "category": "DISPLAY",
+            "type": "TYPOGRAPHY",
+            "variant": "H3",
+            "configs": {
+              "text": "Password Set Successfully"
+            }
+          },
+          {
+            "id": "display_hgvm",
+            "category": "DISPLAY",
+            "type": "RICH_TEXT",
+            "configs": {
+              "text": "<p class=\"rich-text-paragraph rich-text-align-center\"><span class=\"rich-text-pre-wrap\">You have successfully set a password for your account.</span></p>"
+            }
+          }
+        ],
+        "action": {
+          "type": "EXECUTOR",
+          "executor": {
+            "name": "UserProvisioningExecutor"
+          }
+        }
+      },
+      "height": 310.0,
+      "width": 350.0,
+      "coordinateX": 1040.0,
+      "coordinateY": 400.0
+    }
+  ]
+}

--- a/features/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt.server.feature/resources/build.properties
+++ b/features/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt.server.feature/resources/build.properties
@@ -1,0 +1,2 @@
+custom = true
+root.identity-core=conf/flow-defaults

--- a/features/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt.server.feature/resources/p2.inf
+++ b/features/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt.server.feature/resources/p2.inf
@@ -1,0 +1,5 @@
+instructions.configure = \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository); \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository/conf); \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository/conf/flow-defaults); \
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.flow.mgt.server_${feature.version}/INVITED_USER_REGISTRATION.json,target:${installFolder}/../../conf/flow-defaults/INVITED_USER_REGISTRATION.json,overwrite:true);\

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2991,6 +2991,9 @@
         <EnableLegacySelfRegistrationFlow>false</EnableLegacySelfRegistrationFlow>
         <EnableLegacyPasswordRecoveryFlow>false</EnableLegacyPasswordRecoveryFlow>
         <EnableLegacyInvitedUserRegistrationFlow>false</EnableLegacyInvitedUserRegistrationFlow>
+        <DefaultEnabledFlows>
+            <FlowType>INVITED_USER_REGISTRATION</FlowType>
+        </DefaultEnabledFlows>
         <Registration>
             <DisplayClaimAvailability>false</DisplayClaimAvailability>
         </Registration>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -5156,6 +5156,13 @@
         <EnableLegacySelfRegistrationFlow>{{flow_execution.enable_legacy_self_registration_flow}}</EnableLegacySelfRegistrationFlow>
         <EnableLegacyPasswordRecoveryFlow>{{flow_execution.enable_legacy_password_recovery_flow}}</EnableLegacyPasswordRecoveryFlow>
         <EnableLegacyInvitedUserRegistrationFlow>{{flow_execution.enable_legacy_invited_user_registration_flow}}</EnableLegacyInvitedUserRegistrationFlow>
+        {% if flow_execution.default_enabled_flows is defined %}
+        <DefaultEnabledFlows>
+            {% for flow_type in flow_execution.default_enabled_flows %}
+            <FlowType>{{flow_type}}</FlowType>
+            {% endfor %}
+        </DefaultEnabledFlows>
+        {% endif %}
         <Registration>
             <DisplayClaimAvailability>{{flow_execution.registration.display_claim_availability}}</DisplayClaimAvailability>
             <DefaultUserStore>{{flow_execution.registration.default_user_store}}</DefaultUserStore>


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/27011

## Summary

  Introduces system default flows for the flow orchestration framework, with `INVITED_USER_REGISTRATION` shipped as the first system default. When no tenant-specific or org-hierarchy-inherited flow exists for a given flow type, the framework now falls back to a JSON configuration file deployed to `<carbon-home>/repository/conf/flow-defaults/{flowType}.json`.

  Additionally adds a generic server-level configuration (`<DefaultEnabledFlows>` in `identity.xml`) to control which flow types are enabled by default, without requiring per-tenant configuration.

  ### Changes

  #### System default flow loading
  - Added `SystemDefaultFlowProvider` singleton that loads default flows from the Carbon conf directory (`CarbonUtils.getCarbonConfigDirPath()`). Results are cached per flow type; each retrieval returns a deep copy to prevent callers from
  mutating shared cached state.
  - Updated `FlowMgtService.getFlow()` and `getGraphConfig()` to fall back to `SystemDefaultFlowProvider` when `getFirstTenantWithFlow()` returns `null`.

  #### Security
  - `SystemDefaultFlowProvider` validates the `flowType` argument against the `Constants.FlowTypes` whitelist before constructing the file path, preventing path traversal attacks.

  #### Cache correctness
  - `FlowResolveCacheKey` now includes `flowType` in addition to `orgId` in its `equals()` and `hashCode()` implementations, preventing cross-flow cache pollution where a cached resolution for one flow type would be incorrectly returned for
  another.
  - `clearFlowResolveCache()` in `FlowMgtService` updated to accept `flowType` and scope cache invalidation correctly; callers (`updateFlow`, `deleteFlow`) updated accordingly.

  #### Server-level default enabled flows config
  - Added `<DefaultEnabledFlows><FlowType>...</FlowType></DefaultEnabledFlows>` block within `<FlowExecution>` in `identity.xml`.
  - `FlowMgtConfigUtils` reads this config at class load time via `IdentityConfigParser` + AXIOM traversal and uses it as a fallback when returning the default `isEnabled` state for a flow type that has no tenant-specific configuration stored in
   the database.

  #### Feature packaging
  - Added `INVITED_USER_REGISTRATION.json` default flow definition (password setup form → user onboard).

  ### Deployment

  The `INVITED_USER_REGISTRATION` flow will be active by default for all tenants that do not have a custom flow configured. To disable it, either remove `<FlowType>INVITED_USER_REGISTRATION</FlowType>` from `<DefaultEnabledFlows>` in
  `identity.xml`, or explicitly configure the flow as disabled via the tenant-level API.
Default enabled flows can be configured via `deployment.toml`:
  ```toml
  [flow_execution]
  default_enabled_flows = ["INVITED_USER_REGISTRATION"]
