### PR TITLE
Fix NPE in DefaultRequestCoordinator when authentication context is null

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -306,11 +306,11 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                         initialTenantDomainFromThreadLocal = IdentityUtil.threadLocalProperties.get().
                                 get(TENANT_NAME_FROM_CONTEXT).toString();
                     }
-                    if ((context.isOrgApplicationLogin() || context.isSharedAppLogin()) &&
+                    if (context != null && (context.isOrgApplicationLogin() || context.isSharedAppLogin()) &&
                             StringUtils.isNotEmpty(PrivilegedCarbonContext.getThreadLocalCarbonContext().
                                     getOrganizationId())) {
                         isTenantFlowStarted = startCarbonContextForTenantQualifiedOrganizationPaths();
-                    } else if (!(context.isSharedAppLogin() || context.isOrgApplicationLogin()) &&
+                    } else if (context != null && !(context.isSharedAppLogin() || context.isOrgApplicationLogin()) &&
                             StringUtils.isNotEmpty(PrivilegedCarbonContext.getThreadLocalCarbonContext().
                                     getAccessingOrganizationId())) {
                         isTenantFlowStarted = startCarbonContextForOrganizationQualifiedPaths(context,


### PR DESCRIPTION
## Summary

Fixes a `NullPointerException` thrown from `DefaultRequestCoordinator.handle()` when an inbound request hits the CommonAuth endpoint without a `type` parameter and `FrameworkUtils.getContextData(request)` returns `null` (e.g. when the session/context cache has expired).

The block that decides whether to start a tenant- or organization-qualified carbon context was invoking `context.isOrgApplicationLogin()` and `context.isSharedAppLogin()` without first checking that `context` is not `null`, producing the following stack trace observed on iam-cloud:

```
ERROR {org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultRequestCoordinator}
- Exception in Authentication Framework
java.lang.NullPointerException: Cannot invoke
  "org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext.isOrgApplicationLogin()"
  because "context" is null
    at o.w.c.i.a.a.f.handler.request.impl.DefaultRequestCoordinator.handle(DefaultRequestCoordinator.java:309)
    at o.w.c.i.a.a.f.CommonAuthenticationHandler.doPost(CommonAuthenticationHandler.java:59)
    ...
```

This is consistent with the existing null handling a few lines below (`if (context != null && !isApplicationEnabled(...))`) and the prior fix in commit `85c9a758c4` (`Prevent NPE when cache expires`) which guards `associateTransientRequestData` against null contexts.

## Changes

- Added `context != null` guards to both branches of the tenant/org carbon-context bootstrap inside the `isCommonAuthEndpoint` block in `DefaultRequestCoordinator#handle`.
