### PR TITLE
[InFlow-Extentions] Remove creds map from accessConfig temporarily.

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeBuilder.java
@@ -127,26 +127,26 @@ public class FlowExtensionContextTreeBuilder {
                 .children(Collections.emptyList())
                 .build());
 
-        List<FlowExtensionContextTreeNode> credentialsChildren = new ArrayList<>();
-        credentialsChildren.add(FlowExtensionContextTreeNode.builder()
-                .key("password")
-                .title("Password")
-                .path("/user/credentials/password")
-                .dataType("char[]")
-                .nodeType(ContextTree.NODE_LEAF)
-                .allowedOperations(Arrays.asList(ContextTree.OP_EXPOSE, ContextTree.OP_MODIFY))
-                .build());
-
-        children.add(FlowExtensionContextTreeNode.builder()
-                .key("credentials")
-                .title("Credentials")
-                .path("/user/credentials/")
-                .dataType("Map<String, char[]>")
-                .nodeType(ContextTree.NODE_MAP)
-                .allowedOperations(Arrays.asList(ContextTree.OP_EXPOSE, ContextTree.OP_MODIFY))
-                .dynamicEntryAllowed(false)
-                .children(credentialsChildren)
-                .build());
+//        List<FlowExtensionContextTreeNode> credentialsChildren = new ArrayList<>();
+//        credentialsChildren.add(FlowExtensionContextTreeNode.builder()
+//                .key("password")
+//                .title("Password")
+//                .path("/user/credentials/password")
+//                .dataType("char[]")
+//                .nodeType(ContextTree.NODE_LEAF)
+//                .allowedOperations(Arrays.asList(ContextTree.OP_EXPOSE, ContextTree.OP_MODIFY))
+//                .build());
+//
+//        children.add(FlowExtensionContextTreeNode.builder()
+//                .key("credentials")
+//                .title("Credentials")
+//                .path("/user/credentials/")
+//                .dataType("Map<String, char[]>")
+//                .nodeType(ContextTree.NODE_MAP)
+//                .allowedOperations(Arrays.asList(ContextTree.OP_EXPOSE, ContextTree.OP_MODIFY))
+//                .dynamicEntryAllowed(false)
+//                .children(credentialsChildren)
+//                .build());
 
         return FlowExtensionContextTreeNode.builder()
                 .key("user")


### PR DESCRIPTION
This pull request makes a targeted change to the `FlowExtensionContextTreeBuilder.java` file by commenting out the code responsible for adding the `credentials` node (and its child `password`) to the user context tree. This effectively removes the credentials section from the context tree structure.

Context tree structure changes:

* Commented out the creation and addition of the `credentials` node (and its `password` child) to the user context tree, removing the exposure and modification of credentials in the context metadata.