### PR TITLE
Add flow extension connection template

### DIFF
--- a/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/flow-extension/info.json
+++ b/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/flow-extension/info.json
@@ -1,0 +1,10 @@
+{
+  "id": "flow-extension",
+  "name": "Flow Extension",
+  "description": "Extend flows with external services.",
+  "image": "assets/images/logos/flow-extension.svg",
+  "category": "DEFAULT",
+  "displayOrder": 13,
+  "tags": [ "Custom" ],
+  "type": "flow-extension"
+}

--- a/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/flow-extension/template.json
+++ b/features/extension-mgt/org.wso2.carbon.identity.extension.mgt.feature/resources/extensions/connections/flow-extension/template.json
@@ -1,0 +1,12 @@
+{
+  "category": "DEFAULT",
+  "description": "Extend flows with external services.",
+  "displayOrder": 13,
+  "id": "flow-extension",
+  "image": "assets/images/logos/flow-extension.svg",
+  "name": "Flow Extension",
+  "services": [],
+  "disabled": false,
+  "tags": [ "Custom" ],
+  "templateId": "flow-extension"
+}


### PR DESCRIPTION
## Purpose
Add a new `flow-extension` connection template so that the Flow Extension connection type is available in the console. This is the backend extension-management resource that complements the console-side flow extension management support.

## Related Issue
- https://github.com/wso2/product-is/issues/27771

## Related PR
- https://github.com/wso2/identity-apps/pull/10359

## Implementation
- Added `info.json` and `template.json` under `extensions/connections/flow-extension/` in the extension management feature.
- Defined the `flow-extension` template with its id, name, description, category, display order, tags, and logo reference so it surfaces as a selectable connection.