### PR TITLE
Use sub organization resident outbound provisioning configs for shared user creation

### DIFF
--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/DefaultInboundUserProvisioningListener.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/listener/DefaultInboundUserProvisioningListener.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
 import org.wso2.carbon.identity.core.context.IdentityContext;
 import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants;
 import org.wso2.carbon.identity.provisioning.IdentityProvisioningException;
@@ -65,6 +66,7 @@ public class DefaultInboundUserProvisioningListener extends AbstractIdentityUser
 
     private static final String LAST_PASSWORD_UPDATE_TIME_CLAIM =
             "http://wso2.org/claims/identity/lastPasswordUpdateTime";
+    private static final String PROCESS_ADD_SHARED_USER = "processAddSharedUser";
 
     // Flows that create a new user locally; used to suppress the lastPasswordUpdateTime update that would
     // otherwise cause a duplicate POST before the original user-creation POST completes.
@@ -594,8 +596,10 @@ public class DefaultInboundUserProvisioningListener extends AbstractIdentityUser
 
         ThreadLocalProvisioningServiceProvider threadLocalServiceProvider =
                 IdentityApplicationManagementUtil.getThreadLocalProvisioningServiceProvider();
+        boolean isSharedUserCreation =
+                Boolean.TRUE.equals(IdentityUtil.threadLocalProperties.get().get(PROCESS_ADD_SHARED_USER));
 
-        if (threadLocalServiceProvider != null) {
+        if (threadLocalServiceProvider != null && !isSharedUserCreation) {
             String serviceProvider = threadLocalServiceProvider.getServiceProviderName();
             if (threadLocalServiceProvider.getServiceProviderType() == ProvisioningServiceProviderType.OAUTH) {
                 try {

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/test/java/org/wso2/carbon/identity/provisioning/listener/DefaultInboundUserProvisioningListenerTest.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/test/java/org/wso2/carbon/identity/provisioning/listener/DefaultInboundUserProvisioningListenerTest.java
@@ -29,10 +29,13 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.application.common.model.ThreadLocalProvisioningServiceProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
 import org.wso2.carbon.identity.core.context.IdentityContext;
 import org.wso2.carbon.identity.core.context.model.Flow;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.provisioning.IdentityProvisioningConstants;
 import org.wso2.carbon.identity.provisioning.IdentityProvisioningException;
 import org.wso2.carbon.identity.provisioning.OutboundProvisioningManager;
@@ -85,6 +88,11 @@ public class DefaultInboundUserProvisioningListenerTest {
     private static final String DOMAIN_NAME = "PRIMARY";
     private static final String TENANT_DOMAIN = "carbon.super";
     private static final String DOMAIN_AWARE_NAME = DOMAIN_NAME + "/" + OLD_ROLE_NAME;
+    private static final String USER_NAME = "testUser";
+    private static final String USER_DOMAIN_AWARE_NAME = DOMAIN_NAME + "/" + USER_NAME;
+    private static final String PROCESS_ADD_SHARED_USER = "processAddSharedUser";
+    private static final String SP_NAME = "testServiceProvider";
+    private static final String SP_CLAIM_DIALECT = "http://wso2.org/oidc/claim";
 
     @BeforeClass
     public void setUpClass() {
@@ -116,6 +124,8 @@ public class DefaultInboundUserProvisioningListenerTest {
         userCoreUtilMockedStatic.when(() -> UserCoreUtil.getDomainName(realmConfiguration)).thenReturn(DOMAIN_NAME);
         userCoreUtilMockedStatic.when(() -> UserCoreUtil.addDomainToName(OLD_ROLE_NAME, DOMAIN_NAME))
                 .thenReturn(DOMAIN_AWARE_NAME);
+        userCoreUtilMockedStatic.when(() -> UserCoreUtil.addDomainToName(USER_NAME, DOMAIN_NAME))
+                .thenReturn(USER_DOMAIN_AWARE_NAME);
 
         carbonContextMockedStatic.when(CarbonContext::getThreadLocalCarbonContext).thenReturn(carbonContext);
         when(carbonContext.getTenantDomain()).thenReturn(TENANT_DOMAIN);
@@ -139,6 +149,9 @@ public class DefaultInboundUserProvisioningListenerTest {
 
     @AfterMethod
     public void tearDown() {
+        // Clear any thread local state set during the test to avoid leaking across tests.
+        IdentityUtil.threadLocalProperties.get().remove(PROCESS_ADD_SHARED_USER);
+
         // Close all static mocks.
         if (outboundProvisioningManagerMockedStatic != null) {
             outboundProvisioningManagerMockedStatic.close();
@@ -266,5 +279,96 @@ public class DefaultInboundUserProvisioningListenerTest {
             verify(outboundProvisioningManager, Mockito.never()).provision(
                     any(ProvisioningEntity.class), anyString(), anyString(), anyString(), anyBoolean());
         }
+    }
+
+    @Test
+    public void testDoPreAddUserWhenSharedUserCreationUsesResidentOutboundProvisioningConfigs()
+            throws UserStoreException {
+
+        // A service provider is present in the thread local (e.g. the application that initiated the request),
+        // but the request is a shared user creation in a sub organization. In that case the sub organization's
+        // resident outbound provisioning configs (LOCAL_SP) must be used instead of the service provider's.
+        IdentityUtil.threadLocalProperties.get().put(PROCESS_ADD_SHARED_USER, Boolean.TRUE);
+        ThreadLocalProvisioningServiceProvider serviceProvider = mockThreadLocalServiceProvider();
+        identityAppManagementUtilMockedStatic.when(
+                        IdentityApplicationManagementUtil::getThreadLocalProvisioningServiceProvider)
+                .thenReturn(serviceProvider);
+
+        try (MockedStatic<PrivilegedCarbonContext> privilegedCarbonContextMockedStatic =
+                     mockPrivilegedCarbonContext()) {
+
+            boolean result = listener.doPreAddUser(USER_NAME, new StringBuffer("password"), null,
+                    new HashMap<>(), "default", userStoreManager);
+
+            assertTrue(result, "Should return true after provisioning");
+
+            // The resident (local SP) outbound provisioning configs must be used.
+            verify(outboundProvisioningManager).provision(
+                    any(ProvisioningEntity.class),
+                    eq(IdentityProvisioningConstants.LOCAL_SP),
+                    eq(IdentityProvisioningConstants.WSO2_CARBON_DIALECT),
+                    eq(TENANT_DOMAIN),
+                    eq(false));
+
+            // The service provider's outbound provisioning configs must NOT be used.
+            verify(outboundProvisioningManager, Mockito.never()).provision(
+                    any(ProvisioningEntity.class), eq(SP_NAME), anyString(), anyString(), anyBoolean());
+        }
+    }
+
+    @Test
+    public void testDoPreAddUserWhenNotSharedUserCreationUsesServiceProviderOutboundProvisioningConfigs()
+            throws UserStoreException {
+
+        // No shared user creation flag is set, so the service provider present in the thread local
+        // should continue to drive the outbound provisioning configs.
+        ThreadLocalProvisioningServiceProvider serviceProvider = mockThreadLocalServiceProvider();
+        identityAppManagementUtilMockedStatic.when(
+                        IdentityApplicationManagementUtil::getThreadLocalProvisioningServiceProvider)
+                .thenReturn(serviceProvider);
+
+        try (MockedStatic<PrivilegedCarbonContext> privilegedCarbonContextMockedStatic =
+                     mockPrivilegedCarbonContext()) {
+
+            boolean result = listener.doPreAddUser(USER_NAME, new StringBuffer("password"), null,
+                    new HashMap<>(), "default", userStoreManager);
+
+            assertTrue(result, "Should return true after provisioning");
+
+            // The service provider's outbound provisioning configs must be used.
+            verify(outboundProvisioningManager).provision(
+                    any(ProvisioningEntity.class),
+                    eq(SP_NAME),
+                    eq(SP_CLAIM_DIALECT),
+                    eq(TENANT_DOMAIN),
+                    eq(true));
+
+            // The resident (local SP) outbound provisioning configs must NOT be used.
+            verify(outboundProvisioningManager, Mockito.never()).provision(
+                    any(ProvisioningEntity.class), eq(IdentityProvisioningConstants.LOCAL_SP),
+                    anyString(), anyString(), anyBoolean());
+        }
+    }
+
+    private ThreadLocalProvisioningServiceProvider mockThreadLocalServiceProvider() {
+
+        ThreadLocalProvisioningServiceProvider serviceProvider =
+                Mockito.mock(ThreadLocalProvisioningServiceProvider.class);
+        when(serviceProvider.getServiceProviderName()).thenReturn(SP_NAME);
+        when(serviceProvider.getServiceProviderType()).thenReturn(null);
+        when(serviceProvider.getClaimDialect()).thenReturn(SP_CLAIM_DIALECT);
+        when(serviceProvider.isJustInTimeProvisioning()).thenReturn(true);
+        return serviceProvider;
+    }
+
+    private MockedStatic<PrivilegedCarbonContext> mockPrivilegedCarbonContext() {
+
+        MockedStatic<PrivilegedCarbonContext> privilegedCarbonContextMockedStatic =
+                Mockito.mockStatic(PrivilegedCarbonContext.class);
+        PrivilegedCarbonContext privilegedCarbonContext = Mockito.mock(PrivilegedCarbonContext.class);
+        privilegedCarbonContextMockedStatic.when(PrivilegedCarbonContext::getThreadLocalCarbonContext)
+                .thenReturn(privilegedCarbonContext);
+        when(privilegedCarbonContext.getApplicationResidentOrganizationId()).thenReturn(null);
+        return privilegedCarbonContextMockedStatic;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

Currently shared user can be created by only a parent user application flow or using invitation. In both cases, there is no sub organization application applies for the outbound provisioning. Hence, use the resident outbound provisioning configurations for shared user outbound provisioning. 

Issue - https://github.com/wso2/product-is/issues/27857