### PR TITLE
[InflowExtentions] - Normalise claim paths.

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/Constants.java
@@ -168,7 +168,7 @@ public class Constants {
                 "Error occurred while processing policy consent for the %s request of flow id: %s."),
         ERROR_CODE_INFLOW_EXTENSION_ERROR("65034",
                 "Error occurred while invoking the flow extension.",
-                "%s"),
+                "Error occurred while invoking the flow extension."),
 
         // Client errors.
         ERROR_CODE_INVALID_FLOW_ID("60001",
@@ -220,8 +220,8 @@ public class Constants {
                 "Password does not meet the required format.",
                 "The provided password does not meet the configured format requirements."),
         ERROR_CODE_INFLOW_EXTENSION_FAILURE("60017",
-                "%s",
-                "%s")
+                "Flow extension execution failed.",
+                "Something went wrong while executing the flow extension. Please try again.")
         ;
 
         private static final String ERROR_PREFIX = "FE";

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionExecutor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionExecutor.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.flow.extension.executor;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionException;
@@ -167,7 +168,6 @@ public class FlowExtensionExecutor implements Executor {
 
             case FAILED:
                 handleFailedStatus(response, executionStatus);
-                applyRetryMetadata(response, actionId);
                 return response;
 
             case ERROR:
@@ -180,27 +180,6 @@ public class FlowExtensionExecutor implements Executor {
             default:
                 return handleUnknownExecutionStatus(response, executionStatus);
         }
-    }
-
-    /**
-     * Build a user-facing error message from the failure details returned by the external service.
-     * Prefers the failureDescription (human-readable). Falls back to failureReason if description is absent.
-     *
-     * @param failure The failure object from the external service.
-     * @return A display-ready error message string.
-     */
-    private String buildUserFacingErrorMessage(Failure failure) {
-
-        String description = failure.getFailureDescription();
-        String reason = failure.getFailureReason();
-
-        if (description != null && !description.isEmpty()) {
-            return description;
-        }
-        if (reason != null && !reason.isEmpty()) {
-            return reason;
-        }
-        return "The operation could not be completed due to an external service failure.";
     }
 
     private ExecutorResponse buildErrorResponse(String errorMessage, String errorDescription) {
@@ -231,36 +210,17 @@ public class FlowExtensionExecutor implements Executor {
 
     private void handleFailedStatus(ExecutorResponse response, ActionExecutionStatus<?> executionStatus) {
 
-        response.setResult(ExecutorStatus.STATUS_RETRY);
+        response.setResult(ExecutorStatus.STATUS_USER_ERROR);
         Failure failure = (Failure) executionStatus.getResponse();
-        if (failure == null) {
-            return;
-        }
 
-        Map<String, String> failureInfo = new HashMap<>();
-        if (failure.getFailureReason() != null) {
-            failureInfo.put(FlowExtensionConstants.FAILURE_MESSAGE_KEY, failure.getFailureReason());
-        }
-        if (failure.getFailureDescription() != null) {
-            failureInfo.put(FlowExtensionConstants.FAILURE_DESCRIPTION_KEY, failure.getFailureDescription());
-        }
-        response.setAdditionalInfo(failureInfo);
+        String failureReason = StringUtils.isNotBlank(failure.getFailureReason()) ? failure.getFailureReason() :
+                Constants.ErrorMessages.ERROR_CODE_INFLOW_EXTENSION_FAILURE.getMessage();
+        String failureDescription = StringUtils.isNotBlank(failure.getFailureDescription()) ? failure.getFailureDescription() :
+                Constants.ErrorMessages.ERROR_CODE_INFLOW_EXTENSION_FAILURE.getDescription();
+
         response.setErrorCode(Constants.ErrorMessages.ERROR_CODE_INFLOW_EXTENSION_FAILURE.getCode());
-
-        String reason = failure.getFailureReason();
-        String description = failure.getFailureDescription();
-
-        if (reason != null && !reason.isEmpty()) {
-            response.setErrorMessage(reason);
-        } else {
-            response.setErrorMessage("The operation could not be completed.");
-        }
-
-        if (description != null && !description.isEmpty()) {
-            response.setErrorDescription(description);
-        } else {
-            response.setErrorDescription(buildUserFacingErrorMessage(failure));
-        }
+        response.setErrorMessage(failureReason);
+        response.setErrorDescription(failureDescription);
     }
 
     private void handleErrorStatus(ExecutorResponse response, ActionExecutionStatus<?> executionStatus) {
@@ -272,8 +232,13 @@ public class FlowExtensionExecutor implements Executor {
             return;
         }
 
-        response.setErrorMessage(error.getErrorMessage());
-        response.setErrorDescription(error.getErrorDescription());
+        String errorMessage = StringUtils.isNotBlank(error.getErrorMessage()) ? error.getErrorMessage() :
+                Constants.ErrorMessages.ERROR_CODE_INFLOW_EXTENSION_ERROR.getMessage();
+        String errorDescription = StringUtils.isNotBlank(error.getErrorDescription()) ? error.getErrorDescription() :
+                Constants.ErrorMessages.ERROR_CODE_INFLOW_EXTENSION_ERROR.getDescription();
+
+        response.setErrorMessage(errorMessage);
+        response.setErrorDescription(errorDescription);
     }
 
     private ExecutorResponse handleIncompleteExecutionStatus(ExecutorResponse response, FlowContext flowContext,
@@ -307,11 +272,11 @@ public class FlowExtensionExecutor implements Executor {
     private ExecutorResponse handleUnknownExecutionStatus(ExecutorResponse response,
                                                           ActionExecutionStatus<?> executionStatus) {
 
-        LOG.warn("Unknown execution status: " + executionStatus.getStatus());
+        LOG.error("Unknown execution status: " + executionStatus.getStatus());
         response.setResult(ExecutorStatus.STATUS_ERROR);
         response.setErrorCode(Constants.ErrorMessages.ERROR_CODE_INFLOW_EXTENSION_ERROR.getCode());
         response.setErrorMessage(Constants.ErrorMessages.ERROR_CODE_INFLOW_EXTENSION_ERROR.getMessage());
-        response.setErrorDescription("The Flow Extension returned an unrecognised status. Please try again.");
+        response.setErrorDescription("The Flow Extension returned an unrecognized status.");
         return response;
     }
 
@@ -391,7 +356,7 @@ public class FlowExtensionExecutor implements Executor {
         if (actionExecutorService == null) {
             throw FlowExecutionEngineUtils.handleServerException(
                     Constants.ErrorMessages.ERROR_CODE_INFLOW_EXTENSION_ERROR,
-                    "ActionExecutorService is not available. actionId: " + actionId);
+                    "ActionExecutorService is not available.");
         }
         return actionExecutorService;
     }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
@@ -371,7 +371,7 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
                     if (annotation != null) {
                         pathTypeAnnotations.put(cleanPath, annotation);
                     }
-                    cleanPaths.add(toExternalPath(cleanPath));
+                    cleanPaths.add(cleanPath);
                 } else {
                     LOG.warn("Annotation for path " + cleanPath
                             + " exceeds maximum attribute limit. Skipping path.");
@@ -541,7 +541,7 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
                                                 AccessConfig accessConfig, String certificatePEM)
             throws ActionExecutionRequestBuilderException {
 
-        if (!isAreaExposed(FlowContextPaths.USER_CLAIMS_PATH_PREFIX, expose)) {
+        if (!isAreaExposed(FlowContextPaths.USER_CLAIMS_SELECTOR_PREFIX, expose)) {
             return Collections.emptyList();
         }
 
@@ -549,18 +549,35 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
         List<UserClaim> userClaims = new ArrayList<>();
 
         for (String exposePath : expose) {
-            if (!exposePath.startsWith(FlowContextPaths.USER_CLAIMS_PATH_PREFIX)) {
+            String claimUri = extractClaimUriFromSelectorPath(exposePath);
+            if (claimUri == null) {
                 continue;
             }
-            String claimKey = exposePath.substring(FlowContextPaths.USER_CLAIMS_PATH_PREFIX.length());
-            String claimValue = claims != null ? claims.get(claimKey) : null;
+            String claimValue = claims != null ? claims.get(claimUri) : null;
             claimValue = claimValue != null ? claimValue : "";
             if (!claimValue.isEmpty() && shouldEncrypt(exposePath, accessConfig, certificatePEM)) {
                 claimValue = encryptValue(claimValue, certificatePEM);
             }
-            userClaims.add(new UserClaim(claimKey, claimValue));
+            userClaims.add(new UserClaim(claimUri, claimValue));
         }
         return userClaims;
+    }
+
+    /**
+     * Extract the claim URI from a selector-format path.
+     * Accepts {@code /user/claims[uri=<claimUri>]} and returns the claim URI.
+     * Returns {@code null} if the path does not match the selector format.
+     */
+    private static String extractClaimUriFromSelectorPath(String path) {
+
+        if (path != null
+                && path.startsWith(FlowContextPaths.USER_CLAIMS_SELECTOR_PREFIX)
+                && path.endsWith(FlowContextPaths.USER_CLAIMS_SELECTOR_SUFFIX)) {
+            return path.substring(
+                    FlowContextPaths.USER_CLAIMS_SELECTOR_PREFIX.length(),
+                    path.length() - FlowContextPaths.USER_CLAIMS_SELECTOR_SUFFIX.length());
+        }
+        return null;
     }
 
     private static class ExposeResolution {
@@ -613,23 +630,6 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
 
             return skippedPaths;
         }
-    }
-
-    /**
-     * Convert an internal path to its external (API-facing) form.
-     * User-claim paths stored internally as {@code /user/claims/<uri>} are emitted
-     * externally as {@code /user/claims[uri=<uri>]}. All other paths are unchanged.
-     */
-    private static String toExternalPath(String internalPath) {
-
-        if (internalPath != null
-                && internalPath.startsWith(FlowContextPaths.USER_CLAIMS_PATH_PREFIX)) {
-            String claimUri = internalPath.substring(
-                    FlowContextPaths.USER_CLAIMS_PATH_PREFIX.length());
-            return FlowContextPaths.USER_CLAIMS_SELECTOR_PREFIX + claimUri
-                    + FlowContextPaths.USER_CLAIMS_SELECTOR_SUFFIX;
-        }
-        return internalPath;
     }
 
     /**

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
@@ -405,21 +405,14 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
     }
 
     /**
-     * Normalize an external-format claim path to the internal format for encryption checks.
-     * Converts {@code /user/claims[uri=<claimUri>]} to {@code /user/claims/<claimUri>}.
-     * All other paths are returned unchanged.
+     * Normalize a claim path for encryption checks.
+     * Internal and external formats now both use the selector form
+     * {@code /user/claims[uri=<claimUri>]}, so no conversion is needed.
+     * All paths are returned unchanged.
      */
-    private static String normalizeToInternalPath(String externalPath) {
+    private static String normalizeToInternalPath(String path) {
 
-        if (externalPath != null
-                && externalPath.startsWith(FlowExtensionConstants.FlowContextPaths.USER_CLAIMS_SELECTOR_PREFIX)
-                && externalPath.endsWith(FlowExtensionConstants.FlowContextPaths.USER_CLAIMS_SELECTOR_SUFFIX)) {
-            String claimUri = externalPath.substring(
-                    FlowExtensionConstants.FlowContextPaths.USER_CLAIMS_SELECTOR_PREFIX.length(),
-                    externalPath.length() - FlowExtensionConstants.FlowContextPaths.USER_CLAIMS_SELECTOR_SUFFIX.length());
-            return FlowExtensionConstants.FlowContextPaths.USER_CLAIMS_PATH_PREFIX + claimUri;
-        }
-        return externalPath;
+        return path;
     }
 
     @Override

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeBuilder.java
@@ -118,7 +118,7 @@ public class FlowExtensionContextTreeBuilder {
         children.add(FlowExtensionContextTreeNode.builder()
                 .key("claims")
                 .title("Claims")
-                .path("/user/claims/")
+                .path("/user/claims")
                 .dataType("Map<String, String>")
                 .nodeType(ContextTree.NODE_MAP)
                 .allowedOperations(Arrays.asList(ContextTree.OP_EXPOSE, ContextTree.OP_MODIFY))


### PR DESCRIPTION
This pull request standardizes the representation of user claim paths throughout the flow orchestration framework. The main change is the consistent use of the selector format (`/user/claims[uri=<claimUri>]`) for claim paths, both internally and externally, simplifying path handling and reducing conversion logic. Several methods have been updated or removed to reflect this change.

**Path representation standardization:**

* All claim paths now use the selector format (`/user/claims[uri=<claimUri>]`) internally and externally, eliminating the need for conversion between formats. [[1]](diffhunk://#diff-687b08fed67996fa2ff543e22e284f96ab15dd6e5364df72794f8154c1339b55L544-R582) [[2]](diffhunk://#diff-78e5573477fe458cbbd87f496f83886ff7e4791d6bee4ec60c188d810f2e3597L408-R415)
* The `toExternalPath` method, which previously converted internal claim paths to the selector format for external use, has been removed as it is no longer necessary.
* The `normalizeToInternalPath` method in `FlowExtensionResponseProcessor.java` has been simplified to return the path unchanged, reflecting the unified format.

**Claim path extraction and validation:**

* Added the `extractClaimUriFromSelectorPath` method to reliably extract the claim URI from selector-format paths, ensuring correct claim handling in `buildFilteredClaims`.

**Context tree metadata update:**

* Updated the context tree builder to use `/user/claims` (without a trailing slash) as the path for claims, reflecting the new standard.