### PR TITLE
Add support for the HTTP PUT method in the External API Framework

### DIFF
--- a/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/main/java/org/wso2/carbon/identity/external/api/client/api/model/APIRequestContext.java
+++ b/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/main/java/org/wso2/carbon/identity/external/api/client/api/model/APIRequestContext.java
@@ -140,7 +140,7 @@ public class APIRequestContext {
             /* Todo: Payload can be optional for certain HTTP methods like GET.
                      Adjust validation accordingly when introducing new HTTP Method supports
              */
-            if (httpMethod == HttpMethod.POST && (payload == null)) {
+            if ((httpMethod == HttpMethod.POST || httpMethod == HttpMethod.PUT) && payload == null) {
                 throw new APIClientRequestException(ErrorMessage.ERROR_CODE_MISSING_REQUEST_FIELD, "payload");
             }
             if (payload != null && !payload.isRepeatable()) {
@@ -157,7 +157,8 @@ public class APIRequestContext {
     public enum HttpMethod {
 
         POST("post"),
-        GET("get");
+        GET("get"),
+        PUT("put");
 
         private final String name;
 

--- a/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/main/java/org/wso2/carbon/identity/external/api/client/internal/service/APIClient.java
+++ b/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/main/java/org/wso2/carbon/identity/external/api/client/internal/service/APIClient.java
@@ -28,6 +28,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -125,6 +126,12 @@ public class APIClient {
                         new HttpPost(requestContext.getEndpointUrl());
                 httpEntityEnclosingRequestBase.setEntity(requestContext.getPayload());
                 httpRequestBase = httpEntityEnclosingRequestBase;
+                break;
+            case PUT:
+                HttpEntityEnclosingRequestBase httpPutRequestBase =
+                        new HttpPut(requestContext.getEndpointUrl());
+                httpPutRequestBase.setEntity(requestContext.getPayload());
+                httpRequestBase = httpPutRequestBase;
                 break;
             case GET:
                 httpRequestBase = new HttpGet(requestContext.getEndpointUrl());

--- a/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/test/java/org/wso2/carbon/identity/external/api/client/api/model/APIRequestContextTest.java
+++ b/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/test/java/org/wso2/carbon/identity/external/api/client/api/model/APIRequestContextTest.java
@@ -235,6 +235,45 @@ public class APIRequestContextTest {
     }
 
     /**
+     * Test successful creation of APIRequestContext with PUT method and payload.
+     */
+    @Test
+    public void testCreateAPIRequestContextWithPutMethod() throws APIClientRequestException {
+
+        APIRequestContext context = new APIRequestContext.Builder()
+                .httpMethod(APIRequestContext.HttpMethod.PUT)
+                .apiAuthentication(apiAuthentication)
+                .endpointUrl(ENDPOINT_URL)
+                .headers(headers)
+                .payload(PAYLOAD)
+                .build();
+
+        assertNotNull(context);
+        assertEquals(context.getHttpMethod(), APIRequestContext.HttpMethod.PUT);
+        assertEquals(context.getApiAuthentication(), apiAuthentication);
+        assertEquals(context.getEndpointUrl(), ENDPOINT_URL);
+        assertEquals(context.getPayload(), PAYLOAD);
+    }
+
+    /**
+     * Test creation of PUT context without payload throws exception.
+     */
+    @Test
+    public void testCreateAPIRequestContextWithNullPayloadForPut() {
+
+        try {
+            new APIRequestContext.Builder()
+                    .httpMethod(APIRequestContext.HttpMethod.PUT)
+                    .apiAuthentication(apiAuthentication)
+                    .endpointUrl(ENDPOINT_URL)
+                    .build();
+            fail("Expected APIClientRequestException was not thrown");
+        } catch (APIClientRequestException e) {
+            assertEquals(e.getErrorCode(), ErrorMessage.ERROR_CODE_MISSING_REQUEST_FIELD.getCode());
+        }
+    }
+
+    /**
      * Test with multiple headers.
      */
     @Test

--- a/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/test/java/org/wso2/carbon/identity/external/api/client/internal/service/APIClientTest.java
+++ b/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/test/java/org/wso2/carbon/identity/external/api/client/internal/service/APIClientTest.java
@@ -606,6 +606,99 @@ public class APIClientTest {
     }
 
     /**
+     * Test successful API call with PUT method and JSON payload.
+     */
+    @Test
+    public void testCallAPISuccessfulPutRequest() throws Exception {
+
+        httpServer = HttpServer.create(new InetSocketAddress(serverPort), 0);
+        httpServer.createContext(TEST_ENDPOINT, new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+
+                if (!"PUT".equals(exchange.getRequestMethod())) {
+                    exchange.sendResponseHeaders(405, -1);
+                    return;
+                }
+                byte[] response = RESPONSE_BODY.getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, response.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response);
+                }
+            }
+        });
+        httpServer.start();
+        baseUrl = "http://localhost:" + serverPort;
+
+        APIAuthentication authentication = new APIAuthentication.Builder()
+                .authType(APIAuthentication.AuthType.NONE)
+                .build();
+
+        APIRequestContext requestContext = new APIRequestContext.Builder()
+                .httpMethod(APIRequestContext.HttpMethod.PUT)
+                .apiAuthentication(authentication)
+                .endpointUrl(baseUrl + TEST_ENDPOINT)
+                .headers(new HashMap<>())
+                .payload(new StringEntity("{\"test\":\"data\"}", StandardCharsets.UTF_8))
+                .build();
+
+        APIInvocationConfig invocationConfig = new APIInvocationConfig();
+        invocationConfig.setAllowedRetryCount(0);
+
+        APIResponse response = apiClient.callAPI(requestContext, invocationConfig);
+
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+        assertEquals(response.getResponseBody(), RESPONSE_BODY);
+    }
+
+    /**
+     * Test PUT request forwards the payload body to the server.
+     */
+    @Test
+    public void testCallAPIWithPutRequestForwardsPayload() throws Exception {
+
+        final String requestPayload = "{\"name\":\"updated\"}";
+        final String[] receivedPayload = {null};
+
+        httpServer = HttpServer.create(new InetSocketAddress(serverPort), 0);
+        httpServer.createContext(TEST_ENDPOINT, new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+
+                byte[] body = exchange.getRequestBody().readAllBytes();
+                receivedPayload[0] = new String(body, StandardCharsets.UTF_8);
+                byte[] response = RESPONSE_BODY.getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, response.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response);
+                }
+            }
+        });
+        httpServer.start();
+        baseUrl = "http://localhost:" + serverPort;
+
+        APIAuthentication authentication = new APIAuthentication.Builder()
+                .authType(APIAuthentication.AuthType.NONE)
+                .build();
+
+        APIRequestContext requestContext = new APIRequestContext.Builder()
+                .httpMethod(APIRequestContext.HttpMethod.PUT)
+                .apiAuthentication(authentication)
+                .endpointUrl(baseUrl + TEST_ENDPOINT)
+                .headers(new HashMap<>())
+                .payload(new StringEntity(requestPayload, StandardCharsets.UTF_8))
+                .build();
+
+        APIInvocationConfig invocationConfig = new APIInvocationConfig();
+        invocationConfig.setAllowedRetryCount(0);
+
+        apiClient.callAPI(requestContext, invocationConfig);
+
+        assertEquals(receivedPayload[0], requestPayload);
+    }
+
+    /**
      * Test that a per-invocation response limit override higher than the client default allows a
      * response that would otherwise be blocked by the client-level limit.
      */


### PR DESCRIPTION
## Purpose
Extends the External API Framework client to support the HTTP `PUT` method, alongside the existing `POST` and `GET` support.

## Changes

### `APIRequestContext.java`
- Added `PUT("put")` to the `HttpMethod` enum.
- Updated payload validation to require a non-null payload for `PUT` requests (consistent with `POST` behaviour).

### `APIClient.java`
- Added a `PUT` case in the `callAPI` switch statement that constructs an `HttpPut` request and attaches the entity payload before execution.

### Tests
- **`APIRequestContextTest`** — two new tests:
  - Successful `APIRequestContext` creation with `PUT` method and a payload.
  - Validation that building a `PUT` context without a payload throws `APIClientRequestException`.
- **`APIClientTest`** — two new integration-style tests using an embedded `HttpServer`:
  - Verifies a `PUT` call returns the expected status code and response body.
  - Verifies the request payload is correctly forwarded to the server.

### Related Issue
- https://github.com/wso2/product-is/issues/28017