### PR TITLE
Fix NullPointerException in LoggerUtils.getSanitizedErrorMessage when userName is null

### DIFF
--- a/components/central-logger/org.wso2.carbon.identity.central.log.mgt/src/main/java/org/wso2/carbon/identity/central/log/mgt/utils/LoggerUtils.java
+++ b/components/central-logger/org.wso2.carbon.identity.central.log.mgt/src/main/java/org/wso2/carbon/identity/central/log/mgt/utils/LoggerUtils.java
@@ -332,7 +332,7 @@ public class LoggerUtils {
      */
     public static String getSanitizedErrorMessage(String errorMessage, String userName) {
 
-        if (LoggerUtils.isLogMaskingEnable && errorMessage.contains(userName)) {
+        if (LoggerUtils.isLogMaskingEnable && userName != null && errorMessage.contains(userName)) {
             return errorMessage.replace(userName, LoggerUtils.getMaskedContent(userName));
         }
         return errorMessage;


### PR DESCRIPTION
## Summary

- `LoggerUtils.getSanitizedErrorMessage(String errorMessage, String userName)` calls `errorMessage.contains(userName)` without a null-check on `userName`
- When the refresh token grant fails after a user password reset, the user context is unresolved and `userName` is `null` — `String.contains(null)` throws NPE, surfacing as HTTP 500 `server_error`
- Fix: add `userName != null &&` guard before `errorMessage.contains(userName)`

## Related Issues

- https://github.com/wso2/product-is/issues/27853