### PR TITLE
Add feature flags config for console flow extensions

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1672,6 +1672,7 @@
   "console.flows.scopes.update": ["internal_flow_update", "internal_governance_update"],
   "console.flows.scopes.delete": [],
   "console.flow_extensions.enabled": true,
+  "console.flow_extensions.feature_flags": [],
   "console.flow_extensions.scopes.feature": ["console:flowExtensions"],
   "console.flow_extensions.disabled_features": [],
   "console.flow_extensions.scopes.create": ["internal_flow_extension_create"],


### PR DESCRIPTION
## Purpose
Introduce a new `console.flow_extensions.feature_flags` configuration entry for console flow extensions, allowing feature flags to be defined for this capability.

## Related Issue
- N/A

## Implementation
Added the `console.flow_extensions.feature_flags` key (defaulting to an empty array) to `org.wso2.carbon.identity.core.server.feature.default.json`, alongside the existing console flow extensions configuration entries.