### PR TITLE
Add support for closing the HTTP client

### DIFF
--- a/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/main/java/org/wso2/carbon/identity/external/api/client/api/service/AbstractAPIClientManager.java
+++ b/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/main/java/org/wso2/carbon/identity/external/api/client/api/service/AbstractAPIClientManager.java
@@ -27,6 +27,8 @@ import org.wso2.carbon.identity.external.api.client.api.model.APIRequestContext;
 import org.wso2.carbon.identity.external.api.client.api.model.APIResponse;
 import org.wso2.carbon.identity.external.api.client.internal.service.APIClient;
 
+import java.io.IOException;
+
 /**
  * Abstract class for API Client Manager implementations which responsible for handling API calls and responses.
  */
@@ -66,5 +68,15 @@ public abstract class AbstractAPIClientManager {
         }
 
         return apiClient.callAPI(requestContext, apiInvocationConfig);
+    }
+
+    /**
+     * Closes the underlying API client and releases all associated resources.
+     *
+     * @throws IOException if an error occurs while closing the API client.
+     */
+    public void close() throws IOException {
+
+        apiClient.close();
     }
 }

--- a/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/main/java/org/wso2/carbon/identity/external/api/client/internal/service/APIClient.java
+++ b/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/main/java/org/wso2/carbon/identity/external/api/client/internal/service/APIClient.java
@@ -252,4 +252,14 @@ public class APIClient {
 
         return new APIResponse(statusCode, responseBody);
     }
+
+    /**
+     * Closes the underlying HTTP client and releases all associated resources.
+     *
+     * @throws IOException if an error occurs while closing the HTTP client.
+     */
+    public void close() throws IOException {
+
+        httpClient.close();
+    }
 }

--- a/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/test/java/org/wso2/carbon/identity/external/api/client/api/service/AbstractAPIClientManagerTest.java
+++ b/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/test/java/org/wso2/carbon/identity/external/api/client/api/service/AbstractAPIClientManagerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.external.api.client.api.service;
+
+import com.sun.net.httpserver.HttpServer;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.external.api.client.api.model.APIClientConfig;
+
+import java.io.IOException;
+
+/**
+ * Tests for AbstractAPIClientManager.
+ */
+public class AbstractAPIClientManagerTest {
+
+    private HttpServer httpServer;
+    private ConcreteAPIClientManager manager;
+
+    /**
+     * Minimal concrete subclass used in tests.
+     */
+    private static class ConcreteAPIClientManager extends AbstractAPIClientManager {
+
+        ConcreteAPIClientManager(APIClientConfig config) {
+
+            super(config);
+        }
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        APIClientConfig config = new APIClientConfig.Builder()
+                .httpReadTimeoutInMillis(5000)
+                .httpConnectionRequestTimeoutInMillis(3000)
+                .httpConnectionTimeoutInMillis(3000)
+                .poolSizeToBeSet(20)
+                .defaultMaxPerRoute(10)
+                .build();
+        manager = new ConcreteAPIClientManager(config);
+    }
+
+    @AfterMethod
+    public void tearDown() throws IOException {
+
+        if (httpServer != null) {
+            httpServer.stop(0);
+        }
+        if (manager != null) {
+            manager.close();
+        }
+    }
+
+    /**
+     * Test that close() completes without throwing an exception on a newly created manager.
+     */
+    @Test
+    public void testCloseSucceeds() throws IOException {
+
+        manager.close();
+    }
+}

--- a/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/test/java/org/wso2/carbon/identity/external/api/client/internal/service/APIClientTest.java
+++ b/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/test/java/org/wso2/carbon/identity/external/api/client/internal/service/APIClientTest.java
@@ -91,10 +91,13 @@ public class APIClientTest {
     }
 
     @AfterMethod
-    public void tearDown() {
+    public void tearDown() throws IOException {
 
         if (httpServer != null) {
             httpServer.stop(0);
+        }
+        if (apiClient != null) {
+            apiClient.close();
         }
         System.clearProperty(ServerConstants.CARBON_HOME);
     }
@@ -857,5 +860,54 @@ public class APIClientTest {
 
         assertNotNull(response);
         assertEquals(response.getResponseBody(), body);
+    }
+
+    /**
+     * Test that close() completes without throwing an exception on a newly created client.
+     */
+    @Test
+    public void testCloseSucceeds() throws IOException {
+
+        apiClient.close();
+    }
+
+    /**
+     * Test that close() completes without throwing an exception after the client has served requests.
+     */
+    @Test
+    public void testCloseAfterSuccessfulRequestSucceeds() throws Exception {
+
+        httpServer = HttpServer.create(new InetSocketAddress(serverPort), 0);
+        httpServer.createContext(TEST_ENDPOINT, new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+
+                byte[] response = RESPONSE_BODY.getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, response.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response);
+                }
+            }
+        });
+        httpServer.start();
+        baseUrl = "http://localhost:" + serverPort;
+
+        APIAuthentication authentication = new APIAuthentication.Builder()
+                .authType(APIAuthentication.AuthType.NONE)
+                .build();
+        APIRequestContext requestContext = new APIRequestContext.Builder()
+                .httpMethod(APIRequestContext.HttpMethod.GET)
+                .apiAuthentication(authentication)
+                .endpointUrl(baseUrl + TEST_ENDPOINT)
+                .headers(new HashMap<>())
+                .build();
+        APIInvocationConfig invocationConfig = new APIInvocationConfig();
+        invocationConfig.setAllowedRetryCount(0);
+
+        APIResponse response = apiClient.callAPI(requestContext, invocationConfig);
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+
+        apiClient.close();
     }
 }

--- a/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/test/resources/testng.xml
+++ b/components/external-api-framework/org.wso2.carbon.identity.external.api.client/src/test/resources/testng.xml
@@ -40,6 +40,7 @@
     <test name="Service Tests">
         <classes>
             <class name="org.wso2.carbon.identity.external.api.client.internal.service.APIClientTest"/>
+            <class name="org.wso2.carbon.identity.external.api.client.api.service.AbstractAPIClientManagerTest"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose

`APIClient` creates a `PoolingHttpClientConnectionManager` and a `CloseableHttpClient` during construction. Both are long-lived, stateful resources that hold pooled TCP connections. Neither was ever released, meaning implementations that extend `AbstractAPIClientManager` had no way to clean up the underlying HTTP client on shutdown, leading to a resource leak.

## Changes

### `APIClient`
- Added a `close()` method that calls `httpClient.close()`, which in turn shuts down the underlying `PoolingHttpClientConnectionManager` and releases all pooled connections.

### `AbstractAPIClientManager`
- Added a `close()` method that delegates to `apiClient.close()`.
- Downstream components that extend this class should call `close()`.

### Tests
- Updated `APIClientTest.tearDown()` to call `apiClient.close()` after each test for proper cleanup.
- Added `testCloseSucceeds` — verifies `close()` on a fresh `APIClient` does not throw.
- Added `testCloseAfterSuccessfulRequestSucceeds` — makes a real HTTP call then closes, verifying no exception is thrown after the client has been used.
- Added `AbstractAPIClientManagerTest` covering:
  - `testCloseSucceeds` — verifies `close()` on a fresh manager does not throw.
  - `testCloseAfterSuccessfulRequestSucceeds` — verifies close after serving a request.
  - `testCallAPIDelegatesSuccessfully` — verifies the abstract class correctly delegates to the underlying `APIClient`.
  - `testCallAPIWithNullArgumentsThrowsIllegalArgumentException` — covers the null guard in `callAPI()`.

## Related Issue
- https://github.com/wso2/product-is/issues/28017