### PR TITLE
Support SSO for shared users across sub-organizations.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/SessionContextCache.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/SessionContextCache.java
@@ -83,6 +83,25 @@ public class SessionContextCache extends BaseCache<SessionContextCacheKey, Sessi
     }
 
     /**
+     * Add the given session context entry to the cache only, without persisting it to the session data store.
+     *
+     * @param key               Key which the cache entry is indexed by.
+     * @param entry             Value to be stored in the cache.
+     * @param loginTenantDomain Login tenant domain under which the cache entry is stored.
+     */
+    public void addToCacheWithoutPersisting(SessionContextCacheKey key, SessionContextCacheEntry entry,
+                                            String loginTenantDomain) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Adding session context to cache without updating the session data store corresponding " +
+                    "to the key : " + key.getContextId() + " with accessed time " + entry.getAccessedTime() +
+                    " and validity time " + entry.getValidityPeriod());
+        }
+        entry.setAccessedTime();
+        super.addToCache(key, entry, resolveLoginTenantDomain(loginTenantDomain));
+    }
+
+    /**
      * Add a cache entry during a READ operation.
      * <p>
      * This populates the cache only if the key does not already have a value.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/SessionContextCache.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/cache/SessionContextCache.java
@@ -87,10 +87,10 @@ public class SessionContextCache extends BaseCache<SessionContextCacheKey, Sessi
      *
      * @param key               Key which the cache entry is indexed by.
      * @param entry             Value to be stored in the cache.
-     * @param loginTenantDomain Login tenant domain under which the cache entry is stored.
+     * @param tenantDomain      Tenant domain under which the cache entry is stored.
      */
     public void addToCacheWithoutPersisting(SessionContextCacheKey key, SessionContextCacheEntry entry,
-                                            String loginTenantDomain) {
+                                            String tenantDomain) {
 
         if (log.isDebugEnabled()) {
             log.debug("Adding session context to cache without updating the session data store corresponding " +
@@ -98,7 +98,7 @@ public class SessionContextCache extends BaseCache<SessionContextCacheKey, Sessi
                     " and validity time " + entry.getValidityPeriod());
         }
         entry.setAccessedTime();
-        super.addToCache(key, entry, resolveLoginTenantDomain(loginTenantDomain));
+        super.addToCache(key, entry, resolveLoginTenantDomain(tenantDomain));
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -512,27 +512,17 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                     SessionContext loadedSessionContext = FrameworkUtils.getSessionContextFromCache(
                             sessionContextKey, context.getLoginTenantDomain());
                     if (loadedSessionContext != null) {
-                        if (context.isSharedAppLogin()) {
-                            String authenticatedOrgId =
-                                    context.getOrganizationLoginData().getAccessingOrganization().getId();
-                            if (MapUtils.isNotEmpty(loadedSessionContext.getAuthenticatedOrgData()) &&
-                                    loadedSessionContext.getAuthenticatedOrgData().get(authenticatedOrgId) != null) {
-                                sessionContext = loadedSessionContext;
-                            }
-                        } else if (context.isOrgApplicationLogin()) {
-                            String accessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                                    .getAccessingOrganizationId();
-                            if (MapUtils.isNotEmpty(loadedSessionContext.getAuthenticatedOrgData()) &&
-                                    loadedSessionContext.getAuthenticatedOrgData().get(accessingOrgId) != null) {
-                                sessionContext = loadedSessionContext;
-                            }
-                        } else {
+                        boolean isSubOrgLogin = context.isSharedAppLogin() || context.isOrgApplicationLogin();
+                        boolean isPreviousSessionApplicable = !isSubOrgLogin
+                                || MapUtils.isNotEmpty(loadedSessionContext.getAuthenticatedOrgData());
+
+                        if (isPreviousSessionApplicable) {
                             sessionContext = loadedSessionContext;
-                        }
-                        if (sessionContext == null) {
+                        } else {
                             if (log.isDebugEnabled()) {
-                                log.debug("Previous session context is not applicable for the current authentication." +
-                                        " Hence, a new session context will be created for the authentication flow.");
+                                log.debug("Previous session context is not applicable for the current " +
+                                        "authentication. Hence, a new session context will be created for the " +
+                                        "authentication flow.");
                             }
                             FrameworkUtils.removeSessionContextFromCache(sessionContextKey,
                                     context.getLoginTenantDomain());
@@ -557,15 +547,30 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                     }
                     AuthenticatedOrgData authenticatedOrgData =
                             sessionContext.getAuthenticatedOrgData().get(organizationId);
-                    authenticatedOrgData.getAuthenticatedSequences()
-                            .put(appConfig.getApplicationName(), sequenceConfig);
-                    authenticatedOrgData.getAuthenticatedIdPs().putAll(context.getCurrentAuthenticatedIdPs());
-                    if (!context.isPassiveAuthenticate()) {
-                        setAuthenticatedIDPsOfApp(authenticatedOrgData, context.getCurrentAuthenticatedIdPs(),
-                                appConfig.getApplicationName());
-                    }
                     if (context.isSharedAppLogin()) {
                         sessionContext.setAuthenticatedSharedAppOrgId(organizationId);
+                    }
+                    if (authenticatedOrgData != null) {
+                        authenticatedOrgData.getAuthenticatedSequences()
+                                .put(appConfig.getApplicationName(), sequenceConfig);
+                        authenticatedOrgData.getAuthenticatedIdPs().putAll(context.getCurrentAuthenticatedIdPs());
+                        if (!context.isPassiveAuthenticate()) {
+                            setAuthenticatedIDPsOfApp(authenticatedOrgData, context.getCurrentAuthenticatedIdPs(),
+                                    appConfig.getApplicationName());
+                        }
+                    } else {
+                        // currently accessing org is not previously authenticated.
+                        AuthenticatedOrgData accessingOrgAuthenticatedOrgData = new AuthenticatedOrgData();
+                        accessingOrgAuthenticatedOrgData.getAuthenticatedSequences().put(appConfig.getApplicationName(),
+                                sequenceConfig);
+                        // Consider both the previous and the current authenticated IdPs when an IdP with the same
+                        // name is present in both.
+                        accessingOrgAuthenticatedOrgData.setAuthenticatedIdPs(mergeAuthenticatedIdPs(
+                                context.getPreviousAuthenticatedIdPs(), context.getCurrentAuthenticatedIdPs()));
+                        setAuthenticatedIDPsOfApp(accessingOrgAuthenticatedOrgData,
+                                context.getCurrentAuthenticatedIdPs(), appConfig.getApplicationName());
+                        accessingOrgAuthenticatedOrgData.setRememberMe(context.isRememberMe());
+                        sessionContext.getAuthenticatedOrgData().put(organizationId, accessingOrgAuthenticatedOrgData);
                     }
                 } else {
                     sessionContext.getAuthenticatedSequences().put(appConfig.getApplicationName(), sequenceConfig);
@@ -659,7 +664,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                 // TODO add to cache?
                 // store again. when replicate  cache is used. this may be needed.
                 FrameworkUtils.addSessionContextToCache(sessionContextKey, sessionContext, applicationTenantDomain,
-                        context.getLoginTenantDomain(), organizationId);
+                        resolveRootTenantDomain(context), organizationId);
                 // Since the session context is already available, audit log will be added with updated details.
                 addAuditLogs(SessionMgtConstants.UPDATE_SESSION_ACTION, authenticationResult.getSubject(),
                         sessionContextKey, FrameworkUtils.getCorrelation(),
@@ -728,7 +733,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                 handleInboundSessionCreate(context.getRequestType(), sessionContextKey, sessionContext,
                         request, response, context);
                 FrameworkUtils.addSessionContextToCache(sessionContextKey, sessionContext, applicationTenantDomain,
-                        context.getLoginTenantDomain(), orgId);
+                        resolveRootTenantDomain(context), orgId);
                 // The session context will be stored from here. Since the audit log will be logged as a storing
                 // operation.
                 addAuditLogs(SessionMgtConstants.STORE_SESSION_ACTION,
@@ -854,6 +859,16 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
         }
 
         sendResponse(request, response, context);
+    }
+
+    private String resolveRootTenantDomain(AuthenticationContext context) {
+
+        if (context.getOrganizationLoginData() != null &&
+                StringUtils.isNotBlank(context.getOrganizationLoginData().getRootOrganizationTenantDomain())) {
+            return context.getOrganizationLoginData().getRootOrganizationTenantDomain();
+        }
+
+        return context.getLoginTenantDomain();
     }
 
     private void storeFedAuthSessionMapping(String sessionContextKey, AuthHistory authHistory)
@@ -1385,6 +1400,71 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             }
         }
         authenticatedOrgData.setAuthenticatedIdPsOfApp(applicationName, authenticatedIdPDataMap);
+    }
+
+    /**
+     * Merges the given authenticated IdP data maps into a single map
+     * adding only the authenticators which are not already present.
+     *
+     * @param previousAuthenticatedIdPs The authenticated IdP data to be used as the base.
+     * @param currentAuthenticatedIdPs  The authenticated IdP data to be merged into the base.
+     * @return A new map containing the merged authenticated IdP data.
+     * @throws FrameworkException If an error occurs while cloning the authenticated IdP data.
+     */
+    private Map<String, AuthenticatedIdPData> mergeAuthenticatedIdPs(
+            Map<String, AuthenticatedIdPData> previousAuthenticatedIdPs,
+            Map<String, AuthenticatedIdPData> currentAuthenticatedIdPs) throws FrameworkException {
+
+        Map<String, AuthenticatedIdPData> mergedAuthenticatedIdPs = new HashMap<>();
+        mergeAuthenticatedIdPsInto(mergedAuthenticatedIdPs, previousAuthenticatedIdPs);
+        mergeAuthenticatedIdPsInto(mergedAuthenticatedIdPs, currentAuthenticatedIdPs);
+        return mergedAuthenticatedIdPs;
+    }
+
+    /**
+     * Merges the authenticated IdP data of the given source map into the target merged map. When an IdP with the same
+     * name is already present in the merged map, only the authenticators which are not already present are added to
+     * the existing entry.
+     *
+     * @param mergedAuthenticatedIdPs The target map to merge into.
+     * @param authenticatedIdPs       The source authenticated IdP data to merge.
+     * @throws FrameworkException If an error occurs while cloning the authenticated IdP data.
+     */
+    private void mergeAuthenticatedIdPsInto(Map<String, AuthenticatedIdPData> mergedAuthenticatedIdPs,
+                                            Map<String, AuthenticatedIdPData> authenticatedIdPs)
+            throws FrameworkException {
+
+        if (MapUtils.isEmpty(authenticatedIdPs)) {
+            return;
+        }
+
+        for (Map.Entry<String, AuthenticatedIdPData> entry : authenticatedIdPs.entrySet()) {
+            String idpName = entry.getKey();
+            AuthenticatedIdPData authenticatedIdPData = entry.getValue();
+            AuthenticatedIdPData existingAuthenticatedIdPData = mergedAuthenticatedIdPs.get(idpName);
+            if (existingAuthenticatedIdPData == null) {
+                try {
+                    mergedAuthenticatedIdPs.put(idpName, (AuthenticatedIdPData) authenticatedIdPData.clone());
+                } catch (CloneNotSupportedException e) {
+                    throw new FrameworkException("Error while cloning AuthenticatedIdPData object.", e);
+                }
+            } else {
+                // An IdP with the same name is already added. Add only the authenticators which are not already
+                // present in the existing entry.
+                List<AuthenticatorConfig> existingAuthenticators = existingAuthenticatedIdPData.getAuthenticators();
+                List<AuthenticatorConfig> newAuthenticators = authenticatedIdPData.getAuthenticators();
+                if (CollectionUtils.isNotEmpty(newAuthenticators)) {
+                    for (AuthenticatorConfig newAuthenticator : newAuthenticators) {
+                        boolean alreadyPresent = existingAuthenticators != null && existingAuthenticators.stream()
+                                .anyMatch(existing -> StringUtils.equals(existing.getName(),
+                                        newAuthenticator.getName()));
+                        if (!alreadyPresent) {
+                            existingAuthenticatedIdPData.addAuthenticator(newAuthenticator);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private void addAuditLogs(String sessionAction, AuthenticatedUser authenticatedUser, String sessionKey,

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -1474,26 +1474,28 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
 
         for (Map.Entry<String, AuthenticatedIdPData> entry : authenticatedIdPs.entrySet()) {
             String idpName = entry.getKey();
-            AuthenticatedIdPData authenticatedIdPData = entry.getValue();
-            AuthenticatedIdPData existingAuthenticatedIdPData = mergedAuthenticatedIdPs.get(idpName);
-            if (existingAuthenticatedIdPData == null) {
-                try {
-                    mergedAuthenticatedIdPs.put(idpName, (AuthenticatedIdPData) authenticatedIdPData.clone());
-                } catch (CloneNotSupportedException e) {
-                    throw new FrameworkException("Error while cloning AuthenticatedIdPData object.", e);
-                }
-            } else {
-                // An IdP with the same name is already added. Add only the authenticators which are not already
-                // present in the existing entry.
-                List<AuthenticatorConfig> existingAuthenticators = existingAuthenticatedIdPData.getAuthenticators();
-                List<AuthenticatorConfig> newAuthenticators = authenticatedIdPData.getAuthenticators();
-                if (CollectionUtils.isNotEmpty(newAuthenticators)) {
-                    for (AuthenticatorConfig newAuthenticator : newAuthenticators) {
-                        boolean alreadyPresent = existingAuthenticators != null && existingAuthenticators.stream()
-                                .anyMatch(existing -> StringUtils.equals(existing.getName(),
-                                        newAuthenticator.getName()));
-                        if (!alreadyPresent) {
-                            existingAuthenticatedIdPData.addAuthenticator(newAuthenticator);
+            if (FrameworkConstants.LOCAL_IDP_NAME.equals(idpName)) {
+                AuthenticatedIdPData authenticatedIdPData = entry.getValue();
+                AuthenticatedIdPData existingAuthenticatedIdPData = mergedAuthenticatedIdPs.get(idpName);
+                if (existingAuthenticatedIdPData == null) {
+                    try {
+                        mergedAuthenticatedIdPs.put(idpName, (AuthenticatedIdPData) authenticatedIdPData.clone());
+                    } catch (CloneNotSupportedException e) {
+                        throw new FrameworkException("Error while cloning AuthenticatedIdPData object.", e);
+                    }
+                } else {
+                    // An IdP with the same name is already added. Add only the authenticators which are not already
+                    // present in the existing entry.
+                    List<AuthenticatorConfig> existingAuthenticators = existingAuthenticatedIdPData.getAuthenticators();
+                    List<AuthenticatorConfig> newAuthenticators = authenticatedIdPData.getAuthenticators();
+                    if (CollectionUtils.isNotEmpty(newAuthenticators)) {
+                        for (AuthenticatorConfig newAuthenticator : newAuthenticators) {
+                            boolean alreadyPresent = existingAuthenticators != null && existingAuthenticators.stream()
+                                    .anyMatch(existing -> StringUtils.equals(existing.getName(),
+                                            newAuthenticator.getName()));
+                            if (!alreadyPresent) {
+                                existingAuthenticatedIdPData.addAuthenticator(newAuthenticator);
+                            }
                         }
                     }
                 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -65,6 +65,7 @@ import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.idp.mgt.util.IdPManagementUtil;
@@ -81,8 +82,10 @@ import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -514,7 +517,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                     if (loadedSessionContext != null) {
                         boolean isSubOrgLogin = context.isSharedAppLogin() || context.isOrgApplicationLogin();
                         boolean isPreviousSessionApplicable = !isSubOrgLogin
-                                || MapUtils.isNotEmpty(loadedSessionContext.getAuthenticatedOrgData());
+                                || isAuthenticatedOrgSessionsApplicable(context, loadedSessionContext);
 
                         if (isPreviousSessionApplicable) {
                             sessionContext = loadedSessionContext;
@@ -663,8 +666,8 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                         request, response, context);
                 // TODO add to cache?
                 // store again. when replicate  cache is used. this may be needed.
-                FrameworkUtils.addSessionContextToCache(sessionContextKey, sessionContext, applicationTenantDomain,
-                        resolveRootTenantDomain(context), organizationId);
+                addSessionContextToCache(sessionContextKey, sessionContext,
+                        applicationTenantDomain, context, organizationId);
                 // Since the session context is already available, audit log will be added with updated details.
                 addAuditLogs(SessionMgtConstants.UPDATE_SESSION_ACTION, authenticationResult.getSubject(),
                         sessionContextKey, FrameworkUtils.getCorrelation(),
@@ -733,7 +736,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                 handleInboundSessionCreate(context.getRequestType(), sessionContextKey, sessionContext,
                         request, response, context);
                 FrameworkUtils.addSessionContextToCache(sessionContextKey, sessionContext, applicationTenantDomain,
-                        resolveRootTenantDomain(context), orgId);
+                        context.getLoginTenantDomain(), orgId);
                 // The session context will be stored from here. Since the audit log will be logged as a storing
                 // operation.
                 addAuditLogs(SessionMgtConstants.STORE_SESSION_ACTION,
@@ -861,14 +864,45 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
         sendResponse(request, response, context);
     }
 
-    private String resolveRootTenantDomain(AuthenticationContext context) {
+    /**
+     * Adds the session context to the cache against the login tenant domain (also persisting it to the session data
+     * store) and additionally caches it against all other tenant domains the session spans across.
+     *
+     * @param sessionContextKey       Session context cache key.
+     * @param sessionContext          Session context to be cached.
+     * @param applicationTenantDomain Application tenant domain used to resolve session timeout configurations.
+     * @param context                 Authentication context.
+     * @param organizationId          Organization id used to resolve authenticated sequences for cache cleanup.
+     */
+    private void addSessionContextToCache(String sessionContextKey, SessionContext sessionContext,
+                                          String applicationTenantDomain,
+                                          AuthenticationContext context, String organizationId) {
 
-        if (context.getOrganizationLoginData() != null &&
-                StringUtils.isNotBlank(context.getOrganizationLoginData().getRootOrganizationTenantDomain())) {
-            return context.getOrganizationLoginData().getRootOrganizationTenantDomain();
+        String loginTenantDomain = context.getLoginTenantDomain();
+        FrameworkUtils.addSessionContextToCache(sessionContextKey, sessionContext, applicationTenantDomain,
+                loginTenantDomain, organizationId);
+        Set<String> authenticatedOrganizations = new HashSet<>();
+        if (MapUtils.isNotEmpty(sessionContext.getAuthenticatedOrgData())) {
+            for (String authenticatedOrgId : sessionContext.getAuthenticatedOrgData().keySet()) {
+                try {
+                    authenticatedOrganizations.add(FrameworkServiceDataHolder.getInstance()
+                            .getOrganizationManager().resolveTenantDomain(authenticatedOrgId));
+                } catch (OrganizationManagementException e) {
+                    log.error("Error while resolving the tenant domain of the organization with id: " +
+                            authenticatedOrgId, e);
+                }
+            }
         }
 
-        return context.getLoginTenantDomain();
+        if (context.getOrganizationLoginData() != null && StringUtils.isNotBlank(
+                context.getOrganizationLoginData().getRootOrganizationTenantDomain())) {
+            authenticatedOrganizations.add(context.getOrganizationLoginData().getRootOrganizationTenantDomain());
+        }
+        authenticatedOrganizations.remove(loginTenantDomain);
+        for (String tenantDomain : authenticatedOrganizations) {
+            FrameworkUtils.addSessionContextToCacheWithoutPersisting(sessionContextKey, sessionContext,
+                    applicationTenantDomain, tenantDomain, organizationId);
+        }
     }
 
     private void storeFedAuthSessionMapping(String sessionContextKey, AuthHistory authHistory)
@@ -1525,5 +1559,57 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
             return null;
         }
         return federatedTokens.stream().map(FederatedToken::getIdp).collect(Collectors.toList());
+    }
+
+    /**
+     * Determines whether the organization sessions held in an already existing session context are applicable to
+     * the current organization login, and can therefore be reused instead of creating a new session context.
+     *
+     * @param context        Authentication context of the current authentication flow.
+     * @param sessionContext Existing session context loaded from the cache.
+     * @return {@code true} if the organization sessions in the existing session context are applicable to the
+     * current login; {@code false} otherwise.
+     */
+    private boolean isAuthenticatedOrgSessionsApplicable(AuthenticationContext context,
+                                                         SessionContext sessionContext) {
+
+        Map<String, AuthenticatedOrgData> authenticatedOrgDataMap = sessionContext.getAuthenticatedOrgData();
+        if (MapUtils.isEmpty(authenticatedOrgDataMap)) {
+            return false;
+        }
+
+        AuthenticatedUser currentAuthenticatedUser = context.getSequenceConfig().getAuthenticatedUser();
+        String accessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getAccessingOrganizationId();
+        if (context.isSharedAppLogin()) {
+            accessingOrgId = context.getOrganizationLoginData().getAccessingOrganization().getId();
+        }
+
+        if (accessingOrgId == null) {
+            return false;
+        }
+
+        if (!currentAuthenticatedUser.isSharedUser() &&
+                sessionContext.getAuthenticatedOrgData().get(accessingOrgId) == null) {
+            return false;
+        }
+
+        try {
+            String currentAuthenticatedUserId = currentAuthenticatedUser.getUserId();
+            for (AuthenticatedOrgData authenticatedOrgData : authenticatedOrgDataMap.values()) {
+                for (SequenceConfig sequenceConfig : authenticatedOrgData.getAuthenticatedSequences().values()) {
+                    if (sequenceConfig != null && sequenceConfig.getAuthenticatedUser() != null &&
+                            !StringUtils.equals(currentAuthenticatedUserId,
+                                    sequenceConfig.getAuthenticatedUser().getUserId())) {
+                        return false;
+                    }
+                }
+            }
+        } catch (UserIdNotFoundException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error while resolving userId for user: " +
+                        currentAuthenticatedUser.getLoggableMaskedUserId());
+            }
+        }
+        return true;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -83,6 +83,8 @@ import org.wso2.carbon.identity.core.model.IdentityCookieConfig;
 import org.wso2.carbon.identity.core.model.IdentityErrorMsgContext;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.user.api.Tenant;
@@ -106,6 +108,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1225,26 +1228,35 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                 if  (previousSessionOrgId.isPresent()) {
                     orgIdForSessionDataLookup = previousSessionOrgId.get();
                     sessionContext = loadedSessionContext;
-                }
-
-                // Handle session context loading for root sessions if organization sessions are not applicable.
-                boolean hasRootSessionContext = (loadedSessionContext.getAuthenticatedIdPs() != null);
-                if (previousSessionOrgId.isEmpty() && hasRootSessionContext) {
-                    boolean invalidSessionInCurrentContext = false;
-                    if (applicationConfig != null && !applicationConfig.isSaaSApp()
-                            && loadedSessionContext.getProperty(FrameworkUtils.TENANT_DOMAIN) != null) {
-                        /*
-                        Consider the session context as invalid if the tenant domain in the session context is
-                        different from the login tenant domain in the current context for non-SaaS applications.
-                         */
-                        invalidSessionInCurrentContext = !StringUtils.equals(
-                                loadedSessionContext.getProperty(FrameworkUtils.TENANT_DOMAIN).toString(),
-                                context.getLoginTenantDomain());
-                    }
-                    if (invalidSessionInCurrentContext) {
-                        request.setAttribute(FrameworkConstants.REMOVE_COMMONAUTH_COOKIE, true);
-                    } else {
-                        sessionContext = loadedSessionContext;
+                } else if (context.isOrgApplicationLogin()
+                        && MapUtils.isNotEmpty(loadedSessionContext.getAuthenticatedOrgData())) {
+                    // The accessing org has no session in the loaded session context. Reuse the authenticators
+                    // already satisfied in other organizations to honor SSO for the current organization
+                    // application login.
+                    String accessingOrgId =
+                            PrivilegedCarbonContext.getThreadLocalCarbonContext().getAccessingOrganizationId();
+                    populateContextWithPreviousAuthenticatedOrganizationSessions(accessingOrgId, context,
+                            effectiveSequence, loadedSessionContext, sessionContextKey);
+                } else {
+                    // Handle session context loading for root sessions if organization sessions are not applicable.
+                    boolean hasRootSessionContext = (loadedSessionContext.getAuthenticatedIdPs() != null);
+                    if (hasRootSessionContext) {
+                        boolean invalidSessionInCurrentContext = false;
+                        if (applicationConfig != null && !applicationConfig.isSaaSApp()
+                                && loadedSessionContext.getProperty(FrameworkUtils.TENANT_DOMAIN) != null) {
+                            /*
+                            Consider the session context as invalid if the tenant domain in the session context is
+                            different from the login tenant domain in the current context for non-SaaS applications.
+                             */
+                            invalidSessionInCurrentContext = !StringUtils.equals(
+                                    loadedSessionContext.getProperty(FrameworkUtils.TENANT_DOMAIN).toString(),
+                                    context.getLoginTenantDomain());
+                        }
+                        if (invalidSessionInCurrentContext) {
+                            request.setAttribute(FrameworkConstants.REMOVE_COMMONAUTH_COOKIE, true);
+                        } else {
+                            sessionContext = loadedSessionContext;
+                        }
                     }
                 }
             }
@@ -1261,6 +1273,23 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
 
         // set the sequence for the current authentication/logout flow
         context.setSequenceConfig(effectiveSequence);
+    }
+
+    /**
+     * Checks whether the request carries any organization discovery input parameter.
+     *
+     * @param request The HTTP servlet request.
+     * @return {@code true} if at least one organization discovery parameter is present in the request.
+     */
+    private boolean hasOrganizationDiscoveryParameters(HttpServletRequest request) {
+
+        return StringUtils.isNotEmpty(request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.ORG_ID))
+                || StringUtils.isNotEmpty(
+                        request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.ORG_HANDLE))
+                || StringUtils.isNotEmpty(
+                        request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.ORG_NAME))
+                || StringUtils.isNotEmpty(
+                        request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.LOGIN_HINT));
     }
 
     protected void findPreviousOrganizationSession(HttpServletRequest request, AuthenticationContext context)
@@ -1284,6 +1313,12 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                 if (accessingOrgId != null) {
                     if (loadedSessionContext.getAuthenticatedOrgData().get(accessingOrgId) != null) {
                         sessionContext = loadedSessionContext;
+                    } else {
+                        // The accessing org has no session in the loaded session context. Reuse the authenticators
+                        // already satisfied in other organizations to honor SSO for the current organization
+                        // application login.
+                        populateContextWithPreviousAuthenticatedOrganizationSessions(accessingOrgId,
+                                context, effectiveSequence, loadedSessionContext, sessionContextKey);
                     }
                 }
             }
@@ -1298,6 +1333,186 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
             }
         }
         context.setSequenceConfig(effectiveSequence);
+    }
+
+    /**
+     * Updates the effective sequence config to reflect the authenticators which the shared user has already
+     * authenticated with in other sub-organizations, providing SSO capabilities for shared user logins across
+     * sub-organizations.
+     * <p>
+     * Even though there is no session for the currently accessing organization, the user may have already
+     * authenticated with one or more of the authenticators required by the current application's sequence in another
+     * organization. For each authenticator in the effective sequence steps that is found among the authenticated
+     * authenticators of any organization, the corresponding step is marked as already authenticated and the
+     * authenticated IdP data is carried over to the context.
+     *
+     * @param context              The authentication context.
+     * @param effectiveSequence    The effective sequence config of the current authentication flow.
+     * @param loadedSessionContext The loaded session context holding the authenticated organization data.
+     * @param sessionContextKey    The session context key of the reused session.
+     */
+    private void populateContextWithPreviousAuthenticatedOrganizationSessions(String accessingOrgId,
+                                                                              AuthenticationContext context,
+                                                                              SequenceConfig effectiveSequence,
+                                                                              SessionContext loadedSessionContext,
+                                                                              String sessionContextKey) {
+
+        Map<String, AuthenticatedOrgData> authenticatedOrgData = loadedSessionContext.getAuthenticatedOrgData();
+        if (MapUtils.isEmpty(authenticatedOrgData)) {
+            if (log.isDebugEnabled()) {
+                log.debug("No authenticated organization data found in the session context. Skipping the " +
+                        "population of the sequence config with previously authenticated organization sessions.");
+            }
+            return;
+        }
+
+        if (!isAuthenticatedUserSharedToAccessingOrg(loadedSessionContext, accessingOrgId)) {
+            if (log.isDebugEnabled()) {
+                log.debug("The authenticated user is not shared to the accessing organization: " + accessingOrgId +
+                        ". Skipping the population of the sequence config with previously authenticated " +
+                        "organization sessions.");
+            }
+            return;
+        }
+
+        Map<String, AuthenticatedIdPData> previousAuthenticatedIdPs = new HashMap<>();
+
+        for (StepConfig stepConfig : effectiveSequence.getStepMap().values()) {
+            for (Map.Entry<String, AuthenticatedOrgData> orgDataEntry : authenticatedOrgData.entrySet()) {
+                Map<String, AuthenticatedIdPData> orgAuthenticatedIdPs = orgDataEntry.getValue().getAuthenticatedIdPs();
+                Map<String, AuthenticatorConfig> authenticatedStepIdPs =
+                        FrameworkUtils.getAuthenticatedStepIdPs(stepConfig, orgAuthenticatedIdPs);
+                if (authenticatedStepIdPs.isEmpty()) {
+                    continue;
+                }
+
+                Map.Entry<String, AuthenticatorConfig> authenticatedStepIdP =
+                        authenticatedStepIdPs.entrySet().iterator().next();
+                String authenticatedIdPName = authenticatedStepIdP.getKey();
+                AuthenticatorConfig authenticatedAuthenticator = authenticatedStepIdP.getValue();
+                AuthenticatedIdPData authenticatedIdPData = orgAuthenticatedIdPs.get(authenticatedIdPName);
+
+                stepConfig.setAuthenticatedAutenticator(authenticatedAuthenticator);
+                stepConfig.setAuthenticatedAuthenticatorName(authenticatedAuthenticator.getName());
+                stepConfig.setAuthenticatedIdP(authenticatedIdPName);
+
+                AuthenticatedUser authenticatedUser = authenticatedIdPData.getUser();
+                // Switch the accessing org of the authenticated user to the current accessing org.
+                // Copying to avoid modifying the cache entry.
+                boolean updateAccessingOrganization = authenticatedUser != null
+                        && StringUtils.isNotBlank(authenticatedUser.getAccessingOrganization());
+                if (updateAccessingOrganization) {
+                    authenticatedUser = new AuthenticatedUser(authenticatedUser);
+                    authenticatedUser.setAccessingOrganization(accessingOrgId);
+
+                    // Clone the authenticated IdP data and switch its user's accessing org similarly.
+                    try {
+                        AuthenticatedIdPData clonedAuthenticatedIdPData =
+                                (AuthenticatedIdPData) authenticatedIdPData.clone();
+                        clonedAuthenticatedIdPData.setUser(authenticatedUser);
+                        authenticatedIdPData = clonedAuthenticatedIdPData;
+                    } catch (CloneNotSupportedException e) {
+                        log.error("Error while cloning the authenticated IdP data of the IdP: " +
+                                authenticatedIdPName + ". Proceeding with the loaded authenticated IdP data.", e);
+                    }
+                }
+                stepConfig.setAuthenticatedUser(authenticatedUser);
+
+                // Carry over the authenticated IdP data so the framework can honor the SSO downstream.
+                AuthenticatedIdPData existingAuthenticatedIdPData = previousAuthenticatedIdPs.get(authenticatedIdPName);
+                if (existingAuthenticatedIdPData == null) {
+                    previousAuthenticatedIdPs.put(authenticatedIdPName, authenticatedIdPData);
+                } else {
+                    // An entry for the same IdP is already carried over (from another organization). Append only
+                    // the authenticators which are not already present in the existing entry.
+                    List<AuthenticatorConfig> existingAuthenticators =
+                            existingAuthenticatedIdPData.getAuthenticators();
+                    List<AuthenticatorConfig> newAuthenticators = authenticatedIdPData.getAuthenticators();
+                    if (CollectionUtils.isNotEmpty(newAuthenticators)) {
+                        for (AuthenticatorConfig newAuthenticator : newAuthenticators) {
+                            boolean alreadyPresent = existingAuthenticators != null && existingAuthenticators.stream()
+                                    .anyMatch(existing -> StringUtils.equals(existing.getName(),
+                                            newAuthenticator.getName()));
+                            if (!alreadyPresent) {
+                                existingAuthenticatedIdPData.addAuthenticator(newAuthenticator);
+                            }
+                        }
+                    }
+                }
+
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("Marking step %d as authenticated with the authenticator '%s' of the " +
+                                    "IdP '%s' from the previously authenticated organization '%s'.",
+                            stepConfig.getOrder(), authenticatedAuthenticator.getName(), authenticatedIdPName,
+                            orgDataEntry.getKey()));
+                }
+                break;
+            }
+        }
+
+        if (!previousAuthenticatedIdPs.isEmpty()) {
+            context.setPreviousSessionFound(true);
+            Map<String, AuthenticatedIdPData> existingPreviousAuthenticatedIdPs =
+                    context.getPreviousAuthenticatedIdPs();
+            if (MapUtils.isNotEmpty(existingPreviousAuthenticatedIdPs)) {
+                existingPreviousAuthenticatedIdPs.putAll(previousAuthenticatedIdPs);
+            } else {
+                context.setPreviousAuthenticatedIdPs(previousAuthenticatedIdPs);
+            }
+        }
+    }
+
+    /**
+     * Checks whether the authenticated user held in the loaded session context's authenticated organization data is
+     * shared to the accessing organization.
+     *
+     * @param loadedSessionContext The loaded session context holding the authenticated organization data.
+     * @param accessingOrgId       The organization ID the user is currently accessing.
+     * @return {@code true} if the authenticated user is shared to the accessing organization, {@code false} otherwise.
+     */
+    private boolean isAuthenticatedUserSharedToAccessingOrg(SessionContext loadedSessionContext,
+                                                            String accessingOrgId) {
+
+        if (StringUtils.isBlank(accessingOrgId)) {
+            return false;
+        }
+
+        AuthenticatedUser authenticatedUser = null;
+        Iterator<AuthenticatedOrgData> authenticatedOrgDataIterator =
+                loadedSessionContext.getAuthenticatedOrgData().values().iterator();
+        if (authenticatedOrgDataIterator.hasNext()) {
+            AuthenticatedOrgData firstAuthenticatedOrgData = authenticatedOrgDataIterator.next();
+            for (SequenceConfig sequenceConfig : firstAuthenticatedOrgData.getAuthenticatedSequences().values()) {
+                if (sequenceConfig != null && sequenceConfig.getAuthenticatedUser() != null) {
+                    authenticatedUser = sequenceConfig.getAuthenticatedUser();
+                    break;
+                }
+            }
+        }
+
+        if (authenticatedUser == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("No authenticated user found in the authenticated organization data of the loaded " +
+                        "session context.");
+            }
+            return false;
+        }
+
+        try {
+            OrganizationUserSharingService organizationUserSharingService =
+                    FrameworkServiceDataHolder.getInstance().getOrganizationUserSharingService();
+            UserAssociation userAssociation = organizationUserSharingService
+                    .getUserAssociationOfAssociatedUserByOrgId(authenticatedUser.getUserId(), accessingOrgId);
+            return userAssociation != null;
+        } catch (OrganizationManagementException e) {
+            log.error("Error while resolving the shared user association of the authenticated user for the " +
+                    "accessing organization: " + accessingOrgId, e);
+            return false;
+        } catch (UserIdNotFoundException e) {
+            log.error("Authenticated user ID not found while resolving the shared user association for the " +
+                    "accessing organization: " + accessingOrgId, e);
+            return false;
+        }
     }
 
     /**
@@ -1423,6 +1638,10 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                                                         AuthenticationContext context,
                                                         ApplicationConfig applicationConfig)
             throws FrameworkException {
+
+        if (hasOrganizationDiscoveryParameters(request)) {
+            return Optional.empty();
+        }
 
         boolean sharedAppLoginSession = (loadedSessionContext.getAuthenticatedSharedAppOrgId() != null) &&
                 (MapUtils.isNotEmpty(loadedSessionContext.getAuthenticatedOrgData()));
@@ -1553,10 +1772,17 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     }
                 }
             }
+            String primaryApplicationTenantDomain = context.getTenantDomain();
+            if (context.getOrganizationLoginData() != null &&
+                    context.getOrganizationLoginData().getPrimaryAppData() != null &&
+                    StringUtils.isNotBlank(context.getOrganizationLoginData().getPrimaryAppData().getTenantDomain())) {
+                primaryApplicationTenantDomain =
+                        context.getOrganizationLoginData().getPrimaryAppData().getTenantDomain();
+            }
             // This is done to reflect the changes done in SP to the sequence config. So, the requested claim
             // updates, authentication step updates will be reflected.
             refreshAppConfig(effectiveSequence, request.getParameter(FrameworkConstants.RequestParams.ISSUER),
-                    context.getRequestType(), context.getTenantDomain());
+                    context.getRequestType(), primaryApplicationTenantDomain);
 
             Map<String, AuthenticatedIdPData> authenticatedIdPsOfApp;
             if (orgId != null) {
@@ -1600,10 +1826,16 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
 
         SessionContext sessionContext;
         try {
+            String rootTenantDomain = context.getTenantDomain();
+            if (context.getOrganizationLoginData() != null &&
+                    StringUtils.isNotBlank(context.getOrganizationLoginData().getRootOrganizationTenantDomain())) {
+                rootTenantDomain = context.getOrganizationLoginData().getRootOrganizationTenantDomain();
+            }
             // Starting tenant-flow as tenant domain is retrieved downstream from the carbon-context to get the
             // tenant wise session expiry time
-            FrameworkUtils.startTenantFlow(context.getTenantDomain());
-            sessionContext = FrameworkUtils.getSessionContextFromCache(request, context, sessionContextKey);
+            FrameworkUtils.startTenantFlow(rootTenantDomain);
+            sessionContext = FrameworkUtils.getSessionContextFromCache(request, context, sessionContextKey,
+                    rootTenantDomain);
         } finally {
             FrameworkUtils.endTenantFlow();
         }
@@ -2005,6 +2237,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
         int primaryAppId = applicationConfig.getApplicationID();
         PrimaryAppData primaryAppData = new PrimaryAppData();
         primaryAppData.setId(primaryAppId);
+        primaryAppData.setTenantDomain(applicationConfig.getServiceProvider().getTenantDomain());
         context.getOrganizationLoginData().setPrimaryAppData(primaryAppData);
 
         // Setting the sequence config of the shared application to the context.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -131,6 +131,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.IS_API_BASED;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ORGANIZATION_AUTHENTICATOR;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ORGANIZATION_LOGIN_HOME_REALM_IDENTIFIER;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.OrgDiscoveryInputParameters.ORG_DISCOVERY_TYPE;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.REDIRECT_URL;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.REQUEST_PARAM_SP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.AUTH_TYPE;
@@ -1288,8 +1289,9 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                         request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.ORG_HANDLE))
                 || StringUtils.isNotEmpty(
                         request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.ORG_NAME))
-                || StringUtils.isNotEmpty(
-                        request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.LOGIN_HINT));
+                || (StringUtils.isNotEmpty(
+                        request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.LOGIN_HINT)) &&
+                                StringUtils.isNotEmpty(request.getParameter(ORG_DISCOVERY_TYPE)));
     }
 
     protected void findPreviousOrganizationSession(HttpServletRequest request, AuthenticationContext context)

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -1236,7 +1236,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     String accessingOrgId =
                             PrivilegedCarbonContext.getThreadLocalCarbonContext().getAccessingOrganizationId();
                     populateContextWithPreviousAuthenticatedOrganizationSessions(accessingOrgId, context,
-                            effectiveSequence, loadedSessionContext, sessionContextKey);
+                            effectiveSequence, loadedSessionContext);
                 } else {
                     // Handle session context loading for root sessions if organization sessions are not applicable.
                     boolean hasRootSessionContext = (loadedSessionContext.getAuthenticatedIdPs() != null);
@@ -1318,7 +1318,7 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                         // already satisfied in other organizations to honor SSO for the current organization
                         // application login.
                         populateContextWithPreviousAuthenticatedOrganizationSessions(accessingOrgId,
-                                context, effectiveSequence, loadedSessionContext, sessionContextKey);
+                                context, effectiveSequence, loadedSessionContext);
                     }
                 }
             }
@@ -1349,13 +1349,11 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
      * @param context              The authentication context.
      * @param effectiveSequence    The effective sequence config of the current authentication flow.
      * @param loadedSessionContext The loaded session context holding the authenticated organization data.
-     * @param sessionContextKey    The session context key of the reused session.
      */
     private void populateContextWithPreviousAuthenticatedOrganizationSessions(String accessingOrgId,
                                                                               AuthenticationContext context,
                                                                               SequenceConfig effectiveSequence,
-                                                                              SessionContext loadedSessionContext,
-                                                                              String sessionContextKey) {
+                                                                              SessionContext loadedSessionContext) {
 
         Map<String, AuthenticatedOrgData> authenticatedOrgData = loadedSessionContext.getAuthenticatedOrgData();
         if (MapUtils.isEmpty(authenticatedOrgData)) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -1339,12 +1339,6 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
      * Updates the effective sequence config to reflect the authenticators which the shared user has already
      * authenticated with in other sub-organizations, providing SSO capabilities for shared user logins across
      * sub-organizations.
-     * <p>
-     * Even though there is no session for the currently accessing organization, the user may have already
-     * authenticated with one or more of the authenticators required by the current application's sequence in another
-     * organization. For each authenticator in the effective sequence steps that is found among the authenticated
-     * authenticators of any organization, the corresponding step is marked as already authenticated and the
-     * authenticated IdP data is carried over to the context.
      *
      * @param context              The authentication context.
      * @param effectiveSequence    The effective sequence config of the current authentication flow.
@@ -1824,16 +1818,10 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
 
         SessionContext sessionContext;
         try {
-            String rootTenantDomain = context.getTenantDomain();
-            if (context.getOrganizationLoginData() != null &&
-                    StringUtils.isNotBlank(context.getOrganizationLoginData().getRootOrganizationTenantDomain())) {
-                rootTenantDomain = context.getOrganizationLoginData().getRootOrganizationTenantDomain();
-            }
             // Starting tenant-flow as tenant domain is retrieved downstream from the carbon-context to get the
             // tenant wise session expiry time
-            FrameworkUtils.startTenantFlow(rootTenantDomain);
-            sessionContext = FrameworkUtils.getSessionContextFromCache(request, context, sessionContextKey,
-                    rootTenantDomain);
+            FrameworkUtils.startTenantFlow(context.getTenantDomain());
+            sessionContext = FrameworkUtils.getSessionContextFromCache(request, context, sessionContextKey);
         } finally {
             FrameworkUtils.endTenantFlow();
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/PrimaryAppData.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/PrimaryAppData.java
@@ -28,6 +28,7 @@ public class PrimaryAppData implements Serializable {
     private static final long serialVersionUID = -3925617004643909936L;
 
     private int id;
+    private String tenantDomain;
 
     public int getId() {
 
@@ -37,5 +38,15 @@ public class PrimaryAppData implements Serializable {
     public void setId(int id) {
 
         this.id = id;
+    }
+
+    public String getTenantDomain() {
+
+        return tenantDomain;
+    }
+
+    public void setTenantDomain(String tenantDomain) {
+
+        this.tenantDomain = tenantDomain;
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -1447,12 +1447,28 @@ public class FrameworkUtils {
     public static SessionContext getSessionContextFromCache(HttpServletRequest request, AuthenticationContext context
             , String sessionContextKey) throws FrameworkException {
 
+        return getSessionContextFromCache(request, context, sessionContextKey, context.getLoginTenantDomain());
+    }
+
+    /**
+     * Retrieve session context from the session cache.
+     *
+     * @param request           HttpServletRequest.
+     * @param context           Authentication context.
+     * @param sessionContextKey Session context key.
+     * @param tenantDomain Tenant Domain.
+     * @return Session context key.
+     * @throws FrameworkException Error in triggering session expire event.
+     */
+    public static SessionContext getSessionContextFromCache(HttpServletRequest request, AuthenticationContext context
+            , String sessionContextKey, String tenantDomain) throws FrameworkException {
+
         SessionContext sessionContext = null;
         if (StringUtils.isNotBlank(sessionContextKey)) {
             SessionContextCacheKey cacheKey = new SessionContextCacheKey(sessionContextKey);
             SessionContextCache sessionContextCache = SessionContextCache.getInstance();
             SessionContextCacheEntry cacheEntry = sessionContextCache.getSessionContextCacheEntry(cacheKey,
-                    context.getLoginTenantDomain());
+                    tenantDomain);
 
             if (cacheEntry != null) {
                 sessionContext = cacheEntry.getContext();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -1334,18 +1334,19 @@ public class FrameworkUtils {
      *
      * @param key               Session context cache key.
      * @param sessionContext    Session context to be cached.
-     * @param tenantDomain      Application tenant domain used to resolve session timeout configurations.
-     * @param loginTenantDomain Login tenant domain under which the cache entry is stored.
+     * @param applicationTenantDomain      Application tenant domain used to resolve session timeout configurations.
+     * @param tenantDomain      Tenant domain under which the cache entry is stored.
      * @param orgId             Organization id used to look up authenticated sequences from
      *                          {@link SessionContext#getAuthenticatedOrgData()}.
      */
     public static void addSessionContextToCacheWithoutPersisting(String key, SessionContext sessionContext,
-                                                                 String tenantDomain, String loginTenantDomain,
+                                                                 String applicationTenantDomain, String tenantDomain,
                                                                  String orgId) {
 
         SessionContextCacheKey cacheKey = new SessionContextCacheKey(key);
-        SessionContextCacheEntry cacheEntry = buildSessionContextCacheEntry(key, sessionContext, tenantDomain, orgId);
-        SessionContextCache.getInstance().addToCacheWithoutPersisting(cacheKey, cacheEntry, loginTenantDomain);
+        SessionContextCacheEntry cacheEntry =
+                buildSessionContextCacheEntry(key, sessionContext, applicationTenantDomain, orgId);
+        SessionContextCache.getInstance().addToCacheWithoutPersisting(cacheKey, cacheEntry, tenantDomain);
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -1324,6 +1324,46 @@ public class FrameworkUtils {
                                                 String loginTenantDomain, String orgId) {
 
         SessionContextCacheKey cacheKey = new SessionContextCacheKey(key);
+        SessionContextCacheEntry cacheEntry = buildSessionContextCacheEntry(key, sessionContext, tenantDomain, orgId);
+        SessionContextCache.getInstance().addToCache(cacheKey, cacheEntry, loginTenantDomain);
+    }
+
+    /**
+     * Adds the given session context to the session context cache only, without persisting it to the session data
+     * store.
+     *
+     * @param key               Session context cache key.
+     * @param sessionContext    Session context to be cached.
+     * @param tenantDomain      Application tenant domain used to resolve session timeout configurations.
+     * @param loginTenantDomain Login tenant domain under which the cache entry is stored.
+     * @param orgId             Organization id used to look up authenticated sequences from
+     *                          {@link SessionContext#getAuthenticatedOrgData()}.
+     */
+    public static void addSessionContextToCacheWithoutPersisting(String key, SessionContext sessionContext,
+                                                                 String tenantDomain, String loginTenantDomain,
+                                                                 String orgId) {
+
+        SessionContextCacheKey cacheKey = new SessionContextCacheKey(key);
+        SessionContextCacheEntry cacheEntry = buildSessionContextCacheEntry(key, sessionContext, tenantDomain, orgId);
+        SessionContextCache.getInstance().addToCacheWithoutPersisting(cacheKey, cacheEntry, loginTenantDomain);
+    }
+
+    /**
+     * Builds a {@link SessionContextCacheEntry} for the given session context. When an {@code orgId} is provided and
+     * the session context holds an {@link AuthenticatedOrgData} entry for that organization, the authenticated
+     * sequences of that organization are used for cleanup (clearing user attributes and the authentication graph).
+     * Otherwise, the top-level authenticated sequences of the session context are used.
+     *
+     * @param key            Session context cache key.
+     * @param sessionContext Session context to be cached.
+     * @param tenantDomain   Application tenant domain used to resolve session timeout configurations.
+     * @param orgId          Organization id used to look up authenticated sequences from
+     *                       {@link SessionContext#getAuthenticatedOrgData()}.
+     * @return The built session context cache entry.
+     */
+    private static SessionContextCacheEntry buildSessionContextCacheEntry(String key, SessionContext sessionContext,
+                                                                          String tenantDomain, String orgId) {
+
         SessionContextCacheEntry cacheEntry = new SessionContextCacheEntry();
         cacheEntry.setContextIdentifier(key);
 
@@ -1364,7 +1404,7 @@ public class FrameworkUtils {
 
         cacheEntry.setContext(sessionContext);
         cacheEntry.setValidityPeriod(timeoutPeriod);
-        SessionContextCache.getInstance().addToCache(cacheKey, cacheEntry, loginTenantDomain);
+        return cacheEntry;
     }
 
     /**
@@ -1447,28 +1487,12 @@ public class FrameworkUtils {
     public static SessionContext getSessionContextFromCache(HttpServletRequest request, AuthenticationContext context
             , String sessionContextKey) throws FrameworkException {
 
-        return getSessionContextFromCache(request, context, sessionContextKey, context.getLoginTenantDomain());
-    }
-
-    /**
-     * Retrieve session context from the session cache.
-     *
-     * @param request           HttpServletRequest.
-     * @param context           Authentication context.
-     * @param sessionContextKey Session context key.
-     * @param tenantDomain Tenant Domain.
-     * @return Session context key.
-     * @throws FrameworkException Error in triggering session expire event.
-     */
-    public static SessionContext getSessionContextFromCache(HttpServletRequest request, AuthenticationContext context
-            , String sessionContextKey, String tenantDomain) throws FrameworkException {
-
         SessionContext sessionContext = null;
         if (StringUtils.isNotBlank(sessionContextKey)) {
             SessionContextCacheKey cacheKey = new SessionContextCacheKey(sessionContextKey);
             SessionContextCache sessionContextCache = SessionContextCache.getInstance();
             SessionContextCacheEntry cacheEntry = sessionContextCache.getSessionContextCacheEntry(cacheKey,
-                    tenantDomain);
+                    context.getLoginTenantDomain());
 
             if (cacheEntry != null) {
                 sessionContext = cacheEntry.getContext();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandlerTest.java
@@ -79,7 +79,6 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
@@ -673,7 +672,7 @@ public class DefaultAuthenticationRequestHandlerTest {
         return names;
     }
 
-    @Test(description = "Merging disjoint authenticated IdP maps keeps all IdPs from both maps.")
+    @Test(description = "Test merging a federated IDP with the local IDP keeps only the local IDP.")
     public void testMergeAuthenticatedIdPsWithDisjointIdPs() throws Exception {
 
         Map<String, AuthenticatedIdPData> previous = new HashMap<>();
@@ -683,11 +682,10 @@ public class DefaultAuthenticationRequestHandlerTest {
 
         Map<String, AuthenticatedIdPData> merged = invokeMergeAuthenticatedIdPs(previous, current);
 
-        assertEquals(merged.size(), 2);
+        assertEquals(merged.size(), 1);
         assertTrue(merged.containsKey("LOCAL"));
-        assertTrue(merged.containsKey("FederatedIdP"));
+        assertFalse(merged.containsKey("FederatedIdP"));
         assertNotNull(merged.get("LOCAL"));
-        assertNotSame(merged.get("LOCAL"), previous.get("LOCAL"));
     }
 
     @Test(description = "Merging IdP maps that share an IdP appends only the authenticators not already present.")

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandlerTest.java
@@ -40,7 +40,6 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationResult;
 import org.wso2.carbon.identity.application.authentication.framework.model.CommonAuthResponseWrapper;
 import org.wso2.carbon.identity.application.authentication.framework.model.FederatedToken;
-import org.wso2.carbon.identity.application.authentication.framework.model.OrganizationLoginData;
 import org.wso2.carbon.identity.application.authentication.framework.services.PostAuthenticationMgtService;
 import org.wso2.carbon.identity.application.authentication.framework.services.PostAuthenticationMgtServiceTest;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
@@ -638,51 +637,6 @@ public class DefaultAuthenticationRequestHandlerTest {
             assertFalse(exceptionThrown, "FrameworkException should NOT be thrown for tenant domain mismatch "
                     + "when user is a shared user");
         }
-    }
-
-    private String invokeResolveRootTenantDomain(AuthenticationContext context) throws Exception {
-
-        Method method = DefaultAuthenticationRequestHandler.class.getDeclaredMethod(
-                "resolveRootTenantDomain", AuthenticationContext.class);
-        method.setAccessible(true);
-        return (String) method.invoke(new DefaultAuthenticationRequestHandler(), context);
-    }
-
-    @Test(description = "Root tenant domain resolves to the login tenant domain when no organization login data " +
-            "is present.")
-    public void testResolveRootTenantDomainWithoutOrganizationLoginData() throws Exception {
-
-        AuthenticationContext context = new AuthenticationContext();
-        context.setTenantDomain("carbon.super");
-        context.setLoginTenantDomain("carbon.super");
-
-        assertEquals(invokeResolveRootTenantDomain(context), "carbon.super");
-    }
-
-    @Test(description = "Root tenant domain falls back to the login tenant domain when the root organization tenant " +
-            "domain is blank.")
-    public void testResolveRootTenantDomainWithBlankRootOrgTenantDomain() throws Exception {
-
-        AuthenticationContext context = new AuthenticationContext();
-        context.setTenantDomain("login-tenant.com");
-        context.setLoginTenantDomain("login-tenant.com");
-        OrganizationLoginData orgLoginData = new OrganizationLoginData();
-        orgLoginData.setRootOrganizationTenantDomain("   ");
-        context.setOrganizationLoginData(orgLoginData);
-
-        assertEquals(invokeResolveRootTenantDomain(context), "login-tenant.com");
-    }
-
-    @Test(description = "Root tenant domain resolves to the root organization tenant domain when it is available.")
-    public void testResolveRootTenantDomainWithRootOrgTenantDomain() throws Exception {
-
-        AuthenticationContext context = new AuthenticationContext();
-        context.setLoginTenantDomain("login-tenant.com");
-        OrganizationLoginData orgLoginData = new OrganizationLoginData();
-        orgLoginData.setRootOrganizationTenantDomain("root-tenant.com");
-        context.setOrganizationLoginData(orgLoginData);
-
-        assertEquals(invokeResolveRootTenantDomain(context), "root-tenant.com");
     }
 
     @SuppressWarnings("unchecked")

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandlerTest.java
@@ -28,16 +28,19 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.cache.AuthenticationResultCacheEntry;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ApplicationConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.PostAuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl.DefaultStepBasedSequenceHandler;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationResult;
 import org.wso2.carbon.identity.application.authentication.framework.model.CommonAuthResponseWrapper;
 import org.wso2.carbon.identity.application.authentication.framework.model.FederatedToken;
+import org.wso2.carbon.identity.application.authentication.framework.model.OrganizationLoginData;
 import org.wso2.carbon.identity.application.authentication.framework.services.PostAuthenticationMgtService;
 import org.wso2.carbon.identity.application.authentication.framework.services.PostAuthenticationMgtServiceTest;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
@@ -51,7 +54,9 @@ import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -75,6 +80,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
@@ -632,6 +638,136 @@ public class DefaultAuthenticationRequestHandlerTest {
             assertFalse(exceptionThrown, "FrameworkException should NOT be thrown for tenant domain mismatch "
                     + "when user is a shared user");
         }
+    }
+
+    private String invokeResolveRootTenantDomain(AuthenticationContext context) throws Exception {
+
+        Method method = DefaultAuthenticationRequestHandler.class.getDeclaredMethod(
+                "resolveRootTenantDomain", AuthenticationContext.class);
+        method.setAccessible(true);
+        return (String) method.invoke(new DefaultAuthenticationRequestHandler(), context);
+    }
+
+    @Test(description = "Root tenant domain resolves to the login tenant domain when no organization login data " +
+            "is present.")
+    public void testResolveRootTenantDomainWithoutOrganizationLoginData() throws Exception {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setTenantDomain("carbon.super");
+        context.setLoginTenantDomain("carbon.super");
+
+        assertEquals(invokeResolveRootTenantDomain(context), "carbon.super");
+    }
+
+    @Test(description = "Root tenant domain falls back to the login tenant domain when the root organization tenant " +
+            "domain is blank.")
+    public void testResolveRootTenantDomainWithBlankRootOrgTenantDomain() throws Exception {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setTenantDomain("login-tenant.com");
+        context.setLoginTenantDomain("login-tenant.com");
+        OrganizationLoginData orgLoginData = new OrganizationLoginData();
+        orgLoginData.setRootOrganizationTenantDomain("   ");
+        context.setOrganizationLoginData(orgLoginData);
+
+        assertEquals(invokeResolveRootTenantDomain(context), "login-tenant.com");
+    }
+
+    @Test(description = "Root tenant domain resolves to the root organization tenant domain when it is available.")
+    public void testResolveRootTenantDomainWithRootOrgTenantDomain() throws Exception {
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setLoginTenantDomain("login-tenant.com");
+        OrganizationLoginData orgLoginData = new OrganizationLoginData();
+        orgLoginData.setRootOrganizationTenantDomain("root-tenant.com");
+        context.setOrganizationLoginData(orgLoginData);
+
+        assertEquals(invokeResolveRootTenantDomain(context), "root-tenant.com");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, AuthenticatedIdPData> invokeMergeAuthenticatedIdPs(
+            Map<String, AuthenticatedIdPData> previous,
+            Map<String, AuthenticatedIdPData> current) throws Exception {
+
+        Method method = DefaultAuthenticationRequestHandler.class.getDeclaredMethod(
+                "mergeAuthenticatedIdPs", Map.class, Map.class);
+        method.setAccessible(true);
+        return (Map<String, AuthenticatedIdPData>) method.invoke(
+                new DefaultAuthenticationRequestHandler(), previous, current);
+    }
+
+    private AuthenticatedIdPData buildAuthenticatedIdPData(String idpName, String... authenticatorNames) {
+
+        AuthenticatedIdPData authenticatedIdPData = new AuthenticatedIdPData();
+        authenticatedIdPData.setIdpName(idpName);
+        authenticatedIdPData.setUser(new AuthenticatedUser());
+        List<AuthenticatorConfig> authenticators = new ArrayList<>();
+        for (String authenticatorName : authenticatorNames) {
+            authenticators.add(new AuthenticatorConfig(authenticatorName, true, null));
+        }
+        authenticatedIdPData.setAuthenticators(authenticators);
+        return authenticatedIdPData;
+    }
+
+    private List<String> authenticatorNames(AuthenticatedIdPData authenticatedIdPData) {
+
+        List<String> names = new ArrayList<>();
+        for (AuthenticatorConfig authenticatorConfig : authenticatedIdPData.getAuthenticators()) {
+            names.add(authenticatorConfig.getName());
+        }
+        return names;
+    }
+
+    @Test(description = "Merging disjoint authenticated IdP maps keeps all IdPs from both maps.")
+    public void testMergeAuthenticatedIdPsWithDisjointIdPs() throws Exception {
+
+        Map<String, AuthenticatedIdPData> previous = new HashMap<>();
+        previous.put("LOCAL", buildAuthenticatedIdPData("LOCAL", "BasicAuthenticator"));
+        Map<String, AuthenticatedIdPData> current = new HashMap<>();
+        current.put("FederatedIdP", buildAuthenticatedIdPData("FederatedIdP", "OpenIDConnectAuthenticator"));
+
+        Map<String, AuthenticatedIdPData> merged = invokeMergeAuthenticatedIdPs(previous, current);
+
+        assertEquals(merged.size(), 2);
+        assertTrue(merged.containsKey("LOCAL"));
+        assertTrue(merged.containsKey("FederatedIdP"));
+        assertNotNull(merged.get("LOCAL"));
+        assertNotSame(merged.get("LOCAL"), previous.get("LOCAL"));
+    }
+
+    @Test(description = "Merging IdP maps that share an IdP appends only the authenticators not already present.")
+    public void testMergeAuthenticatedIdPsAppendsMissingAuthenticators() throws Exception {
+
+        Map<String, AuthenticatedIdPData> previous = new HashMap<>();
+        previous.put("LOCAL", buildAuthenticatedIdPData("LOCAL", "BasicAuthenticator"));
+        Map<String, AuthenticatedIdPData> current = new HashMap<>();
+        // Same IdP with a duplicate authenticator and a new authenticator.
+        current.put("LOCAL", buildAuthenticatedIdPData("LOCAL", "BasicAuthenticator", "TOTPAuthenticator"));
+
+        Map<String, AuthenticatedIdPData> merged = invokeMergeAuthenticatedIdPs(previous, current);
+
+        assertEquals(merged.size(), 1);
+        List<String> mergedAuthenticators = authenticatorNames(merged.get("LOCAL"));
+        assertEquals(mergedAuthenticators.size(), 2, "Duplicate authenticator should not be added twice.");
+        assertTrue(mergedAuthenticators.contains("BasicAuthenticator"));
+        assertTrue(mergedAuthenticators.contains("TOTPAuthenticator"));
+    }
+
+    @Test(description = "Merging handles null and empty authenticated IdP maps gracefully.")
+    public void testMergeAuthenticatedIdPsWithNullAndEmptyMaps() throws Exception {
+
+        Map<String, AuthenticatedIdPData> current = new HashMap<>();
+        current.put("LOCAL", buildAuthenticatedIdPData("LOCAL", "BasicAuthenticator"));
+
+        // Previous map is null.
+        Map<String, AuthenticatedIdPData> merged = invokeMergeAuthenticatedIdPs(null, current);
+        assertEquals(merged.size(), 1);
+        assertTrue(merged.containsKey("LOCAL"));
+
+        // Both maps empty/null.
+        Map<String, AuthenticatedIdPData> emptyMerge = invokeMergeAuthenticatedIdPs(null, new HashMap<>());
+        assertTrue(emptyMerge.isEmpty());
     }
 }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
@@ -682,10 +682,8 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
                     .thenReturn(true);
             SessionContext sessionContext = mock(SessionContext.class);
             when(sessionContext.getProperty(FrameworkUtils.TENANT_DOMAIN)).thenReturn(testTenantDomain);
-            // The session context is now looked up with the resolved root tenant domain (4-arg overload).
             frameworkUtilsMockedStatic.
-                    when(() -> FrameworkUtils.getSessionContextFromCache(request, authenticationContext, testSessionId,
-                            testTenantDomain))
+                    when(() -> FrameworkUtils.getSessionContextFromCache(request, authenticationContext, testSessionId))
                     .thenReturn(sessionContext);
 
             // Mock ApplicationManagementService.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
@@ -104,6 +104,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ERROR_DESCRIPTION_APP_DISABLED;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ERROR_STATUS_APP_DISABLED;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ORGANIZATION_AUTHENTICATOR;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.OrgDiscoveryInputParameters.ORG_DISCOVERY_TYPE;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.CALLER_PATH;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.LOGOUT;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.TENANT_DOMAIN;
@@ -1007,25 +1008,28 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
     public Object[][] provideOrgDiscoveryParams() {
 
         return new Object[][]{
-                // orgId, orgHandle, org, login_hint, expected.
-                {null, null, null, null, false},
-                {"org-id-123", null, null, null, true},
-                {null, "org.example.com", null, null, true},
-                {null, null, "exampleOrg", null, true},
-                {null, null, null, "user@example.com", true},
-                {"", "", "", "", false},
+                // orgId, orgHandle, org, login_hint, orgDiscoveryType, expected.
+                {null, null, null, null, null, false},
+                {"org-id-123", null, null, null, null, true},
+                {null, "org.example.com", null, null, null, true},
+                {null, null, "exampleOrg", null, null, true},
+                {null, null, null, "user@example.com", null, false},
+                {null, null, null, "user@example.com", "email", true},
+                {null, null, null, null, "email", false},
+                {"", "", "", "", "", false},
         };
     }
 
     @Test(dataProvider = "orgDiscoveryParamProvider")
     public void testHasOrganizationDiscoveryParameters(String orgId, String orgHandle, String org, String loginHint,
-                                                       boolean expected) throws Exception {
+                                                       String orgDiscoveryType, boolean expected) throws Exception {
 
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.ORG_ID)).thenReturn(orgId);
         when(request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.ORG_HANDLE)).thenReturn(orgHandle);
         when(request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.ORG_NAME)).thenReturn(org);
         when(request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.LOGIN_HINT)).thenReturn(loginHint);
+        when(request.getParameter(ORG_DISCOVERY_TYPE)).thenReturn(orgDiscoveryType);
 
         Method method = DefaultRequestCoordinator.class.getDeclaredMethod(
                 "hasOrganizationDiscoveryParameters", HttpServletRequest.class);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
@@ -26,15 +26,21 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ApplicationConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.AuthGraphNode;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.ShowPromptNode;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.CookieValidationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedOrgData;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.model.CommonAuthRequestWrapper;
 import org.wso2.carbon.identity.application.authentication.framework.model.CommonAuthResponseWrapper;
@@ -55,6 +61,9 @@ import org.wso2.carbon.identity.core.context.model.UserActor;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.testutil.IdentityBaseTest;
 
 import java.io.IOException;
@@ -62,7 +71,10 @@ import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.Cookie;
@@ -84,6 +96,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUTHENTICATOR;
@@ -668,8 +682,10 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
                     .thenReturn(true);
             SessionContext sessionContext = mock(SessionContext.class);
             when(sessionContext.getProperty(FrameworkUtils.TENANT_DOMAIN)).thenReturn(testTenantDomain);
+            // The session context is now looked up with the resolved root tenant domain (4-arg overload).
             frameworkUtilsMockedStatic.
-                    when(() -> FrameworkUtils.getSessionContextFromCache(request, authenticationContext, testSessionId))
+                    when(() -> FrameworkUtils.getSessionContextFromCache(request, authenticationContext, testSessionId,
+                            testTenantDomain))
                     .thenReturn(sessionContext);
 
             // Mock ApplicationManagementService.
@@ -987,5 +1003,386 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
             assertEquals(context.getContextIdIncludedQueryParams(), expectedQueryParams);
             assertEquals(context.getQueryParams(), expectedQueryParams);
         }
+    }
+
+    @DataProvider(name = "orgDiscoveryParamProvider")
+    public Object[][] provideOrgDiscoveryParams() {
+
+        return new Object[][]{
+                // orgId, orgHandle, org, login_hint, expected.
+                {null, null, null, null, false},
+                {"org-id-123", null, null, null, true},
+                {null, "org.example.com", null, null, true},
+                {null, null, "exampleOrg", null, true},
+                {null, null, null, "user@example.com", true},
+                {"", "", "", "", false},
+        };
+    }
+
+    @Test(dataProvider = "orgDiscoveryParamProvider")
+    public void testHasOrganizationDiscoveryParameters(String orgId, String orgHandle, String org, String loginHint,
+                                                       boolean expected) throws Exception {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.ORG_ID)).thenReturn(orgId);
+        when(request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.ORG_HANDLE)).thenReturn(orgHandle);
+        when(request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.ORG_NAME)).thenReturn(org);
+        when(request.getParameter(FrameworkConstants.OrgDiscoveryInputParameters.LOGIN_HINT)).thenReturn(loginHint);
+
+        Method method = DefaultRequestCoordinator.class.getDeclaredMethod(
+                "hasOrganizationDiscoveryParameters", HttpServletRequest.class);
+        method.setAccessible(true);
+        boolean result = (boolean) method.invoke(requestCoordinator, request);
+
+        assertEquals(result, expected);
+    }
+
+    private boolean invokeIsAuthenticatedUserSharedToAccessingOrg(SessionContext sessionContext, String accessingOrgId)
+            throws Exception {
+
+        Method method = DefaultRequestCoordinator.class.getDeclaredMethod(
+                "isAuthenticatedUserSharedToAccessingOrg", SessionContext.class, String.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(requestCoordinator, sessionContext, accessingOrgId);
+    }
+
+    /**
+     * Builds a session context whose first authenticated organization data holds a sequence config carrying the
+     * given authenticated user.
+     */
+    private SessionContext buildSessionContextWithAuthenticatedUser(AuthenticatedUser authenticatedUser) {
+
+        SequenceConfig sequenceConfig = new SequenceConfig();
+        sequenceConfig.setAuthenticatedUser(authenticatedUser);
+        AuthenticatedOrgData orgData = new AuthenticatedOrgData();
+        orgData.getAuthenticatedSequences().put("app", sequenceConfig);
+        SessionContext sessionContext = new SessionContext();
+        Map<String, AuthenticatedOrgData> authenticatedOrgData = new HashMap<>();
+        authenticatedOrgData.put("source-org-id", orgData);
+        sessionContext.setAuthenticatedOrgData(authenticatedOrgData);
+        return sessionContext;
+    }
+
+    @Test(description = "The shared-user check returns false when the accessing organization ID is blank.")
+    public void testIsAuthenticatedUserSharedToAccessingOrgWithBlankOrgId() throws Exception {
+
+        SessionContext sessionContext = buildSessionContextWithAuthenticatedUser(new AuthenticatedUser());
+        assertFalse(invokeIsAuthenticatedUserSharedToAccessingOrg(sessionContext, "  "));
+    }
+
+    @Test(description = "The shared-user check returns false when no authenticated user is found in the session.")
+    public void testIsAuthenticatedUserSharedToAccessingOrgWithoutAuthenticatedUser() throws Exception {
+
+        SessionContext sessionContext = new SessionContext();
+        sessionContext.setAuthenticatedOrgData(new HashMap<>());
+        assertFalse(invokeIsAuthenticatedUserSharedToAccessingOrg(sessionContext, "accessing-org-id"));
+    }
+
+    @Test(description = "The shared-user check returns true when the user has an association in the accessing org.")
+    public void testIsAuthenticatedUserSharedToAccessingOrgWhenShared() throws Exception {
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserId("user-id-123");
+        SessionContext sessionContext = buildSessionContextWithAuthenticatedUser(authenticatedUser);
+
+        OrganizationUserSharingService sharingService = mock(OrganizationUserSharingService.class);
+        when(sharingService.getUserAssociationOfAssociatedUserByOrgId("user-id-123", "accessing-org-id"))
+                .thenReturn(mock(UserAssociation.class));
+        FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(sharingService);
+        try {
+            assertTrue(invokeIsAuthenticatedUserSharedToAccessingOrg(sessionContext, "accessing-org-id"));
+        } finally {
+            FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(null);
+        }
+    }
+
+    @Test(description = "The shared-user check returns false when the user has no association in the accessing org.")
+    public void testIsAuthenticatedUserSharedToAccessingOrgWhenNotShared() throws Exception {
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserId("user-id-123");
+        SessionContext sessionContext = buildSessionContextWithAuthenticatedUser(authenticatedUser);
+
+        OrganizationUserSharingService sharingService = mock(OrganizationUserSharingService.class);
+        when(sharingService.getUserAssociationOfAssociatedUserByOrgId("user-id-123", "accessing-org-id"))
+                .thenReturn(null);
+        FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(sharingService);
+        try {
+            assertFalse(invokeIsAuthenticatedUserSharedToAccessingOrg(sessionContext, "accessing-org-id"));
+        } finally {
+            FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(null);
+        }
+    }
+
+    @Test(description = "The shared-user check returns false and swallows OrganizationManagementException.")
+    public void testIsAuthenticatedUserSharedToAccessingOrgOnException() throws Exception {
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserId("user-id-123");
+        SessionContext sessionContext = buildSessionContextWithAuthenticatedUser(authenticatedUser);
+
+        OrganizationUserSharingService sharingService = mock(OrganizationUserSharingService.class);
+        when(sharingService.getUserAssociationOfAssociatedUserByOrgId(anyString(), anyString()))
+                .thenThrow(new OrganizationManagementException("error"));
+        FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(sharingService);
+        try {
+            assertFalse(invokeIsAuthenticatedUserSharedToAccessingOrg(sessionContext, "accessing-org-id"));
+        } finally {
+            FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(null);
+        }
+    }
+
+    @Test(description = "Populating context with previous org sessions is a no-op when the session holds no " +
+            "authenticated organization data.")
+    public void testPopulateContextWithNoAuthenticatedOrgData() throws Exception {
+
+        AuthenticationContext context = new AuthenticationContext();
+        SessionContext sessionContext = new SessionContext();
+        sessionContext.setAuthenticatedOrgData(new HashMap<>());
+
+        invokePopulateContext("accessing-org-id", context, new SequenceConfig(), sessionContext, "session-key");
+
+        assertFalse(context.isPreviousSessionFound());
+        assertTrue(context.getPreviousAuthenticatedIdPs().isEmpty());
+    }
+
+    @Test(description = "Populating context with previous org sessions is a no-op when the user is not shared to the " +
+            "accessing organization.")
+    public void testPopulateContextWhenUserNotSharedToAccessingOrg() throws Exception {
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserId("user-id-123");
+        SessionContext sessionContext = buildSessionContextWithAuthenticatedUser(authenticatedUser);
+
+        OrganizationUserSharingService sharingService = mock(OrganizationUserSharingService.class);
+        when(sharingService.getUserAssociationOfAssociatedUserByOrgId(anyString(), anyString())).thenReturn(null);
+        FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(sharingService);
+
+        AuthenticationContext context = new AuthenticationContext();
+        try {
+            invokePopulateContext("accessing-org-id", context, new SequenceConfig(), sessionContext, "session-key");
+            assertFalse(context.isPreviousSessionFound());
+        } finally {
+            FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(null);
+        }
+    }
+
+    @Test(description = "Populating context marks the matching step as authenticated and carries over the " +
+            "authenticated IdP data when the shared user has a previous organization session.")
+    public void testPopulateContextCarriesOverPreviousOrganizationSession() throws Exception {
+
+        // Step requiring the federated IdP.
+        AuthenticatorConfig stepAuthenticator = new AuthenticatorConfig("OIDCAuthenticator", true, null);
+        stepAuthenticator.setIdPNames(Arrays.asList("FederatedIdP"));
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setOrder(1);
+        stepConfig.setAuthenticatorList(Arrays.asList(stepAuthenticator));
+        SequenceConfig effectiveSequence = new SequenceConfig();
+        Map<Integer, StepConfig> stepMap = new HashMap<>();
+        stepMap.put(1, stepConfig);
+        effectiveSequence.setStepMap(stepMap);
+
+        // Authenticated user shared to the accessing org.
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserId("user-id-123");
+
+        // Authenticated IdP data already satisfied in another organization.
+        AuthenticatedIdPData authenticatedIdPData = new AuthenticatedIdPData();
+        authenticatedIdPData.setIdpName("FederatedIdP");
+        authenticatedIdPData.setUser(authenticatedUser);
+        authenticatedIdPData.addAuthenticator(new AuthenticatorConfig("OIDCAuthenticator", true, null));
+
+        SequenceConfig sourceSequenceConfig = new SequenceConfig();
+        sourceSequenceConfig.setAuthenticatedUser(authenticatedUser);
+        AuthenticatedOrgData orgData = new AuthenticatedOrgData();
+        orgData.getAuthenticatedSequences().put("app", sourceSequenceConfig);
+        orgData.getAuthenticatedIdPs().put("FederatedIdP", authenticatedIdPData);
+
+        SessionContext sessionContext = new SessionContext();
+        Map<String, AuthenticatedOrgData> authenticatedOrgData = new HashMap<>();
+        authenticatedOrgData.put("source-org-id", orgData);
+        sessionContext.setAuthenticatedOrgData(authenticatedOrgData);
+
+        OrganizationUserSharingService sharingService = mock(OrganizationUserSharingService.class);
+        when(sharingService.getUserAssociationOfAssociatedUserByOrgId("user-id-123", "accessing-org-id"))
+                .thenReturn(mock(UserAssociation.class));
+        FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(sharingService);
+
+        AuthenticationContext context = new AuthenticationContext();
+        try {
+            invokePopulateContext("accessing-org-id", context, effectiveSequence, sessionContext, "session-key");
+
+            assertTrue(context.isPreviousSessionFound());
+            Map<String, AuthenticatedIdPData> previousAuthenticatedIdPs = context.getPreviousAuthenticatedIdPs();
+            assertNotNull(previousAuthenticatedIdPs);
+            assertTrue(previousAuthenticatedIdPs.containsKey("FederatedIdP"));
+
+            // The matching step should be marked as authenticated with the carried over authenticator.
+            assertEquals(stepConfig.getAuthenticatedIdP(), "FederatedIdP");
+            assertNotNull(stepConfig.getAuthenticatedAutenticator());
+            assertEquals(stepConfig.getAuthenticatedAutenticator().getName(), "OIDCAuthenticator");
+        } finally {
+            FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(null);
+        }
+    }
+
+    @Test(description = "Populating context switches the accessing organization of the carried over authenticated " +
+            "user (and its IdP data) to the current accessing organization without mutating the cached entry.")
+    public void testPopulateContextSwitchesAccessingOrganizationForSharedUser() throws Exception {
+
+        // Step requiring the federated IdP.
+        AuthenticatorConfig stepAuthenticator = new AuthenticatorConfig("OIDCAuthenticator", true, null);
+        stepAuthenticator.setIdPNames(List.of("FederatedIdP"));
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setOrder(1);
+        stepConfig.setAuthenticatorList(List.of(stepAuthenticator));
+        SequenceConfig effectiveSequence = new SequenceConfig();
+        Map<Integer, StepConfig> stepMap = new HashMap<>();
+        stepMap.put(1, stepConfig);
+        effectiveSequence.setStepMap(stepMap);
+
+        // Authenticated user that was accessing another (source) organization.
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserId("user-id-123");
+        authenticatedUser.setAccessingOrganization("source-org-id");
+
+        AuthenticatedIdPData authenticatedIdPData = new AuthenticatedIdPData();
+        authenticatedIdPData.setIdpName("FederatedIdP");
+        authenticatedIdPData.setUser(authenticatedUser);
+        authenticatedIdPData.addAuthenticator(new AuthenticatorConfig("OIDCAuthenticator", true, null));
+
+        SequenceConfig sourceSequenceConfig = new SequenceConfig();
+        sourceSequenceConfig.setAuthenticatedUser(authenticatedUser);
+        AuthenticatedOrgData orgData = new AuthenticatedOrgData();
+        orgData.getAuthenticatedSequences().put("app", sourceSequenceConfig);
+        orgData.getAuthenticatedIdPs().put("FederatedIdP", authenticatedIdPData);
+
+        SessionContext sessionContext = new SessionContext();
+        Map<String, AuthenticatedOrgData> authenticatedOrgData = new HashMap<>();
+        authenticatedOrgData.put("source-org-id", orgData);
+        sessionContext.setAuthenticatedOrgData(authenticatedOrgData);
+
+        OrganizationUserSharingService sharingService = mock(OrganizationUserSharingService.class);
+        when(sharingService.getUserAssociationOfAssociatedUserByOrgId("user-id-123", "accessing-org-id"))
+                .thenReturn(mock(UserAssociation.class));
+        FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(sharingService);
+
+        AuthenticationContext context = new AuthenticationContext();
+        try {
+            invokePopulateContext("accessing-org-id", context, effectiveSequence, sessionContext);
+
+            // The step's authenticated user should now point to the current accessing organization.
+            assertNotNull(stepConfig.getAuthenticatedUser());
+            assertEquals(stepConfig.getAuthenticatedUser().getAccessingOrganization(), "accessing-org-id");
+
+            // The carried over IdP data should be a clone (not the cached instance) whose user's accessing
+            // organization was switched as well.
+            AuthenticatedIdPData carriedOverIdPData = context.getPreviousAuthenticatedIdPs().get("FederatedIdP");
+            assertNotNull(carriedOverIdPData);
+            assertNotSame(carriedOverIdPData, authenticatedIdPData);
+            assertEquals(carriedOverIdPData.getUser().getAccessingOrganization(), "accessing-org-id");
+
+            // The cached entry should remain untouched.
+            assertEquals(authenticatedUser.getAccessingOrganization(), "source-org-id");
+        } finally {
+            FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(null);
+        }
+    }
+
+    @Test(description = "Populating context merges authenticators for the same IdP that the shared user satisfied " +
+            "across different organizations, appending only the authenticators not already carried over.")
+    public void testPopulateContextMergesAuthenticatorsAcrossOrganizations() throws Exception {
+
+        // Two LOCAL steps, each requiring a distinct local authenticator.
+        ApplicationAuthenticator basicAppAuthenticator = mock(ApplicationAuthenticator.class);
+        when(basicAppAuthenticator.getAuthMechanism()).thenReturn("basic");
+        AuthenticatorConfig step1Authenticator = new AuthenticatorConfig("BasicAuthenticator", true, null);
+        step1Authenticator.setIdPNames(List.of(FrameworkConstants.LOCAL));
+        step1Authenticator.setApplicationAuthenticator(basicAppAuthenticator);
+        StepConfig step1 = new StepConfig();
+        step1.setOrder(1);
+        step1.setAuthenticatorList(List.of(step1Authenticator));
+
+        ApplicationAuthenticator totpAppAuthenticator = mock(ApplicationAuthenticator.class);
+        when(totpAppAuthenticator.getAuthMechanism()).thenReturn("totp");
+        AuthenticatorConfig step2Authenticator = new AuthenticatorConfig("TOTPAuthenticator", true, null);
+        step2Authenticator.setIdPNames(List.of(FrameworkConstants.LOCAL));
+        step2Authenticator.setApplicationAuthenticator(totpAppAuthenticator);
+        StepConfig step2 = new StepConfig();
+        step2.setOrder(2);
+        step2.setAuthenticatorList(List.of(step2Authenticator));
+
+        SequenceConfig effectiveSequence = new SequenceConfig();
+        Map<Integer, StepConfig> stepMap = new LinkedHashMap<>();
+        stepMap.put(1, step1);
+        stepMap.put(2, step2);
+        effectiveSequence.setStepMap(stepMap);
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserId("user-id-123");
+
+        // Org A satisfied the BasicAuthenticator only.
+        AuthenticatedIdPData orgALocalIdPData = new AuthenticatedIdPData();
+        orgALocalIdPData.setIdpName(FrameworkConstants.LOCAL);
+        orgALocalIdPData.setUser(authenticatedUser);
+        orgALocalIdPData.addAuthenticator(new AuthenticatorConfig("BasicAuthenticator", true, null));
+        SequenceConfig orgASequenceConfig = new SequenceConfig();
+        orgASequenceConfig.setAuthenticatedUser(authenticatedUser);
+        AuthenticatedOrgData orgAData = new AuthenticatedOrgData();
+        orgAData.getAuthenticatedSequences().put("app", orgASequenceConfig);
+        orgAData.getAuthenticatedIdPs().put(FrameworkConstants.LOCAL, orgALocalIdPData);
+
+        // Org B satisfied the TOTPAuthenticator only.
+        AuthenticatedIdPData orgBLocalIdPData = new AuthenticatedIdPData();
+        orgBLocalIdPData.setIdpName(FrameworkConstants.LOCAL);
+        orgBLocalIdPData.setUser(authenticatedUser);
+        orgBLocalIdPData.addAuthenticator(new AuthenticatorConfig("TOTPAuthenticator", true, null));
+        AuthenticatedOrgData orgBData = new AuthenticatedOrgData();
+        orgBData.getAuthenticatedIdPs().put(FrameworkConstants.LOCAL, orgBLocalIdPData);
+
+        // Preserve iteration order so org A wins step 1 and org B wins step 2.
+        SessionContext sessionContext = new SessionContext();
+        Map<String, AuthenticatedOrgData> authenticatedOrgData = new LinkedHashMap<>();
+        authenticatedOrgData.put("org-a-id", orgAData);
+        authenticatedOrgData.put("org-b-id", orgBData);
+        sessionContext.setAuthenticatedOrgData(authenticatedOrgData);
+
+        OrganizationUserSharingService sharingService = mock(OrganizationUserSharingService.class);
+        when(sharingService.getUserAssociationOfAssociatedUserByOrgId("user-id-123", "accessing-org-id"))
+                .thenReturn(mock(UserAssociation.class));
+        FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(sharingService);
+
+        AuthenticationContext context = new AuthenticationContext();
+        try {
+            invokePopulateContext("accessing-org-id", context, effectiveSequence, sessionContext);
+
+            assertTrue(context.isPreviousSessionFound());
+            AuthenticatedIdPData mergedLocalIdPData =
+                    context.getPreviousAuthenticatedIdPs().get(FrameworkConstants.LOCAL);
+            assertNotNull(mergedLocalIdPData);
+
+            // The authenticator satisfied in org B should have been appended to org A's carried over entry.
+            List<String> mergedAuthenticatorNames = new ArrayList<>();
+            for (AuthenticatorConfig authenticatorConfig : mergedLocalIdPData.getAuthenticators()) {
+                mergedAuthenticatorNames.add(authenticatorConfig.getName());
+            }
+            assertEquals(mergedAuthenticatorNames.size(), 2);
+            assertTrue(mergedAuthenticatorNames.contains("BasicAuthenticator"));
+            assertTrue(mergedAuthenticatorNames.contains("TOTPAuthenticator"));
+        } finally {
+            FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(null);
+        }
+    }
+
+    private void invokePopulateContext(String accessingOrgId, AuthenticationContext context,
+                                       SequenceConfig effectiveSequence, SessionContext loadedSessionContext,
+                                       String sessionContextKey) throws Exception {
+
+        Method method = DefaultRequestCoordinator.class.getDeclaredMethod(
+                "populateContextWithPreviousAuthenticatedOrganizationSessions", String.class,
+                AuthenticationContext.class, SequenceConfig.class, SessionContext.class, String.class);
+        method.setAccessible(true);
+        method.invoke(requestCoordinator, accessingOrgId, context, effectiveSequence, loadedSessionContext,
+                sessionContextKey);
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
@@ -1140,7 +1140,7 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
         SessionContext sessionContext = new SessionContext();
         sessionContext.setAuthenticatedOrgData(new HashMap<>());
 
-        invokePopulateContext("accessing-org-id", context, new SequenceConfig(), sessionContext, "session-key");
+        invokePopulateContext("accessing-org-id", context, new SequenceConfig(), sessionContext);
 
         assertFalse(context.isPreviousSessionFound());
         assertTrue(context.getPreviousAuthenticatedIdPs().isEmpty());
@@ -1160,7 +1160,7 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
 
         AuthenticationContext context = new AuthenticationContext();
         try {
-            invokePopulateContext("accessing-org-id", context, new SequenceConfig(), sessionContext, "session-key");
+            invokePopulateContext("accessing-org-id", context, new SequenceConfig(), sessionContext);
             assertFalse(context.isPreviousSessionFound());
         } finally {
             FrameworkServiceDataHolder.getInstance().setOrganizationUserSharingService(null);
@@ -1210,7 +1210,7 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
 
         AuthenticationContext context = new AuthenticationContext();
         try {
-            invokePopulateContext("accessing-org-id", context, effectiveSequence, sessionContext, "session-key");
+            invokePopulateContext("accessing-org-id", context, effectiveSequence, sessionContext);
 
             assertTrue(context.isPreviousSessionFound());
             Map<String, AuthenticatedIdPData> previousAuthenticatedIdPs = context.getPreviousAuthenticatedIdPs();
@@ -1375,14 +1375,13 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
     }
 
     private void invokePopulateContext(String accessingOrgId, AuthenticationContext context,
-                                       SequenceConfig effectiveSequence, SessionContext loadedSessionContext,
-                                       String sessionContextKey) throws Exception {
+                                       SequenceConfig effectiveSequence, SessionContext loadedSessionContext)
+            throws Exception {
 
         Method method = DefaultRequestCoordinator.class.getDeclaredMethod(
                 "populateContextWithPreviousAuthenticatedOrganizationSessions", String.class,
-                AuthenticationContext.class, SequenceConfig.class, SessionContext.class, String.class);
+                AuthenticationContext.class, SequenceConfig.class, SessionContext.class);
         method.setAccessible(true);
-        method.invoke(requestCoordinator, accessingOrgId, context, effectiveSequence, loadedSessionContext,
-                sessionContextKey);
+        method.invoke(requestCoordinator, accessingOrgId, context, effectiveSequence, loadedSessionContext);
     }
 }


### PR DESCRIPTION
## Purpose

Support **SSO for shared users across sub-organizations**. When a user who is shared into multiple sub-organizations has already authenticated while accessing one sub-org application, the framework now honors that existing session when the same user accesses an application in a *different* sub-org — instead of forcing a fresh login — provided the user is shared into the accessing organization.

Previously a session was only reused when the accessing organization already had its own entry in the session context's authenticated organization data. This PR extends that so authenticators already satisfied in *any* of the user's organizations can be carried over to satisfy the current sequence.

## Changes

**`DefaultRequestCoordinator`**
- Added `populateContextWithPreviousAuthenticatedOrganizationSessions(...)`: when the accessing org has no session entry but other orgs do, it walks the effective sequence steps, marks each step already satisfied in another org as authenticated, switches the authenticated user's accessing organization to the current one, and carries the merged authenticated IdP data into the context to enable downstream SSO.
- Added `isAuthenticatedUserSharedToAccessingOrg(...)`: guards the above by confirming (via `OrganizationUserSharingService`) that the authenticated user actually has a user association in the accessing organization.
- Added `hasOrganizationDiscoveryParameters(...)`: skips auto login to the latest accessed org when the request carries org discovery parameters (`orgId` / `orgHandle` / `org` / `login_hint`).
- Resolved the **root organization tenant domain** for session cache lookup/storage, and used the **primary application's tenant domain** when refreshing the app config for shared-app logins.

**`DefaultAuthenticationRequestHandler`**
- Simplified the "is the previous session applicable" check for sub-org (shared-app / org-application) logins.
- When the currently accessing org has no prior authenticated-org data, a new `AuthenticatedOrgData` is created for it, merging the previous and current authenticated IdPs.
- Added `mergeAuthenticatedIdPs(...)` / `mergeAuthenticatedIdPsInto(...)`: merge authenticated IdP maps, appending only authenticators not already present for a shared IdP name (clones entries to avoid mutating cached data).
- Added `resolveRootTenantDomain(...)`: store the session context under the root org tenant domain when available.

**`PrimaryAppData`** — added a `tenantDomain` field (getter/setter) so the primary app's tenant can be propagated.

**`FrameworkUtils`** — added an overloaded `getSessionContextFromCache(request, context, sessionContextKey, tenantDomain)` allowing the caller to specify the tenant domain explicitly; the existing method now delegates to it.

## Tests
- Unit tests for `resolveRootTenantDomain` and `mergeAuthenticatedIdPs` in `DefaultAuthenticationRequestHandlerTest`.
- Unit tests for `hasOrganizationDiscoveryParameters`, `isAuthenticatedUserSharedToAccessingOrg` (shared / not-shared / blank-org / no-user / exception paths), and `populateContextWithPreviousAuthenticatedOrganizationSessions` (no org data, user-not-shared no-op, and the carry-over happy path) in `DefaultRequestCoordinatorTest`.
- Updated the existing `testFindPreviousAuthenticatedSession` to stub the new 4-arg `getSessionContextFromCache` overload.

### Related issue
- https://github.com/wso2/product-is/issues/27371