### PR TITLE
Add rule config support for update users of group operation

### DIFF
--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/rule/WorkFlowRuleEvaluationDataProvider.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/rule/WorkFlowRuleEvaluationDataProvider.java
@@ -66,6 +66,7 @@ public class WorkFlowRuleEvaluationDataProvider implements RuleEvaluationDataPro
     private static final String ROLE_AUDIENCE_ID = "Audience ID";
     private static final String EVENT_TYPE = "eventType";
     private static final String CLAIMS = "Claims";
+    private static final String GROUP_NAME = "Group Name";
 
     private static final String ADD_USER_EVENT = "ADD_USER";
     private static final String SELF_REGISTER_USER_EVENT = "SELF_REGISTER_USER";
@@ -84,7 +85,10 @@ public class WorkFlowRuleEvaluationDataProvider implements RuleEvaluationDataPro
         ROLE_AUDIENCE("role.audience"),
         ROLE_PERMISSIONS("role.permissions"),
         ROLE_HAS_ASSIGNED_USERS("role.hasAssignedUsers"),
-        ROLE_HAS_UNASSIGNED_USERS("role.hasUnassignedUsers");
+        ROLE_HAS_UNASSIGNED_USERS("role.hasUnassignedUsers"),
+        GROUP_ID("group.id"),
+        GROUP_HAS_ASSIGNED_USERS("group.hasAssignedUsers"),
+        GROUP_HAS_UNASSIGNED_USERS("group.hasUnassignedUsers");
 
         private final String fieldName;
 
@@ -245,6 +249,15 @@ public class WorkFlowRuleEvaluationDataProvider implements RuleEvaluationDataPro
                 break;
             case ROLE_HAS_UNASSIGNED_USERS:
                 resolveRoleHasUnassignedUsersField(fieldValues, field, contextData);
+                break;
+            case GROUP_ID:
+                resolveGroupIdField(fieldValues, field, contextData);
+                break;
+            case GROUP_HAS_ASSIGNED_USERS:
+                resolveGroupHasAssignedUsersField(fieldValues, field, contextData);
+                break;
+            case GROUP_HAS_UNASSIGNED_USERS:
+                resolveGroupHasUnassignedUsersField(fieldValues, field, contextData);
                 break;
             default:
                 throw new RuleEvaluationDataProviderException(
@@ -487,6 +500,77 @@ public class WorkFlowRuleEvaluationDataProvider implements RuleEvaluationDataPro
 
         if (log.isDebugEnabled()) {
             log.debug("Role has unassigned users: " + hasUnassignedUsers + " (users to unassign count: " +
+                    (usersToBeUnassigned != null ? usersToBeUnassigned.size() : 0) + ")");
+        }
+    }
+
+    /**
+     * Resolve group ID field value by fetching from the user store using the group name from context data.
+     *
+     * @param fieldValues  List of field values to add to.
+     * @param field        Field being processed.
+     * @param contextData  Context data from the flow context.
+     * @throws RuleEvaluationDataProviderException If an error occurs while resolving the group ID.
+     */
+    private void resolveGroupIdField(List<FieldValue> fieldValues, Field field, Map<String, Object> contextData)
+            throws RuleEvaluationDataProviderException {
+
+        String groupName = (String) contextData.get(GROUP_NAME);
+        if (StringUtils.isBlank(groupName)) {
+            log.debug("Cannot fetch group ID without Group Name in context. Adding null group ID.");
+            fieldValues.add(new FieldValue(field.getName(), (String) null, ValueType.STRING));
+            return;
+        }
+        try {
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) CarbonContext
+                    .getThreadLocalCarbonContext().getUserRealm().getUserStoreManager();
+            String groupId = userStoreManager.getGroupIdByGroupName(groupName);
+            fieldValues.add(new FieldValue(field.getName(),
+                    StringUtils.isNotBlank(groupId) ? groupId : null, ValueType.STRING));
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new RuleEvaluationDataProviderException(
+                    "Error retrieving group ID for group name: " + groupName, e);
+        }
+    }
+
+    /**
+     * Resolve group has assigned users field value from context data.
+     * Checks if the "Users to be Added" list in context data is non-empty.
+     *
+     * @param fieldValues List of field values to add to.
+     * @param field       Field being processed.
+     * @param contextData Context data from the flow context.
+     */
+    private void resolveGroupHasAssignedUsersField(List<FieldValue> fieldValues, Field field,
+                                                    Map<String, Object> contextData) {
+
+        List<?> usersToBeAssigned = (List<?>) contextData.get(USERS_TO_BE_ASSIGNED);
+        boolean hasAssignedUsers = CollectionUtils.isNotEmpty(usersToBeAssigned);
+        fieldValues.add(new FieldValue(field.getName(), String.valueOf(hasAssignedUsers), ValueType.STRING));
+
+        if (log.isDebugEnabled()) {
+            log.debug("Group has assigned users: " + hasAssignedUsers + " (users to assign count: " +
+                    (usersToBeAssigned != null ? usersToBeAssigned.size() : 0) + ")");
+        }
+    }
+
+    /**
+     * Resolve group has unassigned users field value from context data.
+     * Checks if the "Users to be Deleted" list in context data is non-empty.
+     *
+     * @param fieldValues List of field values to add to.
+     * @param field       Field being processed.
+     * @param contextData Context data from the flow context.
+     */
+    private void resolveGroupHasUnassignedUsersField(List<FieldValue> fieldValues, Field field,
+                                                      Map<String, Object> contextData) {
+
+        List<?> usersToBeUnassigned = (List<?>) contextData.get(USERS_TO_BE_UNASSIGNED);
+        boolean hasUnassignedUsers = CollectionUtils.isNotEmpty(usersToBeUnassigned);
+        fieldValues.add(new FieldValue(field.getName(), String.valueOf(hasUnassignedUsers), ValueType.STRING));
+
+        if (log.isDebugEnabled()) {
+            log.debug("Group has unassigned users: " + hasUnassignedUsers + " (users to unassign count: " +
                     (usersToBeUnassigned != null ? usersToBeUnassigned.size() : 0) + ")");
         }
     }

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/rule/WorkflowRuleFieldRegistry.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/rule/WorkflowRuleFieldRegistry.java
@@ -138,6 +138,40 @@ public class WorkflowRuleFieldRegistry {
                     .addFixedValue("false", "false")
                 .build());
 
+        fields.put("group.id", new FieldDefinitionBuilder()
+                .name("group.id")
+                .displayName("group identifier")
+                .operators(OPERATOR_EQUALS, OPERATOR_NOT_EQUALS)
+                .options()
+                    .valueType(Value.ValueType.REFERENCE)
+                    .referenceAttr("id")
+                    .displayAttr("displayName")
+                    .addLink(GROUPS_VALUES_LINK, "GET", "values")
+                    .addLink(GROUPS_FILTER_LINK, "GET", "filter")
+                .build());
+
+        fields.put("group.hasAssignedUsers", new FieldDefinitionBuilder()
+                .name("group.hasAssignedUsers")
+                .displayName("new users added to the group")
+                .operators(OPERATOR_EQUALS)
+                .options()
+                    .valueType(Value.ValueType.STRING)
+                    .addFixedValue("true", "true")
+                    .addFixedValue("false", "false")
+                .build());
+
+        fields.put("group.hasUnassignedUsers", new FieldDefinitionBuilder()
+                .name("group.hasUnassignedUsers")
+                .displayName("users removed from the group")
+                .operators(OPERATOR_EQUALS)
+                .options()
+                    .valueType(Value.ValueType.STRING)
+                    .addFixedValue("true", "true")
+                    .addFixedValue("false", "false")
+                .build());
+
+        
+
         FIELDS = Collections.unmodifiableMap(fields);
     }
 

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/test/java/org/wso2/carbon/identity/workflow/mgt/rule/WorkFlowRuleEvaluationDataProviderTest.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/test/java/org/wso2/carbon/identity/workflow/mgt/rule/WorkFlowRuleEvaluationDataProviderTest.java
@@ -541,6 +541,173 @@ public class WorkFlowRuleEvaluationDataProviderTest {
         provider.getEvaluationData(ruleContext, flowContext, TENANT_DOMAIN);
     }
 
+    // ---- group.id ----
+
+    @Test
+    public void testGetEvaluationData_groupId_returnsGroupIdFromUserStore()
+            throws Exception {
+
+        Map<String, Object> contextData = new HashMap<>();
+        contextData.put("Group Name", "engineering");
+        FlowContext flowContext = new FlowContext(FlowType.APPROVAL_WORKFLOW, contextData);
+
+        when(mockUserStoreManager.getGroupIdByGroupName("engineering")).thenReturn("group-id-abc");
+
+        Field field = new Field("group.id", ValueType.STRING);
+        RuleEvaluationContext ruleContext = new RuleEvaluationContext("rule-13",
+                Collections.singletonList(field));
+
+        List<FieldValue> result = provider.getEvaluationData(ruleContext, flowContext, TENANT_DOMAIN);
+
+        assertEquals(result.size(), 1);
+        assertEquals(result.get(0).getName(), "group.id");
+        assertEquals(result.get(0).getValue(), "group-id-abc");
+        assertEquals(result.get(0).getValueType(), ValueType.STRING);
+    }
+
+    @Test
+    public void testGetEvaluationData_groupId_noGroupNameInContext_returnsNull()
+            throws RuleEvaluationDataProviderException {
+
+        Map<String, Object> contextData = new HashMap<>();
+        FlowContext flowContext = new FlowContext(FlowType.APPROVAL_WORKFLOW, contextData);
+
+        Field field = new Field("group.id", ValueType.STRING);
+        RuleEvaluationContext ruleContext = new RuleEvaluationContext("rule-13",
+                Collections.singletonList(field));
+
+        List<FieldValue> result = provider.getEvaluationData(ruleContext, flowContext, TENANT_DOMAIN);
+
+        assertEquals(result.size(), 1);
+        assertNull(result.get(0).getValue());
+    }
+
+    @Test(expectedExceptions = RuleEvaluationDataProviderException.class)
+    public void testGetEvaluationData_groupId_userStoreException_throwsDataProviderException()
+            throws Exception {
+
+        Map<String, Object> contextData = new HashMap<>();
+        contextData.put("Group Name", "engineering");
+        FlowContext flowContext = new FlowContext(FlowType.APPROVAL_WORKFLOW, contextData);
+
+        when(mockUserStoreManager.getGroupIdByGroupName("engineering"))
+                .thenThrow(new org.wso2.carbon.user.core.UserStoreException("DB error"));
+
+        Field field = new Field("group.id", ValueType.STRING);
+        RuleEvaluationContext ruleContext = new RuleEvaluationContext("rule-13",
+                Collections.singletonList(field));
+
+        provider.getEvaluationData(ruleContext, flowContext, TENANT_DOMAIN);
+    }
+
+    // ---- group.hasAssignedUsers ----
+
+    @Test
+    public void testGetEvaluationData_groupHasAssignedUsers_withUsersInContext_returnsTrue()
+            throws RuleEvaluationDataProviderException {
+
+        Map<String, Object> contextData = new HashMap<>();
+        contextData.put("Users to be Added", Arrays.asList("user1", "user2"));
+        FlowContext flowContext = new FlowContext(FlowType.APPROVAL_WORKFLOW, contextData);
+
+        Field field = new Field("group.hasAssignedUsers", ValueType.STRING);
+        RuleEvaluationContext ruleContext = new RuleEvaluationContext("rule-14",
+                Collections.singletonList(field));
+
+        List<FieldValue> result = provider.getEvaluationData(ruleContext, flowContext, TENANT_DOMAIN);
+
+        assertEquals(result.size(), 1);
+        assertEquals(result.get(0).getName(), "group.hasAssignedUsers");
+        assertEquals(result.get(0).getValue(), "true");
+    }
+
+    @Test
+    public void testGetEvaluationData_groupHasAssignedUsers_noUsersInContext_returnsFalse()
+            throws RuleEvaluationDataProviderException {
+
+        Map<String, Object> contextData = new HashMap<>();
+        contextData.put("Users to be Added", Collections.emptyList());
+        FlowContext flowContext = new FlowContext(FlowType.APPROVAL_WORKFLOW, contextData);
+
+        Field field = new Field("group.hasAssignedUsers", ValueType.STRING);
+        RuleEvaluationContext ruleContext = new RuleEvaluationContext("rule-14",
+                Collections.singletonList(field));
+
+        List<FieldValue> result = provider.getEvaluationData(ruleContext, flowContext, TENANT_DOMAIN);
+
+        assertEquals(result.get(0).getValue(), "false");
+    }
+
+    @Test
+    public void testGetEvaluationData_groupHasAssignedUsers_nullInContext_returnsFalse()
+            throws RuleEvaluationDataProviderException {
+
+        Map<String, Object> contextData = new HashMap<>();
+        FlowContext flowContext = new FlowContext(FlowType.APPROVAL_WORKFLOW, contextData);
+
+        Field field = new Field("group.hasAssignedUsers", ValueType.STRING);
+        RuleEvaluationContext ruleContext = new RuleEvaluationContext("rule-14",
+                Collections.singletonList(field));
+
+        List<FieldValue> result = provider.getEvaluationData(ruleContext, flowContext, TENANT_DOMAIN);
+
+        assertEquals(result.get(0).getValue(), "false");
+    }
+
+    // ---- group.hasUnassignedUsers ----
+
+    @Test
+    public void testGetEvaluationData_groupHasUnassignedUsers_withUsersInContext_returnsTrue()
+            throws RuleEvaluationDataProviderException {
+
+        Map<String, Object> contextData = new HashMap<>();
+        contextData.put("Users to be Deleted", Arrays.asList("user3"));
+        FlowContext flowContext = new FlowContext(FlowType.APPROVAL_WORKFLOW, contextData);
+
+        Field field = new Field("group.hasUnassignedUsers", ValueType.STRING);
+        RuleEvaluationContext ruleContext = new RuleEvaluationContext("rule-15",
+                Collections.singletonList(field));
+
+        List<FieldValue> result = provider.getEvaluationData(ruleContext, flowContext, TENANT_DOMAIN);
+
+        assertEquals(result.size(), 1);
+        assertEquals(result.get(0).getName(), "group.hasUnassignedUsers");
+        assertEquals(result.get(0).getValue(), "true");
+    }
+
+    @Test
+    public void testGetEvaluationData_groupHasUnassignedUsers_noUsersInContext_returnsFalse()
+            throws RuleEvaluationDataProviderException {
+
+        Map<String, Object> contextData = new HashMap<>();
+        contextData.put("Users to be Deleted", Collections.emptyList());
+        FlowContext flowContext = new FlowContext(FlowType.APPROVAL_WORKFLOW, contextData);
+
+        Field field = new Field("group.hasUnassignedUsers", ValueType.STRING);
+        RuleEvaluationContext ruleContext = new RuleEvaluationContext("rule-15",
+                Collections.singletonList(field));
+
+        List<FieldValue> result = provider.getEvaluationData(ruleContext, flowContext, TENANT_DOMAIN);
+
+        assertEquals(result.get(0).getValue(), "false");
+    }
+
+    @Test
+    public void testGetEvaluationData_groupHasUnassignedUsers_nullInContext_returnsFalse()
+            throws RuleEvaluationDataProviderException {
+
+        Map<String, Object> contextData = new HashMap<>();
+        FlowContext flowContext = new FlowContext(FlowType.APPROVAL_WORKFLOW, contextData);
+
+        Field field = new Field("group.hasUnassignedUsers", ValueType.STRING);
+        RuleEvaluationContext ruleContext = new RuleEvaluationContext("rule-15",
+                Collections.singletonList(field));
+
+        List<FieldValue> result = provider.getEvaluationData(ruleContext, flowContext, TENANT_DOMAIN);
+
+        assertEquals(result.get(0).getValue(), "false");
+    }
+
     // ---- Multiple fields ----
 
     @Test

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/test/java/org/wso2/carbon/identity/workflow/mgt/rule/WorkflowRuleFieldRegistryTest.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/test/java/org/wso2/carbon/identity/workflow/mgt/rule/WorkflowRuleFieldRegistryTest.java
@@ -60,7 +60,10 @@ public class WorkflowRuleFieldRegistryTest {
             "role.audience",
             "role.permissions",
             "role.hasAssignedUsers",
-            "role.hasUnassignedUsers"
+            "role.hasUnassignedUsers",
+            "group.id",
+            "group.hasAssignedUsers",
+            "group.hasUnassignedUsers"
     );
 
     @Test
@@ -79,10 +82,10 @@ public class WorkflowRuleFieldRegistryTest {
     }
 
     @Test
-    public void testFieldsMapHasExactlyEightEntries() {
+    public void testFieldsMapHasExactlyElevenEntries() {
 
-        assertEquals(WorkflowRuleFieldRegistry.FIELDS.size(), 8,
-                "FIELDS map should have exactly 8 entries.");
+        assertEquals(WorkflowRuleFieldRegistry.FIELDS.size(), 11,
+                "FIELDS map should have exactly 11 entries.");
     }
 
     @Test
@@ -258,5 +261,34 @@ public class WorkflowRuleFieldRegistryTest {
         assertEquals(refValue.getValueReferenceAttribute(), "id");
         assertEquals(refValue.getValueDisplayAttribute(), "name");
         assertEquals(refValue.getLinks().size(), 2);
+    }
+
+    @Test
+    public void testGroupHasAssignedUsersField_hasFixedTrueFalseOptions() {
+
+        FieldDefinition field = WorkflowRuleFieldRegistry.FIELDS.get("group.hasAssignedUsers");
+        assertNotNull(field);
+        assertTrue(field.getValue() instanceof OptionsInputValue,
+                "group.hasAssignedUsers value should be OptionsInputValue.");
+        OptionsInputValue inputValue = (OptionsInputValue) field.getValue();
+        assertEquals(inputValue.getValueType(), Value.ValueType.STRING);
+        assertEquals(inputValue.getValues().size(), 2);
+        assertEquals(inputValue.getValues().get(0).getName(), "true");
+        assertEquals(inputValue.getValues().get(1).getName(), "false");
+        assertEquals(field.getOperators().size(), 1);
+        assertEquals(field.getOperators().get(0).getName(), "equals");
+    }
+
+    @Test
+    public void testGroupHasUnassignedUsersField_hasFixedTrueFalseOptions() {
+
+        FieldDefinition field = WorkflowRuleFieldRegistry.FIELDS.get("group.hasUnassignedUsers");
+        assertNotNull(field);
+        assertTrue(field.getValue() instanceof OptionsInputValue,
+                "group.hasUnassignedUsers value should be OptionsInputValue.");
+        OptionsInputValue inputValue = (OptionsInputValue) field.getValue();
+        assertEquals(inputValue.getValues().size(), 2);
+        assertEquals(inputValue.getValues().get(0).getName(), "true");
+        assertEquals(inputValue.getValues().get(1).getName(), "false");
     }
 }


### PR DESCRIPTION
resolves : https://github.com/wso2/product-is/issues/27001

This pull request adds support for evaluating workflow rules based on group identifiers (`group.id`). It introduces a new field to the rule evaluation system, enables fetching group IDs from the user store using group names, and provides comprehensive unit tests for the new functionality. The changes are organized as follows:

### Feature: Group ID Rule Evaluation

* Added a new field constant `GROUP_NAME` and a new enum value `GROUP_ID` in `WorkFlowRuleEvaluationDataProvider` to support group-based rule evaluation. [[1]](diffhunk://#diff-9c2560d7ab710bafbad9e2163051179ad95ed2be4f2f24dc8380d7c661e8dbc0R69) [[2]](diffhunk://#diff-9c2560d7ab710bafbad9e2163051179ad95ed2be4f2f24dc8380d7c661e8dbc0L87-R89)
* Implemented the `resolveGroupIdField` method in `WorkFlowRuleEvaluationDataProvider` to fetch the group ID from the user store using the group name provided in the context data. The method handles missing group names and user store exceptions gracefully. [[1]](diffhunk://#diff-9c2560d7ab710bafbad9e2163051179ad95ed2be4f2f24dc8380d7c661e8dbc0R251-R253) [[2]](diffhunk://#diff-9c2560d7ab710bafbad9e2163051179ad95ed2be4f2f24dc8380d7c661e8dbc0R498-R526)

### Registry and Metadata Updates

* Registered the new `group.id` field in `WorkflowRuleFieldRegistry` with appropriate display name, operators, value type, and reference links for group values and filtering.

### Testing

* Added unit tests in `WorkFlowRuleEvaluationDataProviderTest` to cover normal, missing context, and error scenarios for the new `group.id` field.
* Updated `WorkflowRuleFieldRegistryTest` to include `group.id` in expected field lists and to check that the field registry now contains nine entries. [[1]](diffhunk://#diff-d6cca2d859b5ff8c47e20f999671f21df5768cd2d5739cb19130d605d3f44906L63-R64) [[2]](diffhunk://#diff-d6cca2d859b5ff8c47e20f999671f21df5768cd2d5739cb19130d605d3f44906L82-R86)