### PR TITLE
Provide capability to resolve non confidential authentication properties of custom authenticators

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/model/Authentication.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/model/Authentication.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.identity.action.management.api.model;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.action.management.api.constant.ErrorMessage;
 import org.wso2.carbon.identity.action.management.api.exception.ActionMgtException;
 import org.wso2.carbon.identity.action.management.internal.util.ActionManagementExceptionHandler;
@@ -35,6 +37,8 @@ import java.util.NoSuchElementException;
  * Authentication class which hold supported authentication types and their properties.
  */
 public class Authentication {
+
+    private static final Log LOG = LogFactory.getLog(Authentication.class);
 
     /**
      * Authentication Type.
@@ -196,6 +200,34 @@ public class Authentication {
                 try {
                     return secretProcessor.decryptProperty(authProperty, this.getType().name(), actionId);
                 } catch (SecretManagementException e) {
+                    LOG.warn(String.format("Error while decrypting authentication property '%s' for action '%s'.",
+                            propertyName, actionId), e);
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the authentication property matching the given name, decrypting its value when the property contains
+     * a secret reference. The {@code propertyName} should be the plain property name to look up; the matched property
+     * may contain either a plain value or a secret reference. Returns {@code null} if no matching property is found
+     * or if decryption fails.
+     *
+     * @param propertyName name of the authentication property to look up.
+     * @return the matching {@link AuthProperty} with a decrypted value when decryption succeeds, or {@code null} if
+     * no matching property exists or decryption fails.
+     */
+    public AuthProperty getPropertyWithDecryptedValue(String propertyName) {
+
+        for (AuthProperty authProperty : this.getProperties()) {
+            if (StringUtils.equalsIgnoreCase(propertyName, authProperty.getName())) {
+                try {
+                    return secretProcessor.decryptPropertyBySecretReference(authProperty);
+                } catch (SecretManagementException e) {
+                    LOG.warn(String.format("Error while decrypting authentication property '%s' for action.",
+                            propertyName), e);
                     return null;
                 }
             }
@@ -213,6 +245,9 @@ public class Authentication {
                 try {
                     return secretProcessor.decryptProperty(authProperty, this.getType().name(), actionId);
                 } catch (SecretManagementException e) {
+                    LOG.warn(String.format(
+                            "Error while decrypting internal authentication property '%s' for action '%s'.",
+                            propertyName, actionId), e);
                     return null;
                 }
             }
@@ -354,6 +389,12 @@ public class Authentication {
                 this.properties.add(new AuthProperty.AuthPropertyBuilder()
                         .name(Property.SCOPES.getName()).value(scopes).isConfidential(false).build());
             }
+            this.internalProperties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.INTERNAL_ACCESS_TOKEN.getName()).value(null).isConfidential(true)
+                    .build());
+            this.internalProperties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.INTERNAL_REFRESH_TOKEN.getName()).value(null).isConfidential(true)
+                    .build());
         }
 
         public Authentication build() {
@@ -416,6 +457,12 @@ public class Authentication {
                 this.properties.add(new AuthProperty.AuthPropertyBuilder()
                         .name(Property.SCOPES.getName()).value(scopes).isConfidential(false).build());
             }
+            this.internalProperties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.INTERNAL_ACCESS_TOKEN.getName()).value(null).isConfidential(true)
+                    .build());
+            this.internalProperties.add(new AuthProperty.AuthPropertyBuilder()
+                    .name(Property.INTERNAL_REFRESH_TOKEN.getName()).value(null).isConfidential(true)
+                    .build());
         }
 
         public Authentication build() {

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/model/Authentication.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/model/Authentication.java
@@ -201,7 +201,7 @@ public class Authentication {
                     return secretProcessor.decryptProperty(authProperty, this.getType().name(), actionId);
                 } catch (SecretManagementException e) {
                     LOG.warn(String.format("Error while decrypting authentication property '%s' for action '%s'.",
-                            propertyName, actionId), e);
+                            propertyName, actionId));
                     return null;
                 }
             }
@@ -227,7 +227,7 @@ public class Authentication {
                     return secretProcessor.decryptPropertyBySecretReference(authProperty);
                 } catch (SecretManagementException e) {
                     LOG.warn(String.format("Error while decrypting authentication property '%s' for action.",
-                            propertyName), e);
+                            propertyName));
                     return null;
                 }
             }
@@ -247,7 +247,7 @@ public class Authentication {
                 } catch (SecretManagementException e) {
                     LOG.warn(String.format(
                             "Error while decrypting internal authentication property '%s' for action '%s'.",
-                            propertyName, actionId), e);
+                            propertyName, actionId));
                     return null;
                 }
             }
@@ -390,10 +390,10 @@ public class Authentication {
                         .name(Property.SCOPES.getName()).value(scopes).isConfidential(false).build());
             }
             this.internalProperties.add(new AuthProperty.AuthPropertyBuilder()
-                    .name(Property.INTERNAL_ACCESS_TOKEN.getName()).value(null).isConfidential(true)
+                    .name(Property.INTERNAL_ACCESS_TOKEN.getName()).isConfidential(true)
                     .build());
             this.internalProperties.add(new AuthProperty.AuthPropertyBuilder()
-                    .name(Property.INTERNAL_REFRESH_TOKEN.getName()).value(null).isConfidential(true)
+                    .name(Property.INTERNAL_REFRESH_TOKEN.getName()).isConfidential(true)
                     .build());
         }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionSecretProcessor.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionSecretProcessor.java
@@ -170,6 +170,55 @@ public class ActionSecretProcessor {
     }
 
     /**
+     * Decrypt secret property by secret reference.
+     *
+     * @param authProperty Authentication property object with secret reference as value.
+     * @return Decrypted Auth Property if it is a confidential property.
+     * @throws SecretManagementException If an error occurs while decrypting the secret.
+     */
+    public AuthProperty decryptPropertyBySecretReference(AuthProperty authProperty) throws SecretManagementException {
+
+        String secretReference = authProperty.getValue();
+        String secretName = resolveSecretName(secretReference, authProperty.getName());
+        if (!isSecretPropertyExists(secretName)) {
+            throw new SecretManagementException(String.format("Unable to find the Secret Property: %s of " +
+                    "Secret Name: %s from the system.", authProperty.getName(), secretName));
+        }
+        ResolvedSecret resolvedSecret = ActionMgtServiceComponentHolder.getInstance().getSecretResolveManager()
+                .getResolvedSecret(IDN_SECRET_TYPE_ACTION_SECRETS, secretName);
+
+        return new AuthProperty.AuthPropertyBuilder()
+                .name(authProperty.getName())
+                .isConfidential(authProperty.getIsConfidential())
+                .value(resolvedSecret.getResolvedSecretValue())
+                .build();
+    }
+
+    /**
+     * Resolve the secret name portion of a secret reference. A reference is formatted as
+     * {@code <secretType>:<secretName>}, where {@code <secretName>} itself may contain ':'
+     * characters (it is composed as {@code actionId:authType:propertyName}). Therefore only the
+     * first ':' is treated as the delimiter; everything after it belongs to the secret name.
+     *
+     * @param secretReference Secret reference value to parse.
+     * @param propertyName    Authentication property name used for diagnostics.
+     * @return Secret name portion of the reference.
+     * @throws SecretManagementException If the reference is null, empty, or does not contain a
+     *                                   non-empty type and name separated by ':'.
+     */
+    private String resolveSecretName(String secretReference, String propertyName) throws SecretManagementException {
+
+        if (secretReference != null) {
+            int separatorIndex = secretReference.indexOf(':');
+            if (separatorIndex > 0 && separatorIndex < secretReference.length() - 1) {
+                return secretReference.substring(separatorIndex + 1);
+            }
+        }
+        throw new SecretManagementException(String.format("Invalid secret reference format for property: %s. " +
+                "Expected format: <secretType>:<secretName>", propertyName));
+    }
+
+    /**
      * Check whether the secret property exists.
      *
      * @param secretName Secret Name.

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionSecretProcessorTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/util/ActionSecretProcessorTest.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.action.management.util;
 
+import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -219,5 +220,103 @@ public class ActionSecretProcessorTest {
 
         actionSecretProcessor.deleteAssociatedSecrets(authentication, PRE_ISSUE_ACCESS_TOKEN_ACTION_ID);
         verify(secretManager, times(1)).deleteSecret(any(), any());
+    }
+
+    @Test
+    public void testDecryptPropertyBySecretReference() throws SecretManagementException {
+
+        // Build a reference whose secret name itself contains ':' characters
+        // (composed as actionId:authType:propertyName), exercising the first-colon-only split.
+        String secretReference = buildSecretName(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID,
+                Authentication.Type.CLIENT_CREDENTIAL, Authentication.Property.CLIENT_ID);
+        String expectedSecretName = PRE_ISSUE_ACCESS_TOKEN_ACTION_ID + ":" +
+                Authentication.Type.CLIENT_CREDENTIAL.getName() + ":" +
+                Authentication.Property.CLIENT_ID.getName();
+
+        AuthProperty authProperty = new AuthProperty.AuthPropertyBuilder()
+                .name(Authentication.Property.CLIENT_ID.getName())
+                .isConfidential(true)
+                .value(secretReference)
+                .build();
+
+        doReturn(true).when(secretManager).isSecretExist(any(), any());
+        ResolvedSecret resolvedSecret = mock(ResolvedSecret.class);
+        doReturn(TEST_USERNAME).when(resolvedSecret).getResolvedSecretValue();
+        doReturn(resolvedSecret).when(secretResolveManager).getResolvedSecret(any(), any());
+
+        AuthProperty decrypted = actionSecretProcessor.decryptPropertyBySecretReference(authProperty);
+
+        Assert.assertEquals(decrypted.getName(), Authentication.Property.CLIENT_ID.getName());
+        Assert.assertTrue(decrypted.getIsConfidential());
+        Assert.assertEquals(decrypted.getValue(), TEST_USERNAME);
+
+        // Verify the resolver received the secret name with its embedded ':' characters intact.
+        ArgumentCaptor<String> nameCaptor = ArgumentCaptor.forClass(String.class);
+        verify(secretResolveManager).getResolvedSecret(any(), nameCaptor.capture());
+        Assert.assertEquals(nameCaptor.getValue(), expectedSecretName);
+    }
+
+    @Test
+    public void testDecryptPropertyBySecretReferencePreservesNonConfidentialFlag()
+            throws SecretManagementException {
+
+        String secretReference = TEST_SECRET_TYPE_ID + ":simple-name";
+        AuthProperty authProperty = new AuthProperty.AuthPropertyBuilder()
+                .name(Authentication.Property.HEADER.getName())
+                .isConfidential(false)
+                .value(secretReference)
+                .build();
+
+        doReturn(true).when(secretManager).isSecretExist(any(), any());
+        ResolvedSecret resolvedSecret = mock(ResolvedSecret.class);
+        doReturn(TEST_API_KEY_HEADER).when(resolvedSecret).getResolvedSecretValue();
+        doReturn(resolvedSecret).when(secretResolveManager).getResolvedSecret(any(), any());
+
+        AuthProperty decrypted = actionSecretProcessor.decryptPropertyBySecretReference(authProperty);
+
+        Assert.assertEquals(decrypted.getName(), Authentication.Property.HEADER.getName());
+        Assert.assertFalse(decrypted.getIsConfidential());
+        Assert.assertEquals(decrypted.getValue(), TEST_API_KEY_HEADER);
+    }
+
+    @Test(expectedExceptions = SecretManagementException.class)
+    public void testDecryptPropertyBySecretReferenceForNonExistingSecret() throws SecretManagementException {
+
+        String secretReference = buildSecretName(PRE_ISSUE_ACCESS_TOKEN_ACTION_ID,
+                Authentication.Type.CLIENT_CREDENTIAL, Authentication.Property.CLIENT_ID);
+        AuthProperty authProperty = new AuthProperty.AuthPropertyBuilder()
+                .name(Authentication.Property.CLIENT_ID.getName())
+                .isConfidential(true)
+                .value(secretReference)
+                .build();
+
+        doReturn(false).when(secretManager).isSecretExist(any(), any());
+
+        actionSecretProcessor.decryptPropertyBySecretReference(authProperty);
+    }
+
+    @DataProvider(name = "invalidSecretReferences")
+    public Object[][] invalidSecretReferences() {
+
+        return new Object[][]{
+                {null},
+                {""},
+                {"missing-delimiter"},
+                {":missing-secret-type"},
+                {"missing-secret-name:"},
+        };
+    }
+
+    @Test(dataProvider = "invalidSecretReferences", expectedExceptions = SecretManagementException.class)
+    public void testDecryptPropertyBySecretReferenceWithInvalidReference(String secretReference)
+            throws SecretManagementException {
+
+        AuthProperty authProperty = new AuthProperty.AuthPropertyBuilder()
+                .name(Authentication.Property.ACCESS_TOKEN.getName())
+                .isConfidential(true)
+                .value(secretReference)
+                .build();
+
+        actionSecretProcessor.decryptPropertyBySecretReference(authProperty);
     }
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/UserDefinedAuthenticatorEndpointConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/UserDefinedAuthenticatorEndpointConfig.java
@@ -41,7 +41,7 @@ public class UserDefinedAuthenticatorEndpointConfig {
 
         endpointConfig = builder.endpointConfig;
     }
-    
+
     public EndpointConfig getEndpointConfig() {
 
         return endpointConfig;
@@ -75,10 +75,63 @@ public class UserDefinedAuthenticatorEndpointConfig {
     public Map<String, String> getAuthenticatorEndpointAuthenticationProperties() {
 
         Map<String, String> propertyMap = new HashMap<>();
-        for (AuthProperty prop: endpointConfig.getAuthentication().getProperties()) {
+        for (AuthProperty prop : endpointConfig.getAuthentication().getProperties()) {
             propertyMap.put(prop.getName(), prop.getValue());
         }
         return propertyMap;
+    }
+
+    /**
+     * Get the authentication properties of the authenticator endpoint shaped for the response view.
+     *
+     * @return Authentication properties with decrypted user-visible confidential properties.
+     */
+    public Map<String, Object> getResolvedEndpointAuthenticationProperties() {
+
+        Authentication authentication = endpointConfig.getAuthentication();
+        Map<String, Object> propertyMap = new HashMap<>();
+        switch (authentication.getType()) {
+            case BASIC:
+                addDecryptedProperty(propertyMap, authentication, Authentication.Property.USERNAME);
+                break;
+            case API_KEY:
+                addStoredProperty(propertyMap, authentication, Authentication.Property.HEADER);
+                break;
+            case CLIENT_CREDENTIAL:
+                addDecryptedProperty(propertyMap, authentication, Authentication.Property.CLIENT_ID);
+                addStoredProperty(propertyMap, authentication, Authentication.Property.TOKEN_ENDPOINT);
+                addStoredProperty(propertyMap, authentication, Authentication.Property.SCOPES);
+                break;
+            case PASSWORD_CREDENTIAL:
+                addDecryptedProperty(propertyMap, authentication, Authentication.Property.CLIENT_ID);
+                addDecryptedProperty(propertyMap, authentication, Authentication.Property.USERNAME);
+                addStoredProperty(propertyMap, authentication, Authentication.Property.TOKEN_ENDPOINT);
+                addStoredProperty(propertyMap, authentication, Authentication.Property.SCOPES);
+                break;
+            case BEARER:
+            case NONE:
+            default:
+                break;
+        }
+        return propertyMap;
+    }
+
+    private void addDecryptedProperty(Map<String, Object> propertyMap, Authentication authentication,
+                                      Authentication.Property property) {
+
+        AuthProperty decrypted = authentication.getPropertyWithDecryptedValue(property.getName());
+        if (decrypted != null) {
+            propertyMap.put(property.getName(), decrypted.getValue());
+        }
+    }
+
+    private void addStoredProperty(Map<String, Object> propertyMap, Authentication authentication,
+                                   Authentication.Property property) {
+
+        AuthProperty prop = authentication.getProperty(property);
+        if (prop != null) {
+            propertyMap.put(property.getName(), prop.getValue());
+        }
     }
 
     /**
@@ -114,6 +167,7 @@ public class UserDefinedAuthenticatorEndpointConfig {
         private EndpointConfig endpointConfig;
 
         public UserDefinedAuthenticatorEndpointConfigBuilder() {
+
         }
 
         public UserDefinedAuthenticatorEndpointConfigBuilder uri(String uri) {
@@ -146,7 +200,7 @@ public class UserDefinedAuthenticatorEndpointConfig {
             this.allowedParameters = allowedParameters;
             return this;
         }
-        
+
         public UserDefinedAuthenticatorEndpointConfig build() {
 
             EndpointConfig.EndpointConfigBuilder endpointConfigBuilder = new EndpointConfig.EndpointConfigBuilder();

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/test/java/org/wso2/carbon/identity/application/common/model/test/UserDefinedAuthenticatorTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/test/java/org/wso2/carbon/identity/application/common/model/test/UserDefinedAuthenticatorTest.java
@@ -18,23 +18,53 @@
 
 package org.wso2.carbon.identity.application.common.model.test;
 
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.management.internal.component.ActionMgtServiceComponentHolder;
 import org.wso2.carbon.identity.application.common.model.UserDefinedAuthenticatorEndpointConfig;
 import org.wso2.carbon.identity.application.common.model.UserDefinedAuthenticatorEndpointConfig.UserDefinedAuthenticatorEndpointConfigBuilder;
 import org.wso2.carbon.identity.application.common.model.UserDefinedFederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.UserDefinedLocalAuthenticatorConfig;
 import org.wso2.carbon.identity.base.AuthenticatorPropertyConstants;
+import org.wso2.carbon.identity.secret.mgt.core.SecretManager;
+import org.wso2.carbon.identity.secret.mgt.core.SecretManagerImpl;
+import org.wso2.carbon.identity.secret.mgt.core.SecretResolveManager;
+import org.wso2.carbon.identity.secret.mgt.core.exception.SecretManagementException;
+import org.wso2.carbon.identity.secret.mgt.core.model.ResolvedSecret;
 
 import java.util.HashMap;
+import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.wso2.carbon.identity.base.AuthenticatorPropertyConstants.TAG_2FA;
 import static org.wso2.carbon.identity.base.AuthenticatorPropertyConstants.TAG_CUSTOM;
 
 public class UserDefinedAuthenticatorTest {
 
     private static final String URI = "http://localhost:8080";
+    private static final String ACTION_ID = "action-id";
+    private static final String SECRET_TYPE = "ACTION_API_ENDPOINT_AUTH_SECRETS";
+
+    private SecretResolveManager secretResolveManager;
+    private SecretManager secretManager;
+
+    @BeforeMethod
+    public void setUp() throws SecretManagementException {
+
+        secretResolveManager = mock(SecretResolveManager.class);
+        secretManager = mock(SecretManagerImpl.class);
+        // decryptPropertyBySecretReference checks isSecretExist before resolving; report present so
+        // the resolve path is reached.
+        doReturn(true).when(secretManager).isSecretExist(any(), any());
+        ActionMgtServiceComponentHolder.getInstance().setSecretResolveManager(secretResolveManager);
+        ActionMgtServiceComponentHolder.getInstance().setSecretManager(secretManager);
+    }
 
     @Test
     public void createUserDefinedLocalVerificationAuthenticator() {
@@ -118,5 +148,115 @@ public class UserDefinedAuthenticatorTest {
         endpointConfigBuilder.authenticationType(authenticationType);
         endpointConfigBuilder.authenticationProperties(endpointConfig);
         endpointConfigBuilder.build();
+    }
+
+    @Test
+    public void resolvedEndpointAuthenticationPropertiesForBasic() throws SecretManagementException {
+
+        stubResolvedSecret(secretName("BASIC", "username"), "alice");
+
+        Map<String, String> input = new HashMap<>();
+        input.put("username", secretReference("BASIC", "username"));
+        input.put("password", secretReference("BASIC", "password"));
+
+        Map<String, Object> resolved = buildEndpointConfig("BASIC", input)
+                .getResolvedEndpointAuthenticationProperties();
+
+        assertEquals(resolved.size(), 1);
+        assertEquals(resolved.get("username"), "alice");
+        assertFalse(resolved.containsKey("password"),
+                "BASIC resolved view must not expose the password secret reference.");
+    }
+
+    @Test
+    public void resolvedEndpointAuthenticationPropertiesForApiKey() {
+
+        Map<String, String> input = new HashMap<>();
+        input.put("header", "Authorization");
+        input.put("value", secretReference("API_KEY", "value"));
+
+        Map<String, Object> resolved = buildEndpointConfig("API_KEY", input)
+                .getResolvedEndpointAuthenticationProperties();
+
+        assertEquals(resolved.size(), 1);
+        assertEquals(resolved.get("header"), "Authorization");
+        assertFalse(resolved.containsKey("value"),
+                "API_KEY resolved view must not expose the api key value secret reference.");
+    }
+
+    @Test
+    public void resolvedEndpointAuthenticationPropertiesForClientCredential() throws SecretManagementException {
+
+        stubResolvedSecret(secretName("CLIENT_CREDENTIAL", "clientId"), "client-123");
+
+        Map<String, String> input = new HashMap<>();
+        input.put("clientId", secretReference("CLIENT_CREDENTIAL", "clientId"));
+        input.put("clientSecret", secretReference("CLIENT_CREDENTIAL", "clientSecret"));
+        input.put("tokenEndpoint", "https://token.example.com");
+        input.put("scopes", "openid profile");
+
+        Map<String, Object> resolved = buildEndpointConfig("CLIENT_CREDENTIAL", input)
+                .getResolvedEndpointAuthenticationProperties();
+
+        assertEquals(resolved.size(), 3);
+        assertEquals(resolved.get("clientId"), "client-123");
+        assertEquals(resolved.get("tokenEndpoint"), "https://token.example.com");
+        assertEquals(resolved.get("scopes"), "openid profile");
+        assertFalse(resolved.containsKey("clientSecret"),
+                "CLIENT_CREDENTIAL resolved view must not expose the client secret reference.");
+    }
+
+    @Test
+    public void resolvedEndpointAuthenticationPropertiesForPasswordCredential() throws SecretManagementException {
+
+        stubResolvedSecret(secretName("PASSWORD_CREDENTIAL", "clientId"), "pwd-client");
+        stubResolvedSecret(secretName("PASSWORD_CREDENTIAL", "username"), "bob");
+
+        Map<String, String> input = new HashMap<>();
+        input.put("clientId", secretReference("PASSWORD_CREDENTIAL", "clientId"));
+        input.put("clientSecret", secretReference("PASSWORD_CREDENTIAL", "clientSecret"));
+        input.put("tokenEndpoint", "https://token.example.com");
+        input.put("username", secretReference("PASSWORD_CREDENTIAL", "username"));
+        input.put("password", secretReference("PASSWORD_CREDENTIAL", "password"));
+
+        Map<String, Object> resolved = buildEndpointConfig("PASSWORD_CREDENTIAL", input)
+                .getResolvedEndpointAuthenticationProperties();
+
+        assertEquals(resolved.size(), 3);
+        assertEquals(resolved.get("clientId"), "pwd-client");
+        assertEquals(resolved.get("username"), "bob");
+        assertEquals(resolved.get("tokenEndpoint"), "https://token.example.com");
+        assertFalse(resolved.containsKey("clientSecret"),
+                "PASSWORD_CREDENTIAL resolved view must not expose the client secret reference.");
+        assertFalse(resolved.containsKey("password"),
+                "PASSWORD_CREDENTIAL resolved view must not expose the password secret reference.");
+        assertFalse(resolved.containsKey("scopes"), "Optional scopes must be absent when not configured.");
+    }
+
+    private UserDefinedAuthenticatorEndpointConfig buildEndpointConfig(String authenticationType,
+                                                                       Map<String, String> properties) {
+
+        return new UserDefinedAuthenticatorEndpointConfigBuilder()
+                .uri(URI)
+                .authenticationType(authenticationType)
+                .authenticationProperties(properties)
+                .build();
+    }
+
+    private void stubResolvedSecret(String secretName, String resolvedValue) throws SecretManagementException {
+
+        ResolvedSecret resolvedSecret = new ResolvedSecret();
+        resolvedSecret.setResolvedSecretValue(resolvedValue);
+        doReturn(resolvedSecret).when(secretResolveManager).getResolvedSecret(any(), eq(secretName));
+    }
+
+    private static String secretReference(String authType, String propertyName) {
+
+        return SECRET_TYPE + ":" + secretName(authType, propertyName);
+    }
+
+    private static String secretName(String authType, String propertyName) {
+
+        return ACTION_ID + ":" + authType + ":" + propertyName;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

- Provide capability to resolve non confidential authentication properties of custom authenticators


### Related Issue

- https://github.com/wso2/product-is/issues/27832


### Summary

This pull request introduces enhancements to the handling and retrieval of confidential authentication properties, particularly focusing on secure decryption of secret references and improved property exposure in response views. The main changes include new utility methods for decrypting secret references, updates to authentication property builders to include internal confidential properties, and a new method for presenting decrypted authentication properties in user-defined authenticator endpoint configurations.

**Improvements to secret property decryption and retrieval:**

* Added a new method `decryptPropertyBySecretReference` in `ActionSecretProcessor` to securely resolve and decrypt authentication properties that use secret references, including robust error handling for invalid references.
* Introduced the method `getPropertyWithDecryptedValue` in the `Authentication` class, enabling retrieval of authentication properties with their values decrypted if they are stored as secret references.

**Enhancements to authentication property management:**

* Updated `ClientCredentialAuthBuilder` and `PasswordCredentialAuthBuilder` in the `Authentication` class to automatically add internal confidential properties for access and refresh tokens during construction. [[1]](diffhunk://#diff-ccac6a854c22a16f9bed2a8ed322ec1a93f4735fb211d6e9dc0bc8758f593a8bR371-R376) [[2]](diffhunk://#diff-ccac6a854c22a16f9bed2a8ed322ec1a93f4735fb211d6e9dc0bc8758f593a8bR439-R444)

**Improvements to authenticator endpoint configuration:**

* Added `getResolvedEndpointAuthenticationProperties` to `UserDefinedAuthenticatorEndpointConfig`, providing a response-ready map of authentication properties with confidential fields decrypted as needed, and supporting helper methods for adding decrypted or stored properties to the response.

