### PR TITLE
Config for revoke cache for account suspension

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -874,6 +874,12 @@
             <UserName>{{oauth.token_generation.include_username_in_access_token}}</UserName>
         </EnableAssertions>
 
+        <!-- Revoke grant cache upon login. If this is set to true, the authorization grant caches will be cleared upon each login, since the inactive account suspension handler updates the login time on every login.
+                Default value : false
+                Supported versions: IS 7.3.0 onwards
+            -->
+        <RevokeCacheAtLogin>{{identity_mgt.inactive_account_suspension.revoke_grant_cache_upon_login}}</RevokeCacheAtLogin>
+
         <!-- This should be true if subject identifier in the token validation response needs to adhere to the
         following SP configuration.
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -2313,9 +2313,8 @@
   "workflow_engine.max_approver_notifications": 15,
   "use_resident_user_id_for_authenticated_shared_users.enabled": true,
   "app_native_authentication.handle_fail_completed_authenticator_status": true,
-
+  "identity_mgt.inactive_account_suspension.revoke_grant_cache_upon_login": false,
   "enhanced_organization_authentication.enabled_by_default_for_new_apps": true,
-
   "saas.enable_app_creation": false,
   "saas.enable_cross_tenant_operations": false
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -340,7 +340,8 @@
       "app_native_authentication.handle_fail_completed_authenticator_status": false,
       "enhanced_organization_authentication.enabled_by_default_for_new_apps" : false,
       "saas.enable_app_creation": true,
-      "saas.enable_cross_tenant_operations": false
+      "saas.enable_cross_tenant_operations": false,
+      "identity_mgt.inactive_account_suspension.revoke_grant_cache_upon_login": false
     },
     "IS_7.1.0": {
       "oauth.dcrm.return_null_fields_in_response": true,
@@ -405,6 +406,7 @@
       "authentication.include_auth_failure_reason_in_api_based_response": false,
       "authentication.include_multi_options_in_api_based_auth_response": false,
       "app_native_authentication.handle_fail_completed_authenticator_status": false,
+      "identity_mgt.inactive_account_suspension.revoke_grant_cache_upon_login": true,
       "actions.action_request.case_insensitive_header_filtering": false,
       "enhanced_organization_authentication.enabled_by_default_for_new_apps" : false,
       "saas.enable_app_creation": true,
@@ -434,6 +436,7 @@
       "authentication.include_auth_failure_reason_in_api_based_response": false,
       "authentication.include_multi_options_in_api_based_auth_response": false,
       "app_native_authentication.handle_fail_completed_authenticator_status": false,
+      "identity_mgt.inactive_account_suspension.revoke_grant_cache_upon_login": true,
       "webhooks.registration.skip_signup_confirmation_if_account_lock_disabled": false,
       "actions.action_request.case_insensitive_header_filtering": false,
       "enhanced_organization_authentication.enabled_by_default_for_new_apps" : false,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -341,7 +341,7 @@
       "enhanced_organization_authentication.enabled_by_default_for_new_apps" : false,
       "saas.enable_app_creation": true,
       "saas.enable_cross_tenant_operations": false,
-      "identity_mgt.inactive_account_suspension.revoke_grant_cache_upon_login": false
+      "identity_mgt.inactive_account_suspension.revoke_grant_cache_upon_login": true
     },
     "IS_7.1.0": {
       "oauth.dcrm.return_null_fields_in_response": true,


### PR DESCRIPTION
### Proposed changes in this pull request
Issue : https://github.com/wso2/product-is/issues/25324

Related PR: 

- https://github.com/wso2-extensions/identity-governance/pull/1102
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3138
- https://github.com/wso2/carbon-identity-framework/pull/7922

With this fixes, authoirzation grant cache wont get cleared when user login when account suspension config is on. Even though, its correct its changing the behaviour cause earlier cache get cleared and refresh token will always has updated login time value (if configured as oidc attribute). To get that behaviour this config should turn on, hence added infer.json.

Note that eventhough the config is ussed by OAuth component, the config is triggered by account suspension handler. So its best to have the name of the config as


```toml
[identity_mgt.inactive_account_suspention]
revoke_grant_cache_upon_login = true
```
mapped internally to Oauth