### PR TITLE
Fix #28038: Reject multiple Authorization headers with 400 Bad Request

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/pom.xml
+++ b/components/identity-core/org.wso2.carbon.identity.core/pom.xml
@@ -165,6 +165,18 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-coyote</artifactId>
+            <version>${apache.tomcat-catalina.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-util</artifactId>
+            <version>${apache.tomcat-catalina.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
@@ -49,24 +49,24 @@ public class IdentityContextCreatorValve extends ValveBase {
     @Override
     public void invoke(Request request, Response response) throws IOException, ServletException {
 
-        // Enforce RFC 9110 §11.6.1: The Authorization header is a single-value field.
-        // Rejecting requests with multiple Authorization headers early at the transport/valve layer
-        // prevents potential header manipulation and security vulnerabilities.
-        Enumeration<String> authHeaders = request.getHeaders("Authorization");
-        if (authHeaders != null) {
-            int authHeaderCount = 0;
-            while (authHeaders.hasMoreElements()) {
-                authHeaders.nextElement();
-                authHeaderCount++;
-                if (authHeaderCount > 1) {
-                    LOG.warn("Multiple Authorization headers detected.");
-                    response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Multiple Authorization headers are not allowed.");
-                    return;
+        try {
+            // Enforce RFC 9110 §11.6.1: The Authorization header is a single-value field.
+            // Rejecting requests with multiple Authorization headers early at the transport/valve layer
+            // prevents potential header manipulation and security vulnerabilities.
+            Enumeration<String> authHeaders = request.getHeaders("Authorization");
+            if (authHeaders != null) {
+                int authHeaderCount = 0;
+                while (authHeaders.hasMoreElements()) {
+                    authHeaders.nextElement();
+                    authHeaderCount++;
+                    if (authHeaderCount > 1) {
+                        LOG.warn("Multiple Authorization headers detected.");
+                        response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Multiple Authorization headers are not allowed.");
+                        return;
+                    }
                 }
             }
-        }
 
-        try {
             initIdentityContext();
             initRequest(request);
             initAccessTokenIssuedOrganization(request.getRequestURI());

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
@@ -59,9 +59,7 @@ public class IdentityContextCreatorValve extends ValveBase {
                 authHeaders.nextElement();
                 authHeaderCount++;
                 if (authHeaderCount > 1) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Multiple Authorization headers detected.");
-                    }
+                    LOG.warn("Multiple Authorization headers detected.");
                     response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Multiple Authorization headers are not allowed.");
                     return;
                 }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
@@ -60,7 +60,7 @@ public class IdentityContextCreatorValve extends ValveBase {
                 authHeaderCount++;
                 if (authHeaderCount > 1) {
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("Rejecting request with multiple Authorization headers for URI: " + request.getRequestURI());
+                        LOG.debug("Multiple Authorization headers detected.");
                     }
                     response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Multiple Authorization headers are not allowed.");
                     return;

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
@@ -28,8 +28,10 @@ import org.wso2.carbon.identity.core.context.IdentityContext;
 import org.wso2.carbon.identity.core.internal.context.OrganizationResolver;
 
 import java.io.IOException;
+import java.util.Enumeration;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
 
 public class IdentityContextCreatorValve extends ValveBase {
 
@@ -46,6 +48,19 @@ public class IdentityContextCreatorValve extends ValveBase {
 
     @Override
     public void invoke(Request request, Response response) throws IOException, ServletException {
+
+        Enumeration<String> authHeaders = request.getHeaders("Authorization");
+        if (authHeaders != null) {
+            int authHeaderCount = 0;
+            while (authHeaders.hasMoreElements()) {
+                authHeaders.nextElement();
+                authHeaderCount++;
+                if (authHeaderCount > 1) {
+                    response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Multiple Authorization headers are not allowed.");
+                    return;
+                }
+            }
+        }
 
         try {
             initIdentityContext();

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValve.java
@@ -49,6 +49,9 @@ public class IdentityContextCreatorValve extends ValveBase {
     @Override
     public void invoke(Request request, Response response) throws IOException, ServletException {
 
+        // Enforce RFC 9110 §11.6.1: The Authorization header is a single-value field.
+        // Rejecting requests with multiple Authorization headers early at the transport/valve layer
+        // prevents potential header manipulation and security vulnerabilities.
         Enumeration<String> authHeaders = request.getHeaders("Authorization");
         if (authHeaders != null) {
             int authHeaderCount = 0;
@@ -56,6 +59,9 @@ public class IdentityContextCreatorValve extends ValveBase {
                 authHeaders.nextElement();
                 authHeaderCount++;
                 if (authHeaderCount > 1) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Rejecting request with multiple Authorization headers for URI: " + request.getRequestURI());
+                    }
                     response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Multiple Authorization headers are not allowed.");
                     return;
                 }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValveTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValveTest.java
@@ -29,6 +29,7 @@ public class IdentityContextCreatorValveTest {
 
     @BeforeMethod
     public void setUp() {
+        System.setProperty("carbon.home", ".");
         closeable = MockitoAnnotations.openMocks(this);
         identityContextCreatorValve = new IdentityContextCreatorValve();
         identityContextCreatorValve.setNext(nextValve);

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValveTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/context/valve/IdentityContextCreatorValveTest.java
@@ -1,0 +1,82 @@
+package org.wso2.carbon.identity.core.context.valve;
+
+import org.apache.catalina.Valve;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.Enumeration;
+import java.util.Vector;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class IdentityContextCreatorValveTest {
+
+    private IdentityContextCreatorValve identityContextCreatorValve;
+
+    @Mock
+    private Valve nextValve;
+
+    private AutoCloseable closeable;
+
+    @BeforeMethod
+    public void setUp() {
+        closeable = MockitoAnnotations.openMocks(this);
+        identityContextCreatorValve = new IdentityContextCreatorValve();
+        identityContextCreatorValve.setNext(nextValve);
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        if (closeable != null) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    public void testInvokeWithMultipleAuthorizationHeaders() throws Exception {
+        Vector<String> headers = new Vector<>();
+        headers.add("Bearer token1");
+        headers.add("Bearer token2");
+        final Enumeration<String> headerEnum = headers.elements();
+
+        Request request = new Request(null) {
+            @Override
+            public Enumeration<String> getHeaders(String name) {
+                if ("Authorization".equals(name)) {
+                    return headerEnum;
+                }
+                return super.getHeaders(name);
+            }
+
+            @Override
+            public String getRequestURI() {
+                return "/oauth2/userinfo";
+            }
+        };
+
+        final int[] errorStatus = new int[1];
+        final String[] errorMessage = new String[1];
+        Response response = new Response() {
+            @Override
+            public void sendError(int status, String message) throws java.io.IOException {
+                errorStatus[0] = status;
+                errorMessage[0] = message;
+            }
+        };
+
+        identityContextCreatorValve.invoke(request, response);
+
+        org.testng.Assert.assertEquals(errorStatus[0], HttpServletResponse.SC_BAD_REQUEST);
+        org.testng.Assert.assertEquals(errorMessage[0], "Multiple Authorization headers are not allowed.");
+        verify(nextValve, never()).invoke(any(Request.class), any(Response.class));
+    }
+}


### PR DESCRIPTION
This PR fixes wso2/product-is#28038 by rejecting incoming HTTP requests containing more than one Authorization header with a 400 Bad Request response code. This ensures compliance with RFC 9110 §11.6.1 and prevents potential security validation bypasses.