### PR TITLE
Fix Can't call commit when autocommit=true on tenant deletion

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/ClaimDialectDAO.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/dao/ClaimDialectDAO.java
@@ -146,12 +146,13 @@ public class ClaimDialectDAO {
     public void removeAllClaimDialects(int tenantId) throws ClaimMetadataException {
 
         String query = SQLConstants.REMOVE_CLAIM_DIALECTS_BY_TENANT_ID;
-        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(true)) {
             try (PreparedStatement prepStmt = connection.prepareStatement(query);) {
                 prepStmt.setInt(1, tenantId);
                 prepStmt.executeUpdate();
                 IdentityDatabaseUtil.commitTransaction(connection);
             } catch (SQLException e) {
+                IdentityDatabaseUtil.rollbackTransaction(connection);
                 throw new ClaimMetadataException("Error while deleting claim dialects of tenant: " + tenantId, e);
             }
         } catch (SQLException e) {


### PR DESCRIPTION
## Proposed changes in this pull request

Fixes the `java.sql.SQLException: Can't call commit when autocommit=true` error logged on every tenant metadata deletion against MySQL/PostgreSQL/Oracle (and any pool with `defaultAutoCommit=true`, which is the IS default).

### Root cause

`ClaimDialectDAO.removeAllClaimDialects(int tenantId)` acquired its JDBC connection via `IdentityDatabaseUtil.getDBConnection(false)`. With `shouldApplyTransaction=false`, `JDBCPersistenceManager` skips `setAutoCommit(false)` and the connection inherits the pool's `defaultAutoCommit=true`. The subsequent `IdentityDatabaseUtil.commitTransaction(connection)` then calls `Connection.commit()` on an autocommit-on connection — strict drivers reject this per the JDBC spec. H2 silently no-ops the call, which is why the bug went unnoticed in default installs.

The DELETE itself was still applied via the per-statement implicit commit, so the REST `DELETE /api/server/v1/tenants/{id}/metadata` call kept returning 204 — but the framework's transactional contract was broken and the error was logged on every tenant deletion.

### Fix

Switch `removeAllClaimDialects` to `IdentityDatabaseUtil.getDBConnection(true)` so `autoCommit=false` is forced and the existing `executeUpdate` + `commitTransaction` pair runs as a single committed transaction. This matches the connection-acquisition pattern already used by every sibling write method in the same DAO (`addClaimDialect`, `renameClaimDialect`, `removeClaimDialect`). Added the matching `rollbackTransaction` in the catch block for symmetry with those siblings.

### Related issues / PRs

- Fixes wso2/product-is#27263
- Same root-cause pattern as the prior fixes in #5528 (UserSessionStore) and #7952 (IdPManagementDAO).

### Audit of similar sites

A scan of `getDBConnection(false)` callers in `claim-mgt` shows the other 5 sites (`LocalClaimDAO:58,428`, `ExternalClaimDAO:58,157,191`, `ClaimDialectDAO:46`) are all SELECT-only (`executeQuery`) and do not call `commitTransaction`, so they are not affected by this bug. A broader audit across the framework is recommended as a separate follow-up.

## Test plan

- [x] Reproduce against IS 7.2.0 + MySQL 8.0.45 with `defaultAutoCommit=true`: `POST /tenants` (201) → `PUT /lifecycle-status activated=false` (200) → `DELETE /tenants/{id}/metadata` (204) — confirms `Can't call commit when autocommit=true` appears in `wso2carbon.log`.
- [x] Apply the patched JAR; rerun the same sequence — assert `grep -c "Can't call commit when autocommit=true" wso2carbon.log == 0` and the tenant's `IDN_CLAIM_DIALECT` rows are gone.
- [x] Cross-check on default H2 (no regression).
- [ ] CI builds.