### PR TITLE
Fix unit tests failures in workflow management by adding WithCarbonHome to allow the mocking

### DIFF
--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/test/java/org/wso2/carbon/identity/workflow/mgt/WorkFlowExecutorManagerTest.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/test/java/org/wso2/carbon/identity/workflow/mgt/WorkFlowExecutorManagerTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.rule.evaluation.api.exception.RuleEvaluationException;
 import org.wso2.carbon.identity.rule.evaluation.api.model.RuleEvaluationResult;
@@ -60,6 +61,7 @@ import static org.testng.Assert.assertNotNull;
 /**
  * Unit tests for {@link WorkFlowExecutorManager}.
  */
+@WithCarbonHome
 public class WorkFlowExecutorManagerTest {
 
     private static final String TEST_UUID = "test-uuid-123";


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject