### PR TITLE
[carbon-identity-framework] Bump Jackson to 2.21.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2293,11 +2293,11 @@
         <kaptcha.wso2.version>2.3.0.wso2v1</kaptcha.wso2.version>
         <json.wso2.version>3.0.0.wso2v4</json.wso2.version>
         <json.wso2.version.range>[3.0.0.wso2v1, 4.0.0)</json.wso2.version.range>
-        <com.fasterxml.jackson.version>2.16.1</com.fasterxml.jackson.version>
-        <com.fasterxml.jackson.annotation.version>2.16.1</com.fasterxml.jackson.annotation.version>
-        <com.fasterxml.jackson.databind.version>2.16.1</com.fasterxml.jackson.databind.version>
-        <com.fasterxml.jackson.cbor.version>2.16.1</com.fasterxml.jackson.cbor.version>
-        <com.fasterxml.jackson.jaxrs-json-provider-version>2.16.1</com.fasterxml.jackson.jaxrs-json-provider-version>
+        <com.fasterxml.jackson.version>2.21.2</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.annotation.version>2.21</com.fasterxml.jackson.annotation.version>
+        <com.fasterxml.jackson.databind.version>2.21.2</com.fasterxml.jackson.databind.version>
+        <com.fasterxml.jackson.cbor.version>2.21.2</com.fasterxml.jackson.cbor.version>
+        <com.fasterxml.jackson.jaxrs-json-provider-version>2.21.2</com.fasterxml.jackson.jaxrs-json-provider-version>
         <com.fasterxml.jackson.annotation.version.range>[2.13.0, 3.0.0)</com.fasterxml.jackson.annotation.version.range>
 
         <apache.wink.version>1.1.3-incubating</apache.wink.version>


### PR DESCRIPTION
## Purpose
Upgrade Jackson Databind and related libraries to the latest stable 2.21.x release.

## Goals
- Align all Jackson artifacts to a consistent 2.21.x baseline across the IS dependency tree
- Replace the 2.16.x versions that are no longer receiving upstream fixes

## Approach
Version property bumps only — no code or logic changes. The following properties were updated in the root `pom.xml`:
- `com.fasterxml.jackson.version` → `2.21.2`
- `com.fasterxml.jackson.annotation.version` → `2.21`
- `com.fasterxml.jackson.databind.version` → `2.21.2`
- `com.fasterxml.jackson.cbor.version` → `2.21.2`
- `com.fasterxml.jackson.jaxrs-json-provider-version` → `2.21.2`