### PR TITLE
Change default Kerberos encryption algorithms to AES

### DIFF
--- a/features/security-mgt/org.wso2.carbon.security.mgt.server.feature/src/main/resources/conf/krb5.conf
+++ b/features/security-mgt/org.wso2.carbon.security.mgt.server.feature/src/main/resources/conf/krb5.conf
@@ -1,7 +1,7 @@
 [libdefaults]
         default_realm = WSO2.COM
-        default_tkt_enctypes = rc4-hmac
-        default_tgs_enctypes = rc4-hmac
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
         dns_lookup_kdc = true
         dns_lookup_realm = false
 


### PR DESCRIPTION
Related Issues:

- [x] https://github.com/wso2/product-is/issues/28012

This pull request updates the Kerberos configuration to strengthen encryption settings for ticket and service-granting ticket exchanges.

**Security configuration improvements:**

* Updated `krb5.conf` to use stronger encryption types (`aes256-cts-hmac-sha1-96` and `aes128-cts-hmac-sha1-96`) for `default_tkt_enctypes` and `default_tgs_enctypes`, replacing the weaker `rc4-hmac` encryption.