### PR TITLE
Add V2 default logout endpoint config for SAML SLO under tenant-qualified URLs

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
+++ b/components/identity-core/org.wso2.carbon.identity.base/src/main/java/org/wso2/carbon/identity/base/IdentityConstants.java
@@ -265,6 +265,7 @@ public class IdentityConstants {
         public final static String SSO_IDP_URL = "SSOService.IdentityProviderURL";
         public final static String SSO_ARTIFACT_URL = "SSOService.ArtifactResolutionEndpoint";
         public final static String DEFAULT_LOGOUT_ENDPOINT = "SSOService.DefaultLogoutEndpoint";
+        public static final String DEFAULT_LOGOUT_ENDPOINT_V2 = "SSOService.V2.DefaultLogoutEndpoint";
         public final static String NOTIFICATION_ENDPOINT = "SSOService.NotificationEndpoint";
         public final static String SSO_ATTRIB_CLAIM_DIALECT = "SSOService.AttributesClaimDialect";
         public static final String SINGLE_LOGOUT_RETRY_COUNT = "SSOService.SingleLogoutRetryCount";

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1619,6 +1619,14 @@
         <ReturnValidNameIDFormat>{{saml.return_valid_name_id_format}}</ReturnValidNameIDFormat>
         <SAMLSLOFrontChannelPostBindingLogoutRequestSignatureWithTenantCert>{{saml.slo.front_channel.post_binding.logout_request_signature_with_tenant_cert}}</SAMLSLOFrontChannelPostBindingLogoutRequestSignatureWithTenantCert>
         <SAMLAllowNestedAssertionsInResponse>{{saml.response.allow_nested_assertions}}</SAMLAllowNestedAssertionsInResponse>
+        {% if saml.endpoints.v2 is defined %}
+        <!-- V2 configs for saml endpoints -->
+        <V2>
+            {% if saml.endpoints.v2.logout is defined %}
+            <DefaultLogoutEndpoint>{{saml.endpoints.v2.logout}}</DefaultLogoutEndpoint>
+            {% endif %}
+        </V2>
+        {% endif %}
     </SSOService>
 
     <Consent>


### PR DESCRIPTION
### Proposed changes

- Added `DEFAULT_LOGOUT_ENDPOINT_V2 = "SSOService.V2.DefaultLogoutEndpoint"` constant to `IdentityConstants.ServerConfig` to allow operators to configure a custom SAML logout URL that takes precedence over the dynamically-built URL when tenant-qualified URLs are enabled.
- Added the corresponding `[saml.endpoints.v2] logout` Jinja2 template block in `identity.xml.j2` so the new config key is wired into `SSOService/V2/DefaultLogoutEndpoint` in `identity.xml`.

### Context

When `tenant_context.enable_tenant_qualified_urls = true` (default in IS 7.2+), the existing `[saml.endpoints] logout` configuration in `deployment.toml` is silently ignored — the server always returns the dynamically-built absolute public URL. This change introduces a `[saml.endpoints.v2] logout` config that is honoured even when tenant-qualified URLs are enabled.

The matching resolution logic in `identity-inbound-auth-saml` is in: https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/459

### Tracking issue

https://github.com/wso2/product-is/issues/27022

### Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?**
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?**

#### Code

- [ ] **Do you fully understand the introduced changes to the code?**

#### Tests

- [ ] **Are there sufficient test cases?**

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**