### PR TITLE
Add Service Provider UUID to threadLocal Properties.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/step/impl/DefaultStepHandler.java
@@ -74,6 +74,7 @@ import org.wso2.carbon.identity.core.model.IdentityErrorMsgContext;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.flow.mgt.Constants;
 import org.wso2.carbon.identity.flow.mgt.exception.FlowMgtServerException;
 import org.wso2.carbon.identity.flow.mgt.utils.FlowMgtConfigUtils;
@@ -153,6 +154,10 @@ public class DefaultStepHandler implements StepHandler {
         Optional<String> appName = FrameworkUtils.getApplicationName(context);
         appName.ifPresent(name ->
                 PrivilegedCarbonContext.getThreadLocalCarbonContext().setApplicationName(name));
+        Optional<String> appResourceId = FrameworkUtils.getApplicationResourceId(context);
+        appResourceId.ifPresent(resourceId ->
+                IdentityUtil.threadLocalProperties.get().put(
+                        IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID, resourceId));
         List<AuthenticatorConfig> authConfigList = stepConfig.getAuthenticatorList();
 
         String authenticatorNames = FrameworkUtils.getAuthenticatorIdPMappingString(authConfigList);


### PR DESCRIPTION
Related Issues:

- [x] https://github.com/wso2/product-is/issues/27039

This pull request introduces a small enhancement to the authentication step handler by ensuring that the service provider's UUID is available as a thread-local property during authentication flows. This will help downstream components access the service provider's unique identifier more reliably.

- **Authentication Context Enhancement:**
  - The handler now retrieves the application resource ID (UUID) from the authentication context and stores it in thread-local properties using the `SERVICE_PROVIDER_UUID` key. This allows other components to reference the service provider's UUID during the authentication process.
  - Added import for `IdentityEventConstants` to support the new thread-local property key.