### PR TITLE
Add operational scope to branding API

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -224,6 +224,8 @@
         <Scopes>
             <Scope displayName="Update Branding Preference" name="internal_branding_preference_update"
                    description="Update branding preferences of the organization (root)"/>
+            <Scope displayName="Update Branding Policy URLs" name="internal_branding_preference_policy_update"
+                   description="Update policy URLs in branding preferences of the organization (root)"/>
         </Scopes>
     </APIResource>
     <APIResource name="Branding Preference Management API"
@@ -233,6 +235,8 @@
         <Scopes>
             <Scope displayName="Update Branding Preference" name="internal_org_branding_preference_update"
                    description="Update branding preferences on user interfaces of the organization"/>
+            <Scope displayName="Update Branding Policy URLs" name="internal_org_branding_preference_policy_update"
+                   description="Update policy URLs in branding preferences of the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Claim Management API" identifier="/api/server/v1/claim-dialects"

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -233,6 +233,8 @@
         <Scopes>
             <Scope displayName="Update Branding Preference" name="internal_branding_preference_update"
                    description="Update branding preferences of the organization (root)"/>
+            <Scope displayName="Update Branding Policy URLs" name="internal_branding_preference_policy_update"
+                               description="Update policy URLs in branding preferences of the organization (root)"/>
         </Scopes>
     </APIResource>
     <APIResource name="Branding Preference Management API"
@@ -242,6 +244,8 @@
         <Scopes>
             <Scope displayName="Update Branding Preference" name="internal_org_branding_preference_update"
                    description="Update branding preferences on user interfaces of the organization"/>
+            <Scope displayName="Update Branding Policy URLs" name="internal_org_branding_preference_policy_update"
+                               description="Update policy URLs in branding preferences of the organization"/>
         </Scopes>
     </APIResource>
     <APIResource name="Claim Management API" identifier="/api/server/v1/claim-dialects"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1655,7 +1655,6 @@
   "console.consents.disabled_features": [],
   "console.consents.scopes.create": [
     "internal_consent_mgt_element_create",
-    "internal_consent_mgt_purpose_app_create",
     "internal_consent_mgt_purpose_create"
   ],
   "console.consents.scopes.read": [
@@ -1667,11 +1666,12 @@
   ],
   "console.consents.scopes.update": [
     "internal_branding_preference_policy_update",
+    "internal_consent_mgt_purpose_app_create",
+    "internal_consent_mgt_purpose_app_delete",
     "internal_consent_mgt_purpose_update"
   ],
   "console.consents.scopes.delete": [
     "internal_consent_mgt_element_delete",
-    "internal_consent_mgt_purpose_app_delete",
     "internal_consent_mgt_purpose_delete"
   ],
   "console.flows.enabled": true,


### PR DESCRIPTION
Related issue https://github.com/wso2/product-is/issues/26859

This pull request introduces new API scopes for updating branding policy URLs and updates the default server feature configuration to align with these changes. It also reorganizes consent management scopes to ensure correct permissions for create, update, and delete operations.

**API Resource Management Updates:**

* Added a new scope `internal_branding_preference_policy_update` to allow updating policy URLs in branding preferences for the organization (root) in both `system-api-resource.xml` and its template (`system-api-resource.xml.j2`). [[1]](diffhunk://#diff-2bb3bf5d98c3e3607e4d52f7be45a06b2e6afc0357ba58dc9bbb71a5bd8102bbR227-R228) [[2]](diffhunk://#diff-a70225dc72f4100048a17b866cc1754e81c34fc31aa4128051d613ac4c64ed5bR236-R237)
* Added a new scope `internal_org_branding_preference_policy_update` for updating policy URLs in branding preferences at the organization level in both `system-api-resource.xml` and its template. [[1]](diffhunk://#diff-2bb3bf5d98c3e3607e4d52f7be45a06b2e6afc0357ba58dc9bbb71a5bd8102bbR238-R239) [[2]](diffhunk://#diff-a70225dc72f4100048a17b866cc1754e81c34fc31aa4128051d613ac4c64ed5bR247-R248)

**Consent Management Scope Configuration:**

* Removed `internal_consent_mgt_purpose_app_create` from the `console.consents.scopes.create` list in the default server feature configuration, and added it (along with `internal_consent_mgt_purpose_app_delete`) to the `console.consents.scopes.update` list, ensuring proper scope assignment for consent management operations. [[1]](diffhunk://#diff-ccd8d78f18b752f00ba42b5384248d7b8e8c6cc965a44569e2654ca6ce5bb616L1658) [[2]](diffhunk://#diff-ccd8d78f18b752f00ba42b5384248d7b8e8c6cc965a44569e2654ca6ce5bb616R1669-L1674)
* Removed `internal_consent_mgt_purpose_app_delete` from the `console.consents.scopes.delete` list, reflecting its new placement in the update scopes.