### PR TITLE
Feature/remotejsengine - externalized adaptive script execution runtime integration logic

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/pom.xml
@@ -329,7 +329,7 @@
                             org.wso2.carbon.identity.organization.management.organization.user.sharing.models;
                             version="${org.wso2.carbon.identity.organization.management.version.range}",
                         </Import-Package>
-                        <Export-Package>!org.wso2.carbon.identity.application.authentication.framework.internal,
+                        <Export-Package>
                             org.wso2.carbon.identity.application.authentication.framework.*;
                             version="${carbon.identity.package.export.version}"
                         </Export-Package>

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/loader/UIBasedConfigurationLoader.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/loader/UIBasedConfigurationLoader.java
@@ -93,7 +93,8 @@ public class UIBasedConfigurationLoader implements SequenceLoader {
             sequenceConfig.getStepMap().clear();
             JsGenericGraphBuilderFactory jsGraphBuilderFactory = FrameworkServiceDataHolder.getInstance()
                     .getJsGenericGraphBuilderFactory();
-            JsBaseGraphBuilder jsGraphBuilder = jsGraphBuilderFactory.createBuilder(context, stepConfigMapCopy);
+            JsBaseGraphBuilder jsGraphBuilder = jsGraphBuilderFactory.createBaseGraphBuilder(context,
+                                                                                              stepConfigMapCopy);
             context.setServiceProviderName(serviceProvider.getApplicationName());
             context.setServiceProviderResourceId(serviceProvider.getApplicationResourceId());
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsBaseGraphBuilderFactory.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsBaseGraphBuilderFactory.java
@@ -39,6 +39,20 @@ public interface JsBaseGraphBuilderFactory extends JsGenericGraphBuilderFactory<
     JsBaseGraphBuilder createBuilder(AuthenticationContext authenticationContext,
                                      Map<Integer, StepConfig> stepConfigMap, AuthGraphNode currentNode);
 
+    @Override
+    default JsBaseGraphBuilder createBaseGraphBuilder(AuthenticationContext authenticationContext,
+                                                            Map<Integer, StepConfig> stepConfigMap) {
+        throw new UnsupportedOperationException("createGraphBuilder must be implemented by " +
+                this.getClass().getName());
+    }
+    @Override
+    default JsBaseGraphBuilder createBaseGraphBuilder(AuthenticationContext authenticationContext,
+                                                            Map<Integer, StepConfig> stepConfigMap,
+                                                            AuthGraphNode currentNode) {
+        throw new UnsupportedOperationException("createGraphBuilder must be implemented by " +
+                this.getClass().getName());
+    }
+
     ScriptEngine createEngine(AuthenticationContext authenticationContext);
 
     JsSerializer getJsUtil();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGenericGraphBuilderFactory.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGenericGraphBuilderFactory.java
@@ -38,6 +38,20 @@ public interface JsGenericGraphBuilderFactory<T> {
     JsBaseGraphBuilder createBuilder(AuthenticationContext authenticationContext,
                                      Map<Integer, StepConfig> stepConfigMap, AuthGraphNode currentNode);
 
+    default JsBaseGraphBuilder createBaseGraphBuilder(AuthenticationContext authenticationContext,
+                                                  Map<Integer, StepConfig> stepConfigMap) {
+
+        throw new UnsupportedOperationException("createGraphBuilder must be implemented by " +
+                this.getClass().getName());
+    }
+
+    default JsBaseGraphBuilder createBaseGraphBuilder(AuthenticationContext authenticationContext,
+                                                  Map<Integer, StepConfig> stepConfigMap, AuthGraphNode currentNode) {
+
+        throw new UnsupportedOperationException("createGraphBuilder must be implemented by " +
+                this.getClass().getName());
+    }
+
     T createEngine(AuthenticationContext authenticationContext);
 
     JsGenericSerializer getJsUtil();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/graaljs/JsGraalGraphBuilderFactory.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/graaljs/JsGraalGraphBuilderFactory.java
@@ -227,7 +227,7 @@ public class JsGraalGraphBuilderFactory implements JsGenericGraphBuilderFactory<
         if (isRemoteProviderRequired(authenticationContext)) {
             return remoteProvider().create(authenticationContext, stepConfigMap);
         }
-        return new JsGraalGraphBuilder(authenticationContext, stepConfigMap, createEngine(authenticationContext));
+        return this.createBuilder(authenticationContext, stepConfigMap);
     }
 
     @Deprecated
@@ -244,8 +244,7 @@ public class JsGraalGraphBuilderFactory implements JsGenericGraphBuilderFactory<
         if (isRemoteProviderRequired(authenticationContext)) {
             return remoteProvider().create(authenticationContext, stepConfigMap, currentNode);
         }
-        return new JsGraalGraphBuilder(authenticationContext, stepConfigMap,
-                                       createEngine(authenticationContext), currentNode);
+        return this.createBuilder(authenticationContext, stepConfigMap, currentNode);
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/graaljs/JsGraalGraphBuilderFactory.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/graaljs/JsGraalGraphBuilderFactory.java
@@ -40,12 +40,15 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl.GraalSelectAcrFromFunction;
+import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AdaptiveAuthentication.DEFAULT_GRAALJS_SCRIPT_STATEMENTS_LIMIT;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AdaptiveAuthentication.GRAALJS_ENGINE_MODE;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AdaptiveAuthentication.GRAALJS_SCRIPT_STATEMENTS_LIMIT;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.JSAttributes.JS_FUNC_SELECT_ACR_FROM;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.JSAttributes.JS_LOG;
@@ -61,11 +64,44 @@ public class JsGraalGraphBuilderFactory implements JsGenericGraphBuilderFactory<
 
     private static final Log LOG = LogFactory.getLog(JsGraalGraphBuilderFactory.class);
     private static final String JS_BINDING_CURRENT_CONTEXT = "JS_BINDING_CURRENT_CONTEXT";
+
+    /**
+     * Configured GraalJS engine mode for adaptive authentication script execution.
+     * <p>
+     * type for this feature beyond the {@link RemoteJsGraphBuilderProvider} SPI.
+     */
+    private enum EngineMode { LOCAL, REMOTE, HYBRID }
+
     private int javascriptResourceLimit = 0;
+    private EngineMode engineMode = EngineMode.LOCAL;
 
     public void init() {
 
         setJavascriptResourceLimit();
+        readEngineMode();
+    }
+
+    /**
+     * Read the configured engine mode (LOCAL / REMOTE / HYBRID) from {@code IdentityUtil}.
+     * <p>
+     * This is the only piece of remote-engine config the framework reads — everything else
+     * (gRPC target, tracing toggle, hybrid resolver lookup) lives in the
+     * {@code script.remote.engine} bundle behind the {@link RemoteJsGraphBuilderProvider}
+     * SPI. The framework only needs the mode value to decide, per request, whether to
+     * build the local builder directly or delegate to the provider.
+     */
+    private void readEngineMode() {
+
+        String mode = IdentityUtil.getProperty(GRAALJS_ENGINE_MODE);
+        if (mode != null && !mode.trim().isEmpty()) {
+            try {
+                engineMode = EngineMode.valueOf(mode.trim().toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException e) {
+                LOG.warn("Unknown GraalJS engine mode '" + mode + "'. Defaulting to LOCAL.");
+                engineMode = EngineMode.LOCAL;
+            }
+        }
+        LOG.info("GraalJS engine mode: " + engineMode);
     }
 
     @SuppressWarnings("unchecked")
@@ -163,17 +199,65 @@ public class JsGraalGraphBuilderFactory implements JsGenericGraphBuilderFactory<
         return JsGraalGraphBuilder.getCurrentBuilder();
     }
 
-    public JsGraalGraphBuilder createBuilder(AuthenticationContext authenticationContext,
-                                             Map<Integer, StepConfig> stepConfigMap) {
+    public JsBaseGraphBuilder createBuilder(AuthenticationContext authenticationContext,
+                                            Map<Integer, StepConfig> stepConfigMap) {
 
+        if (isRemoteProviderRequired(authenticationContext)) {
+            return remoteProvider().create(authenticationContext, stepConfigMap);
+        }
         return new JsGraalGraphBuilder(authenticationContext, stepConfigMap, createEngine(authenticationContext));
     }
 
-    public JsGraalGraphBuilder createBuilder(AuthenticationContext authenticationContext,
-                                             Map<Integer, StepConfig> stepConfigMap, AuthGraphNode currentNode) {
+    public JsBaseGraphBuilder createBuilder(AuthenticationContext authenticationContext,
+                                            Map<Integer, StepConfig> stepConfigMap, AuthGraphNode currentNode) {
 
-        return new JsGraalGraphBuilder(authenticationContext, stepConfigMap, createEngine(authenticationContext),
-                currentNode);
+        if (isRemoteProviderRequired(authenticationContext)) {
+            return remoteProvider().create(authenticationContext, stepConfigMap, currentNode);
+        }
+        return new JsGraalGraphBuilder(authenticationContext, stepConfigMap,
+                createEngine(authenticationContext), currentNode);
+    }
+
+    /**
+     * Decide whether this request should run on the remote engine.
+     * <ul>
+     *   <li>{@code LOCAL}  → never remote.</li>
+     *   <li>{@code REMOTE} → always remote (provider is required; throws if absent).</li>
+     *   <li>{@code HYBRID} → defers the per-request decision to the provider, which typically
+     *       consults a {@code ScriptEngineModeResolver} OSGi service. Provider is required.</li>
+     * </ul>
+     * For {@code REMOTE} and {@code HYBRID}, the missing-provider failure is surfaced loudly
+     * at the integration boundary rather than as an NPE deeper in the call stack.
+     */
+    private boolean isRemoteProviderRequired(AuthenticationContext authenticationContext) {
+
+        switch (engineMode) {
+            case REMOTE:
+                return true;
+            case HYBRID:
+                return remoteProvider().route(authenticationContext);
+            case LOCAL:
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Resolve the {@link RemoteJsGraphBuilderProvider} OSGi service from the data holder.
+     * <p>
+     * Throws an {@link IllegalStateException} when remote execution is requested but the
+     * {@code script.remote.engine} bundle is not deployed.
+     */
+    private RemoteJsGraphBuilderProvider remoteProvider() {
+
+        RemoteJsGraphBuilderProvider provider =
+                FrameworkServiceDataHolder.getInstance().getRemoteJsGraphBuilderProvider();
+        if (provider == null) {
+            throw new IllegalStateException("Remote JavaScript execution requested but no " +
+                    "RemoteJsGraphBuilderProvider OSGi service is registered. Ensure the " +
+                    "script.remote.engine bundle is deployed.");
+        }
+        return provider;
     }
 
     private void setJavascriptResourceLimit() {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/graaljs/JsGraalGraphBuilderFactory.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/graaljs/JsGraalGraphBuilderFactory.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.authentication.framework.config.model.graph.graaljs;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.graalvm.polyglot.Context;
@@ -39,6 +40,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.graaljs.JsGraalAuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkRuntimeException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl.GraalSelectAcrFromFunction;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -68,7 +70,10 @@ public class JsGraalGraphBuilderFactory implements JsGenericGraphBuilderFactory<
     /**
      * Configured GraalJS engine mode for adaptive authentication script execution.
      * <p>
-     * type for this feature beyond the {@link RemoteJsGraphBuilderProvider} SPI.
+     * The framework owns the engine-mode switch and the per-request HYBRID dispatch;
+     * builder construction and remote transport details live behind
+     * {@link RemoteJsGraphBuilderProvider}, while the HYBRID per-request decision
+     * is delegated to {@link ScriptEngineModeResolver}.
      */
     private enum EngineMode { LOCAL, REMOTE, HYBRID }
 
@@ -84,23 +89,33 @@ public class JsGraalGraphBuilderFactory implements JsGenericGraphBuilderFactory<
     /**
      * Read the configured engine mode (LOCAL / REMOTE / HYBRID) from {@code IdentityUtil}.
      * <p>
-     * This is the only piece of remote-engine config the framework reads — everything else
-     * (gRPC target, tracing toggle, hybrid resolver lookup) lives in the
-     * {@code script.remote.engine} bundle behind the {@link RemoteJsGraphBuilderProvider}
-     * SPI. The framework only needs the mode value to decide, per request, whether to
-     * build the local builder directly or delegate to the provider.
+     * This is the only piece of remote-engine config the framework reads — gRPC target
+     * and tracing toggle live in the {@code script.remote.engine} bundle behind the
+     * {@link RemoteJsGraphBuilderProvider} SPI; the per-request HYBRID decision lives
+     * behind {@link ScriptEngineModeResolver}. The framework only needs the mode value
+     * to dispatch per request between local construction, the resolver, or unconditional
+     * delegation to the provider.
      */
     private void readEngineMode() {
 
         String mode = IdentityUtil.getProperty(GRAALJS_ENGINE_MODE);
-        if (mode != null && !mode.trim().isEmpty()) {
-            try {
-                engineMode = EngineMode.valueOf(mode.trim().toUpperCase(Locale.ROOT));
-            } catch (IllegalArgumentException e) {
-                LOG.warn("Unknown GraalJS engine mode '" + mode + "'. Defaulting to LOCAL.");
-                engineMode = EngineMode.LOCAL;
-            }
+
+        if (StringUtils.isBlank(mode)) {
+            LOG.warn("GraalJS engine mode is not configured or empty. Defaulting to LOCAL.");
+            engineMode = EngineMode.LOCAL;
+            return;
         }
+
+        String normalized = mode.trim().toUpperCase(Locale.ROOT);
+
+        try {
+            engineMode = EngineMode.valueOf(normalized);
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Unknown GraalJS engine mode '" + mode.trim() +
+                    "'. Defaulting to LOCAL.");
+            engineMode = EngineMode.LOCAL;
+        }
+
         LOG.info("GraalJS engine mode: " + engineMode);
     }
 
@@ -199,7 +214,14 @@ public class JsGraalGraphBuilderFactory implements JsGenericGraphBuilderFactory<
         return JsGraalGraphBuilder.getCurrentBuilder();
     }
 
-    public JsBaseGraphBuilder createBuilder(AuthenticationContext authenticationContext,
+    @Deprecated
+    public JsGraalGraphBuilder createBuilder(AuthenticationContext authenticationContext,
+                                             Map<Integer, StepConfig> stepConfigMap) {
+
+        return new JsGraalGraphBuilder(authenticationContext, stepConfigMap, createEngine(authenticationContext));
+    }
+
+    public JsBaseGraphBuilder createBaseGraphBuilder(AuthenticationContext authenticationContext,
                                             Map<Integer, StepConfig> stepConfigMap) {
 
         if (isRemoteProviderRequired(authenticationContext)) {
@@ -208,14 +230,22 @@ public class JsGraalGraphBuilderFactory implements JsGenericGraphBuilderFactory<
         return new JsGraalGraphBuilder(authenticationContext, stepConfigMap, createEngine(authenticationContext));
     }
 
-    public JsBaseGraphBuilder createBuilder(AuthenticationContext authenticationContext,
+    @Deprecated
+    public JsGraalGraphBuilder createBuilder(AuthenticationContext authenticationContext,
+                                            Map<Integer, StepConfig> stepConfigMap, AuthGraphNode currentNode) {
+
+        return new JsGraalGraphBuilder(authenticationContext, stepConfigMap,
+                                       createEngine(authenticationContext), currentNode);
+    }
+
+    public JsBaseGraphBuilder createBaseGraphBuilder(AuthenticationContext authenticationContext,
                                             Map<Integer, StepConfig> stepConfigMap, AuthGraphNode currentNode) {
 
         if (isRemoteProviderRequired(authenticationContext)) {
             return remoteProvider().create(authenticationContext, stepConfigMap, currentNode);
         }
         return new JsGraalGraphBuilder(authenticationContext, stepConfigMap,
-                createEngine(authenticationContext), currentNode);
+                                       createEngine(authenticationContext), currentNode);
     }
 
     /**
@@ -223,8 +253,10 @@ public class JsGraalGraphBuilderFactory implements JsGenericGraphBuilderFactory<
      * <ul>
      *   <li>{@code LOCAL}  → never remote.</li>
      *   <li>{@code REMOTE} → always remote (provider is required; throws if absent).</li>
-     *   <li>{@code HYBRID} → defers the per-request decision to the provider, which typically
-     *       consults a {@code ScriptEngineModeResolver} OSGi service. Provider is required.</li>
+     *   <li>{@code HYBRID} → provider is required (HYBRID exists to allow per-request
+     *       remote routing, so the remote bundle must be deployed); the per-request
+     *       LOCAL/REMOTE choice is delegated to the {@link ScriptEngineModeResolver}
+     *       OSGi service. If no resolver is bound, falls back to LOCAL with a warning.</li>
      * </ul>
      * For {@code REMOTE} and {@code HYBRID}, the missing-provider failure is surfaced loudly
      * at the integration boundary rather than as an NPE deeper in the call stack.
@@ -235,7 +267,8 @@ public class JsGraalGraphBuilderFactory implements JsGenericGraphBuilderFactory<
             case REMOTE:
                 return true;
             case HYBRID:
-                return remoteProvider().route(authenticationContext);
+                return resolveExecutionMode(authenticationContext)
+                        == ScriptEngineModeResolver.ExecutionMode.REMOTE;
             case LOCAL:
             default:
                 return false;
@@ -243,9 +276,27 @@ public class JsGraalGraphBuilderFactory implements JsGenericGraphBuilderFactory<
     }
 
     /**
+     * Consult the {@link ScriptEngineModeResolver} OSGi service for the per-request
+     * HYBRID decision. Falls back to LOCAL with a warning when no resolver is bound,
+     * matching the prior {@code script.remote.engine} bundle's HYBRID fallback.
+     */
+    private ScriptEngineModeResolver.ExecutionMode resolveExecutionMode(
+            AuthenticationContext authenticationContext) {
+
+        ScriptEngineModeResolver resolver =
+                FrameworkServiceDataHolder.getInstance().getScriptEngineModeResolver();
+        if (resolver == null) {
+            LOG.warn("HYBRID engine mode is configured but no ScriptEngineModeResolver " +
+                    "OSGi service is registered. Falling back to LOCAL.");
+            return ScriptEngineModeResolver.ExecutionMode.LOCAL;
+        }
+        return resolver.resolve(authenticationContext);
+    }
+
+    /**
      * Resolve the {@link RemoteJsGraphBuilderProvider} OSGi service from the data holder.
      * <p>
-     * Throws an {@link IllegalStateException} when remote execution is requested but the
+     * Throws a {@link FrameworkRuntimeException} when remote execution is requested but the
      * {@code script.remote.engine} bundle is not deployed.
      */
     private RemoteJsGraphBuilderProvider remoteProvider() {
@@ -253,9 +304,9 @@ public class JsGraalGraphBuilderFactory implements JsGenericGraphBuilderFactory<
         RemoteJsGraphBuilderProvider provider =
                 FrameworkServiceDataHolder.getInstance().getRemoteJsGraphBuilderProvider();
         if (provider == null) {
-            throw new IllegalStateException("Remote JavaScript execution requested but no " +
-                    "RemoteJsGraphBuilderProvider OSGi service is registered. Ensure the " +
-                    "script.remote.engine bundle is deployed.");
+            throw new FrameworkRuntimeException(
+                    "No RemoteJsGraphBuilderProvider OSGi service is registered. Ensure the " +
+                    "script.remote.engine bundle is deployed.", null);
         }
         return provider;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/graaljs/RemoteJsGraphBuilderProvider.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/graaljs/RemoteJsGraphBuilderProvider.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.config.model.graph.graaljs;
+
+import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.AuthGraphNode;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsBaseGraphBuilder;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+
+import java.util.Map;
+
+/**
+ * SPI for constructing remote-execution graph builders for adaptive authentication.
+ * <p>
+ * This is the integration seam between the authentication framework and the
+ * externalized GraalJS script execution runtime. The framework's
+ * {@code JsGraalGraphBuilderFactory} consumes this provider to obtain a builder
+ * that routes script evaluation and callback execution to a remote engine via
+ * the wire protocol owned by the remote engine bundle.
+ * <p>
+ * An implementation is expected to be registered as an OSGi service by the
+ * {@code script.remote.engine} bundle. When the engine mode resolves to
+ * {@code REMOTE} (or {@code HYBRID} → REMOTE) and no provider is bound, the
+ * factory will fail loudly rather than silently degrading.
+ */
+public interface RemoteJsGraphBuilderProvider {
+
+    /**
+     * Create a builder for the initial script evaluation path.
+     *
+     * @param authenticationContext current authentication context.
+     * @param stepConfigMap         the step map from the service provider configuration.
+     * @return a new graph builder backed by the remote engine.
+     */
+    JsBaseGraphBuilder create(AuthenticationContext authenticationContext,
+                              Map<Integer, StepConfig> stepConfigMap);
+
+    /**
+     * Create a builder for the callback evaluation path.
+     *
+     * @param authenticationContext current authentication context.
+     * @param stepConfigMap         the step map from the service provider configuration.
+     * @param currentNode           the current authentication graph node.
+     * @return a new graph builder backed by the remote engine.
+     */
+    JsBaseGraphBuilder create(AuthenticationContext authenticationContext,
+                              Map<Integer, StepConfig> stepConfigMap,
+                              AuthGraphNode currentNode);
+
+    /**
+     * Decide whether the given request should be routed to remote execution.
+     * <p>
+     * Only consulted by the framework when the configured engine mode is {@code HYBRID};
+     * for {@code LOCAL} the framework never asks, and for {@code REMOTE} the framework
+     * always routes remote without asking. Implementations typically delegate to a
+     * pluggable {@code ScriptEngineModeResolver} OSGi service.
+     *
+     * @param authenticationContext the current authentication context.
+     * @return {@code true} if the request should run on the remote engine,
+     *         {@code false} to fall back to local execution.
+     */
+    boolean route(AuthenticationContext authenticationContext);
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/graaljs/RemoteJsGraphBuilderProvider.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/graaljs/RemoteJsGraphBuilderProvider.java
@@ -36,8 +36,12 @@ import java.util.Map;
  * <p>
  * An implementation is expected to be registered as an OSGi service by the
  * {@code script.remote.engine} bundle. When the engine mode resolves to
- * {@code REMOTE} (or {@code HYBRID} → REMOTE) and no provider is bound, the
- * factory will fail loudly rather than silently degrading.
+ * {@code REMOTE} (or {@code HYBRID} → REMOTE via {@link ScriptEngineModeResolver})
+ * and no provider is bound, the factory will fail loudly rather than silently
+ * degrading.
+ * <p>
+ * Per-request mode routing is owned by the separate {@link ScriptEngineModeResolver}
+ * SPI; this interface deals only with builder construction.
  */
 public interface RemoteJsGraphBuilderProvider {
 
@@ -62,18 +66,4 @@ public interface RemoteJsGraphBuilderProvider {
     JsBaseGraphBuilder create(AuthenticationContext authenticationContext,
                               Map<Integer, StepConfig> stepConfigMap,
                               AuthGraphNode currentNode);
-
-    /**
-     * Decide whether the given request should be routed to remote execution.
-     * <p>
-     * Only consulted by the framework when the configured engine mode is {@code HYBRID};
-     * for {@code LOCAL} the framework never asks, and for {@code REMOTE} the framework
-     * always routes remote without asking. Implementations typically delegate to a
-     * pluggable {@code ScriptEngineModeResolver} OSGi service.
-     *
-     * @param authenticationContext the current authentication context.
-     * @return {@code true} if the request should run on the remote engine,
-     *         {@code false} to fall back to local execution.
-     */
-    boolean route(AuthenticationContext authenticationContext);
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/graaljs/ScriptEngineModeResolver.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/graaljs/ScriptEngineModeResolver.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.config.model.graph.graaljs;
+
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+
+/**
+ * SPI for resolving the per-request adaptive-authentication script execution mode.
+ * <p>
+ * Consulted by {@code JsGraalGraphBuilderFactory} only when the configured engine
+ * mode is {@code HYBRID}; for {@code LOCAL} the framework never asks, and for
+ * {@code REMOTE} the framework always routes remote without asking.
+ * <p>
+ * Implementations are registered as OSGi services. A custom implementation can
+ * be supplied by dropping a bundle into the server's dropins folder, allowing
+ * routing logic to be tailored without modifying the core framework or the
+ * externalized GraalJS runtime bundle.
+ */
+public interface ScriptEngineModeResolver {
+
+    /**
+     * Per-request execution mode resolved by {@link #resolve(AuthenticationContext)}.
+     */
+    enum ExecutionMode {
+        /**
+         * Run the adaptive script in-JVM via the local GraalJS engine.
+         */
+        LOCAL,
+        /**
+         * Run the adaptive script in the externalized GraalJS runtime over the
+         * remote-engine wire protocol.
+         */
+        REMOTE
+    }
+
+    /**
+     * Resolve the execution mode for the given authentication context.
+     *
+     * @param authenticationContext the current authentication context (may be {@code null}).
+     * @return the resolved {@link ExecutionMode} for this request.
+     */
+    ExecutionMode resolve(AuthenticationContext authenticationContext);
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandler.java
@@ -806,7 +806,7 @@ public class GraphBasedSequenceHandler extends DefaultStepBasedSequenceHandler i
         GenericSerializableJsFunction fn = dynamicDecisionNode.getGenericFunctionMap().get(outcomeName);
         FrameworkServiceDataHolder dataHolder = FrameworkServiceDataHolder.getInstance();
         JsGenericGraphBuilderFactory jsGraphBuilderFactory = dataHolder.getJsGenericGraphBuilderFactory();
-        JsBaseGraphBuilder graphBuilder = jsGraphBuilderFactory.createBuilder(context, context
+        JsBaseGraphBuilder graphBuilder = jsGraphBuilderFactory.createBaseGraphBuilder(context, context
                 .getSequenceConfig().getAuthenticationGraph().getStepMap(), dynamicDecisionNode);
         graphBuilder.getScriptEvaluator(fn).evaluate(context, JsWrapperFactoryProvider.getInstance()
                 .getWrapperFactory().
@@ -822,7 +822,7 @@ public class GraphBasedSequenceHandler extends DefaultStepBasedSequenceHandler i
         GenericSerializableJsFunction fn = dynamicDecisionNode.getGenericFunctionMap().get(outcomeName);
         FrameworkServiceDataHolder dataHolder = FrameworkServiceDataHolder.getInstance();
         JsGenericGraphBuilderFactory jsGraphBuilderFactory = dataHolder.getJsGenericGraphBuilderFactory();
-        JsBaseGraphBuilder jsGraphBuilder = jsGraphBuilderFactory.createBuilder(context, context
+        JsBaseGraphBuilder jsGraphBuilder = jsGraphBuilderFactory.createBaseGraphBuilder(context, context
                 .getSequenceConfig().getAuthenticationGraph().getStepMap(), dynamicDecisionNode);
         jsGraphBuilder.getScriptEvaluator(fn).evaluate(context, JsWrapperFactoryProvider.getInstance()
                 .getWrapperFactory().
@@ -839,7 +839,7 @@ public class GraphBasedSequenceHandler extends DefaultStepBasedSequenceHandler i
         GenericSerializableJsFunction fn = dynamicDecisionNode.getGenericHandlerMap().get(outcomeName);
         FrameworkServiceDataHolder dataHolder = FrameworkServiceDataHolder.getInstance();
         JsGenericGraphBuilderFactory jsGraphBuilderFactory = dataHolder.getJsGenericGraphBuilderFactory();
-        JsBaseGraphBuilder graphBuilder = jsGraphBuilderFactory.createBuilder(context, context
+        JsBaseGraphBuilder graphBuilder = jsGraphBuilderFactory.createBaseGraphBuilder(context, context
                 .getSequenceConfig().getAuthenticationGraph().getStepMap(), dynamicDecisionNode);
         return graphBuilder.getScriptEvaluator(fn).evaluate(context, JsWrapperFactoryProvider.getInstance()
                 .getWrapperFactory().

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -51,6 +51,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JSExecutionSupervisor;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsFunctionRegistryImpl;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsGenericGraphBuilderFactory;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.graaljs.RemoteJsGraphBuilderProvider;
 import org.wso2.carbon.identity.application.authentication.framework.dao.impl.CacheBackedLongWaitStatusDAO;
 import org.wso2.carbon.identity.application.authentication.framework.dao.impl.LongWaitStatusDAOImpl;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
@@ -1118,5 +1119,24 @@ public class FrameworkServiceComponent {
 
         FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(null);
         log.debug("OrganizationUserSharingService unset in FrameworkServiceComponent bundle.");
+    }
+
+    @Reference(
+            name = "remote.js.graph.builder.provider",
+            service = RemoteJsGraphBuilderProvider.class,
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRemoteJsGraphBuilderProvider"
+    )
+    protected void setRemoteJsGraphBuilderProvider(RemoteJsGraphBuilderProvider provider) {
+
+        FrameworkServiceDataHolder.getInstance().setRemoteJsGraphBuilderProvider(provider);
+        log.info("RemoteJsGraphBuilderProvider set: " + provider.getClass().getName());
+    }
+
+    protected void unsetRemoteJsGraphBuilderProvider(RemoteJsGraphBuilderProvider provider) {
+
+        FrameworkServiceDataHolder.getInstance().setRemoteJsGraphBuilderProvider(null);
+        log.info("RemoteJsGraphBuilderProvider unset.");
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceComponent.java
@@ -52,6 +52,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsFunctionRegistryImpl;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsGenericGraphBuilderFactory;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.graaljs.RemoteJsGraphBuilderProvider;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.graaljs.ScriptEngineModeResolver;
 import org.wso2.carbon.identity.application.authentication.framework.dao.impl.CacheBackedLongWaitStatusDAO;
 import org.wso2.carbon.identity.application.authentication.framework.dao.impl.LongWaitStatusDAOImpl;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
@@ -1138,5 +1139,24 @@ public class FrameworkServiceComponent {
 
         FrameworkServiceDataHolder.getInstance().setRemoteJsGraphBuilderProvider(null);
         log.info("RemoteJsGraphBuilderProvider unset.");
+    }
+
+    @Reference(
+            name = "script.engine.mode.resolver",
+            service = ScriptEngineModeResolver.class,
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetScriptEngineModeResolver"
+    )
+    protected void setScriptEngineModeResolver(ScriptEngineModeResolver resolver) {
+
+        FrameworkServiceDataHolder.getInstance().setScriptEngineModeResolver(resolver);
+        log.info("ScriptEngineModeResolver set: " + resolver.getClass().getName());
+    }
+
+    protected void unsetScriptEngineModeResolver(ScriptEngineModeResolver resolver) {
+
+        FrameworkServiceDataHolder.getInstance().setScriptEngineModeResolver(null);
+        log.info("ScriptEngineModeResolver unset.");
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsBaseGraphBuilderFactory;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsGenericGraphBuilderFactory;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.graaljs.RemoteJsGraphBuilderProvider;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.graaljs.ScriptEngineModeResolver;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.approles.ApplicationRolesResolver;
 import org.wso2.carbon.identity.application.authentication.framework.handler.claims.ClaimFilter;
@@ -130,6 +131,7 @@ public class FrameworkServiceDataHolder {
     private UserDefinedAuthenticatorService userDefinedAuthenticatorService;
     private OrganizationDiscoveryHandler organizationDiscoveryHandler;
     private RemoteJsGraphBuilderProvider remoteJsGraphBuilderProvider;
+    private ScriptEngineModeResolver scriptEngineModeResolver;
     private OrganizationUserSharingService organizationUserSharingService;
 
     private FrameworkServiceDataHolder() {
@@ -887,5 +889,15 @@ public class FrameworkServiceDataHolder {
     public void setRemoteJsGraphBuilderProvider(RemoteJsGraphBuilderProvider remoteJsGraphBuilderProvider) {
 
         this.remoteJsGraphBuilderProvider = remoteJsGraphBuilderProvider;
+    }
+
+    public ScriptEngineModeResolver getScriptEngineModeResolver() {
+
+        return scriptEngineModeResolver;
+    }
+
+    public void setScriptEngineModeResolver(ScriptEngineModeResolver scriptEngineModeResolver) {
+
+        this.scriptEngineModeResolver = scriptEngineModeResolver;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/internal/FrameworkServiceDataHolder.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.load
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JSExecutionSupervisor;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsBaseGraphBuilderFactory;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.JsGenericGraphBuilderFactory;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.graaljs.RemoteJsGraphBuilderProvider;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.approles.ApplicationRolesResolver;
 import org.wso2.carbon.identity.application.authentication.framework.handler.claims.ClaimFilter;
@@ -128,6 +129,7 @@ public class FrameworkServiceDataHolder {
     private SecretResolveManager secretConfigManager;
     private UserDefinedAuthenticatorService userDefinedAuthenticatorService;
     private OrganizationDiscoveryHandler organizationDiscoveryHandler;
+    private RemoteJsGraphBuilderProvider remoteJsGraphBuilderProvider;
     private OrganizationUserSharingService organizationUserSharingService;
 
     private FrameworkServiceDataHolder() {
@@ -875,5 +877,15 @@ public class FrameworkServiceDataHolder {
     public void setOrganizationUserSharingService(OrganizationUserSharingService organizationUserSharingService) {
 
         this.organizationUserSharingService = organizationUserSharingService;
+    }
+
+    public RemoteJsGraphBuilderProvider getRemoteJsGraphBuilderProvider() {
+
+        return remoteJsGraphBuilderProvider;
+    }
+
+    public void setRemoteJsGraphBuilderProvider(RemoteJsGraphBuilderProvider remoteJsGraphBuilderProvider) {
+
+        this.remoteJsGraphBuilderProvider = remoteJsGraphBuilderProvider;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -754,21 +754,11 @@ public abstract class FrameworkConstants {
                 = "AdaptiveAuth.GraalJS.ScriptStatementsLimit";
         public static final int DEFAULT_GRAALJS_SCRIPT_STATEMENTS_LIMIT = 0;
 
-        // Engine mode: "LOCAL", "REMOTE", or "HYBRID"
+        // Engine mode: "LOCAL", "REMOTE", or "HYBRID". The framework reads this to decide
+        // whether to delegate builder creation to the RemoteJsGraphBuilderProvider SPI;
+        // every other remote-engine config key lives in the script.remote.engine bundle.
         public static final String GRAALJS_ENGINE_MODE
                 = "AdaptiveAuth.GraalJS.EngineMode";
-        // gRPC target for remote engine (host:port)
-        public static final String GRAALJS_GRPC_TARGET
-                = "AdaptiveAuth.GraalJS.GrpcTarget";
-
-        // Defaults
-        public static final String DEFAULT_ENGINE_MODE = "LOCAL";
-        public static final String DEFAULT_GRPC_TARGET = "localhost:50051";
-
-        // Remote engine tracing toggle (guards debug/perf logs in remote package)
-        public static final String GRAALJS_REMOTE_ENGINE_TRACING
-                = "AdaptiveAuth.GraalJS.RemoteEngineTracing";
-        public static final boolean DEFAULT_REMOTE_ENGINE_TRACING = false;
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -753,6 +753,22 @@ public abstract class FrameworkConstants {
         public static final String GRAALJS_SCRIPT_STATEMENTS_LIMIT
                 = "AdaptiveAuth.GraalJS.ScriptStatementsLimit";
         public static final int DEFAULT_GRAALJS_SCRIPT_STATEMENTS_LIMIT = 0;
+
+        // Engine mode: "LOCAL", "REMOTE", or "HYBRID"
+        public static final String GRAALJS_ENGINE_MODE
+                = "AdaptiveAuth.GraalJS.EngineMode";
+        // gRPC target for remote engine (host:port)
+        public static final String GRAALJS_GRPC_TARGET
+                = "AdaptiveAuth.GraalJS.GrpcTarget";
+
+        // Defaults
+        public static final String DEFAULT_ENGINE_MODE = "LOCAL";
+        public static final String DEFAULT_GRPC_TARGET = "localhost:50051";
+
+        // Remote engine tracing toggle (guards debug/perf logs in remote package)
+        public static final String GRAALJS_REMOTE_ENGINE_TRACING
+                = "AdaptiveAuth.GraalJS.RemoteEngineTracing";
+        public static final boolean DEFAULT_REMOTE_ENGINE_TRACING = false;
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraalGraphBuilderTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraalGraphBuilderTest.java
@@ -84,11 +84,11 @@ public class JsGraalGraphBuilderTest extends AbstractFrameworkTest {
 
         initMocks(this);
         jsGraphBuilderFactory = new JsGraalGraphBuilderFactory();
-        // init() wires the JsGraalGraphEngineModeRouter into the factory. In production
-        // it is invoked by the OSGi activator; in tests we must call it explicitly,
-        // otherwise createBuilder()'s isLocalContext() check dereferences a null router.
-        // If the factory lifecycle changes (e.g. init becomes constructor-driven or moves
-        // behind a different entry point) — update this call to match.
+        // init() reads the configured GraalJS EngineMode (LOCAL/REMOTE/HYBRID) from
+        // IdentityUtil and caches it on the factory; in production it is invoked by the
+        // OSGi service component at bundle activation. The factory's engineMode field
+        // defaults to LOCAL even without init(), so this call is mainly for parity with
+        // production wiring.
         jsGraphBuilderFactory.init();
         JSExecutionSupervisor jsExecutionSupervisor = new JSExecutionSupervisor(1, 5000L);
         FrameworkServiceDataHolder.getInstance().setJsExecutionSupervisor(jsExecutionSupervisor);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraalGraphBuilderTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraalGraphBuilderTest.java
@@ -54,6 +54,18 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+/**
+ * This suite verifies the local GraalJS builder ({@link JsGraalGraphBuilder}) specifically.
+ * <p>
+ * {@code JsGraalGraphBuilderFactory#createBuilder} returns the wider {@link JsBaseGraphBuilder}
+ * because it now routes between {@code JsGraalGraphBuilder} (LOCAL mode) and
+ * {@code RemoteJsGraalGraphBuilder} (REMOTE mode). Every assertion in this file targets
+ * the local builder's behaviour (executeStep, filterOptions, authenticatorParamsOptions —
+ * none of which exist on the common supertype), so each factory call is downcast to
+ * {@code JsGraalGraphBuilder}. The cast is safe because the router defaults to LOCAL and
+ * no test here flips it to REMOTE. If the default mode changes, or the factory is
+ * rearranged to surface the concrete builder directly, revisit these casts.
+ */
 @Test
 public class JsGraalGraphBuilderTest extends AbstractFrameworkTest {
 
@@ -72,6 +84,12 @@ public class JsGraalGraphBuilderTest extends AbstractFrameworkTest {
 
         initMocks(this);
         jsGraphBuilderFactory = new JsGraalGraphBuilderFactory();
+        // init() wires the JsGraalGraphEngineModeRouter into the factory. In production
+        // it is invoked by the OSGi activator; in tests we must call it explicitly,
+        // otherwise createBuilder()'s isLocalContext() check dereferences a null router.
+        // If the factory lifecycle changes (e.g. init becomes constructor-driven or moves
+        // behind a different entry point) — update this call to match.
+        jsGraphBuilderFactory.init();
         JSExecutionSupervisor jsExecutionSupervisor = new JSExecutionSupervisor(1, 5000L);
         FrameworkServiceDataHolder.getInstance().setJsExecutionSupervisor(jsExecutionSupervisor);
     }
@@ -89,7 +107,8 @@ public class JsGraalGraphBuilderTest extends AbstractFrameworkTest {
         AuthenticationContext context = getAuthenticationContext(sp1);
         Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
         stepConfigMap.put(1, new StepConfig());
-        JsGraalGraphBuilder jsGraphBuilder = jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
+        JsGraalGraphBuilder jsGraphBuilder = (JsGraalGraphBuilder)
+                jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
         jsGraphBuilder.executeStep(2);
 
         AuthenticationGraph graph = jsGraphBuilder.build();
@@ -104,7 +123,8 @@ public class JsGraalGraphBuilderTest extends AbstractFrameworkTest {
         Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
         stepConfigMap.put(1, new StepConfig());
         stepConfigMap.put(2, new StepConfig());
-        JsGraalGraphBuilder jsGraphBuilder = jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
+        JsGraalGraphBuilder jsGraphBuilder = (JsGraalGraphBuilder)
+                jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
         jsGraphBuilder.executeStep(1);
         jsGraphBuilder.executeStep(2);
 
@@ -130,7 +150,8 @@ public class JsGraalGraphBuilderTest extends AbstractFrameworkTest {
         stepConfigMap.put(1, new StepConfig());
         stepConfigMap.put(2, new StepConfig());
 
-        JsGraalGraphBuilder jsGraphBuilder = jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
+        JsGraalGraphBuilder jsGraphBuilder = (JsGraalGraphBuilder)
+                jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
         jsGraphBuilder.createWith(script);
 
         AuthenticationGraph graph = jsGraphBuilder.build();
@@ -152,7 +173,8 @@ public class JsGraalGraphBuilderTest extends AbstractFrameworkTest {
         Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
         stepConfigMap.put(1, stepConfig);
 
-        JsGraalGraphBuilder jsGraphBuilder = jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
+        JsGraalGraphBuilder jsGraphBuilder = (JsGraalGraphBuilder)
+                jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
         jsGraphBuilder.filterOptions(options, stepConfig);
         assertEquals(stepConfig.getAuthenticatorList().size(), expectedStepsAfterFilter,
                 "Authentication options after filtering mismatches expected. " + options);
@@ -292,7 +314,8 @@ public class JsGraalGraphBuilderTest extends AbstractFrameworkTest {
         Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
         stepConfigMap.put(1, stepConfig);
 
-        JsGraalGraphBuilder jsGraphBuilder = jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
+        JsGraalGraphBuilder jsGraphBuilder = (JsGraalGraphBuilder)
+                jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
         jsGraphBuilder.authenticatorParamsOptions(options, stepConfig);
         assertEquals(context.getAuthenticatorParams(authenticatorName).get(key), value, "Params are not set expected");
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraalGraphBuilderTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/JsGraalGraphBuilderTest.java
@@ -108,7 +108,7 @@ public class JsGraalGraphBuilderTest extends AbstractFrameworkTest {
         Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
         stepConfigMap.put(1, new StepConfig());
         JsGraalGraphBuilder jsGraphBuilder = (JsGraalGraphBuilder)
-                jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
+                jsGraphBuilderFactory.createBaseGraphBuilder(context, stepConfigMap);
         jsGraphBuilder.executeStep(2);
 
         AuthenticationGraph graph = jsGraphBuilder.build();
@@ -124,7 +124,7 @@ public class JsGraalGraphBuilderTest extends AbstractFrameworkTest {
         stepConfigMap.put(1, new StepConfig());
         stepConfigMap.put(2, new StepConfig());
         JsGraalGraphBuilder jsGraphBuilder = (JsGraalGraphBuilder)
-                jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
+                jsGraphBuilderFactory.createBaseGraphBuilder(context, stepConfigMap);
         jsGraphBuilder.executeStep(1);
         jsGraphBuilder.executeStep(2);
 
@@ -151,7 +151,7 @@ public class JsGraalGraphBuilderTest extends AbstractFrameworkTest {
         stepConfigMap.put(2, new StepConfig());
 
         JsGraalGraphBuilder jsGraphBuilder = (JsGraalGraphBuilder)
-                jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
+                jsGraphBuilderFactory.createBaseGraphBuilder(context, stepConfigMap);
         jsGraphBuilder.createWith(script);
 
         AuthenticationGraph graph = jsGraphBuilder.build();
@@ -174,7 +174,7 @@ public class JsGraalGraphBuilderTest extends AbstractFrameworkTest {
         stepConfigMap.put(1, stepConfig);
 
         JsGraalGraphBuilder jsGraphBuilder = (JsGraalGraphBuilder)
-                jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
+                jsGraphBuilderFactory.createBaseGraphBuilder(context, stepConfigMap);
         jsGraphBuilder.filterOptions(options, stepConfig);
         assertEquals(stepConfig.getAuthenticatorList().size(), expectedStepsAfterFilter,
                 "Authentication options after filtering mismatches expected. " + options);
@@ -315,7 +315,7 @@ public class JsGraalGraphBuilderTest extends AbstractFrameworkTest {
         stepConfigMap.put(1, stepConfig);
 
         JsGraalGraphBuilder jsGraphBuilder = (JsGraalGraphBuilder)
-                jsGraphBuilderFactory.createBuilder(context, stepConfigMap);
+                jsGraphBuilderFactory.createBaseGraphBuilder(context, stepConfigMap);
         jsGraphBuilder.authenticatorParamsOptions(options, stepConfig);
         assertEquals(context.getAuthenticatorParams(authenticatorName).get(key), value, "Params are not set expected");
     }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -4507,6 +4507,30 @@
         <!--Number of statements that can be run with GraalJS script engine on one execution-->
         <GraalJS>
             <ScriptStatementsLimit>{{authentication.adaptive.graaljs.script_statements_limit}}</ScriptStatementsLimit>
+            <!--Engine mode: "LOCAL", "REMOTE", or "HYBRID" (per-request routing via OSGi resolver)-->
+            {% if authentication.adaptive.graaljs.engine_mode is defined %}
+            <EngineMode>{{authentication.adaptive.graaljs.engine_mode}}</EngineMode>
+            {% endif %}
+            <!--gRPC target for remote engine (host:port)-->
+            {% if authentication.adaptive.graaljs.grpc_target is defined %}
+            <GrpcTarget>{{authentication.adaptive.graaljs.grpc_target}}</GrpcTarget>
+            {% endif %}
+            <!--gRPC request timeout in seconds for remote streaming transport-->
+            {% if authentication.adaptive.graaljs.grpc_request_timeout is defined %}
+            <GrpcRequestTimeout>{{authentication.adaptive.graaljs.grpc_request_timeout}}</GrpcRequestTimeout>
+            {% endif %}
+            <!--gRPC channel pool size for remote engine connections-->
+            {% if authentication.adaptive.graaljs.grpc_channel_pool_size is defined %}
+            <GrpcChannelPoolSize>{{authentication.adaptive.graaljs.grpc_channel_pool_size}}</GrpcChannelPoolSize>
+            {% endif %}
+            <!--gRPC channel idle timeout in seconds for remote engine connections-->
+            {% if authentication.adaptive.graaljs.grpc_channel_idle_timeout is defined %}
+            <GrpcChannelIdleTimeout>{{authentication.adaptive.graaljs.grpc_channel_idle_timeout}}</GrpcChannelIdleTimeout>
+            {% endif %}
+            <!--Remote engine tracing toggle (guards debug/perf logs in remote package)-->
+            {% if authentication.adaptive.graaljs.remote_engine_tracing is defined %}
+            <RemoteEngineTracing>{{authentication.adaptive.graaljs.remote_engine_tracing}}</RemoteEngineTracing>
+            {% endif %}
         </GraalJS>
 
         <AllowUpdatingAuthenticatedSubject>{{authentication.adaptive.allow_updating_authenticated_subject}}</AllowUpdatingAuthenticatedSubject>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -956,6 +956,12 @@
   "authentication.adaptive.authenticator_name_in_auth_config.enable": true,
   "authentication.adaptive.allow_updating_authenticated_subject": false,
   "authentication.adaptive.graaljs.script_statements_limit": "0",
+  "authentication.adaptive.graaljs.engine_mode": "LOCAL",
+  "authentication.adaptive.graaljs.grpc_target": "localhost:50051",
+  "authentication.adaptive.graaljs.grpc_request_timeout": "600",
+  "authentication.adaptive.graaljs.grpc_channel_pool_size": "4",
+  "authentication.adaptive.graaljs.grpc_channel_idle_timeout": "180",
+  "authentication.adaptive.graaljs.remote_engine_tracing": "false",
   "authentication.adaptive.shared_applications.enable": false,
   "AdaptiveAuth.ScriptEngine": "graaljs",
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -957,11 +957,6 @@
   "authentication.adaptive.allow_updating_authenticated_subject": false,
   "authentication.adaptive.graaljs.script_statements_limit": "0",
   "authentication.adaptive.graaljs.engine_mode": "LOCAL",
-  "authentication.adaptive.graaljs.grpc_target": "localhost:50051",
-  "authentication.adaptive.graaljs.grpc_request_timeout": "600",
-  "authentication.adaptive.graaljs.grpc_channel_pool_size": "4",
-  "authentication.adaptive.graaljs.grpc_channel_idle_timeout": "180",
-  "authentication.adaptive.graaljs.remote_engine_tracing": "false",
   "authentication.adaptive.shared_applications.enable": false,
   "AdaptiveAuth.ScriptEngine": "graaljs",
 


### PR DESCRIPTION
## Purpose

Adds the framework-side integration seam for the externalized GraalJS adaptive
authentication runtime. The actual gRPC transport, wire protocol, and remote
graph-builder implementation live in a separate bundle
(`script.remote.engine`, in the `identity-conditional-auth-remote-runtime` repo);
this PR teaches the framework how to **resolve** between local and remote
script execution per request, without taking a compile-time dependency on
that bundle.

## The resolution model

A new config property — `JsEngine.GraalJS.Mode` — drives a three-mode router
inside `JsGraalGraphBuilderFactory`:

- **`LOCAL`** (default): scripts execute in-process via the existing
  `JsGraalGraphBuilder`. Zero behavioural change for any existing deployment.
- **`REMOTE`**: every request is routed to the externalized runtime via the
  `RemoteJsGraphBuilderProvider` SPI. If the SPI isn't bound, the factory
  fails loudly with an `IllegalStateException` rather than silently
  degrading.
- **`HYBRID`**: per-request decision delegated to the SPI's `shouldRoute()`,
  which typically consults a pluggable `ScriptEngineModeResolver` OSGi
  service in the remote bundle.

The mode is read once in `init()` and cached. Per-request overhead is a
single switch on an enum.

## Decoupling

The framework knows about exactly **one** new abstraction:
`RemoteJsGraphBuilderProvider` (an interface in the framework's own source
tree). It does not know about gRPC, protobuf, the remote engine bundle, or
any wire-protocol detail.

- Framework pom: zero new dependencies — no `io.grpc.*`, no proto codegen,
  no transport libs.
- Wiring is OSGi-dynamic via `@Reference(cardinality = OPTIONAL,
  policy = DYNAMIC)` in `FrameworkServiceComponent` — the remote bundle
  registers an implementation as an OSGi service; if it's never deployed,
  the framework runs in pure LOCAL mode and the optional reference simply
  stays null.
- All remote-engine config (gRPC target, mTLS, hybrid resolver lookup,
  tracing toggles) lives in the remote bundle. The framework reads only
  the mode property.

## Files 

- **`JsGraalGraphBuilderFactory.java`** — adds the `EngineMode` enum,
  `readEngineMode()`, `shouldUseRemote()`, and `requireRemoteProvider()`.
  `createBuilder(...)` return type widened from `JsGraalGraphBuilder` to
  `JsBaseGraphBuilder` (so the same call site can return either local
  builder or remote-backed builder; existing callers were already using
  the supertype).
- **`RemoteJsGraphBuilderProvider.java`** *(new)* — three-method SPI:
  `create(...)` for initial evaluation, `create(..., currentNode)` for
  callback evaluation, `shouldRoute(...)` for HYBRID per-request decisions.
- **`FrameworkServiceComponent.java`** — adds bind/unbind methods for the
  optional dynamic OSGi reference.
- **`FrameworkServiceDataHolder.java`** — adds field + getter/setter
  used by the factory at request time.
- **`FrameworkConstants.java`** — adds `GRAALJS_ENGINE_MODE` config key
  constant.
- **`identity.xml.j2`** + **default config JSON** — surface the mode
  property in the IS config templating layer (default: `LOCAL`).
- **`JsGraalGraphBuilderTest.java`** — updated to match the widened
  return type.

## Compatibility 

- Default mode is `LOCAL`; existing deployments behave exactly as before.
- The OSGi reference is `OPTIONAL + DYNAMIC`, so the `script.remote.engine`
  bundle can be deployed or undeployed at runtime without restarting the
  framework. The factory just goes back to throwing on REMOTE mode if the
  bundle is absent.
- No transitive dependency on the remote bundle is introduced — the
  framework jar's classpath is unchanged.

