### PR TITLE
Add FLOW_EXTENSION action type for in-flow extension points

### DIFF
--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/api/model/ActionType.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/api/model/ActionType.java
@@ -29,7 +29,8 @@ public enum ActionType {
     PRE_UPDATE_PASSWORD,
     PRE_UPDATE_PROFILE,
     AUTHENTICATION,
-    PRE_ISSUE_ID_TOKEN;
+    PRE_ISSUE_ID_TOKEN,
+    FLOW_EXTENSION;
 
     public String getDisplayName() {
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/api/model/ActionType.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/api/model/ActionType.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.action.execution.api.model;
 
 import org.wso2.carbon.identity.action.management.api.model.Action;
+import org.wso2.carbon.identity.action.management.api.model.Action.ActionTypes.Category;
 
 /**
  * This class models the Action Type.
@@ -35,5 +36,10 @@ public enum ActionType {
     public String getDisplayName() {
 
         return Action.ActionTypes.valueOf(this.name()).getDisplayName();
+    }
+
+    public Category getCategory() {
+
+        return Action.ActionTypes.valueOf(this.name()).getCategory();
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/service/impl/ActionExecutorServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/service/impl/ActionExecutorServiceImpl.java
@@ -154,6 +154,12 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
         } catch (ActionExecutionRuntimeException e) {
             LOG.debug("Skip executing action for action type: " + actionType.name(), e);
             // Skip executing actions when no action available is considered as action execution being successful.
+            Action.ActionTypes.Category category = Action.ActionTypes.valueOf(actionType.toString()).getCategory();
+            if (Action.ActionTypes.Category.FLOW_EXTENSION.equals(category)) {
+                throw new ActionExecutionException(
+                        "Failed to execute flow extension action with id: " + actionId
+                                + " for action type: " + actionType.name(), e);
+            }
             return new SuccessStatus.Builder().setResponseContext(flowContext.getContextData()).build();
         }
     }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/service/impl/ActionExecutorServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/service/impl/ActionExecutorServiceImpl.java
@@ -152,14 +152,12 @@ public class ActionExecutorServiceImpl implements ActionExecutorService {
             Action action = getActionByActionId(actionType, actionId, tenantDomain);
             return execute(action, flowContext, tenantDomain);
         } catch (ActionExecutionRuntimeException e) {
+            if (Action.ActionTypes.Category.FLOW_EXTENSION.equals(actionType.getCategory())) {
+                throw new ActionExecutionException("Failed to execute action with id: " + actionId +
+                    " for action type: " + actionType.name(), e);
+            }
             LOG.debug("Skip executing action for action type: " + actionType.name(), e);
             // Skip executing actions when no action available is considered as action execution being successful.
-            Action.ActionTypes.Category category = Action.ActionTypes.valueOf(actionType.toString()).getCategory();
-            if (Action.ActionTypes.Category.FLOW_EXTENSION.equals(category)) {
-                throw new ActionExecutionException(
-                        "Failed to execute flow extension action with id: " + actionId
-                                + " for action type: " + actionType.name(), e);
-            }
             return new SuccessStatus.Builder().setResponseContext(flowContext.getContextData()).build();
         }
     }

--- a/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/ActionExecutorConfig.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.execution/src/main/java/org/wso2/carbon/identity/action/execution/internal/util/ActionExecutorConfig.java
@@ -87,6 +87,8 @@ public class ActionExecutorConfig {
                 return isActionTypeEnabled(ActionTypeConfig.PRE_UPDATE_PROFILE.getActionTypeEnableProperty());
             case PRE_ISSUE_ID_TOKEN:
                 return isActionTypeEnabled(ActionTypeConfig.PRE_ISSUE_ID_TOKEN.getActionTypeEnableProperty());
+            case FLOW_EXTENSION:
+                return isActionTypeEnabled(ActionTypeConfig.FLOW_EXTENSION.getActionTypeEnableProperty());
             default:
                 return false;
         }
@@ -333,6 +335,8 @@ public class ActionExecutorConfig {
                 return getVersion(ActionTypeConfig.PRE_UPDATE_PROFILE.getRetiredUpToVersionProperty());
             case PRE_ISSUE_ID_TOKEN:
                 return getVersion(ActionTypeConfig.PRE_ISSUE_ID_TOKEN.getRetiredUpToVersionProperty());
+            case FLOW_EXTENSION:
+                return getVersion(ActionTypeConfig.FLOW_EXTENSION.getRetiredUpToVersionProperty());
             default:
                 return null;
         }
@@ -417,7 +421,13 @@ public class ActionExecutorConfig {
                 "Actions.Types.PreIssueIdToken.ActionRequest.ExcludedParameters.Parameter",
                 "Actions.Types.PreIssueIdToken.ActionRequest.AllowedHeaders.Header",
                 "Actions.Types.PreIssueIdToken.ActionRequest.AllowedParameters.Parameter",
-                "Actions.Types.PreIssueIdToken.Version.RetiredUpTo");
+                "Actions.Types.PreIssueIdToken.Version.RetiredUpTo"),
+        FLOW_EXTENSION("Actions.Types.FlowExtension.Enable",
+                "Actions.Types.FlowExtension.ActionRequest.ExcludedHeaders.Header",
+                "Actions.Types.FlowExtension.ActionRequest.ExcludedParameters.Parameter",
+                "Actions.Types.FlowExtension.ActionRequest.AllowedHeaders.Header",
+                "Actions.Types.FlowExtension.ActionRequest.AllowedParameters.Parameter",
+                "Actions.Types.FlowExtension.Version.RetiredUpTo");
 
         private final String actionTypeEnableProperty;
         private final String excludedHeadersProperty;

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/constant/ErrorMessage.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/constant/ErrorMessage.java
@@ -45,13 +45,9 @@ public enum ErrorMessage {
             "The number of configured attributes: %s exceeds the maximum allowed limit: %s"),
     ERROR_INVALID_ATTRIBUTES("60012", "Invalid attribute provided.",
             "%s"),
-    ERROR_EMPTY_ATTRIBUTE_VALUE("60013", "Invalid attribute provided.",
-            "Each attribute must be a non-empty string."),
-    ERROR_UNSUPPORTED_ATTRIBUTE("60014", "Unsupported attribute provided.",
-            "The attribute %s is not supported to be shared with the extension."),
-    ERROR_ACTION_NAME_ALREADY_EXISTS("60015", "Action name already exists.",
+    ERROR_ACTION_NAME_ALREADY_EXISTS("60013", "Action name already exists.",
             "An action with the name '%s' already exists for the action type '%s'."),
-    ERROR_ACTION_NAME_BLANK("60016", "Invalid action name.", 
+    ERROR_ACTION_NAME_BLANK("60014", "Invalid action name.", 
             "An action name must be a non-empty string."),
 
     // Server errors.

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/constant/ErrorMessage.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/constant/ErrorMessage.java
@@ -45,6 +45,14 @@ public enum ErrorMessage {
             "The number of configured attributes: %s exceeds the maximum allowed limit: %s"),
     ERROR_INVALID_ATTRIBUTES("60012", "Invalid attribute provided.",
             "%s"),
+    ERROR_EMPTY_ATTRIBUTE_VALUE("60013", "Invalid attribute provided.",
+            "Each attribute must be a non-empty string."),
+    ERROR_UNSUPPORTED_ATTRIBUTE("60014", "Unsupported attribute provided.",
+            "The attribute %s is not supported to be shared with the extension."),
+    ERROR_ACTION_NAME_ALREADY_EXISTS("60015", "Action name already exists.",
+            "An action with the name '%s' already exists for the action type '%s'."),
+    ERROR_ACTION_NAME_BLANK("60016", "Invalid action name.", 
+            "An action name must be a non-empty string."),
 
     // Server errors.
     ERROR_WHILE_ADDING_ACTION("65001", "Error while adding Action.",

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/model/Action.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/api/model/Action.java
@@ -75,7 +75,13 @@ public class Action {
                 "PRE_ISSUE_ID_TOKEN",
                 "Pre Issue ID Token",
                 "Configure an extension point for modifying ID token via a custom service.",
-                Category.PRE_POST);
+                Category.PRE_POST),
+        FLOW_EXTENSION(
+                "flowExtension",
+                "FLOW_EXTENSION",
+                "Flow Extension",
+                "Configure an extension point within any flow via a custom service.",
+                Category.FLOW_EXTENSION);
 
         private final String pathParam;
         private final String actionType;
@@ -131,7 +137,8 @@ public class Action {
          */
         public enum Category {
             PRE_POST,
-            IN_FLOW
+            IN_FLOW,
+            FLOW_EXTENSION
         }
     }
 

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/dao/impl/ActionDTOModelResolverFactory.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/dao/impl/ActionDTOModelResolverFactory.java
@@ -46,6 +46,8 @@ public class ActionDTOModelResolverFactory {
                 return actionDTOModelResolvers.get(Action.ActionTypes.PRE_UPDATE_PASSWORD);
             case PRE_ISSUE_ACCESS_TOKEN:
                 return actionDTOModelResolvers.get(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN);
+            case FLOW_EXTENSION:
+                return actionDTOModelResolvers.get(Action.ActionTypes.FLOW_EXTENSION);
             default:
                 return null;
         }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionConverterFactory.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionConverterFactory.java
@@ -39,15 +39,7 @@ public class ActionConverterFactory {
 
     public static ActionConverter getActionConverter(Action.ActionTypes actionType) {
 
-        switch (actionType) {
-            case PRE_UPDATE_PROFILE:
-                return actionConverters.get(Action.ActionTypes.PRE_UPDATE_PROFILE);
-            case PRE_UPDATE_PASSWORD:
-                return actionConverters.get(Action.ActionTypes.PRE_UPDATE_PASSWORD);
-            case PRE_ISSUE_ACCESS_TOKEN:
-            default:
-                return null;
-        }
+        return actionConverters.get(actionType);
     }
 
     public static void registerActionConverter(ActionConverter actionConverter) {

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.action.management.api.exception.ActionMgtClientE
 import org.wso2.carbon.identity.action.management.api.exception.ActionMgtException;
 import org.wso2.carbon.identity.action.management.api.exception.ActionMgtServerException;
 import org.wso2.carbon.identity.action.management.api.model.Action;
+import org.wso2.carbon.identity.action.management.api.model.Action.ActionTypes;
 import org.wso2.carbon.identity.action.management.api.model.ActionDTO;
 import org.wso2.carbon.identity.action.management.api.model.Authentication;
 import org.wso2.carbon.identity.action.management.api.model.EndpointConfig;
@@ -76,6 +77,7 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         Action.ActionTypes castedActionType = Action.ActionTypes.valueOf(resolvedActionType);
         ActionValidatorFactory.getActionValidator(castedActionType).doPreAddActionValidations(
                 castedActionType, ActionManagementConfig.getInstance().getLatestVersion(castedActionType), action);
+        validateActionNameUniqueness(action.getName(), null, castedActionType, tenantId);
         // Check whether the maximum allowed actions per type is reached.
         validateMaxActionsPerType(resolvedActionType, tenantDomain);
         String generatedActionId = UUID.randomUUID().toString();
@@ -161,6 +163,7 @@ public class ActionManagementServiceImpl implements ActionManagementService {
         Action.ActionTypes castedActionType = Action.ActionTypes.valueOf(resolvedActionType);
         ActionValidatorFactory.getActionValidator(castedActionType).doPreUpdateActionValidations(
                 castedActionType, resolveActionVersionAtUpdating(action, existingActionDTO), action);
+        validateActionNameUniqueness(action.getName(), actionId, castedActionType, tenantId);
         ActionDTO updatingActionDTO = buildActionDTOForUpdate(resolvedActionType, actionId, action);
 
         DAO_FACADE.updateAction(updatingActionDTO, existingActionDTO, tenantId);
@@ -317,8 +320,10 @@ public class ActionManagementServiceImpl implements ActionManagementService {
      */
     private void validateMaxActionsPerType(String actionType, String tenantDomain) throws ActionMgtException {
 
-        // In-flow actions are not limited by the maximum actions per action type; eg: AUTHENTICATION action type.
-        if (Action.ActionTypes.Category.IN_FLOW.equals(Action.ActionTypes.valueOf(actionType).getCategory())) {
+        // In-flow and extension actions are not limited by the maximum actions per action type.
+        Action.ActionTypes.Category category = Action.ActionTypes.valueOf(actionType).getCategory();
+        if (Action.ActionTypes.Category.IN_FLOW.equals(category)
+                || Action.ActionTypes.Category.FLOW_EXTENSION.equals(category)) {
             return;
         }
         Map<String, Integer> actionsCountPerType = getActionsCountPerType(tenantDomain);
@@ -365,8 +370,13 @@ public class ActionManagementServiceImpl implements ActionManagementService {
             throws ActionMgtServerException {
 
         Action.ActionTypes resolvedActionType = Action.ActionTypes.valueOf(actionType);
-        Action.Status resolvedStatus = resolvedActionType.getCategory() == Action.ActionTypes.Category.IN_FLOW ?
-                Action.Status.ACTIVE : Action.Status.INACTIVE;
+        // Only IN_FLOW and FLOW_EXTENSION category actions (e.g., AUTHENTICATION, FLOW_EXTENSION)
+        // start ACTIVE and can be used immediately. All other categories (e.g., PRE_POST) start
+        // INACTIVE and require explicit activation.
+        Action.ActionTypes.Category category = resolvedActionType.getCategory();
+        Action.Status resolvedStatus = (category == Action.ActionTypes.Category.IN_FLOW
+                || category == Action.ActionTypes.Category.FLOW_EXTENSION)
+                ? Action.Status.ACTIVE : Action.Status.INACTIVE;
 
         String actionVersion = ActionManagementConfig.getInstance().getLatestVersion(resolvedActionType);
 
@@ -469,5 +479,26 @@ public class ActionManagementServiceImpl implements ActionManagementService {
                 .attributes(actionDTO.getAttributes())
                 .rule(actionDTO.getActionRule())
                 .build();
+    }
+
+    private void validateActionNameUniqueness(String name, String excludeId, ActionTypes actionType, int tenantId)
+            throws ActionMgtException {
+
+        if (!ActionTypes.FLOW_EXTENSION.equals(actionType)) {
+            return;
+        }
+        if (StringUtils.isBlank(name)) {
+            throw ActionManagementExceptionHandler.handleClientException(
+                    ErrorMessage.ERROR_ACTION_NAME_BLANK);
+        }
+        List<ActionDTO> existingActions = DAO_FACADE.getActionsByActionType(actionType.getActionType(), tenantId);
+        boolean duplicateExists = existingActions.stream()
+                .filter(dto -> excludeId == null || !excludeId.equals(dto.getId()))
+                .anyMatch(dto -> name.equalsIgnoreCase(dto.getName()));
+
+        if (duplicateExists) {
+            throw ActionManagementExceptionHandler.handleClientException(
+                    ErrorMessage.ERROR_ACTION_NAME_ALREADY_EXISTS, name, actionType.getActionType());
+        }
     }
 }

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -21,7 +21,6 @@ package org.wso2.carbon.identity.action.management.internal.service.impl;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.opensaml.xacml.ctx.ActionType;
 import org.wso2.carbon.identity.action.management.api.constant.ErrorMessage;
 import org.wso2.carbon.identity.action.management.api.exception.ActionMgtClientException;
 import org.wso2.carbon.identity.action.management.api.exception.ActionMgtException;

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/service/impl/ActionManagementServiceImpl.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.action.management.internal.service.impl;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.opensaml.xacml.ctx.ActionType;
 import org.wso2.carbon.identity.action.management.api.constant.ErrorMessage;
 import org.wso2.carbon.identity.action.management.api.exception.ActionMgtClientException;
 import org.wso2.carbon.identity.action.management.api.exception.ActionMgtException;
@@ -484,13 +485,10 @@ public class ActionManagementServiceImpl implements ActionManagementService {
     private void validateActionNameUniqueness(String name, String excludeId, ActionTypes actionType, int tenantId)
             throws ActionMgtException {
 
-        if (!ActionTypes.FLOW_EXTENSION.equals(actionType)) {
+        if (StringUtils.isBlank(name) || !ActionTypes.Category.FLOW_EXTENSION.equals(actionType.getCategory())) {
             return;
         }
-        if (StringUtils.isBlank(name)) {
-            throw ActionManagementExceptionHandler.handleClientException(
-                    ErrorMessage.ERROR_ACTION_NAME_BLANK);
-        }
+
         List<ActionDTO> existingActions = DAO_FACADE.getActionsByActionType(actionType.getActionType(), tenantId);
         boolean duplicateExists = existingActions.stream()
                 .filter(dto -> excludeId == null || !excludeId.equals(dto.getId()))

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementConfig.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/main/java/org/wso2/carbon/identity/action/management/internal/util/ActionManagementConfig.java
@@ -94,7 +94,11 @@ public class ActionManagementConfig {
                 return getVersion(
                         ActionTypeConfig.PRE_UPDATE_PROFILE.getLatestVersionProperty(), actionType);
             case PRE_ISSUE_ID_TOKEN:
-                return getVersion(ActionTypeConfig.PRE_ISSUE_ID_TOKEN.getLatestVersionProperty(), actionType);
+                return getVersion(
+                        ActionTypeConfig.PRE_ISSUE_ID_TOKEN.getLatestVersionProperty(), actionType);
+            case FLOW_EXTENSION:
+                return getVersion(
+                        ActionTypeConfig.FLOW_EXTENSION.getLatestVersionProperty(), actionType);
             default:
                 throw new ActionMgtServerException("Unsupported action type: " + actionType);
         }
@@ -140,6 +144,11 @@ public class ActionManagementConfig {
                 "Actions.Types.PreIssueIdToken.ActionRequest.ExcludedHeaders.Header",
                 "Actions.Types.PreIssueIdToken.ActionRequest.ExcludedParameters.Parameter",
                 "Actions.Types.PreIssueIdToken.Version.Latest"
+        ),
+        FLOW_EXTENSION(
+                "Actions.Types.FlowExtension.ActionRequest.ExcludedHeaders.Header",
+                null,
+                "Actions.Types.FlowExtension.Version.Latest"
         );
 
         private final String excludedHeadersProperty;

--- a/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/model/ActionTypesTest.java
+++ b/components/action-mgt/org.wso2.carbon.identity.action.management/src/test/java/org/wso2/carbon/identity/action/management/model/ActionTypesTest.java
@@ -52,7 +52,11 @@ public class ActionTypesTest {
                 {Action.ActionTypes.PRE_ISSUE_ID_TOKEN, "preIssueIdToken", "PRE_ISSUE_ID_TOKEN",
                         "Pre Issue ID Token",
                         "Configure an extension point for modifying ID token via a custom service.",
-                        Action.ActionTypes.Category.PRE_POST}
+                        Action.ActionTypes.Category.PRE_POST},
+                {Action.ActionTypes.FLOW_EXTENSION, "flowExtension", "FLOW_EXTENSION",
+                        "Flow Extension",
+                        "Configure an extension point within any flow via a custom service.",
+                        Action.ActionTypes.Category.FLOW_EXTENSION}
         };
     }
 
@@ -76,7 +80,9 @@ public class ActionTypesTest {
                         new Action.ActionTypes[]{Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN,
                                 Action.ActionTypes.PRE_UPDATE_PASSWORD, Action.ActionTypes.PRE_UPDATE_PROFILE,
                                 Action.ActionTypes.PRE_REGISTRATION, Action.ActionTypes.PRE_ISSUE_ID_TOKEN}},
-                {Action.ActionTypes.Category.IN_FLOW, new Action.ActionTypes[]{Action.ActionTypes.AUTHENTICATION}}
+                {Action.ActionTypes.Category.IN_FLOW, new Action.ActionTypes[]{Action.ActionTypes.AUTHENTICATION}},
+                {Action.ActionTypes.Category.FLOW_EXTENSION,
+                        new Action.ActionTypes[]{Action.ActionTypes.FLOW_EXTENSION}}
         };
     }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/pom.xml
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/pom.xml
@@ -200,6 +200,16 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <excludeFilterFile>../../../spotbugs-exclude.xml</excludeFilterFile>
+                    <effort>Max</effort>
+                    <threshold>High</threshold>
+                    <xmlOutput>true</xmlOutput>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/pom.xml
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/pom.xml
@@ -235,6 +235,16 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <excludeFilterFile>../../../spotbugs-exclude.xml</excludeFilterFile>
+                    <effort>Max</effort>
+                    <threshold>High</threshold>
+                    <xmlOutput>true</xmlOutput>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/pom.xml
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/pom.xml
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.wso2.carbon.identity.framework</groupId>
+        <artifactId>identity-framework</artifactId>
+        <version>7.11.94-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.flow.extension</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Identity Flow Flow Extension</name>
+    <description>WSO2 flow engine flow extension</description>
+    <url>http://www.wso2.com</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.flow.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.flow.execution.engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.action.execution</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.action.management</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.claim.metadata.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.user.action</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.certificate.management</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            org.wso2.carbon.identity.flow.extension.internal,
+                            org.wso2.carbon.identity.flow.extension.util
+                        </Private-Package>
+                        <Import-Package>
+                            javax.xml.parsers; version="${javax.xml.parsers.import.pkg.version}",
+                            org.xml.sax,
+                            org.w3c.dom,
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.apache.axiom.om; version="${axiom.osgi.version.range}",
+                            org.apache.xerces.util; resolution:=optional,
+                            org.apache.commons.logging; version="${import.package.version.commons.logging}",
+                            org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
+                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.*;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.utils.multitenancy;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.base; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.*; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.*;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.claim.metadata.mgt.*;
+                            version="${carbon.identity.package.import.version.range}",
+                            javax.servlet.http; version="${imp.pkg.version.javax.servlet}",
+                            org.wso2.carbon.identity.flow.execution.engine;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.flow.execution.engine.exception;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.flow.execution.engine.graph;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.flow.execution.engine.model;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.flow.mgt;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.flow.mgt.model;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.flow.mgt.exception;
+                            version="${carbon.identity.package.import.version.range}",
+                            com.nimbusds.jose.*; version="${nimbusds.osgi.version.range}",
+                            com.nimbusds.jwt; version="${nimbusds.osgi.version.range}",
+                            org.wso2.carbon.identity.user.action.api.exception;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.core.util; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.identity.action.execution.api.*;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.action.management.api.*;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.utils;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.certificate.management.exception;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.certificate.management.model;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.certificate.management.service;
+                            version="${carbon.identity.package.import.version.range}",
+                            com.fasterxml.jackson.core.*; version="${com.fasterxml.jackson.annotation.version.range}",
+                            com.fasterxml.jackson.databind.*;
+                            version="${com.fasterxml.jackson.annotation.version.range}",
+                            com.fasterxml.jackson.annotation.*;
+                            version="${com.fasterxml.jackson.annotation.version.range}",
+                            org.wso2.carbon.utils; version="${carbon.kernel.package.import.version.range}",
+                            org.slf4j; version="${org.slf4j.imp.pkg.version.range}"
+                        </Import-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.identity.flow.extension.internal,
+                            org.wso2.carbon.identity.flow.extension,
+                            org.wso2.carbon.identity.flow.extension.executor,
+                            org.wso2.carbon.identity.flow.extension.model,
+                            org.wso2.carbon.identity.flow.extension.management,
+                            org.wso2.carbon.identity.flow.extension.metadata;
+                            version="${carbon.identity.package.export.version}"
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <systemPropertyVariables>
+                        <carbon.home>${project.build.testOutputDirectory}</carbon.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>org/wso2/carbon/identity/flow/extension/internal/**</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-prepare-agent-integration</id>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report-integration</id>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.45</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>21</source>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+</project>

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/pom.xml
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.identity.flow.extension</artifactId>
     <packaging>bundle</packaging>
-    <name>WSO2 Carbon - Identity Flow Flow Extension</name>
+    <name>WSO2 Carbon - Identity Flow Extension</name>
     <description>WSO2 flow engine flow extension</description>
     <url>http://www.wso2.com</url>
 
@@ -207,7 +207,7 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
+            <!-- <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
@@ -219,7 +219,7 @@
                         <carbon.home>${project.build.testOutputDirectory}</carbon.home>
                     </systemPropertyVariables>
                 </configuration>
-            </plugin>
+            </plugin> -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/FlowExtensionConstants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/FlowExtensionConstants.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Constants for the In-Flow Extension executor pipeline.
+ */
+public class FlowExtensionConstants {
+
+    private FlowExtensionConstants() {
+
+    }
+
+    public static final String FLOW_EXECUTION_CONTEXT_KEY = "flowExecutionContext";
+    public static final String PATH_TYPE_ANNOTATIONS_KEY = "pathTypeAnnotations";
+    public static final String MODIFY_PATHS_KEY = "modifyPaths";
+    public static final String PENDING_CLAIMS_KEY = "pendingClaims";
+    public static final String PENDING_CREDENTIALS_KEY = "pendingCredentials";
+    public static final String PENDING_PROPERTIES_KEY = "pendingProperties";
+    public static final String PENDING_REDIRECT_URL_KEY = "pendingRedirectUrl";
+
+    public static final String FAILURE_TYPE_KEY = "failureType";
+    public static final String FLOW_EXTENSION_FAILURE_TYPE = "FLOW_EXTENSION_FAILURE";
+    public static final String FAILURE_MESSAGE_KEY = "failureMessage";
+    public static final String FAILURE_DESCRIPTION_KEY = "failureDescription";
+
+    public static final String ACTION_ID_METADATA_KEY = "actionId";
+
+    public static final class ActionManagement {
+
+        public static final String ACCESS_CONFIG_EXPOSE = "ACCESS_CONFIG_EXPOSE";
+        public static final String ACCESS_CONFIG_MODIFY = "ACCESS_CONFIG_MODIFY";
+        public static final int MAX_EXPOSE_PATHS = 50;
+        public static final String ICON_URL = "ICON_URL";
+        public static final String CERTIFICATE = "CERTIFICATE";
+        public static final String CERTIFICATE_NAME_PREFIX = "ACTIONS:";
+
+        private ActionManagement() {
+
+        }
+    }
+
+    public static final class Log {
+
+        public static final String COMPONENT_ID = "inflow-extension";
+
+        private Log() {
+
+        }
+
+        public static final class ActionIDs {
+
+            public static final String EXECUTE = "execute-inflow-extension";
+            public static final String PROCESS_RESPONSE = "process-inflow-extension-response";
+
+            private ActionIDs() {
+
+            }
+        }
+    }
+
+    /**
+     * Default handover policy: which {@code FlowExecutionContext} and {@code FlowUser} fields
+     * are forwarded to the action framework. Serves as the documented defaults for the
+     * toml-based dynamic config in {@code identity.xml.j2}.
+     */
+    public static final class HandoverPolicy {
+
+        public static final String ATTR_FLOW_USER = "flowUser";
+        public static final String ATTR_CONTEXT_IDENTIFIER = "contextIdentifier";
+        public static final String ATTR_USER_CREDENTIALS = "userCredentials";
+        public static final Set<String> INCLUDED_ATTRIBUTES = Collections.unmodifiableSet(
+                new HashSet<>(Arrays.asList(
+                        "contextIdentifier",
+                        "tenantDomain",
+                        "applicationId",
+                        "flowType",
+                        "callbackUrl",
+                        "portalUrl",
+                        "flowUser"
+                )));
+
+        public static final Set<String> INCLUDED_USER_ATTRIBUTES = Collections.unmodifiableSet(
+                new HashSet<>(Arrays.asList(
+                        "id",
+                        "username",
+                        "userStoreDomain",
+                        "claims",
+                        "userCredentials"
+                )));
+
+        private HandoverPolicy() {
+
+        }
+    }
+
+    /**
+     * JSON-pointer-style path constants for the In-Flow Extension context tree.
+     */
+    public static final class FlowContextPaths {
+
+        public static final String USER_PREFIX = "/user/";
+        public static final String USER_ID_PATH = "/user/id";
+        public static final String USER_STORE_DOMAIN_PATH = "/user/userStoreDomain";
+        public static final String USER_CLAIMS_PATH_PREFIX = "/user/claims/";
+        public static final String USER_CLAIMS_SELECTOR_PREFIX = "/user/claims[uri=";
+        public static final String USER_CLAIMS_SELECTOR_SUFFIX = "]";
+        public static final String USER_CREDENTIALS_PATH_PREFIX = "/user/credentials/";
+
+        public static final String PROPERTIES_PATH_PREFIX = "/properties/";
+
+        public static final String FLOW_PREFIX = "/flow/";
+        public static final String FLOW_TENANT_PATH = "/flow/tenantDomain";
+        public static final String FLOW_APP_ID_PATH = "/flow/applicationId";
+        public static final String FLOW_TYPE_PATH = "/flow/flowType";
+        public static final String FLOW_CALLBACK_URL_PATH = "/flow/callbackUrl";
+        public static final String FLOW_PORTAL_URL_PATH = "/flow/portalUrl";
+
+        public static final String ORGANIZATION_PREFIX = "/organization/";
+        public static final String ORGANIZATION_ID_PATH = "/organization/id";
+        public static final String ORGANIZATION_NAME_PATH = "/organization/name";
+        public static final String ORGANIZATION_HANDLE_PATH = "/organization/orgHandle";
+        public static final String ORGANIZATION_DEPTH_PATH = "/organization/depth";
+
+        private FlowContextPaths() {
+
+        }
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/PathTypeAnnotationUtil.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/PathTypeAnnotationUtil.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.executor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility for parsing and coercing path type annotations.
+ */
+public final class PathTypeAnnotationUtil {
+
+    static final Pattern ANNOTATION_PATTERN = Pattern.compile("\\{([^}]*)}$");
+    static final String LOCAL_CLAIM_DIALECT_PREFIX = "http://wso2.org/claims/";
+    static final String IDENTITY_CLAIM_URI_PREFIX = "http://wso2.org/claims/identity/";
+    static final int MAX_ATTRIBUTES_PER_OBJECT = 10;
+    static final int MAX_ARRAY_ITEMS = 10;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private PathTypeAnnotationUtil() {
+    }
+
+    /**
+     * Strip a trailing annotation from a raw path.
+     *
+     * @return {@code [cleanPath, annotation]}; annotation is {@code null} if absent.
+     */
+    public static String[] stripAnnotation(String rawPath) {
+
+        if (rawPath == null) {
+            return new String[]{null, null};
+        }
+        Matcher matcher = ANNOTATION_PATTERN.matcher(rawPath);
+        if (matcher.find()) {
+            return new String[]{rawPath.substring(0, matcher.start()), matcher.group(1)};
+        }
+        return new String[]{rawPath, null};
+    }
+
+    /**
+     * Coerce a value based on its path annotation: complex returned as-is,
+     * primary arrays become {@code List<String>}, others become String.
+     */
+    @SuppressWarnings("unchecked")
+    public static Object coerceValue(String path, Object value, Map<String, String> pathTypeAnnotations) {
+
+        if (value == null) {
+            return null;
+        }
+        String annotation = pathTypeAnnotations.get(path);
+        if (annotation == null) {
+            return String.valueOf(value);
+        }
+        if (annotation.startsWith("[")) {
+            String inner = annotation.substring(1, annotation.length() - 1);
+            if (inner.contains(":")) {
+                return tryParseJsonString(value);
+            }
+            Object resolved = tryParseJsonString(value);
+            if (resolved instanceof List) {
+                List<String> stringList = new ArrayList<>();
+                for (Object item : (List<Object>) resolved) {
+                    stringList.add(item == null ? null : String.valueOf(item));
+                }
+                return stringList;
+            }
+            List<String> singleList = new ArrayList<>();
+            singleList.add(String.valueOf(value));
+            return singleList;
+        }
+        if (annotation.contains(":")) {
+            return tryParseJsonString(value);
+        }
+        return String.valueOf(value);
+    }
+
+    /**
+     * Validate a complex annotation does not exceed {@link #MAX_ATTRIBUTES_PER_OBJECT}.
+     * Returns {@code true} for non-complex or empty annotations.
+     */
+    public static boolean validateAnnotationLimits(String annotation) {
+
+        if (annotation == null || annotation.isEmpty()) {
+            return true;
+        }
+        String inner = annotation;
+        if (inner.startsWith("[") && inner.endsWith("]")) {
+            inner = inner.substring(1, inner.length() - 1);
+        }
+        if (!inner.contains(":")) {
+            return true;
+        }
+        return parseAnnotationAttributes(inner).size() <= MAX_ATTRIBUTES_PER_OBJECT;
+    }
+
+    /**
+     * Validate a complex object/array value against its schema annotation.
+     * Enforces {@link #MAX_ATTRIBUTES_PER_OBJECT} and {@link #MAX_ARRAY_ITEMS}.
+     * Returns {@code true} for non-complex annotations.
+     */
+    @SuppressWarnings("unchecked")
+    public static boolean validateValueAgainstAnnotation(String path, Object value,
+                                                         Map<String, String> pathTypeAnnotations) {
+
+        String annotation = pathTypeAnnotations.get(path);
+        if (annotation == null) {
+            return true;
+        }
+        boolean isArray = annotation.startsWith("[");
+        String inner = isArray ? annotation.substring(1, annotation.length() - 1) : annotation;
+        if (!inner.contains(":")) {
+            return true;
+        }
+        Map<String, String> schema = parseAnnotationAttributes(inner);
+        Object resolved = tryParseJsonString(value);
+        if (!isArray) {
+            return validateSingleComplexObject(resolved, schema);
+        }
+        if (!(resolved instanceof List)) {
+            return false;
+        }
+        List<Object> items = (List<Object>) resolved;
+        if (items.size() > MAX_ARRAY_ITEMS) {
+            return false;
+        }
+        for (Object item : items) {
+            if (!validateSingleComplexObject(item, schema)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Enforce {@link #MAX_ARRAY_ITEMS} on array-typed values.
+     */
+    @SuppressWarnings("unchecked")
+    public static boolean enforceArrayItemLimit(String path, Object value,
+                                                Map<String, String> pathTypeAnnotations) {
+
+        String annotation = pathTypeAnnotations.get(path);
+        if (annotation == null || !annotation.startsWith("[")) {
+            return true;
+        }
+        if (!(value instanceof List)) {
+            return true;
+        }
+        return ((List<Object>) value).size() <= MAX_ARRAY_ITEMS;
+    }
+
+    /**
+     * Parse a String as JSON if it starts with {@code [} or {@code {}; otherwise return as-is.
+     * Handles serialized JSON arriving from external services (e.g. after JWE decryption).
+     */
+    private static Object tryParseJsonString(Object value) {
+
+        if (!(value instanceof String)) {
+            return value;
+        }
+        String str = ((String) value).trim();
+        if (!str.startsWith("[") && !str.startsWith("{")) {
+            return value;
+        }
+        try {
+            return OBJECT_MAPPER.readValue(str, Object.class);
+        } catch (IOException ignored) {
+            return value;
+        }
+    }
+
+    /**
+     * Parse complex annotation attributes into a name-to-type map.
+     */
+    private static Map<String, String> parseAnnotationAttributes(String inner) {
+
+        Map<String, String> attributes = new HashMap<>();
+        for (String part : inner.split(",")) {
+            String trimmed = part.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            int colonIndex = trimmed.indexOf(':');
+            if (colonIndex > 0) {
+                attributes.put(trimmed.substring(0, colonIndex).trim(),
+                        trimmed.substring(colonIndex + 1).trim());
+            }
+        }
+        return attributes;
+    }
+
+    /**
+     * Validate a single complex object: must be a Map with schema-only keys,
+     * attribute count within limits, and only single-level nesting.
+     */
+    @SuppressWarnings("unchecked")
+    private static boolean validateSingleComplexObject(Object value, Map<String, String> schema) {
+
+        if (!isMapAndWithinAttributeLimit(value)) {
+            return false;
+        }
+        Map<String, Object> map = (Map<String, Object>) value;
+        if (!containsOnlySchemaKeys(map, schema)) {
+            return false;
+        }
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            if (!validateEntryValueAgainstType(entry, schema)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isMapAndWithinAttributeLimit(Object value) {
+
+        return value instanceof Map && ((Map<?, ?>) value).size() <= MAX_ATTRIBUTES_PER_OBJECT;
+    }
+
+    private static boolean containsOnlySchemaKeys(Map<String, Object> valueMap, Map<String, String> schema) {
+
+        for (String key : valueMap.keySet()) {
+            if (!schema.containsKey(key)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean validateEntryValueAgainstType(Map.Entry<String, Object> entry, Map<String, String> schema) {
+
+        String type = schema.get(entry.getKey());
+        Object attrValue = entry.getValue();
+        if (type != null && type.endsWith("[]")) {
+            return validatePrimaryArrayAttribute(attrValue);
+        }
+        return !isNestedStructure(attrValue);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean validatePrimaryArrayAttribute(Object value) {
+
+        if (!(value instanceof List)) {
+            return false;
+        }
+        List<Object> list = (List<Object>) value;
+        if (list.size() > MAX_ARRAY_ITEMS) {
+            return false;
+        }
+        for (Object item : list) {
+            if (isNestedStructure(item)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isNestedStructure(Object value) {
+
+        return value instanceof Map || value instanceof List;
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionConverter.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionConverter.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.management;
+
+import org.wso2.carbon.identity.action.management.api.model.Action;
+import org.wso2.carbon.identity.action.management.api.model.ActionDTO;
+import org.wso2.carbon.identity.action.management.api.model.ActionProperty;
+import org.wso2.carbon.identity.action.management.api.service.ActionConverter;
+import org.wso2.carbon.identity.certificate.management.model.Certificate;
+import org.wso2.carbon.identity.flow.extension.model.AccessConfig;
+import org.wso2.carbon.identity.flow.extension.model.ContextPath;
+import org.wso2.carbon.identity.flow.extension.model.FlowExtensionAction;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.ACCESS_CONFIG_EXPOSE;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.ACCESS_CONFIG_MODIFY;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.CERTIFICATE;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.ICON_URL;
+
+/**
+ * ActionConverter implementation for Flow Extension actions.
+ * <p>
+ * Handles the conversion between {@link FlowExtensionAction} (domain model) and
+ * {@link ActionDTO} (data transfer object) by mapping the {@link AccessConfig} fields
+ * to/from action properties.
+ * </p>
+ */
+public class FlowExtensionActionConverter implements ActionConverter {
+
+    @Override
+    public Action.ActionTypes getSupportedActionType() {
+
+        return Action.ActionTypes.FLOW_EXTENSION;
+    }
+
+    /**
+     * Converts an {@link FlowExtensionAction} to an {@link ActionDTO} for persistence.
+     * Maps the access config fields (expose, modify) into the DTO's properties map.
+     *
+     * @param action The FlowExtensionAction to convert.
+     * @return ActionDTO with access config properties.
+     */
+    @Override
+    public ActionDTO buildActionDTO(Action action) {
+
+        if (!(action instanceof FlowExtensionAction flowExtensionAction)) {
+            return new ActionDTO.Builder(action).build();
+        }
+
+        Map<String, ActionProperty> properties = new HashMap<>();
+        putDefaultAccessConfigProperties(properties, flowExtensionAction.getAccessConfig());
+        putCertificateProperty(properties, flowExtensionAction.getCertificate());
+        if (flowExtensionAction.getIconUrl() != null) {
+            properties.put(ICON_URL,
+                    new ActionProperty.BuilderForService(flowExtensionAction.getIconUrl()).build());
+        }
+
+        return new ActionDTO.Builder(flowExtensionAction)
+                .properties(properties)
+                .build();
+    }
+
+    private void putDefaultAccessConfigProperties(Map<String, ActionProperty> properties, AccessConfig accessConfig) {
+
+        if (accessConfig == null) {
+            return;
+        }
+        if (accessConfig.getExpose() != null) {
+            properties.put(ACCESS_CONFIG_EXPOSE,
+                    new ActionProperty.BuilderForService(accessConfig.getExpose()).build());
+        }
+        if (accessConfig.getModify() != null) {
+            properties.put(ACCESS_CONFIG_MODIFY,
+                    new ActionProperty.BuilderForService(accessConfig.getModify()).build());
+        }
+    }
+
+    private void putCertificateProperty(Map<String, ActionProperty> properties, Certificate certificate) {
+
+        if (certificate == null) {
+            return;
+        }
+        String content = certificate.getCertificateContent();
+        if (content != null && !content.isEmpty()) {
+            properties.put(CERTIFICATE,
+                    new ActionProperty.BuilderForService(certificate).build());
+        } else {
+            // Certificate with no content — signals explicit removal at the resolver layer.
+            properties.put(CERTIFICATE,
+                    new ActionProperty.BuilderForService("").build());
+        }
+    }
+
+    /**
+     * Converts an {@link ActionDTO} back to an {@link FlowExtensionAction}.
+     * Reconstructs the default {@link AccessConfig} from the DTO's properties map.
+     *
+     * @param actionDTO The ActionDTO to convert.
+     * @return FlowExtensionAction with access config populated.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public Action buildAction(ActionDTO actionDTO) {
+
+        // Default access config.
+        List<ContextPath> expose = (List<ContextPath>) actionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE);
+        List<ContextPath> modify =
+                (List<ContextPath>) actionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY);
+
+        AccessConfig accessConfig = null;
+        if (expose != null || modify != null) {
+            accessConfig = new AccessConfig(expose, modify);
+        }
+
+        // External service certificate (separate from access config).
+        Certificate certificate = null;
+        Object certValue = actionDTO.getPropertyValue(CERTIFICATE);
+        if (certValue instanceof Certificate cert) {
+            certificate = cert;
+        }
+
+        // Icon URL.
+        String iconUrl = null;
+        Object iconUrlValue = actionDTO.getPropertyValue(ICON_URL);
+        if (iconUrlValue instanceof String iconUrlStr) {
+            iconUrl = iconUrlStr;
+        }
+
+        return new FlowExtensionAction.ResponseBuilder()
+                .id(actionDTO.getId())
+                .type(actionDTO.getType())
+                .name(actionDTO.getName())
+                .description(actionDTO.getDescription())
+                .status(actionDTO.getStatus())
+                .actionVersion(actionDTO.getActionVersion())
+                .createdAt(actionDTO.getCreatedAt())
+                .updatedAt(actionDTO.getUpdatedAt())
+                .endpoint(actionDTO.getEndpoint())
+                .accessConfig(accessConfig)
+                .certificate(certificate)
+                .iconUrl(iconUrl)
+                .rule(actionDTO.getActionRule())
+                .build();
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionConverter.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionConverter.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.flow.extension.management;
 
+import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.identity.action.management.api.model.Action;
 import org.wso2.carbon.identity.action.management.api.model.ActionDTO;
 import org.wso2.carbon.identity.action.management.api.model.ActionProperty;
@@ -26,6 +27,8 @@ import org.wso2.carbon.identity.certificate.management.model.Certificate;
 import org.wso2.carbon.identity.flow.extension.model.AccessConfig;
 import org.wso2.carbon.identity.flow.extension.model.ContextPath;
 import org.wso2.carbon.identity.flow.extension.model.FlowExtensionAction;
+
+import com.ctc.wstx.util.StringUtil;
 
 import java.util.HashMap;
 import java.util.List;
@@ -100,7 +103,7 @@ public class FlowExtensionActionConverter implements ActionConverter {
             return;
         }
         String content = certificate.getCertificateContent();
-        if (content != null && !content.isEmpty()) {
+        if (StringUtils.isBlank(content)) {
             properties.put(CERTIFICATE,
                     new ActionProperty.BuilderForService(certificate).build());
         } else {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolver.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolver.java
@@ -1,0 +1,443 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.management;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverClientException;
+import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverException;
+import org.wso2.carbon.identity.action.management.api.model.Action;
+import org.wso2.carbon.identity.action.management.api.model.ActionDTO;
+import org.wso2.carbon.identity.action.management.api.model.ActionProperty;
+import org.wso2.carbon.identity.action.management.api.model.BinaryObject;
+import org.wso2.carbon.identity.action.management.api.service.ActionDTOModelResolver;
+import org.wso2.carbon.identity.certificate.management.exception.CertificateMgtException;
+import org.wso2.carbon.identity.certificate.management.model.Certificate;
+import org.wso2.carbon.identity.certificate.management.service.CertificateManagementService;
+import org.wso2.carbon.identity.flow.extension.model.ContextPath;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.emptyList;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.ACCESS_CONFIG_EXPOSE;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.ACCESS_CONFIG_MODIFY;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.CERTIFICATE;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.CERTIFICATE_NAME_PREFIX;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.ICON_URL;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.MAX_EXPOSE_PATHS;
+
+/**
+ * ActionDTOModelResolver implementation for Flow Extension actions.
+ */
+public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolver {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<List<ContextPath>> CONTEXT_PATH_LIST_TYPE_REF =
+            new TypeReference<List<ContextPath>>() { };
+
+    private final CertificateManagementService certificateManagementService;
+
+    public FlowExtensionActionDTOModelResolver(CertificateManagementService certificateManagementService) {
+
+        this.certificateManagementService = certificateManagementService;
+    }
+
+    @Override
+    public Action.ActionTypes getSupportedActionType() {
+
+        return Action.ActionTypes.FLOW_EXTENSION;
+    }
+
+    @Override
+    public ActionDTO resolveForAddOperation(ActionDTO actionDTO, String tenantDomain)
+            throws ActionDTOModelResolverException {
+
+        Map<String, ActionProperty> properties = new HashMap<>();
+
+        Object exposeValue = actionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE);
+        if (exposeValue != null) {
+            List<ContextPath> validatedExpose = validateExpose(exposeValue);
+            properties.put(ACCESS_CONFIG_EXPOSE, createBlobProperty(validatedExpose));
+        }
+
+        Object modifyValue = actionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY);
+        if (modifyValue != null) {
+            List<ContextPath> validatedModify = validateExpose(modifyValue);
+            properties.put(ACCESS_CONFIG_MODIFY, createBlobProperty(validatedModify));
+        }
+
+        handleCertificateAdd(actionDTO, properties, tenantDomain);
+
+        Object iconUrlValue = actionDTO.getPropertyValue(ICON_URL);
+        if (iconUrlValue instanceof String iconUrlStr && !iconUrlStr.isEmpty()) {
+            properties.put(ICON_URL, new ActionProperty.BuilderForDAO(iconUrlStr).build());
+        }
+
+        return new ActionDTO.Builder(actionDTO)
+                .properties(properties)
+                .build();
+    }
+
+    @Override
+    public ActionDTO resolveForGetOperation(ActionDTO actionDTO, String tenantDomain)
+            throws ActionDTOModelResolverException {
+
+        Map<String, ActionProperty> properties = new HashMap<>();
+
+        if (actionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE) != null) {
+            properties.put(ACCESS_CONFIG_EXPOSE, deserializeExposeProperty(
+                    ((BinaryObject) actionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE)).getJSONString()));
+        }
+
+        if (actionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY) != null) {
+            properties.put(ACCESS_CONFIG_MODIFY, deserializeExposeProperty(
+                    ((BinaryObject) actionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY)).getJSONString()));
+        }
+
+        handleCertificateGet(actionDTO, properties, tenantDomain);
+
+        Object iconUrlValue = actionDTO.getPropertyValue(ICON_URL);
+        if (iconUrlValue != null) {
+            properties.put(ICON_URL, new ActionProperty.BuilderForService(iconUrlValue.toString()).build());
+        }
+
+        return new ActionDTO.Builder(actionDTO)
+                .properties(properties)
+                .build();
+    }
+
+    @Override
+    public List<ActionDTO> resolveForGetOperation(List<ActionDTO> actionDTOList, String tenantDomain)
+            throws ActionDTOModelResolverException {
+
+        List<ActionDTO> resolvedList = new ArrayList<>();
+        for (ActionDTO actionDTO : actionDTOList) {
+            resolvedList.add(resolveForGetOperation(actionDTO, tenantDomain));
+        }
+        return resolvedList;
+    }
+
+    @Override
+    public ActionDTO resolveForUpdateOperation(ActionDTO updatingActionDTO, ActionDTO existingActionDTO,
+                                               String tenantDomain) throws ActionDTOModelResolverException {
+
+        Map<String, ActionProperty> properties = new HashMap<>();
+
+        // DAO layer treats action property updates as PUT, so unchanged properties must be re-sent.
+        List<ContextPath> expose = getResolvedUpdatingExpose(updatingActionDTO, existingActionDTO);
+        if (!expose.isEmpty()) {
+            properties.put(ACCESS_CONFIG_EXPOSE, createBlobProperty(expose));
+        }
+
+        List<ContextPath> modify = getResolvedUpdatingModify(updatingActionDTO, existingActionDTO);
+        if (!modify.isEmpty()) {
+            properties.put(ACCESS_CONFIG_MODIFY, createBlobProperty(modify));
+        }
+
+        handleCertificateUpdate(updatingActionDTO, existingActionDTO, properties, tenantDomain);
+        resolveUpdateIconUrl(updatingActionDTO, existingActionDTO, properties);
+
+        return new ActionDTO.Builder(updatingActionDTO)
+                .properties(properties)
+                .build();
+    }
+
+    private void resolveUpdateIconUrl(ActionDTO updatingActionDTO, ActionDTO existingActionDTO,
+                                      Map<String, ActionProperty> properties)
+            throws ActionDTOModelResolverException {
+
+        Object updatingIconUrl = updatingActionDTO.getPropertyValue(ICON_URL);
+        if (updatingIconUrl instanceof String updatingIconUrlStr && !updatingIconUrlStr.isEmpty()) {
+            properties.put(ICON_URL, new ActionProperty.BuilderForDAO(updatingIconUrlStr).build());
+        } else if (existingActionDTO.getPropertyValue(ICON_URL) != null) {
+            properties.put(ICON_URL, new ActionProperty.BuilderForDAO(
+                    existingActionDTO.getPropertyValue(ICON_URL).toString()).build());
+        }
+    }
+
+    @Override
+    public void resolveForDeleteOperation(ActionDTO deletingActionDTO, String tenantDomain)
+            throws ActionDTOModelResolverException {
+
+        handleCertificateDelete(deletingActionDTO, tenantDomain);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<ContextPath> getResolvedUpdatingExpose(ActionDTO updatingActionDTO, ActionDTO existingActionDTO)
+            throws ActionDTOModelResolverException {
+
+        if (updatingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE) != null) {
+            return validateExpose(updatingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE));
+        } else if (existingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE) != null) {
+            return (List<ContextPath>) existingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE);
+        }
+        return emptyList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<ContextPath> getResolvedUpdatingModify(ActionDTO updatingActionDTO,
+                                                       ActionDTO existingActionDTO)
+            throws ActionDTOModelResolverException {
+
+        if (updatingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY) != null) {
+            return validateExpose(updatingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY));
+        } else if (existingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY) != null) {
+            return (List<ContextPath>) existingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY);
+        }
+        return emptyList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<ContextPath> validateExpose(Object exposeValue) throws ActionDTOModelResolverException {
+
+        if (!(exposeValue instanceof List<?>)) {
+            throw new ActionDTOModelResolverClientException("Invalid expose format.",
+                    "Expose should be provided as a list.");
+        }
+
+        List<?> exposeList = (List<?>) exposeValue;
+        List<ContextPath> result = new ArrayList<>();
+
+        for (Object item : exposeList) {
+            if (item instanceof Map) {
+                Map<?, ?> map = (Map<?, ?>) item;
+                if (!map.containsKey("path") || !(map.get("path") instanceof String)) {
+                    throw new ActionDTOModelResolverClientException("Invalid expose format.",
+                            "Each expose entry must be an object with a 'path' field.");
+                }
+                String path = (String) map.get("path");
+                boolean encrypted = map.containsKey("encrypted") && toBooleanSafe(map.get("encrypted"));
+                result.add(new ContextPath(path, encrypted));
+            } else if (item instanceof ContextPath contextPath) {
+                result.add(contextPath);
+            } else {
+                throw new ActionDTOModelResolverClientException("Invalid expose format.",
+                        "Each expose entry must be an object with 'path' and optional 'encrypted' fields.");
+            }
+        }
+
+        validateExposeCount(result);
+        validateContextPathFormat(result);
+        return result;
+    }
+
+    private void validateExposeCount(List<ContextPath> expose) throws ActionDTOModelResolverClientException {
+
+        if (expose.size() > MAX_EXPOSE_PATHS) {
+            throw new ActionDTOModelResolverClientException("Maximum expose paths limit exceeded.",
+                    String.format("The number of configured expose paths: %d exceeds the maximum allowed limit: %d.",
+                            expose.size(), MAX_EXPOSE_PATHS));
+        }
+    }
+
+    private void validateContextPathFormat(List<ContextPath> expose) throws ActionDTOModelResolverClientException {
+
+        Set<String> seen = new HashSet<>();
+        for (ContextPath exposePath : expose) {
+            String path = exposePath.getPath();
+            if (path == null || path.trim().isEmpty()) {
+                throw new ActionDTOModelResolverClientException("Invalid expose path.",
+                        "Expose paths must not be null or empty.");
+            }
+            if (!path.startsWith("/")) {
+                throw new ActionDTOModelResolverClientException("Invalid expose path.",
+                        String.format("Expose path '%s' must start with '/'.", path));
+            }
+            if (path.endsWith("/")) {
+                throw new ActionDTOModelResolverClientException("Invalid expose path.",
+                        String.format("Expose path '%s' must not end with a trailing '/'.", path));
+            }
+            if (!seen.add(path)) {
+                throw new ActionDTOModelResolverClientException("Duplicate expose path.",
+                        String.format("The expose path '%s' is duplicated.", path));
+            }
+        }
+    }
+
+    private void handleCertificateAdd(ActionDTO actionDTO, Map<String, ActionProperty> properties,
+                                      String tenantDomain) throws ActionDTOModelResolverException {
+
+        Object certValue = actionDTO.getPropertyValue(CERTIFICATE);
+        if (certValue == null) {
+            return;
+        }
+
+        String certificatePEM = extractCertificatePEM(certValue);
+        String certName = CERTIFICATE_NAME_PREFIX + actionDTO.getId();
+
+        try {
+            String certificateId = certificateManagementService.addCertificate(
+                    new Certificate.Builder()
+                            .name(certName)
+                            .certificateContent(certificatePEM)
+                            .build(),
+                    tenantDomain);
+
+            properties.put(CERTIFICATE,
+                    new ActionProperty.BuilderForDAO(certificateId).build());
+        } catch (CertificateMgtException e) {
+            throw new ActionDTOModelResolverException("Error storing certificate for action: "
+                    + actionDTO.getId(), e);
+        }
+    }
+
+    private void handleCertificateGet(ActionDTO actionDTO, Map<String, ActionProperty> properties,
+                                      String tenantDomain) throws ActionDTOModelResolverException {
+
+        Object certIdValue = actionDTO.getPropertyValue(CERTIFICATE);
+        if (certIdValue == null) {
+            return;
+        }
+
+        try {
+            String certIdStr = certIdValue.toString();
+            Certificate certificate = certificateManagementService.getCertificate(
+                    certIdStr, tenantDomain);
+            properties.put(CERTIFICATE,
+                    new ActionProperty.BuilderForService(certificate).build());
+        } catch (CertificateMgtException e) {
+            throw new ActionDTOModelResolverException("Error retrieving certificate for action: "
+                    + actionDTO.getId(), e);
+        }
+    }
+
+    private void handleCertificateUpdate(ActionDTO updatingActionDTO, ActionDTO existingActionDTO,
+                                         Map<String, ActionProperty> properties, String tenantDomain)
+            throws ActionDTOModelResolverException {
+
+        Object newCertValue = updatingActionDTO.getPropertyValue(CERTIFICATE);
+        Object existingCertValue = existingActionDTO.getPropertyValue(CERTIFICATE);
+
+        // Empty string signals explicit certificate removal.
+        boolean isExplicitRemoval = newCertValue instanceof String s && s.isEmpty();
+
+        if (isExplicitRemoval && existingCertValue != null) {
+            try {
+                String existingCertId = extractCertificateId(existingCertValue);
+                certificateManagementService.deleteCertificate(existingCertId, tenantDomain);
+            } catch (CertificateMgtException e) {
+                throw new ActionDTOModelResolverException("Error deleting certificate for action: "
+                        + updatingActionDTO.getId(), e);
+            }
+        } else if (newCertValue != null && !isExplicitRemoval && existingCertValue != null) {
+            String certificatePEM = extractCertificatePEM(newCertValue);
+            try {
+                String existingCertId = extractCertificateId(existingCertValue);
+                certificateManagementService.updateCertificateContent(
+                        existingCertId, certificatePEM, tenantDomain);
+                properties.put(CERTIFICATE,
+                        new ActionProperty.BuilderForDAO(existingCertId).build());
+            } catch (CertificateMgtException e) {
+                throw new ActionDTOModelResolverException("Error updating certificate for action: "
+                        + updatingActionDTO.getId(), e);
+            }
+        } else if (newCertValue != null && !isExplicitRemoval) {
+            handleCertificateAdd(updatingActionDTO, properties, tenantDomain);
+        } else if (existingCertValue != null) {
+            // Carry forward existing certificate ID — PUT semantics.
+            properties.put(CERTIFICATE,
+                    new ActionProperty.BuilderForDAO(extractCertificateId(existingCertValue)).build());
+        }
+    }
+
+    private void handleCertificateDelete(ActionDTO deletingActionDTO, String tenantDomain)
+            throws ActionDTOModelResolverException {
+
+        Object certIdValue = deletingActionDTO.getPropertyValue(CERTIFICATE);
+        if (certIdValue == null) {
+            return;
+        }
+
+        try {
+            String certId = extractCertificateId(certIdValue);
+            certificateManagementService.deleteCertificate(certId, tenantDomain);
+        } catch (CertificateMgtException e) {
+            throw new ActionDTOModelResolverException("Error deleting certificate for action: "
+                    + deletingActionDTO.getId(), e);
+        }
+    }
+
+    // Handles both raw UUID strings and Certificate objects, since the GET resolver replaces
+    // the stored UUID with the full Certificate.
+    private String extractCertificateId(Object certValue) {
+
+        if (certValue instanceof Certificate certificate) {
+            return certificate.getId();
+        }
+        return certValue.toString();
+    }
+
+    private String extractCertificatePEM(Object certValue) throws ActionDTOModelResolverClientException {
+
+        if (certValue instanceof Certificate certificate) {
+            return certificate.getCertificateContent();
+        } else if (certValue instanceof Map) {
+            Map<?, ?> certMap = (Map<?, ?>) certValue;
+            Object content = certMap.get("certificateContent");
+            if (content instanceof String pem) {
+                return pem;
+            }
+            throw new ActionDTOModelResolverClientException("Invalid certificate format.",
+                    "Certificate object must contain a 'certificateContent' field.");
+        } else if (certValue instanceof String pem) {
+            return pem;
+        }
+        throw new ActionDTOModelResolverClientException("Invalid certificate format.",
+                "Certificate must be a PEM string, a Certificate object, or a map with 'certificateContent'.");
+    }
+
+    private ActionProperty createBlobProperty(Object value) throws ActionDTOModelResolverException {
+
+        try {
+            BinaryObject binaryObject = BinaryObject.fromJsonString(OBJECT_MAPPER.writeValueAsString(value));
+            return new ActionProperty.BuilderForDAO(binaryObject).build();
+        } catch (JsonProcessingException e) {
+            throw new ActionDTOModelResolverException("Failed to serialize access config property to JSON.", e);
+        }
+    }
+
+    private ActionProperty deserializeExposeProperty(String jsonString) throws ActionDTOModelResolverException {
+
+        try {
+            List<ContextPath> expose = OBJECT_MAPPER.readValue(jsonString, CONTEXT_PATH_LIST_TYPE_REF);
+            return new ActionProperty.BuilderForService(expose).build();
+        } catch (IOException e) {
+            throw new ActionDTOModelResolverException("Error reading expose values from storage.", e);
+        }
+    }
+
+    // Jackson deserializes JSON true as Boolean but JSON "true" as String — handle both.
+    private static boolean toBooleanSafe(Object value) {
+
+        if (value instanceof Boolean b) {
+            return b;
+        }
+        if (value instanceof String s) {
+            return Boolean.parseBoolean(s);
+        }
+        return false;
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolver.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolver.java
@@ -21,6 +21,8 @@ package org.wso2.carbon.identity.flow.extension.management;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverClientException;
 import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverException;
 import org.wso2.carbon.identity.action.management.api.model.Action;
@@ -54,6 +56,7 @@ import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.Act
  */
 public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolver {
 
+    private static final Log LOG = LogFactory.getLog(FlowExtensionActionDTOModelResolver.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final TypeReference<List<ContextPath>> CONTEXT_PATH_LIST_TYPE_REF =
             new TypeReference<List<ContextPath>>() { };
@@ -79,13 +82,13 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
 
         Object exposeValue = actionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE);
         if (exposeValue != null) {
-            List<ContextPath> validatedExpose = validateExpose(exposeValue);
+            List<ContextPath> validatedExpose = validateAccessConfig(exposeValue);
             properties.put(ACCESS_CONFIG_EXPOSE, createBlobProperty(validatedExpose));
         }
 
         Object modifyValue = actionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY);
         if (modifyValue != null) {
-            List<ContextPath> validatedModify = validateExpose(modifyValue);
+            List<ContextPath> validatedModify = validateAccessConfig(modifyValue);
             properties.put(ACCESS_CONFIG_MODIFY, createBlobProperty(validatedModify));
         }
 
@@ -190,7 +193,7 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
             throws ActionDTOModelResolverException {
 
         if (updatingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE) != null) {
-            return validateExpose(updatingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE));
+            return validateAccessConfig(updatingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE));
         } else if (existingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE) != null) {
             return (List<ContextPath>) existingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE);
         }
@@ -203,7 +206,7 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
             throws ActionDTOModelResolverException {
 
         if (updatingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY) != null) {
-            return validateExpose(updatingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY));
+            return validateAccessConfig(updatingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY));
         } else if (existingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY) != null) {
             return (List<ContextPath>) existingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY);
         }
@@ -211,7 +214,7 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
     }
 
     @SuppressWarnings("unchecked")
-    private List<ContextPath> validateExpose(Object exposeValue) throws ActionDTOModelResolverException {
+    private List<ContextPath> validateAccessConfig(Object exposeValue) throws ActionDTOModelResolverException {
 
         if (!(exposeValue instanceof List<?>)) {
             throw new ActionDTOModelResolverClientException("Invalid expose format.",
@@ -261,9 +264,9 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
                         String.format("Expose path '%s' must not end with a trailing '/'.", path));
             }
             if (!seen.add(path)) {
-                throw new ActionDTOModelResolverClientException("Duplicate expose path.",
-                        String.format("The expose path '%s' is duplicated.", path));
+                LOG.debug(String.format("Ignoring duplicate expose path '%s'.", path));
             }
+            //Todo: validate user/claims format
         }
     }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolver.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolver.java
@@ -239,18 +239,8 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
             }
         }
 
-        validateExposeCount(result);
         validateContextPathFormat(result);
         return result;
-    }
-
-    private void validateExposeCount(List<ContextPath> expose) throws ActionDTOModelResolverClientException {
-
-        if (expose.size() > MAX_EXPOSE_PATHS) {
-            throw new ActionDTOModelResolverClientException("Maximum expose paths limit exceeded.",
-                    String.format("The number of configured expose paths: %d exceeds the maximum allowed limit: %d.",
-                            expose.size(), MAX_EXPOSE_PATHS));
-        }
     }
 
     private void validateContextPathFormat(List<ContextPath> expose) throws ActionDTOModelResolverClientException {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/AccessConfig.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/AccessConfig.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.model;
+
+import org.wso2.carbon.identity.flow.extension.executor.PathTypeAnnotationUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Configures flow context access for external services.
+ * * - expose: Paths sent to the service; 'encrypted' flag toggles outbound JWE.
+ * - modify: Paths the service can REPLACE; 'encrypted' flag toggles inbound JWE.
+ * * Note: External certificates are managed on {@link FlowExtensionAction#getCertificate()}, not here.
+ */
+public class AccessConfig {
+
+    private final List<ContextPath> expose;
+    private final List<ContextPath> modify;
+
+    /**
+     * Constructs an AccessConfig with the given expose and modify paths.
+     *
+     * @param expose List of expose path entries. May be {@code null}.
+     * @param modify List of modify path entries. May be {@code null}.
+     */
+    public AccessConfig(List<ContextPath> expose, List<ContextPath> modify) {
+
+        this.expose = expose != null ? Collections.unmodifiableList(new ArrayList<>(expose)) : null;
+        this.modify = modify != null ? Collections.unmodifiableList(new ArrayList<>(modify)) : null;
+    }
+
+    /**
+     * Returns the list of expose path entries.
+     *
+     * @return Unmodifiable list of {@link ContextPath} entries, or {@code null} if not configured.
+     */
+    public List<ContextPath> getExpose() {
+
+        return expose;
+    }
+
+    /**
+     * Returns the flat list of expose path strings (without encryption metadata).
+     * Convenience method for components that only need path prefixes.
+     *
+     * @return List of path strings, or an empty list if expose is not configured.
+     */
+    public List<String> getExposePaths() {
+
+        if (expose == null) {
+            return Collections.emptyList();
+        }
+        return expose.stream().map(ContextPath::getPath).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the list of modify path entries.
+     *
+     * @return Unmodifiable list of {@link ContextPath} entries, or {@code null} if not configured.
+     */
+    public List<ContextPath> getModify() {
+
+        return modify;
+    }
+
+    /**
+     * Returns the flat list of modify path strings (without encryption metadata).
+     * Convenience method for components that only need path strings.
+     *
+     * @return List of path strings, or an empty list if modify is not configured.
+     */
+    public List<String> getModifyPaths() {
+
+        if (modify == null) {
+            return Collections.emptyList();
+        }
+        return modify.stream().map(ContextPath::getPath).collect(Collectors.toList());
+    }
+
+    /**
+     * Check if a given expose path has outbound encryption enabled.
+     * With leaf-only expose paths, this performs an exact match lookup.
+     *
+     * @param path The expose path to check.
+     * @return {@code true} if the matching expose entry has {@code encrypted = true}.
+     */
+    public boolean isExposePathEncrypted(String path) {
+
+        if (expose == null) {
+            return false;
+        }
+        return expose.stream()
+                .filter(ep -> ep.getPath().equals(path))
+                .findFirst()
+                .map(ContextPath::isEncrypted)
+                .orElse(false);
+    }
+
+    /**
+     * Check if a given modify path has inbound encryption enabled.
+     * Matches the modify entry whose path (after stripping type annotations) exactly equals the given path.
+     *
+     * @param path The terminal path to check (clean, without annotations).
+     * @return {@code true} if the matching modify entry has {@code encrypted = true}.
+     */
+    public boolean isModifyPathEncrypted(String path) {
+
+        if (modify == null) {
+            return false;
+        }
+        return modify.stream()
+                .filter(mp -> path.equals(PathTypeAnnotationUtil.stripAnnotation(mp.getPath())[0]))
+                .findFirst()
+                .map(ContextPath::isEncrypted)
+                .orElse(false);
+    }
+
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/ContextPath.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/ContextPath.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Domain model for a context path with an optional encryption flag.
+ * Used for both expose and modify path entries in {@link AccessConfig}.
+ * <p>
+ * When {@code encrypted} is {@code true}, the value at this path prefix is JWE-encrypted:
+ * for expose paths, outbound values are encrypted with the external service's certificate;
+ * for modify paths, inbound values from the external service are encrypted with IS's key.
+ * </p>
+ */
+public class ContextPath {
+
+    private final String path;
+    private final boolean encrypted;
+
+    @JsonCreator
+    public ContextPath(@JsonProperty("path") String path,
+                       @JsonProperty("encrypted") boolean encrypted) {
+
+        this.path = path;
+        this.encrypted = encrypted;
+    }
+
+    /**
+     * Returns the hierarchical path prefix (e.g. {@code "/user/credentials/"}).
+     *
+     * @return The path string.
+     */
+    public String getPath() {
+
+        return path;
+    }
+
+    /**
+     * Returns whether values at this path should be JWE-encrypted before sending
+     * to the external service.
+     *
+     * @return {@code true} if encryption is enabled for this path.
+     */
+    public boolean isEncrypted() {
+
+        return encrypted;
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionAction.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionAction.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.model;
+
+import org.wso2.carbon.identity.action.management.api.model.Action;
+import org.wso2.carbon.identity.action.management.api.model.EndpointConfig;
+import org.wso2.carbon.identity.certificate.management.model.Certificate;
+
+import java.sql.Timestamp;
+
+/**
+ * Flow Extension Action.
+ * <p>
+ * Extends the base {@link Action} with an {@link AccessConfig} that defines what flow context data
+ * is exposed to the external service and which operations are allowed.
+ * </p>
+ */
+public class FlowExtensionAction extends Action {
+
+    private final AccessConfig accessConfig;
+    private final Certificate certificate;
+    private final String iconUrl;
+
+    public FlowExtensionAction(ResponseBuilder responseBuilder) {
+
+        super(responseBuilder);
+        this.accessConfig = responseBuilder.accessConfig;
+        this.certificate = responseBuilder.certificate;
+        this.iconUrl = responseBuilder.iconUrl;
+    }
+
+    public FlowExtensionAction(RequestBuilder requestBuilder) {
+
+        super(requestBuilder);
+        this.accessConfig = requestBuilder.accessConfig;
+        this.certificate = requestBuilder.certificate;
+        this.iconUrl = requestBuilder.iconUrl;
+    }
+
+    /**
+     * Returns the default access configuration for this In-Flow Extension action.
+     *
+     * @return The access config, or {@code null} if not configured.
+     */
+    public AccessConfig getAccessConfig() {
+
+        return accessConfig;
+    }
+
+    /**
+     * Returns the external service's X.509 public certificate used for outbound JWE encryption
+     * of expose-path values marked {@code encrypted: true}.
+     *
+     * @return The certificate, or {@code null} if not configured.
+     */
+    public Certificate getCertificate() {
+
+        return certificate;
+    }
+
+    /**
+     * Returns the icon URL for this In-Flow Extension action.
+     *
+     * @return The icon URL, or {@code null} if not configured.
+     */
+    public String getIconUrl() {
+
+        return iconUrl;
+    }
+
+    /**
+     * Response Builder for FlowExtensionAction.
+     * Used when building from persisted data (DAO → service layer).
+     */
+    public static class ResponseBuilder extends ActionResponseBuilder {
+
+        private AccessConfig accessConfig;
+        private Certificate certificate;
+        private String iconUrl;
+
+        @Override
+        public ResponseBuilder id(String id) {
+
+            super.id(id);
+            return this;
+        }
+
+        @Override
+        public ResponseBuilder type(ActionTypes type) {
+
+            super.type(type);
+            return this;
+        }
+
+        @Override
+        public ResponseBuilder name(String name) {
+
+            super.name(name);
+            return this;
+        }
+
+        @Override
+        public ResponseBuilder description(String description) {
+
+            super.description(description);
+            return this;
+        }
+
+        @Override
+        public ResponseBuilder status(Status status) {
+
+            super.status(status);
+            return this;
+        }
+
+        @Override
+        public ResponseBuilder actionVersion(String actionVersion) {
+
+            super.actionVersion(actionVersion);
+            return this;
+        }
+
+        @Override
+        public ResponseBuilder createdAt(Timestamp createdAt) {
+
+            super.createdAt(createdAt);
+            return this;
+        }
+
+        @Override
+        public ResponseBuilder updatedAt(Timestamp updatedAt) {
+
+            super.updatedAt(updatedAt);
+            return this;
+        }
+
+        @Override
+        public ResponseBuilder endpoint(EndpointConfig endpoint) {
+
+            super.endpoint(endpoint);
+            return this;
+        }
+
+        @Override
+        public ResponseBuilder rule(org.wso2.carbon.identity.action.management.api.model.ActionRule rule) {
+
+            super.rule(rule);
+            return this;
+        }
+
+        public ResponseBuilder accessConfig(AccessConfig accessConfig) {
+
+            this.accessConfig = accessConfig;
+            return this;
+        }
+
+        public ResponseBuilder certificate(Certificate certificate) {
+
+            this.certificate = certificate;
+            return this;
+        }
+
+        public ResponseBuilder iconUrl(String iconUrl) {
+
+            this.iconUrl = iconUrl;
+            return this;
+        }
+
+        @Override
+        public FlowExtensionAction build() {
+
+            return new FlowExtensionAction(this);
+        }
+    }
+
+    /**
+     * Request Builder for FlowExtensionAction.
+     * Used when building from REST API request (API → service layer).
+     */
+    public static class RequestBuilder extends ActionRequestBuilder {
+
+        private AccessConfig accessConfig;
+        private Certificate certificate;
+        private String iconUrl;
+
+        public RequestBuilder(Action action) {
+
+            name(action.getName());
+            description(action.getDescription());
+            actionVersion(action.getActionVersion());
+            endpoint(action.getEndpoint());
+            rule(action.getActionRule());
+        }
+
+        @Override
+        public RequestBuilder name(String name) {
+
+            super.name(name);
+            return this;
+        }
+
+        @Override
+        public RequestBuilder description(String description) {
+
+            super.description(description);
+            return this;
+        }
+
+        @Override
+        public RequestBuilder endpoint(EndpointConfig endpoint) {
+
+            super.endpoint(endpoint);
+            return this;
+        }
+
+        public RequestBuilder accessConfig(AccessConfig accessConfig) {
+
+            this.accessConfig = accessConfig;
+            return this;
+        }
+
+        public RequestBuilder certificate(Certificate certificate) {
+
+            this.certificate = certificate;
+            return this;
+        }
+
+        public RequestBuilder iconUrl(String iconUrl) {
+
+            this.iconUrl = iconUrl;
+            return this;
+        }
+
+        @Override
+        public FlowExtensionAction build() {
+
+            return new FlowExtensionAction(this);
+        }
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/pom.xml
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/pom.xml
@@ -131,6 +131,16 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <excludeFilterFile>../../../spotbugs-exclude.xml</excludeFilterFile>
+                    <effort>Max</effort>
+                    <threshold>High</threshold>
+                    <xmlOutput>true</xmlOutput>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>

--- a/components/flow-orchestration-framework/pom.xml
+++ b/components/flow-orchestration-framework/pom.xml
@@ -37,6 +37,7 @@
     <modules>
         <module>org.wso2.carbon.identity.flow.mgt</module>
         <module>org.wso2.carbon.identity.flow.execution.engine</module>
+        <module>org.wso2.carbon.identity.flow.extension</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Proposed changes in this pull request
- Introduce a new `FLOW_EXTENSION` action type and `FLOW_EXTENSION` category in `Action` / `ActionType` to allow configuring extension points within any flow via a custom service.
- Wire up the new action type through:
  - `ActionExecutorServiceImpl` and `ActionExecutorConfig` (execution side)
  - `ActionManagementServiceImpl`, `ActionDTOModelResolverFactory`, `ActionConverterFactory`, and `ActionManagementConfig` (management side)
- Add new error codes in `ErrorMessage` for attribute validation, unsupported attributes, attribute limit, and duplicate action names within the same action type.
- Extend the `User` model with additional fields needed by the new flow extension execution path.
- Update `ActionTypesTest` to cover the new type.

## When should reviewers check this pull request?
- Review the new `FLOW_EXTENSION` semantics — particularly the new `Category.FLOW_EXTENSION` and whether duplicate-name uniqueness should be scoped per action type as implemented.
- Validate the new error codes (`60011`–`60015`) and messages.
- Confirm the configuration knobs added to `ActionExecutorConfig` / `ActionManagementConfig` are named and defaulted correctly.

> **Draft:** still in progress — additional tests, doc updates, and possible attribute-validation tightening to follow.

## Related issues
N/A