### PR TITLE
Fix Bug in Agent Token obtain when email as username feature enabled

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -204,6 +204,8 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUTH_ENTITY;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUTH_ENTITY_AGENT;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AdaptiveAuthentication.AUTHENTICATOR_NAME_IN_AUTH_CONFIG;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Application.CONSOLE_APP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Application.CONSOLE_APP_PATH;
@@ -4282,6 +4284,11 @@ public class FrameworkUtils {
             throws InvalidCredentialsException {
 
         if (IdentityUtil.isEmailUsernameEnabled()) {
+            if (context != null && context.getProperties() != null
+                    && context.getProperties().containsKey(AUTH_ENTITY)
+                    && AUTH_ENTITY_AGENT.equals(context.getProperty(AUTH_ENTITY))) {
+                return;
+            }
             String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
             if (StringUtils.countMatches(tenantAwareUsername, "@") < 1) {
                 context.setProperty(CONTEXT_PROP_INVALID_EMAIL_USERNAME, true);


### PR DESCRIPTION
When email as username feature enabled then when try to get agent token it get failed in authn endpoint because it failed at the validateUsername section. The reason is that Agent username is not a email but a randomly generated UUID hence it throws an error saying username is not a valid email. 

As a fix for that inside the validateUsername function check where this context has the aget_identity param with the agent as the value if yes that means this is an agent. For agents we don't validate the username instead return from that function. 

Related Issue:- https://github.com/wso2/product-is/issues/27856