### PR TITLE
Add DecodeRedirectUrisInResponse config knob for DCR redirect_uris response

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1298,6 +1298,9 @@
             <EnableFAPIEnforcement>{{oauth.dcr.enable_fapi_enforcement}}</EnableFAPIEnforcement>
             <EnableSectorIdentifierURIValidation>{{oauth.dcr.enable_sector_identifier_validation}}</EnableSectorIdentifierURIValidation>
             <ReturnNullFieldsInResponse>{{oauth.dcrm.return_null_fields_in_response}}</ReturnNullFieldsInResponse>
+            {% if oauth.dcrm.decode_redirect_uris_in_response is defined %}
+            <DecodeRedirectUrisInResponse>{{oauth.dcrm.decode_redirect_uris_in_response}}</DecodeRedirectUrisInResponse>
+            {% endif %}
         </DCRM>
 
         <!--

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1298,9 +1298,7 @@
             <EnableFAPIEnforcement>{{oauth.dcr.enable_fapi_enforcement}}</EnableFAPIEnforcement>
             <EnableSectorIdentifierURIValidation>{{oauth.dcr.enable_sector_identifier_validation}}</EnableSectorIdentifierURIValidation>
             <ReturnNullFieldsInResponse>{{oauth.dcrm.return_null_fields_in_response}}</ReturnNullFieldsInResponse>
-            {% if oauth.dcrm.decode_redirect_uris_in_response is defined %}
             <DecodeRedirectUrisInResponse>{{oauth.dcrm.decode_redirect_uris_in_response}}</DecodeRedirectUrisInResponse>
-            {% endif %}
         </DCRM>
 
         <!--

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -237,6 +237,7 @@
   "oauth.grant_type.ciba.allow_public_client": false,
   "oauth.dcrm.application_role_permission_required_to_view": true,
   "oauth.dcrm.return_null_fields_in_response": false,
+  "oauth.dcrm.decode_redirect_uris_in_response": false,
   "oauth.dcr.enable_fapi_enforcement": false,
   "oauth.dcr.enable_sector_identifier_validation": false,
   "oauth.dcr.authentication_required": true,


### PR DESCRIPTION
## Root cause and fix

- When an application is registered with multiple redirect URIs, the DCR response incorrectly returned the internal `regexp=(uri1|uri2|...)` encoding as a single-element `redirect_uris` array instead of the original URI list.
- This PR adds the Jinja2 template entry and default config value for the `DecodeRedirectUrisInResponse` knob that gates the decode fix in `identity-inbound-auth-oauth`.
- The `{% if oauth.dcrm.decode_redirect_uris_in_response is defined %}` guard ensures no change to the generated `identity.xml` unless the property is set.

## Related PR

wso2-extensions/identity-inbound-auth-oauth#3262

## Linked issue

https://github.com/wso2/product-is/issues/27851