### PR TITLE
Fix: Deprecated handle method in JIT Provisioning flow breaks customizations extended from DefaultProvisioningHandler

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/ProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/ProvisioningHandler.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.authentication.framework.handler.provisioning;
 
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 
 import java.util.List;
@@ -77,5 +78,22 @@ public interface ProvisioningHandler {
                                    String provisioningUserStoreId, String tenantDomain) throws FrameworkException {
 
         throw new FrameworkException("Operation is not supported.");
+    }
+
+    /**
+     * Handle provisioning with v2 roles.
+     *
+     * @param roleIdList              List of role ids.
+     * @param subject                 Subject identifier.
+     * @param attributes              Attributes.
+     * @param provisioningUserStoreId Provisioning user store Id.
+     * @param tenantDomain            Tenant domain.
+     * @param context                 Authentication context
+     * @throws FrameworkException If an error occurred while handling provisioning with v2 roles.
+     */
+    default void handleWithV2Roles(List<String> roleIdList, String subject, Map<String, String> attributes,
+                                   String provisioningUserStoreId, String tenantDomain, AuthenticationContext context) 
+                                   throws FrameworkException {
+        handleWithV2Roles(roleIdList, subject, attributes, provisioningUserStoreId, tenantDomain);
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/ProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/ProvisioningHandler.java
@@ -94,6 +94,7 @@ public interface ProvisioningHandler {
     default void handleWithV2Roles(List<String> roleIdList, String subject, Map<String, String> attributes,
                                    String provisioningUserStoreId, String tenantDomain, AuthenticationContext context) 
                                    throws FrameworkException {
+                                    
         handleWithV2Roles(roleIdList, subject, attributes, provisioningUserStoreId, tenantDomain);
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -175,14 +175,14 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
 
     @Override
     public void handleWithV2Roles(List<String> roleIdList, String subject, Map<String, String> attributes,
-                  String provisioningUserStoreId, String tenantDomain) throws FrameworkException {
-        handleWithV2Roles(roleIdList, subject, attributes, provisioningUserStoreId, tenantDomain, null);
+                  String provisioningUserStoreId, String tenantDomain, AuthenticationContext context) throws FrameworkException {
+
+        handleWithV2Roles(roleIdList, subject, attributes, provisioningUserStoreId, tenantDomain);
     }
 
     @Override
     public void handleWithV2Roles(List<String> roleIdList, String subject, Map<String, String> attributes,
-                       String provisioningUserStoreId, String tenantDomain, 
-                       AuthenticationContext context) throws FrameworkException {
+                       String provisioningUserStoreId, String tenantDomain) throws FrameworkException {
 
         RealmService realmService = FrameworkServiceDataHolder.getInstance().getRealmService();
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -27,6 +27,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.core.util.PermissionUpdateUtil;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.provisioning.ProvisioningHandler;
@@ -174,7 +175,14 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
 
     @Override
     public void handleWithV2Roles(List<String> roleIdList, String subject, Map<String, String> attributes,
-                       String provisioningUserStoreId, String tenantDomain) throws FrameworkException {
+                  String provisioningUserStoreId, String tenantDomain) throws FrameworkException {
+        handleWithV2Roles(roleIdList, subject, attributes, provisioningUserStoreId, tenantDomain, null);
+    }
+
+    @Override
+    public void handleWithV2Roles(List<String> roleIdList, String subject, Map<String, String> attributes,
+                       String provisioningUserStoreId, String tenantDomain, 
+                       AuthenticationContext context) throws FrameworkException {
 
         RealmService realmService = FrameworkServiceDataHolder.getInstance().getRealmService();
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -175,7 +175,8 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
 
     @Override
     public void handleWithV2Roles(List<String> roleIdList, String subject, Map<String, String> attributes,
-                  String provisioningUserStoreId, String tenantDomain, AuthenticationContext context) throws FrameworkException {
+                  String provisioningUserStoreId, String tenantDomain, 
+                  AuthenticationContext context) throws FrameworkException {
 
         handleWithV2Roles(roleIdList, subject, attributes, provisioningUserStoreId, tenantDomain);
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -692,7 +692,7 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
 
             FrameworkUtils.getProvisioningHandler()
                     .handleWithV2Roles(assignedRoleIdList, subjectIdentifier, extAttributesValueMap, userStoreDomain,
-                            context.getTenantDomain());
+                            context.getTenantDomain(), context);
         } catch (FrameworkException e) {
             if (FrameworkUtils.isAuthenticationFailOnJitFail()) {
                 throw e;


### PR DESCRIPTION
Related issue: https://github.com/wso2/product-is/issues/27454

### Problem
When v2 roles were introduced, the `handleWithV2Roles` method in the JIT provisioning flow did not expose the `AuthenticationContext` to the provisioning handler. This broke customizations where deployers extended `DefaultProvisioningHandler` to intercept and transform raw IDP roles before applying them to the local user.

Without access to AuthenticationContext, custom provisioning handlers had no way to retrieve the original claims sent by the federated IDP, making it impossible to replicate the role-mapping logic.

### Root Cause
`DefaultStepBasedSequenceHandler` called `handleWithV2Roles(roleIdList, subject, attributes, userStoreDomain, tenantDomain)` without passing the `AuthenticationContext`. As a result, custom subclasses of `DefaultProvisioningHandler` had no access to the authentication context (and therefore the raw IDP claims) when the method was invoked.

### Fix
- Added a new overloaded `handleWithV2Roles` method to the `ProvisioningHandler` interface that accepts `AuthenticationContext` as an additional parameter. 
- A default implementation is provided that delegates to the existing 5-argument method, ensuring full backward compatibility for existing custom implementations.
- Overrode this new method in DefaultProvisioningHandler, delegating to the existing implementation.
- Updated `DefaultStepBasedSequenceHandler` to call the new 6-argument overload, passing the `AuthenticationContext` through to the handler.

### Impact
Custom provisioning handlers extending `DefaultProvisioningHandler` can now override `handleWithV2Roles(List, String, Map, String, String, AuthenticationContext)` to access the full authentication context, including IDP-provided claims, to implement custom role-mapping logic. Existing implementations that do not override the new signature are unaffected due to the default delegation.