### PR TITLE
Fix unsafe write path cache update

### DIFF
--- a/components/system-config-mgt/org.wso2.carbon.identity.system.config.mgt/src/main/java/org/wso2/carbon/identity/system/config/mgt/advisory/DBBasedAdminBannerDAO.java
+++ b/components/system-config-mgt/org.wso2.carbon.identity.system.config.mgt/src/main/java/org/wso2/carbon/identity/system/config/mgt/advisory/DBBasedAdminBannerDAO.java
@@ -77,7 +77,7 @@ public class DBBasedAdminBannerDAO implements AdminAdvisoryBannerDAO {
 
             Pair<Boolean, String> valueToCache =
                     Pair.of(adminAdvisoryBannerDTO.getEnableBanner(), adminAdvisoryBannerDTO.getBannerContent());
-            advisoryBannerCache.addToCacheOnRead(CACHE_KEY, valueToCache, tenantDomain);
+            advisoryBannerCache.addToCache(CACHE_KEY, valueToCache, tenantDomain);
         } catch (ConfigurationManagementException e) {
             throw new AdminAdvisoryMgtException("Error occurred while saving advisory banner configuration.", e);
         }
@@ -128,7 +128,7 @@ public class DBBasedAdminBannerDAO implements AdminAdvisoryBannerDAO {
 
             Pair<Boolean, String> valueToCache =
                     Pair.of(adminAdvisoryBannerDTO.getEnableBanner(), adminAdvisoryBannerDTO.getBannerContent());
-            advisoryBannerCache.addToCache(CACHE_KEY, valueToCache, tenantDomain);
+            advisoryBannerCache.addToCacheOnRead(CACHE_KEY, valueToCache, tenantDomain);
 
             return Optional.of(adminAdvisoryBannerDTO);
         } catch (ConfigurationManagementException e) {


### PR DESCRIPTION
### Proposed changes in this pull request

Related PR: https://github.com/wso2/carbon-identity-framework/pull/7871

This PR fixes the unsafe use of `addToCacheOnRead(...)` in the write path update flow. According to the behavior of `BaseCache.addToCacheOnRead`, existing cache entries are not overwritten. As a result, updated banner values may remain stale in the cache after a save operation.

This fix ensures that the cache is updated correctly during writes.