### PR TITLE
Remove flow properties support from In-Flow Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,19 @@
 *.jar
 *.war
 *.ear
+*.versionsBackup
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 # Ignore everything in this directory
 target
+/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/tasks/README.md
+/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/tasks/task-02-enable-tenant-node.md
+/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/tasks/task-03-enable-organization-node.md
+/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/tasks/task-04-enable-user-identity-leaves.md
+/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/tasks/task-05-enable-user-credentials-node.md
+/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/tasks/task-06-validate-user-claims-path-format.md
+/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/tasks/task-07-harden-credential-plaintext-handling.md
+/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/tasks/task-08-credential-key-validation.md
+/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/tasks/task-09-configurable-key-cache-ttl.md

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/FlowExtensionConstants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/FlowExtensionConstants.java
@@ -192,6 +192,7 @@ public class FlowExtensionConstants {
 
         public static final String USER_PREFIX = "/user/";
         public static final String USER_ID_PATH = "/user/id";
+        public static final String USER_USERNAME_PATH = "/user/username";
         public static final String USER_STORE_DOMAIN_PATH = "/user/userStoreDomain";
         public static final String USER_CLAIMS_PATH_PREFIX = "/user/claims/";
         public static final String USER_CLAIMS_SELECTOR_PREFIX = "/user/claims[uri=";

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/FlowExtensionConstants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/FlowExtensionConstants.java
@@ -37,7 +37,6 @@ public class FlowExtensionConstants {
     public static final String MODIFY_PATHS_KEY = "modifyPaths";
     public static final String PENDING_CLAIMS_KEY = "pendingClaims";
     public static final String PENDING_CREDENTIALS_KEY = "pendingCredentials";
-    public static final String PENDING_PROPERTIES_KEY = "pendingProperties";
     public static final String PENDING_REDIRECT_URL_KEY = "pendingRedirectUrl";
 
     public static final String FAILURE_TYPE_KEY = "failureType";
@@ -198,8 +197,6 @@ public class FlowExtensionConstants {
         public static final String USER_CLAIMS_SELECTOR_PREFIX = "/user/claims[uri=";
         public static final String USER_CLAIMS_SELECTOR_SUFFIX = "]";
         public static final String USER_CREDENTIALS_PATH_PREFIX = "/user/credentials/";
-
-        public static final String PROPERTIES_PATH_PREFIX = "/properties/";
 
         public static final String FLOW_PREFIX = "/flow/";
         public static final String FLOW_TYPE_PATH = "/flow/flowType";

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionExecutor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionExecutor.java
@@ -53,7 +53,7 @@ import java.util.Map;
 /**
  * Executes In-Flow Extension actions during flow execution by delegating to
  * {@link ActionExecutorService} and mapping the result to an {@link ExecutorResponse}.
- * On success, pending context updates (claims, credentials, properties) are forwarded
+ * On success, pending context updates (claims, credentials) are forwarded
  * to the flow engine through the response object.
  */
 public class FlowExtensionExecutor implements Executor {
@@ -295,17 +295,10 @@ public class FlowExtensionExecutor implements Executor {
             response.setUserCredentials(pendingCredentials);
         }
 
-        Map<String, Object> pendingProperties =
-                flowContext.getValue(FlowExtensionConstants.PENDING_PROPERTIES_KEY, Map.class);
-        if (pendingProperties != null && !pendingProperties.isEmpty()) {
-            response.setContextProperty(pendingProperties);
-        }
-
         if (LOG.isDebugEnabled()) {
             LOG.debug("Flow Extension action succeeded. actionId: " + actionId
                     + ", pendingClaims: " + (pendingClaims != null ? pendingClaims.size() : 0)
-                    + ", pendingCredentials: " + (pendingCredentials != null ? pendingCredentials.size() : 0)
-                    + ", pendingProperties: " + (pendingProperties != null ? pendingProperties.size() : 0));
+                    + ", pendingCredentials: " + (pendingCredentials != null ? pendingCredentials.size() : 0));
         }
     }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
@@ -164,7 +164,6 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
         applyApplication(eventBuilder, context, expose);
         applyUserAndUserStore(flowBuilder, context, expose, accessConfig, certificatePEM);
         applyFlowMetadata(flowBuilder, context, expose);
-        applyFlowProperties(eventBuilder, context, expose, accessConfig, certificatePEM);
 
         eventBuilder.flow(flowBuilder.build());
         return eventBuilder.build();
@@ -502,32 +501,6 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
         }
     }
 
-    private void applyFlowProperties(FlowExtensionEvent.Builder eventBuilder, FlowExecutionContext context,
-                                     List<String> expose, AccessConfig accessConfig,
-                                     String certificatePEM) throws ActionExecutionRequestBuilderException {
-
-        if (!isAreaExposed(FlowContextPaths.PROPERTIES_PATH_PREFIX, expose)) {
-            return;
-        }
-
-        Map<String, Object> properties = context.getProperties();
-        Map<String, Object> filteredProperties = new HashMap<>();
-
-        for (String exposePath : expose) {
-            if (!exposePath.startsWith(FlowContextPaths.PROPERTIES_PATH_PREFIX)) {
-                continue;
-            }
-            String propKey = exposePath.substring(FlowContextPaths.PROPERTIES_PATH_PREFIX.length());
-            Object value = properties != null ? properties.get(propKey) : null;
-            if (value != null && shouldEncrypt(exposePath, accessConfig, certificatePEM)) {
-                value = encryptValue(String.valueOf(value), certificatePEM);
-            }
-            filteredProperties.put(propKey, value != null ? value : "");
-        }
-
-        eventBuilder.flowProperties(filteredProperties);
-    }
-
     private String resolveUserId(FlowUser flowUser, List<String> expose) {
 
         if (isLeafExposed(FlowContextPaths.USER_ID_PATH, expose)) {
@@ -634,7 +607,7 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
 
     /**
      * Check if any exposed leaf path falls under the given area prefix.
-     * Used as a gate before iterating a data block (claims, credentials, properties).
+     * Used as a gate before iterating a data block (claims, credentials).
      */
     private boolean isAreaExposed(String areaPrefix, List<String> expose) {
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.flow.extension.model.ContextPath;
 import org.wso2.carbon.identity.flow.extension.model.FlowExtensionAction;
 import org.wso2.carbon.identity.flow.extension.model.FlowExtensionEvent;
 import org.wso2.carbon.identity.flow.extension.model.FlowExtensionFlow;
+import org.wso2.carbon.identity.flow.extension.model.FlowExtensionUser;
 import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.carbon.identity.action.execution.api.model.ActionExecutionRequest;
 import org.wso2.carbon.identity.action.execution.api.model.ActionExecutionRequestContext;
@@ -183,7 +184,18 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
                            AccessConfig accessConfig, String certificatePEM)
             throws ActionExecutionRequestBuilderException {
 
-        User.Builder userBuilder = new User.Builder(resolveUserId(flowUser, expose));
+        FlowExtensionUser.Builder userBuilder =
+                new FlowExtensionUser.Builder(resolveUserId(flowUser, expose));
+
+        if (isLeafExposed(FlowContextPaths.USER_USERNAME_PATH, expose)) {
+            String username = flowUser.getUsername();
+            userBuilder.username(username != null ? username : "");
+        }
+        if (isLeafExposed(FlowContextPaths.USER_STORE_DOMAIN_PATH, expose)) {
+            String userStoreDomain = flowUser.getUserStoreDomain();
+            userBuilder.userStoreDomain(userStoreDomain != null ? userStoreDomain : "");
+        }
+
         List<UserClaim> userClaims = buildFilteredClaims(flowUser, expose, accessConfig, certificatePEM);
         if (!userClaims.isEmpty()) {
             userBuilder.claims(userClaims);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
@@ -65,7 +65,7 @@ import java.util.Optional;
 
 /**
  * Processes responses from In-Flow Extension actions, applying {@code REPLACE} operations on
- * flow properties, user claims, and user credentials. Updates are collected into pending maps on
+ * user claims and user credentials. Updates are collected into pending maps on
  * {@link FlowContext} for the executor to forward via
  * {@link org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse}.
  *
@@ -115,7 +115,6 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
 
         Map<String, Object> pendingClaims = new HashMap<>();
         Map<String, char[]> pendingCredentials = new HashMap<>();
-        Map<String, Object> pendingProperties = new HashMap<>();
 
         List<OperationExecutionResult> results = new ArrayList<>();
 
@@ -129,7 +128,7 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
                 }
                 results.add(processOperation(
                         operation, pathTypeAnnotations, pendingClaims, pendingCredentials,
-                        pendingProperties, tenantDomain));
+                        tenantDomain));
             }
         } else {
             if (LOG.isDebugEnabled()) {
@@ -142,9 +141,6 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
         }
         if (!pendingCredentials.isEmpty()) {
             flowContext.add(FlowExtensionConstants.PENDING_CREDENTIALS_KEY, pendingCredentials);
-        }
-        if (!pendingProperties.isEmpty()) {
-            flowContext.add(FlowExtensionConstants.PENDING_PROPERTIES_KEY, pendingProperties);
         }
 
         logOperationExecutionResults(results);
@@ -162,7 +158,6 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
      * @param pathTypeAnnotations Map of clean paths to their type annotations from allowed operations.
      * @param pendingClaims       Accumulator map for user claim updates.
      * @param pendingCredentials  Accumulator map for user credential updates.
-     * @param pendingProperties   Accumulator map for flow property updates.
      * @param tenantDomain        Tenant domain, used for claim URI validation.
      * @return The result of the operation execution.
      */
@@ -170,7 +165,6 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
                                                       Map<String, String> pathTypeAnnotations,
                                                       Map<String, Object> pendingClaims,
                                                       Map<String, char[]> pendingCredentials,
-                                                      Map<String, Object> pendingProperties,
                                                       String tenantDomain)
             throws ActionExecutionResponseProcessorException {
 
@@ -190,9 +184,7 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
                     "Modifications are not allowed for the read-only paths" );
         }
 
-        if (path.startsWith(FlowExtensionConstants.FlowContextPaths.PROPERTIES_PATH_PREFIX)) {
-            return handlePropertyOperation(operation, pathTypeAnnotations, pendingProperties);
-        } else if (path.startsWith(FlowExtensionConstants.FlowContextPaths.USER_CLAIMS_SELECTOR_PREFIX)) {
+        if (path.startsWith(FlowExtensionConstants.FlowContextPaths.USER_CLAIMS_SELECTOR_PREFIX)) {
             return handleUserClaimOperation(operation, pendingClaims, tenantDomain);
         } else if (path.startsWith(FlowExtensionConstants.FlowContextPaths.USER_CREDENTIALS_PATH_PREFIX)) {
             return handleUserCredentialOperation(operation, pendingCredentials);
@@ -200,57 +192,6 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
 
         return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
                 "Unknown path");
-    }
-
-    /**
-     * Handle operation on flow properties — collect into pending properties map.
-     *
-     * <p>Only flat property paths are supported (e.g., {@code /properties/riskScore}).
-     * Value coercion is applied based on path type annotations from the request builder via
-     * {@link PathTypeAnnotationUtil#coerceValue}.</p>
-     *
-     * @param operation           The performable operation.
-     * @param pathTypeAnnotations Path type annotations map from request builder.
-     * @param pendingProperties   Accumulator map for property updates.
-     */
-    private OperationExecutionResult handlePropertyOperation(PerformableOperation operation,
-                                                             Map<String, String> pathTypeAnnotations, Map<String, Object> pendingProperties) {
-
-        String propertyName = extractNameFromPath(operation.getPath(),
-                FlowExtensionConstants.FlowContextPaths.PROPERTIES_PATH_PREFIX);
-
-        if (StringUtils.isBlank(propertyName)) {
-            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
-                    "Invalid property path. Property name is required.");
-        }
-
-        if (operation.getValue() == null) {
-            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
-                    ERROR_VALUE_REQUIRED_FOR_REPLACE);
-        }
-
-        // Validate complex object structure against annotation schema before coercion.
-        if (!PathTypeAnnotationUtil.validateValueAgainstAnnotation(
-                operation.getPath(), operation.getValue(), pathTypeAnnotations)) {
-            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
-                    "Value does not match annotation schema for path: " + operation.getPath());
-        }
-
-        // Coerce value based on path type annotation.
-        Object coercedValue = PathTypeAnnotationUtil.coerceValue(
-                operation.getPath(), operation.getValue(), pathTypeAnnotations);
-
-        // Enforce array item limits after coercion.
-        if (!PathTypeAnnotationUtil.enforceArrayItemLimit(
-                operation.getPath(), coercedValue, pathTypeAnnotations)) {
-            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
-                    "Array value exceeds maximum item limit for path.");
-        }
-
-        pendingProperties.put(propertyName, coercedValue);
-
-        return new OperationExecutionResult(operation, OperationExecutionResult.Status.SUCCESS,
-                "Property replace applied.");
     }
 
     /**

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeBuilder.java
@@ -47,7 +47,7 @@ public class FlowExtensionContextTreeBuilder {
 
         List<FlowExtensionContextTreeNode> tree = new ArrayList<>();
         tree.add(buildUserNode());
-//        tree.add(buildTenantNode());
+        tree.add(buildTenantNode());
         tree.add(buildApplicationNode());
 //        tree.add(buildOrganizationNode());
         tree.add(buildFlowNode());
@@ -86,33 +86,33 @@ public class FlowExtensionContextTreeBuilder {
 
         List<FlowExtensionContextTreeNode> children = new ArrayList<>();
 
-//        children.add(FlowExtensionContextTreeNode.builder()
-//                .key("id")
-//                .title("User ID")
-//                .path("/user/id")
-//                .dataType(ContextTree.DATA_TYPE_STRING)
-//                .nodeType(ContextTree.NODE_LEAF)
-//                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
-//                .replaceable(false)
-//                .build());
-//        children.add(FlowExtensionContextTreeNode.builder()
-//                .key("username")
-//                .title("Username")
-//                .path("/user/username")
-//                .dataType(ContextTree.DATA_TYPE_STRING)
-//                .nodeType(ContextTree.NODE_LEAF)
-//                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
-//                .replaceable(false)
-//                .build());
-//        children.add(FlowExtensionContextTreeNode.builder()
-//                .key("userStoreDomain")
-//                .title("User Store Domain")
-//                .path("/user/userStoreDomain")
-//                .dataType(ContextTree.DATA_TYPE_STRING)
-//                .nodeType(ContextTree.NODE_LEAF)
-//                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
-//                .replaceable(false)
-//                .build());
+        children.add(FlowExtensionContextTreeNode.builder()
+                .key("id")
+                .title("User ID")
+                .path(FlowContextPaths.USER_ID_PATH)
+                .dataType(ContextTree.DATA_TYPE_STRING)
+                .nodeType(ContextTree.NODE_LEAF)
+                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
+                .replaceable(false)
+                .build());
+        children.add(FlowExtensionContextTreeNode.builder()
+                .key("username")
+                .title("Username")
+                .path(FlowContextPaths.USER_USERNAME_PATH)
+                .dataType(ContextTree.DATA_TYPE_STRING)
+                .nodeType(ContextTree.NODE_LEAF)
+                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
+                .replaceable(false)
+                .build());
+        children.add(FlowExtensionContextTreeNode.builder()
+                .key("userStoreDomain")
+                .title("User Store Domain")
+                .path(FlowContextPaths.USER_STORE_DOMAIN_PATH)
+                .dataType(ContextTree.DATA_TYPE_STRING)
+                .nodeType(ContextTree.NODE_LEAF)
+                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
+                .replaceable(false)
+                .build());
 
         children.add(FlowExtensionContextTreeNode.builder()
                 .key("claims")
@@ -176,21 +176,21 @@ public class FlowExtensionContextTreeBuilder {
                 .build();
     }
 
-//    private FlowExtensionContextTreeNode buildTenantNode() {
-//
-//        List<FlowExtensionContextTreeNode> children = new ArrayList<>();
-//        children.add(readOnlyLeaf("domain", "Tenant Domain", FlowContextPaths.TENANT_DOMAIN_PATH));
-//        return FlowExtensionContextTreeNode.builder()
-//                .key("tenant")
-//                .title("Tenant")
-//                .path(FlowContextPaths.TENANT_PREFIX)
-//                .dataType("")
-//                .nodeType(ContextTree.NODE_OBJECT)
-//                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
-//                .readOnly(true)
-//                .children(children)
-//                .build();
-//    }
+    private FlowExtensionContextTreeNode buildTenantNode() {
+
+        List<FlowExtensionContextTreeNode> children = new ArrayList<>();
+        children.add(readOnlyLeaf("domain", "Tenant Domain", FlowContextPaths.TENANT_DOMAIN_PATH));
+        return FlowExtensionContextTreeNode.builder()
+                .key("tenant")
+                .title("Tenant")
+                .path(FlowContextPaths.TENANT_PREFIX)
+                .dataType("")
+                .nodeType(ContextTree.NODE_OBJECT)
+                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
+                .readOnly(true)
+                .children(children)
+                .build();
+    }
 
     private FlowExtensionContextTreeNode buildApplicationNode() {
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeBuilder.java
@@ -29,7 +29,7 @@ import java.util.List;
 /**
  * Builds the controlled In-Flow Extension context tree returned by the metadata endpoint.
  * The set of exposed attributes is governed at code level by this builder so the frontend
- * receives the user/flow/properties tree shape the Console UI expects.
+ * receives the user/flow tree shape the Console UI expects.
  */
 public class FlowExtensionContextTreeBuilder {
 
@@ -47,7 +47,6 @@ public class FlowExtensionContextTreeBuilder {
 
         List<FlowExtensionContextTreeNode> tree = new ArrayList<>();
         tree.add(buildUserNode());
-//        tree.add(buildPropertiesNode());
 //        tree.add(buildTenantNode());
         tree.add(buildApplicationNode());
 //        tree.add(buildOrganizationNode());
@@ -240,21 +239,6 @@ public class FlowExtensionContextTreeBuilder {
                 .readOnly(true)
                 .build();
     }
-
-//    private FlowExtensionContextTreeNode buildPropertiesNode() {
-//
-//        return FlowExtensionContextTreeNode.builder()
-//                .key("properties")
-//                .title("Properties")
-//                .path("/properties/")
-//                .dataType("Map<String, Object>")
-//                .nodeType(ContextTree.NODE_COMPLEX_MAP)
-//                .allowedOperations(Collections.singletonList(ContextTree.OP_MODIFY))
-//                .dynamicEntryAllowed(true)
-//                .dynamicEntryType("Object")
-//                .children(Collections.emptyList())
-//                .build();
-//    }
 
     private static String attrTitle(String attr) {
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionEvent.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionEvent.java
@@ -25,10 +25,6 @@ import org.wso2.carbon.identity.action.execution.api.model.Organization;
 import org.wso2.carbon.identity.action.execution.api.model.Tenant;
 import org.wso2.carbon.identity.action.execution.api.model.UserStore;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * This class models the In-Flow Extension Event.
  * It represents the event sent to the In-Flow Extension action over the Action Execution Request.
@@ -37,7 +33,6 @@ public class FlowExtensionEvent extends Event {
 
     private final FlowExtensionFlow flow;
     private final String callbackUrl;
-    private final Map<String, Object> flowProperties;
 
     private FlowExtensionEvent(Builder builder) {
 
@@ -47,8 +42,6 @@ public class FlowExtensionEvent extends Event {
         this.application = builder.application;
         this.flow = builder.flow;
         this.callbackUrl = builder.callbackUrl;
-        this.flowProperties = builder.flowProperties != null ?
-                Collections.unmodifiableMap(new HashMap<>(builder.flowProperties)) : Collections.emptyMap();
     }
 
     /**
@@ -76,16 +69,6 @@ public class FlowExtensionEvent extends Event {
     }
 
     /**
-     * Get the flow properties/context data.
-     *
-     * @return Unmodifiable map of flow properties.
-     */
-    public Map<String, Object> getFlowProperties() {
-
-        return flowProperties;
-    }
-
-    /**
      * Builder for the InFlowExtensionEvent.
      */
     public static class Builder {
@@ -96,7 +79,6 @@ public class FlowExtensionEvent extends Event {
         private UserStore userStore;
         private Application application;
         private String callbackUrl;
-        private Map<String, Object> flowProperties;
 
         public Builder flow(FlowExtensionFlow flow) {
 
@@ -131,12 +113,6 @@ public class FlowExtensionEvent extends Event {
         public Builder callbackUrl(String callbackUrl) {
 
             this.callbackUrl = callbackUrl;
-            return this;
-        }
-
-        public Builder flowProperties(Map<String, Object> flowProperties) {
-
-            this.flowProperties = flowProperties != null ? new HashMap<>(flowProperties) : null;
             return this;
         }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionUser.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionUser.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.model;
+
+import org.wso2.carbon.identity.action.execution.api.model.User;
+import org.wso2.carbon.identity.action.execution.api.model.UserClaim;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Models the user object sent to an In-Flow Extension action.
+ *
+ * <p>Extends the shared {@link User} with the identity leaves specific to the flow extension
+ * contract ({@code /user/username} and {@code /user/userStoreDomain}). These are kept out of
+ * the shared {@link User} model so they are not advertised to action types that have no notion
+ * of them. This mirrors the existing pattern used by {@code PasswordUpdatingUser}.</p>
+ *
+ * <p>Both fields are nullable: they are only populated when the corresponding path is exposed.
+ * The request mapper serializes with {@code NON_NULL}/{@code NON_EMPTY}, so an unset field is
+ * omitted from the outbound payload.</p>
+ */
+public class FlowExtensionUser extends User {
+
+    private final String username;
+    private final String userStoreDomain;
+
+    private FlowExtensionUser(Builder builder) {
+
+        super(new User.Builder(builder.id)
+                .claims(builder.claims));
+        this.username = builder.username;
+        this.userStoreDomain = builder.userStoreDomain;
+    }
+
+    public String getUsername() {
+
+        return username;
+    }
+
+    public String getUserStoreDomain() {
+
+        return userStoreDomain;
+    }
+
+    /**
+     * Builder for {@link FlowExtensionUser}.
+     */
+    public static class Builder {
+
+        private final String id;
+        private String username;
+        private String userStoreDomain;
+        private final List<UserClaim> claims = new ArrayList<>();
+
+        public Builder(String id) {
+
+            this.id = id;
+        }
+
+        public Builder username(String username) {
+
+            this.username = username;
+            return this;
+        }
+
+        public Builder userStoreDomain(String userStoreDomain) {
+
+            this.userStoreDomain = userStoreDomain;
+            return this;
+        }
+
+        public Builder claims(List<? extends UserClaim> claims) {
+
+            this.claims.addAll(claims);
+            return this;
+        }
+
+        public FlowExtensionUser build() {
+
+            return new FlowExtensionUser(this);
+        }
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeBuilderTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeBuilderTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.metadata;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ContextTree;
+import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.FlowContextPaths;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link FlowExtensionContextTreeBuilder}, focused on the user identity leaves
+ * (id / username / userStoreDomain) exposed under the {@code /user/} branch.
+ */
+public class FlowExtensionContextTreeBuilderTest {
+
+    private Map<String, FlowExtensionContextTreeNode> userLeaves;
+
+    @BeforeClass
+    public void buildTree() {
+
+        FlowExtensionContextTreeMetadata metadata = new FlowExtensionContextTreeBuilder().build(null);
+        FlowExtensionContextTreeNode userNode = metadata.getContextTree().stream()
+                .filter(n -> "user".equals(n.getKey()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(userNode, "The /user/ node must be present in the context tree.");
+        assertEquals(userNode.getPath(), FlowContextPaths.USER_PREFIX);
+
+        userLeaves = userNode.getChildren().stream()
+                .collect(Collectors.toMap(FlowExtensionContextTreeNode::getKey, n -> n));
+    }
+
+    @Test
+    public void testIdentityLeavesPresentUnderUser() {
+
+        assertTrue(userLeaves.containsKey("id"), "/user/id leaf must be advertised.");
+        assertTrue(userLeaves.containsKey("username"), "/user/username leaf must be advertised.");
+        assertTrue(userLeaves.containsKey("userStoreDomain"),
+                "/user/userStoreDomain leaf must be advertised.");
+    }
+
+    @Test
+    public void testIdentityLeafPaths() {
+
+        assertEquals(userLeaves.get("id").getPath(), FlowContextPaths.USER_ID_PATH);
+        assertEquals(userLeaves.get("username").getPath(), FlowContextPaths.USER_USERNAME_PATH);
+        assertEquals(userLeaves.get("userStoreDomain").getPath(), FlowContextPaths.USER_STORE_DOMAIN_PATH);
+    }
+
+    @Test
+    public void testIdentityLeavesAreExposeOnlyAndNonReplaceable() {
+
+        for (String key : new String[]{"id", "username", "userStoreDomain"}) {
+            FlowExtensionContextTreeNode leaf = userLeaves.get(key);
+            assertEquals(leaf.getNodeType(), ContextTree.NODE_LEAF, key + " must be a leaf node.");
+            assertEquals(leaf.getDataType(), ContextTree.DATA_TYPE_STRING, key + " must be a string.");
+            List<String> ops = leaf.getAllowedOperations();
+            assertEquals(ops, java.util.Collections.singletonList(ContextTree.OP_EXPOSE),
+                    key + " must allow EXPOSE only (no MODIFY).");
+            assertFalse(leaf.isReplaceable(), key + " must not be replaceable.");
+        }
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionUserTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionUserTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.execution.api.model.User;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for {@link FlowExtensionUser}, verifying the identity leaves the flow extension adds on
+ * top of the shared {@link User} model are carried and serialized, while the shared model stays
+ * free of them.
+ */
+public class FlowExtensionUserTest {
+
+    private ObjectMapper mapper;
+
+    @BeforeClass
+    public void setUp() {
+
+        // Mirror the request mapper configuration in ActionExecutorServiceImpl.
+        mapper = new ObjectMapper();
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+    }
+
+    @Test
+    public void testGettersCarryIdentityLeaves() {
+
+        FlowExtensionUser user = new FlowExtensionUser.Builder("uid-1")
+                .username("alice")
+                .userStoreDomain("PRIMARY")
+                .build();
+
+        assertEquals(user.getId(), "uid-1");
+        assertEquals(user.getUsername(), "alice");
+        assertEquals(user.getUserStoreDomain(), "PRIMARY");
+    }
+
+    @Test
+    public void testIdentityLeavesSerializedPolymorphically() throws Exception {
+
+        User user = new FlowExtensionUser.Builder("uid-1")
+                .username("alice")
+                .userStoreDomain("PRIMARY")
+                .build();
+
+        // Serialized via the static User type — Jackson uses the runtime type, so subclass
+        // getters must still appear.
+        String json = mapper.writeValueAsString(user);
+        assertTrue(json.contains("\"username\":\"alice\""), json);
+        assertTrue(json.contains("\"userStoreDomain\":\"PRIMARY\""), json);
+        assertTrue(json.contains("\"id\":\"uid-1\""), json);
+    }
+
+    @Test
+    public void testUnsetLeavesAreOmitted() throws Exception {
+
+        User user = new FlowExtensionUser.Builder("uid-1").build();
+
+        String json = mapper.writeValueAsString(user);
+        assertFalse(json.contains("username"), json);
+        assertFalse(json.contains("userStoreDomain"), json);
+    }
+
+    @Test
+    public void testSharedUserModelHasNoIdentityLeaves() {
+
+        // Guard against the regression of leaking these fields into the shared User API.
+        for (java.lang.reflect.Method m : User.class.getMethods()) {
+            assertFalse("getUsername".equals(m.getName()),
+                    "Shared User model must not expose getUsername().");
+            assertFalse("getUserStoreDomain".equals(m.getName()),
+                    "Shared User model must not expose getUserStoreDomain().");
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
The flow properties data block in the In-Flow Extension component was unused and not exposed through the metadata endpoint (the properties node was already commented out in the context tree builder). This removes that dead path so the component only handles the user/flow areas it actually supports.

## Related Issue
- N/A

## Implementation
Removed the properties path handling end to end across the In-Flow Extension flow:

- `FlowExtensionConstants` — dropped the `PENDING_PROPERTIES_KEY` and `PROPERTIES_PATH_PREFIX` constants.
- `FlowExtensionRequestBuilder` — removed the `applyFlowProperties` method and its invocation, so flow properties are no longer collected, filtered, or attached to the outgoing event.
- `FlowExtensionResponseProcessor` — removed the `handlePropertyOperation` method, the pending-properties accumulator, and the properties branch in `processOperation`.
- `FlowExtensionExecutor` — removed forwarding of pending properties onto the response and the related debug logging.
- `FlowExtensionContextTreeBuilder` — removed the already-disabled `buildPropertiesNode` method.
- `FlowExtensionEvent` — removed the `flowProperties` field, builder method, getter, and now-unused imports.

Doc comments referencing the properties block were updated to match.