### PR TITLE
Add conditional auth config for max http connections

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2792,6 +2792,10 @@
         <AsyncSequenceExecutorPoolSize>5</AsyncSequenceExecutorPoolSize>
         <MaxTotalConnections>20</MaxTotalConnections>
         <MaxTotalConnectionsPerRoute>20</MaxTotalConnectionsPerRoute>
+        <HTTPFunctions>
+            <MaxConnections>20</MaxConnections>
+            <MaxConnectionsPerRoute>20</MaxConnectionsPerRoute>
+        </HTTPFunctions>
 
         <!--Timeouts in milliseconds-->
         <!--Default configs for timeouts-->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2794,7 +2794,7 @@
         <MaxTotalConnectionsPerRoute>20</MaxTotalConnectionsPerRoute>
         <HTTPFunctions>
             <MaxConnections>20</MaxConnections>
-            <MaxConnectionsPerRoute>20</MaxConnectionsPerRoute>
+            <MaxConnectionsPerRoute>2</MaxConnectionsPerRoute>
         </HTTPFunctions>
 
         <!--Timeouts in milliseconds-->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -4517,6 +4517,10 @@
         <AsyncSequenceExecutorPoolSize>{{authentication.adaptive.async_executer_pool_size}}</AsyncSequenceExecutorPoolSize>
         <MaxTotalConnections>{{authentication.adaptive.http_connections.max}}</MaxTotalConnections>
         <MaxTotalConnectionsPerRoute>{{authentication.adaptive.http_connections.max_per_route}}</MaxTotalConnectionsPerRoute>
+        <HTTPFunctions>
+            <MaxConnections>{{authentication.adaptive.http_functions.max_connections}}</MaxConnections>
+            <MaxConnectionsPerRoute>{{authentication.adaptive.http_functions.max_connections_per_route}}</MaxConnectionsPerRoute>
+        </HTTPFunctions>
 
         <!--Timeouts in milliseconds-->
         <!--Default configs for timeouts-->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -950,7 +950,7 @@
   "authentication.adaptive.http_connections.max": "20",
   "authentication.adaptive.http_connections.max_per_route": "20",
   "authentication.adaptive.http_functions.max_connections": "20",
-  "authentication.adaptive.http_functions.max_connections_per_route": "20",
+  "authentication.adaptive.http_functions.max_connections_per_route": "2",
   "authentication.adaptive.choreo_token_endpoint": "https://sts.choreo.dev/oauth2/token",
   "authentication.adaptive.http_connections.default_timeout": "3s",
   "authentication.adaptive.http_connections.connection_timeout": "$ref{authentication.adaptive.http_connections.default_timeout}",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -949,6 +949,8 @@
   "authentication.adaptive.async_executer_pool_size": "5",
   "authentication.adaptive.http_connections.max": "20",
   "authentication.adaptive.http_connections.max_per_route": "20",
+  "authentication.adaptive.http_functions.max_connections": "20",
+  "authentication.adaptive.http_functions.max_connections_per_route": "20",
   "authentication.adaptive.choreo_token_endpoint": "https://sts.choreo.dev/oauth2/token",
   "authentication.adaptive.http_connections.default_timeout": "3s",
   "authentication.adaptive.http_connections.connection_timeout": "$ref{authentication.adaptive.http_connections.default_timeout}",


### PR DESCRIPTION
## Purpose

This pull request introduces new configuration options for managing HTTP connection limits specifically for conditional authentication scenarios. The changes add parameters for maximum total connections and maximum connections per route, ensuring better control and scalability for conditional authentication flows.

New configuration options for conditional authentication HTTP connections:

* Added `ConditionalAuthMaxTotalConnections` and `ConditionalAuthMaxTotalConnectionsPerRoute` parameters to the `identity.xml` file to define connection limits for conditional authentication.
* Updated the `identity.xml.j2` template to support templated values for these new parameters, allowing customization via deployment configuration.
* Introduced corresponding default values for these parameters in `org.wso2.carbon.identity.core.server.feature.default.json`.