### PR TITLE
Add ConvertOnlyMultiValuedClaimsToArray config for selective multi-valued claim handling

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1038,6 +1038,7 @@
             <UserInfoEndpointRequestValidator>{{oauth.oidc.extensions.user_info_request_validator}}</UserInfoEndpointRequestValidator>
             <UserInfoEndpointAccessTokenValidator>{{oauth.oidc.extensions.user_info_access_token_validator}}</UserInfoEndpointAccessTokenValidator>
             <UserInfoMultiValueSupportEnabled>{{oauth.oidc.user_info.enable_multi_value_support}}</UserInfoMultiValueSupportEnabled>
+            <ConvertOnlyMultiValuedClaimsToArray>{{oauth.oidc.convert_only_multi_valued_claims_to_array}}</ConvertOnlyMultiValuedClaimsToArray>
             <UserInfoRemoveInternalPrefixFromRoles>{{oauth.oidc.user_info.remove_internal_prefix_from_roles}}</UserInfoRemoveInternalPrefixFromRoles>
             <ReturnOnlyAppAssociatedRolesInUserInfo>{{oauth.oidc.user_info.return_only_app_associated_roles}}</ReturnOnlyAppAssociatedRolesInUserInfo>
             {% if oauth.oidc.extensions.user_info_response_builder is defined %}

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -309,6 +309,7 @@
   "oauth.oidc.extensions.user_info_request_validator": "org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInforRequestDefaultValidator",
   "oauth.oidc.extensions.user_info_access_token_validator": "org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoISAccessTokenValidator",
   "oauth.oidc.user_info.enable_multi_value_support": true,
+  "oauth.oidc.convert_only_multi_valued_claims_to_array": false,
   "oauth.oidc.user_info.return_only_app_associated_roles": true,
   "oauth.oidc.user_info.remove_internal_prefix_from_roles": true,
 


### PR DESCRIPTION
## Purpose
Resolves wso2/product-is#27652.

Exposes the opt-in config key `oauth.oidc.convert_only_multi_valued_claims_to_array` (default `false`) in the `identity.xml.j2` template and the identity-core feature default JSON, so it can be set via `deployment.toml`:

```toml
[oauth.oidc]
convert_only_multi_valued_claims_to_array = true
```

When `true`, a claim value containing the multi-attribute separator is emitted as a JSON array in JWT access tokens, ID tokens and the UserInfo response **only** when the claim's local-claim metadata has `multiValued=true`. Default `false` preserves the legacy comma-split behaviour unchanged.

## Related PR
Consuming logic: wso2-extensions/identity-inbound-auth-oauth#3255

## Doc
New config key; default `false` → no behavioural change for existing deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)