### PR TITLE
Add push device update endpoints to allowed endpoints

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
-  ~ Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2023-2026, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -977,9 +977,11 @@
         <!-- [Organization] Push Device Management API -->
         <Resource context="(.*)/o/api/users/v1/me/push/devices" secured="false" http-method="POST"/>
         <Resource context="(.*)/o/api/users/v1/me/push/devices/(.*)/remove" secured="false" http-method="POST"/>
+        <Resource context="(.*)/o/api/users/v1/me/push/devices/(.*)/update" secured="false" http-method="POST"/>
         <!-- Push Device Management API -->
         <Resource context="(.*)/api/users/v1/me/push/devices" secured="false" http-method="POST"/>
         <Resource context="(.*)/api/users/v1/me/push/devices/(.*)/remove" secured="false" http-method="POST"/>
+        <Resource context="(.*)/api/users/v1/me/push/devices/(.*)/update" secured="false" http-method="POST"/>
 
         <Resource context="(.*)/api/users/v1/me(.*)" secured="true" http-method="GET, HEAD, POST, PUT, DELETE, PATCH">
             <Scopes>internal_login</Scopes>


### PR DESCRIPTION
## Purpose
 The new push device update endpoint (`POST /devices/{deviceId}/update`) added in `identity-api-user` needs to be registered in the resource access control configuration. Without this, the endpoint would be blocked by the framework's access control layer.

## Related Issue
 - https://github.com/wso2/product-is/issues/26207

## Related PRs
 - **(prerequisite)** https://github.com/wso2-extensions/identity-notification-push/pull/25
 - **(prerequisite)** https://github.com/wso2/identity-api-user/pull/289

## Goals
 - Allow the new push device update endpoint to be accessible from both tenant and organization contexts without authentication (same as the existing registration and removal endpoints), since the request itself is authenticated via a signed JWT token.

## Approach
 - Added two new `<Resource>` entries in `resource-access-control-v2.xml.j2`:
   - Organization context: `(.*)/o/api/users/v1/me/push/devices/(.*)/update` with `secured="false"` for POST.
   - Tenant context: `(.*)/api/users/v1/me/push/devices/(.*)/update` with `secured="false"` for POST.
 - Follows the same pattern as the existing `/remove` endpoint entries.

## User stories
 As a mobile app user, I want the device update endpoint to be accessible so that I can update my device's push notification token or device name.

## Release note
 Added the push device update endpoint (`/devices/{deviceId}/update`) to the allowed endpoints in the resource access control configuration.

## Documentation
 N/A - Internal framework configuration change. No user-facing documentation impact.

## Training
 N/A

## Certification
 N/A - Configuration change with no impact on certification content.

## Marketing
 N/A

## Automation tests
 - Unit tests
   N/A - Configuration file change only.
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
 N/A

## Migrations (if applicable)
 No migrations required. Existing deployments will pick up the new resource access control entries on upgrade.

## Learning
 Followed the existing pattern used by the `/remove` endpoint for registering unsecured push device endpoints in both organization and tenant contexts.