### PR TITLE
Merge same policy scopes into a single authorized scope entry

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationConstants.java
@@ -149,6 +149,7 @@ public class ApplicationConstants {
     public static final String MYACCOUNT_PORTAL_PATH = "MyAccount.AppBaseName";
     public static final String AUTHORIZE_ALL_SCOPES = "OAuth.AuthorizeAllScopes";
     public static final String AUTHORIZE_INTERNAL_SCOPES = "OAuth.AuthorizeInternalScopes";
+    public static final String MERGE_AUTHORIZED_SCOPES_BY_POLICY = "OAuth.MergeAuthorizedScopesByPolicy";
     public static final String RBAC = "RBAC";
     public static final String SYSTEM_PORTALS = "SystemPortals";
     public static final String IMPERSONATE_SCOPE_NAME = "internal_user_impersonate";

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
@@ -60,6 +60,7 @@ import static org.wso2.carbon.identity.application.common.util.IdentityApplicati
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.AUTHORIZE_ALL_SCOPES;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.AUTHORIZE_INTERNAL_SCOPES;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.ENABLE_CROSS_TENANT_AUTHORIZED_API_VALIDATION_PROPERTY;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.MERGE_AUTHORIZED_SCOPES_BY_POLICY;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.IS_FRAGMENT_APP;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.RBAC;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.APPLICATION;
@@ -243,11 +244,39 @@ public class AuthorizedAPIManagementServiceImpl implements AuthorizedAPIManageme
                 if (authoriseInternalScopes) {
                     authorizedScopes = new ArrayList<>(authorizedScopesMap.values());
                 } else {
-                    authorizedScopes = new ArrayList<>(getScopesExcludingInternalScopes(authorizedScopesMap));
                     List<AuthorizedScopes> appAuthorisedScopes = authorizedAPIDAO.getAuthorizedScopes(appId,
                             IdentityTenantUtil.getTenantId(tenantDomain));
-                    // Get the scopes authorised in the application and add them too.
-                    authorizedScopes.addAll(appAuthorisedScopes);
+                    boolean mergeByPolicy = !Boolean.FALSE.toString().equalsIgnoreCase(
+                            IdentityUtil.getProperty(MERGE_AUTHORIZED_SCOPES_BY_POLICY));
+                    if (mergeByPolicy) {
+                        List<AuthorizedScopes> nonInternalTenantScopes =
+                                new ArrayList<>(getScopesExcludingInternalScopes(authorizedScopesMap));
+                        // Tenant scopes are always RBAC-only; merge in internal/console scopes from
+                        // the app's RBAC subscription into that single entry.
+                        List<String> appRbacInternalScopes = appAuthorisedScopes.stream()
+                                .filter(as -> RBAC.equals(as.getPolicyId()))
+                                .flatMap(as -> as.getScopes().stream())
+                                .filter(s -> s.startsWith(INTERNAL_SCOPE_PREFIX)
+                                        || s.startsWith(CONSOLE_SCOPE_PREFIX))
+                                .distinct()
+                                .collect(Collectors.toList());
+                        if (!appRbacInternalScopes.isEmpty() && !nonInternalTenantScopes.isEmpty()) {
+                            AuthorizedScopes rbacEntry = nonInternalTenantScopes.get(0);
+                            List<String> merged = new ArrayList<>(rbacEntry.getScopes());
+                            appRbacInternalScopes.stream()
+                                    .filter(s -> !merged.contains(s))
+                                    .forEach(merged::add);
+                            nonInternalTenantScopes.set(0, new AuthorizedScopes(RBAC, merged));
+                        }
+                        authorizedScopes = nonInternalTenantScopes;
+                        // Non-RBAC app policies have no tenant-level conflict; add them directly.
+                        appAuthorisedScopes.stream()
+                                .filter(as -> !RBAC.equals(as.getPolicyId()))
+                                .forEach(authorizedScopes::add);
+                    } else {
+                        authorizedScopes = new ArrayList<>(getScopesExcludingInternalScopes(authorizedScopesMap));
+                        authorizedScopes.addAll(appAuthorisedScopes);
+                    }
                 }
             } else {
                 authorizedScopes = authorizedAPIDAO.getAuthorizedScopes(appId,

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImpl.java
@@ -60,8 +60,8 @@ import static org.wso2.carbon.identity.application.common.util.IdentityApplicati
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.AUTHORIZE_ALL_SCOPES;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.AUTHORIZE_INTERNAL_SCOPES;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.ENABLE_CROSS_TENANT_AUTHORIZED_API_VALIDATION_PROPERTY;
-import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.MERGE_AUTHORIZED_SCOPES_BY_POLICY;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.IS_FRAGMENT_APP;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.MERGE_AUTHORIZED_SCOPES_BY_POLICY;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.RBAC;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.APPLICATION;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.CONSOLE_SCOPE_PREFIX;

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImplMockUnitTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/AuthorizedAPIManagementServiceImplMockUnitTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.mgt;
+
+import org.mockito.MockedStatic;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.api.resource.mgt.APIResourceManager;
+import org.wso2.carbon.identity.application.common.model.AuthorizedScopes;
+import org.wso2.carbon.identity.application.common.model.Scope;
+import org.wso2.carbon.identity.application.mgt.dao.AuthorizedAPIDAO;
+import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponentHolder;
+import org.wso2.carbon.identity.application.mgt.internal.ApplicationMgtListenerServiceComponent;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.AUTHORIZE_ALL_SCOPES;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.AUTHORIZE_INTERNAL_SCOPES;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.MERGE_AUTHORIZED_SCOPES_BY_POLICY;
+
+/**
+ * Unit tests for AuthorizedAPIManagementServiceImpl.
+ * All external dependencies (DB, OSGi services) are mocked.
+ */
+@WithCarbonHome
+public class AuthorizedAPIManagementServiceImplMockUnitTest {
+
+    private static final String APP_ID = "test-app-id";
+    private static final String TENANT_DOMAIN = "test.tenant.com";
+    private static final int TENANT_ID = 1;
+
+    private AuthorizedAPIManagementServiceImpl service;
+    private AuthorizedAPIDAO mockDAO;
+    private APIResourceManager mockAPIResourceManager;
+    private ApplicationManagementServiceImpl mockAppMgtService;
+
+    private MockedStatic<ApplicationManagementServiceImpl> mockedAppMgtServiceClass;
+    private MockedStatic<ApplicationMgtListenerServiceComponent> mockedListenerComponent;
+    private MockedStatic<IdentityUtil> mockedIdentityUtil;
+    private MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        service = new AuthorizedAPIManagementServiceImpl();
+
+        mockDAO = mock(AuthorizedAPIDAO.class);
+        Field daoField = AuthorizedAPIManagementServiceImpl.class.getDeclaredField("authorizedAPIDAO");
+        daoField.setAccessible(true);
+        daoField.set(service, mockDAO);
+
+        mockAPIResourceManager = mock(APIResourceManager.class);
+        ApplicationManagementServiceComponentHolder.getInstance().setAPIResourceManager(mockAPIResourceManager);
+
+        mockAppMgtService = mock(ApplicationManagementServiceImpl.class);
+
+        mockedAppMgtServiceClass = mockStatic(ApplicationManagementServiceImpl.class);
+        mockedAppMgtServiceClass.when(ApplicationManagementServiceImpl::getInstance).thenReturn(mockAppMgtService);
+
+        mockedListenerComponent = mockStatic(ApplicationMgtListenerServiceComponent.class);
+        mockedListenerComponent.when(ApplicationMgtListenerServiceComponent::getAuthorizedAPIManagementListeners)
+                .thenReturn(Collections.emptyList());
+
+        mockedIdentityUtil = mockStatic(IdentityUtil.class);
+        mockedIdentityUtil.when(() -> IdentityUtil.getProperty(anyString())).thenReturn(null);
+
+        mockedIdentityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
+
+        when(mockAppMgtService.getMainAppId(APP_ID)).thenReturn(null);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        mockedAppMgtServiceClass.close();
+        mockedListenerComponent.close();
+        mockedIdentityUtil.close();
+        mockedIdentityTenantUtil.close();
+    }
+
+    private void stubProperties(boolean mergeByPolicy) {
+
+        mockedIdentityUtil.when(() -> IdentityUtil.getProperty(AUTHORIZE_ALL_SCOPES)).thenReturn("true");
+        mockedIdentityUtil.when(() -> IdentityUtil.getProperty(AUTHORIZE_INTERNAL_SCOPES)).thenReturn("false");
+        mockedIdentityUtil.when(() -> IdentityUtil.getProperty(MERGE_AUTHORIZED_SCOPES_BY_POLICY))
+                .thenReturn(String.valueOf(mergeByPolicy));
+    }
+
+    private static Scope scope(String name) {
+
+        return new Scope.ScopeBuilder().name(name).build();
+    }
+
+    private static AuthorizedScopes authorizedScopes(String policyId, String... scopeNames) {
+
+        return new AuthorizedScopes(policyId, new ArrayList<>(Arrays.asList(scopeNames)));
+    }
+
+    @Test
+    public void shouldMergeInternalScopesIntoMatchingAllTenantPolicyEntry() throws Exception {
+
+        stubProperties(true);
+        when(mockAPIResourceManager.getScopesByTenantDomain(TENANT_DOMAIN, null))
+                .thenReturn(Arrays.asList(scope("regular_scope"), scope("internal_scope")));
+        when(mockDAO.getAuthorizedScopes(APP_ID, TENANT_ID))
+                .thenReturn(Collections.singletonList(
+                        authorizedScopes("RBAC", "regular_scope", "internal_scope")));
+
+        List<AuthorizedScopes> result = service.getAuthorizedScopes(APP_ID, TENANT_DOMAIN);
+
+        Assert.assertEquals(result.size(), 1, "Expected a single merged RBAC entry");
+        AuthorizedScopes rbac = result.get(0);
+        Assert.assertEquals(rbac.getPolicyId(), "RBAC");
+        Assert.assertTrue(rbac.getScopes().contains("regular_scope"),
+                "Non-internal scope from all-tenant map must be present");
+        Assert.assertTrue(rbac.getScopes().contains("internal_scope"),
+                "Internal scope from app subscription must be merged into the RBAC entry");
+    }
+
+    @Test
+    public void shouldAddAppOnlyPolicyIdAsSeparateEntry() throws Exception {
+
+        stubProperties(true);
+        when(mockAPIResourceManager.getScopesByTenantDomain(TENANT_DOMAIN, null))
+                .thenReturn(Collections.singletonList(scope("regular_scope")));
+        when(mockDAO.getAuthorizedScopes(APP_ID, TENANT_ID))
+                .thenReturn(Arrays.asList(
+                        authorizedScopes("RBAC", "regular_scope"),
+                        authorizedScopes("No Policy", "internal_scope")));
+
+        List<AuthorizedScopes> result = service.getAuthorizedScopes(APP_ID, TENANT_DOMAIN);
+
+        AuthorizedScopes rbac = result.stream()
+                .filter(s -> "RBAC".equals(s.getPolicyId())).findFirst().orElse(null);
+        AuthorizedScopes noPolicy = result.stream()
+                .filter(s -> "No Policy".equals(s.getPolicyId())).findFirst().orElse(null);
+
+        Assert.assertEquals(result.size(), 2);
+        Assert.assertNotNull(rbac, "RBAC entry must be present");
+        Assert.assertNotNull(noPolicy, "App-only policy ID must be added as a separate entry");
+        Assert.assertTrue(rbac.getScopes().contains("regular_scope"));
+        Assert.assertTrue(noPolicy.getScopes().contains("internal_scope"));
+    }
+
+    @Test
+    public void shouldDeduplicateInternalScopesWhenAppHasMultipleRbacEntries() throws Exception {
+
+        stubProperties(true);
+        when(mockAPIResourceManager.getScopesByTenantDomain(TENANT_DOMAIN, null))
+                .thenReturn(Collections.singletonList(scope("regular_scope")));
+        // Two app subscription entries share the RBAC policyId with an overlapping internal scope.
+        when(mockDAO.getAuthorizedScopes(APP_ID, TENANT_ID))
+                .thenReturn(Arrays.asList(
+                        authorizedScopes("RBAC", "regular_scope", "internal_shared"),
+                        authorizedScopes("RBAC", "internal_shared", "internal_other")));
+
+        List<AuthorizedScopes> result = service.getAuthorizedScopes(APP_ID, TENANT_DOMAIN);
+
+        AuthorizedScopes rbac = result.stream()
+                .filter(s -> "RBAC".equals(s.getPolicyId())).findFirst().orElse(null);
+        Assert.assertNotNull(rbac);
+        long count = rbac.getScopes().stream().filter("internal_shared"::equals).count();
+        Assert.assertEquals(count, 1, "Duplicate internal scope must not appear more than once in the merged result");
+        Assert.assertTrue(rbac.getScopes().contains("internal_other"));
+    }
+
+    @Test
+    public void shouldPreserveInternalScopesInNonRbacAppEntries() throws Exception {
+
+        stubProperties(true);
+        when(mockAPIResourceManager.getScopesByTenantDomain(TENANT_DOMAIN, null))
+                .thenReturn(Collections.singletonList(scope("regular_scope")));
+        // Non-RBAC app entry carries internal scopes; they must not be stripped.
+        when(mockDAO.getAuthorizedScopes(APP_ID, TENANT_ID))
+                .thenReturn(Arrays.asList(
+                        authorizedScopes("RBAC", "regular_scope"),
+                        authorizedScopes("No Policy", "internal_admin", "console_manage")));
+
+        List<AuthorizedScopes> result = service.getAuthorizedScopes(APP_ID, TENANT_DOMAIN);
+
+        AuthorizedScopes noPolicy = result.stream()
+                .filter(s -> "No Policy".equals(s.getPolicyId())).findFirst().orElse(null);
+        Assert.assertNotNull(noPolicy, "Non-RBAC app entry must be present");
+        Assert.assertTrue(noPolicy.getScopes().contains("internal_admin"),
+                "Internal scope in non-RBAC entry must not be filtered");
+        Assert.assertTrue(noPolicy.getScopes().contains("console_manage"),
+                "Console scope in non-RBAC entry must not be filtered");
+    }
+
+    @Test
+    public void shouldAddAppScopesAsSeparateEntriesWhenMergeByPolicyDisabled() throws Exception {
+
+        stubProperties(false);
+        when(mockAPIResourceManager.getScopesByTenantDomain(TENANT_DOMAIN, null))
+                .thenReturn(Arrays.asList(scope("regular_scope"), scope("internal_scope")));
+        when(mockDAO.getAuthorizedScopes(APP_ID, TENANT_ID))
+                .thenReturn(Collections.singletonList(
+                        authorizedScopes("RBAC", "regular_scope", "internal_scope")));
+
+        List<AuthorizedScopes> result = service.getAuthorizedScopes(APP_ID, TENANT_DOMAIN);
+
+        // All-tenant entry (non-internal scopes only) and app entry are kept separate.
+        boolean allTenantEntryStripsInternal = result.stream()
+                .anyMatch(s -> "RBAC".equals(s.getPolicyId())
+                        && s.getScopes().contains("regular_scope")
+                        && !s.getScopes().contains("internal_scope"));
+        boolean appEntryCarriesInternalScope = result.stream()
+                .anyMatch(s -> "RBAC".equals(s.getPolicyId())
+                        && s.getScopes().contains("internal_scope"));
+
+        Assert.assertTrue(allTenantEntryStripsInternal,
+                "All-tenant RBAC entry must not contain internal scopes when mergeByPolicy is disabled");
+        Assert.assertTrue(appEntryCarriesInternalScope,
+                "App-sourced entry must carry the internal scope as-is when mergeByPolicy is disabled");
+    }
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/resources/testng.xml
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/resources/testng.xml
@@ -25,6 +25,7 @@
             <class name="org.wso2.carbon.identity.application.mgt.ApplicationManagementServiceImplTest"/>
             <class name="org.wso2.carbon.identity.application.mgt.validator.DefaultApplicationValidatorTest"/>
             <class name="org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementServiceImplTest"/>
+            <class name="org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementServiceImplMockUnitTest"/>
             <class name="org.wso2.carbon.identity.application.mgt.AdminRoleListenerTest"/>
             <class name="org.wso2.carbon.identity.application.mgt.listener.ApplicationIdentityProviderMgtListenerTest"/>
             <class name="org.wso2.carbon.identity.application.mgt.dao.impl.ApplicationDAOImplTest"/>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1489,6 +1489,7 @@
 
         <AuthorizeAllScopes>{{oauth.authorize_all_scopes}}</AuthorizeAllScopes>
         <AuthorizeInternalScopes>{{oauth.authorize_internal_scopes}}</AuthorizeInternalScopes>
+        <MergeAuthorizedScopesByPolicy>{{oauth.merge_authorized_scopes_by_policy}}</MergeAuthorizedScopesByPolicy>
 
         <!--
             When this configuration is enabled, the system supports the features defined in RFC9396,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -2325,6 +2325,7 @@
 
   "oauth.authorize_all_scopes": false,
   "oauth.authorize_internal_scopes": false,
+  "oauth.merge_authorized_scopes_by_policy": true,
   "oauth.enable_rich_authorization_requests" : true,
 
   "system_applications.system_portals": ["Console", "My Account"],


### PR DESCRIPTION
### Purpose
When `authorize_all_scopes = true` and `authorize_internal_scopes = false`, the `AuthorizedAPIManagementServiceImpl.getAuthorizedScopes()` method returns two separate `AuthorizedScopes` entries both carrying `policyId = RBAC`:

1. An all-tenant entry (all non-internal scopes, including server level default scopes (Ex:- `default`))
2. The app's API resource subscription entry (only the subscribed scopes)

The `DefaultOAuth2ScopeValidator` iterates over these entries and stores handler results in a map keyed by handler name. Since both entries are handled by `M2MScopeValidationHandler` (same policyId), the second result overwrites the first, and scopes like `"default"` that are absent from the app's subscriptions are dropped.

The fix is to merge the app's internal/console scopes into the single all-tenant RBAC entry instead of appending a separate RBAC entry — ensuring the handler processes only one entry and the overwrite never occurs.

**Config combination behaviour:**

| `authorize_all_scopes` | `authorize_internal_scopes` | App has subscriptions | Result |
|---|---|---|---|
| `false` | any | any | Only app's subscribed scopes returned — no issue |
| `true` | `true` | any | Single all-tenant entry (internal scopes included) — no issue |
| `true` | `false` | no | Single filtered all-tenant entry — no issue |
| `true` | `false` | yes | **Two RBAC entries → second overwrites first → scopes like `"default"` dropped** |

To control this behavior, a new configuration `merge_authorized_scopes_by_policy` will be introduced:

```toml
[oauth]
merge_authorized_scopes_by_policy = true
```

When enabled, authorized scope entries sharing the same `policyId` are merged into a single entry before validation, preventing the overwrite. **This will be enabled by default**, as it represents the correct behavior aligned with the intent of `authorize_all_scopes = true`. If an user reports a regression expecting the previous behavior (apps with subscriptions restricted to only their subscribed scopes), they can be guided to explicitly set `merge_authorized_scopes_by_policy = false` to restore the old behavior.

### Related Issue
- https://github.com/wso2/product-is/issues/27644