### PR TITLE
Enable default flows only for new tenants using compatibility settings

### DIFF
--- a/components/compatibility-settings-mgt/org.wso2.carbon.identity.compatibility.settings.core/pom.xml
+++ b/components/compatibility-settings-mgt/org.wso2.carbon.identity.compatibility.settings.core/pom.xml
@@ -57,10 +57,6 @@
             <artifactId>org.wso2.carbon.identity.base</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
@@ -101,8 +97,8 @@
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.base;
                             version="${carbon.identity.package.import.version.range}",
-                            org.wso2.carbon.identity.application.authentication.framework.util;
-                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.context;
+                            version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.configuration.mgt.core;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.configuration.mgt.core.constant;

--- a/components/compatibility-settings-mgt/org.wso2.carbon.identity.compatibility.settings.core/src/main/java/org/wso2/carbon/identity/compatibility/settings/core/util/IdentityCompatibilitySettingsUtil.java
+++ b/components/compatibility-settings-mgt/org.wso2.carbon.identity.compatibility.settings.core/src/main/java/org/wso2/carbon/identity/compatibility/settings/core/util/IdentityCompatibilitySettingsUtil.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.compatibility.settings.core.cache.CompatibilitySettingCache;
 import org.wso2.carbon.identity.compatibility.settings.core.cache.CompatibilitySettingCacheEntry;
 import org.wso2.carbon.identity.compatibility.settings.core.constant.IdentityCompatibilitySettingsConstants.ErrorMessages;
@@ -261,7 +261,8 @@ public class IdentityCompatibilitySettingsUtil {
             try {
                 // Start a tenant flow as the root org to access parent organization details since organizational
                 // manager does no support accessing super organization details in a sub-organization tenant flow.
-                FrameworkUtils.startTenantFlow(parentTenantDomain);
+                PrivilegedCarbonContext.startTenantFlow();
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(parentTenantDomain, true);
                 String rootOrgId = organizationManager.resolveOrganizationId(parentTenantDomain);
                 if (rootOrgId != null && !rootOrgId.equals(organization.getId())) {
                     Organization rootorganization =
@@ -271,7 +272,7 @@ public class IdentityCompatibilitySettingsUtil {
                     }
                 }
             } finally {
-                FrameworkUtils.endTenantFlow();
+                PrivilegedCarbonContext.endTenantFlow();
             }
 
         }

--- a/components/compatibility-settings-mgt/org.wso2.carbon.identity.compatibility.settings.core/src/test/java/org/wso2/carbon/identity/compatibility/settings/core/util/IdentityCompatibilitySettingsUtilTest.java
+++ b/components/compatibility-settings-mgt/org.wso2.carbon.identity.compatibility.settings.core/src/test/java/org/wso2/carbon/identity/compatibility/settings/core/util/IdentityCompatibilitySettingsUtilTest.java
@@ -21,12 +21,14 @@ package org.wso2.carbon.identity.compatibility.settings.core.util;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.compatibility.settings.core.cache.CompatibilitySettingCache;
 import org.wso2.carbon.identity.compatibility.settings.core.cache.CompatibilitySettingCacheEntry;
 import org.wso2.carbon.identity.compatibility.settings.core.constant.IdentityCompatibilitySettingsConstants.ErrorMessages;
@@ -90,6 +92,18 @@ public class IdentityCompatibilitySettingsUtilTest {
     private MockedStatic<CompatibilitySettingCache> cacheMockedStatic;
     private IdentityCompatibilitySettingsDataHolder dataHolder;
     private CompatibilitySettingCache cache;
+
+    @BeforeClass
+    public void setUpClass() {
+
+        System.setProperty("carbon.home", System.getProperty("java.io.tmpdir"));
+    }
+
+    @AfterClass
+    public void tearDownClass() {
+
+        System.clearProperty("carbon.home");
+    }
 
     @BeforeMethod
     public void setUp() {
@@ -428,12 +442,16 @@ public class IdentityCompatibilitySettingsUtilTest {
 
         try (MockedStatic<OrganizationManagementUtil> orgUtilMockedStatic =
                      mockStatic(OrganizationManagementUtil.class);
-             MockedStatic<FrameworkUtils> frameworkUtilsMockedStatic = mockStatic(FrameworkUtils.class)) {
+             MockedStatic<PrivilegedCarbonContext> carbonContextMockedStatic =
+                     mockStatic(PrivilegedCarbonContext.class)) {
 
             orgUtilMockedStatic.when(() -> OrganizationManagementUtil.getRootOrgTenantDomainBySubOrgTenantDomain(
                     TENANT_DOMAIN)).thenReturn(ROOT_TENANT_DOMAIN);
-            frameworkUtilsMockedStatic.when(() -> FrameworkUtils.startTenantFlow(anyString())).thenAnswer(i -> null);
-            frameworkUtilsMockedStatic.when(FrameworkUtils::endTenantFlow).thenAnswer(i -> null);
+            PrivilegedCarbonContext mockContext = mock(PrivilegedCarbonContext.class);
+            carbonContextMockedStatic.when(PrivilegedCarbonContext::getThreadLocalCarbonContext)
+                    .thenReturn(mockContext);
+            carbonContextMockedStatic.when(PrivilegedCarbonContext::startTenantFlow).thenAnswer(i -> null);
+            carbonContextMockedStatic.when(PrivilegedCarbonContext::endTenantFlow).thenAnswer(i -> null);
 
             Instant result = IdentityCompatibilitySettingsUtil.getOrganizationCreationTime(TENANT_DOMAIN, true);
             assertEquals(result, rootCreatedTime);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/pom.xml
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/pom.xml
@@ -109,6 +109,10 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.compatibility.settings.core</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -177,6 +181,7 @@
                             org.wso2.carbon.identity.ai.service.mgt.*; version="${carbon.identity.package.import.version.range}",
                             org.apache.http.client.methods; version="${httpcomponents-httpclient.imp.pkg.version.range}",
                             org.apache.axiom.om; version="${axiom.osgi.version.range}",
+                            org.wso2.carbon.identity.compatibility.settings.core.*; version="${carbon.identity.package.import.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.flow.mgt.internal,

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
@@ -143,27 +143,26 @@ public class Constants {
 
     public enum FlowTypes {
 
-        REGISTRATION("REGISTRATION", "enableFlowBasedRegistration",
+        REGISTRATION("REGISTRATION", "defaultEnableRegistration",
                 FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED,
                 FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED, FlowCompletionConfig.IS_AUTO_LOGIN_ENABLED,
                 FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED),
-        PASSWORD_RECOVERY("PASSWORD_RECOVERY", "enableFlowBasedPasswordRecovery",
+        PASSWORD_RECOVERY("PASSWORD_RECOVERY", "defaultEnablePasswordRecovery",
                 FlowCompletionConfig.IS_AUTO_LOGIN_ENABLED,
                 FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED),
-        INVITED_USER_REGISTRATION("INVITED_USER_REGISTRATION", 
-                "enableFlowBasedInvitedUserRegistration",
+        INVITED_USER_REGISTRATION("INVITED_USER_REGISTRATION", "defaultEnableInvitedUserRegistration",
                 FlowCompletionConfig.IS_AUTO_LOGIN_ENABLED,
                 FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED);
 
         private final String type;
-        private final String enableFeatureCompatibilitySettingKey;
+        private final String defaultEnablementCompatibilityKey;
         private final ArrayList<FlowCompletionConfig> supportedFlowCompletionConfigs = new ArrayList<>();
 
-        FlowTypes(String type, String enableFeatureCompatibilitySettingKey,
+        FlowTypes(String type, String defaultEnablementCompatibilityKey,
                   FlowCompletionConfig... requiredFlowCompletionConfigs) {
 
             this.type = type;
-            this.enableFeatureCompatibilitySettingKey = enableFeatureCompatibilitySettingKey;
+            this.defaultEnablementCompatibilityKey = defaultEnablementCompatibilityKey;
             this.supportedFlowCompletionConfigs.addAll(Arrays.asList(requiredFlowCompletionConfigs));
         }
 
@@ -172,9 +171,9 @@ public class Constants {
             return type;
         }
 
-        public String getEnableFeatureCompatibilitySettingKey() {
+        public String getDefaultEnablementCompatibilityKey() {
 
-            return enableFeatureCompatibilitySettingKey;
+            return defaultEnablementCompatibilityKey;
         }
 
         public ArrayList<FlowCompletionConfig> getSupportedFlowCompletionConfigs() {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
@@ -143,26 +143,37 @@ public class Constants {
 
     public enum FlowTypes {
 
-        REGISTRATION("REGISTRATION", FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED,
+        REGISTRATION("REGISTRATION", "enableFlowBasedRegistration",
+                FlowCompletionConfig.IS_ACCOUNT_LOCK_ON_CREATION_ENABLED,
                 FlowCompletionConfig.IS_EMAIL_VERIFICATION_ENABLED, FlowCompletionConfig.IS_AUTO_LOGIN_ENABLED,
                 FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED),
-        PASSWORD_RECOVERY("PASSWORD_RECOVERY", FlowCompletionConfig.IS_AUTO_LOGIN_ENABLED,
+        PASSWORD_RECOVERY("PASSWORD_RECOVERY", "enableFlowBasedPasswordRecovery",
+                FlowCompletionConfig.IS_AUTO_LOGIN_ENABLED,
                 FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED),
-        INVITED_USER_REGISTRATION("INVITED_USER_REGISTRATION", FlowCompletionConfig.IS_AUTO_LOGIN_ENABLED,
+        INVITED_USER_REGISTRATION("INVITED_USER_REGISTRATION", 
+                "enableFlowBasedInvitedUserRegistration",
+                FlowCompletionConfig.IS_AUTO_LOGIN_ENABLED,
                 FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED);
 
         private final String type;
+        private final String compatibilitySettingKey;
         private final ArrayList<FlowCompletionConfig> supportedFlowCompletionConfigs = new ArrayList<>();
 
-        FlowTypes(String type, FlowCompletionConfig... requiredFlowCompletionConfigs) {
+        FlowTypes(String type, String compatibilitySettingKey, FlowCompletionConfig... requiredFlowCompletionConfigs) {
 
             this.type = type;
+            this.compatibilitySettingKey = compatibilitySettingKey;
             this.supportedFlowCompletionConfigs.addAll(Arrays.asList(requiredFlowCompletionConfigs));
         }
 
         public String getType() {
 
             return type;
+        }
+
+        public String getCompatibilitySettingKey() {
+
+            return compatibilitySettingKey;
         }
 
         public ArrayList<FlowCompletionConfig> getSupportedFlowCompletionConfigs() {
@@ -254,6 +265,7 @@ public class Constants {
         public static final String FLOW_EXECUTION_CONFIG = "FlowExecution";
         public static final String DEFAULT_ENABLED_FLOWS_CONFIG = "DefaultEnabledFlows";
         public static final String FLOW_TYPE_ELEMENT = "FlowType";
+        public static final String COMPATIBILITY_SETTING_GROUP = "flowExecution";
 
         private FlowConfigConstants() {
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
@@ -156,13 +156,14 @@ public class Constants {
                 FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED);
 
         private final String type;
-        private final String compatibilitySettingKey;
+        private final String enableFeatureCompatibilitySettingKey;
         private final ArrayList<FlowCompletionConfig> supportedFlowCompletionConfigs = new ArrayList<>();
 
-        FlowTypes(String type, String compatibilitySettingKey, FlowCompletionConfig... requiredFlowCompletionConfigs) {
+        FlowTypes(String type, String enableFeatureCompatibilitySettingKey,
+                  FlowCompletionConfig... requiredFlowCompletionConfigs) {
 
             this.type = type;
-            this.compatibilitySettingKey = compatibilitySettingKey;
+            this.enableFeatureCompatibilitySettingKey = enableFeatureCompatibilitySettingKey;
             this.supportedFlowCompletionConfigs.addAll(Arrays.asList(requiredFlowCompletionConfigs));
         }
 
@@ -171,9 +172,9 @@ public class Constants {
             return type;
         }
 
-        public String getCompatibilitySettingKey() {
+        public String getEnableFeatureCompatibilitySettingKey() {
 
-            return compatibilitySettingKey;
+            return enableFeatureCompatibilitySettingKey;
         }
 
         public ArrayList<FlowCompletionConfig> getSupportedFlowCompletionConfigs() {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/internal/FlowMgtServiceComponent.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/internal/FlowMgtServiceComponent.java
@@ -28,6 +28,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.compatibility.settings.core.CompatibilitySettingsManager;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.flow.mgt.FlowAIService;
 import org.wso2.carbon.identity.flow.mgt.FlowMgtService;
@@ -112,5 +113,21 @@ public class FlowMgtServiceComponent {
     protected void unsetConfigurationManager(ConfigurationManager configurationManager) {
 
         FlowMgtServiceDataHolder.getInstance().setConfigurationManager(null);
+    }
+
+    @Reference(
+            name = "compatibility.settings.manager",
+            service = CompatibilitySettingsManager.class,
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetCompatibilitySettingsManager")
+    protected void setCompatibilitySettingsManager(CompatibilitySettingsManager compatibilitySettingsManager) {
+
+        FlowMgtServiceDataHolder.getInstance().setCompatibilitySettingsManager(compatibilitySettingsManager);
+    }
+
+    protected void unsetCompatibilitySettingsManager(CompatibilitySettingsManager compatibilitySettingsManager) {
+
+        FlowMgtServiceDataHolder.getInstance().setCompatibilitySettingsManager(null);
     }
 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/internal/FlowMgtServiceDataHolder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/internal/FlowMgtServiceDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.flow.mgt.internal;
 
+import org.wso2.carbon.identity.compatibility.settings.core.CompatibilitySettingsManager;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
@@ -30,6 +31,7 @@ public class FlowMgtServiceDataHolder {
     private OrganizationManager organizationManager;
     private OrgResourceResolverService orgResourceResolverService;
     private ConfigurationManager configurationManager;
+    private CompatibilitySettingsManager compatibilitySettingsManager;
 
     private static final FlowMgtServiceDataHolder INSTANCE = new FlowMgtServiceDataHolder();
 
@@ -70,5 +72,15 @@ public class FlowMgtServiceDataHolder {
     public void setConfigurationManager(ConfigurationManager configurationManager) {
 
         this.configurationManager = configurationManager;
+    }
+
+    public CompatibilitySettingsManager getCompatibilitySettingsManager() {
+
+        return compatibilitySettingsManager;
+    }
+
+    public void setCompatibilitySettingsManager(CompatibilitySettingsManager compatibilitySettingsManager) {
+
+        this.compatibilitySettingsManager = compatibilitySettingsManager;
     }
 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
@@ -23,6 +23,10 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.compatibility.settings.core.CompatibilitySettingsManager;
+import org.wso2.carbon.identity.compatibility.settings.core.exception.CompatibilitySettingException;
+import org.wso2.carbon.identity.compatibility.settings.core.model.CompatibilitySetting;
+import org.wso2.carbon.identity.compatibility.settings.core.model.CompatibilitySettingGroup;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants;
@@ -156,7 +160,7 @@ public class FlowMgtConfigUtils {
             List<FlowConfigDTO> flowMgtConfigs = new ArrayList<>();
             Resources resources = getConfigurationManager().getResourcesByType(RESOURCE_TYPE);
             if (resources == null || CollectionUtils.isEmpty(resources.getResources())) {
-                return getDefaultFlowConfigs();
+                return getDefaultFlowConfigs(tenantDomain);
             }
             resources.getResources()
                     .forEach(resource -> {
@@ -166,7 +170,7 @@ public class FlowMgtConfigUtils {
             Arrays.stream(Constants.FlowTypes.values()).map(
                     Constants.FlowTypes::getType).forEach(flowType -> {
                 if (flowMgtConfigs.stream().noneMatch(config -> config.getFlowType().equals(flowType))) {
-                    FlowConfigDTO defaultConfig = getDefaultConfig(flowType);
+                    FlowConfigDTO defaultConfig = getDefaultConfig(flowType, tenantDomain);
                     flowMgtConfigs.add(defaultConfig);
                 }
             });
@@ -178,7 +182,7 @@ public class FlowMgtConfigUtils {
                         tenantDomain);
             }
         }
-        return getDefaultFlowConfigs();
+        return getDefaultFlowConfigs(tenantDomain);
     }
 
     /**
@@ -186,12 +190,12 @@ public class FlowMgtConfigUtils {
      *
      * @return FlowMgtConfig
      */
-    private static List<FlowConfigDTO> getDefaultFlowConfigs() {
+    private static List<FlowConfigDTO> getDefaultFlowConfigs(String tenantDomain) {
 
         List<FlowConfigDTO> flowConfigDTOS = new ArrayList<>();
         Arrays.stream(Constants.FlowTypes.values()).map(
                 Constants.FlowTypes::getType).forEach(flowType -> {
-            FlowConfigDTO flowConfigDTO = getDefaultConfig(flowType);
+            FlowConfigDTO flowConfigDTO = getDefaultConfig(flowType, tenantDomain);
             flowConfigDTOS.add(flowConfigDTO);
         });
         return flowConfigDTOS;
@@ -210,7 +214,7 @@ public class FlowMgtConfigUtils {
 
         String resourceName = RESOURCE_NAME_PREFIX + flowType;
         Resource resource = getResource(resourceName, tenantDomain);
-        return buildAndPopulateFlowConfigFromResource(flowType, resource);
+        return buildAndPopulateFlowConfigFromResource(flowType, resource, tenantDomain);
     }
 
     /**
@@ -219,15 +223,46 @@ public class FlowMgtConfigUtils {
      * @param flowType The type of the flow.
      * @return FlowConfigDTO
      */
-    private static FlowConfigDTO getDefaultConfig(String flowType) {
+    private static FlowConfigDTO getDefaultConfig(String flowType, String tenantDomain) {
 
         LOG.debug("Returning default flow configuration for flow type: " + flowType);
         Constants.FlowTypes requestedFlowType = Constants.FlowTypes.valueOf(flowType);
         FlowConfigDTO flowConfigDTO = new FlowConfigDTO();
         flowConfigDTO.setFlowType(flowType);
-        flowConfigDTO.setIsEnabled(SERVER_DEFAULT_ENABLED_FLOWS.contains(flowType));
+        boolean isEnabled = SERVER_DEFAULT_ENABLED_FLOWS.contains(flowType)
+                && isFlowEnabledForTenant(flowType, tenantDomain);
+        flowConfigDTO.setIsEnabled(isEnabled);
         flowConfigDTO.addAllFlowCompletionConfigs(requestedFlowType.getSupportedFlowCompletionConfigs());
         return flowConfigDTO;
+    }
+
+    private static boolean isFlowEnabledForTenant(String flowType, String tenantDomain) {
+
+        if (tenantDomain == null) {
+            return false;
+        }
+        CompatibilitySettingsManager manager =
+                FlowMgtServiceDataHolder.getInstance().getCompatibilitySettingsManager();
+        if (manager == null) {
+            return false;
+        }
+        try {
+            String settingKey = Constants.FlowTypes.valueOf(flowType).getCompatibilitySettingKey();
+            CompatibilitySetting setting = manager.getCompatibilitySettingsByGroupAndSetting(
+                    tenantDomain,
+                    Constants.FlowConfigConstants.COMPATIBILITY_SETTING_GROUP,
+                    settingKey);
+            CompatibilitySettingGroup group = setting.getCompatibilitySetting(
+                    Constants.FlowConfigConstants.COMPATIBILITY_SETTING_GROUP);
+            if (group == null) {
+                return false;
+            }
+            return Boolean.parseBoolean(group.getSettingValue(settingKey));
+        } catch (CompatibilitySettingException e) {
+            LOG.warn("Could not evaluate compatibility setting for tenant: " + tenantDomain +
+                    ". Default flows will not be enabled.", e);
+            return false;
+        }
     }
 
     /**
@@ -236,10 +271,11 @@ public class FlowMgtConfigUtils {
      * @param resource The resource containing flow configuration attributes.
      * @return FlowConfigDTO
      */
-    private static FlowConfigDTO buildAndPopulateFlowConfigFromResource(String flowType, Resource resource) {
+    private static FlowConfigDTO buildAndPopulateFlowConfigFromResource(String flowType, Resource resource,
+                                                                         String tenantDomain) {
 
         if (resource == null || CollectionUtils.isEmpty(resource.getAttributes())) {
-            return getDefaultConfig(flowType);
+            return getDefaultConfig(flowType, tenantDomain);
         }
         return buildAndPopulateFlowConfigFromResource(resource);
     }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
@@ -238,7 +238,7 @@ public class FlowMgtConfigUtils {
 
     private static boolean isFlowEnabledForTenant(String flowType, String tenantDomain) {
 
-        if (tenantDomain == null) {
+        if (StringUtils.isBlank(tenantDomain)) {
             return false;
         }
         CompatibilitySettingsManager manager =
@@ -259,8 +259,10 @@ public class FlowMgtConfigUtils {
             }
             return Boolean.parseBoolean(group.getSettingValue(settingKey));
         } catch (CompatibilitySettingException e) {
-            LOG.warn("Could not evaluate compatibility setting for tenant: " + tenantDomain +
-                    ". Default flows will not be enabled.", e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Could not evaluate compatibility setting for tenant: " + tenantDomain +
+                        ". Default flows will not be enabled.", e);
+            }
             return false;
         }
     }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
@@ -247,7 +247,7 @@ public class FlowMgtConfigUtils {
             return false;
         }
         try {
-            String settingKey = Constants.FlowTypes.valueOf(flowType).getCompatibilitySettingKey();
+            String settingKey = Constants.FlowTypes.valueOf(flowType).getEnableFeatureCompatibilitySettingKey();
             CompatibilitySetting setting = manager.getCompatibilitySettingsByGroupAndSetting(
                     tenantDomain,
                     Constants.FlowConfigConstants.COMPATIBILITY_SETTING_GROUP,

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
@@ -230,13 +230,13 @@ public class FlowMgtConfigUtils {
         FlowConfigDTO flowConfigDTO = new FlowConfigDTO();
         flowConfigDTO.setFlowType(flowType);
         boolean isEnabled = SERVER_DEFAULT_ENABLED_FLOWS.contains(flowType)
-                && isFlowEnabledForTenant(flowType, tenantDomain);
+                && isFlowEnabledForTenantByDefault(flowType, tenantDomain);
         flowConfigDTO.setIsEnabled(isEnabled);
         flowConfigDTO.addAllFlowCompletionConfigs(requestedFlowType.getSupportedFlowCompletionConfigs());
         return flowConfigDTO;
     }
 
-    private static boolean isFlowEnabledForTenant(String flowType, String tenantDomain) {
+    private static boolean isFlowEnabledForTenantByDefault(String flowType, String tenantDomain) {
 
         if (StringUtils.isBlank(tenantDomain)) {
             return false;

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtils.java
@@ -247,7 +247,7 @@ public class FlowMgtConfigUtils {
             return false;
         }
         try {
-            String settingKey = Constants.FlowTypes.valueOf(flowType).getEnableFeatureCompatibilitySettingKey();
+            String settingKey = Constants.FlowTypes.valueOf(flowType).getDefaultEnablementCompatibilityKey();
             CompatibilitySetting setting = manager.getCompatibilitySettingsByGroupAndSetting(
                     tenantDomain,
                     Constants.FlowConfigConstants.COMPATIBILITY_SETTING_GROUP,

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
@@ -25,6 +25,10 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.compatibility.settings.core.CompatibilitySettingsManager;
+import org.wso2.carbon.identity.compatibility.settings.core.exception.CompatibilitySettingException;
+import org.wso2.carbon.identity.compatibility.settings.core.model.CompatibilitySetting;
+import org.wso2.carbon.identity.compatibility.settings.core.model.CompatibilitySettingGroup;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants;
 import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
@@ -65,6 +69,7 @@ import static org.wso2.carbon.identity.flow.mgt.Constants.FlowConfigConstants.RE
 public class FlowMgtConfigUtilsTest {
 
     private ConfigurationManager configurationManager;
+    private FlowMgtServiceDataHolder serviceDataHolder;
     private MockedStatic<FlowMgtServiceDataHolder> flowMgtServiceDataHolderMock;
     private static final String TENANT_DOMAIN = "carbon.super";
     private static final String FLOW_TYPE_REGISTRATION = "REGISTRATION";
@@ -75,7 +80,7 @@ public class FlowMgtConfigUtilsTest {
     public void setUp() {
 
         configurationManager = mock(ConfigurationManager.class);
-        FlowMgtServiceDataHolder serviceDataHolder = mock(FlowMgtServiceDataHolder.class);
+        serviceDataHolder = mock(FlowMgtServiceDataHolder.class);
 
         flowMgtServiceDataHolderMock = Mockito.mockStatic(FlowMgtServiceDataHolder.class);
 
@@ -511,6 +516,79 @@ public class FlowMgtConfigUtilsTest {
         Assert.assertEquals(registrationCount, 1);
         Assert.assertEquals(passwordRecoveryCount, 1);
         Assert.assertEquals(invitedUserCount, 1);
+    }
+
+    @Test
+    public void testIsFlowEnabledForTenantReturnsFalseWhenTenantDomainIsNull() throws Exception {
+
+        java.lang.reflect.Method method =
+                FlowMgtConfigUtils.class.getDeclaredMethod("isFlowEnabledForTenant", String.class, String.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(null, FLOW_TYPE_REGISTRATION, null);
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testIsFlowEnabledForTenantReturnsFalseWhenManagerIsNull() throws Exception {
+
+        // serviceDataHolder.getCompatibilitySettingsManager() is not stubbed → returns null
+        java.lang.reflect.Method method =
+                FlowMgtConfigUtils.class.getDeclaredMethod("isFlowEnabledForTenant", String.class, String.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(null, FLOW_TYPE_REGISTRATION, TENANT_DOMAIN);
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testIsFlowEnabledForTenantReturnsTrueForNewTenant() throws Exception {
+
+        CompatibilitySettingsManager manager = mock(CompatibilitySettingsManager.class);
+        when(serviceDataHolder.getCompatibilitySettingsManager()).thenReturn(manager);
+
+        CompatibilitySetting setting = new CompatibilitySetting();
+        CompatibilitySettingGroup group = new CompatibilitySettingGroup();
+        group.setSettingGroup(Constants.FlowConfigConstants.COMPATIBILITY_SETTING_GROUP);
+        group.addSetting(Constants.FlowTypes.REGISTRATION.getCompatibilitySettingKey(), "true");
+        setting.addCompatibilitySetting(group);
+        when(manager.getCompatibilitySettingsByGroupAndSetting(anyString(), anyString(), anyString()))
+                .thenReturn(setting);
+
+        java.lang.reflect.Method method =
+                FlowMgtConfigUtils.class.getDeclaredMethod("isFlowEnabledForTenant", String.class, String.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(null, FLOW_TYPE_REGISTRATION, TENANT_DOMAIN);
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void testIsFlowEnabledForTenantReturnsFalseWhenSettingGroupAbsent() throws Exception {
+
+        CompatibilitySettingsManager manager = mock(CompatibilitySettingsManager.class);
+        when(serviceDataHolder.getCompatibilitySettingsManager()).thenReturn(manager);
+
+        when(manager.getCompatibilitySettingsByGroupAndSetting(anyString(), anyString(), anyString()))
+                .thenReturn(new CompatibilitySetting());
+
+        java.lang.reflect.Method method =
+                FlowMgtConfigUtils.class.getDeclaredMethod("isFlowEnabledForTenant", String.class, String.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(null, FLOW_TYPE_REGISTRATION, TENANT_DOMAIN);
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testIsFlowEnabledForTenantReturnsFalseOnException() throws Exception {
+
+        CompatibilitySettingsManager manager = mock(CompatibilitySettingsManager.class);
+        when(serviceDataHolder.getCompatibilitySettingsManager()).thenReturn(manager);
+        when(manager.getCompatibilitySettingsByGroupAndSetting(anyString(), anyString(), anyString()))
+                .thenThrow(new CompatibilitySettingException("TEST-001", "Test error", "Test description"));
+
+        java.lang.reflect.Method method =
+                FlowMgtConfigUtils.class.getDeclaredMethod("isFlowEnabledForTenant", String.class, String.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(null, FLOW_TYPE_REGISTRATION, TENANT_DOMAIN);
+        Assert.assertFalse(result);
     }
 
     @Test

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
@@ -522,7 +522,8 @@ public class FlowMgtConfigUtilsTest {
     public void testIsFlowEnabledForTenantReturnsFalseWhenTenantDomainIsNull() throws Exception {
 
         java.lang.reflect.Method method =
-                FlowMgtConfigUtils.class.getDeclaredMethod("isFlowEnabledForTenant", String.class, String.class);
+                FlowMgtConfigUtils.class
+                        .getDeclaredMethod("isFlowEnabledForTenantByDefault", String.class, String.class);
         method.setAccessible(true);
         boolean result = (boolean) method.invoke(null, FLOW_TYPE_REGISTRATION, null);
         Assert.assertFalse(result);
@@ -533,7 +534,8 @@ public class FlowMgtConfigUtilsTest {
 
         // serviceDataHolder.getCompatibilitySettingsManager() is not stubbed → returns null
         java.lang.reflect.Method method =
-                FlowMgtConfigUtils.class.getDeclaredMethod("isFlowEnabledForTenant", String.class, String.class);
+                FlowMgtConfigUtils.class
+                        .getDeclaredMethod("isFlowEnabledForTenantByDefault", String.class, String.class);
         method.setAccessible(true);
         boolean result = (boolean) method.invoke(null, FLOW_TYPE_REGISTRATION, TENANT_DOMAIN);
         Assert.assertFalse(result);
@@ -554,7 +556,8 @@ public class FlowMgtConfigUtilsTest {
                 .thenReturn(setting);
 
         java.lang.reflect.Method method =
-                FlowMgtConfigUtils.class.getDeclaredMethod("isFlowEnabledForTenant", String.class, String.class);
+                FlowMgtConfigUtils.class
+                        .getDeclaredMethod("isFlowEnabledForTenantByDefault", String.class, String.class);
         method.setAccessible(true);
         boolean result = (boolean) method.invoke(null, FLOW_TYPE_REGISTRATION, TENANT_DOMAIN);
         Assert.assertTrue(result);
@@ -570,7 +573,8 @@ public class FlowMgtConfigUtilsTest {
                 .thenReturn(new CompatibilitySetting());
 
         java.lang.reflect.Method method =
-                FlowMgtConfigUtils.class.getDeclaredMethod("isFlowEnabledForTenant", String.class, String.class);
+                FlowMgtConfigUtils.class
+                        .getDeclaredMethod("isFlowEnabledForTenantByDefault", String.class, String.class);
         method.setAccessible(true);
         boolean result = (boolean) method.invoke(null, FLOW_TYPE_REGISTRATION, TENANT_DOMAIN);
         Assert.assertFalse(result);
@@ -585,7 +589,8 @@ public class FlowMgtConfigUtilsTest {
                 .thenThrow(new CompatibilitySettingException("TEST-001", "Test error", "Test description"));
 
         java.lang.reflect.Method method =
-                FlowMgtConfigUtils.class.getDeclaredMethod("isFlowEnabledForTenant", String.class, String.class);
+                FlowMgtConfigUtils.class
+                        .getDeclaredMethod("isFlowEnabledForTenantByDefault", String.class, String.class);
         method.setAccessible(true);
         boolean result = (boolean) method.invoke(null, FLOW_TYPE_REGISTRATION, TENANT_DOMAIN);
         Assert.assertFalse(result);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
@@ -548,7 +548,7 @@ public class FlowMgtConfigUtilsTest {
         CompatibilitySetting setting = new CompatibilitySetting();
         CompatibilitySettingGroup group = new CompatibilitySettingGroup();
         group.setSettingGroup(Constants.FlowConfigConstants.COMPATIBILITY_SETTING_GROUP);
-        group.addSetting(Constants.FlowTypes.REGISTRATION.getCompatibilitySettingKey(), "true");
+        group.addSetting(Constants.FlowTypes.REGISTRATION.getEnableFeatureCompatibilitySettingKey(), "true");
         setting.addCompatibilitySetting(group);
         when(manager.getCompatibilitySettingsByGroupAndSetting(anyString(), anyString(), anyString()))
                 .thenReturn(setting);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
@@ -548,7 +548,7 @@ public class FlowMgtConfigUtilsTest {
         CompatibilitySetting setting = new CompatibilitySetting();
         CompatibilitySettingGroup group = new CompatibilitySettingGroup();
         group.setSettingGroup(Constants.FlowConfigConstants.COMPATIBILITY_SETTING_GROUP);
-        group.addSetting(Constants.FlowTypes.REGISTRATION.getEnableFeatureCompatibilitySettingKey(), "true");
+        group.addSetting(Constants.FlowTypes.REGISTRATION.getDefaultEnablementCompatibilityKey(), "true");
         setting.addCompatibilitySetting(group);
         when(manager.getCompatibilitySettingsByGroupAndSetting(anyString(), anyString(), anyString()))
                 .thenReturn(setting);

--- a/features/compatibility-settings-mgt/org.wso2.carbon.identity.compatibility.settings.management.server.feature/resources/identity/compatibilitysettings/compatibility-settings-metadata.json.j2
+++ b/features/compatibility-settings-mgt/org.wso2.carbon.identity.compatibility.settings.management.server.feature/resources/identity/compatibilitysettings/compatibility-settings-metadata.json.j2
@@ -54,10 +54,10 @@
             "targetValue" : {{compatibility_setting.flow_execution.enable_legacy_password_recovery_flow.target_value | default("true")}},
             "defaultValue" : {{compatibility_setting.flow_execution.enable_legacy_password_recovery_flow.default_value | default("false")}}
       },
-      "enableFlowBasedInvitedUserRegistration" : {
-        "timestampReference" : "{{compatibility_setting.flow_execution.enable_flow_based_invited_user_registration.timestamp_reference | default('2026-01-01T00:00:00Z')}}",
-        "targetValue" : {{compatibility_setting.flow_execution.enable_flow_based_invited_user_registration.target_value | default("false")}},
-        "defaultValue" : {{compatibility_setting.flow_execution.enable_flow_based_invited_user_registration.default_value | default("true")}}
+      "defaultEnableInvitedUserRegistration" : {
+        "timestampReference" : "{{compatibility_setting.flow_execution.default_enable_flow_based_invited_user_registration.timestamp_reference | default('2026-01-01T00:00:00Z')}}",
+        "targetValue" : {{compatibility_setting.flow_execution.default_enable_flow_based_invited_user_registration.target_value | default("false")}},
+        "defaultValue" : {{compatibility_setting.flow_execution.default_enable_flow_based_invited_user_registration.default_value | default("true")}}
       }
   },
   "scim2": {

--- a/features/compatibility-settings-mgt/org.wso2.carbon.identity.compatibility.settings.management.server.feature/resources/identity/compatibilitysettings/compatibility-settings-metadata.json.j2
+++ b/features/compatibility-settings-mgt/org.wso2.carbon.identity.compatibility.settings.management.server.feature/resources/identity/compatibilitysettings/compatibility-settings-metadata.json.j2
@@ -53,6 +53,11 @@
             "timestampReference" : "{{compatibility_setting.flow_execution.enable_legacy_password_recovery_flow.timestamp_reference | default('2026-01-01T00:00:00Z')}}",
             "targetValue" : {{compatibility_setting.flow_execution.enable_legacy_password_recovery_flow.target_value | default("true")}},
             "defaultValue" : {{compatibility_setting.flow_execution.enable_legacy_password_recovery_flow.default_value | default("false")}}
+      },
+      "enableFlowBasedInvitedUserRegistration" : {
+        "timestampReference" : "{{compatibility_setting.flow_execution.enable_flow_based_invited_user_registration.timestamp_reference | default('2026-01-01T00:00:00Z')}}",
+        "targetValue" : {{compatibility_setting.flow_execution.enable_flow_based_invited_user_registration.target_value | default("false")}},
+        "defaultValue" : {{compatibility_setting.flow_execution.enable_flow_based_invited_user_registration.default_value | default("true")}}
       }
   },
   "scim2": {


### PR DESCRIPTION
Implements https://github.com/wso2/product-is/issues/27011

Introduce compatibility settings support in the flow management module to enable server-default flows (e.g., invited user registration) only for newly created tenants, preserving backward compatibility for existing tenants.

Each FlowTypes enum entry now carries a compatibilitySettingKey which maps to an entry in the compatibility-settings-metadata.json. The OrganizationalCreationTimeBasedEvaluator determines whether a tenant is "new" based on the configured timestampReference.

Additionally, replace FrameworkUtils with PrivilegedCarbonContext in IdentityCompatibilitySettingsUtil to break the cyclic dependency between compatibility-settings-core and authentication-framework.