### PR TITLE
Track user-updated claim URIs on FlowUser for downstream filtering

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNode.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/graph/TaskExecutionNode.java
@@ -205,7 +205,8 @@ public class TaskExecutionNode implements Node {
 
         FlowUser user = context.getFlowUser();
         if (response.getUpdatedUserClaims() != null) {
-            response.getUpdatedUserClaims().forEach((key, value) -> user.addClaim(key, String.valueOf(value)));
+            response.getUpdatedUserClaims()
+                    .forEach((key, value) -> user.addUpdatedClaim(key, String.valueOf(value)));
         }
         if (response.getUserCredentials() != null) {
             user.getUserCredentials().putAll(response.getUserCredentials());

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowUser.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowUser.java
@@ -49,10 +49,13 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.EMAIL_ADDRESS_CLAIM;
@@ -70,6 +73,7 @@ public class FlowUser implements Serializable {
     private static final String LOCAL_CREDENTIAL_EXISTS_CLAIM_URI = "http://wso2.org/claims/identity/localCredentialExists";
 
     private final Map<String, String> claims = new HashMap<>();
+    private final Set<String> updatedClaimUris = new HashSet<>();
     private List<UserConsent> userConsents = new ArrayList<>();
 
     @JsonProperty("userCredentials")
@@ -134,6 +138,28 @@ public class FlowUser implements Serializable {
     public void addClaim(String claimUri, String claimValue) {
 
         this.claims.put(claimUri, claimValue);
+    }
+
+    /**
+     * Adds a claim and marks its URI as user-updated in this flow.
+     *
+     * @param claimUri   claim URI to set and mark as updated.
+     * @param claimValue claim value.
+     */
+    public void addUpdatedClaim(String claimUri, String claimValue) {
+
+        this.claims.put(claimUri, claimValue);
+        this.updatedClaimUris.add(claimUri);
+    }
+
+    /**
+     * Returns the URIs of claims marked as user-updated via {@link #addUpdatedClaim}.
+     *
+     * @return unmodifiable view of the updated claim URI set.
+     */
+    public Set<String> getUpdatedClaimUris() {
+
+        return Collections.unmodifiableSet(updatedClaimUris);
     }
 
     public Map<String, char[]> getUserCredentials() {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
@@ -192,7 +192,7 @@ public class InputValidationService {
         context.getUserInputData().forEach(
                 (key, value) -> {
                     if (key.startsWith(CLAIM_URI_PREFIX)) {
-                        context.getFlowUser().addClaim(key, value);
+                        context.getFlowUser().addUpdatedClaim(key, value);
                     } else if (CONSENT_KEY.equals(key) || PREFERENCE_KEY.equals(key)) {
                         context.getFlowUser().addUserConsents(FlowUser.UserConsent.fromJson(value));
                     }


### PR DESCRIPTION
## Purpose

During the flow-orchestration password-recovery / ask-password flow, consumers (recovery executors) bulk-write the entire preloaded CONSOLE-profile claim snapshot back to the user store, including non-attribute claims like `role` and `roles`. On AD/LDAP user stores this fails with `NoSuchAttributeException`; on JDBC it silently rewrites unchanged claims.

To fix this in the consumer (`identity-governance`), the engine needs to distinguish claims the **user actually changed during the flow** from claims merely **preloaded for reference**. This PR adds that instrumentation to `FlowUser`.

## Changes

- `FlowUser`: add a `Set<String> updatedClaimUris` field plus `addUpdatedClaim(uri, value)` and `getUpdatedClaimUris()` accessors. The setter both stores the claim and marks its URI as user-updated; the getter returns an unmodifiable view.
- `InputValidationService.handleUserInputs`: per-step claim-typed user input is absorbed via `addUpdatedClaim` instead of `addClaim`.
- `TaskExecutionNode.handleCompleteStatus`: executor-returned `updatedUserClaims` are absorbed via `addUpdatedClaim` instead of `addClaim`.

`addClaim` / `addClaims` / `setUsername` and bulk preload sites (e.g. `ConfirmationCodeValidationExecutor.setupFlowUser`) are deliberately left on `addClaim`, so preloaded claims are **not** marked. Downstream executors can then filter on `getUpdatedClaimUris()`.

## Behaviour

Pure instrumentation — no in-tree consumer of `getUpdatedClaimUris()` in this repo, so observable behaviour for every existing flow is unchanged. The consumer that uses it is the paired `identity-governance` PR. `FlowUser` Jackson serialisation stays backward-compatible (the new field initialises to an empty set), and `serialVersionUID` is unchanged (additive field).

## Related

- Paired consumer PR: wso2-extensions/identity-governance#1131
- Public issue: https://github.com/wso2/product-is/issues/27738
