### PR TITLE
Register suspension.notification.date.format default + key mapping

### DIFF
--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.default.json
@@ -84,6 +84,7 @@
   "identity_mgt.events.schemes.'suspension.notification'.properties.'account.disable.delay'": "90d",
   "identity_mgt.events.schemes.'suspension.notification'.properties.'trigger.time'": "20:00:00",
   "identity_mgt.events.schemes.'suspension.notification'.properties.delays": "30,45,60,75",
+  "identity_mgt.events.schemes.'suspension.notification'.properties.'date.format'": "dd-MM-yyyy",
   "identity_mgt.events.schemes.handleRequestObject.module_index": "11",
   "identity_mgt.events.schemes.handleRequestObject.subscriptions": [
     "POST_REVOKE_ACESS_TOKEN",

--- a/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.key-mappings.json
+++ b/features/identity-event/org.wso2.carbon.identity.event.server.feature/resources/org.wso2.carbon.identity.event.server.feature.key-mappings.json
@@ -22,6 +22,7 @@
   "identity_mgt.inactive_account_suspension.suspend_when_inactive_for": "identity_mgt.events.schemes.'suspension.notification'.properties.'account.disable.delay'",
   "identity_mgt.inactive_account_suspension.notify_when_inactive_for": "identity_mgt.events.schemes.'suspension.notification'.properties.delays",
   "identity_mgt.inactive_account_suspension.trigger_notifications_at": "identity_mgt.events.schemes.'suspension.notification'.properties.'trigger.time'",
+  "identity_mgt.inactive_account_suspension.date_format": "identity_mgt.events.schemes.'suspension.notification'.properties.'date.format'",
 
   "identity_mgt.analytics_login_data_publisher.subscriptions": "identity_mgt.events.schemes.analyticsLoginDataPublisher.subscriptions",
   "identity_mgt.analytics_login_data_publisher.enable": "identity_mgt.events.schemes.analyticsLoginDataPublisher.properties.enable",


### PR DESCRIPTION
## Summary
- `org.wso2.carbon.identity.event.server.feature.default.json`: register `dd-MM-yyyy` default for `suspension.notification.date.format`.
- `org.wso2.carbon.identity.event.server.feature.key-mappings.json`: map customer-friendly `identity_mgt.inactive_account_suspension.date_format` to the underlying governance key.

## Related
- wso2/product-is#27784
- wso2-extensions/identity-governance#1128

## Test plan
- [x] Built locally; nested suspension scheme key gets emitted into `identity-event.properties` via existing dynamic j2; friendly TOML key round-trips end-to-end with the identity-governance change.