### PR TITLE
Fix returning immutable objects from the service level in APIAuthorization and RoleManagement

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
@@ -264,10 +264,10 @@ public class AuthorizedAPIManagementServiceImpl implements AuthorizedAPIManageme
                     List<String> filteredScopes = authorizedScopes.getScopes().stream()
                             .filter(scope -> !scope.startsWith(INTERNAL_SCOPE_PREFIX))
                             .filter(scope -> !scope.startsWith(CONSOLE_SCOPE_PREFIX))
-                            .collect(Collectors.toList());
+                            .collect(Collectors.toCollection(ArrayList::new));
                     return new AuthorizedScopes(authorizedScopes.getPolicyId(), filteredScopes);
                 })
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     @Override

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/AuthorizedAPIDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/AuthorizedAPIDAOImpl.java
@@ -125,9 +125,10 @@ public class AuthorizedAPIDAOImpl implements AuthorizedAPIDAO {
                             .apiId(apiId)
                             .policyId(resultSet.getString(
                                     ApplicationConstants.ApplicationTableColumns.POLICY_ID))
-                            .scopes(scope == null ? Collections.emptyList() : Collections.singletonList(scope))
+                            .scopes(scope == null ? new ArrayList<>()
+                                    : new ArrayList<>(Collections.singletonList(scope)))
                             .authorizationDetailsTypes(type == null
-                                    ? Collections.emptyList() : Collections.singletonList(type));
+                                    ? new ArrayList<>() : new ArrayList<>(Collections.singletonList(type)));
                     authorizedAPIMap.put(apiId, authorizedAPIBuilder.build());
                 } else {
                     AuthorizedAPI authorizedAPI = authorizedAPIMap.get(apiId);
@@ -188,8 +189,8 @@ public class AuthorizedAPIDAOImpl implements AuthorizedAPIDAO {
                     AuthorizedScopes.AuthorizedScopesBuilder authorizedScopesBuilder =
                             new AuthorizedScopes.AuthorizedScopesBuilder()
                                     .policyId(policyId)
-                                    .scopes(Collections.singletonList(resultSet.getString(
-                                            ApplicationConstants.ApplicationTableColumns.SCOPE_NAME)));
+                                    .scopes(new ArrayList<>(Collections.singletonList(resultSet.getString(
+                                            ApplicationConstants.ApplicationTableColumns.SCOPE_NAME))));
                     authorizedScopesMap.put(policyId, authorizedScopesBuilder.build());
                 } else {
                     AuthorizedScopes authorizedScopes = authorizedScopesMap.get(policyId);
@@ -229,7 +230,7 @@ public class AuthorizedAPIDAOImpl implements AuthorizedAPIDAO {
                         Scope scope = new Scope.ScopeBuilder()
                                 .name(resultSet.getString(ApplicationConstants.ApplicationTableColumns.SCOPE_NAME))
                                 .build();
-                        authorizedAPI.setScopes(Collections.singletonList(scope));
+                        authorizedAPI.setScopes(new ArrayList<>(Collections.singletonList(scope)));
                     }
                     addAuthorizationDetailsTypeToAuthorizedApi(authorizedAPI, buildAuthorizationDetailsType(resultSet));
                 } else {

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/AuthorizedAPIDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/AuthorizedAPIDAOImpl.java
@@ -120,15 +120,21 @@ public class AuthorizedAPIDAOImpl implements AuthorizedAPIDAO {
                 final AuthorizationDetailsType type = this.buildAuthorizationDetailsType(resultSet);
 
                 if (!authorizedAPIMap.containsKey(apiId)) {
+                    List<Scope> scopes = new ArrayList<>();
+                    if (scope != null) {
+                        scopes.add(scope);
+                    }
+                    List<AuthorizationDetailsType> authorizationDetailsTypes = new ArrayList<>();
+                    if (type != null) {
+                        authorizationDetailsTypes.add(type);
+                    }
                     AuthorizedAPI.AuthorizedAPIBuilder authorizedAPIBuilder = new AuthorizedAPI.AuthorizedAPIBuilder()
                             .appId(applicationId)
                             .apiId(apiId)
                             .policyId(resultSet.getString(
                                     ApplicationConstants.ApplicationTableColumns.POLICY_ID))
-                            .scopes(scope == null ? new ArrayList<>()
-                                    : new ArrayList<>(Collections.singletonList(scope)))
-                            .authorizationDetailsTypes(type == null
-                                    ? new ArrayList<>() : new ArrayList<>(Collections.singletonList(type)));
+                            .scopes(scopes)
+                            .authorizationDetailsTypes(authorizationDetailsTypes);
                     authorizedAPIMap.put(apiId, authorizedAPIBuilder.build());
                 } else {
                     AuthorizedAPI authorizedAPI = authorizedAPIMap.get(apiId);
@@ -186,11 +192,12 @@ public class AuthorizedAPIDAOImpl implements AuthorizedAPIDAO {
             while (resultSet.next()) {
                 String policyId = resultSet.getString(ApplicationConstants.ApplicationTableColumns.POLICY_ID);
                 if (!authorizedScopesMap.containsKey(policyId)) {
+                    List<String> scopes = new ArrayList<>();
+                    scopes.add(resultSet.getString(ApplicationConstants.ApplicationTableColumns.SCOPE_NAME));
                     AuthorizedScopes.AuthorizedScopesBuilder authorizedScopesBuilder =
                             new AuthorizedScopes.AuthorizedScopesBuilder()
                                     .policyId(policyId)
-                                    .scopes(new ArrayList<>(Collections.singletonList(resultSet.getString(
-                                            ApplicationConstants.ApplicationTableColumns.SCOPE_NAME))));
+                                    .scopes(scopes);
                     authorizedScopesMap.put(policyId, authorizedScopesBuilder.build());
                 } else {
                     AuthorizedScopes authorizedScopes = authorizedScopesMap.get(policyId);
@@ -226,11 +233,11 @@ public class AuthorizedAPIDAOImpl implements AuthorizedAPIDAO {
                             .appId(applicationId)
                             .policyId(resultSet.getString(ApplicationConstants.ApplicationTableColumns.POLICY_ID))
                             .build();
-                    if (resultSet.getString(ApplicationConstants.ApplicationTableColumns.SCOPE_NAME) != null) {
-                        Scope scope = new Scope.ScopeBuilder()
-                                .name(resultSet.getString(ApplicationConstants.ApplicationTableColumns.SCOPE_NAME))
-                                .build();
-                        authorizedAPI.setScopes(new ArrayList<>(Collections.singletonList(scope)));
+                    String scopeName = resultSet.getString(ApplicationConstants.ApplicationTableColumns.SCOPE_NAME);
+                    if (scopeName != null) {
+                        List<Scope> scopes = new ArrayList<>();
+                        scopes.add(new Scope.ScopeBuilder().name(scopeName).build());
+                        authorizedAPI.setScopes(scopes);
                     }
                     addAuthorizationDetailsTypeToAuthorizedApi(authorizedAPI, buildAuthorizationDetailsType(resultSet));
                 } else {

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -1783,7 +1783,7 @@ public class RoleDAOImpl implements RoleDAO {
                     List<Permission> permissions = getPermissions(mainRoleId, mainTenantDomain);
                     return permissions.stream()
                             .filter(permission -> isValidSubOrgPermission(permission.getName()))
-                            .collect(Collectors.toList());
+                            .collect(Collectors.toCollection(ArrayList::new));
                 }
             }
         } catch (SQLException | IdentityRoleManagementException e) {
@@ -3281,7 +3281,7 @@ public class RoleDAOImpl implements RoleDAO {
 
         // If the system roles are not enabled in the system no need to continue.
         if (!IdentityUtil.isSystemRolesEnabled()) {
-            return Collections.emptySet();
+            return new HashSet<>();
         }
         Set<String> systemRoles = new HashSet<>();
         IdentityConfigParser configParser = IdentityConfigParser.getInstance();
@@ -3292,7 +3292,7 @@ public class RoleDAOImpl implements RoleDAO {
                 LOG.debug("'" + IdentityConstants.SystemRoles.SYSTEM_ROLES_CONFIG_ELEMENT
                         + "' config cannot be found.");
             }
-            return Collections.emptySet();
+            return new HashSet<>();
         }
 
         Iterator roleIdentifierIterator = systemRolesConfig
@@ -3301,7 +3301,7 @@ public class RoleDAOImpl implements RoleDAO {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("'" + IdentityConstants.SystemRoles.ROLE_CONFIG_ELEMENT + "' config cannot be found.");
             }
-            return Collections.emptySet();
+            return new HashSet<>();
         }
 
         while (roleIdentifierIterator.hasNext()) {


### PR DESCRIPTION
### Purpose
> $subject
- Returning immutable objects can be problematic, as there can be requirements to apply modifications to those objects in the Listener level. Hence remove the immutability options from the ApplicationAPIAuthorization and Role Manangement


### Related issue
- https://github.com/wso2/product-is/issues/28023

