### PR TITLE
Add config to enable shared user identifier by default.

### DIFF
--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -267,6 +267,9 @@
   "authentication.authenticator.org_identifier_handler.name": "OrganizationIdentifierHandler",
   "authentication.authenticator.org_identifier_handler.enable": true,
 
+  "authentication.authenticator.shared_user_identifier.name": "SharedUserIdentifierExecutor",
+  "authentication.authenticator.shared_user_identifier.enable": true,
+
   "authentication.local_authenticators.hide_user_existence": true,
 
   "account_recovery.endpoint.auth.name":"dashboard",


### PR DESCRIPTION
This pull request introduces a new authenticator configuration to the authentication framework. The main change is the addition of the `SharedUserIdentifierExecutor` authenticator, which is now enabled by default.

**Authenticator configuration updates:**

* Added configuration entries for the `SharedUserIdentifierExecutor` authenticator, including its name and enabled status in the `org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json` file.

### Related pr
- https://github.com/wso2-extensions/identity-auth-organization-login/pull/75

### Related issue
- https://github.com/wso2/product-is/issues/27371