### PR TITLE
Fix APP-65001 when role references group in unregistered user store domain

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/GroupDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/GroupDAOImpl.java
@@ -151,6 +151,15 @@ public class GroupDAOImpl implements GroupDAO {
                     } else {
                         throw e;
                     }
+                } catch (UserStoreException e) {
+                    if (StringUtils.startsWith(e.getMessage(), "Invalid Domain Name")) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug(String.format("Skipping group: %s in tenant: %s. " +
+                                    "User store domain not registered.", name, tenantDomain));
+                        }
+                    } else {
+                        throw e;
+                    }
                 }
             }
             return groupNamesToIDs;


### PR DESCRIPTION
## Issue
Fixes: https://github.com/wso2/product-is/issues/27191

## Proposed Changes
`GroupDAOImpl.getGroupIDsByNames` resolves each `domain/group` name via `userStoreManager.getGroupIdByGroupName(name)` and only catches `UserStoreClientException` inside the per-name loop. When a role references a group whose user store domain is no longer registered (e.g. a removed `SECONDARY` user store), `AbstractUserStoreManager.getUserStoreInternalWithGroupName` throws a plain `UserStoreException("Invalid Domain Name: <domain>")` with no error code. That escapes the inner loop, is rewrapped as `IdentityRoleManagementServerException`, and surfaces in `SharedRoleMgtListener.doPreUpdateApplication` as `APP-65001` — failing every application update in the tenant.

This change adds a second `catch (UserStoreException e)` arm to the inner loop that matches the message prefix `"Invalid Domain Name"` (the kernel throw site does not set an error code, so a message-based check is unavoidable here). The orphan group is logged at `DEBUG` and skipped; the remaining names still resolve and the application update succeeds. Other `UserStoreException` cases are rethrown unchanged, preserving existing semantics.

## Pre-fix behavior
```
PATCH /api/server/v1/applications/{id}  →  HTTP 500
{"code":"APP-65001",
 "message":"Error patching application with id: ...",
 "description":"Error while retrieving organization roles to be updated related to application 33 update"}
```

## Post-fix behavior
```
PATCH /api/server/v1/applications/{id}  →  HTTP 200
DEBUG GroupDAOImpl - Skipping group: SECONDARY/<name> in tenantDomain: carbon.super as its user store domain is not registered. Invalid Domain Name: SECONDARY
```