### PR TITLE
Fix unresolved CUSTOM placeholder in My Account impersonation callback URL

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -1215,15 +1215,23 @@ public class ApplicationMgtUtil {
         }
 
         if (StringUtils.isEmpty(basePath)) {
-            return resolveOriginUrlFromPlaceholders(absoluteUrl);
+            basePath = getAbsolutePublicUrlWithoutPath();
         }
         absoluteUrl = StringUtils.replace(absoluteUrl, BASE_URL_PLACEHOLDER, basePath);
 
         if (ApplicationConstants.MY_ACCOUNT_APPLICATION_NAME.equals(appName)) {
             String consoleBasePath = IdentityUtil.getProperty(CONSOLE_ACCESS_ORIGIN);
+            if (StringUtils.isEmpty(consoleBasePath)) {
+                consoleBasePath = getAbsolutePublicUrlWithoutPath();
+            }
             absoluteUrl = StringUtils.replace(absoluteUrl, BASE_URL_CUSTOM_PLACEHOLDER, consoleBasePath);
         }
         return absoluteUrl;
+    }
+
+    private static String getAbsolutePublicUrlWithoutPath() throws URLBuilderException {
+
+        return ServiceURLBuilder.create().build().getAbsolutePublicUrlWithoutPath();
     }
 
     /**


### PR DESCRIPTION
## Purpose

- After migrating from IS 7.1.0 to IS 7.2.0, the `MyAccountForImpersonationMigrator` adds the impersonation redirect URL to the My Account OAuth app's callback URL list using the `<CUSTOM_PROTOCOL>://<CUSTOM_HOSTNAME>:<CUSTOM_PORT>` placeholder. When `Console.Origin` is not configured, this placeholder was left unresolved at OAuth redirect_uri validation time, causing user impersonation via Console to fail.
- Root cause: 
   - When `MyAccount.Origin` is not configured, the standard `<PROTOCOL>://<HOSTNAME>:<PORT>` placeholder in the My Account callback URL was resolved correctly, but the CUSTOM  `<CUSTOM_PROTOCOL>://<CUSTOM_HOSTNAME>:<CUSTOM_PORT>` placeholder for the impersonation redirect URL was not — leaving it unresolved.
- Fix:
  - Fixes the read path (`resolveOriginUrlFromPlaceholders`) to fall back to the server base URL when `Console.Origin` is not configured, ensuring the CUSTOM placeholder in the impersonation callback URL is resolved correctly.
    - Removes the dependency on the `@Deprecated` single-argument overload of `resolveOriginUrlFromPlaceholders.`

## Related Issues 
- Internal : https://github.com/wso2-enterprise/wso2-iam-internal/issues/7255
- Public : https://github.com/wso2/product-is/issues/27809