### PR TITLE
Add RestrictAssertionClaimsToConfiguredAttributes to identity.xml template

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1172,6 +1172,7 @@
             <EnableTLSCertificateBoundAccessTokensViaBindingType>{{oauth.oidc.enable_tls_certificate_bound_access_tokens_via_binding_type}}</EnableTLSCertificateBoundAccessTokensViaBindingType>
             <EnableHybridFlowAppLevelValidation>{{oauth.oidc.enable_hybrid_flow_app_level_validation}}</EnableHybridFlowAppLevelValidation>
             <EnableClaimsSeparationForAccessToken>{{oauth.oidc.enable_claims_separation_for_access_tokens}}</EnableClaimsSeparationForAccessToken>
+            <RestrictAssertionClaimsToConfiguredAttributes>{{oauth.oidc.restrict_assertion_claims_to_configured_attributes}}</RestrictAssertionClaimsToConfiguredAttributes>
         </OpenIDConnect>
 
         <!-- OIDCSessionStateManager configuration -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -322,6 +322,7 @@
   "oauth.oidc.enable_tls_certificate_bound_access_tokens_via_binding_type": true,
   "oauth.oidc.enable_hybrid_flow_app_level_validation": true,
   "oauth.oidc.enable_claims_separation_for_access_tokens": true,
+  "oauth.oidc.restrict_assertion_claims_to_configured_attributes": false,
 
   "oauth.oidc.fapi.enable_ciba_profile": false,
   "oauth.oidc.fapi.enable_security_profile": false,


### PR DESCRIPTION
## Purpose
Adds the `RestrictAssertionClaimsToConfiguredAttributes` OpenID Connect configuration to the `identity.xml` template and default values, mapping the toml key `oauth.oidc.restrict_assertion_claims_to_configured_attributes` (default **false**).

Configuration companion to the federated assertion claim restriction fix in identity-inbound-auth-oauth: wso2-extensions/identity-inbound-auth-oauth#3259.

## Related Issues
- Fixes wso2/product-is#27611
- wso2-extensions/identity-inbound-auth-oauth#3259