### PR TITLE
Introduce new property to track runtime claims in ClaimMapping object.

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ClaimMapping.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ClaimMapping.java
@@ -53,6 +53,9 @@ public class ClaimMapping implements Serializable {
     @XmlElement(name = "MandatoryClaim")
     private boolean isMandatory;
 
+    @XmlElement(name = "RuntimeClaim")
+    private boolean isRuntimeValue = false;
+
     /**
      * @param localClaimUri
      * @param remoteClaimUri
@@ -145,6 +148,10 @@ public class ClaimMapping implements Serializable {
 
             if ("MandatoryClaim".equals(elementName)) {
                 claimMapping.setMandatory(Boolean.parseBoolean(element.getText()));
+            }
+
+            if ("RuntimeClaim".equals(elementName)) {
+                claimMapping.setRuntimeValue(Boolean.parseBoolean(element.getText()));
             }
 
         }
@@ -266,5 +273,21 @@ public class ClaimMapping implements Serializable {
     public void setMandatory(boolean isMandatory) {
 
         this.isMandatory = isMandatory;
+    }
+
+    /**
+     * @return
+     */
+    public boolean isRuntimeValue() {
+
+        return isRuntimeValue;
+    }
+
+    /**
+     * @param isRuntimeValue
+     */
+    public void setRuntimeValue(boolean isRuntimeValue) {
+
+        this.isRuntimeValue = isRuntimeValue;
     }
 }

--- a/service-stubs/identity/org.wso2.carbon.identity.application.default.authentication.sequence.mgt.stub/src/main/resources/IdentityDefaultSeqManagementService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.default.authentication.sequence.mgt.stub/src/main/resources/IdentityDefaultSeqManagementService.wsdl
@@ -178,6 +178,7 @@
                     <xs:element minOccurs="0" name="mandatory" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="remoteClaim" nillable="true" type="ax2177:Claim"/>
                     <xs:element minOccurs="0" name="requested" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="runtimeValue" type="xs:boolean"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="Claim">

--- a/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.identity.application.mgt.stub/src/main/resources/IdentityApplicationManagementService.wsdl
@@ -423,6 +423,7 @@
                     <xs:element minOccurs="0" name="mandatory" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="remoteClaim" nillable="true" type="ax2163:Claim"/>
                     <xs:element minOccurs="0" name="requested" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="runtimeValue" type="xs:boolean"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="Claim">

--- a/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
@@ -58,6 +58,7 @@
                     <xs:element minOccurs="0" name="mandatory" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="remoteClaim" nillable="true" type="ax2408:Claim"/>
                     <xs:element minOccurs="0" name="requested" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="runtimeValue" type="xs:boolean"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="Claim">


### PR DESCRIPTION
This pull request introduces support for a new claim property called "runtimeValue" in the claim mapping model and updates the relevant WSDL files to include this property. The main goal is to allow claims to be marked as runtime values, which can be used to indicate that their values are determined at runtime.

Model enhancements:

* Added a new boolean field `isRuntimeValue` (with XML element name `RuntimeClaim`) to the `ClaimMapping` class, along with corresponding getter and setter methods. [[1]](diffhunk://#diff-ce3c480c7cc1e02b0287b621c4c5531e316286e6ceca8500b22f80fda0cb850aR56-R58) [[2]](diffhunk://#diff-ce3c480c7cc1e02b0287b621c4c5531e316286e6ceca8500b22f80fda0cb850aR277-R292)
* Updated the static `build` method in `ClaimMapping` to parse the `RuntimeClaim` XML element and set the `isRuntimeValue` property accordingly.

Service contract updates:

* Added a new `runtimeValue` boolean element to the claim mapping sequences in the following WSDL files to expose the property in service interfaces:
  - `IdentityDefaultSeqManagementService.wsdl`
  - `IdentityApplicationManagementService.wsdl`
  - `IdentityProviderMgtService.wsdl`