### PR TITLE
[InflowExtensions] - Handle multi-valued attribute onboarding.

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
@@ -61,6 +61,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Processes responses from In-Flow Extension actions, applying {@code REPLACE} operations on
@@ -85,6 +86,7 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
     private static final Log LOG = LogFactory.getLog(FlowExtensionResponseProcessor.class);
     private static final String ERROR_VALUE_REQUIRED_FOR_REPLACE = "Value is required for REPLACE operation.";
     private static final String DIAG_PARAM_ACTION_TYPE = "actionType";
+    private static final String MULTI_VALUED_CLAIM_PROPERTY = "multiValued";
 
     @Override
     public ActionType getSupportedActionType() {
@@ -295,12 +297,14 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
                     "Identity-system claims cannot be modified by In-Flow Extensions: " + claimUri);
         }
 
-        if (!validateLocalClaimExists(claimUri, tenantDomain)) {
+        Optional<LocalClaim> optionalLocalClaim = getLocalClaim(claimUri, tenantDomain);
+        if (optionalLocalClaim.isEmpty()) {
             return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
                     "Unknown local claim URI: " + claimUri);
         }
 
-        pendingClaims.put(claimUri, String.valueOf(operation.getValue()));
+        String resolvedClaimValue = getResolvedClaimValue(operation.getValue(), optionalLocalClaim.get());
+        pendingClaims.put(claimUri, resolvedClaimValue);
         return new OperationExecutionResult(operation, OperationExecutionResult.Status.SUCCESS,
                 "User claim replace applied.");
     }
@@ -319,7 +323,7 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
      * @throws ActionExecutionResponseProcessorException if the claim metadata service is
      *         unavailable or the lookup throws.
      */
-    private boolean validateLocalClaimExists(String claimUri, String tenantDomain)
+    private Optional<LocalClaim> getLocalClaim(String claimUri, String tenantDomain)
             throws ActionExecutionResponseProcessorException {
 
         org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService claimService =
@@ -329,14 +333,34 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
                     "ClaimMetadataManagementService is unavailable; cannot validate claim URI: " + claimUri);
         }
         try {
-            java.util.Optional<LocalClaim> localClaim = claimService.getLocalClaim(claimUri, tenantDomain);
-            return localClaim.isPresent();
+            return claimService.getLocalClaim(claimUri, tenantDomain);
         } catch (ClaimMetadataException e) {
             throw new ActionExecutionResponseProcessorException(
                     "Failed to look up local claim '" + claimUri + "' in tenant '" + tenantDomain + "'.", e);
         }
     }
 
+    private String getResolvedClaimValue(Object operationValue, LocalClaim localClaim) throws
+            ActionExecutionResponseProcessorException {
+
+        if (isMultiValuedClaim(localClaim)) {
+            if (operationValue instanceof List) {
+                List<String> valueList = (List<String>) operationValue;
+                return StringUtils.join(valueList, ",");
+            }
+            throw new ActionExecutionResponseProcessorException(
+                    "Expected a list value for multi-valued claim: " + localClaim.getClaimURI());
+        } else if (operationValue instanceof String) {
+            return String.valueOf(operationValue);
+        }
+        throw new ActionExecutionResponseProcessorException(
+                "Expected a string value for single-valued claim: " + localClaim.getClaimURI());
+    }
+
+    private boolean isMultiValuedClaim(LocalClaim localClaim) {
+
+        return Boolean.parseBoolean(localClaim.getClaimProperty(MULTI_VALUED_CLAIM_PROPERTY));
+    }
     /**
      * Handle REPLACE operation on user credentials — collect into pending credentials map.
      * No key validation is applied; any credential key is accepted. The value is converted

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
@@ -309,20 +309,6 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
                 "User claim replace applied.");
     }
 
-    /**
-     * Validate that the given claim URI corresponds to a registered local claim in the tenant.
-     * Infrastructure failures (claim metadata service unavailable, or the lookup itself throwing)
-     * are treated as contract-level: this method throws
-     * {@link ActionExecutionResponseProcessorException} and the whole response aborts. A clean
-     * "claim does not exist" result is returned as {@code false} so the caller can drop the
-     * single offending operation per the per-operation failure policy.
-     *
-     * @param claimUri     Local claim URI to check.
-     * @param tenantDomain Tenant domain for the lookup.
-     * @return {@code true} if the claim is registered in the tenant, {@code false} otherwise.
-     * @throws ActionExecutionResponseProcessorException if the claim metadata service is
-     *         unavailable or the lookup throws.
-     */
     private Optional<LocalClaim> getLocalClaim(String claimUri, String tenantDomain)
             throws ActionExecutionResponseProcessorException {
 


### PR DESCRIPTION
This pull request refactors and improves the handling of user claim operations in the `FlowExtensionResponseProcessor` class. The main focus is on better validation and processing of claim values, especially for multi-valued claims. The code now retrieves the full `LocalClaim` object for more robust handling and introduces logic to correctly process both single-valued and multi-valued claims.

**User claim operation enhancements:**

* Replaced the validation method `validateLocalClaimExists` with `getLocalClaim`, which retrieves the full `LocalClaim` object instead of just checking existence. This allows for more detailed claim property handling. [[1]](diffhunk://#diff-78e5573477fe458cbbd87f496f83886ff7e4791d6bee4ec60c188d810f2e3597L322-R326) [[2]](diffhunk://#diff-78e5573477fe458cbbd87f496f83886ff7e4791d6bee4ec60c188d810f2e3597L332-R363)
* Modified claim value processing to use a new method `getResolvedClaimValue`, which distinguishes between single-valued and multi-valued claims, ensuring that multi-valued claims are handled as comma-separated lists. [[1]](diffhunk://#diff-78e5573477fe458cbbd87f496f83886ff7e4791d6bee4ec60c188d810f2e3597L298-R307) [[2]](diffhunk://#diff-78e5573477fe458cbbd87f496f83886ff7e4791d6bee4ec60c188d810f2e3597L332-R363)
* Added a new constant `MULTI_VALUED_CLAIM_PROPERTY` and supporting methods to determine if a claim is multi-valued and to process its value accordingly. [[1]](diffhunk://#diff-78e5573477fe458cbbd87f496f83886ff7e4791d6bee4ec60c188d810f2e3597R89) [[2]](diffhunk://#diff-78e5573477fe458cbbd87f496f83886ff7e4791d6bee4ec60c188d810f2e3597L332-R363)

These changes improve the correctness and flexibility of claim value handling in the flow extension framework.