### PR TITLE
Fix circuit breaker config parsing to handle float-formatted integer and long values

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/circuitbreaker/DefaultPolicyConfigurationLoader.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/circuitbreaker/DefaultPolicyConfigurationLoader.java
@@ -102,6 +102,15 @@ public final class DefaultPolicyConfigurationLoader {
         try {
             return Math.max(Integer.parseInt(value.trim()), min);
         } catch (NumberFormatException ex) {
+            // Attempt a double parse and truncate if the value has no fractional part.
+            try {
+                double d = Double.parseDouble(value.trim());
+                if (d == Math.floor(d) && !Double.isInfinite(d)) {
+                    return Math.max((int) d, min);
+                }
+            } catch (NumberFormatException ignored) {
+                // fall through to default.
+            }
             LOG.warn("Invalid integer for property '" + key + "', using default " + defaultValue + ".", ex);
             return defaultValue;
         }
@@ -116,6 +125,15 @@ public final class DefaultPolicyConfigurationLoader {
         try {
             return Math.max(Long.parseLong(value.trim()), min);
         } catch (NumberFormatException ex) {
+            // Attempt a double parse and truncate if the value has no fractional part.
+            try {
+                double d = Double.parseDouble(value.trim());
+                if (d == Math.floor(d) && !Double.isInfinite(d)) {
+                    return Math.max((long) d, min);
+                }
+            } catch (NumberFormatException ignored) {
+                // fall through to default.
+            }
             LOG.warn("Invalid long for property '" + key + "', using default " + defaultValue + ".", ex);
             return defaultValue;
         }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/circuitbreaker/DefaultPolicyConfigurationLoaderTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/circuitbreaker/DefaultPolicyConfigurationLoaderTest.java
@@ -249,6 +249,22 @@ public class DefaultPolicyConfigurationLoaderTest {
         assertEquals(invokeParseInt(TEST_KEY, 1, 1), 15);
     }
 
+    @Test
+    public void testParseIntHandlesFloatFormattedInteger() throws Exception {
+
+        identityConfig.put(TEST_KEY, "20.0");
+
+        assertEquals(invokeParseInt(TEST_KEY, 1, 1), 20);
+    }
+
+    @Test
+    public void testParseIntReturnsDefaultOnFractionalFloat() throws Exception {
+
+        identityConfig.put(TEST_KEY, "20.7");
+
+        assertEquals(invokeParseInt(TEST_KEY, 8, 1), 8);
+    }
+
     // ─────────────────────────── parseLong ───────────────────────────
 
     @Test
@@ -295,6 +311,22 @@ public class DefaultPolicyConfigurationLoaderTest {
         identityConfig.put(TEST_KEY, "  500  ");
 
         assertEquals(invokeParseLong(TEST_KEY, 1L, 1L), 500L);
+    }
+
+    @Test
+    public void testParseLongHandlesFloatFormattedInteger() throws Exception {
+
+        identityConfig.put(TEST_KEY, "60000.0");
+
+        assertEquals(invokeParseLong(TEST_KEY, 1L, 1L), 60000L);
+    }
+
+    @Test
+    public void testParseLongReturnsDefaultOnFractionalFloat() throws Exception {
+
+        identityConfig.put(TEST_KEY, "60000.7");
+
+        assertEquals(invokeParseLong(TEST_KEY, 20L, 1L), 20L);
     }
 
     // ─────────────────────────── parseDouble ───────────────────────────


### PR DESCRIPTION
## Summary

When circuit breaker policy properties are stored as float-formatted numbers (e.g., `"20.0"`, `"60000.0"`), `Integer.parseInt` and `Long.parseLong` throw `NumberFormatException` and the configuration silently falls back to defaults. This can silently misconfigure circuit breaker thresholds such as failure counts and timeout durations.

This fix adds a double-parse fallback in both `parseInt` and `parseLong` in `DefaultPolicyConfigurationLoader`:
- Values with no fractional part (e.g., `"20.0"`) are safely cast to `int`/`long`.
- Fractional values (e.g., `"20.7"`) still fall back to the configured default and emit a warning log.

## Related Issue
- https://github.com/wso2/product-is/issues/28017