### PR TITLE
Fix sub-org Console silent re-auth when adaptive script is configured

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -1522,6 +1522,11 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
             context.setPreviousSessionFound(true);
 
             effectiveSequence.setStepMap(new HashMap<>(previousAuthenticatedSeq.getStepMap()));
+            // prepareSequenceConfig may have filtered OrganizationAuthenticator out of the authentication graph's
+            // start-node StepConfig for portal apps. GraphBasedSequenceHandler writes that graph-node StepConfig
+            // back into the stepMap, which would otherwise override the authenticators just restored from the
+            // previous session and break silent re-authentication for scripted portal apps.
+            syncAuthenticationGraphStartNodeWithStepMap(effectiveSequence);
             effectiveSequence.setReqPathAuthenticators(
                     new ArrayList<>(previousAuthenticatedSeq.getReqPathAuthenticators()));
             effectiveSequence.setAuthenticatedUser(previousAuthenticatedSeq.getAuthenticatedUser());
@@ -1885,6 +1890,34 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                             .equals(ORGANIZATION_AUTHENTICATOR)).collect(Collectors.toList());
             graphNode.getStepConfig().setAuthenticatorList(authenticatorList);
         }
+    }
+
+    /**
+     * Re-sync the authentication graph's start-node StepConfig with the effective sequence's stepMap after the
+     * stepMap has been restored from a previously authenticated session. For portal apps with an adaptive script,
+     * {@link #removeOrganizationSsoStepsForPortalApps(SequenceConfig)} mutates the graph-node StepConfig
+     * independently of the stepMap. Restoring the stepMap alone would leave the graph node out-of-sync, and the
+     * GraphBasedSequenceHandler would later overwrite the restored stepMap with the stale graph-node StepConfig.
+     */
+    private void syncAuthenticationGraphStartNodeWithStepMap(SequenceConfig effectiveSequence) {
+
+        AuthenticationGraph authenticationGraph = effectiveSequence.getAuthenticationGraph();
+        if (authenticationGraph == null) {
+            return;
+        }
+        AuthGraphNode startNode = authenticationGraph.getStartNode();
+        if (!(startNode instanceof StepConfigGraphNode)) {
+            return;
+        }
+        StepConfig graphStepConfig = ((StepConfigGraphNode) startNode).getStepConfig();
+        if (graphStepConfig == null) {
+            return;
+        }
+        StepConfig restoredStepConfig = effectiveSequence.getStepMap().get(graphStepConfig.getOrder());
+        if (restoredStepConfig == null || restoredStepConfig.getAuthenticatorList() == null) {
+            return;
+        }
+        graphStepConfig.setAuthenticatorList(new ArrayList<>(restoredStepConfig.getAuthenticatorList()));
     }
 
     private boolean isStepHasMultiOption(AuthenticationContext context) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
@@ -28,9 +28,13 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ApplicationConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.AuthGraphNode;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.AuthenticationGraph;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.ShowPromptNode;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.StepConfigGraphNode;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.CookieValidationFailedException;
@@ -62,7 +66,10 @@ import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.Cookie;
@@ -987,5 +994,264 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
             assertEquals(context.getContextIdIncludedQueryParams(), expectedQueryParams);
             assertEquals(context.getQueryParams(), expectedQueryParams);
         }
+    }
+
+    /**
+     * Regression test for issue #27506. After the session-cookie restore puts {@code OrganizationAuthenticator}
+     * back into the effective sequence's stepMap, the helper must also re-sync the authentication graph's
+     * start-node {@link StepConfig} so that {@code GraphBasedSequenceHandler} does not later overwrite the
+     * restored stepMap with a stale graph-node StepConfig that had the authenticator stripped.
+     */
+    @Test
+    public void testSyncAuthenticationGraphStartNodeWithStepMap_graphNodeSyncedAfterSessionRestore()
+            throws Exception {
+
+        // Graph-node StepConfig was mutated by removeOrganizationSsoStepsForPortalApps and has only BasicAuthenticator.
+        StepConfig graphStepConfig = buildStepConfig(1, "BasicAuthenticator");
+        StepConfigGraphNode startNode = new StepConfigGraphNode(graphStepConfig);
+        AuthenticationGraph graph = new AuthenticationGraph();
+        graph.setStartNode(startNode);
+
+        // StepMap is what the session-cookie restore re-populated — OrganizationAuthenticator is present again.
+        StepConfig restoredStepConfig = buildStepConfig(1, ORGANIZATION_AUTHENTICATOR, "BasicAuthenticator");
+        Map<Integer, StepConfig> restoredStepMap = new HashMap<>();
+        restoredStepMap.put(1, restoredStepConfig);
+
+        SequenceConfig effectiveSequence = new SequenceConfig();
+        effectiveSequence.setStepMap(restoredStepMap);
+        effectiveSequence.setAuthenticationGraph(graph);
+
+        invokeSyncAuthenticationGraphStartNodeWithStepMap(effectiveSequence);
+
+        // After the fix, the graph-node StepConfig must contain OrganizationAuthenticator again.
+        List<String> graphAuthenticators = authenticatorNames(
+                ((StepConfigGraphNode) graph.getStartNode()).getStepConfig().getAuthenticatorList());
+        assertTrue(graphAuthenticators.contains(ORGANIZATION_AUTHENTICATOR),
+                "Graph node StepConfig should contain OrganizationAuthenticator after sync. Got: "
+                        + graphAuthenticators);
+        assertEquals(graphAuthenticators, Arrays.asList(ORGANIZATION_AUTHENTICATOR, "BasicAuthenticator"));
+
+        // StepMap must be untouched — it was already correct.
+        List<String> stepMapAuthenticators = authenticatorNames(
+                effectiveSequence.getStepMap().get(1).getAuthenticatorList());
+        assertEquals(stepMapAuthenticators, Arrays.asList(ORGANIZATION_AUTHENTICATOR, "BasicAuthenticator"));
+    }
+
+    /**
+     * Sync helper must be a no-op when the effective sequence has no authentication graph (non-scripted flow).
+     */
+    @Test
+    public void testSyncAuthenticationGraphStartNodeWithStepMap_noAuthenticationGraph() throws Exception {
+
+        StepConfig stepConfig = buildStepConfig(1, ORGANIZATION_AUTHENTICATOR, "BasicAuthenticator");
+        Map<Integer, StepConfig> stepMap = new HashMap<>();
+        stepMap.put(1, stepConfig);
+
+        SequenceConfig effectiveSequence = new SequenceConfig();
+        effectiveSequence.setStepMap(stepMap);
+        // No authentication graph.
+
+        invokeSyncAuthenticationGraphStartNodeWithStepMap(effectiveSequence);
+
+        // StepMap is unchanged; no exception raised.
+        List<String> stepMapAuthenticators = authenticatorNames(
+                effectiveSequence.getStepMap().get(1).getAuthenticatorList());
+        assertEquals(stepMapAuthenticators, Arrays.asList(ORGANIZATION_AUTHENTICATOR, "BasicAuthenticator"));
+    }
+
+    /**
+     * Sync helper must leave the graph untouched when the start node is not a {@link StepConfigGraphNode}.
+     */
+    @Test
+    public void testSyncAuthenticationGraphStartNodeWithStepMap_startNodeNotStepConfigGraphNode() throws Exception {
+
+        AuthGraphNode nonStepNode = mock(ShowPromptNode.class);
+        AuthenticationGraph graph = new AuthenticationGraph();
+        graph.setStartNode(nonStepNode);
+
+        StepConfig stepConfig = buildStepConfig(1, ORGANIZATION_AUTHENTICATOR, "BasicAuthenticator");
+        Map<Integer, StepConfig> stepMap = new HashMap<>();
+        stepMap.put(1, stepConfig);
+
+        SequenceConfig effectiveSequence = new SequenceConfig();
+        effectiveSequence.setStepMap(stepMap);
+        effectiveSequence.setAuthenticationGraph(graph);
+
+        invokeSyncAuthenticationGraphStartNodeWithStepMap(effectiveSequence);
+
+        // Start node is unchanged.
+        assertEquals(graph.getStartNode(), nonStepNode);
+    }
+
+    /**
+     * Sync helper must be a no-op when the stepMap has no entry for the graph node's step order — e.g. a
+     * malformed state where the restore did not repopulate step 1. The graph-node StepConfig must be kept as-is.
+     */
+    @Test
+    public void testSyncAuthenticationGraphStartNodeWithStepMap_stepMapMissingOrder() throws Exception {
+
+        StepConfig graphStepConfig = buildStepConfig(1, "BasicAuthenticator");
+        StepConfigGraphNode startNode = new StepConfigGraphNode(graphStepConfig);
+        AuthenticationGraph graph = new AuthenticationGraph();
+        graph.setStartNode(startNode);
+
+        SequenceConfig effectiveSequence = new SequenceConfig();
+        effectiveSequence.setStepMap(new HashMap<>()); // Empty — no step 1.
+        effectiveSequence.setAuthenticationGraph(graph);
+
+        invokeSyncAuthenticationGraphStartNodeWithStepMap(effectiveSequence);
+
+        // Graph node preserves its existing authenticator list.
+        List<String> graphAuthenticators = authenticatorNames(
+                ((StepConfigGraphNode) graph.getStartNode()).getStepConfig().getAuthenticatorList());
+        assertEquals(graphAuthenticators, Collections.singletonList("BasicAuthenticator"));
+    }
+
+    /**
+     * removeOrganizationSsoStepsForPortalApps baseline: strips OrganizationAuthenticator from the stepMap
+     * step and from the authentication graph's start-node StepConfig. This test locks in the pre-session-restore
+     * filtering behaviour that the new sync helper sits on top of.
+     */
+    @Test
+    public void testRemoveOrganizationSsoStepsForPortalApps_stripsFromStepMapAndGraphNode() throws Exception {
+
+        StepConfig graphStepConfig = buildStepConfig(1, ORGANIZATION_AUTHENTICATOR, "BasicAuthenticator");
+        StepConfigGraphNode startNode = new StepConfigGraphNode(graphStepConfig);
+        AuthenticationGraph graph = new AuthenticationGraph();
+        graph.setStartNode(startNode);
+
+        StepConfig stepMapStepConfig = buildStepConfig(1, ORGANIZATION_AUTHENTICATOR, "BasicAuthenticator");
+        Map<Integer, StepConfig> stepMap = new HashMap<>();
+        stepMap.put(1, stepMapStepConfig);
+
+        SequenceConfig effectiveSequence = new SequenceConfig();
+        effectiveSequence.setStepMap(stepMap);
+        effectiveSequence.setAuthenticationGraph(graph);
+
+        invokeRemoveOrganizationSsoStepsForPortalApps(effectiveSequence);
+
+        assertEquals(authenticatorNames(effectiveSequence.getStepMap().get(1).getAuthenticatorList()),
+                Collections.singletonList("BasicAuthenticator"));
+        assertEquals(authenticatorNames(
+                        ((StepConfigGraphNode) graph.getStartNode()).getStepConfig().getAuthenticatorList()),
+                Collections.singletonList("BasicAuthenticator"));
+    }
+
+    /**
+     * Full bug-scenario regression for issue #27506. Simulates the sequence of operations inside
+     * {@code DefaultRequestCoordinator.populateContextWithPreviousSession} for a portal app with an adaptive
+     * script when a session cookie is replaying the existing SSO identity:
+     *
+     * <ol>
+     *   <li>{@code removeOrganizationSsoStepsForPortalApps} strips OrganizationAuthenticator from both the
+     *       stepMap and the graph-node StepConfig.</li>
+     *   <li>The previous-authenticated-session restore replaces the stepMap with the previous sequence's
+     *       stepMap (which still has OrganizationAuthenticator).</li>
+     *   <li>{@code syncAuthenticationGraphStartNodeWithStepMap} re-syncs the graph node from the restored
+     *       stepMap so that a subsequent {@code GraphBasedSequenceHandler.handleAuthenticationStep} call,
+     *       which writes the graph-node StepConfig back into the stepMap, does not strip
+     *       OrganizationAuthenticator a second time.</li>
+     * </ol>
+     *
+     * Before the fix, the graph node's StepConfig (only BasicAuthenticator) would overwrite the restored
+     * stepMap, bouncing sub-org users to the root-tenant login page. After the fix, the graph node must
+     * contain OrganizationAuthenticator after the sync.
+     */
+    @Test
+    public void testPortalAppAdaptiveScriptSessionRestore_graphNodeSyncedWithStepMap() throws Exception {
+
+        // Initial effective sequence: step 1 has [OrganizationAuthenticator, BasicAuthenticator] in both places.
+        StepConfig graphStepConfig = buildStepConfig(1, ORGANIZATION_AUTHENTICATOR, "BasicAuthenticator");
+        StepConfigGraphNode startNode = new StepConfigGraphNode(graphStepConfig);
+        AuthenticationGraph graph = new AuthenticationGraph();
+        graph.setStartNode(startNode);
+
+        StepConfig stepMapStepConfig = buildStepConfig(1, ORGANIZATION_AUTHENTICATOR, "BasicAuthenticator");
+        Map<Integer, StepConfig> stepMap = new HashMap<>();
+        stepMap.put(1, stepMapStepConfig);
+
+        SequenceConfig effectiveSequence = new SequenceConfig();
+        effectiveSequence.setStepMap(stepMap);
+        effectiveSequence.setAuthenticationGraph(graph);
+
+        // Previous authenticated sequence (what the session cookie carried) — step 1 still has both authenticators.
+        StepConfig previousStepConfig = buildStepConfig(1, ORGANIZATION_AUTHENTICATOR, "BasicAuthenticator");
+        Map<Integer, StepConfig> previousStepMap = new HashMap<>();
+        previousStepMap.put(1, previousStepConfig);
+        SequenceConfig previousAuthenticatedSeq = new SequenceConfig();
+        previousAuthenticatedSeq.setStepMap(previousStepMap);
+
+        // Step 1: portal-app filtering strips OrganizationAuthenticator from both stepMap and graph-node.
+        invokeRemoveOrganizationSsoStepsForPortalApps(effectiveSequence);
+        assertEquals(authenticatorNames(effectiveSequence.getStepMap().get(1).getAuthenticatorList()),
+                Collections.singletonList("BasicAuthenticator"));
+        assertEquals(authenticatorNames(
+                        ((StepConfigGraphNode) graph.getStartNode()).getStepConfig().getAuthenticatorList()),
+                Collections.singletonList("BasicAuthenticator"));
+
+        // Step 2: session-cookie restore replaces the stepMap — graph-node stays out-of-sync without the fix.
+        effectiveSequence.setStepMap(new HashMap<>(previousAuthenticatedSeq.getStepMap()));
+        invokeSyncAuthenticationGraphStartNodeWithStepMap(effectiveSequence);
+
+        // Step 3: post-fix, graph-node StepConfig has OrganizationAuthenticator again. If
+        // GraphBasedSequenceHandler.handleAuthenticationStep now writes the graph-node StepConfig back
+        // into the stepMap (`context.getSequenceConfig().getStepMap().put(stepNumber, stepConfig)`),
+        // the stepMap still has OrganizationAuthenticator available for silent re-authentication.
+        List<String> graphAuthenticators = authenticatorNames(
+                ((StepConfigGraphNode) graph.getStartNode()).getStepConfig().getAuthenticatorList());
+        assertTrue(graphAuthenticators.contains(ORGANIZATION_AUTHENTICATOR),
+                "Graph node StepConfig must contain OrganizationAuthenticator after session restore + sync. "
+                        + "Got: " + graphAuthenticators);
+
+        // Simulate GraphBasedSequenceHandler writing the graph-node StepConfig back into the stepMap.
+        effectiveSequence.getStepMap().put(1,
+                ((StepConfigGraphNode) graph.getStartNode()).getStepConfig());
+        List<String> finalStepMapAuthenticators = authenticatorNames(
+                effectiveSequence.getStepMap().get(1).getAuthenticatorList());
+        assertTrue(finalStepMapAuthenticators.contains(ORGANIZATION_AUTHENTICATOR),
+                "StepMap must still contain OrganizationAuthenticator after GraphBasedSequenceHandler "
+                        + "writes back the graph-node StepConfig. Got: " + finalStepMapAuthenticators);
+    }
+
+    private static StepConfig buildStepConfig(int order, String... authenticatorNames) {
+
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setOrder(order);
+        List<AuthenticatorConfig> authenticators = new ArrayList<>();
+        for (String name : authenticatorNames) {
+            AuthenticatorConfig authenticator = new AuthenticatorConfig();
+            authenticator.setName(name);
+            authenticators.add(authenticator);
+        }
+        stepConfig.setAuthenticatorList(authenticators);
+        return stepConfig;
+    }
+
+    private static List<String> authenticatorNames(List<AuthenticatorConfig> authenticators) {
+
+        List<String> names = new ArrayList<>();
+        if (authenticators != null) {
+            for (AuthenticatorConfig authenticator : authenticators) {
+                names.add(authenticator.getName());
+            }
+        }
+        return names;
+    }
+
+    private void invokeSyncAuthenticationGraphStartNodeWithStepMap(SequenceConfig effectiveSequence)
+            throws Exception {
+
+        Method method = DefaultRequestCoordinator.class.getDeclaredMethod(
+                "syncAuthenticationGraphStartNodeWithStepMap", SequenceConfig.class);
+        method.setAccessible(true);
+        method.invoke(requestCoordinator, effectiveSequence);
+    }
+
+    private void invokeRemoveOrganizationSsoStepsForPortalApps(SequenceConfig effectiveSequence) throws Exception {
+
+        Method method = DefaultRequestCoordinator.class.getDeclaredMethod(
+                "removeOrganizationSsoStepsForPortalApps", SequenceConfig.class);
+        method.setAccessible(true);
+        method.invoke(requestCoordinator, effectiveSequence);
     }
 }


### PR DESCRIPTION
## Issue

Fixes wso2/product-is#27506 — *Sub-org console login fails when an adaptive script is configured on the root Console application.*

## Root Cause

`DefaultRequestCoordinator.removeOrganizationSsoStepsForPortalApps()` runs on every silent-auth request to a portal app (Console / My Account) when `fidp=OrganizationSSO` is not on the URL. It strips `OrganizationAuthenticator` from **two** places:

1. The effective sequence's `stepMap.get(1).getAuthenticatorList()`.
2. The authentication graph's `StepConfigGraphNode.getStepConfig().getAuthenticatorList()`.

Immediately afterwards, when a session cookie is present, `populateContextWithPreviousSession` restores the stepMap from the previous authenticated sequence:

```java
effectiveSequence.setStepMap(new HashMap<>(previousAuthenticatedSeq.getStepMap()));
```

That puts `OrganizationAuthenticator` back into the stepMap — **but the graph node's embedded `StepConfig` is not restored.**

When the flow uses `DefaultStepBasedSequenceHandler` (no script), it reads from the restored stepMap and silent auth succeeds. When it uses `GraphBasedSequenceHandler` (script present), `handleAuthenticationStep` writes the graph node's mutated `StepConfig` (without `OrganizationAuthenticator`) back into the stepMap:

```java
context.getSequenceConfig().getStepMap().put(stepNumber, stepConfig);
```

This overrides the session-restored step, so `DefaultStepHandler` only sees `BasicAuthenticator`, the existing SSO identity cannot match, `prompt=none` silent auth fails, and the user is bounced to the root-tenant `authenticationendpoint/login.do` page where the sub-org credentials do not work.

Runtime DEBUG logs match the issue's pasted logs exactly — without the script, `OrganizationAuthenticator`/`SSO` is considered first; with the script, only `BasicAuthenticator`/`LOCAL` is present at Step 1.

## Fix

In `populateContextWithPreviousSession`, immediately after `effectiveSequence.setStepMap(...)`, call a new helper `syncAuthenticationGraphStartNodeWithStepMap(effectiveSequence)` that re-applies the restored step's authenticator list to the `AuthenticationGraph`'s start `StepConfigGraphNode.stepConfig`. The graph-based handler will subsequently see the session-restored authenticators (including `OrganizationAuthenticator`) and silent re-authentication works end-to-end.

The fix is confined to the session-restore branch (`previousAuthenticatedSeq != null`) so the existing UI-level filtering for non-session scripted portal logins (the original purpose of `removeOrganizationSsoStepsForPortalApps`) is untouched.

## Files Changed

- `components/authentication-framework/.../DefaultRequestCoordinator.java`
  - `populateContextWithPreviousSession`: invoke new helper after `setStepMap`.
  - New private helper `syncAuthenticationGraphStartNodeWithStepMap`.
- `components/authentication-framework/.../DefaultRequestCoordinatorTest.java`
  - 6 new TestNG tests (5 fail without the fix, 1 baseline regression guard).

## How Verified

**Unit tests** — `mvn -Dtest=DefaultRequestCoordinatorTest test` in the `org.wso2.carbon.identity.application.authentication.framework` module:
- With the fix: `Tests run: 37, Failures: 0`.
- Without the fix (production change `git stash`'ed, tests kept): `Tests run: 37, Failures: 5` — the 5 new sync-helper tests + combined-scenario test fail. The 6th new test (`testRemoveOrganizationSsoStepsForPortalApps_stripsFromStepMapAndGraphNode`) is a regression guard for the pre-existing filter and continues to pass.

**Runtime / Playwright** — built `org.wso2.carbon.identity.application.authentication.framework-7.10.149.jar` from this branch on top of `v7.10.149`, dropped into `wso2is-7.3.0-rc1-SNAPSHOT/repository/components/patches/patch9999/`, then:

1. Created sub-org `subOrg1`.
2. Created sub-org user `subuser1` and assigned the Console-audience `Administrator` role.
3. Patched the root-tenant Console application's authentication sequence with the exact adaptive script from the issue (`onLoginRequest` → `executeStep(1)` → `Log.info(...)`).
4. Ran a fresh-browser headless Chromium login against `https://localhost:9443/t/carbon.super/o/<ORG_ID>/console` as `subuser1`.

**Result:** `subuser1` authenticates via OrganizationSSO and lands on the sub-org Console `getting-started` page — not the root-tenant login page. The adaptive script executes (two `JsLogger` `INFO` entries in `wso2carbon.log`, proving the `GraphBasedSequenceHandler` path is active). No `ERROR` / `FATAL` entries during startup or during the flow.

Before the fix the same flow ended at `https://localhost:9443/authenticationendpoint/login.do?...&authenticators=BasicAuthenticator%3ALOCAL` with an empty username field.

## Risk

Localized change — single helper added in one method in `DefaultRequestCoordinator`. No schema, config, or wire-format changes. Both scripted and non-scripted portal-login paths verified.