### PR TITLE
Add proxy host support to the External API Framework

### DIFF
--- a/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/main/java/org/wso2/carbon/identity/external/api/client/api/model/APIClientConfig.java
+++ b/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/main/java/org/wso2/carbon/identity/external/api/client/api/model/APIClientConfig.java
@@ -34,6 +34,8 @@ public class APIClientConfig {
     private final int poolSizeToBeSet;
     private final int maxPerRoute;
     private final long responseLimitInBytes;
+    private final String proxyHost;
+    private final int proxyPort;
 
     public APIClientConfig(Builder builder) {
 
@@ -43,6 +45,8 @@ public class APIClientConfig {
         this.poolSizeToBeSet = builder.poolSizeToBeSet;
         this.maxPerRoute = builder.defaultMaxPerRoute;
         this.responseLimitInBytes = builder.responseLimitInBytes;
+        this.proxyHost = builder.proxyHost;
+        this.proxyPort = builder.proxyPort;
     }
 
     /**
@@ -106,6 +110,26 @@ public class APIClientConfig {
     }
 
     /**
+     * Get the proxy host.
+     *
+     * @return proxy host, or null if no proxy is configured.
+     */
+    public String getProxyHost() {
+
+        return proxyHost;
+    }
+
+    /**
+     * Get the proxy port.
+     *
+     * @return proxy port, or 0 if no proxy is configured.
+     */
+    public int getProxyPort() {
+
+        return proxyPort;
+    }
+
+    /**
      * Builder class for APIClientConfig.
      */
     public static class Builder {
@@ -117,6 +141,8 @@ public class APIClientConfig {
         protected int poolSizeToBeSet = APIClientUtils.getDefaultPoolSizeToBeSet();
         protected int defaultMaxPerRoute = APIClientUtils.getDefaultMaxPerRoute();
         protected long responseLimitInBytes = APIClientUtils.getDefaultResponseLimit();
+        protected String proxyHost = null;
+        protected int proxyPort = 0;
 
         public APIClientConfig.Builder httpReadTimeoutInMillis(int httpReadTimeoutInMillis) {
 
@@ -157,6 +183,30 @@ public class APIClientConfig {
         public APIClientConfig.Builder responseLimitInBytes(long responseLimitInBytes) {
 
             this.responseLimitInBytes = responseLimitInBytes;
+            return this;
+        }
+
+        /**
+         * Set the proxy host. If blank or null, no proxy will be configured.
+         *
+         * @param proxyHost proxy host name or IP address.
+         * @return this builder.
+         */
+        public APIClientConfig.Builder proxyHost(String proxyHost) {
+
+            this.proxyHost = proxyHost;
+            return this;
+        }
+
+        /**
+         * Set the proxy port. Required when a proxy host is set.
+         *
+         * @param proxyPort proxy port number.
+         * @return this builder.
+         */
+        public APIClientConfig.Builder proxyPort(int proxyPort) {
+
+            this.proxyPort = proxyPort;
             return this;
         }
 

--- a/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/main/java/org/wso2/carbon/identity/external/api/client/internal/service/APIClient.java
+++ b/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/main/java/org/wso2/carbon/identity/external/api/client/internal/service/APIClient.java
@@ -18,10 +18,12 @@
 
 package org.wso2.carbon.identity.external.api.client.internal.service;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -79,8 +81,13 @@ public class APIClient {
         PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
         connectionManager.setMaxTotal(apiClientConfig.getPoolSizeToBeSet());
         connectionManager.setDefaultMaxPerRoute(apiClientConfig.getMaxPerRoute());
-        httpClient = HttpClientBuilder.create().setDefaultRequestConfig(config).setConnectionManager(connectionManager)
-                .build();
+        HttpClientBuilder clientBuilder = HttpClientBuilder.create()
+                .setDefaultRequestConfig(config)
+                .setConnectionManager(connectionManager);
+        if (StringUtils.isNotBlank(apiClientConfig.getProxyHost())) {
+            clientBuilder.setProxy(new HttpHost(apiClientConfig.getProxyHost(), apiClientConfig.getProxyPort()));
+        }
+        httpClient = clientBuilder.build();
         defaultResponseLimitInBytes = apiClientConfig.getResponseLimitInBytes();
 
         if (LOG.isDebugEnabled()) {

--- a/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/test/java/org/wso2/carbon/identity/external/api/client/api/model/APIClientConfigTest.java
+++ b/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/test/java/org/wso2/carbon/identity/external/api/client/api/model/APIClientConfigTest.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.utils.ServerConstants;
 import java.io.File;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -111,5 +112,68 @@ public class APIClientConfigTest {
     public void testBuilderThrowsOnNegativeResponseLimit() throws APIClientConfigException {
 
         new APIClientConfig.Builder().responseLimitInBytes(-1L).build();
+    }
+
+    /**
+     * Test that the builder stores a proxy host correctly.
+     */
+    @Test
+    public void testBuilderStoresProxyHost() throws APIClientConfigException {
+
+        APIClientConfig config = new APIClientConfig.Builder()
+                .proxyHost("proxy.example.com")
+                .proxyPort(8080)
+                .build();
+        assertEquals(config.getProxyHost(), "proxy.example.com",
+                "Proxy host should reflect the value supplied to the builder.");
+    }
+
+    /**
+     * Test that the builder stores a proxy port correctly.
+     */
+    @Test
+    public void testBuilderStoresProxyPort() throws APIClientConfigException {
+
+        APIClientConfig config = new APIClientConfig.Builder()
+                .proxyHost("proxy.example.com")
+                .proxyPort(3128)
+                .build();
+        assertEquals(config.getProxyPort(), 3128,
+                "Proxy port should reflect the value supplied to the builder.");
+    }
+
+    /**
+     * Test that the default proxy host is null when not configured.
+     */
+    @Test
+    public void testDefaultProxyHostIsNull() throws APIClientConfigException {
+
+        APIClientConfig config = new APIClientConfig.Builder().build();
+        assertNull(config.getProxyHost(),
+                "Default proxy host should be null when not configured.");
+    }
+
+    /**
+     * Test that the default proxy port is zero when not configured.
+     */
+    @Test
+    public void testDefaultProxyPortIsZero() throws APIClientConfigException {
+
+        APIClientConfig config = new APIClientConfig.Builder().build();
+        assertEquals(config.getProxyPort(), 0,
+                "Default proxy port should be 0 when not configured.");
+    }
+
+    /**
+     * Test that explicitly setting a null proxy host stores null.
+     */
+    @Test
+    public void testBuilderWithNullProxyHostStoresNull() throws APIClientConfigException {
+
+        APIClientConfig config = new APIClientConfig.Builder()
+                .proxyHost(null)
+                .build();
+        assertNull(config.getProxyHost(),
+                "Explicitly null proxy host should be stored as null.");
     }
 }

--- a/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/test/java/org/wso2/carbon/identity/external/api/client/internal/service/APIClientTest.java
+++ b/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/test/java/org/wso2/carbon/identity/external/api/client/internal/service/APIClientTest.java
@@ -698,6 +698,111 @@ public class APIClientTest {
         assertEquals(receivedPayload[0], requestPayload);
     }
 
+    @Test
+    public void testAPICallFailsWhenProxyIsUnreachable() throws Exception {
+
+        httpServer = HttpServer.create(new InetSocketAddress(serverPort), 0);
+        httpServer.createContext(TEST_ENDPOINT, new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+
+                byte[] response = RESPONSE_BODY.getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, response.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response);
+                }
+            }
+        });
+        httpServer.start();
+        baseUrl = "http://localhost:" + serverPort;
+
+        // Configure a proxy at a port where nothing is listening.
+        int unusedProxyPort = serverPort + 10000;
+        APIClientConfig config = new APIClientConfig.Builder()
+                .httpReadTimeoutInMillis(1000)
+                .httpConnectionRequestTimeoutInMillis(1000)
+                .httpConnectionTimeoutInMillis(1000)
+                .poolSizeToBeSet(5)
+                .defaultMaxPerRoute(5)
+                .proxyHost("localhost")
+                .proxyPort(unusedProxyPort)
+                .build();
+        APIClient proxiedClient = new APIClient(config);
+
+        APIAuthentication authentication = new APIAuthentication.Builder()
+                .authType(APIAuthentication.AuthType.NONE)
+                .build();
+
+        APIRequestContext requestContext = new APIRequestContext.Builder()
+                .httpMethod(APIRequestContext.HttpMethod.GET)
+                .apiAuthentication(authentication)
+                .endpointUrl(baseUrl + TEST_ENDPOINT)
+                .headers(new HashMap<>())
+                .build();
+
+        APIInvocationConfig invocationConfig = new APIInvocationConfig();
+        invocationConfig.setAllowedRetryCount(0);
+
+        try {
+            proxiedClient.callAPI(requestContext, invocationConfig);
+            fail("Expected APIClientInvocationException when configured proxy is unreachable.");
+        } catch (APIClientInvocationException e) {
+            assertEquals(e.getErrorCode(),
+                    ErrorMessageConstant.ErrorMessage.ERROR_CODE_WHILE_INVOKING_API.getCode());
+        }
+    }
+
+    @Test
+    public void testAPICallSucceedsWhenProxyHostIsBlank() throws Exception {
+
+        httpServer = HttpServer.create(new InetSocketAddress(serverPort), 0);
+        httpServer.createContext(TEST_ENDPOINT, new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+
+                byte[] response = RESPONSE_BODY.getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, response.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response);
+                }
+            }
+        });
+        httpServer.start();
+        baseUrl = "http://localhost:" + serverPort;
+
+        // Blank proxy host must be ignored; the client should connect directly.
+        APIClientConfig config = new APIClientConfig.Builder()
+                .httpReadTimeoutInMillis(5000)
+                .httpConnectionRequestTimeoutInMillis(3000)
+                .httpConnectionTimeoutInMillis(3000)
+                .poolSizeToBeSet(5)
+                .defaultMaxPerRoute(5)
+                .proxyHost("   ")
+                .proxyPort(8080)
+                .build();
+        APIClient directClient = new APIClient(config);
+
+        APIAuthentication authentication = new APIAuthentication.Builder()
+                .authType(APIAuthentication.AuthType.NONE)
+                .build();
+
+        APIRequestContext requestContext = new APIRequestContext.Builder()
+                .httpMethod(APIRequestContext.HttpMethod.GET)
+                .apiAuthentication(authentication)
+                .endpointUrl(baseUrl + TEST_ENDPOINT)
+                .headers(new HashMap<>())
+                .build();
+
+        APIInvocationConfig invocationConfig = new APIInvocationConfig();
+        invocationConfig.setAllowedRetryCount(0);
+
+        APIResponse response = directClient.callAPI(requestContext, invocationConfig);
+
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+        assertEquals(response.getResponseBody(), RESPONSE_BODY);
+    }
+
     /**
      * Test that a per-invocation response limit override higher than the client default allows a
      * response that would otherwise be blocked by the client-level limit.


### PR DESCRIPTION
## Purpose

Adds optional HTTP proxy support to the External API Framework client. Callers can now configure a proxy host and port via `APIClientConfig.Builder`, and the underlying Apache HttpClient will route all requests through the specified proxy.

## Changes

### `APIClientConfig`
- Added `proxyHost` (String) and `proxyPort` (int) fields with defaults of `null` and `0`.
- Exposed `getProxyHost()` and `getProxyPort()` getters.
- Added `proxyHost(String)` and `proxyPort(int)` builder methods.

### `APIClient`
- After building the `HttpClientBuilder`, checks `StringUtils.isNotBlank(proxyHost)` and calls `clientBuilder.setProxy(new HttpHost(host, port))` only when a proxy is configured — no behaviour change for existing callers.

### Tests
- **`APIClientConfigTest`** — 5 new unit tests covering: builder stores proxy host/port, default values are `null`/`0`, and explicit `null` is preserved.
- **`APIClientTest`** — 2 new integration tests:
  - Verifies that an unreachable proxy causes the call to fail even when the target server is up (proves the proxy path is taken).
  - Verifies that a blank proxy host is ignored and the direct connection succeeds.

## Related Issue
- https://github.com/wso2/product-is/issues/28017