### PR TITLE
Implement batch session data clearing methods for improved performance

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -704,17 +704,20 @@ public class SessionDataStore {
                     count++;
                     if (count % batchInsertChunkSize == 0) {
                         preparedStatement.executeBatch();
+                        IdentityDatabaseUtil.commitTransaction(connection);
                     }
                 }
             }
             if (count % batchInsertChunkSize != 0) {
                 preparedStatement.executeBatch();
+                IdentityDatabaseUtil.commitTransaction(connection);
             }
-            IdentityDatabaseUtil.commitTransaction(connection);
             if (log.isDebugEnabled()) {
                 log.debug("Batch removed " + count + " SessionContextData entries from DB. type: " + type);
             }
         } catch (Exception e) {
+            // Only the current uncommitted chunk is rolled back. Previously committed chunks
+            // remain, matching the original per-entry commit semantics of removeSessionData.
             IdentityDatabaseUtil.rollbackTransaction(connection);
             log.error("Error while storing batch DELETE operation session data.", e);
         } finally {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -656,7 +656,7 @@ public class SessionDataStore {
      * @param type     The session data type.
      * @param nanoTime The operation timestamp in nanoseconds.
      */
-    public void removeSessionDataBatch(List<String> keys, String type, long nanoTime) {
+    private void removeSessionDataBatch(List<String> keys, String type, long nanoTime) {
 
         if (!enablePersist || keys == null || keys.isEmpty()) {
             return;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -42,6 +42,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.BlockingDeque;
@@ -616,7 +617,17 @@ public class SessionDataStore {
             return;
         }
         long nanoTime = FrameworkUtils.getCurrentStandardNano();
-        if (maxSessionDataPoolSize > 0 && !isTempCache(type)) {
+        // Route temp-cache deletions through the dedicated cleanup queue, consistent with
+        // the single-key clearSessionData path.
+        if (tempDataCleanupEnabled && maxTempDataPoolSize > 0 && isTempCache(type)) {
+            for (String key : keys) {
+                if (StringUtils.isNotBlank(key)) {
+                    tempAuthnContextDataDeleteQueue.push(new SessionContextDO(key, type, null, nanoTime));
+                }
+            }
+            return;
+        }
+        if (maxSessionDataPoolSize > 0) {
             for (String key : keys) {
                 if (StringUtils.isNotBlank(key)) {
                     sessionContextQueue.push(new SessionContextDO(key, type, null, nanoTime));
@@ -640,6 +651,23 @@ public class SessionDataStore {
 
         if (!enablePersist || keys == null || keys.isEmpty()) {
             return;
+        }
+
+        // Filter out keys that already have a DELETE marker, consistent with the single-key
+        // removeSessionData path. This is a per-key DB query, so it is only applied when
+        // checkExistingEntryForDeleteOperationInsert is explicitly enabled.
+        if (checkExistingEntryForDeleteOperationInsert) {
+            List<String> filteredKeys = new ArrayList<>();
+            for (String key : keys) {
+                if (StringUtils.isNotBlank(key) &&
+                        !validateLastOperationOnSessionData(key, type, OPERATION_DELETE)) {
+                    filteredKeys.add(key);
+                }
+            }
+            keys = filteredKeys;
+            if (keys.isEmpty()) {
+                return;
+            }
         }
 
         Connection connection = null;
@@ -672,15 +700,14 @@ public class SessionDataStore {
                 preparedStatement.executeBatch();
             }
             IdentityDatabaseUtil.commitTransaction(connection);
+            if (log.isDebugEnabled()) {
+                log.debug("Batch removed " + count + " SessionContextData entries from DB. type: " + type);
+            }
         } catch (Exception e) {
             IdentityDatabaseUtil.rollbackTransaction(connection);
             log.error("Error while storing batch DELETE operation session data.", e);
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, null, preparedStatement);
-        }
-
-        if (log.isDebugEnabled()) {
-            log.debug("Batch removed " + keys.size() + " SessionContextData entries from DB. type: " + type);
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -179,7 +179,10 @@ public class SessionDataStore {
     private static final String INFORMIX_DATABASE = "Informix";
 
     private static final int DEFAULT_DELETE_LIMIT = 50000;
-    private static final int BATCH_INSERT_CHUNK_SIZE = 10000;
+    private static final int DEFAULT_BATCH_INSERT_CHUNK_SIZE = 1000;
+    private static final String BATCH_INSERT_CHUNK_SIZE_PROPERTY =
+            "JDBCPersistenceManager.SessionDataPersist.BatchInsertChunkSize";
+    private static int batchInsertChunkSize = DEFAULT_BATCH_INSERT_CHUNK_SIZE;
     public static final String DEFAULT_SESSION_STORE_TABLE_NAME = "IDN_AUTH_SESSION_STORE";
     private static final String CACHE_MANAGER_NAME = "IdentityApplicationManagementCacheManager";
     public static final String DEFAULT_TEMP_SESSION_STORE_TABLE_NAME = "IDN_AUTH_TEMP_SESSION_STORE";
@@ -354,6 +357,16 @@ public class SessionDataStore {
         if (StringUtils.isNotBlank(checkExistingEntryForDeleteOperationInsertProperty)) {
             checkExistingEntryForDeleteOperationInsert = Boolean.parseBoolean(
                     checkExistingEntryForDeleteOperationInsertProperty);
+        }
+
+        String batchInsertChunkSizeValue = IdentityUtil.getProperty(BATCH_INSERT_CHUNK_SIZE_PROPERTY);
+        if (StringUtils.isNotBlank(batchInsertChunkSizeValue)) {
+            try {
+                batchInsertChunkSize = Integer.parseInt(batchInsertChunkSizeValue);
+            } catch (NumberFormatException e) {
+                log.warn("Invalid value for " + BATCH_INSERT_CHUNK_SIZE_PROPERTY + ": "
+                        + batchInsertChunkSizeValue + ". Using default: " + DEFAULT_BATCH_INSERT_CHUNK_SIZE);
+            }
         }
     }
 
@@ -640,8 +653,7 @@ public class SessionDataStore {
 
     /**
      * Removes session data for a batch of keys using JDBC batch operations. Each key gets a DELETE marker row
-     * inserted into the session store. To avoid issues with very large batches, keys are processed in chunks of
-     * {@link #BATCH_INSERT_CHUNK_SIZE}. Physical removal is deferred to the cleanup stored procedure.
+     * inserted into the session store.
      *
      * @param keys     List of session data keys to remove.
      * @param type     The session data type.
@@ -691,12 +703,12 @@ public class SessionDataStore {
                     preparedStatement.setLong(5, timeoutNano);
                     preparedStatement.addBatch();
                     count++;
-                    if (count % BATCH_INSERT_CHUNK_SIZE == 0) {
+                    if (count % batchInsertChunkSize == 0) {
                         preparedStatement.executeBatch();
                     }
                 }
             }
-            if (count % BATCH_INSERT_CHUNK_SIZE != 0) {
+            if (count % batchInsertChunkSize != 0) {
                 preparedStatement.executeBatch();
             }
             IdentityDatabaseUtil.commitTransaction(connection);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -362,7 +362,14 @@ public class SessionDataStore {
         String batchInsertChunkSizeValue = IdentityUtil.getProperty(BATCH_INSERT_CHUNK_SIZE_PROPERTY);
         if (StringUtils.isNotBlank(batchInsertChunkSizeValue)) {
             try {
-                batchInsertChunkSize = Integer.parseInt(batchInsertChunkSizeValue);
+                int parsedChunkSize = Integer.parseInt(batchInsertChunkSizeValue);
+                if (parsedChunkSize > 0) {
+                    batchInsertChunkSize = parsedChunkSize;
+                } else {
+                    log.warn("Invalid value for " + BATCH_INSERT_CHUNK_SIZE_PROPERTY + ": "
+                            + batchInsertChunkSizeValue + ". Value must be positive. Using default: "
+                            + DEFAULT_BATCH_INSERT_CHUNK_SIZE);
+                }
             } catch (NumberFormatException e) {
                 log.warn("Invalid value for " + BATCH_INSERT_CHUNK_SIZE_PROPERTY + ": "
                         + batchInsertChunkSizeValue + ". Using default: " + DEFAULT_BATCH_INSERT_CHUNK_SIZE);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -179,7 +179,7 @@ public class SessionDataStore {
     private static final String INFORMIX_DATABASE = "Informix";
 
     private static final int DEFAULT_DELETE_LIMIT = 50000;
-    private static final int DEFAULT_BATCH_INSERT_CHUNK_SIZE = 1000;
+    private static final int DEFAULT_BATCH_INSERT_CHUNK_SIZE = 500;
     private static final String BATCH_INSERT_CHUNK_SIZE_PROPERTY =
             "JDBCPersistenceManager.SessionDataPersist.BatchInsertChunkSize";
     private static int batchInsertChunkSize = DEFAULT_BATCH_INSERT_CHUNK_SIZE;
@@ -630,25 +630,15 @@ public class SessionDataStore {
             return;
         }
         long nanoTime = FrameworkUtils.getCurrentStandardNano();
-        // Route temp-cache deletions through the dedicated cleanup queue, consistent with
-        // the single-key clearSessionData path.
-        if (tempDataCleanupEnabled && maxTempDataPoolSize > 0 && isTempCache(type)) {
-            for (String key : keys) {
-                if (StringUtils.isNotBlank(key)) {
-                    tempAuthnContextDataDeleteQueue.push(new SessionContextDO(key, type, null, nanoTime));
-                }
-            }
-            return;
-        }
-        if (maxSessionDataPoolSize > 0) {
+        if (maxSessionDataPoolSize > 0 && !isTempCache(type)) {
             for (String key : keys) {
                 if (StringUtils.isNotBlank(key)) {
                     sessionContextQueue.push(new SessionContextDO(key, type, null, nanoTime));
                 }
             }
-            return;
+        } else {
+            removeSessionDataBatch(keys, type, nanoTime);
         }
-        removeSessionDataBatch(keys, type, nanoTime);
     }
 
     /**
@@ -662,6 +652,15 @@ public class SessionDataStore {
     public void removeSessionDataBatch(List<String> keys, String type, long nanoTime) {
 
         if (!enablePersist || keys == null || keys.isEmpty()) {
+            return;
+        }
+
+        if (tempDataCleanupEnabled && maxTempDataPoolSize > 0 && isTempCache(type)) {
+            for (String key : keys) {
+                if (StringUtils.isNotBlank(key)) {
+                    tempAuthnContextDataDeleteQueue.push(new SessionContextDO(key, type, null, nanoTime));
+                }
+            }
             return;
         }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -42,6 +42,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.ExecutorService;
@@ -177,6 +178,7 @@ public class SessionDataStore {
     private static final String INFORMIX_DATABASE = "Informix";
 
     private static final int DEFAULT_DELETE_LIMIT = 50000;
+    private static final int BATCH_INSERT_CHUNK_SIZE = 10000;
     public static final String DEFAULT_SESSION_STORE_TABLE_NAME = "IDN_AUTH_SESSION_STORE";
     private static final String CACHE_MANAGER_NAME = "IdentityApplicationManagementCacheManager";
     public static final String DEFAULT_TEMP_SESSION_STORE_TABLE_NAME = "IDN_AUTH_TEMP_SESSION_STORE";
@@ -597,6 +599,88 @@ public class SessionDataStore {
             sessionContextQueue.push(new SessionContextDO(key, type, null, nanoTime));
         } else {
             removeSessionData(key, type, nanoTime);
+        }
+    }
+
+    /**
+     * Clears session data for a batch of keys in a single database operation. This avoids the overhead of individual
+     * DELETE marker inserts when clearing a large number of cache entries (e.g., during bulk OAuth token cache
+     * eviction triggered by user claim updates).
+     *
+     * @param keys List of session data keys to clear.
+     * @param type The session data type.
+     */
+    public void clearSessionDataBatch(List<String> keys, String type) {
+
+        if (!enablePersist || keys == null || keys.isEmpty()) {
+            return;
+        }
+        long nanoTime = FrameworkUtils.getCurrentStandardNano();
+        if (maxSessionDataPoolSize > 0 && !isTempCache(type)) {
+            for (String key : keys) {
+                if (StringUtils.isNotBlank(key)) {
+                    sessionContextQueue.push(new SessionContextDO(key, type, null, nanoTime));
+                }
+            }
+            return;
+        }
+        removeSessionDataBatch(keys, type, nanoTime);
+    }
+
+    /**
+     * Removes session data for a batch of keys using JDBC batch operations. Each key gets a DELETE marker row
+     * inserted into the session store. To avoid issues with very large batches, keys are processed in chunks of
+     * {@link #BATCH_INSERT_CHUNK_SIZE}. Physical removal is deferred to the cleanup stored procedure.
+     *
+     * @param keys     List of session data keys to remove.
+     * @param type     The session data type.
+     * @param nanoTime The operation timestamp in nanoseconds.
+     */
+    public void removeSessionDataBatch(List<String> keys, String type, long nanoTime) {
+
+        if (!enablePersist || keys == null || keys.isEmpty()) {
+            return;
+        }
+
+        Connection connection = null;
+        try {
+            connection = IdentityDatabaseUtil.getSessionDBConnection(true);
+        } catch (IdentityRuntimeException e) {
+            log.error(e.getMessage(), e);
+            return;
+        }
+        PreparedStatement preparedStatement = null;
+        long timeoutNano = nanoTime + getCleanupTimeout(type, MultitenantConstants.INVALID_TENANT_ID);
+        try {
+            preparedStatement = connection.prepareStatement(getSessionStoreDBQuery(sqlInsertDELETE, type));
+            int count = 0;
+            for (String key : keys) {
+                if (StringUtils.isNotBlank(key)) {
+                    preparedStatement.setString(1, key);
+                    preparedStatement.setString(2, type);
+                    preparedStatement.setString(3, OPERATION_DELETE);
+                    preparedStatement.setLong(4, nanoTime);
+                    preparedStatement.setLong(5, timeoutNano);
+                    preparedStatement.addBatch();
+                    count++;
+                    if (count % BATCH_INSERT_CHUNK_SIZE == 0) {
+                        preparedStatement.executeBatch();
+                    }
+                }
+            }
+            if (count % BATCH_INSERT_CHUNK_SIZE != 0) {
+                preparedStatement.executeBatch();
+            }
+            IdentityDatabaseUtil.commitTransaction(connection);
+        } catch (Exception e) {
+            IdentityDatabaseUtil.rollbackTransaction(connection);
+            log.error("Error while storing batch DELETE operation session data.", e);
+        } finally {
+            IdentityDatabaseUtil.closeAllConnections(connection, null, preparedStatement);
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Batch removed " + keys.size() + " SessionContextData entries from DB. type: " + type);
         }
     }
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -58,6 +58,7 @@
             <UserSessionMapping>
                 <Enable>true</Enable>
             </UserSessionMapping>
+            <BatchInsertChunkSize>1000</BatchInsertChunkSize>
         </SessionDataPersist>
         <PushedAuthReqCleanUp>
             <Enable>true</Enable>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -58,7 +58,7 @@
             <UserSessionMapping>
                 <Enable>true</Enable>
             </UserSessionMapping>
-            <BatchInsertChunkSize>500</BatchInsertChunkSize>
+            <BatchInsertChunkSize>250</BatchInsertChunkSize>
         </SessionDataPersist>
         <PushedAuthReqCleanUp>
             <Enable>true</Enable>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -58,7 +58,7 @@
             <UserSessionMapping>
                 <Enable>true</Enable>
             </UserSessionMapping>
-            <BatchInsertChunkSize>1000</BatchInsertChunkSize>
+            <BatchInsertChunkSize>500</BatchInsertChunkSize>
         </SessionDataPersist>
         <PushedAuthReqCleanUp>
             <Enable>true</Enable>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -67,6 +67,7 @@
                 <Enable>{{session_data.persistence.enable_user_session_mapping}}</Enable>
             </UserSessionMapping>
             <CheckExistingEntryForDeleteOperationInsert>{{session_data.session_data_persist.check_existing_entry_for_delete_operation_insert}}</CheckExistingEntryForDeleteOperationInsert>
+            <BatchInsertChunkSize>{{session_data.session_data_persist.batch_insert_chunk_size}}</BatchInsertChunkSize>
         </SessionDataPersist>
         <PushedAuthReqCleanUp>
             <Enable>{{par.cleanup.enable_expired_requests_cleanup}}</Enable>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -39,6 +39,7 @@
   "session_data.cleanup.enable_periodic_pre_session_data_cleanup": true,
   "session_data.session_data_persist.session_and_temp_data_separation_enabled.enable": true,
   "session_data.session_data_persist.check_existing_entry_for_delete_operation_insert": false,
+  "session_data.session_data_persist.batch_insert_chunk_size": 1000,
   "session_data.cleanup.pre_session_data_cleanup_thread_pool_size": "20",
   "session.nonce.cookie.enabled": true,
   "session.nonce.cookie.default_whitelist_authenticators": ["MagicLinkAuthenticator"],

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -39,7 +39,7 @@
   "session_data.cleanup.enable_periodic_pre_session_data_cleanup": true,
   "session_data.session_data_persist.session_and_temp_data_separation_enabled.enable": true,
   "session_data.session_data_persist.check_existing_entry_for_delete_operation_insert": false,
-  "session_data.session_data_persist.batch_insert_chunk_size": 500,
+  "session_data.session_data_persist.batch_insert_chunk_size": "250",
   "session_data.cleanup.pre_session_data_cleanup_thread_pool_size": "20",
   "session.nonce.cookie.enabled": true,
   "session.nonce.cookie.default_whitelist_authenticators": ["MagicLinkAuthenticator"],

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -39,7 +39,7 @@
   "session_data.cleanup.enable_periodic_pre_session_data_cleanup": true,
   "session_data.session_data_persist.session_and_temp_data_separation_enabled.enable": true,
   "session_data.session_data_persist.check_existing_entry_for_delete_operation_insert": false,
-  "session_data.session_data_persist.batch_insert_chunk_size": 1000,
+  "session_data.session_data_persist.batch_insert_chunk_size": 500,
   "session_data.cleanup.pre_session_data_cleanup_thread_pool_size": "20",
   "session.nonce.cookie.enabled": true,
   "session.nonce.cookie.default_whitelist_authenticators": ["MagicLinkAuthenticator"],


### PR DESCRIPTION
This pull request adds efficient batch operations for clearing session data in the `SessionDataStore` class, which will help improve performance and reduce database overhead during large-scale session or cache evictions (such as those triggered by OAuth token cache invalidation).

**Enhancements to session data management:**

* Introduced `clearSessionDataBatch` and `removeSessionDataBatch` methods to enable batch deletion of session data keys, reducing overhead compared to individual deletions. These methods use JDBC batch operations and process large batches in manageable chunks for efficiency.
* Added a constant `BATCH_INSERT_CHUNK_SIZE` to control the size of each batch chunk during batch operations, set to 10,000 entries per batch.
* Imported `java.util.List` to support batch operations with collections of session keys.

### Related Issues
- https://github.com/wso2/product-is/issues/27576