### PR TITLE
[inFlowExtensions] Include patch operations in resource-access-control-v2.xml.j2

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -1795,7 +1795,7 @@
     <Resource context="(.*)/o/api/server/v1/flow/extension" secured="true" http-method="POST">
         <Scopes>internal_org_flow_extension_create</Scopes>
     </Resource>
-    <Resource context="(.*)/o/api/server/v1/flow/extension/(.*)" secured="true" http-method="PUT">
+    <Resource context="(.*)/o/api/server/v1/flow/extension/(.*)" secured="true" http-method="PUT, PATCH">
         <Scopes>internal_org_flow_extension_update</Scopes>
     </Resource>
     <Resource context="(.*)/o/api/server/v1/flow/extension/(.*)" secured="true" http-method="DELETE">
@@ -1809,7 +1809,7 @@
     <Resource context="(.*)/api/server/v1/flow/extension" secured="true" http-method="POST">
         <Scopes>internal_flow_extension_create</Scopes>
     </Resource>
-    <Resource context="(.*)/api/server/v1/flow/extension/(.*)" secured="true" http-method="PUT">
+    <Resource context="(.*)/api/server/v1/flow/extension/(.*)" secured="true" http-method="PUT, PATCH">
         <Scopes>internal_flow_extension_update</Scopes>
     </Resource>
     <Resource context="(.*)/api/server/v1/flow/extension/(.*)" secured="true" http-method="DELETE">

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -1981,7 +1981,7 @@
         <Resource context="(.*)/o/api/server/v1/flow/extension" secured="true" http-method="POST">
             <Scopes>internal_org_flow_extension_create</Scopes>
         </Resource>
-        <Resource context="(.*)/o/api/server/v1/flow/extension/(.*)" secured="true" http-method="PUT">
+        <Resource context="(.*)/o/api/server/v1/flow/extension/(.*)" secured="true" http-method="PUT, PATCH">
             <Scopes>internal_org_flow_extension_update</Scopes>
         </Resource>
         <Resource context="(.*)/o/api/server/v1/flow/extension/(.*)" secured="true" http-method="DELETE">
@@ -1995,7 +1995,7 @@
         <Resource context="(.*)/api/server/v1/flow/extension" secured="true" http-method="POST">
             <Scopes>internal_flow_extension_create</Scopes>
         </Resource>
-        <Resource context="(.*)/api/server/v1/flow/extension/(.*)" secured="true" http-method="PUT">
+        <Resource context="(.*)/api/server/v1/flow/extension/(.*)" secured="true" http-method="PUT, PATCH">
             <Scopes>internal_flow_extension_update</Scopes>
         </Resource>
         <Resource context="(.*)/api/server/v1/flow/extension/(.*)" secured="true" http-method="DELETE">


### PR DESCRIPTION
This pull request updates the resource access control configuration to allow both PUT and PATCH HTTP methods for updating flow extensions in the relevant API endpoints. This change ensures that PATCH requests, in addition to PUT, are now permitted for these endpoints, aligning the access control rules with possible API usage.

Access control updates:

* Updated the `resource-access-control-v2.xml` and its template (`resource-access-control-v2.xml.j2`) to allow both PUT and PATCH methods (instead of just PUT) for the `/o/api/server/v1/flow/extension/(.*)` and `/api/server/v1/flow/extension/(.*)` endpoints, under the `internal_org_flow_extension_update` and `internal_flow_extension_update` scopes, respectively. [[1]](diffhunk://#diff-8d3e33818f8d0a815cd470310be01f25928d196ce5ad9992cd21a2f7b81ca9aaL1798-R1798) [[2]](diffhunk://#diff-8d3e33818f8d0a815cd470310be01f25928d196ce5ad9992cd21a2f7b81ca9aaL1812-R1812) [[3]](diffhunk://#diff-c1d66ea18073ea8342745dd465ae3028cc45019079d18f6c838c8d2cfb94da50L1984-R1984) [[4]](diffhunk://#diff-c1d66ea18073ea8342745dd465ae3028cc45019079d18f6c838c8d2cfb94da50L1998-R1998)