### PR TITLE
Add attribute mapping for action objects

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -440,6 +440,7 @@ public class ActionManagementServiceImpl implements ActionManagementService {
                 .actionVersion(actionDTO.getActionVersion())
                 .createdAt(actionDTO.getCreatedAt())
                 .updatedAt(actionDTO.getUpdatedAt())
+                .attributes(actionDTO.getAttributes())
                 .build();
     }
 
@@ -465,6 +466,7 @@ public class ActionManagementServiceImpl implements ActionManagementService {
                 .createdAt(actionDTO.getCreatedAt())
                 .updatedAt(actionDTO.getUpdatedAt())
                 .endpoint(actionDTO.getEndpoint())
+                .attributes(actionDTO.getAttributes())
                 .rule(actionDTO.getActionRule())
                 .build();
     }


### PR DESCRIPTION
This pull request adds support for handling custom attributes in action objects within the `ActionManagementServiceImpl` class. The main change is the inclusion of the `attributes` field when building `Action` instances from `ActionDTO` objects.

Enhancements to action object construction:

* Added the `attributes` field from `ActionDTO` to the builder in the `buildBasicAction` method, ensuring that any custom attributes are preserved when creating basic action objects.
* Included the `attributes` field from `ActionDTO` in the builder in the `buildAction` method, allowing custom attributes to be set for more complex action objects as well.

Related Issue:
- https://github.com/wso2/product-is/issues/27830

> Note:  Attributes are now a first-class field in the base Action/ActionDTO model, pre update password and profile actions still use type-specific converter paths. Therefore attribute mapping must remain in `PreUpdatePasswordActionConverter` and `PreUpdateProfileActionConverter`.