### PR TITLE
Add config to enable claim description as attribute name for PassiveSTS

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -457,6 +457,8 @@ public class IdentityConstants {
                 "PassiveSTS.EnableDefaultSignatureAndDigestAlgorithm";
         public static final String PASSIVE_STS_LOGOUT_WREPLY_VALIDATION =
                 "PassiveSTS.EnableLogoutWreplyValidation";
+        public static final String PASSIVE_STS_ENABLE_CLAIM_DESCRIPTION_IN_ATTRIBUTE_NAME =
+                "PassiveSTS.EnableClaimDescriptionInAttributeName";
     }
 
     /**

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1657,6 +1657,7 @@
         <EnableDefaultSignatureAndDigestAlgorithm>{{passive_sts.enable_default_signature_and_digest_alg}}</EnableDefaultSignatureAndDigestAlgorithm>
         <EnableLogoutWreplyValidation>{{passive_sts.enable_logout_wreply_validation}}</EnableLogoutWreplyValidation>
         <SOAPEnabled>{{passive_sts.soap_enabled}}</SOAPEnabled>
+        <EnableClaimDescriptionInAttributeName>{{passive_sts.enable_claim_description_in_attribute_name}}</EnableClaimDescriptionInAttributeName>
     </PassiveSTS>
 
     <UserAccountAssociation>


### PR DESCRIPTION
## Purpose

Front-ports the Passive STS *claim-description-as-attribute-name* configuration to master.

Adds:
- The `PASSIVE_STS_ENABLE_CLAIM_DESCRIPTION_IN_ATTRIBUTE_NAME` constant (`PassiveSTS.EnableClaimDescriptionInAttributeName`) to `IdentityConstants.STS`.
- The matching `<EnableClaimDescriptionInAttributeName>{{passive_sts.enable_claim_description_in_attribute_name}}</EnableClaimDescriptionInAttributeName>` binding in `identity.xml.j2`, so the feature can be toggled via `deployment.toml`:

```toml
[passive_sts]
enable_claim_description_in_attribute_name = true
```

When enabled, Passive STS uses the claim's display tag as the SAML `AttributeName`. The property is consumed in `identity-inbound-auth-sts` (see related PR below). Backward compatible — when the property is absent/`false`, behaviour is unchanged.

## Related Issue
- https://github.com/wso2/product-is/issues/27690

## Related PR
- https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/199
