### PR TITLE
[InFlowExtension] Rename flow-extension to flow/extension.

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -2204,7 +2204,7 @@
                    description="Delete flow in the organization"/>
         </Scopes>
     </APIResource>
-    <APIResource name="Flow Extension Management API" identifier="/api/server/v1/flow/flow-extension"
+    <APIResource name="Flow Extension Management API" identifier="/api/server/v1/flow/extension"
                  requiresAuthorization="true"
                  description="API representation of the Flow Extension Management API" type="TENANT">
         <Scopes>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -2218,7 +2218,7 @@
                    description="Delete flow extension in the organization (root)"/>
         </Scopes>
     </APIResource>
-    <APIResource name="Flow Extension Management API" identifier="/o/api/server/v1/flow/flow-extension"
+    <APIResource name="Flow Extension Management API" identifier="/o/api/server/v1/flow/extension"
                  requiresAuthorization="true"
                  description="API representation of the Flow Extension Management API" type="ORGANIZATION">
         <Scopes>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -2255,7 +2255,7 @@
                    description="Delete flow in the organization"/>
         </Scopes>
     </APIResource>
-    <APIResource name="Flow Extension Management API" identifier="/api/server/v1/flow/flow-extension"
+    <APIResource name="Flow Extension Management API" identifier="/api/server/v1/flow/extension"
                  requiresAuthorization="true"
                  description="API representation of the Flow Extension Management API" type="TENANT">
         <Scopes>
@@ -2269,7 +2269,7 @@
                    description="Delete flow extension in the organization (root)"/>
         </Scopes>
     </APIResource>
-    <APIResource name="Flow Extension Management API" identifier="/o/api/server/v1/flow/flow-extension"
+    <APIResource name="Flow Extension Management API" identifier="/o/api/server/v1/flow/extension"
                  requiresAuthorization="true"
                  description="API representation of the Flow Extension Management API" type="ORGANIZATION">
         <Scopes>


### PR DESCRIPTION
This pull request updates the API resource identifiers for the Flow Extension Management API to use a simplified and consistent path. The changes affect both the main and organization-specific API resource definitions in the respective XML and Jinja2 template files.

**API Resource Identifier Updates:**

* Changed the `identifier` for the Flow Extension Management API from `/api/server/v1/flow/flow-extension` to `/api/server/v1/flow/extension` in `system-api-resource.xml`.
* Updated the same identifier in the Jinja2 template file `system-api-resource.xml.j2` for both the main API resource and the organization-specific resource from `/api/server/v1/flow/flow-extension` and `/o/api/server/v1/flow/flow-extension` to `/api/server/v1/flow/extension` and `/o/api/server/v1/flow/extension`, respectively. [[1]](diffhunk://#diff-a70225dc72f4100048a17b866cc1754e81c34fc31aa4128051d613ac4c64ed5bL2258-R2258) [[2]](diffhunk://#diff-a70225dc72f4100048a17b866cc1754e81c34fc31aa4128051d613ac4c64ed5bL2272-R2272)