### PR TITLE
Provide OAuth 2.0 password grant based Authentication support for actions

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/service/impl/ActionExecutorServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/service/impl/ActionExecutorServiceImpl.java
@@ -289,13 +289,13 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
             ActionInvocationResponse actionInvocationResponse =
                     executeActionAsynchronously(action, authenticationMethod, payload);
 
-            if (endpointAuthentication.getType() == Authentication.Type.CLIENT_CREDENTIAL) {
+            if (isOAuth2GrantBasedAuth(endpointAuthentication.getType())) {
                 int maxRetries = ActionExecutorConfig.getInstance().getHttpRequestRetryCount();
                 int attempt = 0;
                 while (actionInvocationResponse.isUnauthorized() && attempt < maxRetries) {
                     attempt++;
                     logRetryAttemptDueToUnauthorizedResponse(action, attempt, maxRetries);
-                    authenticationMethod = buildClientCredentialAuthMethod(action, endpointAuthentication, true);
+                    authenticationMethod = buildOAuth2GrantAuthMethod(action, endpointAuthentication, true);
                     logActionRequest(action, payload);
                     actionInvocationResponse = executeActionAsynchronously(action, authenticationMethod, payload);
                 }
@@ -719,7 +719,8 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
                 authProperties = authentication.getPropertiesWithDecryptedValues(action.getId());
                 return new AuthMethods.APIKeyAuth(authProperties);
             case CLIENT_CREDENTIAL:
-                return buildClientCredentialAuthMethod(action, authentication, false);
+            case PASSWORD_CREDENTIAL:
+                return buildOAuth2GrantAuthMethod(action, authentication, false);
             case NONE:
                 return null;
             default:
@@ -727,8 +728,8 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
         }
     }
 
-    private AuthMethods.AuthMethod buildClientCredentialAuthMethod(Action action, Authentication authentication,
-                                                                   boolean isRetry)
+    private AuthMethods.AuthMethod buildOAuth2GrantAuthMethod(Action action, Authentication authentication,
+                                                              boolean isRetry)
             throws ActionExecutionException, ActionMgtException {
 
         if (!isRetry) {
@@ -740,7 +741,7 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Using existing access token for action: " + action.getId() + " for authentication");
                 }
-                return buildClientCredentialAuth(decryptedInternalAccessToken.getValue());
+                return buildOAuth2GrantAuth(authentication.getType(), decryptedInternalAccessToken.getValue());
             }
             if (LOG.isDebugEnabled()) {
                 LOG.debug("No existing access token found for action: " + action.getId() +
@@ -759,17 +760,31 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
             throw e;
         }
         logSuccessResponseForAccessTokenRetrieval(action, authentication);
-        return buildClientCredentialAuth(newAccessToken);
+        return buildOAuth2GrantAuth(authentication.getType(), newAccessToken);
     }
 
-    private AuthMethods.AuthMethod buildClientCredentialAuth(String accessToken) {
+    private AuthMethods.AuthMethod buildOAuth2GrantAuth(Authentication.Type type, String accessToken)
+            throws ActionExecutionException {
 
         AuthProperty internalAccessToken = new AuthProperty.AuthPropertyBuilder()
                 .name(Authentication.Property.INTERNAL_ACCESS_TOKEN.getName())
                 .value(accessToken)
                 .isConfidential(true)
                 .build();
-        return new AuthMethods.ClientCredentialAuth(Collections.singletonList(internalAccessToken));
+        List<AuthProperty> properties = Collections.singletonList(internalAccessToken);
+        switch (type) {
+            case CLIENT_CREDENTIAL:
+                return new AuthMethods.ClientCredentialAuth(properties);
+            case PASSWORD_CREDENTIAL:
+                return new AuthMethods.PasswordCredentialAuth(properties);
+            default:
+                throw new ActionExecutionException("Unsupported OAuth2 grant authentication type: " + type);
+        }
+    }
+
+    private boolean isOAuth2GrantBasedAuth(Authentication.Type type) {
+
+        return type == Authentication.Type.CLIENT_CREDENTIAL || type == Authentication.Type.PASSWORD_CREDENTIAL;
     }
 
     private String resolveInternalRefreshToken(Action action, Authentication authentication) {

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/AuthMethods.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/AuthMethods.java
@@ -32,6 +32,9 @@ import java.util.List;
  */
 public final class AuthMethods {
 
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
     private AuthMethods() {
 
     }
@@ -65,7 +68,7 @@ public final class AuthMethods {
         @Override
         public void applyAuth(HttpPost httpPost) {
 
-            httpPost.setHeader("Authorization", "Bearer " + token);
+            httpPost.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + token);
         }
 
         @Override
@@ -100,7 +103,7 @@ public final class AuthMethods {
             String auth = username + ":" + password;
             byte[] encodedAuth = Base64.getEncoder().encode(auth.getBytes(StandardCharsets.UTF_8));
             String authHeader = "Basic " + new String(encodedAuth, StandardCharsets.UTF_8);
-            httpPost.setHeader("Authorization", authHeader);
+            httpPost.setHeader(AUTHORIZATION_HEADER, authHeader);
         }
 
         @Override
@@ -161,13 +164,42 @@ public final class AuthMethods {
         @Override
         public void applyAuth(HttpPost httpPost) {
 
-            httpPost.setHeader("Authorization", "Bearer " + internalAccessToken);
+            httpPost.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + internalAccessToken);
         }
 
         @Override
         public String getAuthType() {
 
             return Authentication.Type.CLIENT_CREDENTIAL.getName();
+        }
+    }
+
+    /**
+     * This class applies password credential authentication to the http request.
+     */
+    public static final class PasswordCredentialAuth implements AuthMethod {
+
+        private String internalAccessToken;
+
+        public PasswordCredentialAuth(List<AuthProperty> authPropertyList) {
+
+            authPropertyList.forEach(authProperty -> {
+                if (Authentication.Property.INTERNAL_ACCESS_TOKEN.getName().equals(authProperty.getName())) {
+                    this.internalAccessToken = authProperty.getValue();
+                }
+            });
+        }
+
+        @Override
+        public void applyAuth(HttpPost httpPost) {
+
+            httpPost.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + internalAccessToken);
+        }
+
+        @Override
+        public String getAuthType() {
+
+            return Authentication.Type.PASSWORD_CREDENTIAL.getName();
         }
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/TokenManager.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/TokenManager.java
@@ -40,7 +40,8 @@ import java.util.Map;
 import java.util.function.IntConsumer;
 
 /**
- * Manager class for handling Client Credentials Token acquisition and management for actions.
+ * Manager class for handling Client Credentials and Password Credential token acquisition
+ * and management for actions.
  */
 public class TokenManager {
 
@@ -79,13 +80,19 @@ public class TokenManager {
     public String getNewAccessToken(String actionId, Authentication authentication, String refreshToken)
             throws ActionExecutionException, ActionMgtException {
 
-        if (authentication.getType() != Authentication.Type.CLIENT_CREDENTIAL) {
+        if (authentication.getType() != Authentication.Type.CLIENT_CREDENTIAL
+                && authentication.getType() != Authentication.Type.PASSWORD_CREDENTIAL) {
             throw new ActionExecutionException("Unsupported authentication type for access token request, only " +
-                    "supported for client credential type.");
+                    "supported for client credential and password credential types.");
         }
 
         List<AuthProperty> authProperties = authentication.getPropertiesWithDecryptedValues(actionId);
-        TokenRequestContext tokenRequestContext = buildTokenRequestContext(authProperties);
+        TokenRequestContext tokenRequestContext;
+        if (authentication.getType() == Authentication.Type.PASSWORD_CREDENTIAL) {
+            tokenRequestContext = buildPasswordCredentialTokenRequestContext(authProperties);
+        } else {
+            tokenRequestContext = buildTokenRequestContext(authProperties);
+        }
         tokenAcquirerService.setTokenRequestContext(tokenRequestContext);
 
         TokenInvocationResult tokenInvocationResult;
@@ -177,6 +184,44 @@ public class TokenManager {
         } catch (TokenHandlerException e) {
             throw new ActionExecutionException(
                     "Error while building token request context for Client Credential grant.", e);
+        }
+    }
+
+    private TokenRequestContext buildPasswordCredentialTokenRequestContext(List<AuthProperty> decryptedProperties)
+            throws ActionExecutionException {
+
+        try {
+            Map<String, String> grantTypeProperties = new HashMap<>();
+            grantTypeProperties.put(
+                    GrantContext.Property.CLIENT_ID.getName(),
+                    getPropertyValue(decryptedProperties, Authentication.Property.CLIENT_ID));
+            grantTypeProperties.put(
+                    GrantContext.Property.CLIENT_SECRET.getName(),
+                    getPropertyValue(decryptedProperties, Authentication.Property.CLIENT_SECRET));
+            grantTypeProperties.put(
+                    GrantContext.Property.USERNAME.getName(),
+                    getPropertyValue(decryptedProperties, Authentication.Property.USERNAME));
+            grantTypeProperties.put(
+                    GrantContext.Property.PASSWORD.getName(),
+                    getPropertyValue(decryptedProperties, Authentication.Property.PASSWORD));
+            String scopes = getPropertyValue(decryptedProperties, Authentication.Property.SCOPES);
+            if (StringUtils.isNotBlank(scopes)) {
+                grantTypeProperties.put(GrantContext.Property.SCOPE.getName(), scopes);
+            }
+
+            GrantContext grantContext = new GrantContext.Builder()
+                    .grantType(GrantContext.GrantType.PASSWORD)
+                    .properties(grantTypeProperties)
+                    .build();
+
+            TokenRequestContext.Builder builder = new TokenRequestContext.Builder()
+                    .grantContext(grantContext)
+                    .endpointUrl(getPropertyValue(decryptedProperties, Authentication.Property.TOKEN_ENDPOINT));
+
+            return builder.build();
+        } catch (TokenHandlerException e) {
+            throw new ActionExecutionException(
+                    "Error while building token request context for Password Credential grant.", e);
         }
     }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImplTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/impl/ActionExecutorServiceImplTest.java
@@ -868,6 +868,108 @@ public class ActionExecutorServiceImplTest {
         }
     }
 
+    @Test
+    public void testActionExecuteWithPasswordCredentialUsesExistingAccessTokenWhenAvailable() throws Exception {
+
+        ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
+        Action action = createPasswordCredentialAction("existing-access-token", null);
+        wireClientCredentialPipeline(action, actionType);
+
+        ActionInvocationResponse successInvocation = createSuccessActionInvocationResponse();
+        when(apiClient.callAPI(any(), any(), any(), any(), any())).thenReturn(successInvocation);
+
+        ActionExecutionStatus expected = new SuccessStatus.Builder().build();
+        when(actionExecutionResponseProcessor.processSuccessResponse(any(), any())).thenReturn(expected);
+
+        ActionExecutionStatus actual = actionExecutorService.execute(actionType, FlowContext.create(), "tenant");
+
+        assertEquals(actual.getStatus(), expected.getStatus());
+        verify(tokenManager, times(0)).getNewAccessToken(any(), any(), any());
+        verify(apiClient, times(1)).callAPI(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void testActionExecuteWithPasswordCredentialFetchesAccessTokenWhenAbsent() throws Exception {
+
+        ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
+        Action action = createPasswordCredentialAction(null, null);
+        wireClientCredentialPipeline(action, actionType);
+
+        when(tokenManager.getNewAccessToken(any(), any(), any())).thenReturn("new-token");
+        ActionInvocationResponse successInvocation = createSuccessActionInvocationResponse();
+        when(apiClient.callAPI(any(), any(), any(), any(), any())).thenReturn(successInvocation);
+
+        ActionExecutionStatus expected = new SuccessStatus.Builder().build();
+        when(actionExecutionResponseProcessor.processSuccessResponse(any(), any())).thenReturn(expected);
+
+        ActionExecutionStatus actual = actionExecutorService.execute(actionType, FlowContext.create(), "tenant");
+
+        assertEquals(actual.getStatus(), expected.getStatus());
+        verify(tokenManager, times(1)).getNewAccessToken(any(), any(), any());
+        verify(apiClient, times(1)).callAPI(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void testActionExecuteWithPasswordCredentialRefreshesTokenAndRetriesOnUnauthorized() throws Exception {
+
+        ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
+        Action action = createPasswordCredentialAction("expired-token", "refresh-token");
+        wireClientCredentialPipeline(action, actionType);
+
+        ActionInvocationResponse unauthorized = createUnauthorizedActionInvocationResponse();
+        ActionInvocationResponse successInvocation = createSuccessActionInvocationResponse();
+        when(apiClient.callAPI(any(), any(), any(), any(), any()))
+                .thenReturn(unauthorized)
+                .thenReturn(successInvocation);
+        when(tokenManager.getNewAccessToken(any(), any(), any())).thenReturn("refreshed-token");
+
+        ActionExecutionStatus expected = new SuccessStatus.Builder().build();
+        when(actionExecutionResponseProcessor.processSuccessResponse(any(), any())).thenReturn(expected);
+
+        ActionExecutionStatus actual = actionExecutorService.execute(actionType, FlowContext.create(), "tenant");
+
+        assertEquals(actual.getStatus(), expected.getStatus());
+        verify(tokenManager, times(1)).getNewAccessToken(any(), any(), any());
+        verify(apiClient, times(2)).callAPI(any(), any(), any(), any(), any());
+    }
+
+    @Test(expectedExceptions = ActionExecutionException.class)
+    public void testActionExecuteWithPasswordCredentialExhaustsRetriesOnRepeatedUnauthorized() throws Exception {
+
+        ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
+        Action action = createPasswordCredentialAction("expired-token", "refresh-token");
+        wireClientCredentialPipeline(action, actionType);
+
+        ActionInvocationResponse unauthorized = createUnauthorizedActionInvocationResponse();
+        when(apiClient.callAPI(any(), any(), any(), any(), any())).thenReturn(unauthorized);
+        when(tokenManager.getNewAccessToken(any(), any(), any())).thenReturn("refreshed-token");
+
+        try {
+            actionExecutorService.execute(actionType, FlowContext.create(), "tenant");
+        } finally {
+            verify(apiClient, times(3)).callAPI(any(), any(), any(), any(), any());
+            verify(tokenManager, times(2)).getNewAccessToken(any(), any(), any());
+        }
+    }
+
+    @Test(expectedExceptions = ActionExecutionException.class,
+            expectedExceptionsMessageRegExp = "Error occurred while retrieving access token for actions.")
+    public void testActionExecuteWithPasswordCredentialFailsWhenInitialTokenRetrievalFails() throws Exception {
+
+        ActionType actionType = ActionType.PRE_ISSUE_ACCESS_TOKEN;
+        Action action = createPasswordCredentialAction(null, null);
+        wireClientCredentialPipeline(action, actionType);
+
+        when(tokenManager.getNewAccessToken(any(), any(), any()))
+                .thenThrow(new ActionExecutionException("Error occurred while retrieving access token for actions."));
+
+        try {
+            actionExecutorService.execute(actionType, FlowContext.create(), "tenant");
+        } finally {
+            verify(apiClient, times(0)).callAPI(any(), any(), any(), any(), any());
+        }
+    }
+
     private void wireClientCredentialPipeline(Action action, ActionType actionType) throws Exception {
 
         when(actionManagementService.getActionsByActionType(any(), any()))
@@ -923,6 +1025,67 @@ public class ActionExecutorServiceImplTest {
                 new AuthProperty.AuthPropertyBuilder()
                         .name(Authentication.Property.SCOPES.getName())
                         .value("read").isConfidential(false).build()
+        );
+        when(authentication.getPropertiesWithDecryptedValues(any())).thenReturn(decryptedProperties);
+
+        if (existingAccessToken != null) {
+            AuthProperty internalAccessToken = new AuthProperty.AuthPropertyBuilder()
+                    .name(Authentication.Property.INTERNAL_ACCESS_TOKEN.getName())
+                    .value(existingAccessToken)
+                    .isConfidential(true).build();
+            when(authentication.getInternalPropertyWithDecryptedValue(any(),
+                    eq(Authentication.Property.INTERNAL_ACCESS_TOKEN.getName())))
+                    .thenReturn(internalAccessToken);
+        }
+        if (existingRefreshToken != null) {
+            AuthProperty internalRefreshToken = new AuthProperty.AuthPropertyBuilder()
+                    .name(Authentication.Property.INTERNAL_REFRESH_TOKEN.getName())
+                    .value(existingRefreshToken)
+                    .isConfidential(true).build();
+            when(authentication.getInternalPropertyWithDecryptedValue(any(),
+                    eq(Authentication.Property.INTERNAL_REFRESH_TOKEN.getName())))
+                    .thenReturn(internalRefreshToken);
+        }
+
+        when(endpointConfig.getAuthentication()).thenReturn(authentication);
+        return action;
+    }
+
+    private Action createPasswordCredentialAction(String existingAccessToken, String existingRefreshToken)
+            throws ActionMgtException {
+
+        Action action = mock(Action.class);
+        when(action.getStatus()).thenReturn(Action.Status.ACTIVE);
+        when(action.getId()).thenReturn("actionId");
+        when(action.getType()).thenReturn(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN);
+        when(action.getActionVersion()).thenReturn("v1");
+
+        EndpointConfig endpointConfig = mock(EndpointConfig.class);
+        when(action.getEndpoint()).thenReturn(endpointConfig);
+        when(endpointConfig.getUri()).thenReturn("http://example.com");
+
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getType()).thenReturn(Authentication.Type.PASSWORD_CREDENTIAL);
+
+        List<AuthProperty> decryptedProperties = Arrays.asList(
+                new AuthProperty.AuthPropertyBuilder()
+                        .name(Authentication.Property.CLIENT_ID.getName())
+                        .value("clientId").isConfidential(true).build(),
+                new AuthProperty.AuthPropertyBuilder()
+                        .name(Authentication.Property.CLIENT_SECRET.getName())
+                        .value("clientSecret").isConfidential(true).build(),
+                new AuthProperty.AuthPropertyBuilder()
+                        .name(Authentication.Property.TOKEN_ENDPOINT.getName())
+                        .value("http://token-endpoint").isConfidential(false).build(),
+                new AuthProperty.AuthPropertyBuilder()
+                        .name(Authentication.Property.SCOPES.getName())
+                        .value("read").isConfidential(false).build(),
+                new AuthProperty.AuthPropertyBuilder()
+                        .name(Authentication.Property.USERNAME.getName())
+                        .value("user1").isConfidential(true).build(),
+                new AuthProperty.AuthPropertyBuilder()
+                        .name(Authentication.Property.PASSWORD.getName())
+                        .value("pass1").isConfidential(true).build()
         );
         when(authentication.getPropertiesWithDecryptedValues(any())).thenReturn(decryptedProperties);
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/AuthMethodsTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/AuthMethodsTest.java
@@ -168,4 +168,62 @@ public class AuthMethodsTest {
         clientCredentialAuth.applyAuth(httpPost);
         verify(httpPost).setHeader("Authorization", "Bearer null");
     }
+
+    @Test
+    public void testPasswordCredentialAuth() {
+
+        AuthProperty internalAccessToken = new AuthProperty.AuthPropertyBuilder()
+                .name(Authentication.Property.INTERNAL_ACCESS_TOKEN.getName())
+                .isConfidential(true)
+                .value("internalAccessToken")
+                .build();
+
+        List<AuthProperty> authProperties = Collections.singletonList(internalAccessToken);
+        AuthMethods.PasswordCredentialAuth passwordCredentialAuth =
+                new AuthMethods.PasswordCredentialAuth(authProperties);
+
+        assertEquals(Authentication.Type.PASSWORD_CREDENTIAL.getName(), passwordCredentialAuth.getAuthType());
+
+        passwordCredentialAuth.applyAuth(httpPost);
+        verify(httpPost).setHeader("Authorization", "Bearer internalAccessToken");
+    }
+
+    @Test
+    public void testPasswordCredentialAuthIgnoresUnrelatedProperties() {
+
+        AuthProperty username = new AuthProperty.AuthPropertyBuilder()
+                .name(Authentication.Property.USERNAME.getName())
+                .isConfidential(true)
+                .value("user1")
+                .build();
+        AuthProperty internalAccessToken = new AuthProperty.AuthPropertyBuilder()
+                .name(Authentication.Property.INTERNAL_ACCESS_TOKEN.getName())
+                .isConfidential(true)
+                .value("token-xyz")
+                .build();
+        AuthProperty internalRefreshToken = new AuthProperty.AuthPropertyBuilder()
+                .name(Authentication.Property.INTERNAL_REFRESH_TOKEN.getName())
+                .isConfidential(true)
+                .value("refresh-xyz")
+                .build();
+
+        List<AuthProperty> authProperties = Arrays.asList(username, internalAccessToken, internalRefreshToken);
+        AuthMethods.PasswordCredentialAuth passwordCredentialAuth =
+                new AuthMethods.PasswordCredentialAuth(authProperties);
+
+        passwordCredentialAuth.applyAuth(httpPost);
+        verify(httpPost).setHeader("Authorization", "Bearer token-xyz");
+    }
+
+    @Test
+    public void testPasswordCredentialAuthWithEmptyProperties() {
+
+        AuthMethods.PasswordCredentialAuth passwordCredentialAuth =
+                new AuthMethods.PasswordCredentialAuth(Collections.emptyList());
+
+        assertEquals(Authentication.Type.PASSWORD_CREDENTIAL.getName(), passwordCredentialAuth.getAuthType());
+
+        passwordCredentialAuth.applyAuth(httpPost);
+        verify(httpPost).setHeader("Authorization", "Bearer null");
+    }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/TokenManagerTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/test/java/org/wso2/carbon/identity/action/execution/util/TokenManagerTest.java
@@ -215,6 +215,89 @@ public class TokenManagerTest {
         assertEquals(TokenManager.getInstance(), TokenManager.getInstance());
     }
 
+    @Test
+    public void testGetNewAccessTokenForPasswordCredentialReturnsAccessTokenOnSuccess() throws Exception {
+
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getType()).thenReturn(Authentication.Type.PASSWORD_CREDENTIAL);
+        when(authentication.getPropertiesWithDecryptedValues(ACTION_ID)).thenReturn(
+                passwordCredentialProperties("client-id", "client-secret", "https://token.endpoint",
+                        "openid email", "user1", "pass1"));
+
+        TokenInvocationResult successResult = mock(TokenInvocationResult.class);
+        when(successResult.getStatus()).thenReturn(TokenInvocationResult.Status.SUCCESS);
+        TokenResponse tokenResponse = mock(TokenResponse.class);
+        when(tokenResponse.getAccessToken()).thenReturn("new-access-token");
+        when(tokenResponse.getRefreshToken()).thenReturn("new-refresh-token");
+        when(successResult.getTokenResponse()).thenReturn(tokenResponse);
+
+        when(tokenAcquirerService.getNewAccessToken("existing-refresh-token")).thenReturn(successResult);
+
+        String result = tokenManager.getNewAccessToken(ACTION_ID, authentication, "existing-refresh-token");
+
+        assertEquals(result, "new-access-token");
+
+        ArgumentCaptor<TokenRequestContext> contextCaptor = ArgumentCaptor.forClass(TokenRequestContext.class);
+        verify(tokenAcquirerService).setTokenRequestContext(contextCaptor.capture());
+        TokenRequestContext capturedContext = contextCaptor.getValue();
+        assertEquals(capturedContext.getTokenEndpointUrl(), "https://token.endpoint");
+    }
+
+    @Test
+    public void testGetNewAccessTokenForPasswordCredentialWithoutRefreshTokenPassesNullToService() throws Exception {
+
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getType()).thenReturn(Authentication.Type.PASSWORD_CREDENTIAL);
+        when(authentication.getPropertiesWithDecryptedValues(ACTION_ID)).thenReturn(
+                passwordCredentialProperties("client-id", "client-secret", "https://token.endpoint",
+                        null, "user1", "pass1"));
+
+        TokenInvocationResult successResult = mock(TokenInvocationResult.class);
+        when(successResult.getStatus()).thenReturn(TokenInvocationResult.Status.SUCCESS);
+        TokenResponse tokenResponse = mock(TokenResponse.class);
+        when(tokenResponse.getAccessToken()).thenReturn("a");
+        when(tokenResponse.getRefreshToken()).thenReturn("r");
+        when(successResult.getTokenResponse()).thenReturn(tokenResponse);
+
+        when(tokenAcquirerService.getNewAccessToken(any())).thenReturn(successResult);
+
+        tokenManager.getNewAccessToken(ACTION_ID, authentication, null);
+
+        verify(tokenAcquirerService).getNewAccessToken((String) null);
+    }
+
+    @Test(expectedExceptions = ActionExecutionException.class,
+            expectedExceptionsMessageRegExp = "Error occurred while retrieving access token for actions.")
+    public void testGetNewAccessTokenForPasswordCredentialWrapsTokenHandlerException() throws Exception {
+
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getType()).thenReturn(Authentication.Type.PASSWORD_CREDENTIAL);
+        when(authentication.getPropertiesWithDecryptedValues(ACTION_ID)).thenReturn(
+                passwordCredentialProperties("c", "s", "http://t", null, "u", "p"));
+
+        when(tokenAcquirerService.getNewAccessToken(any()))
+                .thenThrow(new TokenHandlerException(
+                        ErrorMessage.ERROR_CODE_GETTING_ACCESS_TOKEN, "password"));
+
+        tokenManager.getNewAccessToken(ACTION_ID, authentication, null);
+    }
+
+    @Test(expectedExceptions = ActionExecutionException.class,
+            expectedExceptionsMessageRegExp = "Error occurred while retrieving access token for actions.")
+    public void testGetNewAccessTokenForPasswordCredentialThrowsWhenStatusIsNotSuccess() throws Exception {
+
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getType()).thenReturn(Authentication.Type.PASSWORD_CREDENTIAL);
+        when(authentication.getPropertiesWithDecryptedValues(ACTION_ID)).thenReturn(
+                passwordCredentialProperties("c", "s", "http://t", "scope", "u", "p"));
+
+        TokenInvocationResult result = mock(TokenInvocationResult.class);
+        when(result.getStatus()).thenReturn(TokenInvocationResult.Status.ERROR);
+        when(tokenAcquirerService.getNewAccessToken(any())).thenReturn(result);
+
+        tokenManager.getNewAccessToken(ACTION_ID, authentication, null);
+    }
+
     private List<AuthProperty> clientCredentialProperties(String clientId, String clientSecret,
                                                           String tokenEndpoint, String scopes) {
 
@@ -231,6 +314,32 @@ public class TokenManagerTest {
                 new AuthProperty.AuthPropertyBuilder()
                         .name(Authentication.Property.SCOPES.getName())
                         .value(scopes).isConfidential(false).build()
+        );
+    }
+
+    private List<AuthProperty> passwordCredentialProperties(String clientId, String clientSecret,
+                                                            String tokenEndpoint, String scopes,
+                                                            String username, String password) {
+
+        return Arrays.asList(
+                new AuthProperty.AuthPropertyBuilder()
+                        .name(Authentication.Property.CLIENT_ID.getName())
+                        .value(clientId).isConfidential(true).build(),
+                new AuthProperty.AuthPropertyBuilder()
+                        .name(Authentication.Property.CLIENT_SECRET.getName())
+                        .value(clientSecret).isConfidential(true).build(),
+                new AuthProperty.AuthPropertyBuilder()
+                        .name(Authentication.Property.TOKEN_ENDPOINT.getName())
+                        .value(tokenEndpoint).isConfidential(false).build(),
+                new AuthProperty.AuthPropertyBuilder()
+                        .name(Authentication.Property.SCOPES.getName())
+                        .value(scopes).isConfidential(false).build(),
+                new AuthProperty.AuthPropertyBuilder()
+                        .name(Authentication.Property.USERNAME.getName())
+                        .value(username).isConfidential(true).build(),
+                new AuthProperty.AuthPropertyBuilder()
+                        .name(Authentication.Property.PASSWORD.getName())
+                        .value(password).isConfidential(true).build()
         );
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/constant/ErrorMessage.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/constant/ErrorMessage.java
@@ -63,14 +63,7 @@ public enum ErrorMessage {
             "Error while retrieving count of Actions per Action Type from the system."),
     ERROR_WHILE_DECRYPTING_ACTION_ENDPOINT_AUTH_PROPERTIES("65009",
             "Error while decrypting Action Endpoint Authentication properties",
-            "Error while decrypting Action Endpoint Authentication properties in the system."),
-    ERROR_CODE_ERROR_WHILE_RETRIEVING_TOKEN("65010", "Error while retrieving access token.",
-            "Error occurred while retrieving access token for actions."),
-    ERROR_CODE_ERROR_UNSUPPORTED_AUTH_TYPE_FOR_TOKEN_RETRIEVAL("65011",
-            "Unsupported authentication type.", "Unsupported authentication type for access " +
-            "token request, only supported for client credential type."),
-    ERROR_CODE_ERROR_WHILE_TOKEN_REQUEST_BUILDING("65012", "Error while building token request.",
-            "Error while building token request context for Client Credential grant.");
+            "Error while decrypting Action Endpoint Authentication properties in the system.");
 
     private final String code;
     private final String message;

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/model/Authentication.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/model/Authentication.java
@@ -45,7 +45,8 @@ public class Authentication {
         BEARER("bearer", "BEARER"),
         BASIC("basic", "BASIC"),
         API_KEY("apiKey", "API_KEY"),
-        CLIENT_CREDENTIAL("clientCredential", "CLIENT_CREDENTIAL");
+        CLIENT_CREDENTIAL("clientCredential", "CLIENT_CREDENTIAL"),
+        PASSWORD_CREDENTIAL("passwordCredential", "PASSWORD_CREDENTIAL");
 
         private final String pathParam;
         private final String name;
@@ -145,6 +146,13 @@ public class Authentication {
         this.type = clientCredentialAuthBuilder.type;
         this.properties = clientCredentialAuthBuilder.properties;
         this.internalAuthProperties = clientCredentialAuthBuilder.internalProperties;
+    }
+
+    public Authentication(PasswordCredentialAuthBuilder passwordCredentialAuthBuilder) {
+
+        this.type = passwordCredentialAuthBuilder.type;
+        this.properties = passwordCredentialAuthBuilder.properties;
+        this.internalAuthProperties = passwordCredentialAuthBuilder.internalProperties;
     }
 
     public Type getType() {
@@ -355,6 +363,68 @@ public class Authentication {
     }
 
     /**
+     * Password Credential Authentication builder.
+     */
+    public static class PasswordCredentialAuthBuilder {
+
+        private final Type type;
+        private final List<AuthProperty> properties = new ArrayList<>();
+        private final List<AuthProperty> internalProperties = new ArrayList<>();
+
+        public PasswordCredentialAuthBuilder(String clientId, String clientSecret, String tokenEndpoint, String scopes,
+                                             String username, String password,
+                                             String internalAccessToken, String internalRefreshToken) {
+
+            this.type = Type.PASSWORD_CREDENTIAL;
+            this.properties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.CLIENT_ID.getName()).value(clientId).isConfidential(true).build());
+            this.properties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.CLIENT_SECRET.getName()).value(clientSecret).isConfidential(true).build());
+            this.properties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.TOKEN_ENDPOINT.getName()).value(tokenEndpoint).isConfidential(false).build());
+            this.properties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.USERNAME.getName()).value(username).isConfidential(true).build());
+            this.properties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.PASSWORD.getName()).value(password).isConfidential(true).build());
+            if (StringUtils.isNotBlank(scopes)) {
+                this.properties.add(new AuthProperty.AuthPropertyBuilder()
+                        .name(Property.SCOPES.getName()).value(scopes).isConfidential(false).build());
+            }
+            this.internalProperties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.INTERNAL_ACCESS_TOKEN.getName()).value(internalAccessToken).isConfidential(true)
+                    .build());
+            this.internalProperties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.INTERNAL_REFRESH_TOKEN.getName()).value(internalRefreshToken).isConfidential(true)
+                    .build());
+        }
+
+        public PasswordCredentialAuthBuilder(String clientId, String clientSecret, String tokenEndpoint, String scopes,
+                                             String username, String password) {
+
+            this.type = Type.PASSWORD_CREDENTIAL;
+            this.properties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.CLIENT_ID.getName()).value(clientId).isConfidential(true).build());
+            this.properties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.CLIENT_SECRET.getName()).value(clientSecret).isConfidential(true).build());
+            this.properties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.TOKEN_ENDPOINT.getName()).value(tokenEndpoint).isConfidential(false).build());
+            this.properties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.USERNAME.getName()).value(username).isConfidential(true).build());
+            this.properties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.PASSWORD.getName()).value(password).isConfidential(true).build());
+            if (StringUtils.isNotBlank(scopes)) {
+                this.properties.add(new AuthProperty.AuthPropertyBuilder()
+                        .name(Property.SCOPES.getName()).value(scopes).isConfidential(false).build());
+            }
+        }
+
+        public Authentication build() {
+
+            return new Authentication(this);
+        }
+    }
+
+    /**
      * This builder build endpoint by taking the authentication type and properties as input.
      */
     public static class AuthenticationBuilder {
@@ -394,6 +464,18 @@ public class Authentication {
                             getProperty(Type.CLIENT_CREDENTIAL, authPropertiesMap, Property.CLIENT_SECRET.getName()),
                             getProperty(Type.CLIENT_CREDENTIAL, authPropertiesMap, Property.TOKEN_ENDPOINT.getName()),
                             getOptionalProperty(authPropertiesMap, Property.SCOPES.getName()),
+                            getOptionalProperty(authPropertiesMap, Property.INTERNAL_ACCESS_TOKEN.getName()),
+                            getOptionalProperty(authPropertiesMap, Property.INTERNAL_REFRESH_TOKEN.getName())
+                    ).build();
+                case PASSWORD_CREDENTIAL:
+                    return new Authentication.PasswordCredentialAuthBuilder(
+                            getProperty(Type.PASSWORD_CREDENTIAL, authPropertiesMap, Property.CLIENT_ID.getName()),
+                            getProperty(Type.PASSWORD_CREDENTIAL, authPropertiesMap, Property.CLIENT_SECRET.getName()),
+                            getProperty(Type.PASSWORD_CREDENTIAL, authPropertiesMap,
+                                    Property.TOKEN_ENDPOINT.getName()),
+                            getOptionalProperty(authPropertiesMap, Property.SCOPES.getName()),
+                            getProperty(Type.PASSWORD_CREDENTIAL, authPropertiesMap, Property.USERNAME.getName()),
+                            getProperty(Type.PASSWORD_CREDENTIAL, authPropertiesMap, Property.PASSWORD.getName()),
                             getOptionalProperty(authPropertiesMap, Property.INTERNAL_ACCESS_TOKEN.getName()),
                             getOptionalProperty(authPropertiesMap, Property.INTERNAL_REFRESH_TOKEN.getName())
                     ).build();

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/service/impl/DefaultActionValidator.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/service/impl/DefaultActionValidator.java
@@ -150,6 +150,18 @@ public class DefaultActionValidator implements ActionValidator {
                 validateEndpointUri(ActionMgtConstants.TOKEN_ENDPOINT_FIELD,
                         authentication.getProperty(Authentication.Property.TOKEN_ENDPOINT).getValue());
                 break;
+            case PASSWORD_CREDENTIAL:
+                validateForBlank(ActionMgtConstants.CLIENT_ID_FIELD,
+                        authentication.getProperty(Authentication.Property.CLIENT_ID).getValue());
+                validateForBlank(ActionMgtConstants.CLIENT_SECRET_FIELD,
+                        authentication.getProperty(Authentication.Property.CLIENT_SECRET).getValue());
+                validateEndpointUri(ActionMgtConstants.TOKEN_ENDPOINT_FIELD,
+                        authentication.getProperty(Authentication.Property.TOKEN_ENDPOINT).getValue());
+                validateForBlank(ActionMgtConstants.USERNAME_FIELD,
+                        authentication.getProperty(Authentication.Property.USERNAME).getValue());
+                validateForBlank(ActionMgtConstants.PASSWORD_FIELD,
+                        authentication.getProperty(Authentication.Property.PASSWORD).getValue());
+                break;
             case NONE:
             default:
                 break;

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/dao/impl/ActionManagementDAOImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/dao/impl/ActionManagementDAOImpl.java
@@ -452,6 +452,22 @@ public class ActionManagementDAOImpl implements ActionManagementDAO {
                         scopesValue)
                         .build();
                 break;
+            case PASSWORD_CREDENTIAL:
+                ActionProperty passwordGrantScopesProperty =
+                        propertiesFromDB.remove(Authentication.Property.SCOPES.getName());
+                String passwordGrantScopesValue =
+                        (passwordGrantScopesProperty != null && passwordGrantScopesProperty.getValue() != null)
+                                ? passwordGrantScopesProperty.getValue().toString()
+                                : StringUtils.EMPTY;
+                authentication = new Authentication.PasswordCredentialAuthBuilder(
+                        propertiesFromDB.remove(Authentication.Property.CLIENT_ID.getName()).getValue().toString(),
+                        propertiesFromDB.remove(Authentication.Property.CLIENT_SECRET.getName()).getValue().toString(),
+                        propertiesFromDB.remove(Authentication.Property.TOKEN_ENDPOINT.getName()).getValue().toString(),
+                        passwordGrantScopesValue,
+                        propertiesFromDB.remove(Authentication.Property.USERNAME.getName()).getValue().toString(),
+                        propertiesFromDB.remove(Authentication.Property.PASSWORD.getName()).getValue().toString())
+                        .build();
+                break;
             case NONE:
                 authentication = new Authentication.NoneAuthBuilder().build();
                 break;

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/service/ActionManagementServiceImplTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/service/ActionManagementServiceImplTest.java
@@ -74,11 +74,13 @@ import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_INVA
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_INVALID_API_KEY_HEADER;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_INVALID_TOKEN_ENDPOINT;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_PASSWORD;
+import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_PASSWORD_UPDATED;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_SCOPES;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_SCOPES_UPDATED;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_TOKEN_ENDPOINT;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_TOKEN_ENDPOINT_UPDATED;
 import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_USERNAME;
+import static org.wso2.carbon.identity.action.management.util.TestUtil.TEST_USERNAME_UPDATED;
 
 /**
  * This class is a test suite for the ActionManagementServiceImpl class.
@@ -690,6 +692,228 @@ public class ActionManagementServiceImplTest {
                 TEST_ACTION_URI,
                 TestUtil.buildMockClientCredentialAuthentication(TEST_CLIENT_ID, TEST_CLIENT_SECRET,
                         TEST_INVALID_TOKEN_ENDPOINT, TEST_SCOPES));
+        actionManagementService.addAction(PRE_ISSUE_ACCESS_TOKEN_PATH, creatingAction, TENANT_DOMAIN);
+    }
+
+    @Test(priority = 28)
+    public void testAddActionWithPasswordCredentialAuthentication()
+            throws ActionMgtException, SecretManagementException {
+
+        Action creatingAction = TestUtil.buildMockAction(
+                TEST_ACTION_NAME,
+                TEST_ACTION_DESCRIPTION,
+                TEST_ACTION_URI,
+                TestUtil.buildMockPasswordCredentialAuthentication(TEST_CLIENT_ID, TEST_CLIENT_SECRET,
+                        TEST_TOKEN_ENDPOINT, TEST_SCOPES, TEST_USERNAME, TEST_PASSWORD));
+        sampleAction = actionManagementService.addAction(PRE_ISSUE_ACCESS_TOKEN_PATH, creatingAction, TENANT_DOMAIN);
+
+        Assert.assertNotNull(sampleAction.getId());
+        Assert.assertEquals(sampleAction.getName(), creatingAction.getName());
+        Assert.assertEquals(sampleAction.getDescription(), creatingAction.getDescription());
+        Assert.assertEquals(sampleAction.getStatus(), Action.Status.INACTIVE);
+        Assert.assertEquals(sampleAction.getType(), Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN);
+        Assert.assertEquals(sampleAction.getEndpoint().getUri(), creatingAction.getEndpoint().getUri());
+
+        Authentication sampleActionAuth = sampleAction.getEndpoint().getAuthentication();
+        Authentication creatingActionAuth = creatingAction.getEndpoint().getAuthentication();
+        Map<String, String> secretProperties = resolveAuthPropertiesMap(creatingActionAuth, sampleAction.getId());
+
+        Assert.assertEquals(sampleActionAuth.getType(), Authentication.Type.PASSWORD_CREDENTIAL);
+        Assert.assertEquals(sampleActionAuth.getProperties().size(), creatingActionAuth.getProperties().size());
+        Assert.assertEquals(sampleActionAuth.getProperty(Authentication.Property.CLIENT_ID).getValue(),
+                secretProperties.get(Authentication.Property.CLIENT_ID.getName()));
+        Assert.assertEquals(sampleActionAuth.getProperty(Authentication.Property.CLIENT_SECRET).getValue(),
+                secretProperties.get(Authentication.Property.CLIENT_SECRET.getName()));
+        Assert.assertEquals(sampleActionAuth.getProperty(Authentication.Property.TOKEN_ENDPOINT).getValue(),
+                TEST_TOKEN_ENDPOINT);
+        Assert.assertEquals(sampleActionAuth.getProperty(Authentication.Property.SCOPES).getValue(), TEST_SCOPES);
+        Assert.assertEquals(sampleActionAuth.getProperty(Authentication.Property.USERNAME).getValue(),
+                secretProperties.get(Authentication.Property.USERNAME.getName()));
+        Assert.assertEquals(sampleActionAuth.getProperty(Authentication.Property.PASSWORD).getValue(),
+                secretProperties.get(Authentication.Property.PASSWORD.getName()));
+    }
+
+    @Test(priority = 29)
+    public void testGetActionWithPasswordCredentialAuthentication() throws ActionMgtException {
+
+        Action result = actionManagementService.getActionByActionId(PRE_ISSUE_ACCESS_TOKEN_PATH, sampleAction.getId(),
+                TENANT_DOMAIN);
+        Assert.assertEquals(result.getId(), sampleAction.getId());
+
+        Authentication resultActionAuth = result.getEndpoint().getAuthentication();
+        Authentication sampleActionAuth = sampleAction.getEndpoint().getAuthentication();
+
+        Assert.assertEquals(resultActionAuth.getType(), Authentication.Type.PASSWORD_CREDENTIAL);
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.CLIENT_ID).getValue(),
+                sampleActionAuth.getProperty(Authentication.Property.CLIENT_ID).getValue());
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.CLIENT_SECRET).getValue(),
+                sampleActionAuth.getProperty(Authentication.Property.CLIENT_SECRET).getValue());
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.TOKEN_ENDPOINT).getValue(),
+                TEST_TOKEN_ENDPOINT);
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.SCOPES).getValue(), TEST_SCOPES);
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.USERNAME).getValue(),
+                sampleActionAuth.getProperty(Authentication.Property.USERNAME).getValue());
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.PASSWORD).getValue(),
+                sampleActionAuth.getProperty(Authentication.Property.PASSWORD).getValue());
+    }
+
+    @Test(priority = 30)
+    public void testUpdateActionEndpointAuthenticationWithSamePasswordCredentialType()
+            throws ActionMgtException, SecretManagementException {
+
+        Authentication updatingAuthentication = TestUtil.buildMockPasswordCredentialAuthentication(
+                TEST_CLIENT_ID_UPDATED, TEST_CLIENT_SECRET_UPDATED, TEST_TOKEN_ENDPOINT_UPDATED, TEST_SCOPES_UPDATED,
+                TEST_USERNAME_UPDATED, TEST_PASSWORD_UPDATED);
+        Action result = actionManagementService.updateActionEndpointAuthentication(PRE_ISSUE_ACCESS_TOKEN_PATH,
+                sampleAction.getId(), updatingAuthentication, TENANT_DOMAIN);
+
+        Authentication resultActionAuth = result.getEndpoint().getAuthentication();
+        Map<String, String> secretProperties = resolveAuthPropertiesMap(updatingAuthentication, sampleAction.getId());
+
+        Assert.assertEquals(resultActionAuth.getType(), Authentication.Type.PASSWORD_CREDENTIAL);
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.CLIENT_ID).getValue(),
+                secretProperties.get(Authentication.Property.CLIENT_ID.getName()));
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.CLIENT_SECRET).getValue(),
+                secretProperties.get(Authentication.Property.CLIENT_SECRET.getName()));
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.TOKEN_ENDPOINT).getValue(),
+                TEST_TOKEN_ENDPOINT_UPDATED);
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.SCOPES).getValue(),
+                TEST_SCOPES_UPDATED);
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.USERNAME).getValue(),
+                secretProperties.get(Authentication.Property.USERNAME.getName()));
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.PASSWORD).getValue(),
+                secretProperties.get(Authentication.Property.PASSWORD.getName()));
+        Assert.assertEquals(result.getCreatedAt(), sampleAction.getCreatedAt());
+        Assert.assertTrue(result.getUpdatedAt().after(sampleAction.getUpdatedAt()));
+        sampleAction = result;
+    }
+
+    @Test(priority = 31)
+    public void testUpdateActionEndpointAuthenticationFromPasswordCredentialToClientCredential()
+            throws ActionMgtException, SecretManagementException {
+
+        Authentication updatingAuthentication = TestUtil.buildMockClientCredentialAuthentication(
+                TEST_CLIENT_ID, TEST_CLIENT_SECRET, TEST_TOKEN_ENDPOINT, TEST_SCOPES);
+        Action result = actionManagementService.updateActionEndpointAuthentication(PRE_ISSUE_ACCESS_TOKEN_PATH,
+                sampleAction.getId(), updatingAuthentication, TENANT_DOMAIN);
+
+        Authentication resultActionAuth = result.getEndpoint().getAuthentication();
+        Map<String, String> secretProperties = resolveAuthPropertiesMap(updatingAuthentication, sampleAction.getId());
+
+        Assert.assertEquals(resultActionAuth.getType(), Authentication.Type.CLIENT_CREDENTIAL);
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.CLIENT_ID).getValue(),
+                secretProperties.get(Authentication.Property.CLIENT_ID.getName()));
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.CLIENT_SECRET).getValue(),
+                secretProperties.get(Authentication.Property.CLIENT_SECRET.getName()));
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.TOKEN_ENDPOINT).getValue(),
+                TEST_TOKEN_ENDPOINT);
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.SCOPES).getValue(), TEST_SCOPES);
+        Assert.assertNull(resultActionAuth.getProperty(Authentication.Property.USERNAME));
+        Assert.assertNull(resultActionAuth.getProperty(Authentication.Property.PASSWORD));
+        Assert.assertEquals(result.getCreatedAt(), sampleAction.getCreatedAt());
+        Assert.assertTrue(result.getUpdatedAt().after(sampleAction.getUpdatedAt()));
+        sampleAction = result;
+    }
+
+    @Test(priority = 32)
+    public void testUpdateActionEndpointAuthenticationFromClientCredentialToPasswordCredential()
+            throws ActionMgtException, SecretManagementException {
+
+        Authentication updatingAuthentication = TestUtil.buildMockPasswordCredentialAuthentication(
+                TEST_CLIENT_ID, TEST_CLIENT_SECRET, TEST_TOKEN_ENDPOINT, TEST_SCOPES, TEST_USERNAME, TEST_PASSWORD);
+        Action result = actionManagementService.updateActionEndpointAuthentication(PRE_ISSUE_ACCESS_TOKEN_PATH,
+                sampleAction.getId(), updatingAuthentication, TENANT_DOMAIN);
+
+        Authentication resultActionAuth = result.getEndpoint().getAuthentication();
+        Map<String, String> secretProperties = resolveAuthPropertiesMap(updatingAuthentication, sampleAction.getId());
+
+        Assert.assertEquals(resultActionAuth.getType(), Authentication.Type.PASSWORD_CREDENTIAL);
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.CLIENT_ID).getValue(),
+                secretProperties.get(Authentication.Property.CLIENT_ID.getName()));
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.CLIENT_SECRET).getValue(),
+                secretProperties.get(Authentication.Property.CLIENT_SECRET.getName()));
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.TOKEN_ENDPOINT).getValue(),
+                TEST_TOKEN_ENDPOINT);
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.SCOPES).getValue(), TEST_SCOPES);
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.USERNAME).getValue(),
+                secretProperties.get(Authentication.Property.USERNAME.getName()));
+        Assert.assertEquals(resultActionAuth.getProperty(Authentication.Property.PASSWORD).getValue(),
+                secretProperties.get(Authentication.Property.PASSWORD.getName()));
+        Assert.assertEquals(result.getCreatedAt(), sampleAction.getCreatedAt());
+        Assert.assertTrue(result.getUpdatedAt().after(sampleAction.getUpdatedAt()));
+        sampleAction = result;
+    }
+
+    @Test(priority = 33)
+    public void testDeleteActionWithPasswordCredentialAuthentication() throws ActionMgtException {
+
+        actionManagementService.deleteAction(PRE_ISSUE_ACCESS_TOKEN_PATH, sampleAction.getId(), TENANT_DOMAIN);
+        Assert.assertNull(actionManagementService.getActionByActionId(PRE_ISSUE_ACCESS_TOKEN_PATH, sampleAction.getId(),
+                TENANT_DOMAIN));
+    }
+
+    @Test(priority = 34, expectedExceptions = ActionMgtClientException.class,
+            expectedExceptionsMessageRegExp = "Invalid request.")
+    public void testAddActionWithPasswordCredentialMissingClientId() throws ActionMgtException {
+
+        Action creatingAction = TestUtil.buildMockAction(
+                TEST_ACTION_NAME,
+                TEST_ACTION_DESCRIPTION,
+                TEST_ACTION_URI,
+                TestUtil.buildMockPasswordCredentialAuthentication(StringUtils.EMPTY, TEST_CLIENT_SECRET,
+                        TEST_TOKEN_ENDPOINT, TEST_SCOPES, TEST_USERNAME, TEST_PASSWORD));
+        actionManagementService.addAction(PRE_ISSUE_ACCESS_TOKEN_PATH, creatingAction, TENANT_DOMAIN);
+    }
+
+    @Test(priority = 35, expectedExceptions = ActionMgtClientException.class,
+            expectedExceptionsMessageRegExp = "Invalid request.")
+    public void testAddActionWithPasswordCredentialMissingClientSecret() throws ActionMgtException {
+
+        Action creatingAction = TestUtil.buildMockAction(
+                TEST_ACTION_NAME,
+                TEST_ACTION_DESCRIPTION,
+                TEST_ACTION_URI,
+                TestUtil.buildMockPasswordCredentialAuthentication(TEST_CLIENT_ID, StringUtils.EMPTY,
+                        TEST_TOKEN_ENDPOINT, TEST_SCOPES, TEST_USERNAME, TEST_PASSWORD));
+        actionManagementService.addAction(PRE_ISSUE_ACCESS_TOKEN_PATH, creatingAction, TENANT_DOMAIN);
+    }
+
+    @Test(priority = 36, expectedExceptions = ActionMgtClientException.class,
+            expectedExceptionsMessageRegExp = "Invalid request.")
+    public void testAddActionWithPasswordCredentialInvalidTokenEndpoint() throws ActionMgtException {
+
+        Action creatingAction = TestUtil.buildMockAction(
+                TEST_ACTION_NAME,
+                TEST_ACTION_DESCRIPTION,
+                TEST_ACTION_URI,
+                TestUtil.buildMockPasswordCredentialAuthentication(TEST_CLIENT_ID, TEST_CLIENT_SECRET,
+                        TEST_INVALID_TOKEN_ENDPOINT, TEST_SCOPES, TEST_USERNAME, TEST_PASSWORD));
+        actionManagementService.addAction(PRE_ISSUE_ACCESS_TOKEN_PATH, creatingAction, TENANT_DOMAIN);
+    }
+
+    @Test(priority = 37, expectedExceptions = ActionMgtClientException.class,
+            expectedExceptionsMessageRegExp = "Invalid request.")
+    public void testAddActionWithPasswordCredentialMissingUsername() throws ActionMgtException {
+
+        Action creatingAction = TestUtil.buildMockAction(
+                TEST_ACTION_NAME,
+                TEST_ACTION_DESCRIPTION,
+                TEST_ACTION_URI,
+                TestUtil.buildMockPasswordCredentialAuthentication(TEST_CLIENT_ID, TEST_CLIENT_SECRET,
+                        TEST_TOKEN_ENDPOINT, TEST_SCOPES, StringUtils.EMPTY, TEST_PASSWORD));
+        actionManagementService.addAction(PRE_ISSUE_ACCESS_TOKEN_PATH, creatingAction, TENANT_DOMAIN);
+    }
+
+    @Test(priority = 38, expectedExceptions = ActionMgtClientException.class,
+            expectedExceptionsMessageRegExp = "Invalid request.")
+    public void testAddActionWithPasswordCredentialMissingPassword() throws ActionMgtException {
+
+        Action creatingAction = TestUtil.buildMockAction(
+                TEST_ACTION_NAME,
+                TEST_ACTION_DESCRIPTION,
+                TEST_ACTION_URI,
+                TestUtil.buildMockPasswordCredentialAuthentication(TEST_CLIENT_ID, TEST_CLIENT_SECRET,
+                        TEST_TOKEN_ENDPOINT, TEST_SCOPES, TEST_USERNAME, StringUtils.EMPTY));
         actionManagementService.addAction(PRE_ISSUE_ACCESS_TOKEN_PATH, creatingAction, TENANT_DOMAIN);
     }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/TestUtil.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/TestUtil.java
@@ -63,9 +63,11 @@ public class TestUtil {
     public static final String TEST_UPDATED_AT = "2025-08-22 15:25:41.388";
 
     public static final String TEST_USERNAME = "sampleUsername";
+    public static final String TEST_USERNAME_UPDATED = "UpdatedSampleUsername";
     public static final String TEST_USERNAME_SECRET_REFERENCE = buildSecretName(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID,
             Authentication.Type.BASIC, Authentication.Property.USERNAME);
     public static final String TEST_PASSWORD = "samplePassword";
+    public static final String TEST_PASSWORD_UPDATED = "UpdatedSamplePassword";
     public static final String TEST_PASSWORD_SECRET_REFERENCE = buildSecretName(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID,
             Authentication.Type.BASIC, Authentication.Property.PASSWORD);
     public static final String TEST_ACCESS_TOKEN = "5e482c2a-e83a-3afe-bc6a-ff79e1fdaaba";
@@ -182,6 +184,14 @@ public class TestUtil {
                                                                          String tokenEndpoint, String scopes) {
 
         return new Authentication.ClientCredentialAuthBuilder(clientId, clientSecret, tokenEndpoint, scopes).build();
+    }
+
+    public static Authentication buildMockPasswordCredentialAuthentication(String clientId, String clientSecret,
+                                                                           String tokenEndpoint, String scopes,
+                                                                           String username, String password) {
+
+        return new Authentication.PasswordCredentialAuthBuilder(
+                clientId, clientSecret, tokenEndpoint, scopes, username, password).build();
     }
 
     public static EndpointConfig buildMockEndpointConfig(String uri, Authentication authentication) {


### PR DESCRIPTION
### Proposed changes in this pull request

- Provide OAuth 2.0 password grant based Authentication support for actions

### Related Issue
- https://github.com/wso2/product-is/issues/27756

### Summary

This pull request adds support for the OAuth2 Password Credential grant type in the action execution module, alongside the existing Client Credential grant. It refactors authentication handling to generalize OAuth2 grant-based flows, introduces a new authentication method class, and expands test coverage to ensure correct behavior for the new grant type.

**Support for OAuth2 Password Credential Grant:**

* Added handling for `PASSWORD_CREDENTIAL` authentication type throughout the action execution flow, enabling actions to use the OAuth2 Password Credential grant for token acquisition and authorization. [[1]](diffhunk://#diff-616714d1e790350aeeb43d77f9730a586548405f557a13620273262b5421678cL722-R731) [[2]](diffhunk://#diff-616714d1e790350aeeb43d77f9730a586548405f557a13620273262b5421678cL762-R787) [[3]](diffhunk://#diff-178344363feb8ba3bd43e2d2cbc46e4dda666d4b612b876cf39ee3ba3671a36dL82-R95) [[4]](diffhunk://#diff-178344363feb8ba3bd43e2d2cbc46e4dda666d4b612b876cf39ee3ba3671a36dR190-R227)
* Refactored token acquisition logic in `TokenManager` to build the appropriate token request context for both Client Credential and Password Credential grant types. [[1]](diffhunk://#diff-178344363feb8ba3bd43e2d2cbc46e4dda666d4b612b876cf39ee3ba3671a36dL82-R95) [[2]](diffhunk://#diff-178344363feb8ba3bd43e2d2cbc46e4dda666d4b612b876cf39ee3ba3671a36dR190-R227)

**Authentication Method Abstraction:**

* Introduced the `PasswordCredentialAuth` class implementing `AuthMethods.AuthMethod`, which applies the access token to HTTP requests for the password credential flow, similar to the existing client credential flow.
* Refactored method names and logic to generalize OAuth2 grant-based authentication, including renaming methods and adding `isOAuth2GrantBasedAuth` helper. [[1]](diffhunk://#diff-616714d1e790350aeeb43d77f9730a586548405f557a13620273262b5421678cL292-R298) [[2]](diffhunk://#diff-616714d1e790350aeeb43d77f9730a586548405f557a13620273262b5421678cL722-R731) [[3]](diffhunk://#diff-616714d1e790350aeeb43d77f9730a586548405f557a13620273262b5421678cL743-R744) [[4]](diffhunk://#diff-616714d1e790350aeeb43d77f9730a586548405f557a13620273262b5421678cL762-R787)

**Testing and Validation:**

* Added comprehensive unit tests for the new password credential authentication flow, including scenarios for token reuse, token fetching, retry on unauthorized, and error handling. [[1]](diffhunk://#diff-08c2875fdae685577430142e72d66d35c4d5379b70d51fa71c0f13c2aa74c2d0R871-R972) [[2]](diffhunk://#diff-08c2875fdae685577430142e72d66d35c4d5379b70d51fa71c0f13c2aa74c2d0R1054-R1114)
* Extended tests for the new `PasswordCredentialAuth` class, verifying correct header application and property handling.

**Documentation and Comments:**

* Updated class-level documentation to reflect support for both Client Credential and Password Credential grants.

---

**References:**  
[[1]](diffhunk://#diff-616714d1e790350aeeb43d77f9730a586548405f557a13620273262b5421678cL292-R298) [[2]](diffhunk://#diff-616714d1e790350aeeb43d77f9730a586548405f557a13620273262b5421678cL722-R731) [[3]](diffhunk://#diff-616714d1e790350aeeb43d77f9730a586548405f557a13620273262b5421678cL743-R744) [[4]](diffhunk://#diff-616714d1e790350aeeb43d77f9730a586548405f557a13620273262b5421678cL762-R787) [[5]](diffhunk://#diff-5ea98dc9cd11e69d4860d0bf814beb69d4f61eca520bfee13e76c36edad16986R173-R201) [[6]](diffhunk://#diff-178344363feb8ba3bd43e2d2cbc46e4dda666d4b612b876cf39ee3ba3671a36dL43-R44) [[7]](diffhunk://#diff-178344363feb8ba3bd43e2d2cbc46e4dda666d4b612b876cf39ee3ba3671a36dL82-R95) [[8]](diffhunk://#diff-178344363feb8ba3bd43e2d2cbc46e4dda666d4b612b876cf39ee3ba3671a36dR190-R227) [[9]](diffhunk://#diff-08c2875fdae685577430142e72d66d35c4d5379b70d51fa71c0f13c2aa74c2d0R871-R972) [[10]](diffhunk://#diff-08c2875fdae685577430142e72d66d35c4d5379b70d51fa71c0f13c2aa74c2d0R1054-R1114) [[11]](diffhunk://#diff-537a8e00033a685821b21e921b4935e770894b35dc61e032175a90b4b27c12d2R171-R228)

### Related Issue

- https://github.com/wso2/product-is/issues/27756


