### PR TITLE
Register scopes for User Credential Management API v2

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -1681,6 +1681,7 @@
                 <Scope name="internal_user_credential_mgt_delete"/>
             </Delete>
             <Create>
+                <Scope name="internal_user_credential_mgt_create"/>
             </Create>
             <Read>
                 <Scope name="internal_user_credential_mgt_view"/>
@@ -2264,6 +2265,7 @@
                 <Scope name="internal_org_user_credential_mgt_delete"/>
             </Delete>
             <Create>
+                <Scope name="internal_org_user_credential_mgt_create"/>
             </Create>
             <Read>
                 <Scope name="internal_org_user_credential_mgt_view"/>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -1791,6 +1791,7 @@
                 <Scope name="internal_user_credential_mgt_delete"/>
             </Delete>
             <Create>
+                <Scope name="internal_user_credential_mgt_create"/>
             </Create>
             <Read>
                 <Scope name="internal_user_credential_mgt_view"/>
@@ -2451,6 +2452,7 @@
                 <Scope name="internal_org_user_credential_mgt_delete"/>
             </Delete>
             <Create>
+                <Scope name="internal_org_user_credential_mgt_create"/>
             </Create>
             <Read>
                 <Scope name="internal_org_user_credential_mgt_view"/>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -2387,6 +2387,30 @@
                    description="Delete credentials of end users in the organization"/>
         </Scopes>
     </APIResource>
+    <APIResource name="User Credential Management API v2" identifier="/api/users/v2/(.*)/credentials"
+                 requiresAuthorization="true"
+                 description="API representation of the User Credential Management API v2" type="TENANT">
+        <Scopes>
+            <Scope displayName="View Credential" name="internal_user_credential_mgt_view"
+                   description="View credentials of end users in the organization"/>
+            <Scope displayName="Create Credential" name="internal_user_credential_mgt_create"
+                   description="Create credentials for end users in the organization"/>
+            <Scope displayName="Delete Credential" name="internal_user_credential_mgt_delete"
+                   description="Delete credentials of end users in the organization"/>
+        </Scopes>
+    </APIResource>
+    <APIResource name="User Credential Management API v2" identifier="/o/api/users/v2/(.*)/credentials"
+                 requiresAuthorization="true"
+                 description="API representation of the User Credential Management API v2" type="ORGANIZATION">
+        <Scopes>
+            <Scope displayName="View Credential" name="internal_org_user_credential_mgt_view"
+                   description="View credentials of end users in the organization"/>
+            <Scope displayName="Create Credential" name="internal_org_user_credential_mgt_create"
+                   description="Create credentials for end users in the organization"/>
+            <Scope displayName="Delete Credential" name="internal_org_user_credential_mgt_delete"
+                   description="Delete credentials of end users in the organization"/>
+        </Scopes>
+    </APIResource>
     <APIResource name="VC Templates Management API" identifier="/api/server/v1/vc-templates"
                  requiresAuthorization="true"
                  description="API representation of the VC Templates Management API" type="TENANT">

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -2444,6 +2444,30 @@
                        description="Delete credentials of end users in the organization"/>
             </Scopes>
     </APIResource>
+    <APIResource name="User Credential Management API v2" identifier="/api/users/v2/(.*)/credentials"
+                 requiresAuthorization="true"
+                 description="API representation of the User Credential Management API v2" type="TENANT">
+        <Scopes>
+            <Scope displayName="View Credential" name="internal_user_credential_mgt_view"
+                   description="View credentials of end users in the organization"/>
+            <Scope displayName="Create Credential" name="internal_user_credential_mgt_create"
+                   description="Create credentials for end users in the organization"/>
+            <Scope displayName="Delete Credential" name="internal_user_credential_mgt_delete"
+                   description="Delete credentials of end users in the organization"/>
+        </Scopes>
+    </APIResource>
+    <APIResource name="User Credential Management API v2" identifier="/o/api/users/v2/(.*)/credentials"
+                 requiresAuthorization="true"
+                 description="API representation of the User Credential Management API v2" type="ORGANIZATION">
+        <Scopes>
+            <Scope displayName="View Credential" name="internal_org_user_credential_mgt_view"
+                   description="View credentials of end users in the organization"/>
+            <Scope displayName="Create Credential" name="internal_org_user_credential_mgt_create"
+                   description="Create credentials for end users in the organization"/>
+            <Scope displayName="Delete Credential" name="internal_org_user_credential_mgt_delete"
+                   description="Delete credentials of end users in the organization"/>
+        </Scopes>
+    </APIResource>
     <APIResource name="VC Templates Management API" identifier="/api/server/v1/vc-templates"
                  requiresAuthorization="true"
                  description="API representation of the VC Templates Management API" type="TENANT">

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -2115,6 +2115,28 @@
         <Scopes>internal_user_credential_mgt_delete</Scopes>
     </Resource>
 
+    <!-- [Organization] User Credential Management API v2 -->
+    <Resource context="(.*)/o/api/users/v2/(.*)/credentials" secured="true" http-method="GET">
+        <Scopes>internal_org_user_credential_mgt_view</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/users/v2/(.*)/credentials/(.*)" secured="true" http-method="POST">
+        <Scopes>internal_org_user_credential_mgt_create</Scopes>
+    </Resource>
+    <Resource context="(.*)/o/api/users/v2/(.*)/credentials/(.*)" secured="true" http-method="DELETE">
+        <Scopes>internal_org_user_credential_mgt_delete</Scopes>
+    </Resource>
+
+    <!-- User Credential Management API v2 -->
+    <Resource context="(.*)/api/users/v2/(.*)/credentials" secured="true" http-method="GET">
+        <Scopes>internal_user_credential_mgt_view</Scopes>
+    </Resource>
+    <Resource context="(.*)/api/users/v2/(.*)/credentials/(.*)" secured="true" http-method="POST">
+        <Scopes>internal_user_credential_mgt_create</Scopes>
+    </Resource>
+    <Resource context="(.*)/api/users/v2/(.*)/credentials/(.*)" secured="true" http-method="DELETE">
+        <Scopes>internal_user_credential_mgt_delete</Scopes>
+    </Resource>
+
     <!-- VC Template Management API -->
     <Resource context="(.*)/api/server/v1/vc-templates/(.*)/offer" secured="true" http-method="POST">
         <Scopes>internal_vc_template_update</Scopes>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -2321,6 +2321,28 @@
               <Scopes>internal_user_credential_mgt_delete</Scopes>
           </Resource>
 
+          <!-- [Organization] User Credential Management API v2 -->
+          <Resource context="(.*)/o/api/users/v2/(.*)/credentials" secured="true" http-method="GET">
+              <Scopes>internal_org_user_credential_mgt_view</Scopes>
+          </Resource>
+          <Resource context="(.*)/o/api/users/v2/(.*)/credentials/(.*)" secured="true" http-method="POST">
+              <Scopes>internal_org_user_credential_mgt_create</Scopes>
+          </Resource>
+          <Resource context="(.*)/o/api/users/v2/(.*)/credentials/(.*)" secured="true" http-method="DELETE">
+              <Scopes>internal_org_user_credential_mgt_delete</Scopes>
+          </Resource>
+
+          <!-- User Credential Management API v2 -->
+          <Resource context="(.*)/api/users/v2/(.*)/credentials" secured="true" http-method="GET">
+              <Scopes>internal_user_credential_mgt_view</Scopes>
+          </Resource>
+          <Resource context="(.*)/api/users/v2/(.*)/credentials/(.*)" secured="true" http-method="POST">
+              <Scopes>internal_user_credential_mgt_create</Scopes>
+          </Resource>
+          <Resource context="(.*)/api/users/v2/(.*)/credentials/(.*)" secured="true" http-method="DELETE">
+              <Scopes>internal_user_credential_mgt_delete</Scopes>
+          </Resource>
+
           <!-- Moesif Configuration Management API -->
           <Resource context="(.*)/api/server/v1/moesif-publishers" secured="true" http-method="GET">
               <Scopes>internal_moesif_config_view</Scopes>


### PR DESCRIPTION
## Summary

- Adds `internal_user_credential_mgt_create` scope to the tenant-level User Credential Management API (`/api/server/v1/users/(.*)/credentials`)
- Adds `internal_org_user_credential_mgt_create` scope to the organization-level User Credential Management API (`/o/api/server/v1/users/(.*)/credentials`)
- Registers the `POST` HTTP method in resource access control for both contexts

## Changes

The following files are updated:
- `features/.../system-api-resource.xml` and `.xml.j2` — new scope declaration for both TENANT and ORGANIZATION API resources
- `features/.../api-resource-collection.xml` and `.xml.j2` — `<Create>` section now includes the new scope for `userCredentialManagement` and `org_userCredentialManagement` collections
- `features/.../resource-access-control-v2.xml` and `.xml.j2` — POST resource access rules added for both tenant and organization credential endpoints
- `components/.../system-api-resource.xml` (test resource) — mirrors the production scope changes

## Related to
https://github.com/wso2/product-is/issues/28021