### PR TITLE
Add granular scope feature

### DIFF
--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/pom.xml
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/pom.xml
@@ -109,6 +109,7 @@
                             org.wso2.carbon.identity.base; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.model; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.utils; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.api.resource.mgt;
                             version="${carbon.identity.package.import.version.range}",

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionManagerImpl.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionManagerImpl.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.api.resource.collection.mgt.util.APIResourceCollectionManagementUtil.handleServerException;
+import static org.wso2.carbon.identity.api.resource.collection.mgt.util.APIResourceCollectionManagementUtil.isGranularConsolePermissionsEnabled;
 
 /**
  * API Resource Collection Manager Implementation.
@@ -127,22 +128,51 @@ public class APIResourceCollectionManagerImpl implements APIResourceCollectionMa
         }
         try {
             APIResourceCollection clonedCollection = cloneAPIResourceCollection(collection);
+            boolean granularEnabled = isGranularConsolePermissionsEnabled();
 
-            // Combine read and write scopes for a single fetch.
+            Set<String> writeScopes = new HashSet<>();
+            Optional.ofNullable(clonedCollection.getReadScopes()).ifPresent(writeScopes::addAll);
+            Optional.ofNullable(clonedCollection.getWriteScopes()).ifPresent(writeScopes::addAll);
+
             Set<String> combinedScopes = new HashSet<>();
             Optional.ofNullable(clonedCollection.getReadScopes()).ifPresent(combinedScopes::addAll);
             Optional.ofNullable(clonedCollection.getWriteScopes()).ifPresent(combinedScopes::addAll);
+            if (granularEnabled) {
+                Optional.ofNullable(clonedCollection.getCreateScopes()).ifPresent(combinedScopes::addAll);
+                Optional.ofNullable(clonedCollection.getUpdateScopes()).ifPresent(combinedScopes::addAll);
+                Optional.ofNullable(clonedCollection.getDeleteScopes()).ifPresent(combinedScopes::addAll);
+            }
             List<APIResource> allAPIResources = APIResourceCollectionMgtServiceDataHolder.getInstance()
                     .getAPIResourceManagementService().getScopeMetadata(new ArrayList<>(combinedScopes), tenantDomain);
 
             List<APIResource> readAPIResources =
                     filterAPIResources(allAPIResources, clonedCollection.getReadScopes());
             List<APIResource> writeAPIResources =
-                    filterAPIResources(allAPIResources, new ArrayList<>(combinedScopes));
+                    filterAPIResources(allAPIResources, new ArrayList<>(writeScopes));
 
             Map<String, List<APIResource>> apiResourcesMap = new HashMap<>();
             apiResourcesMap.put(APIResourceCollectionManagementConstants.READ, readAPIResources);
             apiResourcesMap.put(APIResourceCollectionManagementConstants.WRITE, writeAPIResources);
+            if (granularEnabled) {
+                Set<String> createScopes = new HashSet<>();
+                Optional.ofNullable(clonedCollection.getReadScopes()).ifPresent(createScopes::addAll);
+                Optional.ofNullable(clonedCollection.getCreateScopes()).ifPresent(createScopes::addAll);
+
+                Set<String> updateScopes = new HashSet<>();
+                Optional.ofNullable(clonedCollection.getReadScopes()).ifPresent(updateScopes::addAll);
+                Optional.ofNullable(clonedCollection.getUpdateScopes()).ifPresent(updateScopes::addAll);
+
+                Set<String> deleteScopes = new HashSet<>();
+                Optional.ofNullable(clonedCollection.getReadScopes()).ifPresent(deleteScopes::addAll);
+                Optional.ofNullable(clonedCollection.getDeleteScopes()).ifPresent(deleteScopes::addAll);
+
+                apiResourcesMap.put(APIResourceCollectionManagementConstants.CREATE,
+                        filterAPIResources(allAPIResources, new ArrayList<>(createScopes)));
+                apiResourcesMap.put(APIResourceCollectionManagementConstants.UPDATE,
+                        filterAPIResources(allAPIResources, new ArrayList<>(updateScopes)));
+                apiResourcesMap.put(APIResourceCollectionManagementConstants.DELETE,
+                        filterAPIResources(allAPIResources, new ArrayList<>(deleteScopes)));
+            }
             clonedCollection.setApiResources(apiResourcesMap);
             return clonedCollection;
         } catch (APIResourceMgtException e) {
@@ -199,10 +229,16 @@ public class APIResourceCollectionManagerImpl implements APIResourceCollectionMa
                 .type(apiResourceCollection.getType())
                 .readScopes(apiResourceCollection.getReadScopes())
                 .writeScopes(apiResourceCollection.getWriteScopes())
+                .createScopes(apiResourceCollection.getCreateScopes())
+                .updateScopes(apiResourceCollection.getUpdateScopes())
+                .deleteScopes(apiResourceCollection.getDeleteScopes())
                 .legacyReadScopes(apiResourceCollection.getLegacyReadScopes())
                 .legacyWriteScopes(apiResourceCollection.getLegacyWriteScopes())
                 .viewFeatureScope(apiResourceCollection.getViewFeatureScope())
                 .editFeatureScope(apiResourceCollection.getEditFeatureScope())
+                .createFeatureScope(apiResourceCollection.getCreateFeatureScope())
+                .updateFeatureScope(apiResourceCollection.getUpdateFeatureScope())
+                .deleteFeatureScope(apiResourceCollection.getDeleteFeatureScope())
                 .apiResources(apiResourceCollection.getApiResources())
                 .build();
     }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/constant/APIResourceCollectionManagementConstants.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/constant/APIResourceCollectionManagementConstants.java
@@ -38,7 +38,12 @@ public class APIResourceCollectionManagementConstants {
     public static final String WRITE_SCOPES = "writeScopes";
     public static final String READ = "read";
     public static final String WRITE = "write";
+    public static final String CREATE = "create";
+    public static final String UPDATE = "update";
+    public static final String DELETE = "delete";
     public static final String API_RESOURCES = "apiResources";
+    public static final String USE_GRANULAR_CONSOLE_PERMISSIONS_CONFIG =
+            "ConsoleSettings.UseGranularConsolePermissions";
 
     /**
      * API resource collection configuration builder constants.
@@ -53,10 +58,16 @@ public class APIResourceCollectionManagementConstants {
         public static final String DISPLAY_NAME = "displayName";
         public static final String TYPE = "type";
         public static final String READ = "Read";
+        public static final String CREATE = "Create";
+        public static final String UPDATE = "Update";
+        public static final String DELETE = "Delete";
         public static final String FEATURE = "Feature";
         public static final String VERSION = "version";
         public static final String VIEW_FEATURE_SCOPE_SUFFIX = "_view";
         public static final String EDIT_FEATURE_SCOPE_SUFFIX = "_edit";
+        public static final String CREATE_FEATURE_SCOPE_SUFFIX = "_create";
+        public static final String UPDATE_FEATURE_SCOPE_SUFFIX = "_update";
+        public static final String DELETE_FEATURE_SCOPE_SUFFIX = "_delete";
         public static final String CONSOLE_SCOPE_PREFIX = "console:";
         public static final String COLLECTION_VERSION_V0 = "v0";
     }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/model/APIResourceCollection.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/model/APIResourceCollection.java
@@ -34,10 +34,16 @@ public class APIResourceCollection {
     private String type;
     private List<String> readScopes;
     private List<String> writeScopes;
+    private List<String> createScopes;
+    private List<String> updateScopes;
+    private List<String> deleteScopes;
     private List<String> legacyReadScopes;
     private List<String> legacyWriteScopes;
     private String viewFeatureScope;
     private String editFeatureScope;
+    private String createFeatureScope;
+    private String updateFeatureScope;
+    private String deleteFeatureScope;
     private Map<String, List<APIResource>> apiResources;
 
     public APIResourceCollection() {
@@ -52,10 +58,16 @@ public class APIResourceCollection {
             this.apiResources = apiResourceCollectionBuilder.apiResources;
             this.readScopes = apiResourceCollectionBuilder.readScopes;
             this.writeScopes = apiResourceCollectionBuilder.writeScopes;
+            this.createScopes = apiResourceCollectionBuilder.createScopes;
+            this.updateScopes = apiResourceCollectionBuilder.updateScopes;
+            this.deleteScopes = apiResourceCollectionBuilder.deleteScopes;
             this.legacyReadScopes = apiResourceCollectionBuilder.legacyReadScopes;
             this.legacyWriteScopes = apiResourceCollectionBuilder.legacyWriteScopes;
             this.viewFeatureScope = apiResourceCollectionBuilder.viewFeatureScope;
             this.editFeatureScope = apiResourceCollectionBuilder.editFeatureScope;
+            this.createFeatureScope = apiResourceCollectionBuilder.createFeatureScope;
+            this.updateFeatureScope = apiResourceCollectionBuilder.updateFeatureScope;
+            this.deleteFeatureScope = apiResourceCollectionBuilder.deleteFeatureScope;
     }
 
     public String getId() {
@@ -108,6 +120,36 @@ public class APIResourceCollection {
         this.writeScopes = writeScopes;
     }
 
+    public List<String> getCreateScopes() {
+
+        return createScopes;
+    }
+
+    public void setCreateScopes(List<String> createScopes) {
+
+        this.createScopes = createScopes;
+    }
+
+    public List<String> getUpdateScopes() {
+
+        return updateScopes;
+    }
+
+    public void setUpdateScopes(List<String> updateScopes) {
+
+        this.updateScopes = updateScopes;
+    }
+
+    public List<String> getDeleteScopes() {
+
+        return deleteScopes;
+    }
+
+    public void setDeleteScopes(List<String> deleteScopes) {
+
+        this.deleteScopes = deleteScopes;
+    }
+
     public List<String> getLegacyReadScopes() {
 
         return legacyReadScopes;
@@ -148,6 +190,36 @@ public class APIResourceCollection {
         this.editFeatureScope = editFeatureScope;
     }
 
+    public String getCreateFeatureScope() {
+
+        return createFeatureScope;
+    }
+
+    public void setCreateFeatureScope(String createFeatureScope) {
+
+        this.createFeatureScope = createFeatureScope;
+    }
+
+    public String getUpdateFeatureScope() {
+
+        return updateFeatureScope;
+    }
+
+    public void setUpdateFeatureScope(String updateFeatureScope) {
+
+        this.updateFeatureScope = updateFeatureScope;
+    }
+
+    public String getDeleteFeatureScope() {
+
+        return deleteFeatureScope;
+    }
+
+    public void setDeleteFeatureScope(String deleteFeatureScope) {
+
+        this.deleteFeatureScope = deleteFeatureScope;
+    }
+
     /**
      * Builder class for API Resource Collection.
      */
@@ -159,10 +231,16 @@ public class APIResourceCollection {
         private String type;
         private List<String> readScopes;
         private List<String> writeScopes;
+        private List<String> createScopes;
+        private List<String> updateScopes;
+        private List<String> deleteScopes;
         private List<String> legacyReadScopes;
         private List<String> legacyWriteScopes;
         private String viewFeatureScope;
         private String editFeatureScope;
+        private String createFeatureScope;
+        private String updateFeatureScope;
+        private String deleteFeatureScope;
         private Map<String, List<APIResource>> apiResources;
 
         public APIResourceCollectionBuilder() {
@@ -204,6 +282,24 @@ public class APIResourceCollection {
             return this;
         }
 
+        public APIResourceCollectionBuilder createScopes(List<String> createScopes) {
+
+            this.createScopes = createScopes;
+            return this;
+        }
+
+        public APIResourceCollectionBuilder updateScopes(List<String> updateScopes) {
+
+            this.updateScopes = updateScopes;
+            return this;
+        }
+
+        public APIResourceCollectionBuilder deleteScopes(List<String> deleteScopes) {
+
+            this.deleteScopes = deleteScopes;
+            return this;
+        }
+
 
         public APIResourceCollectionBuilder legacyReadScopes(List<String> legacyReadScopes) {
 
@@ -226,6 +322,24 @@ public class APIResourceCollection {
         public APIResourceCollectionBuilder editFeatureScope(String editFeatureScope) {
 
             this.editFeatureScope = editFeatureScope;
+            return this;
+        }
+
+        public APIResourceCollectionBuilder createFeatureScope(String createFeatureScope) {
+
+            this.createFeatureScope = createFeatureScope;
+            return this;
+        }
+
+        public APIResourceCollectionBuilder updateFeatureScope(String updateFeatureScope) {
+
+            this.updateFeatureScope = updateFeatureScope;
+            return this;
+        }
+
+        public APIResourceCollectionBuilder deleteFeatureScope(String deleteFeatureScope) {
+
+            this.deleteFeatureScope = deleteFeatureScope;
             return this;
         }
 

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionManagementUtil.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionManagementUtil.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.wso2.carbon.identity.api.resource.collection.mgt.constant.APIResourceCollectionManagementConstants;
 import org.wso2.carbon.identity.api.resource.collection.mgt.exception.APIResourceCollectionMgtClientException;
 import org.wso2.carbon.identity.api.resource.collection.mgt.exception.APIResourceCollectionMgtServerException;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 /**
  * Utility class for API Resource Collection Management.
@@ -62,5 +63,16 @@ public class APIResourceCollectionManagementUtil {
             description = String.format(description, data);
         }
         return new APIResourceCollectionMgtServerException(error.getMessage(), description, error.getCode(), e);
+    }
+
+    /**
+     * Check whether the granular console permission model (create/update/delete feature scopes) is enabled. Controlled
+     *
+     * @return True if granular console permissions are enabled.
+     */
+    public static boolean isGranularConsolePermissionsEnabled() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(
+                APIResourceCollectionManagementConstants.USE_GRANULAR_CONSOLE_PERMISSIONS_CONFIG));
     }
 }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionMgtConfigBuilder.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionMgtConfigBuilder.java
@@ -127,12 +127,16 @@ public class APIResourceCollectionMgtConfigBuilder {
             if (scopesElement != null) {
                 Set<String> readScopeSet = new HashSet<>();
                 Set<String> writeScopeSet = new HashSet<>();
+                Set<String> createScopeSet = new HashSet<>();
+                Set<String> updateScopeSet = new HashSet<>();
+                Set<String> deleteScopeSet = new HashSet<>();
                 Iterator<?> actionElements = scopesElement.getChildElements();
                 while (actionElements.hasNext()) {
                     OMElement actionElement = (OMElement) actionElements.next();
                     if (actionElement == null) {
                         continue;
                     }
+                    String actionName = actionElement.getLocalName();
                     Iterator<OMElement> scopes = actionElement.getChildrenWithName(
                             new QName(APIResourceCollectionConfigBuilderConstants.SCOPE_ELEMENT));
                     while (scopes.hasNext()) {
@@ -140,21 +144,40 @@ public class APIResourceCollectionMgtConfigBuilder {
                         String scopeName = scope.getAttributeValue(
                                 new QName(APIResourceCollectionConfigBuilderConstants.NAME));
                         // Read and old Feature scope are considered as read scopes.
-                        boolean isReadAction = APIResourceCollectionConfigBuilderConstants.READ
-                                .equals(actionElement.getLocalName());
-                        boolean isFeatureAction = APIResourceCollectionConfigBuilderConstants.FEATURE.
-                                equals(actionElement.getLocalName());
+                        boolean isReadAction = APIResourceCollectionConfigBuilderConstants.READ.equals(actionName);
+                        boolean isCreateAction = APIResourceCollectionConfigBuilderConstants.CREATE.equals(actionName);
+                        boolean isUpdateAction = APIResourceCollectionConfigBuilderConstants.UPDATE.equals(actionName);
+                        boolean isDeleteAction = APIResourceCollectionConfigBuilderConstants.DELETE.equals(actionName);
+                        boolean isFeatureAction = APIResourceCollectionConfigBuilderConstants.FEATURE
+                            .equals(actionName);
                         if (APIResourceCollectionConfigBuilderConstants.COLLECTION_VERSION_V0
                                 .equals(collectionVersion)) {
                             if (isReadAction || isFeatureAction) {
                                 readScopeSet.add(scopeName);
                             } else {
+                                // Create / Update / Delete actions aggregate into write and into their own bucket.
                                 writeScopeSet.add(scopeName);
+                                if (isCreateAction) {
+                                    createScopeSet.add(scopeName);
+                                } else if (isUpdateAction) {
+                                    updateScopeSet.add(scopeName);
+                                } else if (isDeleteAction) {
+                                    deleteScopeSet.add(scopeName);
+                                }
                             }
                         } else {
                             // Process new scopes with feature scopes.
                             if (isReadAction) {
                                 readScopeSet.add(scopeName);
+                            } else if (isCreateAction) {
+                                createScopeSet.add(scopeName);
+                                writeScopeSet.add(scopeName);
+                            } else if (isUpdateAction) {
+                                updateScopeSet.add(scopeName);
+                                writeScopeSet.add(scopeName);
+                            } else if (isDeleteAction) {
+                                deleteScopeSet.add(scopeName);
+                                writeScopeSet.add(scopeName);
                             } else if (isFeatureAction) {
                                 if (isViewFeatureScope(scopeName)) {
                                     apiResourceCollectionObj.setViewFeatureScope(scopeName);
@@ -162,6 +185,15 @@ public class APIResourceCollectionMgtConfigBuilder {
                                 } else if (isEditFeatureScope(scopeName)) {
                                     apiResourceCollectionObj.setEditFeatureScope(scopeName);
                                     writeScopeSet.add(scopeName);
+                                } else if (isCreateFeatureScope(scopeName)) {
+                                    apiResourceCollectionObj.setCreateFeatureScope(scopeName);
+                                    createScopeSet.add(scopeName);
+                                } else if (isUpdateFeatureScope(scopeName)) {
+                                    apiResourceCollectionObj.setUpdateFeatureScope(scopeName);
+                                    updateScopeSet.add(scopeName);
+                                } else if (isDeleteFeatureScope(scopeName)) {
+                                    apiResourceCollectionObj.setDeleteFeatureScope(scopeName);
+                                    deleteScopeSet.add(scopeName);
                                 } else {
                                     readScopeSet.add(scopeName);
                                 }
@@ -181,9 +213,21 @@ public class APIResourceCollectionMgtConfigBuilder {
                     if (apiResourceCollectionObj.getWriteScopes() == null) {
                         apiResourceCollectionObj.setWriteScopes(new ArrayList<>(writeScopeSet));
                     }
+                    if (apiResourceCollectionObj.getCreateScopes() == null) {
+                        apiResourceCollectionObj.setCreateScopes(new ArrayList<>(createScopeSet));
+                    }
+                    if (apiResourceCollectionObj.getUpdateScopes() == null) {
+                        apiResourceCollectionObj.setUpdateScopes(new ArrayList<>(updateScopeSet));
+                    }
+                    if (apiResourceCollectionObj.getDeleteScopes() == null) {
+                        apiResourceCollectionObj.setDeleteScopes(new ArrayList<>(deleteScopeSet));
+                    }
                 } else {
                     apiResourceCollectionObj.setReadScopes(new ArrayList<>(readScopeSet));
                     apiResourceCollectionObj.setWriteScopes(new ArrayList<>(writeScopeSet));
+                    apiResourceCollectionObj.setCreateScopes(new ArrayList<>(createScopeSet));
+                    apiResourceCollectionObj.setUpdateScopes(new ArrayList<>(updateScopeSet));
+                    apiResourceCollectionObj.setDeleteScopes(new ArrayList<>(deleteScopeSet));
                 }
             }
             apiResourceCollectionMgtConfigurations.put(apiResourceCollectionObj.getId(), apiResourceCollectionObj);
@@ -221,5 +265,26 @@ public class APIResourceCollectionMgtConfigBuilder {
         return StringUtils.isNotBlank(scope) &&
                 scope.startsWith(APIResourceCollectionConfigBuilderConstants.CONSOLE_SCOPE_PREFIX) &&
                 scope.endsWith(APIResourceCollectionConfigBuilderConstants.EDIT_FEATURE_SCOPE_SUFFIX);
+    }
+
+    private boolean isCreateFeatureScope(String scope) {
+
+        return StringUtils.isNotBlank(scope) &&
+                scope.startsWith(APIResourceCollectionConfigBuilderConstants.CONSOLE_SCOPE_PREFIX) &&
+                scope.endsWith(APIResourceCollectionConfigBuilderConstants.CREATE_FEATURE_SCOPE_SUFFIX);
+    }
+
+    private boolean isUpdateFeatureScope(String scope) {
+
+        return StringUtils.isNotBlank(scope) &&
+                scope.startsWith(APIResourceCollectionConfigBuilderConstants.CONSOLE_SCOPE_PREFIX) &&
+                scope.endsWith(APIResourceCollectionConfigBuilderConstants.UPDATE_FEATURE_SCOPE_SUFFIX);
+    }
+
+    private boolean isDeleteFeatureScope(String scope) {
+
+        return StringUtils.isNotBlank(scope) &&
+                scope.startsWith(APIResourceCollectionConfigBuilderConstants.CONSOLE_SCOPE_PREFIX) &&
+                scope.endsWith(APIResourceCollectionConfigBuilderConstants.DELETE_FEATURE_SCOPE_SUFFIX);
     }
 }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionMgtConfigBuilder.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionMgtConfigBuilder.java
@@ -36,6 +36,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -110,6 +111,8 @@ public class APIResourceCollectionMgtConfigBuilder {
 
     private void buildAPIResourceCollectionConfig() {
 
+        Map<String, Set<String>> holderResolutionMap = buildHolderResolutionMap();
+
         Iterator<OMElement> apiResourceCollections = this.documentElement.getChildrenWithName(
                 new QName(APIResourceCollectionConfigBuilderConstants.API_RESOURCE_COLLECTION_ELEMENT));
 
@@ -168,16 +171,42 @@ public class APIResourceCollectionMgtConfigBuilder {
                         } else {
                             // Process new scopes with feature scopes.
                             if (isReadAction) {
-                                readScopeSet.add(scopeName);
+                                if (isHolderScope(scopeName)) {
+                                    readScopeSet.addAll(holderResolutionMap.getOrDefault(
+                                            scopeName, Collections.emptySet()));
+                                } else {
+                                    readScopeSet.add(scopeName);
+                                }
                             } else if (isCreateAction) {
-                                createScopeSet.add(scopeName);
-                                writeScopeSet.add(scopeName);
+                                if (isHolderScope(scopeName)) {
+                                    Set<String> resolved = holderResolutionMap.getOrDefault(
+                                            scopeName, Collections.emptySet());
+                                    createScopeSet.addAll(resolved);
+                                    writeScopeSet.addAll(resolved);
+                                } else {
+                                    createScopeSet.add(scopeName);
+                                    writeScopeSet.add(scopeName);
+                                }
                             } else if (isUpdateAction) {
-                                updateScopeSet.add(scopeName);
-                                writeScopeSet.add(scopeName);
+                                if (isHolderScope(scopeName)) {
+                                    Set<String> resolved = holderResolutionMap.getOrDefault(
+                                            scopeName, Collections.emptySet());
+                                    updateScopeSet.addAll(resolved);
+                                    writeScopeSet.addAll(resolved);
+                                } else {
+                                    updateScopeSet.add(scopeName);
+                                    writeScopeSet.add(scopeName);
+                                }
                             } else if (isDeleteAction) {
-                                deleteScopeSet.add(scopeName);
-                                writeScopeSet.add(scopeName);
+                                if (isHolderScope(scopeName)) {
+                                    Set<String> resolved = holderResolutionMap.getOrDefault(
+                                            scopeName, Collections.emptySet());
+                                    deleteScopeSet.addAll(resolved);
+                                    writeScopeSet.addAll(resolved);
+                                } else {
+                                    deleteScopeSet.add(scopeName);
+                                    writeScopeSet.add(scopeName);
+                                }
                             } else if (isFeatureAction) {
                                 if (isViewFeatureScope(scopeName)) {
                                     apiResourceCollectionObj.setViewFeatureScope(scopeName);
@@ -286,5 +315,128 @@ public class APIResourceCollectionMgtConfigBuilder {
         return StringUtils.isNotBlank(scope) &&
                 scope.startsWith(APIResourceCollectionConfigBuilderConstants.CONSOLE_SCOPE_PREFIX) &&
                 scope.endsWith(APIResourceCollectionConfigBuilderConstants.DELETE_FEATURE_SCOPE_SUFFIX);
+    }
+
+    private boolean isHolderScope(String scope) {
+
+        return isViewFeatureScope(scope) || isEditFeatureScope(scope) || isCreateFeatureScope(scope)
+                || isUpdateFeatureScope(scope) || isDeleteFeatureScope(scope);
+    }
+
+    /**
+     * Build a map of holder scopes to their raw leaf scopes. Any nested holders are left unresolved.
+     * Cycles are short-circuited to an empty branch.
+     */
+    private Map<String, Set<String>> buildHolderResolutionMap() {
+
+        Map<String, Set<String>> rawMap = new HashMap<>();
+        Iterator<OMElement> collections = this.documentElement.getChildrenWithName(
+                new QName(APIResourceCollectionConfigBuilderConstants.API_RESOURCE_COLLECTION_ELEMENT));
+        while (collections.hasNext()) {
+            OMElement collection = collections.next();
+            String version = collection.getAttributeValue(
+                    new QName(APIResourceCollectionConfigBuilderConstants.VERSION));
+            if (APIResourceCollectionConfigBuilderConstants.COLLECTION_VERSION_V0.equals(version)) {
+                continue;
+            }
+            OMElement scopesElement = collection.getFirstChildWithName(
+                    new QName(APIResourceCollectionConfigBuilderConstants.SCOPES_ELEMENT));
+            if (scopesElement == null) {
+                continue;
+            }
+            Map<String, Set<String>> scopesByBlock = collectScopesByBlock(scopesElement);
+            Set<String> featureScopes = scopesByBlock.getOrDefault(
+                    APIResourceCollectionConfigBuilderConstants.FEATURE, Collections.emptySet());
+            for (String featureScope : featureScopes) {
+                Set<String> raw = resolveOwnerActionScopes(featureScope, scopesByBlock);
+                if (raw != null) {
+                    rawMap.put(featureScope, raw);
+                }
+            }
+        }
+
+        Map<String, Set<String>> resolvedMap = new HashMap<>();
+        for (String holder : rawMap.keySet()) {
+            resolveLeaves(holder, rawMap, resolvedMap, new HashSet<>());
+        }
+        return resolvedMap;
+    }
+
+    /**
+     * Recursively flatten a holder's raw scope set into its leaf scopes. Any nested holder is replaced by
+     * its own resolved leaves; cycles short-circuit to an empty branch. Memoized in {@code memo}.
+     */
+    private Set<String> resolveLeaves(String holder, Map<String, Set<String>> rawMap,
+                                      Map<String, Set<String>> memo, Set<String> visiting) {
+
+        if (memo.containsKey(holder)) {
+            return memo.get(holder);
+        }
+        if (!visiting.add(holder)) {
+            return Collections.emptySet();
+        }
+        Set<String> leaves = new HashSet<>();
+        for (String scope : rawMap.getOrDefault(holder, Collections.emptySet())) {
+            if (isHolderScope(scope)) {
+                leaves.addAll(resolveLeaves(scope, rawMap, memo, visiting));
+            } else {
+                leaves.add(scope);
+            }
+        }
+        visiting.remove(holder);
+        memo.put(holder, leaves);
+        return leaves;
+    }
+
+    private Map<String, Set<String>> collectScopesByBlock(OMElement scopesElement) {
+
+        Map<String, Set<String>> scopesByBlock = new HashMap<>();
+        Iterator<?> actionElements = scopesElement.getChildElements();
+        while (actionElements.hasNext()) {
+            OMElement actionElement = (OMElement) actionElements.next();
+            if (actionElement == null) {
+                continue;
+            }
+            String blockName = actionElement.getLocalName();
+            Set<String> blockScopes = scopesByBlock.computeIfAbsent(blockName, k -> new HashSet<>());
+            Iterator<OMElement> scopes = actionElement.getChildrenWithName(
+                    new QName(APIResourceCollectionConfigBuilderConstants.SCOPE_ELEMENT));
+            while (scopes.hasNext()) {
+                String name = scopes.next().getAttributeValue(
+                        new QName(APIResourceCollectionConfigBuilderConstants.NAME));
+                if (StringUtils.isNotBlank(name)) {
+                    blockScopes.add(name);
+                }
+            }
+        }
+        return scopesByBlock;
+    }
+
+    private Set<String> resolveOwnerActionScopes(String featureScope, Map<String, Set<String>> scopesByBlock) {
+
+        if (isViewFeatureScope(featureScope)) {
+            return new HashSet<>(scopesByBlock.getOrDefault(
+                    APIResourceCollectionConfigBuilderConstants.READ, Collections.emptySet()));
+        } else if (isCreateFeatureScope(featureScope)) {
+            return new HashSet<>(scopesByBlock.getOrDefault(
+                    APIResourceCollectionConfigBuilderConstants.CREATE, Collections.emptySet()));
+        } else if (isUpdateFeatureScope(featureScope)) {
+            return new HashSet<>(scopesByBlock.getOrDefault(
+                    APIResourceCollectionConfigBuilderConstants.UPDATE, Collections.emptySet()));
+        } else if (isDeleteFeatureScope(featureScope)) {
+            return new HashSet<>(scopesByBlock.getOrDefault(
+                    APIResourceCollectionConfigBuilderConstants.DELETE, Collections.emptySet()));
+        } else if (isEditFeatureScope(featureScope)) {
+            // Legacy coarse write — union of Create + Update + Delete leaf scopes.
+            Set<String> union = new HashSet<>();
+            union.addAll(scopesByBlock.getOrDefault(
+                    APIResourceCollectionConfigBuilderConstants.CREATE, Collections.emptySet()));
+            union.addAll(scopesByBlock.getOrDefault(
+                    APIResourceCollectionConfigBuilderConstants.UPDATE, Collections.emptySet()));
+            union.addAll(scopesByBlock.getOrDefault(
+                    APIResourceCollectionConfigBuilderConstants.DELETE, Collections.emptySet()));
+            return union;
+        }
+        return null;
     }
 }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionMgtConfigBuilder.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/main/java/org/wso2/carbon/identity/api/resource/collection/mgt/util/APIResourceCollectionMgtConfigBuilder.java
@@ -171,14 +171,14 @@ public class APIResourceCollectionMgtConfigBuilder {
                         } else {
                             // Process new scopes with feature scopes.
                             if (isReadAction) {
-                                if (isHolderScope(scopeName)) {
+                                if (isFeatureScope(scopeName)) {
                                     readScopeSet.addAll(holderResolutionMap.getOrDefault(
                                             scopeName, Collections.emptySet()));
                                 } else {
                                     readScopeSet.add(scopeName);
                                 }
                             } else if (isCreateAction) {
-                                if (isHolderScope(scopeName)) {
+                                if (isFeatureScope(scopeName)) {
                                     Set<String> resolved = holderResolutionMap.getOrDefault(
                                             scopeName, Collections.emptySet());
                                     createScopeSet.addAll(resolved);
@@ -188,7 +188,7 @@ public class APIResourceCollectionMgtConfigBuilder {
                                     writeScopeSet.add(scopeName);
                                 }
                             } else if (isUpdateAction) {
-                                if (isHolderScope(scopeName)) {
+                                if (isFeatureScope(scopeName)) {
                                     Set<String> resolved = holderResolutionMap.getOrDefault(
                                             scopeName, Collections.emptySet());
                                     updateScopeSet.addAll(resolved);
@@ -198,7 +198,7 @@ public class APIResourceCollectionMgtConfigBuilder {
                                     writeScopeSet.add(scopeName);
                                 }
                             } else if (isDeleteAction) {
-                                if (isHolderScope(scopeName)) {
+                                if (isFeatureScope(scopeName)) {
                                     Set<String> resolved = holderResolutionMap.getOrDefault(
                                             scopeName, Collections.emptySet());
                                     deleteScopeSet.addAll(resolved);
@@ -317,7 +317,7 @@ public class APIResourceCollectionMgtConfigBuilder {
                 scope.endsWith(APIResourceCollectionConfigBuilderConstants.DELETE_FEATURE_SCOPE_SUFFIX);
     }
 
-    private boolean isHolderScope(String scope) {
+    private boolean isFeatureScope(String scope) {
 
         return isViewFeatureScope(scope) || isEditFeatureScope(scope) || isCreateFeatureScope(scope)
                 || isUpdateFeatureScope(scope) || isDeleteFeatureScope(scope);
@@ -377,7 +377,7 @@ public class APIResourceCollectionMgtConfigBuilder {
         }
         Set<String> leaves = new HashSet<>();
         for (String scope : rawMap.getOrDefault(holder, Collections.emptySet())) {
-            if (isHolderScope(scope)) {
+            if (isFeatureScope(scope)) {
                 leaves.addAll(resolveLeaves(scope, rawMap, memo, visiting));
             } else {
                 leaves.add(scope);

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionManagementUtilTest.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionManagementUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionManagementUtilTest.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionManagementUtilTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.resource.collection.mgt;
+
+import org.mockito.MockedStatic;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.api.resource.collection.mgt.constant.APIResourceCollectionManagementConstants;
+import org.wso2.carbon.identity.api.resource.collection.mgt.util.APIResourceCollectionManagementUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Unit tests for {@link APIResourceCollectionManagementUtil}.
+ */
+public class APIResourceCollectionManagementUtilTest {
+
+    @DataProvider(name = "granularConsolePermissionsConfigProvider")
+    public Object[][] granularConsolePermissionsConfigProvider() {
+
+        // {configured value of ConsoleSettings.UseGranularConsolePermissions, expected boolean}
+        return new Object[][]{
+                {"true", true},
+                {"TRUE", true},
+                {"false", false},
+                {"", false},
+                {null, false},
+                {"not-a-boolean", false},
+        };
+    }
+
+    @Test(dataProvider = "granularConsolePermissionsConfigProvider")
+    public void testIsGranularConsolePermissionsEnabled(String configuredValue, boolean expected) {
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(
+                            APIResourceCollectionManagementConstants.USE_GRANULAR_CONSOLE_PERMISSIONS_CONFIG))
+                    .thenReturn(configuredValue);
+
+            Assert.assertEquals(
+                    APIResourceCollectionManagementUtil.isGranularConsolePermissionsEnabled(), expected,
+                    "Unexpected granular console permission resolution for configured value: " + configuredValue);
+        }
+    }
+}

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionManagerTest.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionManagerTest.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.api.resource.collection.mgt.constant.APIResource
 import org.wso2.carbon.identity.api.resource.collection.mgt.internal.APIResourceCollectionMgtServiceDataHolder;
 import org.wso2.carbon.identity.api.resource.collection.mgt.model.APIResourceCollection;
 import org.wso2.carbon.identity.api.resource.collection.mgt.model.APIResourceCollectionSearchResult;
+import org.wso2.carbon.identity.api.resource.collection.mgt.util.APIResourceCollectionManagementUtil;
 import org.wso2.carbon.identity.api.resource.mgt.APIResourceManager;
 import org.wso2.carbon.identity.application.common.model.APIResource;
 import org.wso2.carbon.identity.application.common.model.Scope;
@@ -38,13 +39,17 @@ import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -56,9 +61,16 @@ public class APIResourceCollectionManagerTest {
     private APIResourceCollectionManager apiResourceCollectionManager;
     private Map<String, APIResourceCollection> apiResourceCollectionMapMock;
     private MockedStatic<APIResourceCollectionMgtServiceDataHolder> apiResourceCollectionMgtServiceData;
+    private MockedStatic<APIResourceCollectionManagementUtil> apiResourceCollectionMgtUtil;
+    private APIResourceManager apiResourceManagerMock;
 
     @BeforeMethod
     public void setUp() throws Exception {
+
+        // Exercise the granular console permission path by default; the granular-disabled case re-stubs this to false.
+        apiResourceCollectionMgtUtil = mockStatic(APIResourceCollectionManagementUtil.class, CALLS_REAL_METHODS);
+        apiResourceCollectionMgtUtil.when(
+                APIResourceCollectionManagementUtil::isGranularConsolePermissionsEnabled).thenReturn(true);
 
         apiResourceCollectionMgtServiceData = mockStatic(APIResourceCollectionMgtServiceDataHolder.class);
         APIResourceCollectionMgtServiceDataHolder serviceDataHolderMock =
@@ -66,7 +78,7 @@ public class APIResourceCollectionManagerTest {
         apiResourceCollectionMgtServiceData.when(
                 APIResourceCollectionMgtServiceDataHolder::getInstance).thenReturn(serviceDataHolderMock);
 
-        APIResourceManager apiResourceManagerMock = mock(APIResourceManager.class);
+        apiResourceManagerMock = mock(APIResourceManager.class);
         when(serviceDataHolderMock.getAPIResourceManagementService()).thenReturn(apiResourceManagerMock);
         when(apiResourceManagerMock.getScopeMetadata(anyList(), anyString())).thenReturn(
                 getListOfAPIResources());
@@ -82,6 +94,7 @@ public class APIResourceCollectionManagerTest {
     public void tearDown() {
 
         apiResourceCollectionMgtServiceData.close();
+        apiResourceCollectionMgtUtil.close();
     }
 
     @DataProvider(name = "getAPIResourceCollectionsDataProvider")
@@ -112,6 +125,223 @@ public class APIResourceCollectionManagerTest {
         APIResourceCollection apiResourceCollection =
                 apiResourceCollectionManager.getAPIResourceCollectionById(encodedName1, "test");
         Assert.assertNotNull(apiResourceCollection);
+    }
+
+    @Test
+    public void testGetAPIResourceCollectionByIdPopulatesGranularApiResources() throws Exception {
+
+        // Build a collection whose create/update/delete scopes line up with distinct mocked API resources.
+        String name = "granular";
+        APIResourceCollection granularCollection = new APIResourceCollection.APIResourceCollectionBuilder()
+                .id(getEncodedName(name))
+                .name(name)
+                .displayName("Display Name granular")
+                .type("BUSINESS")
+                .readScopes(new ArrayList<>())
+                .writeScopes(new ArrayList<>())
+                .createScopes(singletonScopeList("testScopeOne test1"))
+                .updateScopes(singletonScopeList("testScopeTwo test2"))
+                .deleteScopes(singletonScopeList("testScopeOne test3"))
+                .build();
+        apiResourceCollectionMapMock.put(granularCollection.getId(), granularCollection);
+
+        APIResourceCollection result =
+                apiResourceCollectionManager.getAPIResourceCollectionById(getEncodedName(name), "test");
+
+        Assert.assertNotNull(result);
+        Map<String, List<APIResource>> apiResources = result.getApiResources();
+        Assert.assertNotNull(apiResources);
+        Assert.assertTrue(apiResources.containsKey(APIResourceCollectionManagementConstants.CREATE));
+        Assert.assertTrue(apiResources.containsKey(APIResourceCollectionManagementConstants.UPDATE));
+        Assert.assertTrue(apiResources.containsKey(APIResourceCollectionManagementConstants.DELETE));
+
+        assertSingleResourceWithScope(apiResources.get(APIResourceCollectionManagementConstants.CREATE),
+                "testScopeOne test1");
+        assertSingleResourceWithScope(apiResources.get(APIResourceCollectionManagementConstants.UPDATE),
+                "testScopeTwo test2");
+        assertSingleResourceWithScope(apiResources.get(APIResourceCollectionManagementConstants.DELETE),
+                "testScopeOne test3");
+    }
+
+    @Test
+    public void testGranularEnabledWithNoActionScopesYieldsEmptyBuckets() throws Exception {
+
+        // Granular enabled, but the collection declares no create/update/delete scopes: the action buckets are
+        // emitted as present-but-empty lists (never null).
+        addTestAPIResourceCollections();
+        String encodedName1 = getEncodedName("nametest1");
+        APIResourceCollection result =
+                apiResourceCollectionManager.getAPIResourceCollectionById(encodedName1, "test");
+
+        Assert.assertNotNull(result);
+        Map<String, List<APIResource>> apiResources = result.getApiResources();
+        Assert.assertNotNull(apiResources.get(APIResourceCollectionManagementConstants.CREATE));
+        Assert.assertTrue(apiResources.get(APIResourceCollectionManagementConstants.CREATE).isEmpty());
+        Assert.assertNotNull(apiResources.get(APIResourceCollectionManagementConstants.UPDATE));
+        Assert.assertTrue(apiResources.get(APIResourceCollectionManagementConstants.UPDATE).isEmpty());
+        Assert.assertNotNull(apiResources.get(APIResourceCollectionManagementConstants.DELETE));
+        Assert.assertTrue(apiResources.get(APIResourceCollectionManagementConstants.DELETE).isEmpty());
+    }
+
+    @Test
+    public void testGranularDisabledYieldsOnlyReadWriteBuckets() throws Exception {
+
+        // With granular console permissions disabled, only the legacy read/write buckets are emitted; the
+        // create/update/delete keys are absent altogether.
+        apiResourceCollectionMgtUtil.when(
+                APIResourceCollectionManagementUtil::isGranularConsolePermissionsEnabled).thenReturn(false);
+
+        addTestAPIResourceCollections();
+        String encodedName1 = getEncodedName("nametest1");
+        APIResourceCollection result =
+                apiResourceCollectionManager.getAPIResourceCollectionById(encodedName1, "test");
+
+        Assert.assertNotNull(result);
+        Map<String, List<APIResource>> apiResources = result.getApiResources();
+        Assert.assertTrue(apiResources.containsKey(APIResourceCollectionManagementConstants.READ));
+        Assert.assertTrue(apiResources.containsKey(APIResourceCollectionManagementConstants.WRITE));
+        Assert.assertFalse(apiResources.containsKey(APIResourceCollectionManagementConstants.CREATE));
+        Assert.assertFalse(apiResources.containsKey(APIResourceCollectionManagementConstants.UPDATE));
+        Assert.assertFalse(apiResources.containsKey(APIResourceCollectionManagementConstants.DELETE));
+    }
+
+    // Plain feature scope shared across every action bucket.
+    private static final String FEATURE_SCOPE = "console:apiResources";
+    // Per-action feature scopes (console:*).
+    private static final String VIEW_FEATURE_SCOPE = "console:apiResources_view";
+    private static final String EDIT_FEATURE_SCOPE = "console:apiResources_edit";
+    private static final String CREATE_FEATURE_SCOPE = "console:apiResources_create";
+    private static final String UPDATE_FEATURE_SCOPE = "console:apiResources_update";
+    private static final String DELETE_FEATURE_SCOPE = "console:apiResources_delete";
+    // Per-action normal (internal_*) scopes.
+    private static final String READ_NORMAL_SCOPE = "internal_api_resource_view";
+    private static final String CREATE_NORMAL_SCOPE = "internal_api_resource_create";
+    private static final String UPDATE_NORMAL_SCOPE = "internal_api_resource_update";
+    private static final String DELETE_NORMAL_SCOPE = "internal_api_resource_delete";
+
+    /**
+     * Verifies the bucket contract enforced by {@code populateAPIResourcesForCollection}. The read scopes are merged
+     * into every other bucket, so each action bucket carries the read-side scopes (plain feature + view feature +
+     * read normal) on top of its own action and feature scopes. Granular actions do not bleed into one another.
+     * <ul>
+     *   <li>view    = plain feature + view feature + read normal</li>
+     *   <li>write   = read scopes + edit feature + write normal (create/update/delete normal)</li>
+     *   <li>create  = read scopes + create feature + create normal</li>
+     *   <li>update  = read scopes + update feature + update normal</li>
+     *   <li>delete  = read scopes + delete feature + delete normal</li>
+     * </ul>
+     */
+    @Test
+    public void testPopulatedBucketsCarryFeatureAndActionScopes() throws Exception {
+
+        // A single API resource that owns every scope; the manager trims it down per bucket.
+        APIResource allScopesResource = apiResourceWithScopes("collectionResource",
+                FEATURE_SCOPE, VIEW_FEATURE_SCOPE, EDIT_FEATURE_SCOPE, CREATE_FEATURE_SCOPE, UPDATE_FEATURE_SCOPE,
+                DELETE_FEATURE_SCOPE, READ_NORMAL_SCOPE, CREATE_NORMAL_SCOPE, UPDATE_NORMAL_SCOPE, DELETE_NORMAL_SCOPE);
+        List<APIResource> metadata = new ArrayList<>();
+        metadata.add(allScopesResource);
+        when(apiResourceManagerMock.getScopeMetadata(anyList(), anyString())).thenReturn(metadata);
+
+        // Buckets composed as the config builder emits them: the plain feature scope is read-side only and the
+        // manager merges the read scopes into every other bucket.
+        String name = "featureCollection";
+        APIResourceCollection collection = new APIResourceCollection.APIResourceCollectionBuilder()
+                .id(getEncodedName(name))
+                .name(name)
+                .displayName("Display Name " + name)
+                .type("tenant")
+                .readScopes(Arrays.asList(READ_NORMAL_SCOPE, VIEW_FEATURE_SCOPE, FEATURE_SCOPE))
+                .writeScopes(Arrays.asList(CREATE_NORMAL_SCOPE, UPDATE_NORMAL_SCOPE, DELETE_NORMAL_SCOPE,
+                        EDIT_FEATURE_SCOPE, VIEW_FEATURE_SCOPE, FEATURE_SCOPE))
+                .createScopes(Arrays.asList(CREATE_NORMAL_SCOPE, CREATE_FEATURE_SCOPE,
+                        READ_NORMAL_SCOPE, VIEW_FEATURE_SCOPE, FEATURE_SCOPE))
+                .updateScopes(Arrays.asList(UPDATE_NORMAL_SCOPE, UPDATE_FEATURE_SCOPE,
+                        READ_NORMAL_SCOPE, VIEW_FEATURE_SCOPE, FEATURE_SCOPE))
+                .deleteScopes(Arrays.asList(DELETE_NORMAL_SCOPE, DELETE_FEATURE_SCOPE,
+                        READ_NORMAL_SCOPE, VIEW_FEATURE_SCOPE, FEATURE_SCOPE))
+                .build();
+        apiResourceCollectionMapMock.put(collection.getId(), collection);
+
+        APIResourceCollection result =
+                apiResourceCollectionManager.getAPIResourceCollectionById(getEncodedName(name), "test");
+
+        Assert.assertNotNull(result);
+        Map<String, List<APIResource>> apiResources = result.getApiResources();
+
+        // view (read) = plain feature + view feature + read normal.
+        assertBucketScopes(apiResources, APIResourceCollectionManagementConstants.READ,
+                FEATURE_SCOPE, VIEW_FEATURE_SCOPE, READ_NORMAL_SCOPE);
+        // create = read scopes (plain feature) + create feature + create normal; no other action scopes bleed in.
+        assertBucketScopes(apiResources, APIResourceCollectionManagementConstants.CREATE,
+                CREATE_FEATURE_SCOPE, CREATE_NORMAL_SCOPE,
+                VIEW_FEATURE_SCOPE, READ_NORMAL_SCOPE, FEATURE_SCOPE);
+        // update = read scopes (plain feature) + update feature + update normal; no other action scopes bleed in.
+        assertBucketScopes(apiResources, APIResourceCollectionManagementConstants.UPDATE,
+                FEATURE_SCOPE, UPDATE_FEATURE_SCOPE, UPDATE_NORMAL_SCOPE,
+                VIEW_FEATURE_SCOPE, READ_NORMAL_SCOPE, FEATURE_SCOPE);
+        // delete = read scopes (plain feature) + delete feature + delete normal; no other action scopes bleed in.
+        assertBucketScopes(apiResources, APIResourceCollectionManagementConstants.DELETE,
+                FEATURE_SCOPE, DELETE_FEATURE_SCOPE, DELETE_NORMAL_SCOPE,
+                VIEW_FEATURE_SCOPE, READ_NORMAL_SCOPE, FEATURE_SCOPE);
+        // write = read scopes (plain feature) + edit feature + write normal (create/update/delete normal).
+        assertBucketScopes(apiResources, APIResourceCollectionManagementConstants.WRITE,
+                CREATE_NORMAL_SCOPE, UPDATE_NORMAL_SCOPE, DELETE_NORMAL_SCOPE, READ_NORMAL_SCOPE,
+                VIEW_FEATURE_SCOPE, EDIT_FEATURE_SCOPE,  FEATURE_SCOPE);
+    }
+
+    /**
+     * Asserts that the given bucket exists and the union of scopes across its API resources contains every expected
+     * scope. The bucket may legitimately hold more (e.g. the write bucket also inherits read scopes), so this checks
+     * containment rather than equality.
+     */
+    private static void assertBucketScopes(Map<String, List<APIResource>> apiResources, String bucketKey,
+                                           String... expectedScopes) {
+
+        List<APIResource> bucket = apiResources.get(bucketKey);
+        Assert.assertNotNull(bucket, "Bucket should be present: " + bucketKey);
+        Set<String> scopeNames = new HashSet<>();
+        for (APIResource apiResource : bucket) {
+            for (Scope scope : apiResource.getScopes()) {
+                scopeNames.add(scope.getName());
+            }
+        }
+        for (String expectedScope : expectedScopes) {
+            Assert.assertTrue(scopeNames.contains(expectedScope),
+                    "Bucket '" + bucketKey + "' should expose scope '" + expectedScope + "' but had " + scopeNames);
+        }
+    }
+
+    private static APIResource apiResourceWithScopes(String name, String... scopeNames) {
+
+        List<Scope> scopes = new ArrayList<>();
+        for (String scopeName : scopeNames) {
+            scopes.add(createScope(scopeName));
+        }
+        return new APIResource.APIResourceBuilder()
+                .name("testAPIResource name " + name)
+                .identifier("testAPIResource identifier " + name)
+                .description("testAPIResource description " + name)
+                .type("BUSINESS")
+                .requiresAuthorization(true)
+                .scopes(scopes)
+                .build();
+    }
+
+    private static List<String> singletonScopeList(String scope) {
+
+        List<String> scopes = new ArrayList<>();
+        scopes.add(scope);
+        return scopes;
+    }
+
+    private static void assertSingleResourceWithScope(List<APIResource> apiResources, String expectedScope) {
+
+        Assert.assertNotNull(apiResources);
+        Assert.assertEquals(apiResources.size(), 1,
+                "Exactly one API resource should match the granular scope: " + expectedScope);
+        List<Scope> scopes = apiResources.get(0).getScopes();
+        Assert.assertEquals(scopes.size(), 1, "Only the matching scope should be retained on the resource.");
+        Assert.assertEquals(scopes.get(0).getName(), expectedScope);
     }
 
     private void addTestAPIResourceCollections() {

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionManagerTest.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionManagerTest.java
@@ -290,25 +290,25 @@ public class APIResourceCollectionManagerTest {
     }
 
     /**
-     * Asserts that the given bucket exists and the union of scopes across its API resources contains every expected
-     * scope. The bucket may legitimately hold more (e.g. the write bucket also inherits read scopes), so this checks
-     * containment rather than equality.
+     * Asserts that the given bucket exists and the union of scopes across its API resources matches exactly the
+     * expected set. Exact equality is required so that scopes from one granular bucket (create/update/delete)
+     * cannot silently leak into another.
      */
     private static void assertBucketScopes(Map<String, List<APIResource>> apiResources, String bucketKey,
                                            String... expectedScopes) {
 
         List<APIResource> bucket = apiResources.get(bucketKey);
         Assert.assertNotNull(bucket, "Bucket should be present: " + bucketKey);
-        Set<String> scopeNames = new HashSet<>();
+        Set<String> actual = new HashSet<>();
         for (APIResource apiResource : bucket) {
             for (Scope scope : apiResource.getScopes()) {
-                scopeNames.add(scope.getName());
+                actual.add(scope.getName());
             }
         }
-        for (String expectedScope : expectedScopes) {
-            Assert.assertTrue(scopeNames.contains(expectedScope),
-                    "Bucket '" + bucketKey + "' should expose scope '" + expectedScope + "' but had " + scopeNames);
-        }
+        Set<String> expected = new HashSet<>(Arrays.asList(expectedScopes));
+        Assert.assertEquals(actual, expected,
+                "Bucket '" + bucketKey + "' scope set must match exactly. Expected " + expected
+                        + " but had " + actual);
     }
 
     private static APIResource apiResourceWithScopes(String name, String... scopeNames) {

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionMgtConfigBuilderTest.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionMgtConfigBuilderTest.java
@@ -1,34 +1,244 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.api.resource.collection.mgt;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.api.resource.collection.mgt.constant.APIResourceCollectionManagementConstants;
 import org.wso2.carbon.identity.api.resource.collection.mgt.model.APIResourceCollection;
 import org.wso2.carbon.identity.api.resource.collection.mgt.util.APIResourceCollectionMgtConfigBuilder;
 import org.wso2.carbon.identity.common.testng.WithAxisConfiguration;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
-import org.wso2.carbon.identity.event.IdentityEventException;
 
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Map;
 
+/**
+ * Unit tests for {@link APIResourceCollectionMgtConfigBuilder}.
+ * <p>
+ * The builder parses {@code api-resource-collection.xml} from the test resources. That config declares two
+ * {@code apiResources} collections that share the same name (a {@code version="v0"} collection and a new one);
+ * because the name is base64-encoded into the id, both merge into a single parsed {@link APIResourceCollection}.
+ * The tests below pin the scope buckets produced for that merged collection, grouped by the concern they cover.
+ */
 @WithCarbonHome
 @WithAxisConfiguration
 public class APIResourceCollectionMgtConfigBuilderTest {
 
-    APIResourceCollectionMgtConfigBuilder configBuilder;
+    private static final String COLLECTION_NAME = "apiResources";
+    private static final String COLLECTION_DISPLAY_NAME = "API Resources";
+    private static final String COLLECTION_TYPE = "tenant";
+
+    // Action scopes (internal_*) declared under <Read>/<Create>/<Update>/<Delete>.
+    private static final String READ_SCOPE = "internal_api_resource_view";
+    private static final String CREATE_SCOPE = "internal_api_resource_create";
+    private static final String UPDATE_SCOPE = "internal_api_resource_update";
+    private static final String DELETE_SCOPE = "internal_api_resource_delete";
+
+    // Feature scopes (console:*) declared under <Feature>.
+    private static final String FEATURE_SCOPE = "console:apiResources";
+    private static final String VIEW_FEATURE_SCOPE = "console:apiResources_view";
+    private static final String EDIT_FEATURE_SCOPE = "console:apiResources_edit";
+    private static final String CREATE_FEATURE_SCOPE = "console:apiResources_create";
+    private static final String UPDATE_FEATURE_SCOPE = "console:apiResources_update";
+    private static final String DELETE_FEATURE_SCOPE = "console:apiResources_delete";
+
+    private APIResourceCollectionMgtConfigBuilder configBuilder;
 
     @BeforeMethod
-    public void setUp() throws IdentityEventException {
+    public void setUp() throws URISyntaxException {
+
+        URL confResource = getClass().getResource(
+                "/repository/conf/" + APIResourceCollectionManagementConstants.API_RESOURCE_COLLECTION_FILE_NAME);
+        Assert.assertNotNull(confResource, "Test api-resource-collection.xml must be on the classpath.");
+        String confDir = new File(confResource.toURI()).getParent();
+        System.setProperty("carbon.config.dir.path", confDir);
+
         configBuilder = APIResourceCollectionMgtConfigBuilder.getInstance();
     }
 
-    @Test
-    public void testGetApIResourceCollections() {
+    @Test(groups = "configLoading", description = "The config file is parsed into a non-empty collection map.")
+    public void testConfigurationsAreLoaded() {
 
-        APIResourceCollectionMgtConfigBuilder instance = APIResourceCollectionMgtConfigBuilder.getInstance();
-        Map<String, APIResourceCollection> apiResourceCollectionMap = instance
-                .getApiResourceCollectionMgtConfigurations();
-        Assert.assertNotNull(apiResourceCollectionMap);
-        Assert.assertFalse(apiResourceCollectionMap.isEmpty());
+        Map<String, APIResourceCollection> configurations = configBuilder.getApiResourceCollectionMgtConfigurations();
+        Assert.assertNotNull(configurations);
+        Assert.assertFalse(configurations.isEmpty());
+    }
+
+    @Test(groups = "configLoading",
+            description = "Basic info (id, name, display name, type) is parsed for the merged collection.")
+    public void testApiResourcesCollectionBasicInfo() {
+
+        APIResourceCollection collection = getApiResourcesCollection();
+
+        Assert.assertNotNull(collection.getId(), "Collection id should be set.");
+        Assert.assertEquals(collection.getName(), COLLECTION_NAME);
+        Assert.assertEquals(collection.getDisplayName(), COLLECTION_DISPLAY_NAME);
+        Assert.assertEquals(collection.getType(), COLLECTION_TYPE);
+    }
+
+    @Test(groups = "readScopes",
+            description = "Read scopes contain the read action scope and the view feature scopes, "
+                    + "without write-side scopes leaking in.")
+    public void testReadScopesContainReadAndPlainFeatureScopes() {
+
+        APIResourceCollection collection = getApiResourcesCollection();
+
+        Assert.assertTrue(collection.getReadScopes().contains(READ_SCOPE));
+        Assert.assertTrue(collection.getReadScopes().contains(FEATURE_SCOPE));
+        Assert.assertTrue(collection.getReadScopes().contains(VIEW_FEATURE_SCOPE));
+
+        // Write-side scopes should not leak into the read bucket.
+        Assert.assertFalse(collection.getReadScopes().contains(CREATE_SCOPE));
+        Assert.assertFalse(collection.getReadScopes().contains(EDIT_FEATURE_SCOPE));
+    }
+
+    @Test(groups = "writeScopes",
+            description = "Create/update/delete action scopes are aggregated into the combined write bucket.")
+    public void testWriteScopesAggregateCreateUpdateDelete() {
+
+        APIResourceCollection collection = getApiResourcesCollection();
+
+        Assert.assertTrue(collection.getWriteScopes().contains(CREATE_SCOPE));
+        Assert.assertTrue(collection.getWriteScopes().contains(UPDATE_SCOPE));
+        Assert.assertTrue(collection.getWriteScopes().contains(DELETE_SCOPE));
+    }
+
+    @Test(groups = "writeScopes",
+            description = "The edit feature scope is aggregated into the write bucket only (not a granular bucket).")
+    public void testEditFeatureScopeAggregatedIntoWriteScopes() {
+
+        APIResourceCollection collection = getApiResourcesCollection();
+
+        Assert.assertTrue(collection.getWriteScopes().contains(EDIT_FEATURE_SCOPE));
+        
+        Assert.assertFalse(collection.getCreateScopes().contains(EDIT_FEATURE_SCOPE));
+        Assert.assertFalse(collection.getUpdateScopes().contains(EDIT_FEATURE_SCOPE));
+        Assert.assertFalse(collection.getDeleteScopes().contains(EDIT_FEATURE_SCOPE));
+    }
+
+    @Test(groups = "writeScopes",
+            description = "Write bucket holds the edit feature scope and the write normal (create/update/delete "
+                    + "action) scopes.")
+    public void testWriteScopesContainEditFeatureScopes() {
+
+        APIResourceCollection collection = getApiResourcesCollection();
+
+        // write feature + write normal scopes.
+        Assert.assertTrue(collection.getWriteScopes().contains(EDIT_FEATURE_SCOPE));
+        Assert.assertTrue(collection.getWriteScopes().contains(CREATE_SCOPE));
+        Assert.assertTrue(collection.getWriteScopes().contains(UPDATE_SCOPE));
+        Assert.assertTrue(collection.getWriteScopes().contains(DELETE_SCOPE));
+
+        // The plain and view feature scopes are read-side; they are not stored in the write bucket itself.
+        Assert.assertFalse(collection.getWriteScopes().contains(FEATURE_SCOPE));
+        Assert.assertFalse(collection.getWriteScopes().contains(VIEW_FEATURE_SCOPE));
+    }
+
+    @Test(groups = "granularActionScopes",
+            description = "Create/update/delete action scopes land in their own bucket and do not bleed across.")
+    public void testGranularActionScopesAreBucketed() {
+
+        APIResourceCollection collection = getApiResourcesCollection();
+
+        Assert.assertNotNull(collection.getCreateScopes());
+        Assert.assertNotNull(collection.getUpdateScopes());
+        Assert.assertNotNull(collection.getDeleteScopes());
+        Assert.assertTrue(collection.getCreateScopes().contains(CREATE_SCOPE),
+                "Create action scope should be bucketed into createScopes.");
+        Assert.assertTrue(collection.getUpdateScopes().contains(UPDATE_SCOPE),
+                "Update action scope should be bucketed into updateScopes.");
+        Assert.assertTrue(collection.getDeleteScopes().contains(DELETE_SCOPE),
+                "Delete action scope should be bucketed into deleteScopes.");
+
+        // Granular buckets must not bleed into each other.
+        Assert.assertFalse(collection.getCreateScopes().contains(UPDATE_SCOPE));
+        Assert.assertFalse(collection.getCreateScopes().contains(DELETE_SCOPE));
+        Assert.assertFalse(collection.getUpdateScopes().contains(CREATE_SCOPE));
+        Assert.assertFalse(collection.getUpdateScopes().contains(DELETE_SCOPE));
+        Assert.assertFalse(collection.getDeleteScopes().contains(CREATE_SCOPE));
+        Assert.assertFalse(collection.getDeleteScopes().contains(UPDATE_SCOPE));
+    }
+
+    @Test(groups = "granularActionScopes",
+            description = "Create bucket holds the create action scope and the create feature scope, without the "
+                    + "plain feature scope (read-side) or the update/delete action scopes leaking in.")
+    public void testCreateScopesContainCreateActionAndFeatureScopes() {
+
+        APIResourceCollection collection = getApiResourcesCollection();
+
+        Assert.assertTrue(collection.getCreateScopes().contains(CREATE_SCOPE));
+        Assert.assertTrue(collection.getCreateScopes().contains(CREATE_FEATURE_SCOPE));
+
+        // Other write-side action scopes should not leak into the create bucket.
+        Assert.assertFalse(collection.getCreateScopes().contains(UPDATE_SCOPE));
+        Assert.assertFalse(collection.getCreateScopes().contains(DELETE_SCOPE));
+    }
+
+    @Test(groups = "granularFeatureScopes",
+            description = "Granular console feature scopes resolve to their dedicated fields and matching buckets.")
+    public void testGranularFeatureScopesAreResolved() {
+
+        APIResourceCollection collection = getApiResourcesCollection();
+
+        Assert.assertEquals(collection.getViewFeatureScope(), VIEW_FEATURE_SCOPE);
+        Assert.assertEquals(collection.getEditFeatureScope(), EDIT_FEATURE_SCOPE);
+        Assert.assertEquals(collection.getCreateFeatureScope(), CREATE_FEATURE_SCOPE);
+        Assert.assertEquals(collection.getUpdateFeatureScope(), UPDATE_FEATURE_SCOPE);
+        Assert.assertEquals(collection.getDeleteFeatureScope(), DELETE_FEATURE_SCOPE);
+
+        // Each granular feature scope is also added to its respective action bucket.
+        Assert.assertTrue(collection.getCreateScopes().contains(CREATE_FEATURE_SCOPE));
+        Assert.assertTrue(collection.getUpdateScopes().contains(UPDATE_FEATURE_SCOPE));
+        Assert.assertTrue(collection.getDeleteScopes().contains(DELETE_FEATURE_SCOPE));
+    }
+
+    @Test(groups = "legacyScopes",
+            description = "Legacy read/write scopes are populated from the v0 collection.")
+    public void testLegacyScopesPopulatedFromV0Collection() {
+
+        APIResourceCollection collection = getApiResourcesCollection();
+
+        Assert.assertNotNull(collection.getLegacyReadScopes());
+        Assert.assertTrue(collection.getLegacyReadScopes().contains(READ_SCOPE));
+        Assert.assertTrue(collection.getLegacyReadScopes().contains(FEATURE_SCOPE));
+
+        Assert.assertNotNull(collection.getLegacyWriteScopes());
+        Assert.assertTrue(collection.getLegacyWriteScopes().contains(CREATE_SCOPE));
+        Assert.assertTrue(collection.getLegacyWriteScopes().contains(UPDATE_SCOPE));
+        Assert.assertTrue(collection.getLegacyWriteScopes().contains(DELETE_SCOPE));
+    }
+
+    /**
+     * Resolves the single merged {@code apiResources} collection from the parsed config.
+     */
+    private APIResourceCollection getApiResourcesCollection() {
+
+        Map<String, APIResourceCollection> configurations = configBuilder.getApiResourceCollectionMgtConfigurations();
+        APIResourceCollection collection = configurations.values().stream()
+                .filter(c -> COLLECTION_NAME.equals(c.getName()))
+                .findFirst()
+                .orElse(null);
+        Assert.assertNotNull(collection, "apiResources collection should be present in the parsed config.");
+        return collection;
     }
 }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionMgtConfigBuilderTest.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionMgtConfigBuilderTest.java
@@ -228,17 +228,135 @@ public class APIResourceCollectionMgtConfigBuilderTest {
         Assert.assertTrue(collection.getLegacyWriteScopes().contains(DELETE_SCOPE));
     }
 
+    private static final String HOLDER_CONSUMER_NAME = "holderConsumer";
+
+    @Test(groups = "holderResolution",
+            description = "A holder scope (e.g. console:holderOwner_update) inside another collection's <Update> "
+                    + "block is replaced by the owner's Update-block leaf scopes; the holder name itself is dropped.")
+    public void testUpdateHolderResolvesToOwnerUpdateLeaves() {
+
+        APIResourceCollection collection = getCollectionByName(HOLDER_CONSUMER_NAME);
+
+        // holderConsumer's <Update> references console:holderTransitive_update, which (recursively) yields
+        // internal_holder_transitive_update + internal_holder_owner_update.
+        Assert.assertTrue(collection.getUpdateScopes().contains("internal_holder_transitive_update"));
+        Assert.assertTrue(collection.getUpdateScopes().contains("internal_holder_owner_update"));
+
+        // The holder name itself must not be in updateScopes.
+        Assert.assertFalse(collection.getUpdateScopes().contains("console:holderTransitive_update"),
+                "Holder scope name must be dropped after resolution.");
+    }
+
+    @Test(groups = "holderResolution",
+            description = "_edit holder resolves to the union of the owner's Create + Update + Delete leaves "
+                    + "(legacy coarse write semantic).")
+    public void testEditHolderResolvesToCreateUpdateDeleteUnion() {
+
+        APIResourceCollection collection = getCollectionByName(HOLDER_CONSUMER_NAME);
+
+        Assert.assertTrue(collection.getUpdateScopes().contains("internal_holder_owner_create"),
+                "_edit holder should pull in the owner's Create leaves.");
+        Assert.assertTrue(collection.getUpdateScopes().contains("internal_holder_owner_update"),
+                "_edit holder should pull in the owner's Update leaves.");
+        Assert.assertTrue(collection.getUpdateScopes().contains("internal_holder_owner_delete"),
+                "_edit holder should pull in the owner's Delete leaves.");
+
+        Assert.assertFalse(collection.getUpdateScopes().contains("console:holderOwner_edit"),
+                "The _edit holder name itself must not appear in updateScopes.");
+    }
+
+    @Test(groups = "holderResolution",
+            description = "_view holder inside a <Read> block resolves to the owner's Read-block leaves; the "
+                    + "holder name itself is dropped from readScopes.")
+    public void testViewHolderInReadBlockResolvesToOwnerReadLeaves() {
+
+        APIResourceCollection collection = getCollectionByName(HOLDER_CONSUMER_NAME);
+
+        Assert.assertTrue(collection.getReadScopes().contains("internal_holder_owner_view"),
+                "_view holder should resolve to the owner's Read leaves.");
+        Assert.assertFalse(collection.getReadScopes().contains("console:holderOwner_view"),
+                "The _view holder name itself must not appear in readScopes.");
+    }
+
+    @Test(groups = "holderResolution",
+            description = "writeScopes also receives the leaves resolved from any holder in <Create>/<Update>/"
+                    + "<Delete> blocks — and does not receive the holder name itself.")
+    public void testHolderResolutionPropagatesToWriteScopes() {
+
+        APIResourceCollection collection = getCollectionByName(HOLDER_CONSUMER_NAME);
+
+        Assert.assertTrue(collection.getWriteScopes().contains("internal_holder_owner_create"));
+        Assert.assertTrue(collection.getWriteScopes().contains("internal_holder_owner_update"));
+        Assert.assertTrue(collection.getWriteScopes().contains("internal_holder_owner_delete"));
+        Assert.assertTrue(collection.getWriteScopes().contains("internal_holder_transitive_update"));
+        Assert.assertTrue(collection.getWriteScopes().contains("internal_holder_consumer_update"));
+
+        Assert.assertFalse(collection.getWriteScopes().contains("console:holderOwner_edit"));
+        Assert.assertFalse(collection.getWriteScopes().contains("console:holderTransitive_update"));
+    }
+
+    @Test(groups = "holderResolution",
+            description = "Holder resolution recurses through nested holders: holderConsumer references "
+                    + "holderTransitive_update, whose own <Update> block contains the holder holderOwner_update; "
+                    + "the consumer's bucket must end up with the deepest leaf and contain no holder names.")
+    public void testHolderResolutionRecursesThroughNestedHolders() {
+
+        APIResourceCollection collection = getCollectionByName(HOLDER_CONSUMER_NAME);
+
+        // Deepest leaf from the holderOwner_update branch reached through holderTransitive_update.
+        Assert.assertTrue(collection.getUpdateScopes().contains("internal_holder_owner_update"),
+                "Nested holder must be transitively resolved to its leaf.");
+
+        // No intermediate holder names should remain.
+        Assert.assertFalse(collection.getUpdateScopes().contains("console:holderTransitive_update"));
+        Assert.assertFalse(collection.getUpdateScopes().contains("console:holderOwner_update"));
+    }
+
+    @Test(groups = "holderResolution",
+            description = "Literal (non-holder) scopes declared next to holders are preserved verbatim.")
+    public void testLiteralScopesAlongsideHoldersArePreserved() {
+
+        APIResourceCollection collection = getCollectionByName(HOLDER_CONSUMER_NAME);
+
+        Assert.assertTrue(collection.getUpdateScopes().contains("internal_holder_consumer_update"),
+                "Literal scope in <Update> alongside holders must be kept.");
+    }
+
+    @Test(groups = "holderResolution",
+            description = "The owner collection's own buckets are unaffected by holder resolution: its Feature-block "
+                    + "feature action scopes still land in their dedicated buckets and singleton fields.")
+    public void testOwnerCollectionUnaffectedByHolderResolution() {
+
+        APIResourceCollection owner = getCollectionByName("holderOwner");
+
+        Assert.assertEquals(owner.getCreateFeatureScope(), "console:holderOwner_create");
+        Assert.assertEquals(owner.getUpdateFeatureScope(), "console:holderOwner_update");
+        Assert.assertEquals(owner.getDeleteFeatureScope(), "console:holderOwner_delete");
+        Assert.assertEquals(owner.getViewFeatureScope(), "console:holderOwner_view");
+        Assert.assertEquals(owner.getEditFeatureScope(), "console:holderOwner_edit");
+
+        Assert.assertTrue(owner.getCreateScopes().contains("internal_holder_owner_create"));
+        Assert.assertTrue(owner.getUpdateScopes().contains("internal_holder_owner_update"));
+        Assert.assertTrue(owner.getDeleteScopes().contains("internal_holder_owner_delete"));
+        Assert.assertTrue(owner.getReadScopes().contains("internal_holder_owner_view"));
+    }
+
     /**
      * Resolves the single merged {@code apiResources} collection from the parsed config.
      */
     private APIResourceCollection getApiResourcesCollection() {
 
+        return getCollectionByName(COLLECTION_NAME);
+    }
+
+    private APIResourceCollection getCollectionByName(String name) {
+
         Map<String, APIResourceCollection> configurations = configBuilder.getApiResourceCollectionMgtConfigurations();
         APIResourceCollection collection = configurations.values().stream()
-                .filter(c -> COLLECTION_NAME.equals(c.getName()))
+                .filter(c -> name.equals(c.getName()))
                 .findFirst()
                 .orElse(null);
-        Assert.assertNotNull(collection, "apiResources collection should be present in the parsed config.");
+        Assert.assertNotNull(collection, name + " collection should be present in the parsed config.");
         return collection;
     }
 }

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionTest.java
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/java/org/wso2/carbon/identity/api/resource/collection/mgt/APIResourceCollectionTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.resource.collection.mgt;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.api.resource.collection.mgt.model.APIResourceCollection;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Unit tests for the granular create/update/delete fields added to {@link APIResourceCollection}.
+ */
+public class APIResourceCollectionTest {
+
+    @Test
+    public void testBuilderPopulatesGranularScopeFields() {
+
+        List<String> createScopes = Arrays.asList("create_scope_1", "create_scope_2");
+        List<String> updateScopes = Collections.singletonList("update_scope_1");
+        List<String> deleteScopes = Collections.singletonList("delete_scope_1");
+
+        APIResourceCollection collection = new APIResourceCollection.APIResourceCollectionBuilder()
+                .id("id")
+                .name("name")
+                .createScopes(createScopes)
+                .updateScopes(updateScopes)
+                .deleteScopes(deleteScopes)
+                .createFeatureScope("console:feature_create")
+                .updateFeatureScope("console:feature_update")
+                .deleteFeatureScope("console:feature_delete")
+                .build();
+
+        Assert.assertEquals(collection.getCreateScopes(), createScopes);
+        Assert.assertEquals(collection.getUpdateScopes(), updateScopes);
+        Assert.assertEquals(collection.getDeleteScopes(), deleteScopes);
+        Assert.assertEquals(collection.getCreateFeatureScope(), "console:feature_create");
+        Assert.assertEquals(collection.getUpdateFeatureScope(), "console:feature_update");
+        Assert.assertEquals(collection.getDeleteFeatureScope(), "console:feature_delete");
+    }
+
+    @Test
+    public void testGranularScopeSettersRoundTrip() {
+
+        APIResourceCollection collection = new APIResourceCollection();
+
+        List<String> createScopes = Collections.singletonList("create_scope");
+        List<String> updateScopes = Collections.singletonList("update_scope");
+        List<String> deleteScopes = Collections.singletonList("delete_scope");
+
+        collection.setCreateScopes(createScopes);
+        collection.setUpdateScopes(updateScopes);
+        collection.setDeleteScopes(deleteScopes);
+        collection.setCreateFeatureScope("console:feature_create");
+        collection.setUpdateFeatureScope("console:feature_update");
+        collection.setDeleteFeatureScope("console:feature_delete");
+
+        Assert.assertEquals(collection.getCreateScopes(), createScopes);
+        Assert.assertEquals(collection.getUpdateScopes(), updateScopes);
+        Assert.assertEquals(collection.getDeleteScopes(), deleteScopes);
+        Assert.assertEquals(collection.getCreateFeatureScope(), "console:feature_create");
+        Assert.assertEquals(collection.getUpdateFeatureScope(), "console:feature_update");
+        Assert.assertEquals(collection.getDeleteFeatureScope(), "console:feature_delete");
+    }
+
+    @Test
+    public void testGranularScopeFieldsDefaultToNull() {
+
+        APIResourceCollection collection = new APIResourceCollection();
+
+        Assert.assertNull(collection.getCreateScopes());
+        Assert.assertNull(collection.getUpdateScopes());
+        Assert.assertNull(collection.getDeleteScopes());
+        Assert.assertNull(collection.getCreateFeatureScope());
+        Assert.assertNull(collection.getUpdateFeatureScope());
+        Assert.assertNull(collection.getDeleteFeatureScope());
+    }
+}

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/resources/repository/conf/api-resource-collection.xml
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/resources/repository/conf/api-resource-collection.xml
@@ -45,6 +45,9 @@
                 <Scope name="console:apiResources"/>
                 <Scope name="console:apiResources_view"/>
                 <Scope name="console:apiResources_edit"/>
+                <Scope name="console:apiResources_create"/>
+                <Scope name="console:apiResources_update"/>
+                <Scope name="console:apiResources_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_api_resource_update"/>

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/resources/repository/conf/api-resource-collection.xml
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/resources/repository/conf/api-resource-collection.xml
@@ -63,4 +63,76 @@
             </Delete>
         </Scopes>
     </APIResourceCollection>
+
+    <!-- Collections used to exercise holder-scope resolution.
+         holderOwner declares the full set of granular console feature action scopes (view/edit/create/update/delete)
+         in its <Feature> block, with one internal_* leaf per matching action block.
+         holderTransitive's own <Update> block carries a holder pointing back at holderOwner_update — that lets a
+         consumer's holder of holderTransitive_update exercise recursive (transitive) resolution.
+         holderConsumer references holderOwner_edit + holderTransitive_update from its <Update> block, and
+         holderOwner_view from its <Read> block; none of these holder names should appear in any bucket. -->
+    <APIResourceCollection name="holderOwner" displayName="Holder Owner" type="tenant">
+        <Scopes>
+            <Feature>
+                <Scope name="console:holderOwner"/>
+                <Scope name="console:holderOwner_view"/>
+                <Scope name="console:holderOwner_edit"/>
+                <Scope name="console:holderOwner_create"/>
+                <Scope name="console:holderOwner_update"/>
+                <Scope name="console:holderOwner_delete"/>
+            </Feature>
+            <Create>
+                <Scope name="internal_holder_owner_create"/>
+            </Create>
+            <Update>
+                <Scope name="internal_holder_owner_update"/>
+            </Update>
+            <Delete>
+                <Scope name="internal_holder_owner_delete"/>
+            </Delete>
+            <Read>
+                <Scope name="internal_holder_owner_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="holderTransitive" displayName="Holder Transitive" type="tenant">
+        <Scopes>
+            <Feature>
+                <Scope name="console:holderTransitive"/>
+                <Scope name="console:holderTransitive_view"/>
+                <Scope name="console:holderTransitive_edit"/>
+                <Scope name="console:holderTransitive_create"/>
+                <Scope name="console:holderTransitive_update"/>
+                <Scope name="console:holderTransitive_delete"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_holder_transitive_update"/>
+                <Scope name="console:holderOwner_update"/>
+            </Update>
+            <Create>
+                <Scope name="internal_holder_transitive_create"/>
+            </Create>
+            <Delete>
+                <Scope name="internal_holder_transitive_delete"/>
+            </Delete>
+            <Read>
+                <Scope name="internal_holder_transitive_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
+    <APIResourceCollection name="holderConsumer" displayName="Holder Consumer" type="tenant">
+        <Scopes>
+            <Feature>
+                <Scope name="console:holderConsumer"/>
+            </Feature>
+            <Update>
+                <Scope name="internal_holder_consumer_update"/>
+                <Scope name="console:holderOwner_edit"/>
+                <Scope name="console:holderTransitive_update"/>
+            </Update>
+            <Read>
+                <Scope name="console:holderOwner_view"/>
+            </Read>
+        </Scopes>
+    </APIResourceCollection>
 </APIResourceCollections>

--- a/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/resources/testng.xml
+++ b/components/api-resource-mgt/org.wso2.carbon.identity.api.resource.collection.mgt/src/test/resources/testng.xml
@@ -22,7 +22,9 @@
     <test name="api-resource-collection-mgt-tests" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.carbon.identity.api.resource.collection.mgt.APIResourceCollectionManagerTest"/>
+            <class name="org.wso2.carbon.identity.api.resource.collection.mgt.APIResourceCollectionManagementUtilTest"/>
             <class name="org.wso2.carbon.identity.api.resource.collection.mgt.APIResourceCollectionMgtConfigBuilderTest"/>
+            <class name="org.wso2.carbon.identity.api.resource.collection.mgt.APIResourceCollectionTest"/>
         </classes>
     </test>
 </suite>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -772,6 +772,9 @@
                 <Scope name="console:apiResources"/>
                 <Scope name="console:apiResources_view"/>
                 <Scope name="console:apiResources_edit"/>
+                <Scope name="console:apiResources_create"/>
+                <Scope name="console:apiResources_update"/>
+                <Scope name="console:apiResources_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_api_resource_update"/>
@@ -793,6 +796,9 @@
                 <Scope name="console:applicationAuthenticationScript"/>
                 <Scope name="console:applicationAuthenticationScript_view"/>
                 <Scope name="console:applicationAuthenticationScript_edit"/>
+                <Scope name="console:applicationAuthenticationScript_create"/>
+                <Scope name="console:applicationAuthenticationScript_update"/>
+                <Scope name="console:applicationAuthenticationScript_delete"/>
                 <Scope name="console:applications"/>
             </Feature>
             <Update>
@@ -810,6 +816,9 @@
                 <Scope name="console:applications"/>
                 <Scope name="console:applications_view"/>
                 <Scope name="console:applications_edit"/>
+                <Scope name="console:applications_create"/>
+                <Scope name="console:applications_update"/>
+                <Scope name="console:applications_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -851,6 +860,9 @@
                 <Scope name="console:application_client_secrets"/>
                 <Scope name="console:application_client_secrets_view"/>
                 <Scope name="console:application_client_secrets_edit"/>
+                <Scope name="console:application_client_secrets_create"/>
+                <Scope name="console:application_client_secrets_update"/>
+                <Scope name="console:application_client_secrets_delete"/>
                 <Scope name="console:applications"/>
             </Feature>
             <Update>
@@ -871,6 +883,9 @@
                 <Scope name="console:application_internal_api_management"/>
                 <Scope name="console:application_internal_api_management_view"/>
                 <Scope name="console:application_internal_api_management_edit"/>
+                <Scope name="console:application_internal_api_management_create"/>
+                <Scope name="console:application_internal_api_management_update"/>
+                <Scope name="console:application_internal_api_management_delete"/>
                 <Scope name="console:applications"/>
             </Feature>
             <Update>
@@ -888,6 +903,9 @@
                 <Scope name="console:branding"/>
                 <Scope name="console:branding_view"/>
                 <Scope name="console:branding_edit"/>
+                <Scope name="console:branding_create"/>
+                <Scope name="console:branding_update"/>
+                <Scope name="console:branding_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_branding_preference_update"/>
@@ -909,6 +927,9 @@
                 <Scope name="console:approvalWorkflows"/>
                 <Scope name="console:approvalWorkflows_view"/>
                 <Scope name="console:approvalWorkflows_edit"/>
+                <Scope name="console:approvalWorkflows_create"/>
+                <Scope name="console:approvalWorkflows_update"/>
+                <Scope name="console:approvalWorkflows_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_workflow_update"/>
@@ -936,6 +957,9 @@
                 <Scope name="console:workflowInstances"/>
                 <Scope name="console:workflowInstances_view"/>
                 <Scope name="console:workflowInstances_edit"/>
+                <Scope name="console:workflowInstances_create"/>
+                <Scope name="console:workflowInstances_update"/>
+                <Scope name="console:workflowInstances_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_workflow_instance_update"/>
@@ -954,6 +978,9 @@
                 <Scope name="console:attributes"/>
                 <Scope name="console:attributes_view"/>
                 <Scope name="console:attributes_edit"/>
+                <Scope name="console:attributes_create"/>
+                <Scope name="console:attributes_update"/>
+                <Scope name="console:attributes_delete"/>
             </Feature>
             <Create>
                 <Scope name="internal_claim_meta_create"/>
@@ -978,6 +1005,9 @@
                 <Scope name="console:certificates"/>
                 <Scope name="console:certificates_view"/>
                 <Scope name="console:certificates_edit"/>
+                <Scope name="console:certificates_create"/>
+                <Scope name="console:certificates_update"/>
+                <Scope name="console:certificates_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_keystore_update"/>
@@ -999,6 +1029,9 @@
                 <Scope name="console:settings"/>
                 <Scope name="console:settings_view"/>
                 <Scope name="console:settings_edit"/>
+                <Scope name="console:settings_create"/>
+                <Scope name="console:settings_update"/>
+                <Scope name="console:settings_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -1031,6 +1064,9 @@
                 <Scope name="console:emailTemplates"/>
                 <Scope name="console:emailTemplates_view"/>
                 <Scope name="console:emailTemplates_edit"/>
+                <Scope name="console:emailTemplates_create"/>
+                <Scope name="console:emailTemplates_update"/>
+                <Scope name="console:emailTemplates_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_email_mgt_update"/>
@@ -1052,6 +1088,9 @@
                 <Scope name="console:smsTemplates"/>
                 <Scope name="console:smsTemplates_view"/>
                 <Scope name="console:smsTemplates_edit"/>
+                <Scope name="console:smsTemplates_create"/>
+                <Scope name="console:smsTemplates_update"/>
+                <Scope name="console:smsTemplates_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_template_mgt_update"/>
@@ -1073,6 +1112,9 @@
                 <Scope name="console:groups"/>
                 <Scope name="console:groups_view"/>
                 <Scope name="console:groups_edit"/>
+                <Scope name="console:groups_create"/>
+                <Scope name="console:groups_update"/>
+                <Scope name="console:groups_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_group_mgt_update"/>
@@ -1098,6 +1140,9 @@
                 <Scope name="console:home"/>
                 <Scope name="console:home_view"/>
                 <Scope name="console:home_edit"/>
+                <Scope name="console:home_create"/>
+                <Scope name="console:home_update"/>
+                <Scope name="console:home_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -1120,6 +1165,9 @@
                 <Scope name="console:idps"/>
                 <Scope name="console:idps_view"/>
                 <Scope name="console:idps_edit"/>
+                <Scope name="console:idps_create"/>
+                <Scope name="console:idps_update"/>
+                <Scope name="console:idps_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_idp_update"/>
@@ -1150,6 +1198,9 @@
                 <Scope name="console:idvps"/>
                 <Scope name="console:idvps_view"/>
                 <Scope name="console:idvps_edit"/>
+                <Scope name="console:idvps_create"/>
+                <Scope name="console:idvps_update"/>
+                <Scope name="console:idvps_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_idvp_update"/>
@@ -1171,6 +1222,9 @@
                 <Scope name="console:loginAndRegistration"/>
                 <Scope name="console:loginAndRegistration_view"/>
                 <Scope name="console:loginAndRegistration_edit"/>
+                <Scope name="console:loginAndRegistration_create"/>
+                <Scope name="console:loginAndRegistration_update"/>
+                <Scope name="console:loginAndRegistration_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_governance_update"/>
@@ -1192,6 +1246,9 @@
                 <Scope name="console:org:loginAndRegistration"/>
                 <Scope name="console:org:loginAndRegistration_view"/>
                 <Scope name="console:org:loginAndRegistration_edit"/>
+                <Scope name="console:org:loginAndRegistration_create"/>
+                <Scope name="console:org:loginAndRegistration_update"/>
+                <Scope name="console:org:loginAndRegistration_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_governance_update"/>
@@ -1213,6 +1270,9 @@
                 <Scope name="console:notificationChannels"/>
                 <Scope name="console:notificationChannels_view"/>
                 <Scope name="console:notificationChannels_edit"/>
+                <Scope name="console:notificationChannels_create"/>
+                <Scope name="console:notificationChannels_update"/>
+                <Scope name="console:notificationChannels_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_notification_senders_update"/>
@@ -1234,6 +1294,9 @@
                 <Scope name="console:scopes:oidc"/>
                 <Scope name="console:scopes:oidc_view"/>
                 <Scope name="console:scopes:oidc_edit"/>
+                <Scope name="console:scopes:oidc_create"/>
+                <Scope name="console:scopes:oidc_update"/>
+                <Scope name="console:scopes:oidc_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_oidc_scope_mgt_update"/>
@@ -1267,6 +1330,9 @@
                 <Scope name="console:organizations"/>
                 <Scope name="console:organizations_view"/>
                 <Scope name="console:organizations_edit"/>
+                <Scope name="console:organizations_create"/>
+                <Scope name="console:organizations_update"/>
+                <Scope name="console:organizations_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_organization_update"/>
@@ -1290,6 +1356,9 @@
                 <Scope name="console:organizationDiscovery"/>
                 <Scope name="console:organizationDiscovery_view"/>
                 <Scope name="console:organizationDiscovery_edit"/>
+                <Scope name="console:organizationDiscovery_create"/>
+                <Scope name="console:organizationDiscovery_update"/>
+                <Scope name="console:organizationDiscovery_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_organization_discovery_update"/>
@@ -1314,6 +1383,9 @@
                 <Scope name="console:residentOutboundProvisioning"/>
                 <Scope name="console:residentOutboundProvisioning_view"/>
                 <Scope name="console:residentOutboundProvisioning_edit"/>
+                <Scope name="console:residentOutboundProvisioning_create"/>
+                <Scope name="console:residentOutboundProvisioning_update"/>
+                <Scope name="console:residentOutboundProvisioning_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -1336,6 +1408,9 @@
                 <Scope name="console:roles"/>
                 <Scope name="console:roles_view"/>
                 <Scope name="console:roles_edit"/>
+                <Scope name="console:roles_create"/>
+                <Scope name="console:roles_update"/>
+                <Scope name="console:roles_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_role_mgt_update"/>
@@ -1364,6 +1439,9 @@
                 <Scope name="console:roles"/>
                 <Scope name="console:roles_view"/>
                 <Scope name="console:roles_edit"/>
+                <Scope name="console:roles_create"/>
+                <Scope name="console:roles_update"/>
+                <Scope name="console:roles_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_role_mgt_update"/>
@@ -1390,6 +1468,9 @@
                 <Scope name="console:userSharing"/>
                 <Scope name="console:userSharing_view"/>
                 <Scope name="console:userSharing_edit"/>
+                <Scope name="console:userSharing_create"/>
+                <Scope name="console:userSharing_update"/>
+                <Scope name="console:userSharing_delete"/>
                 <Scope name="console:users"/>
             </Feature>
             <Create>
@@ -1421,6 +1502,9 @@
                 <Scope name="console:users"/>
                 <Scope name="console:users_view"/>
                 <Scope name="console:users_edit"/>
+                <Scope name="console:users_create"/>
+                <Scope name="console:users_update"/>
+                <Scope name="console:users_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_user_mgt_update"/>
@@ -1464,6 +1548,9 @@
                 <Scope name="console:agents"/>
                 <Scope name="console:agents_view"/>
                 <Scope name="console:agents_edit"/>
+                <Scope name="console:agents_create"/>
+                <Scope name="console:agents_update"/>
+                <Scope name="console:agents_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_agent_mgt_update"/>
@@ -1495,6 +1582,9 @@
                 <Scope name="console:userstores"/>
                 <Scope name="console:userstores_view"/>
                 <Scope name="console:userstores_edit"/>
+                <Scope name="console:userstores_create"/>
+                <Scope name="console:userstores_update"/>
+                <Scope name="console:userstores_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_userstore_update"/>
@@ -1516,6 +1606,9 @@
                 <Scope name="console:actions"/>
                 <Scope name="console:actions_view"/>
                 <Scope name="console:actions_edit"/>
+                <Scope name="console:actions_create"/>
+                <Scope name="console:actions_update"/>
+                <Scope name="console:actions_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_action_mgt_update"/>
@@ -1540,6 +1633,9 @@
                 <Scope name="console:webhooks"/>
                 <Scope name="console:webhooks_view"/>
                 <Scope name="console:webhooks_edit"/>
+                <Scope name="console:webhooks_create"/>
+                <Scope name="console:webhooks_update"/>
+                <Scope name="console:webhooks_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_webhook_mgt_update"/>
@@ -1562,6 +1658,9 @@
                 <Scope name="console:tenants"/>
                 <Scope name="console:tenants_view"/>
                 <Scope name="console:tenants_edit"/>
+                <Scope name="console:tenants_create"/>
+                <Scope name="console:tenants_update"/>
+                <Scope name="console:tenants_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_modify_tenants"/>
@@ -1583,6 +1682,9 @@
                 <Scope name="console:flows"/>
                 <Scope name="console:flows_view"/>
                 <Scope name="console:flows_edit"/>
+                <Scope name="console:flows_create"/>
+                <Scope name="console:flows_update"/>
+                <Scope name="console:flows_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_flow_update"/>
@@ -1605,6 +1707,9 @@
                 <Scope name="console:flowExtensions"/>
                 <Scope name="console:flowExtensions_view"/>
                 <Scope name="console:flowExtensions_edit"/>
+                <Scope name="console:flowExtensions_create"/>
+                <Scope name="console:flowExtensions_update"/>
+                <Scope name="console:flowExtensions_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_flow_extension_update"/>
@@ -1627,6 +1732,9 @@
                 <Scope name="console:consents"/>
                 <Scope name="console:consents_view"/>
                 <Scope name="console:consents_edit"/>
+                <Scope name="console:consents_create"/>
+                <Scope name="console:consents_update"/>
+                <Scope name="console:consents_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_consent_mgt_purpose_update"/>
@@ -1657,6 +1765,9 @@
                 <Scope name="console:org:consents"/>
                 <Scope name="console:org:consents_view"/>
                 <Scope name="console:org:consents_edit"/>
+                <Scope name="console:org:consents_create"/>
+                <Scope name="console:org:consents_update"/>
+                <Scope name="console:org:consents_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_consent_mgt_purpose_update"/>
@@ -1687,6 +1798,9 @@
                 <Scope name="console:user_credentials"/>
                 <Scope name="console:user_credentials_view"/>
                 <Scope name="console:user_credentials_edit"/>
+                <Scope name="console:user_credentials_create"/>
+                <Scope name="console:user_credentials_update"/>
+                <Scope name="console:user_credentials_delete"/>
             </Feature>
             <Update>
             </Update>
@@ -1708,6 +1822,9 @@
                 <Scope name="console:org:settings"/>
                 <Scope name="console:org:settings_view"/>
                 <Scope name="console:org:settings_edit"/>
+                <Scope name="console:org:settings_create"/>
+                <Scope name="console:org:settings_update"/>
+                <Scope name="console:org:settings_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_application_mgt_update"/>
@@ -1739,6 +1856,9 @@
                 <Scope name="console:org:idps"/>
                 <Scope name="console:org:idps_view"/>
                 <Scope name="console:org:idps_edit"/>
+                <Scope name="console:org:idps_create"/>
+                <Scope name="console:org:idps_update"/>
+                <Scope name="console:org:idps_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_idp_update"/>
@@ -1768,6 +1888,9 @@
                 <Scope name="console:org:userSharing"/>
                 <Scope name="console:org:userSharing_view"/>
                 <Scope name="console:org:userSharing_edit"/>
+                <Scope name="console:org:userSharing_create"/>
+                <Scope name="console:org:userSharing_update"/>
+                <Scope name="console:org:userSharing_delete"/>
                 <Scope name="console:org:users"/>
             </Feature>
             <Create>
@@ -1799,6 +1922,9 @@
                 <Scope name="console:org:users"/>
                 <Scope name="console:org:users_view"/>
                 <Scope name="console:org:users_edit"/>
+                <Scope name="console:org:users_create"/>
+                <Scope name="console:org:users_update"/>
+                <Scope name="console:org:users_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_user_mgt_update"/>
@@ -1834,6 +1960,9 @@
                 <Scope name="console:org:organizations"/>
                 <Scope name="console:org:organizations_view"/>
                 <Scope name="console:org:organizations_edit"/>
+                <Scope name="console:org:organizations_create"/>
+                <Scope name="console:org:organizations_update"/>
+                <Scope name="console:org:organizations_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_organization_update"/>
@@ -1858,6 +1987,9 @@
                 <Scope name="console:org:groups"/>
                 <Scope name="console:org:groups_view"/>
                 <Scope name="console:org:groups_edit"/>
+                <Scope name="console:org:groups_create"/>
+                <Scope name="console:org:groups_update"/>
+                <Scope name="console:org:groups_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_group_mgt_update"/>
@@ -1883,6 +2015,9 @@
                 <Scope name="console:org:roles"/>
                 <Scope name="console:org:roles_view"/>
                 <Scope name="console:org:roles_edit"/>
+                <Scope name="console:org:roles_create"/>
+                <Scope name="console:org:roles_update"/>
+                <Scope name="console:org:roles_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_role_mgt_update"/>
@@ -1910,6 +2045,9 @@
                 <Scope name="console:org:roles"/>
                 <Scope name="console:org:roles_view"/>
                 <Scope name="console:org:roles_edit"/>
+                <Scope name="console:org:roles_create"/>
+                <Scope name="console:org:roles_update"/>
+                <Scope name="console:org:roles_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_role_mgt_update"/>
@@ -1934,6 +2072,9 @@
                 <Scope name="console:org:applicationAuthenticationScript"/>
                 <Scope name="console:org:applicationAuthenticationScript_view"/>
                 <Scope name="console:org:applicationAuthenticationScript_edit"/>
+                <Scope name="console:org:applicationAuthenticationScript_create"/>
+                <Scope name="console:org:applicationAuthenticationScript_update"/>
+                <Scope name="console:org:applicationAuthenticationScript_delete"/>
                 <Scope name="console:org:applications"/>
             </Feature>
             <Update>
@@ -1951,6 +2092,9 @@
                 <Scope name="console:org:applications"/>
                 <Scope name="console:org:applications_view"/>
                 <Scope name="console:org:applications_edit"/>
+                <Scope name="console:org:applications_create"/>
+                <Scope name="console:org:applications_update"/>
+                <Scope name="console:org:applications_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_application_mgt_update"/>
@@ -1983,6 +2127,9 @@
                 <Scope name="console:org:application_internal_api_management"/>
                 <Scope name="console:org:application_internal_api_management_view"/>
                 <Scope name="console:org:application_internal_api_management_edit"/>
+                <Scope name="console:org:application_internal_api_management_create"/>
+                <Scope name="console:org:application_internal_api_management_update"/>
+                <Scope name="console:org:application_internal_api_management_delete"/>
                 <Scope name="console:org:applications"/>
             </Feature>
             <Update>
@@ -2000,6 +2147,9 @@
                 <Scope name="console:org:application_client_secrets"/>
                 <Scope name="console:org:application_client_secrets_view"/>
                 <Scope name="console:org:application_client_secrets_edit"/>
+                <Scope name="console:org:application_client_secrets_create"/>
+                <Scope name="console:org:application_client_secrets_update"/>
+                <Scope name="console:org:application_client_secrets_delete"/>
                 <Scope name="console:org:applications"/>
             </Feature>
             <Update>
@@ -2020,6 +2170,9 @@
                 <Scope name="console:org:branding"/>
                 <Scope name="console:org:branding_view"/>
                 <Scope name="console:org:branding_edit"/>
+                <Scope name="console:org:branding_create"/>
+                <Scope name="console:org:branding_update"/>
+                <Scope name="console:org:branding_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_branding_preference_update"/>
@@ -2041,6 +2194,9 @@
                 <Scope name="console:org:approvalWorkflows"/>
                 <Scope name="console:org:approvalWorkflows_view"/>
                 <Scope name="console:org:approvalWorkflows_edit"/>
+                <Scope name="console:org:approvalWorkflows_create"/>
+                <Scope name="console:org:approvalWorkflows_update"/>
+                <Scope name="console:org:approvalWorkflows_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_workflow_update"/>
@@ -2068,6 +2224,9 @@
                 <Scope name="console:org:workflowInstances"/>
                 <Scope name="console:org:workflowInstances_view"/>
                 <Scope name="console:org:workflowInstances_edit"/>
+                <Scope name="console:org:workflowInstances_create"/>
+                <Scope name="console:org:workflowInstances_update"/>
+                <Scope name="console:org:workflowInstances_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_workflow_instance_update"/>
@@ -2086,6 +2245,9 @@
                 <Scope name="console:org:emailTemplates"/>
                 <Scope name="console:org:emailTemplates_view"/>
                 <Scope name="console:org:emailTemplates_edit"/>
+                <Scope name="console:org:emailTemplates_create"/>
+                <Scope name="console:org:emailTemplates_update"/>
+                <Scope name="console:org:emailTemplates_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_email_mgt_update"/>
@@ -2107,6 +2269,9 @@
                 <Scope name="console:org:smsTemplates"/>
                 <Scope name="console:org:smsTemplates_view"/>
                 <Scope name="console:org:smsTemplates_edit"/>
+                <Scope name="console:org:smsTemplates_create"/>
+                <Scope name="console:org:smsTemplates_update"/>
+                <Scope name="console:org:smsTemplates_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_template_mgt_update"/>
@@ -2128,6 +2293,9 @@
                 <Scope name="console:org:home"/>
                 <Scope name="console:org:home_view"/>
                 <Scope name="console:org:home_edit"/>
+                <Scope name="console:org:home_create"/>
+                <Scope name="console:org:home_update"/>
+                <Scope name="console:org:home_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_application_mgt_update"/>
@@ -2150,6 +2318,9 @@
                 <Scope name="console:org:apiResources"/>
                 <Scope name="console:org:apiResources_view"/>
                 <Scope name="console:org:apiResources_edit"/>
+                <Scope name="console:org:apiResources_create"/>
+                <Scope name="console:org:apiResources_update"/>
+                <Scope name="console:org:apiResources_delete"/>
             </Feature>
             <Read>
                 <Scope name="internal_org_api_resource_view"/>
@@ -2162,6 +2333,9 @@
                 <Scope name="console:org:userstores"/>
                 <Scope name="console:org:userstores_view"/>
                 <Scope name="console:org:userstores_edit"/>
+                <Scope name="console:org:userstores_create"/>
+                <Scope name="console:org:userstores_update"/>
+                <Scope name="console:org:userstores_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_userstore_update"/>
@@ -2183,6 +2357,9 @@
                 <Scope name="console:org:attributes"/>
                 <Scope name="console:org:attributes_view"/>
                 <Scope name="console:org:attributes_edit"/>
+                <Scope name="console:org:attributes_create"/>
+                <Scope name="console:org:attributes_update"/>
+                <Scope name="console:org:attributes_delete"/>
             </Feature>
             <Create>
             </Create>
@@ -2203,6 +2380,9 @@
                 <Scope name="console:org:actions"/>
                 <Scope name="console:org:actions_view"/>
                 <Scope name="console:org:actions_edit"/>
+                <Scope name="console:org:actions_create"/>
+                <Scope name="console:org:actions_update"/>
+                <Scope name="console:org:actions_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_action_mgt_update"/>
@@ -2227,6 +2407,9 @@
                 <Scope name="console:org:flows"/>
                 <Scope name="console:org:flows_view"/>
                 <Scope name="console:org:flows_edit"/>
+                <Scope name="console:org:flows_create"/>
+                <Scope name="console:org:flows_update"/>
+                <Scope name="console:org:flows_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_flow_update"/>
@@ -2250,6 +2433,9 @@
                 <Scope name="console:org:flowExtensions"/>
                 <Scope name="console:org:flowExtensions_view"/>
                 <Scope name="console:org:flowExtensions_edit"/>
+                <Scope name="console:org:flowExtensions_create"/>
+                <Scope name="console:org:flowExtensions_update"/>
+                <Scope name="console:org:flowExtensions_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_flow_extension_update"/>
@@ -2272,6 +2458,9 @@
                 <Scope name="console:org:user_credentials"/>
                 <Scope name="console:org:user_credentials_view"/>
                 <Scope name="console:org:user_credentials_edit"/>
+                <Scope name="console:org:user_credentials_create"/>
+                <Scope name="console:org:user_credentials_update"/>
+                <Scope name="console:org:user_credentials_delete"/>
             </Feature>
             <Update>
             </Update>
@@ -2292,6 +2481,9 @@
                 <Scope name="console:org:residentOutboundProvisioning"/>
                 <Scope name="console:org:residentOutboundProvisioning_view"/>
                 <Scope name="console:org:residentOutboundProvisioning_edit"/>
+                <Scope name="console:org:residentOutboundProvisioning_create"/>
+                <Scope name="console:org:residentOutboundProvisioning_update"/>
+                <Scope name="console:org:residentOutboundProvisioning_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_application_mgt_update"/>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -870,6 +870,9 @@
             <Update>
                 <Scope name="internal_application_script_update"/>
                 <Scope name="console:applications_edit"/>
+                <Scope name="console:applications_create"/>
+                <Scope name="console:applications_update"/>
+                <Scope name="console:applications_delete"/>
             </Update>
             <Read>
                 <Scope name="console:applications_view"/>
@@ -934,6 +937,9 @@
             </Feature>
             <Update>
                <Scope name="console:applications_edit"/>
+               <Scope name="console:applications_create"/>
+               <Scope name="console:applications_update"/>
+               <Scope name="console:applications_delete"/>
             </Update>
             <Create>
                 <Scope name="internal_application_mgt_client_secret_create"/>
@@ -957,6 +963,9 @@
             </Feature>
             <Update>
                 <Scope name="console:applications_edit"/>
+                <Scope name="console:applications_create"/>
+                <Scope name="console:applications_update"/>
+                <Scope name="console:applications_delete"/>
                 <Scope name="internal_application_internal_api_update"/>
             </Update>
             <Read>
@@ -1622,6 +1631,9 @@
             <Create>
                 <Scope name="internal_user_share"/>
                 <Scope name="console:users_edit"/>
+                <Scope name="console:users_create"/>
+                <Scope name="console:users_update"/>
+                <Scope name="console:users_delete"/>
             </Create>
             <Delete>
                 <Scope name="internal_user_unshare"/>
@@ -2023,6 +2035,9 @@
             <Create>
                 <Scope name="internal_org_user_share"/>
                 <Scope name="console:org:users_edit"/>
+                <Scope name="console:org:users_create"/>
+                <Scope name="console:org:users_update"/>
+                <Scope name="console:org:users_delete"/>
             </Create>
             <Delete>
                 <Scope name="internal_org_user_unshare"/>
@@ -2279,6 +2294,9 @@
             <Update>
                 <Scope name="internal_org_application_script_update"/>
                 <Scope name="console:org:applications_edit"/>
+                <Scope name="console:org:applications_create"/>
+                <Scope name="console:org:applications_update"/>
+                <Scope name="console:org:applications_delete"/>
             </Update>
             <Read>
                 <Scope name="console:org:applications_view"/>
@@ -2334,6 +2352,9 @@
             </Feature>
             <Update>
                 <Scope name="console:org:applications_edit"/>
+                <Scope name="console:org:applications_create"/>
+                <Scope name="console:org:applications_update"/>
+                <Scope name="console:org:applications_delete"/>
                 <Scope name="internal_org_application_internal_api_update"/>
             </Update>
             <Read>
@@ -2354,6 +2375,9 @@
             </Feature>
             <Update>
                 <Scope name="console:org:applications_edit"/>
+                <Scope name="console:org:applications_create"/>
+                <Scope name="console:org:applications_update"/>
+                <Scope name="console:org:applications_delete"/>
             </Update>
             <Create>
                 <Scope name="internal_org_application_mgt_client_secret_create"/>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -521,6 +521,9 @@
                 <Scope name="console:agents"/>
                 <Scope name="console:agents_view"/>
                 <Scope name="console:agents_edit"/>
+                <Scope name="console:agents_create"/>
+                <Scope name="console:agents_update"/>
+                <Scope name="console:agents_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_agent_mgt_update"/>
@@ -835,6 +838,9 @@
                 <Scope name="console:apiResources"/>
                 <Scope name="console:apiResources_view"/>
                 <Scope name="console:apiResources_edit"/>
+                <Scope name="console:apiResources_create"/>
+                <Scope name="console:apiResources_update"/>
+                <Scope name="console:apiResources_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_api_resource_update"/>
@@ -856,6 +862,9 @@
                 <Scope name="console:applicationAuthenticationScript"/>
                 <Scope name="console:applicationAuthenticationScript_view"/>
                 <Scope name="console:applicationAuthenticationScript_edit"/>
+                <Scope name="console:applicationAuthenticationScript_create"/>
+                <Scope name="console:applicationAuthenticationScript_update"/>
+                <Scope name="console:applicationAuthenticationScript_delete"/>
                 <Scope name="console:applications"/>
             </Feature>
             <Update>
@@ -873,6 +882,9 @@
                 <Scope name="console:applications"/>
                 <Scope name="console:applications_view"/>
                 <Scope name="console:applications_edit"/>
+                <Scope name="console:applications_create"/>
+                <Scope name="console:applications_update"/>
+                <Scope name="console:applications_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -915,6 +927,9 @@
                 <Scope name="console:application_client_secrets"/>
                 <Scope name="console:application_client_secrets_view"/>
                 <Scope name="console:application_client_secrets_edit"/>
+                <Scope name="console:application_client_secrets_create"/>
+                <Scope name="console:application_client_secrets_update"/>
+                <Scope name="console:application_client_secrets_delete"/>
                 <Scope name="console:applications"/>
             </Feature>
             <Update>
@@ -935,6 +950,9 @@
                 <Scope name="console:application_internal_api_management"/>
                 <Scope name="console:application_internal_api_management_view"/>
                 <Scope name="console:application_internal_api_management_edit"/>
+                <Scope name="console:application_internal_api_management_create"/>
+                <Scope name="console:application_internal_api_management_update"/>
+                <Scope name="console:application_internal_api_management_delete"/>
                 <Scope name="console:applications"/>
             </Feature>
             <Update>
@@ -952,6 +970,9 @@
                 <Scope name="console:branding"/>
                 <Scope name="console:branding_view"/>
                 <Scope name="console:branding_edit"/>
+                <Scope name="console:branding_create"/>
+                <Scope name="console:branding_update"/>
+                <Scope name="console:branding_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_branding_preference_update"/>
@@ -973,6 +994,9 @@
                 <Scope name="console:approvalWorkflows"/>
                 <Scope name="console:approvalWorkflows_view"/>
                 <Scope name="console:approvalWorkflows_edit"/>
+                <Scope name="console:approvalWorkflows_create"/>
+                <Scope name="console:approvalWorkflows_update"/>
+                <Scope name="console:approvalWorkflows_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_workflow_update"/>
@@ -1000,6 +1024,9 @@
                 <Scope name="console:workflowInstances"/>
                 <Scope name="console:workflowInstances_view"/>
                 <Scope name="console:workflowInstances_edit"/>
+                <Scope name="console:workflowInstances_create"/>
+                <Scope name="console:workflowInstances_update"/>
+                <Scope name="console:workflowInstances_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_workflow_instance_update"/>
@@ -1018,6 +1045,9 @@
                 <Scope name="console:attributes"/>
                 <Scope name="console:attributes_view"/>
                 <Scope name="console:attributes_edit"/>
+                <Scope name="console:attributes_create"/>
+                <Scope name="console:attributes_update"/>
+                <Scope name="console:attributes_delete"/>
             </Feature>
             <Create>
                 <Scope name="internal_claim_meta_create"/>
@@ -1043,6 +1073,9 @@
                 <Scope name="console:certificates"/>
                 <Scope name="console:certificates_view"/>
                 <Scope name="console:certificates_edit"/>
+                <Scope name="console:certificates_create"/>
+                <Scope name="console:certificates_update"/>
+                <Scope name="console:certificates_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_keystore_update"/>
@@ -1064,6 +1097,9 @@
                 <Scope name="console:settings"/>
                 <Scope name="console:settings_view"/>
                 <Scope name="console:settings_edit"/>
+                <Scope name="console:settings_create"/>
+                <Scope name="console:settings_update"/>
+                <Scope name="console:settings_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -1102,6 +1138,9 @@
                 <Scope name="console:emailTemplates"/>
                 <Scope name="console:emailTemplates_view"/>
                 <Scope name="console:emailTemplates_edit"/>
+                <Scope name="console:emailTemplates_create"/>
+                <Scope name="console:emailTemplates_update"/>
+                <Scope name="console:emailTemplates_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_email_mgt_update"/>
@@ -1123,6 +1162,9 @@
                 <Scope name="console:smsTemplates"/>
                 <Scope name="console:smsTemplates_view"/>
                 <Scope name="console:smsTemplates_edit"/>
+                <Scope name="console:smsTemplates_create"/>
+                <Scope name="console:smsTemplates_update"/>
+                <Scope name="console:smsTemplates_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_template_mgt_update"/>
@@ -1144,6 +1186,9 @@
                 <Scope name="console:groups"/>
                 <Scope name="console:groups_view"/>
                 <Scope name="console:groups_edit"/>
+                <Scope name="console:groups_create"/>
+                <Scope name="console:groups_update"/>
+                <Scope name="console:groups_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_group_mgt_update"/>
@@ -1169,6 +1214,9 @@
                 <Scope name="console:home"/>
                 <Scope name="console:home_view"/>
                 <Scope name="console:home_edit"/>
+                <Scope name="console:home_create"/>
+                <Scope name="console:home_update"/>
+                <Scope name="console:home_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -1191,6 +1239,9 @@
                 <Scope name="console:idps"/>
                 <Scope name="console:idps_view"/>
                 <Scope name="console:idps_edit"/>
+                <Scope name="console:idps_create"/>
+                <Scope name="console:idps_update"/>
+                <Scope name="console:idps_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_idp_update"/>
@@ -1224,6 +1275,9 @@
                 <Scope name="console:idvps"/>
                 <Scope name="console:idvps_view"/>
                 <Scope name="console:idvps_edit"/>
+                <Scope name="console:idvps_create"/>
+                <Scope name="console:idvps_update"/>
+                <Scope name="console:idvps_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_idvp_update"/>
@@ -1245,6 +1299,9 @@
                 <Scope name="console:loginAndRegistration"/>
                 <Scope name="console:loginAndRegistration_view"/>
                 <Scope name="console:loginAndRegistration_edit"/>
+                <Scope name="console:loginAndRegistration_create"/>
+                <Scope name="console:loginAndRegistration_update"/>
+                <Scope name="console:loginAndRegistration_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_governance_update"/>
@@ -1267,6 +1324,9 @@
                 <Scope name="console:org:loginAndRegistration"/>
                 <Scope name="console:org:loginAndRegistration_view"/>
                 <Scope name="console:org:loginAndRegistration_edit"/>
+                <Scope name="console:org:loginAndRegistration_create"/>
+                <Scope name="console:org:loginAndRegistration_update"/>
+                <Scope name="console:org:loginAndRegistration_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_governance_update"/>
@@ -1289,6 +1349,9 @@
                 <Scope name="console:notificationChannels"/>
                 <Scope name="console:notificationChannels_view"/>
                 <Scope name="console:notificationChannels_edit"/>
+                <Scope name="console:notificationChannels_create"/>
+                <Scope name="console:notificationChannels_update"/>
+                <Scope name="console:notificationChannels_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_notification_senders_update"/>
@@ -1310,6 +1373,9 @@
                 <Scope name="console:scopes:oidc"/>
                 <Scope name="console:scopes:oidc_view"/>
                 <Scope name="console:scopes:oidc_edit"/>
+                <Scope name="console:scopes:oidc_create"/>
+                <Scope name="console:scopes:oidc_update"/>
+                <Scope name="console:scopes:oidc_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_oidc_scope_mgt_update"/>
@@ -1343,6 +1409,9 @@
                 <Scope name="console:organizations"/>
                 <Scope name="console:organizations_view"/>
                 <Scope name="console:organizations_edit"/>
+                <Scope name="console:organizations_create"/>
+                <Scope name="console:organizations_update"/>
+                <Scope name="console:organizations_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_organization_update"/>
@@ -1366,6 +1435,9 @@
                 <Scope name="console:organizationDiscovery"/>
                 <Scope name="console:organizationDiscovery_view"/>
                 <Scope name="console:organizationDiscovery_edit"/>
+                <Scope name="console:organizationDiscovery_create"/>
+                <Scope name="console:organizationDiscovery_update"/>
+                <Scope name="console:organizationDiscovery_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_organization_discovery_update"/>
@@ -1390,6 +1462,9 @@
                 <Scope name="console:residentOutboundProvisioning"/>
                 <Scope name="console:residentOutboundProvisioning_view"/>
                 <Scope name="console:residentOutboundProvisioning_edit"/>
+                <Scope name="console:residentOutboundProvisioning_create"/>
+                <Scope name="console:residentOutboundProvisioning_update"/>
+                <Scope name="console:residentOutboundProvisioning_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_application_mgt_update"/>
@@ -1412,6 +1487,9 @@
                 <Scope name="console:roles"/>
                 <Scope name="console:roles_view"/>
                 <Scope name="console:roles_edit"/>
+                <Scope name="console:roles_create"/>
+                <Scope name="console:roles_update"/>
+                <Scope name="console:roles_delete"/>
             </Feature>
             <Update>
                 {% if scim2.enable_scim2_roles_v3_api is sameas false %}
@@ -1449,6 +1527,9 @@
                 <Scope name="console:role_assignments"/>
                 <Scope name="console:role_assignments_view"/>
                 <Scope name="console:role_assignments_edit"/>
+                <Scope name="console:role_assignments_create"/>
+                <Scope name="console:role_assignments_update"/>
+                <Scope name="console:role_assignments_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_role_mgt_update"/>
@@ -1476,6 +1557,9 @@
                 <Scope name="console:role_permission_assignments"/>
                 <Scope name="console:role_permission_assignments_view"/>
                 <Scope name="console:role_permission_assignments_edit"/>
+                <Scope name="console:role_permission_assignments_create"/>
+                <Scope name="console:role_permission_assignments_update"/>
+                <Scope name="console:role_permission_assignments_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_role_mgt_update"/>
@@ -1501,6 +1585,9 @@
                 <Scope name="console:roles"/>
                 <Scope name="console:roles_view"/>
                 <Scope name="console:roles_edit"/>
+                <Scope name="console:roles_create"/>
+                <Scope name="console:roles_update"/>
+                <Scope name="console:roles_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_role_mgt_update"/>
@@ -1527,6 +1614,9 @@
                 <Scope name="console:userSharing"/>
                 <Scope name="console:userSharing_view"/>
                 <Scope name="console:userSharing_edit"/>
+                <Scope name="console:userSharing_create"/>
+                <Scope name="console:userSharing_update"/>
+                <Scope name="console:userSharing_delete"/>
                 <Scope name="console:users"/>
             </Feature>
             <Create>
@@ -1558,6 +1648,9 @@
                 <Scope name="console:users"/>
                 <Scope name="console:users_view"/>
                 <Scope name="console:users_edit"/>
+                <Scope name="console:users_create"/>
+                <Scope name="console:users_update"/>
+                <Scope name="console:users_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_user_mgt_update"/>
@@ -1602,6 +1695,9 @@
                 <Scope name="console:userstores"/>
                 <Scope name="console:userstores_view"/>
                 <Scope name="console:userstores_edit"/>
+                <Scope name="console:userstores_create"/>
+                <Scope name="console:userstores_update"/>
+                <Scope name="console:userstores_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_userstore_update"/>
@@ -1623,6 +1719,9 @@
                 <Scope name="console:actions"/>
                 <Scope name="console:actions_view"/>
                 <Scope name="console:actions_edit"/>
+                <Scope name="console:actions_create"/>
+                <Scope name="console:actions_update"/>
+                <Scope name="console:actions_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_action_mgt_update"/>
@@ -1647,6 +1746,9 @@
                 <Scope name="console:webhooks"/>
                 <Scope name="console:webhooks_view"/>
                 <Scope name="console:webhooks_edit"/>
+                <Scope name="console:webhooks_create"/>
+                <Scope name="console:webhooks_update"/>
+                <Scope name="console:webhooks_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_webhook_mgt_update"/>
@@ -1669,6 +1771,9 @@
                 <Scope name="console:tenants"/>
                 <Scope name="console:tenants_view"/>
                 <Scope name="console:tenants_edit"/>
+                <Scope name="console:tenants_create"/>
+                <Scope name="console:tenants_update"/>
+                <Scope name="console:tenants_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_modify_tenants"/>
@@ -1691,6 +1796,9 @@
                 <Scope name="console:flows"/>
                 <Scope name="console:flows_view"/>
                 <Scope name="console:flows_edit"/>
+                <Scope name="console:flows_create"/>
+                <Scope name="console:flows_update"/>
+                <Scope name="console:flows_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_flow_update"/>
@@ -1715,6 +1823,9 @@
                 <Scope name="console:flowExtensions"/>
                 <Scope name="console:flowExtensions_view"/>
                 <Scope name="console:flowExtensions_edit"/>
+                <Scope name="console:flowExtensions_create"/>
+                <Scope name="console:flowExtensions_update"/>
+                <Scope name="console:flowExtensions_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_flow_extension_update"/>
@@ -1738,6 +1849,9 @@
                 <Scope name="console:consents"/>
                 <Scope name="console:consents_view"/>
                 <Scope name="console:consents_edit"/>
+                <Scope name="console:consents_create"/>
+                <Scope name="console:consents_update"/>
+                <Scope name="console:consents_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_consent_mgt_purpose_update"/>
@@ -1768,6 +1882,9 @@
                 <Scope name="console:org:consents"/>
                 <Scope name="console:org:consents_view"/>
                 <Scope name="console:org:consents_edit"/>
+                <Scope name="console:org:consents_create"/>
+                <Scope name="console:org:consents_update"/>
+                <Scope name="console:org:consents_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_consent_mgt_purpose_update"/>
@@ -1799,6 +1916,9 @@
                 <Scope name="console:user_credentials"/>
                 <Scope name="console:user_credentials_view"/>
                 <Scope name="console:user_credentials_edit"/>
+                <Scope name="console:user_credentials_create"/>
+                <Scope name="console:user_credentials_update"/>
+                <Scope name="console:user_credentials_delete"/>
             </Feature>
             <Update>
             </Update>
@@ -1820,6 +1940,9 @@
                 <Scope name="console:org:settings"/>
                 <Scope name="console:org:settings_view"/>
                 <Scope name="console:org:settings_edit"/>
+                <Scope name="console:org:settings_create"/>
+                <Scope name="console:org:settings_update"/>
+                <Scope name="console:org:settings_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_application_mgt_update"/>
@@ -1857,6 +1980,9 @@
                 <Scope name="console:org:idps"/>
                 <Scope name="console:org:idps_view"/>
                 <Scope name="console:org:idps_edit"/>
+                <Scope name="console:org:idps_create"/>
+                <Scope name="console:org:idps_update"/>
+                <Scope name="console:org:idps_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_idp_update"/>
@@ -1889,6 +2015,9 @@
                 <Scope name="console:org:userSharing"/>
                 <Scope name="console:org:userSharing_view"/>
                 <Scope name="console:org:userSharing_edit"/>
+                <Scope name="console:org:userSharing_create"/>
+                <Scope name="console:org:userSharing_update"/>
+                <Scope name="console:org:userSharing_delete"/>
                 <Scope name="console:org:users"/>
             </Feature>
             <Create>
@@ -1920,6 +2049,9 @@
                 <Scope name="console:org:users"/>
                 <Scope name="console:org:users_view"/>
                 <Scope name="console:org:users_edit"/>
+                <Scope name="console:org:users_create"/>
+                <Scope name="console:org:users_update"/>
+                <Scope name="console:org:users_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_user_mgt_update"/>
@@ -1964,6 +2096,9 @@
                 <Scope name="console:org:organizations"/>
                 <Scope name="console:org:organizations_view"/>
                 <Scope name="console:org:organizations_edit"/>
+                <Scope name="console:org:organizations_create"/>
+                <Scope name="console:org:organizations_update"/>
+                <Scope name="console:org:organizations_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_organization_update"/>
@@ -1988,6 +2123,9 @@
                 <Scope name="console:org:groups"/>
                 <Scope name="console:org:groups_view"/>
                 <Scope name="console:org:groups_edit"/>
+                <Scope name="console:org:groups_create"/>
+                <Scope name="console:org:groups_update"/>
+                <Scope name="console:org:groups_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_group_mgt_update"/>
@@ -2013,6 +2151,9 @@
                 <Scope name="console:org:roles"/>
                 <Scope name="console:org:roles_view"/>
                 <Scope name="console:org:roles_edit"/>
+                <Scope name="console:org:roles_create"/>
+                <Scope name="console:org:roles_update"/>
+                <Scope name="console:org:roles_delete"/>
             </Feature>
             <Update>
                 {% if scim2.enable_scim2_roles_v3_api is sameas false %}
@@ -2049,6 +2190,9 @@
                 <Scope name="console:org:role_assignments"/>
                 <Scope name="console:org:role_assignments_view"/>
                 <Scope name="console:org:role_assignments_edit"/>
+                <Scope name="console:org:role_assignments_create"/>
+                <Scope name="console:org:role_assignments_update"/>
+                <Scope name="console:org:role_assignments_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_role_mgt_update"/>
@@ -2074,6 +2218,9 @@
                     <Scope name="console:org:role_permission_assignments"/>
                     <Scope name="console:org:role_permission_assignments_view"/>
                     <Scope name="console:org:role_permission_assignments_edit"/>
+                    <Scope name="console:org:role_permission_assignments_create"/>
+                    <Scope name="console:org:role_permission_assignments_update"/>
+                    <Scope name="console:org:role_permission_assignments_delete"/>
                 </Feature>
                 <Update>
                     <Scope name="internal_org_role_mgt_update"/>
@@ -2097,6 +2244,9 @@
                 <Scope name="console:org:roles"/>
                 <Scope name="console:org:roles_view"/>
                 <Scope name="console:org:roles_edit"/>
+                <Scope name="console:org:roles_create"/>
+                <Scope name="console:org:roles_update"/>
+                <Scope name="console:org:roles_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_role_mgt_update"/>
@@ -2121,6 +2271,9 @@
                 <Scope name="console:org:applicationAuthenticationScript"/>
                 <Scope name="console:org:applicationAuthenticationScript_view"/>
                 <Scope name="console:org:applicationAuthenticationScript_edit"/>
+                <Scope name="console:org:applicationAuthenticationScript_create"/>
+                <Scope name="console:org:applicationAuthenticationScript_update"/>
+                <Scope name="console:org:applicationAuthenticationScript_delete"/>
                 <Scope name="console:org:applications"/>
             </Feature>
             <Update>
@@ -2138,6 +2291,9 @@
                 <Scope name="console:org:applications"/>
                 <Scope name="console:org:applications_view"/>
                 <Scope name="console:org:applications_edit"/>
+                <Scope name="console:org:applications_create"/>
+                <Scope name="console:org:applications_update"/>
+                <Scope name="console:org:applications_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_application_mgt_update"/>
@@ -2171,6 +2327,9 @@
                 <Scope name="console:org:application_internal_api_management"/>
                 <Scope name="console:org:application_internal_api_management_view"/>
                 <Scope name="console:org:application_internal_api_management_edit"/>
+                <Scope name="console:org:application_internal_api_management_create"/>
+                <Scope name="console:org:application_internal_api_management_update"/>
+                <Scope name="console:org:application_internal_api_management_delete"/>
                 <Scope name="console:org:applications"/>
             </Feature>
             <Update>
@@ -2188,6 +2347,9 @@
                 <Scope name="console:org:application_client_secrets"/>
                 <Scope name="console:org:application_client_secrets_view"/>
                 <Scope name="console:org:application_client_secrets_edit"/>
+                <Scope name="console:org:application_client_secrets_create"/>
+                <Scope name="console:org:application_client_secrets_update"/>
+                <Scope name="console:org:application_client_secrets_delete"/>
                 <Scope name="console:org:applications"/>
             </Feature>
             <Update>
@@ -2208,6 +2370,9 @@
                 <Scope name="console:org:branding"/>
                 <Scope name="console:org:branding_view"/>
                 <Scope name="console:org:branding_edit"/>
+                <Scope name="console:org:branding_create"/>
+                <Scope name="console:org:branding_update"/>
+                <Scope name="console:org:branding_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_branding_preference_update"/>
@@ -2229,6 +2394,9 @@
                 <Scope name="console:org:approvalWorkflows"/>
                 <Scope name="console:org:approvalWorkflows_view"/>
                 <Scope name="console:org:approvalWorkflows_edit"/>
+                <Scope name="console:org:approvalWorkflows_create"/>
+                <Scope name="console:org:approvalWorkflows_update"/>
+                <Scope name="console:org:approvalWorkflows_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_workflow_update"/>
@@ -2256,6 +2424,9 @@
                 <Scope name="console:org:workflowInstances"/>
                 <Scope name="console:org:workflowInstances_view"/>
                 <Scope name="console:org:workflowInstances_edit"/>
+                <Scope name="console:org:workflowInstances_create"/>
+                <Scope name="console:org:workflowInstances_update"/>
+                <Scope name="console:org:workflowInstances_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_workflow_instance_update"/>
@@ -2274,6 +2445,9 @@
                 <Scope name="console:org:emailTemplates"/>
                 <Scope name="console:org:emailTemplates_view"/>
                 <Scope name="console:org:emailTemplates_edit"/>
+                <Scope name="console:org:emailTemplates_create"/>
+                <Scope name="console:org:emailTemplates_update"/>
+                <Scope name="console:org:emailTemplates_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_email_mgt_update"/>
@@ -2295,6 +2469,9 @@
                 <Scope name="console:org:smsTemplates"/>
                 <Scope name="console:org:smsTemplates_view"/>
                 <Scope name="console:org:smsTemplates_edit"/>
+                <Scope name="console:org:smsTemplates_create"/>
+                <Scope name="console:org:smsTemplates_update"/>
+                <Scope name="console:org:smsTemplates_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_template_mgt_update"/>
@@ -2316,6 +2493,9 @@
                 <Scope name="console:org:home"/>
                 <Scope name="console:org:home_view"/>
                 <Scope name="console:org:home_edit"/>
+                <Scope name="console:org:home_create"/>
+                <Scope name="console:org:home_update"/>
+                <Scope name="console:org:home_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_application_mgt_update"/>
@@ -2338,6 +2518,9 @@
                 <Scope name="console:org:apiResources"/>
                 <Scope name="console:org:apiResources_view"/>
                 <Scope name="console:org:apiResources_edit"/>
+                <Scope name="console:org:apiResources_create"/>
+                <Scope name="console:org:apiResources_update"/>
+                <Scope name="console:org:apiResources_delete"/>
             </Feature>
             <Read>
                 <Scope name="internal_org_api_resource_view"/>
@@ -2350,6 +2533,9 @@
                 <Scope name="console:org:userstores"/>
                 <Scope name="console:org:userstores_view"/>
                 <Scope name="console:org:userstores_edit"/>
+                <Scope name="console:org:userstores_create"/>
+                <Scope name="console:org:userstores_update"/>
+                <Scope name="console:org:userstores_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_userstore_update"/>
@@ -2371,6 +2557,9 @@
                 <Scope name="console:org:attributes"/>
                 <Scope name="console:org:attributes_view"/>
                 <Scope name="console:org:attributes_edit"/>
+                <Scope name="console:org:attributes_create"/>
+                <Scope name="console:org:attributes_update"/>
+                <Scope name="console:org:attributes_delete"/>
             </Feature>
             <Create>
             </Create>
@@ -2392,6 +2581,9 @@
                 <Scope name="console:org:actions"/>
                 <Scope name="console:org:actions_view"/>
                 <Scope name="console:org:actions_edit"/>
+                <Scope name="console:org:actions_create"/>
+                <Scope name="console:org:actions_update"/>
+                <Scope name="console:org:actions_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_action_mgt_update"/>
@@ -2416,6 +2608,9 @@
                 <Scope name="console:org:flows"/>
                 <Scope name="console:org:flows_view"/>
                 <Scope name="console:org:flows_edit"/>
+                <Scope name="console:org:flows_create"/>
+                <Scope name="console:org:flows_update"/>
+                <Scope name="console:org:flows_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_flow_update"/>
@@ -2441,6 +2636,9 @@
                 <Scope name="console:org:flowExtensions"/>
                 <Scope name="console:org:flowExtensions_view"/>
                 <Scope name="console:org:flowExtensions_edit"/>
+                <Scope name="console:org:flowExtensions_create"/>
+                <Scope name="console:org:flowExtensions_update"/>
+                <Scope name="console:org:flowExtensions_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_flow_extension_update"/>
@@ -2463,6 +2661,9 @@
                 <Scope name="console:org:user_credentials"/>
                 <Scope name="console:org:user_credentials_view"/>
                 <Scope name="console:org:user_credentials_edit"/>
+                <Scope name="console:org:user_credentials_create"/>
+                <Scope name="console:org:user_credentials_update"/>
+                <Scope name="console:org:user_credentials_delete"/>
             </Feature>
             <Update>
             </Update>
@@ -2483,6 +2684,9 @@
                 <Scope name="console:org:residentOutboundProvisioning"/>
                 <Scope name="console:org:residentOutboundProvisioning_view"/>
                 <Scope name="console:org:residentOutboundProvisioning_edit"/>
+                <Scope name="console:org:residentOutboundProvisioning_create"/>
+                <Scope name="console:org:residentOutboundProvisioning_update"/>
+                <Scope name="console:org:residentOutboundProvisioning_delete"/>
             </Feature>
             <Update>
                 <Scope name="internal_org_application_mgt_update"/>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -1392,6 +1392,12 @@
                    description="Manage views of applications from the Console"/>
             <Scope displayName="Application Edit Feature" name="console:applications_edit"
                    description="Manage edits of applications from the Console"/>
+            <Scope displayName="Application Update Feature" name="console:applications_update"
+                   description="Manage updates of applications from the Console"/>
+            <Scope displayName="Application Create Feature" name="console:applications_create"
+                   description="Manage creates of applications from the Console"/>
+            <Scope displayName="Application Delete Feature" name="console:applications_delete"
+                   description="Manage deletes of applications from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Application Management Feature" identifier="console:org:applications"
@@ -1405,6 +1411,12 @@
                    description="Manage views of applications in the organization from the Console"/>
             <Scope displayName="Application Edit Feature" name="console:org:applications_edit"
                    description="Manage edits of applications in the organization from the Console"/>
+            <Scope displayName="Application Update Feature" name="console:org:applications_update"
+                   description="Manage updates of applications in the organization from the Console"/>
+            <Scope displayName="Application Create Feature" name="console:org:applications_create"
+                   description="Manage creates of applications in the organization from the Console"/>
+            <Scope displayName="Application Delete Feature" name="console:org:applications_delete"
+                   description="Manage deletes of applications in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Application Internal API management feature" identifier="console:application_internal_api_management"
@@ -1418,6 +1430,12 @@
                    description="Manage views of application internal APIs from the Console"/>
             <Scope displayName="Application Internal API Management Edit Feature" name="console:application_internal_api_management_edit"
                    description="Manage edits of application internal APIs from the Console"/>
+            <Scope displayName="Application Internal API Management Update Feature" name="console:application_internal_api_management_update"
+                   description="Manage updates of application internal APIs from the Console"/>
+            <Scope displayName="Application Internal API Management Create Feature" name="console:application_internal_api_management_create"
+                   description="Manage creates of application internal APIs from the Console"/>
+            <Scope displayName="Application Internal API Management Delete Feature" name="console:application_internal_api_management_delete"
+                   description="Manage deletes of application internal APIs from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Application Internal API management feature" identifier="console:org:application_internal_api_management"
@@ -1431,6 +1449,12 @@
                    description="Manage views of application internal APIs in the organization from the Console"/>
             <Scope displayName="Application Internal API Management Edit Feature" name="console:org:application_internal_api_management_edit"
                    description="Manage edits of application internal APIs in the organization from the Console"/>
+            <Scope displayName="Application Internal API Management Update Feature" name="console:org:application_internal_api_management_update"
+                   description="Manage updates of application internal APIs in the organization from the Console"/>
+            <Scope displayName="Application Internal API Management Create Feature" name="console:org:application_internal_api_management_create"
+                   description="Manage creates of application internal APIs in the organization from the Console"/>
+            <Scope displayName="Application Internal API Management Delete Feature" name="console:org:application_internal_api_management_delete"
+                   description="Manage deletes of application internal APIs in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Application client secret management feature" identifier="console:application_client_secrets"
@@ -1444,6 +1468,12 @@
                    description="Manage views of application client secrets from the Console"/>
             <Scope displayName="Application Secret Management Edit Feature" name="console:application_client_secrets_edit"
                    description="Manage edits of application client secrets from the Console"/>
+            <Scope displayName="Application Secret Management Update Feature" name="console:application_client_secrets_update"
+                   description="Manage updates of application client secrets from the Console"/>
+            <Scope displayName="Application Secret Management Create Feature" name="console:application_client_secrets_create"
+                   description="Manage creates of application client secrets from the Console"/>
+            <Scope displayName="Application Secret Management Delete Feature" name="console:application_client_secrets_delete"
+                   description="Manage deletes of application client secrets from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Application client secret management feature" identifier="console:org:application_client_secrets"
@@ -1457,6 +1487,12 @@
                    description="Manage views of application client secrets in the organization from the Console"/>
             <Scope displayName="Application Secret Management Edit Feature" name="console:org:application_client_secrets_edit"
                    description="Manage edits of application client secrets in the organization from the Console"/>
+            <Scope displayName="Application Secret Management Update Feature" name="console:org:application_client_secrets_update"
+                   description="Manage updates of application client secrets in the organization from the Console"/>
+            <Scope displayName="Application Secret Management Create Feature" name="console:org:application_client_secrets_create"
+                   description="Manage creates of application client secrets in the organization from the Console"/>
+            <Scope displayName="Application Secret Management Delete Feature" name="console:org:application_client_secrets_delete"
+                   description="Manage deletes of application client secrets in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Branding Management Feature" identifier="console:branding"
@@ -1470,6 +1506,12 @@
                    description="Manage views of branding from the Console"/>
             <Scope displayName="Branding Edit Feature" name="console:branding_edit"
                    description="Manage edits of branding from the Console"/>
+            <Scope displayName="Branding Update Feature" name="console:branding_update"
+                   description="Manage updates of branding from the Console"/>
+            <Scope displayName="Branding Create Feature" name="console:branding_create"
+                   description="Manage creates of branding from the Console"/>
+            <Scope displayName="Branding Delete Feature" name="console:branding_delete"
+                   description="Manage deletes of branding from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Branding Management Feature" identifier="console:org:branding"
@@ -1483,6 +1525,12 @@
                    description="Manage views of branding in the organization from the Console"/>
             <Scope displayName="Branding Edit Feature" name="console:org:branding_edit"
                    description="Manage edits of branding in the organization from the Console"/>
+            <Scope displayName="Branding Update Feature" name="console:org:branding_update"
+                   description="Manage updates of branding in the organization from the Console"/>
+            <Scope displayName="Branding Create Feature" name="console:org:branding_create"
+                   description="Manage creates of branding in the organization from the Console"/>
+            <Scope displayName="Branding Delete Feature" name="console:org:branding_delete"
+                   description="Manage deletes of branding in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Attribute Management Feature" identifier="console:attributes"
@@ -1496,6 +1544,12 @@
                    description="Manage views of user attributes from the Console"/>
             <Scope displayName="Attribute Edit Feature" name="console:attributes_edit"
                    description="Manage edits of user attributes from the Console"/>
+            <Scope displayName="Attribute Update Feature" name="console:attributes_update"
+                   description="Manage updates of user attributes from the Console"/>
+            <Scope displayName="Attribute Create Feature" name="console:attributes_create"
+                   description="Manage creates of user attributes from the Console"/>
+            <Scope displayName="Attribute Delete Feature" name="console:attributes_delete"
+                   description="Manage deletes of user attributes from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Attribute Management Feature" identifier="console:org:attributes"
@@ -1509,6 +1563,12 @@
                    description="Manage views of user attributes from the Console"/>
             <Scope displayName="Attribute Edit Feature" name="console:org:attributes_edit"
                    description="Manage edits of user attributes from the Console"/>
+            <Scope displayName="Attribute Update Feature" name="console:org:attributes_update"
+                   description="Manage updates of user attributes from the Console"/>
+            <Scope displayName="Attribute Create Feature" name="console:org:attributes_create"
+                   description="Manage creates of user attributes from the Console"/>
+            <Scope displayName="Attribute Delete Feature" name="console:org:attributes_delete"
+                   description="Manage deletes of user attributes from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Store Management Feature" identifier="console:userstores"
@@ -1522,6 +1582,12 @@
                    description="Manage user stores from the Console"/>
             <Scope displayName="User Store Edit Feature" name="console:userstores_edit"
                    description="Manage edits of user stores from the Console"/>
+            <Scope displayName="User Store Update Feature" name="console:userstores_update"
+                   description="Manage updates of user stores from the Console"/>
+            <Scope displayName="User Store Create Feature" name="console:userstores_create"
+                   description="Manage creates of user stores from the Console"/>
+            <Scope displayName="User Store Delete Feature" name="console:userstores_delete"
+                   description="Manage deletes of user stores from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Store Management Feature" identifier="console:org:userstores"
@@ -1535,6 +1601,12 @@
                    description="Manage views of user stores from the Console"/>
             <Scope displayName="User Store Edit Feature" name="console:org:userstores_edit"
                    description="Manage edits of user stores from the Console"/>
+            <Scope displayName="User Store Update Feature" name="console:org:userstores_update"
+                   description="Manage updates of user stores from the Console"/>
+            <Scope displayName="User Store Create Feature" name="console:org:userstores_create"
+                   description="Manage creates of user stores from the Console"/>
+            <Scope displayName="User Store Delete Feature" name="console:org:userstores_delete"
+                   description="Manage deletes of user stores from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Group Management Feature" identifier="console:groups"
@@ -1548,6 +1620,12 @@
                    description="Manage views of groups from the Console"/>
             <Scope displayName="Group Edit Feature" name="console:groups_edit"
                    description="Manage edits of groups from the Console"/>
+            <Scope displayName="Group Update Feature" name="console:groups_update"
+                   description="Manage updates of groups from the Console"/>
+            <Scope displayName="Group Create Feature" name="console:groups_create"
+                   description="Manage creates of groups from the Console"/>
+            <Scope displayName="Group Delete Feature" name="console:groups_delete"
+                   description="Manage deletes of groups from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Group Management Feature" identifier="console:org:groups"
@@ -1561,6 +1639,12 @@
                    description="Manage views of groups in the organization from the Console"/>
             <Scope displayName="Group Edit Feature" name="console:org:groups_edit"
                    description="Manage edits of groups in the organization from the Console"/>
+            <Scope displayName="Group Update Feature" name="console:org:groups_update"
+                   description="Manage updates of groups in the organization from the Console"/>
+            <Scope displayName="Group Create Feature" name="console:org:groups_create"
+                   description="Manage creates of groups in the organization from the Console"/>
+            <Scope displayName="Group Delete Feature" name="console:org:groups_delete"
+                   description="Manage deletes of groups in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Identity Provider Management Feature" identifier="console:idps"
@@ -1574,6 +1658,12 @@
                    description="Manage views of identity providers from the Console"/>
             <Scope displayName="Identity Provider Edit Feature" name="console:idps_edit"
                    description="Manage edits of identity providers from the Console"/>
+            <Scope displayName="Identity Provider Update Feature" name="console:idps_update"
+                   description="Manage updates of identity providers from the Console"/>
+            <Scope displayName="Identity Provider Create Feature" name="console:idps_create"
+                   description="Manage creates of identity providers from the Console"/>
+            <Scope displayName="Identity Provider Delete Feature" name="console:idps_delete"
+                   description="Manage deletes of identity providers from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Identity Provider Management Feature" identifier="console:org:idps"
@@ -1587,6 +1677,12 @@
                    description="Manage views of identity providers in the organization from the Console"/>
             <Scope displayName="Identity Provider Edit Feature" name="console:org:idps_edit"
                    description="Manage edits of identity providers in the organization from the Console"/>
+            <Scope displayName="Identity Provider Update Feature" name="console:org:idps_update"
+                   description="Manage updates of identity providers in the organization from the Console"/>
+            <Scope displayName="Identity Provider Create Feature" name="console:org:idps_create"
+                   description="Manage creates of identity providers in the organization from the Console"/>
+            <Scope displayName="Identity Provider Delete Feature" name="console:org:idps_delete"
+                   description="Manage deletes of identity providers in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="API Resource Management Feature" identifier="console:apiResources"
@@ -1600,6 +1696,12 @@
                    description="Manage views of api resources from the Console"/>
             <Scope displayName="API Resource Edit Feature" name="console:apiResources_edit"
                    description="Manage edits of api resources from the Console"/>
+            <Scope displayName="API Resource Update Feature" name="console:apiResources_update"
+                   description="Manage updates of api resources from the Console"/>
+            <Scope displayName="API Resource Create Feature" name="console:apiResources_create"
+                   description="Manage creates of api resources from the Console"/>
+            <Scope displayName="API Resource Delete Feature" name="console:apiResources_delete"
+                   description="Manage deletes of api resources from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="API Resource Management Feature" identifier="console:org:apiResources"
@@ -1613,6 +1715,12 @@
                    description="Manage views of api resources in the organization from the Console"/>
             <Scope displayName="API Resource Edit Feature" name="console:org:apiResources_edit"
                    description="Manage edits of api resources in the organization from the Console"/>
+            <Scope displayName="API Resource Update Feature" name="console:org:apiResources_update"
+                   description="Manage updates of api resources in the organization from the Console"/>
+            <Scope displayName="API Resource Create Feature" name="console:org:apiResources_create"
+                   description="Manage creates of api resources in the organization from the Console"/>
+            <Scope displayName="API Resource Delete Feature" name="console:org:apiResources_delete"
+                   description="Manage deletes of api resources in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="OIDC Scope Management Feature" identifier="console:scopes:oidc"
@@ -1626,6 +1734,12 @@
                    description="Manage views of OIDC scopes from the Console"/>
             <Scope displayName="OIDC Scope Edit Feature" name="console:scopes:oidc_edit"
                    description="Manage edits of OIDC scopes from the Console"/>
+            <Scope displayName="OIDC Scope Update Feature" name="console:scopes:oidc_update"
+                   description="Manage updates of OIDC scopes from the Console"/>
+            <Scope displayName="OIDC Scope Create Feature" name="console:scopes:oidc_create"
+                   description="Manage creates of OIDC scopes from the Console"/>
+            <Scope displayName="OIDC Scope Delete Feature" name="console:scopes:oidc_delete"
+                   description="Manage deletes of OIDC scopes from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="OIDC Scope Management Feature" identifier="console:org:scopes:oidc"
@@ -1650,6 +1764,12 @@
                    description="Manage views of login and regisgtration from the Console"/>
             <Scope displayName="Login And Registration Edit Feature" name="console:loginAndRegistration_edit"
                    description="Manage edits of login and regisgtration from the Console"/>
+            <Scope displayName="Login And Registration Update Feature" name="console:loginAndRegistration_update"
+                   description="Manage updates of login and regisgtration from the Console"/>
+            <Scope displayName="Login And Registration Create Feature" name="console:loginAndRegistration_create"
+                   description="Manage creates of login and regisgtration from the Console"/>
+            <Scope displayName="Login And Registration Delete Feature" name="console:loginAndRegistration_delete"
+                   description="Manage deletes of login and regisgtration from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Login And Registration Management Feature" identifier="console:org:loginAndRegistration"
@@ -1663,6 +1783,12 @@
                    description="Manage views of login and registration from the Console"/>
             <Scope displayName="Login And Registration Edit Feature" name="console:org:loginAndRegistration_edit"
                    description="Manage edits of login and registration from the Console"/>
+            <Scope displayName="Login And Registration Update Feature" name="console:org:loginAndRegistration_update"
+                   description="Manage updates of login and registration from the Console"/>
+            <Scope displayName="Login And Registration Create Feature" name="console:org:loginAndRegistration_create"
+                   description="Manage creates of login and registration from the Console"/>
+            <Scope displayName="Login And Registration Delete Feature" name="console:org:loginAndRegistration_delete"
+                   description="Manage deletes of login and registration from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Organization Management Feature" identifier="console:organizations"
@@ -1676,6 +1802,12 @@
                    description="Manage views of organizations from the Console"/>
             <Scope displayName="Organization Edit Feature" name="console:organizations_edit"
                    description="Manage edits of organizations from the Console"/>
+            <Scope displayName="Organization Update Feature" name="console:organizations_update"
+                   description="Manage updates of organizations from the Console"/>
+            <Scope displayName="Organization Create Feature" name="console:organizations_create"
+                   description="Manage creates of organizations from the Console"/>
+            <Scope displayName="Organization Delete Feature" name="console:organizations_delete"
+                   description="Manage deletes of organizations from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Organization Management Feature" identifier="console:org:organizations"
@@ -1689,6 +1821,12 @@
                    description="Manage views of organizations in the organization from the Console"/>
             <Scope displayName="Organization Edit Feature" name="console:org:organizations_edit"
                    description="Manage edits of organizations in the organization from the Console"/>
+            <Scope displayName="Organization Update Feature" name="console:org:organizations_update"
+                   description="Manage updates of organizations in the organization from the Console"/>
+            <Scope displayName="Organization Create Feature" name="console:org:organizations_create"
+                   description="Manage creates of organizations in the organization from the Console"/>
+            <Scope displayName="Organization Delete Feature" name="console:org:organizations_delete"
+                   description="Manage deletes of organizations in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Organization Discovery Management Feature" identifier="console:organizationDiscovery"
@@ -1702,6 +1840,12 @@
                    description="Manage views of organization discovery from the Console"/>
             <Scope displayName="Organization Discovery Edit Feature" name="console:organizationDiscovery_edit"
                    description="Manage edits of organization discovery from the Console"/>
+            <Scope displayName="Organization Discovery Update Feature" name="console:organizationDiscovery_update"
+                   description="Manage updates of organization discovery from the Console"/>
+            <Scope displayName="Organization Discovery Create Feature" name="console:organizationDiscovery_create"
+                   description="Manage creates of organization discovery from the Console"/>
+            <Scope displayName="Organization Discovery Delete Feature" name="console:organizationDiscovery_delete"
+                   description="Manage deletes of organization discovery from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Resident Application Outbound Provisioning Configuration Feature" identifier="console:residentOutboundProvisioning"
@@ -1715,6 +1859,12 @@
                    description="Manage views of resident application outbound provisioning configuration from the Console"/>
             <Scope displayName="Resident Application Outbound Provisioning Edit Feature" name="console:residentOutboundProvisioning_edit"
                    description="Manage edits of resident application outbound provisioning configuration from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning Update Feature" name="console:residentOutboundProvisioning_update"
+                   description="Manage updates of resident application outbound provisioning configuration from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning Create Feature" name="console:residentOutboundProvisioning_create"
+                   description="Manage creates of resident application outbound provisioning configuration from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning Delete Feature" name="console:residentOutboundProvisioning_delete"
+                   description="Manage deletes of resident application outbound provisioning configuration from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Resident Application Outbound Provisioning Configuration Feature" identifier="console:org:residentOutboundProvisioning"
@@ -1728,6 +1878,12 @@
                    description="Manage views of resident application outbound provisioning configuration in the organization from the Console"/>
             <Scope displayName="Resident Application Outbound Provisioning Edit Feature" name="console:org:residentOutboundProvisioning_edit"
                    description="Manage edits of resident application outbound provisioning configuration in the organization from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning Update Feature" name="console:org:residentOutboundProvisioning_update"
+                   description="Manage updates of resident application outbound provisioning configuration in the organization from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning Create Feature" name="console:org:residentOutboundProvisioning_create"
+                   description="Manage creates of resident application outbound provisioning configuration in the organization from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning Delete Feature" name="console:org:residentOutboundProvisioning_delete"
+                   description="Manage deletes of resident application outbound provisioning configuration in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Management Feature" identifier="console:roles"
@@ -1741,6 +1897,12 @@
                    description="Manage views of roles from the Console"/>
             <Scope displayName="Role Edit Feature" name="console:roles_edit"
                    description="Manage edits of roles from the Console"/>
+            <Scope displayName="Role Update Feature" name="console:roles_update"
+                   description="Manage updates of roles from the Console"/>
+            <Scope displayName="Role Create Feature" name="console:roles_create"
+                   description="Manage creates of roles from the Console"/>
+            <Scope displayName="Role Delete Feature" name="console:roles_delete"
+                   description="Manage deletes of roles from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Management Feature" identifier="console:org:roles"
@@ -1754,6 +1916,12 @@
                    description="Manage views of roles in the organization from the Console"/>
             <Scope displayName="Role Edit Feature" name="console:org:roles_edit"
                    description="Manage edits of roles in the organization from the Console"/>
+            <Scope displayName="Role Update Feature" name="console:org:roles_update"
+                   description="Manage updates of roles in the organization from the Console"/>
+            <Scope displayName="Role Create Feature" name="console:org:roles_create"
+                   description="Manage creates of roles in the organization from the Console"/>
+            <Scope displayName="Role Delete Feature" name="console:org:roles_delete"
+                   description="Manage deletes of roles in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Assignments Feature" identifier="console:role_assignments"
@@ -1767,6 +1935,12 @@
                    description="Manage views of role assignments from the Console"/>
             <Scope displayName="Role Assignments Edit Feature" name="console:role_assignments_edit"
                    description="Manage edits of role assignments from the Console"/>
+            <Scope displayName="Role Assignments Update Feature" name="console:role_assignments_update"
+                   description="Manage updates of role assignments from the Console"/>
+            <Scope displayName="Role Assignments Create Feature" name="console:role_assignments_create"
+                   description="Manage creates of role assignments from the Console"/>
+            <Scope displayName="Role Assignments Delete Feature" name="console:role_assignments_delete"
+                   description="Manage deletes of role assignments from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Assignments Feature" identifier="console:org:role_assignments"
@@ -1780,6 +1954,12 @@
                    description="Manage views of role assignments from the Console"/>
             <Scope displayName="Role Assignments Edit Feature" name="console:org:role_assignments_edit"
                    description="Manage edits of role assignments from the Console"/>
+            <Scope displayName="Role Assignments Update Feature" name="console:org:role_assignments_update"
+                   description="Manage updates of role assignments from the Console"/>
+            <Scope displayName="Role Assignments Create Feature" name="console:org:role_assignments_create"
+                   description="Manage creates of role assignments from the Console"/>
+            <Scope displayName="Role Assignments Delete Feature" name="console:org:role_assignments_delete"
+                   description="Manage deletes of role assignments from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Permission Assignments Feature" identifier="console:role_permission_assignments"
@@ -1793,6 +1973,12 @@
                    description="Manage views of role permission assignments from the Console"/>
             <Scope displayName="Role Permission Assignments Edit Feature" name="console:role_permission_assignments_edit"
                    description="Manage edits of role permission assignments from the Console"/>
+            <Scope displayName="Role Permission Assignments Update Feature" name="console:role_permission_assignments_update"
+                   description="Manage updates of role permission assignments from the Console"/>
+            <Scope displayName="Role Permission Assignments Create Feature" name="console:role_permission_assignments_create"
+                   description="Manage creates of role permission assignments from the Console"/>
+            <Scope displayName="Role Permission Assignments Delete Feature" name="console:role_permission_assignments_delete"
+                   description="Manage deletes of role permission assignments from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Permission Assignments Feature" identifier="console:org:role_permission_assignments"
@@ -1806,6 +1992,12 @@
                    description="Manage views of role permission assignments from the Console"/>
             <Scope displayName="Role Permission Assignments Edit Feature" name="console:org:role_permission_assignments_edit"
                    description="Manage edits of role permission assignments from the Console"/>
+            <Scope displayName="Role Permission Assignments Update Feature" name="console:org:role_permission_assignments_update"
+                   description="Manage updates of role permission assignments from the Console"/>
+            <Scope displayName="Role Permission Assignments Create Feature" name="console:org:role_permission_assignments_create"
+                   description="Manage creates of role permission assignments from the Console"/>
+            <Scope displayName="Role Permission Assignments Delete Feature" name="console:org:role_permission_assignments_delete"
+                   description="Manage deletes of role permission assignments from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Management Feature" identifier="console:users"
@@ -1819,6 +2011,12 @@
                    description="Manage views of users from the Console"/>
             <Scope displayName="User Edit Feature" name="console:users_edit"
                    description="Manage edits of users from the Console"/>
+            <Scope displayName="User Update Feature" name="console:users_update"
+                   description="Manage updates of users from the Console"/>
+            <Scope displayName="User Create Feature" name="console:users_create"
+                   description="Manage creates of users from the Console"/>
+            <Scope displayName="User Delete Feature" name="console:users_delete"
+                   description="Manage deletes of users from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Sharing Management Feature" identifier="console:userSharing"
@@ -1832,6 +2030,12 @@
                    description="View user sharing from the Console"/>
             <Scope displayName="User Sharing Management Edit Feature" name="console:userSharing_edit"
                    description="Manage edits of user sharing from the Console"/>
+            <Scope displayName="User Sharing Management Update Feature" name="console:userSharing_update"
+                   description="Manage updates of user sharing from the Console"/>
+            <Scope displayName="User Sharing Management Create Feature" name="console:userSharing_create"
+                   description="Manage creates of user sharing from the Console"/>
+            <Scope displayName="User Sharing Management Delete Feature" name="console:userSharing_delete"
+                   description="Manage deletes of user sharing from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Agent Management Feature" identifier="console:agents"
@@ -1845,6 +2049,12 @@
                    description="Manage views of agents from the Console"/>
             <Scope displayName="User Edit Feature" name="console:agents_edit"
                    description="Manage edits of agents from the Console"/>
+            <Scope displayName="User Update Feature" name="console:agents_update"
+                   description="Manage updates of agents from the Console"/>
+            <Scope displayName="User Create Feature" name="console:agents_create"
+                   description="Manage creates of agents from the Console"/>
+            <Scope displayName="User Delete Feature" name="console:agents_delete"
+                   description="Manage deletes of agents from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Management Feature" identifier="console:org:users"
@@ -1858,6 +2068,12 @@
                    description="Manage views of users in the organization from the Console"/>
             <Scope displayName="User Edit Feature" name="console:org:users_edit"
                    description="Manage edits of users in the organization from the Console"/>
+            <Scope displayName="User Update Feature" name="console:org:users_update"
+                   description="Manage updates of users in the organization from the Console"/>
+            <Scope displayName="User Create Feature" name="console:org:users_create"
+                   description="Manage creates of users in the organization from the Console"/>
+            <Scope displayName="User Delete Feature" name="console:org:users_delete"
+                   description="Manage deletes of users in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Sharing Management Feature" identifier="console:org:userSharing"
@@ -1871,6 +2087,12 @@
                    description="View user sharing in the organization from the Console"/>
             <Scope displayName="User Sharing Management Edit Feature" name="console:org:userSharing_edit"
                    description="Manage edits of user sharing in the organization from the Console"/>
+            <Scope displayName="User Sharing Management Update Feature" name="console:org:userSharing_update"
+                   description="Manage updates of user sharing in the organization from the Console"/>
+            <Scope displayName="User Sharing Management Create Feature" name="console:org:userSharing_create"
+                   description="Manage creates of user sharing in the organization from the Console"/>
+            <Scope displayName="User Sharing Management Delete Feature" name="console:org:userSharing_delete"
+                   description="Manage deletes of user sharing in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Server Management Feature" identifier="console:server"
@@ -1893,6 +2115,12 @@
                    description="Manage views of workflows from the Console"/>
             <Scope displayName="Approval Workflow Edit Feature" name="console:approvalWorkflows_edit"
                    description="Manage edits of workflows from the Console"/>
+            <Scope displayName="Approval Workflow Update Feature" name="console:approvalWorkflows_update"
+                   description="Manage updates of workflows from the Console"/>
+            <Scope displayName="Approval Workflow Create Feature" name="console:approvalWorkflows_create"
+                   description="Manage creates of workflows from the Console"/>
+            <Scope displayName="Approval Workflow Delete Feature" name="console:approvalWorkflows_delete"
+                   description="Manage deletes of workflows from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Approval Workflow Management Feature Organization" identifier="console:org:approvalWorkflows"
@@ -1906,6 +2134,12 @@
                    description="Manage views of approval workflows from the Console"/>
             <Scope displayName="Approval Workflow Edit Feature" name="console:org:approvalWorkflows_edit"
                    description="Manage edits of approval workflows from the Console"/>
+            <Scope displayName="Approval Workflow Update Feature" name="console:org:approvalWorkflows_update"
+                   description="Manage updates of approval workflows from the Console"/>
+            <Scope displayName="Approval Workflow Create Feature" name="console:org:approvalWorkflows_create"
+                   description="Manage creates of approval workflows from the Console"/>
+            <Scope displayName="Approval Workflow Delete Feature" name="console:org:approvalWorkflows_delete"
+                   description="Manage deletes of approval workflows from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Workflow Instance Management Feature" identifier="console:workflowInstances"
@@ -1919,6 +2153,12 @@
                    description="Manage views of workflow instances from the Console"/>
             <Scope displayName="Workflow Instance Edit Feature" name="console:workflowInstances_edit"
                    description="Manage edits of workflow instances from the Console"/>
+            <Scope displayName="Workflow Instance Update Feature" name="console:workflowInstances_update"
+                   description="Manage updates of workflow instances from the Console"/>
+            <Scope displayName="Workflow Instance Create Feature" name="console:workflowInstances_create"
+                   description="Manage creates of workflow instances from the Console"/>
+            <Scope displayName="Workflow Instance Delete Feature" name="console:workflowInstances_delete"
+                   description="Manage deletes of workflow instances from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Workflow Instance Management Feature" identifier="console:org:workflowInstances"
@@ -1932,6 +2172,12 @@
                    description="Manage views of workflow instances in the organization from the Console"/>
             <Scope displayName="Workflow Instance Edit Feature" name="console:org:workflowInstances_edit"
                    description="Manage edits of workflow instances in the organization from the Console"/>
+            <Scope displayName="Workflow Instance Update Feature" name="console:org:workflowInstances_update"
+                   description="Manage updates of workflow instances in the organization from the Console"/>
+            <Scope displayName="Workflow Instance Create Feature" name="console:org:workflowInstances_create"
+                   description="Manage creates of workflow instances in the organization from the Console"/>
+            <Scope displayName="Workflow Instance Delete Feature" name="console:org:workflowInstances_delete"
+                   description="Manage deletes of workflow instances in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Notification Channel Management Feature" identifier="console:notificationChannels"
@@ -1945,6 +2191,12 @@
                    description="Manage views of notification channels from the Console"/>
             <Scope displayName="Notification Channel Edit Feature" name="console:notificationChannels_edit"
                    description="Manage edits of notification channels from the Console"/>
+            <Scope displayName="Notification Channel Update Feature" name="console:notificationChannels_update"
+                   description="Manage updates of notification channels from the Console"/>
+            <Scope displayName="Notification Channel Create Feature" name="console:notificationChannels_create"
+                   description="Manage creates of notification channels from the Console"/>
+            <Scope displayName="Notification Channel Delete Feature" name="console:notificationChannels_delete"
+                   description="Manage deletes of notification channels from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Identity Verification Provider Management Feature" identifier="console:idvps"
@@ -1958,6 +2210,12 @@
                    description="Manage views of identity verfication providers from the Console"/>
             <Scope displayName="Identity Verification Provider Edit Feature" name="console:idvps_edit"
                    description="Manage edits of identity verfication providers from the Console"/>
+            <Scope displayName="Identity Verification Provider Update Feature" name="console:idvps_update"
+                   description="Manage updates of identity verfication providers from the Console"/>
+            <Scope displayName="Identity Verification Provider Create Feature" name="console:idvps_create"
+                   description="Manage creates of identity verfication providers from the Console"/>
+            <Scope displayName="Identity Verification Provider Delete Feature" name="console:idvps_delete"
+                   description="Manage deletes of identity verfication providers from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Event Publishing Management Feature" identifier="console:eventPublishing"
@@ -1980,6 +2238,12 @@
                    description="Manage views of email templates from the Console"/>
             <Scope displayName="Email Template Edit Feature" name="console:emailTemplates_edit"
                    description="Manage edits of email templates from the Console"/>
+            <Scope displayName="Email Template Update Feature" name="console:emailTemplates_update"
+                   description="Manage updates of email templates from the Console"/>
+            <Scope displayName="Email Template Create Feature" name="console:emailTemplates_create"
+                   description="Manage creates of email templates from the Console"/>
+            <Scope displayName="Email Template Delete Feature" name="console:emailTemplates_delete"
+                   description="Manage deletes of email templates from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Email Template Management Feature" identifier="console:org:emailTemplates"
@@ -1993,6 +2257,12 @@
                    description="Manage views of email templates in the organization from the Console"/>
             <Scope displayName="Email Template Edit Feature" name="console:org:emailTemplates_edit"
                    description="Manage edits of email templates in the organization from the Console"/>
+            <Scope displayName="Email Template Update Feature" name="console:org:emailTemplates_update"
+                   description="Manage updates of email templates in the organization from the Console"/>
+            <Scope displayName="Email Template Create Feature" name="console:org:emailTemplates_create"
+                   description="Manage creates of email templates in the organization from the Console"/>
+            <Scope displayName="Email Template Delete Feature" name="console:org:emailTemplates_delete"
+                   description="Manage deletes of email templates in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="SMS Template Management Feature" identifier="console:smsTemplates"
@@ -2006,6 +2276,12 @@
                    description="Manage views of SMS templates from the Console"/>
             <Scope displayName="SMS Template Edit Feature" name="console:smsTemplates_edit"
                    description="Manage edits of SMS templates from the Console"/>
+            <Scope displayName="SMS Template Update Feature" name="console:smsTemplates_update"
+                   description="Manage updates of SMS templates from the Console"/>
+            <Scope displayName="SMS Template Create Feature" name="console:smsTemplates_create"
+                   description="Manage creates of SMS templates from the Console"/>
+            <Scope displayName="SMS Template Delete Feature" name="console:smsTemplates_delete"
+                   description="Manage deletes of SMS templates from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="SMS Template Management Feature" identifier="console:org:smsTemplates"
@@ -2019,6 +2295,12 @@
                    description="Manage views of SMS templates in the organization from the Console"/>
             <Scope displayName="SMS Template Edit Feature" name="console:org:smsTemplates_edit"
                    description="Manage edits of SMS templates in the organization from the Console"/>
+            <Scope displayName="SMS Template Update Feature" name="console:org:smsTemplates_update"
+                   description="Manage updates of SMS templates in the organization from the Console"/>
+            <Scope displayName="SMS Template Create Feature" name="console:org:smsTemplates_create"
+                   description="Manage creates of SMS templates in the organization from the Console"/>
+            <Scope displayName="SMS Template Delete Feature" name="console:org:smsTemplates_delete"
+                   description="Manage deletes of SMS templates in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Console Setting Management Feature" identifier="console:settings"
@@ -2032,6 +2314,12 @@
                    description="Manage views of console setting from the Console"/>
             <Scope displayName="Console Setting Edit Feature" name="console:settings_edit"
                    description="Manage edits of console setting from the Console"/>
+            <Scope displayName="Console Setting Update Feature" name="console:settings_update"
+                   description="Manage updates of console setting from the Console"/>
+            <Scope displayName="Console Setting Create Feature" name="console:settings_create"
+                   description="Manage creates of console setting from the Console"/>
+            <Scope displayName="Console Setting Delete Feature" name="console:settings_delete"
+                   description="Manage deletes of console setting from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Console Setting Management Feature" identifier="console:org:settings"
@@ -2045,6 +2333,12 @@
                    description="Manage views of console setting in the organization from the Console"/>
             <Scope displayName="Console Setting Edit Feature" name="console:org:settings_edit"
                    description="Manage edits of console setting in the organization from the Console"/>
+            <Scope displayName="Console Setting Update Feature" name="console:org:settings_update"
+                   description="Manage updates of console setting in the organization from the Console"/>
+            <Scope displayName="Console Setting Create Feature" name="console:org:settings_create"
+                   description="Manage creates of console setting in the organization from the Console"/>
+            <Scope displayName="Console Setting Delete Feature" name="console:org:settings_delete"
+                   description="Manage deletes of console setting in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Getting Started Feature" identifier="console:home"
@@ -2058,6 +2352,12 @@
                    description="Manage views of home settings from the Console"/>
             <Scope displayName="Getting Started Edit Feature" name="console:home_edit"
                    description="Manage edits of home settings from the Console"/>
+            <Scope displayName="Getting Started Update Feature" name="console:home_update"
+                   description="Manage updates of home settings from the Console"/>
+            <Scope displayName="Getting Started Create Feature" name="console:home_create"
+                   description="Manage creates of home settings from the Console"/>
+            <Scope displayName="Getting Started Delete Feature" name="console:home_delete"
+                   description="Manage deletes of home settings from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Getting Started Feature" identifier="console:org:home"
@@ -2071,6 +2371,12 @@
                    description="Manage views of home settings in the organization from the Console"/>
             <Scope displayName="Getting Started Edit Feature" name="console:org:home_edit"
                    description="Manage edits of home settings in the organization from the Console"/>
+            <Scope displayName="Getting Started Update Feature" name="console:org:home_update"
+                   description="Manage updates of home settings in the organization from the Console"/>
+            <Scope displayName="Getting Started Create Feature" name="console:org:home_create"
+                   description="Manage creates of home settings in the organization from the Console"/>
+            <Scope displayName="Getting Started Delete Feature" name="console:org:home_delete"
+                   description="Manage deletes of home settings in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Secret Management Feature" identifier="console:secretsManagement"
@@ -2093,6 +2399,12 @@
                    description="Manage views of certificates from the Console"/>
             <Scope displayName="Certificate Edit Feature" name="console:certificates_edit"
                    description="Manage edits of certificates from the Console"/>
+            <Scope displayName="Certificate Update Feature" name="console:certificates_update"
+                   description="Manage updates of certificates from the Console"/>
+            <Scope displayName="Certificate Create Feature" name="console:certificates_create"
+                   description="Manage creates of certificates from the Console"/>
+            <Scope displayName="Certificate Delete Feature" name="console:certificates_delete"
+                   description="Manage deletes of certificates from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Action Management Feature" identifier="console:actions"
@@ -2106,6 +2418,12 @@
                    description="Manage views of actions from the Console"/>
             <Scope displayName="Action Edit Feature" name="console:actions_edit"
                    description="Manage edits of actions from the Console"/>
+            <Scope displayName="Action Update Feature" name="console:actions_update"
+                   description="Manage updates of actions from the Console"/>
+            <Scope displayName="Action Create Feature" name="console:actions_create"
+                   description="Manage creates of actions from the Console"/>
+            <Scope displayName="Action Delete Feature" name="console:actions_delete"
+                   description="Manage deletes of actions from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Action Management Feature" identifier="console:org:actions"
@@ -2119,6 +2437,12 @@
                 description="Manage views of actions from the Console"/>
             <Scope displayName="Action Edit Feature" name="console:org:actions_edit"
                 description="Manage edits of actions from the Console"/>
+            <Scope displayName="Action Update Feature" name="console:org:actions_update"
+                description="Manage updates of actions from the Console"/>
+            <Scope displayName="Action Create Feature" name="console:org:actions_create"
+                description="Manage creates of actions from the Console"/>
+            <Scope displayName="Action Delete Feature" name="console:org:actions_delete"
+                description="Manage deletes of actions from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Webhook Management Feature" identifier="console:webhooks"
@@ -2132,6 +2456,12 @@
                    description="Manage views of webhooks from the Console"/>
             <Scope displayName="Webhook Edit Feature" name="console:webhooks_edit"
                    description="Manage edits of webhooks from the Console"/>
+            <Scope displayName="Webhook Update Feature" name="console:webhooks_update"
+                   description="Manage updates of webhooks from the Console"/>
+            <Scope displayName="Webhook Create Feature" name="console:webhooks_create"
+                   description="Manage creates of webhooks from the Console"/>
+            <Scope displayName="Webhook Delete Feature" name="console:webhooks_delete"
+                   description="Manage deletes of webhooks from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Tenant Management Feature" identifier="console:tenants"
@@ -2145,6 +2475,12 @@
                    description="Manage views of tenants from the Console"/>
             <Scope displayName="Tenants Edit Feature" name="console:tenants_edit"
                    description="Manage edits of tenants from the Console"/>
+            <Scope displayName="Tenants Update Feature" name="console:tenants_update"
+                   description="Manage updates of tenants from the Console"/>
+            <Scope displayName="Tenants Create Feature" name="console:tenants_create"
+                   description="Manage creates of tenants from the Console"/>
+            <Scope displayName="Tenants Delete Feature" name="console:tenants_delete"
+                   description="Manage deletes of tenants from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Consent Management Feature" identifier="console:consents"
@@ -2158,6 +2494,12 @@
                    description="Manage views of consent from the Console"/>
             <Scope displayName="Consent Management Edit Feature" name="console:consents_edit"
                    description="Manage edits of consent from the Console"/>
+            <Scope displayName="Consent Management Update Feature" name="console:consents_update"
+                   description="Manage updates of consent from the Console"/>
+            <Scope displayName="Consent Management Create Feature" name="console:consents_create"
+                   description="Manage creates of consent from the Console"/>
+            <Scope displayName="Consent Management Delete Feature" name="console:consents_delete"
+                   description="Manage deletes of consent from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Consent Management Feature" identifier="console:org:consents"
@@ -2171,6 +2513,12 @@
                    description="Manage views of consent in the organization from the Console"/>
             <Scope displayName="Consent Management Edit Feature" name="console:org:consents_edit"
                    description="Manage edits of consent in the organization from the Console"/>
+            <Scope displayName="Consent Management Update Feature" name="console:org:consents_update"
+                   description="Manage updates of consent in the organization from the Console"/>
+            <Scope displayName="Consent Management Create Feature" name="console:org:consents_create"
+                   description="Manage creates of consent in the organization from the Console"/>
+            <Scope displayName="Consent Management Delete Feature" name="console:org:consents_delete"
+                   description="Manage deletes of consent in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Flows Feature" identifier="console:flows"
@@ -2184,6 +2532,12 @@
                    description="Manage views of flows from the Console"/>
             <Scope displayName="Flows Edit Feature" name="console:flows_edit"
                    description="Manage edits of flows from the Console"/>
+            <Scope displayName="Flows Update Feature" name="console:flows_update"
+                   description="Manage updates of flows from the Console"/>
+            <Scope displayName="Flows Create Feature" name="console:flows_create"
+                   description="Manage creates of flows from the Console"/>
+            <Scope displayName="Flows Delete Feature" name="console:flows_delete"
+                   description="Manage deletes of flows from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Flows Feature" identifier="console:org:flows"
@@ -2197,6 +2551,12 @@
                    description="Manage views of flows from the Console"/>
             <Scope displayName="Flows Edit Feature" name="console:org:flows_edit"
                    description="Manage edits of flows from the Console"/>
+            <Scope displayName="Flows Update Feature" name="console:org:flows_update"
+                   description="Manage updates of flows from the Console"/>
+            <Scope displayName="Flows Create Feature" name="console:org:flows_create"
+                   description="Manage creates of flows from the Console"/>
+            <Scope displayName="Flows Delete Feature" name="console:org:flows_delete"
+                   description="Manage deletes of flows from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Flow Extensions Feature" identifier="console:flowExtensions"
@@ -2210,6 +2570,12 @@
                    description="Manage views of flow extensions from the Console"/>
             <Scope displayName="Flow Extensions Edit Feature" name="console:flowExtensions_edit"
                    description="Manage edits of flow extensions from the Console"/>
+            <Scope displayName="Flow Extensions Update Feature" name="console:flowExtensions_update"
+                   description="Manage updates of flow extensions from the Console"/>
+            <Scope displayName="Flow Extensions Create Feature" name="console:flowExtensions_create"
+                   description="Manage creates of flow extensions from the Console"/>
+            <Scope displayName="Flow Extensions Delete Feature" name="console:flowExtensions_delete"
+                   description="Manage deletes of flow extensions from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Flow Extensions Feature" identifier="console:org:flowExtensions"
@@ -2223,6 +2589,12 @@
                    description="Manage views of flow extensions from the Console"/>
             <Scope displayName="Flow Extensions Edit Feature" name="console:org:flowExtensions_edit"
                    description="Manage edits of flow extensions from the Console"/>
+            <Scope displayName="Flow Extensions Update Feature" name="console:org:flowExtensions_update"
+                   description="Manage updates of flow extensions from the Console"/>
+            <Scope displayName="Flow Extensions Create Feature" name="console:org:flowExtensions_create"
+                   description="Manage creates of flow extensions from the Console"/>
+            <Scope displayName="Flow Extensions Delete Feature" name="console:org:flowExtensions_delete"
+                   description="Manage deletes of flow extensions from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Offline User Onboard API" identifier="/o/api/users/v1/offline-invite-link/"
@@ -2496,6 +2868,12 @@
                    description="Manage views of VC templates from the Console"/>
             <Scope displayName="VC Templates Edit Feature" name="console:vc_templates_edit"
                    description="Manage edits of VC templates from the Console"/>
+            <Scope displayName="VC Templates Update Feature" name="console:vc_templates_update"
+                   description="Manage updates of VC templates from the Console"/>
+            <Scope displayName="VC Templates Create Feature" name="console:vc_templates_create"
+                   description="Manage creates of VC templates from the Console"/>
+            <Scope displayName="VC Templates Delete Feature" name="console:vc_templates_delete"
+                   description="Manage deletes of VC templates from the Console"/>
         </Scopes>
     </APIResource>
 </APIResources>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -1389,6 +1389,12 @@
                                 description="Manage views of applications from the Console"/>
             <Scope displayName="Application Edit Feature" name="console:applications_edit"
                                 description="Manage edits of applications from the Console"/>
+            <Scope displayName="Application Update Feature" name="console:applications_update"
+                                description="Manage updates of applications from the Console"/>
+            <Scope displayName="Application Create Feature" name="console:applications_create"
+                                description="Manage creates of applications from the Console"/>
+            <Scope displayName="Application Delete Feature" name="console:applications_delete"
+                                description="Manage deletes of applications from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Application Management Feature" identifier="console:org:applications"
@@ -1402,6 +1408,12 @@
                    description="Manage views of applications in the organization from the Console"/>
             <Scope displayName="Application Edit Feature" name="console:org:applications_edit"
                    description="Manage edits of applications in the organization from the Console"/>
+            <Scope displayName="Application Update Feature" name="console:org:applications_update"
+                   description="Manage updates of applications in the organization from the Console"/>
+            <Scope displayName="Application Create Feature" name="console:org:applications_create"
+                   description="Manage creates of applications in the organization from the Console"/>
+            <Scope displayName="Application Delete Feature" name="console:org:applications_delete"
+                   description="Manage deletes of applications in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Application Internal API management feature" identifier="console:application_internal_api_management"
@@ -1415,6 +1427,12 @@
                     description="Manage views of application internal APIs from the Console"/>
             <Scope displayName="Application Internal API Management Edit Feature" name="console:application_internal_api_management_edit"
                     description="Manage edits of application internal APIs from the Console"/>
+            <Scope displayName="Application Internal API Management Update Feature" name="console:application_internal_api_management_update"
+                    description="Manage updates of application internal APIs from the Console"/>
+            <Scope displayName="Application Internal API Management Create Feature" name="console:application_internal_api_management_create"
+                    description="Manage creates of application internal APIs from the Console"/>
+            <Scope displayName="Application Internal API Management Delete Feature" name="console:application_internal_api_management_delete"
+                    description="Manage deletes of application internal APIs from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Application Internal API management feature" identifier="console:org:application_internal_api_management"
@@ -1428,6 +1446,12 @@
                     description="Manage views of application internal APIs in the organization from the Console"/>
             <Scope displayName="Application Internal API Management Edit Feature" name="console:org:application_internal_api_management_edit"
                     description="Manage edits of application internal APIs in the organization from the Console"/>
+            <Scope displayName="Application Internal API Management Update Feature" name="console:org:application_internal_api_management_update"
+                    description="Manage updates of application internal APIs in the organization from the Console"/>
+            <Scope displayName="Application Internal API Management Create Feature" name="console:org:application_internal_api_management_create"
+                    description="Manage creates of application internal APIs in the organization from the Console"/>
+            <Scope displayName="Application Internal API Management Delete Feature" name="console:org:application_internal_api_management_delete"
+                    description="Manage deletes of application internal APIs in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Application client secret management feature" identifier="console:application_client_secrets"
@@ -1441,6 +1465,12 @@
                     description="Manage views of application client secrets from the Console"/>
             <Scope displayName="Application Secret Management Edit Feature" name="console:application_client_secrets_edit"
                     description="Manage edits of application client secrets from the Console"/>
+            <Scope displayName="Application Secret Management Update Feature" name="console:application_client_secrets_update"
+                    description="Manage updates of application client secrets from the Console"/>
+            <Scope displayName="Application Secret Management Create Feature" name="console:application_client_secrets_create"
+                    description="Manage creates of application client secrets from the Console"/>
+            <Scope displayName="Application Secret Management Delete Feature" name="console:application_client_secrets_delete"
+                    description="Manage deletes of application client secrets from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Application client secret management feature" identifier="console:org:application_client_secrets"
@@ -1454,6 +1484,12 @@
                     description="Manage views of application client secrets in the organization from the Console"/>
             <Scope displayName="Application Secret Management Edit Feature" name="console:org:application_client_secrets_edit"
                     description="Manage edits of application client secrets in the organization from the Console"/>
+            <Scope displayName="Application Secret Management Update Feature" name="console:org:application_client_secrets_update"
+                    description="Manage updates of application client secrets in the organization from the Console"/>
+            <Scope displayName="Application Secret Management Create Feature" name="console:org:application_client_secrets_create"
+                    description="Manage creates of application client secrets in the organization from the Console"/>
+            <Scope displayName="Application Secret Management Delete Feature" name="console:org:application_client_secrets_delete"
+                    description="Manage deletes of application client secrets in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Application Authentication Script Management Feature" identifier="console:applicationAuthenticationScript"
@@ -1467,6 +1503,12 @@
                    description="Manage views of application authentication script from the Console"/>
             <Scope displayName="Application Authentication Script Edit Feature" name="console:applicationAuthenticationScript_edit"
                    description="Manage edits of application authentication script from the Console"/>
+            <Scope displayName="Application Authentication Script Update Feature" name="console:applicationAuthenticationScript_update"
+                   description="Manage updates of application authentication script from the Console"/>
+            <Scope displayName="Application Authentication Script Create Feature" name="console:applicationAuthenticationScript_create"
+                   description="Manage creates of application authentication script from the Console"/>
+            <Scope displayName="Application Authentication Script Delete Feature" name="console:applicationAuthenticationScript_delete"
+                   description="Manage deletes of application authentication script from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Application Authentication Script Management Feature" identifier="console:org:applicationAuthenticationScript"
@@ -1480,6 +1522,12 @@
                    description="Manage views of application authentication script from the Console"/>
             <Scope displayName="Application Authentication Script Edit Feature" name="console:org:applicationAuthenticationScript_edit"
                    description="Manage edits of application authentication script from the Console"/>
+            <Scope displayName="Application Authentication Script Update Feature" name="console:org:applicationAuthenticationScript_update"
+                   description="Manage updates of application authentication script from the Console"/>
+            <Scope displayName="Application Authentication Script Create Feature" name="console:org:applicationAuthenticationScript_create"
+                   description="Manage creates of application authentication script from the Console"/>
+            <Scope displayName="Application Authentication Script Delete Feature" name="console:org:applicationAuthenticationScript_delete"
+                   description="Manage deletes of application authentication script from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Branding Management Feature" identifier="console:branding"
@@ -1493,6 +1541,12 @@
                     description="Manage views of branding from the Console"/>
             <Scope displayName="Branding Edit Feature" name="console:branding_edit"
                     description="Manage edits of branding from the Console"/>
+            <Scope displayName="Branding Update Feature" name="console:branding_update"
+                    description="Manage updates of branding from the Console"/>
+            <Scope displayName="Branding Create Feature" name="console:branding_create"
+                    description="Manage creates of branding from the Console"/>
+            <Scope displayName="Branding Delete Feature" name="console:branding_delete"
+                    description="Manage deletes of branding from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Branding Management Feature" identifier="console:org:branding"
@@ -1506,6 +1560,12 @@
                    description="Manage views of branding in the organization from the Console"/>
             <Scope displayName="Branding Edit Feature" name="console:org:branding_edit"
                    description="Manage edits of branding in the organization from the Console"/>
+            <Scope displayName="Branding Update Feature" name="console:org:branding_update"
+                   description="Manage updates of branding in the organization from the Console"/>
+            <Scope displayName="Branding Create Feature" name="console:org:branding_create"
+                   description="Manage creates of branding in the organization from the Console"/>
+            <Scope displayName="Branding Delete Feature" name="console:org:branding_delete"
+                   description="Manage deletes of branding in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Attribute Management Feature" identifier="console:attributes"
@@ -1519,6 +1579,12 @@
                     description="Manage views of user attributes from the Console"/>
             <Scope displayName="Attribute Edit Feature" name="console:attributes_edit"
                     description="Manage edits of user attributes from the Console"/>
+            <Scope displayName="Attribute Update Feature" name="console:attributes_update"
+                    description="Manage updates of user attributes from the Console"/>
+            <Scope displayName="Attribute Create Feature" name="console:attributes_create"
+                    description="Manage creates of user attributes from the Console"/>
+            <Scope displayName="Attribute Delete Feature" name="console:attributes_delete"
+                    description="Manage deletes of user attributes from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Attribute Management Feature" identifier="console:org:attributes"
@@ -1532,6 +1598,12 @@
                        description="Manage views of user attributes from the Console"/>
                <Scope displayName="Attribute Edit Feature" name="console:org:attributes_edit"
                        description="Manage edits of user attributes from the Console"/>
+               <Scope displayName="Attribute Update Feature" name="console:org:attributes_update"
+                       description="Manage updates of user attributes from the Console"/>
+               <Scope displayName="Attribute Create Feature" name="console:org:attributes_create"
+                       description="Manage creates of user attributes from the Console"/>
+               <Scope displayName="Attribute Delete Feature" name="console:org:attributes_delete"
+                       description="Manage deletes of user attributes from the Console"/>
            </Scopes>
     </APIResource>
     <APIResource name="User Store Management Feature" identifier="console:userstores"
@@ -1545,6 +1617,12 @@
                     description="Manage user stores from the Console"/>
             <Scope displayName="User Store Edit Feature" name="console:userstores_edit"
                     description="Manage edits of user stores from the Console"/>
+            <Scope displayName="User Store Update Feature" name="console:userstores_update"
+                    description="Manage updates of user stores from the Console"/>
+            <Scope displayName="User Store Create Feature" name="console:userstores_create"
+                    description="Manage creates of user stores from the Console"/>
+            <Scope displayName="User Store Delete Feature" name="console:userstores_delete"
+                    description="Manage deletes of user stores from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Store Management Feature" identifier="console:org:userstores"
@@ -1558,6 +1636,12 @@
                     description="Manage views of user stores from the Console"/>
             <Scope displayName="User Store Edit Feature" name="console:org:userstores_edit"
                     description="Manage edits of user stores from the Console"/>
+            <Scope displayName="User Store Update Feature" name="console:org:userstores_update"
+                    description="Manage updates of user stores from the Console"/>
+            <Scope displayName="User Store Create Feature" name="console:org:userstores_create"
+                    description="Manage creates of user stores from the Console"/>
+            <Scope displayName="User Store Delete Feature" name="console:org:userstores_delete"
+                    description="Manage deletes of user stores from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Group Management Feature" identifier="console:groups"
@@ -1571,6 +1655,12 @@
                     description="Manage views of groups from the Console"/>
             <Scope displayName="Group Edit Feature" name="console:groups_edit"
                     description="Manage edits of groups from the Console"/>
+            <Scope displayName="Group Update Feature" name="console:groups_update"
+                    description="Manage updates of groups from the Console"/>
+            <Scope displayName="Group Create Feature" name="console:groups_create"
+                    description="Manage creates of groups from the Console"/>
+            <Scope displayName="Group Delete Feature" name="console:groups_delete"
+                    description="Manage deletes of groups from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Group Management Feature" identifier="console:org:groups"
@@ -1584,6 +1674,12 @@
                    description="Manage views of groups in the organization from the Console"/>
             <Scope displayName="Group Edit Feature" name="console:org:groups_edit"
                    description="Manage edits of groups in the organization from the Console"/>
+            <Scope displayName="Group Update Feature" name="console:org:groups_update"
+                   description="Manage updates of groups in the organization from the Console"/>
+            <Scope displayName="Group Create Feature" name="console:org:groups_create"
+                   description="Manage creates of groups in the organization from the Console"/>
+            <Scope displayName="Group Delete Feature" name="console:org:groups_delete"
+                   description="Manage deletes of groups in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Identity Provider Management Feature" identifier="console:idps"
@@ -1597,6 +1693,12 @@
                     description="Manage views of identity providers from the Console"/>
             <Scope displayName="Identity Provider Edit Feature" name="console:idps_edit"
                     description="Manage edits of identity providers from the Console"/>
+            <Scope displayName="Identity Provider Update Feature" name="console:idps_update"
+                    description="Manage updates of identity providers from the Console"/>
+            <Scope displayName="Identity Provider Create Feature" name="console:idps_create"
+                    description="Manage creates of identity providers from the Console"/>
+            <Scope displayName="Identity Provider Delete Feature" name="console:idps_delete"
+                    description="Manage deletes of identity providers from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Identity Provider Management Feature" identifier="console:org:idps"
@@ -1610,6 +1712,12 @@
                    description="Manage views of identity providers in the organization from the Console"/>
             <Scope displayName="Identity Provider Edit Feature" name="console:org:idps_edit"
                    description="Manage edits of identity providers in the organization from the Console"/>
+            <Scope displayName="Identity Provider Update Feature" name="console:org:idps_update"
+                   description="Manage updates of identity providers in the organization from the Console"/>
+            <Scope displayName="Identity Provider Create Feature" name="console:org:idps_create"
+                   description="Manage creates of identity providers in the organization from the Console"/>
+            <Scope displayName="Identity Provider Delete Feature" name="console:org:idps_delete"
+                   description="Manage deletes of identity providers in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="API Resource Management Feature" identifier="console:apiResources"
@@ -1623,6 +1731,12 @@
                                 description="Manage views of api resources from the Console"/>
             <Scope displayName="API Resource Edit Feature" name="console:apiResources_edit"
                                 description="Manage edits of api resources from the Console"/>
+            <Scope displayName="API Resource Update Feature" name="console:apiResources_update"
+                                description="Manage updates of api resources from the Console"/>
+            <Scope displayName="API Resource Create Feature" name="console:apiResources_create"
+                                description="Manage creates of api resources from the Console"/>
+            <Scope displayName="API Resource Delete Feature" name="console:apiResources_delete"
+                                description="Manage deletes of api resources from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="API Resource Management Feature" identifier="console:org:apiResources"
@@ -1636,6 +1750,12 @@
                     description="Manage views of api resources in the organization from the Console"/>
             <Scope displayName="API Resource Edit Feature" name="console:org:apiResources_edit"
                     description="Manage edits of api resources in the organization from the Console"/>
+            <Scope displayName="API Resource Update Feature" name="console:org:apiResources_update"
+                    description="Manage updates of api resources in the organization from the Console"/>
+            <Scope displayName="API Resource Create Feature" name="console:org:apiResources_create"
+                    description="Manage creates of api resources in the organization from the Console"/>
+            <Scope displayName="API Resource Delete Feature" name="console:org:apiResources_delete"
+                    description="Manage deletes of api resources in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="OIDC Scope Management Feature" identifier="console:scopes:oidc"
@@ -1649,6 +1769,12 @@
                     description="Manage views of OIDC scopes from the Console"/>
             <Scope displayName="OIDC Scope Edit Feature" name="console:scopes:oidc_edit"
                     description="Manage edits of OIDC scopes from the Console"/>
+            <Scope displayName="OIDC Scope Update Feature" name="console:scopes:oidc_update"
+                    description="Manage updates of OIDC scopes from the Console"/>
+            <Scope displayName="OIDC Scope Create Feature" name="console:scopes:oidc_create"
+                    description="Manage creates of OIDC scopes from the Console"/>
+            <Scope displayName="OIDC Scope Delete Feature" name="console:scopes:oidc_delete"
+                    description="Manage deletes of OIDC scopes from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="OIDC Scope Management Feature" identifier="console:org:scopes:oidc"
@@ -1673,6 +1799,12 @@
                     description="Manage views of login and regisgtration from the Console"/>
             <Scope displayName="Login And Registration Edit Feature" name="console:loginAndRegistration_edit"
                     description="Manage edits of login and regisgtration from the Console"/>
+            <Scope displayName="Login And Registration Update Feature" name="console:loginAndRegistration_update"
+                    description="Manage updates of login and regisgtration from the Console"/>
+            <Scope displayName="Login And Registration Create Feature" name="console:loginAndRegistration_create"
+                    description="Manage creates of login and regisgtration from the Console"/>
+            <Scope displayName="Login And Registration Delete Feature" name="console:loginAndRegistration_delete"
+                    description="Manage deletes of login and regisgtration from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Login And Registration Management Feature" identifier="console:org:loginAndRegistration"
@@ -1686,6 +1818,12 @@
                    description="Manage views of login and registration from the Console"/>
            <Scope displayName="Login And Registration Edit Feature" name="console:org:loginAndRegistration_edit"
                    description="Manage edits of login and registration from the Console"/>
+           <Scope displayName="Login And Registration Update Feature" name="console:org:loginAndRegistration_update"
+                   description="Manage updates of login and registration from the Console"/>
+           <Scope displayName="Login And Registration Create Feature" name="console:org:loginAndRegistration_create"
+                   description="Manage creates of login and registration from the Console"/>
+           <Scope displayName="Login And Registration Delete Feature" name="console:org:loginAndRegistration_delete"
+                   description="Manage deletes of login and registration from the Console"/>
        </Scopes>
    </APIResource>
     <APIResource name="Organization Management Feature" identifier="console:organizations"
@@ -1699,6 +1837,12 @@
                     description="Manage views of organizations from the Console"/>
             <Scope displayName="Organization Edit Feature" name="console:organizations_edit"
                     description="Manage edits of organizations from the Console"/>
+            <Scope displayName="Organization Update Feature" name="console:organizations_update"
+                    description="Manage updates of organizations from the Console"/>
+            <Scope displayName="Organization Create Feature" name="console:organizations_create"
+                    description="Manage creates of organizations from the Console"/>
+            <Scope displayName="Organization Delete Feature" name="console:organizations_delete"
+                    description="Manage deletes of organizations from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Organization Management Feature" identifier="console:org:organizations"
@@ -1712,6 +1856,12 @@
                    description="Manage views of organizations in the organization from the Console"/>
             <Scope displayName="Organization Edit Feature" name="console:org:organizations_edit"
                    description="Manage edits of organizations in the organization from the Console"/>
+            <Scope displayName="Organization Update Feature" name="console:org:organizations_update"
+                   description="Manage updates of organizations in the organization from the Console"/>
+            <Scope displayName="Organization Create Feature" name="console:org:organizations_create"
+                   description="Manage creates of organizations in the organization from the Console"/>
+            <Scope displayName="Organization Delete Feature" name="console:org:organizations_delete"
+                   description="Manage deletes of organizations in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Organization Discovery Management Feature" identifier="console:organizationDiscovery"
@@ -1725,6 +1875,12 @@
                     description="Manage views of organization discovery from the Console"/>
             <Scope displayName="Organization Discovery Edit Feature" name="console:organizationDiscovery_edit"
                     description="Manage edits of organization discovery from the Console"/>
+            <Scope displayName="Organization Discovery Update Feature" name="console:organizationDiscovery_update"
+                    description="Manage updates of organization discovery from the Console"/>
+            <Scope displayName="Organization Discovery Create Feature" name="console:organizationDiscovery_create"
+                    description="Manage creates of organization discovery from the Console"/>
+            <Scope displayName="Organization Discovery Delete Feature" name="console:organizationDiscovery_delete"
+                    description="Manage deletes of organization discovery from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Resident Application Outbound Provisioning Configuration Feature" identifier="console:residentOutboundProvisioning"
@@ -1738,6 +1894,12 @@
                     description="Manage views of resident application outbound provisioning configuration from the Console"/>
             <Scope displayName="Resident Application Outbound Provisioning Edit Feature" name="console:residentOutboundProvisioning_edit"
                     description="Manage edits of resident application outbound provisioning configuration from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning Update Feature" name="console:residentOutboundProvisioning_update"
+                    description="Manage updates of resident application outbound provisioning configuration from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning Create Feature" name="console:residentOutboundProvisioning_create"
+                    description="Manage creates of resident application outbound provisioning configuration from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning Delete Feature" name="console:residentOutboundProvisioning_delete"
+                    description="Manage deletes of resident application outbound provisioning configuration from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Resident Application Outbound Provisioning Configuration Feature" identifier="console:org:residentOutboundProvisioning"
@@ -1751,6 +1913,12 @@
                    description="Manage views of resident application outbound provisioning configuration in the organization from the Console"/>
             <Scope displayName="Resident Application Outbound Provisioning Edit Feature" name="console:org:residentOutboundProvisioning_edit"
                    description="Manage edits of resident application outbound provisioning configuration in the organization from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning Update Feature" name="console:org:residentOutboundProvisioning_update"
+                   description="Manage updates of resident application outbound provisioning configuration in the organization from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning Create Feature" name="console:org:residentOutboundProvisioning_create"
+                   description="Manage creates of resident application outbound provisioning configuration in the organization from the Console"/>
+            <Scope displayName="Resident Application Outbound Provisioning Delete Feature" name="console:org:residentOutboundProvisioning_delete"
+                   description="Manage deletes of resident application outbound provisioning configuration in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Management Feature" identifier="console:roles"
@@ -1764,6 +1932,12 @@
                     description="Manage views of roles from the Console"/>
             <Scope displayName="Role Edit Feature" name="console:roles_edit"
                     description="Manage edits of roles from the Console"/>
+            <Scope displayName="Role Update Feature" name="console:roles_update"
+                    description="Manage updates of roles from the Console"/>
+            <Scope displayName="Role Create Feature" name="console:roles_create"
+                    description="Manage creates of roles from the Console"/>
+            <Scope displayName="Role Delete Feature" name="console:roles_delete"
+                    description="Manage deletes of roles from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Management Feature" identifier="console:org:roles"
@@ -1777,6 +1951,12 @@
                    description="Manage views of roles in the organization from the Console"/>
             <Scope displayName="Role Edit Feature" name="console:org:roles_edit"
                    description="Manage edits of roles in the organization from the Console"/>
+            <Scope displayName="Role Update Feature" name="console:org:roles_update"
+                   description="Manage updates of roles in the organization from the Console"/>
+            <Scope displayName="Role Create Feature" name="console:org:roles_create"
+                   description="Manage creates of roles in the organization from the Console"/>
+            <Scope displayName="Role Delete Feature" name="console:org:roles_delete"
+                   description="Manage deletes of roles in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Assignments Feature" identifier="console:role_assignments"
@@ -1790,6 +1970,12 @@
                 description="Manage views of role assignments from the Console"/>
             <Scope displayName="Role Assignments Edit Feature" name="console:role_assignments_edit"
                 description="Manage edits of role assignments from the Console"/>
+            <Scope displayName="Role Assignments Update Feature" name="console:role_assignments_update"
+                description="Manage updates of role assignments from the Console"/>
+            <Scope displayName="Role Assignments Create Feature" name="console:role_assignments_create"
+                description="Manage creates of role assignments from the Console"/>
+            <Scope displayName="Role Assignments Delete Feature" name="console:role_assignments_delete"
+                description="Manage deletes of role assignments from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Assignments Feature" identifier="console:org:role_assignments"
@@ -1803,6 +1989,12 @@
                 description="Manage views of role assignments from the Console"/>
             <Scope displayName="Role Assignments Edit Feature" name="console:org:role_assignments_edit"
                 description="Manage edits of role assignments from the Console"/>
+            <Scope displayName="Role Assignments Update Feature" name="console:org:role_assignments_update"
+                description="Manage updates of role assignments from the Console"/>
+            <Scope displayName="Role Assignments Create Feature" name="console:org:role_assignments_create"
+                description="Manage creates of role assignments from the Console"/>
+            <Scope displayName="Role Assignments Delete Feature" name="console:org:role_assignments_delete"
+                description="Manage deletes of role assignments from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Permission Assignments Feature" identifier="console:role_permission_assignments"
@@ -1816,6 +2008,12 @@
                 description="Manage views of role permission assignments from the Console"/>
             <Scope displayName="Role Permission Assignments Edit Feature" name="console:role_permission_assignments_edit"
                 description="Manage edits of role permission assignments from the Console"/>
+            <Scope displayName="Role Permission Assignments Update Feature" name="console:role_permission_assignments_update"
+                description="Manage updates of role permission assignments from the Console"/>
+            <Scope displayName="Role Permission Assignments Create Feature" name="console:role_permission_assignments_create"
+                description="Manage creates of role permission assignments from the Console"/>
+            <Scope displayName="Role Permission Assignments Delete Feature" name="console:role_permission_assignments_delete"
+                description="Manage deletes of role permission assignments from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Role Permission Assignments Feature" identifier="console:org:role_permission_assignments"
@@ -1829,6 +2027,12 @@
                 description="Manage views of role permission assignments from the Console"/>
             <Scope displayName="Role Permission Assignments Edit Feature" name="console:org:role_permission_assignments_edit"
                 description="Manage edits of role permission assignments from the Console"/>
+            <Scope displayName="Role Permission Assignments Update Feature" name="console:org:role_permission_assignments_update"
+                description="Manage updates of role permission assignments from the Console"/>
+            <Scope displayName="Role Permission Assignments Create Feature" name="console:org:role_permission_assignments_create"
+                description="Manage creates of role permission assignments from the Console"/>
+            <Scope displayName="Role Permission Assignments Delete Feature" name="console:org:role_permission_assignments_delete"
+                description="Manage deletes of role permission assignments from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Management Feature" identifier="console:users"
@@ -1842,6 +2046,12 @@
                     description="Manage views of users from the Console"/>
             <Scope displayName="User Edit Feature" name="console:users_edit"
                     description="Manage edits of users from the Console"/>
+            <Scope displayName="User Update Feature" name="console:users_update"
+                    description="Manage updates of users from the Console"/>
+            <Scope displayName="User Create Feature" name="console:users_create"
+                    description="Manage creates of users from the Console"/>
+            <Scope displayName="User Delete Feature" name="console:users_delete"
+                    description="Manage deletes of users from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Sharing Management Feature" identifier="console:userSharing"
@@ -1854,6 +2064,12 @@
             <Scope displayName="User Sharing Management View Feature" name="console:userSharing_view"
                    description="View user sharing status from the Console"/>
             <Scope displayName="User Sharing Management Edit Feature" name="console:userSharing_edit"
+                   description="Update user sharing status from the Console"/>
+            <Scope displayName="User Sharing Management Update Feature" name="console:userSharing_update"
+                   description="Update user sharing status from the Console"/>
+            <Scope displayName="User Sharing Management Create Feature" name="console:userSharing_create"
+                   description="Update user sharing status from the Console"/>
+            <Scope displayName="User Sharing Management Delete Feature" name="console:userSharing_delete"
                    description="Update user sharing status from the Console"/>
         </Scopes>
     </APIResource>
@@ -1868,6 +2084,12 @@
                    description="Manage views of users in the organization from the Console"/>
             <Scope displayName="User Edit Feature" name="console:org:users_edit"
                    description="Manage edits of users in the organization from the Console"/>
+            <Scope displayName="User Update Feature" name="console:org:users_update"
+                   description="Manage updates of users in the organization from the Console"/>
+            <Scope displayName="User Create Feature" name="console:org:users_create"
+                   description="Manage creates of users in the organization from the Console"/>
+            <Scope displayName="User Delete Feature" name="console:org:users_delete"
+                   description="Manage deletes of users in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="User Sharing Management Feature" identifier="console:org:userSharing"
@@ -1881,6 +2103,12 @@
                    description="View the shared status of users within the organization from the Console"/>
             <Scope displayName="User Sharing Management Edit Feature" name="console:org:userSharing_edit"
                    description="Manage edits of user sharing status in the organization from the Console"/>
+            <Scope displayName="User Sharing Management Update Feature" name="console:org:userSharing_update"
+                   description="Manage updates of user sharing status in the organization from the Console"/>
+            <Scope displayName="User Sharing Management Create Feature" name="console:org:userSharing_create"
+                   description="Manage creates of user sharing status in the organization from the Console"/>
+            <Scope displayName="User Sharing Management Delete Feature" name="console:org:userSharing_delete"
+                   description="Manage deletes of user sharing status in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Agent Management Feature" identifier="console:agents"
@@ -1894,6 +2122,12 @@
                     description="Manage views of agents from the Console"/>
             <Scope displayName="User Edit Feature" name="console:agents_edit"
                     description="Manage edits of agents from the Console"/>
+            <Scope displayName="User Update Feature" name="console:agents_update"
+                    description="Manage updates of agents from the Console"/>
+            <Scope displayName="User Create Feature" name="console:agents_create"
+                    description="Manage creates of agents from the Console"/>
+            <Scope displayName="User Delete Feature" name="console:agents_delete"
+                    description="Manage deletes of agents from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Server Management Feature" identifier="console:server"
@@ -1916,6 +2150,12 @@
                     description="Manage views of workflows from the Console"/>
             <Scope displayName="Approval Workflow Edit Feature" name="console:approvalWorkflows_edit"
                     description="Manage edits of workflows from the Console"/>
+            <Scope displayName="Approval Workflow Update Feature" name="console:approvalWorkflows_update"
+                    description="Manage updates of workflows from the Console"/>
+            <Scope displayName="Approval Workflow Create Feature" name="console:approvalWorkflows_create"
+                    description="Manage creates of workflows from the Console"/>
+            <Scope displayName="Approval Workflow Delete Feature" name="console:approvalWorkflows_delete"
+                    description="Manage deletes of workflows from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Approval Workflow Management Feature Organization" identifier="console:org:approvalWorkflows"
@@ -1929,6 +2169,12 @@
                     description="Manage views of approval workflows from the Console"/>
             <Scope displayName="Approval Workflow Edit Feature" name="console:org:approvalWorkflows_edit"
                     description="Manage edits of approval workflows from the Console"/>
+            <Scope displayName="Approval Workflow Update Feature" name="console:org:approvalWorkflows_update"
+                    description="Manage updates of approval workflows from the Console"/>
+            <Scope displayName="Approval Workflow Create Feature" name="console:org:approvalWorkflows_create"
+                    description="Manage creates of approval workflows from the Console"/>
+            <Scope displayName="Approval Workflow Delete Feature" name="console:org:approvalWorkflows_delete"
+                    description="Manage deletes of approval workflows from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Workflow Instance Management Feature" identifier="console:workflowInstances"
@@ -1942,6 +2188,12 @@
                     description="Manage views of workflow instances from the Console"/>
             <Scope displayName="Workflow Instance Edit Feature" name="console:workflowInstances_edit"
                     description="Manage edits of workflow instances from the Console"/>
+            <Scope displayName="Workflow Instance Update Feature" name="console:workflowInstances_update"
+                    description="Manage updates of workflow instances from the Console"/>
+            <Scope displayName="Workflow Instance Create Feature" name="console:workflowInstances_create"
+                    description="Manage creates of workflow instances from the Console"/>
+            <Scope displayName="Workflow Instance Delete Feature" name="console:workflowInstances_delete"
+                    description="Manage deletes of workflow instances from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Workflow Instance Management Feature" identifier="console:org:workflowInstances"
@@ -1955,6 +2207,12 @@
                     description="Manage views of workflow instances in the organization from the Console"/>
             <Scope displayName="Workflow Instance Edit Feature" name="console:org:workflowInstances_edit"
                     description="Manage edits of workflow instances in the organization from the Console"/>
+            <Scope displayName="Workflow Instance Update Feature" name="console:org:workflowInstances_update"
+                    description="Manage updates of workflow instances in the organization from the Console"/>
+            <Scope displayName="Workflow Instance Create Feature" name="console:org:workflowInstances_create"
+                    description="Manage creates of workflow instances in the organization from the Console"/>
+            <Scope displayName="Workflow Instance Delete Feature" name="console:org:workflowInstances_delete"
+                    description="Manage deletes of workflow instances in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Notification Channel Management Feature" identifier="console:notificationChannels"
@@ -1968,6 +2226,12 @@
                     description="Manage views of notification channels from the Console"/>
             <Scope displayName="Notification Channel Edit Feature" name="console:notificationChannels_edit"
                     description="Manage edits of notification channels from the Console"/>
+            <Scope displayName="Notification Channel Update Feature" name="console:notificationChannels_update"
+                    description="Manage updates of notification channels from the Console"/>
+            <Scope displayName="Notification Channel Create Feature" name="console:notificationChannels_create"
+                    description="Manage creates of notification channels from the Console"/>
+            <Scope displayName="Notification Channel Delete Feature" name="console:notificationChannels_delete"
+                    description="Manage deletes of notification channels from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Identity Verification Provider Management Feature" identifier="console:idvps"
@@ -1981,6 +2245,12 @@
                     description="Manage views of identity verfication providers from the Console"/>
             <Scope displayName="Identity Verification Provider Edit Feature" name="console:idvps_edit"
                     description="Manage edits of identity verfication providers from the Console"/>
+            <Scope displayName="Identity Verification Provider Update Feature" name="console:idvps_update"
+                    description="Manage updates of identity verfication providers from the Console"/>
+            <Scope displayName="Identity Verification Provider Create Feature" name="console:idvps_create"
+                    description="Manage creates of identity verfication providers from the Console"/>
+            <Scope displayName="Identity Verification Provider Delete Feature" name="console:idvps_delete"
+                    description="Manage deletes of identity verfication providers from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Event Publishing Management Feature" identifier="console:eventPublishing"
@@ -2003,6 +2273,12 @@
                     description="Manage views of email templates from the Console"/>
             <Scope displayName="Email Template Edit Feature" name="console:emailTemplates_edit"
                     description="Manage edits of email templates from the Console"/>
+            <Scope displayName="Email Template Update Feature" name="console:emailTemplates_update"
+                    description="Manage updates of email templates from the Console"/>
+            <Scope displayName="Email Template Create Feature" name="console:emailTemplates_create"
+                    description="Manage creates of email templates from the Console"/>
+            <Scope displayName="Email Template Delete Feature" name="console:emailTemplates_delete"
+                    description="Manage deletes of email templates from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Email Template Management Feature" identifier="console:org:emailTemplates"
@@ -2016,6 +2292,12 @@
                    description="Manage views of email templates in the organization from the Console"/>
             <Scope displayName="Email Template Edit Feature" name="console:org:emailTemplates_edit"
                    description="Manage edits of email templates in the organization from the Console"/>
+            <Scope displayName="Email Template Update Feature" name="console:org:emailTemplates_update"
+                   description="Manage updates of email templates in the organization from the Console"/>
+            <Scope displayName="Email Template Create Feature" name="console:org:emailTemplates_create"
+                   description="Manage creates of email templates in the organization from the Console"/>
+            <Scope displayName="Email Template Delete Feature" name="console:org:emailTemplates_delete"
+                   description="Manage deletes of email templates in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="SMS Template Management Feature" identifier="console:smsTemplates"
@@ -2029,6 +2311,12 @@
                    description="Manage views of SMS templates from the Console"/>
             <Scope displayName="SMS Template Edit Feature" name="console:smsTemplates_edit"
                    description="Manage edits of SMS templates from the Console"/>
+            <Scope displayName="SMS Template Update Feature" name="console:smsTemplates_update"
+                   description="Manage updates of SMS templates from the Console"/>
+            <Scope displayName="SMS Template Create Feature" name="console:smsTemplates_create"
+                   description="Manage creates of SMS templates from the Console"/>
+            <Scope displayName="SMS Template Delete Feature" name="console:smsTemplates_delete"
+                   description="Manage deletes of SMS templates from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="SMS Template Management Feature" identifier="console:org:smsTemplates"
@@ -2042,6 +2330,12 @@
                    description="Manage views of SMS templates in the organization from the Console"/>
             <Scope displayName="SMS Template Edit Feature" name="console:org:smsTemplates_edit"
                    description="Manage edits of SMS templates in the organization from the Console"/>
+            <Scope displayName="SMS Template Update Feature" name="console:org:smsTemplates_update"
+                   description="Manage updates of SMS templates in the organization from the Console"/>
+            <Scope displayName="SMS Template Create Feature" name="console:org:smsTemplates_create"
+                   description="Manage creates of SMS templates in the organization from the Console"/>
+            <Scope displayName="SMS Template Delete Feature" name="console:org:smsTemplates_delete"
+                   description="Manage deletes of SMS templates in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Console Setting Management Feature" identifier="console:settings"
@@ -2055,6 +2349,12 @@
                     description="Manage views of console setting from the Console"/>
             <Scope displayName="Console Setting Edit Feature" name="console:settings_edit"
                     description="Manage edits of console setting from the Console"/>
+            <Scope displayName="Console Setting Update Feature" name="console:settings_update"
+                    description="Manage updates of console setting from the Console"/>
+            <Scope displayName="Console Setting Create Feature" name="console:settings_create"
+                    description="Manage creates of console setting from the Console"/>
+            <Scope displayName="Console Setting Delete Feature" name="console:settings_delete"
+                    description="Manage deletes of console setting from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Console Setting Management Feature" identifier="console:org:settings"
@@ -2068,6 +2368,12 @@
                    description="Manage views of console setting in the organization from the Console"/>
             <Scope displayName="Console Setting Edit Feature" name="console:org:settings_edit"
                    description="Manage edits of console setting in the organization from the Console"/>
+            <Scope displayName="Console Setting Update Feature" name="console:org:settings_update"
+                   description="Manage updates of console setting in the organization from the Console"/>
+            <Scope displayName="Console Setting Create Feature" name="console:org:settings_create"
+                   description="Manage creates of console setting in the organization from the Console"/>
+            <Scope displayName="Console Setting Delete Feature" name="console:org:settings_delete"
+                   description="Manage deletes of console setting in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Getting Started Feature" identifier="console:home"
@@ -2081,6 +2387,12 @@
                     description="Manage views of home settings from the Console"/>
             <Scope displayName="Getting Started Edit Feature" name="console:home_edit"
                     description="Manage edits of home settings from the Console"/>
+            <Scope displayName="Getting Started Update Feature" name="console:home_update"
+                    description="Manage updates of home settings from the Console"/>
+            <Scope displayName="Getting Started Create Feature" name="console:home_create"
+                    description="Manage creates of home settings from the Console"/>
+            <Scope displayName="Getting Started Delete Feature" name="console:home_delete"
+                    description="Manage deletes of home settings from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Getting Started Feature" identifier="console:org:home"
@@ -2094,6 +2406,12 @@
                    description="Manage views of home settings in the organization from the Console"/>
             <Scope displayName="Getting Started Edit Feature" name="console:org:home_edit"
                    description="Manage edits of home settings in the organization from the Console"/>
+            <Scope displayName="Getting Started Update Feature" name="console:org:home_update"
+                   description="Manage updates of home settings in the organization from the Console"/>
+            <Scope displayName="Getting Started Create Feature" name="console:org:home_create"
+                   description="Manage creates of home settings in the organization from the Console"/>
+            <Scope displayName="Getting Started Delete Feature" name="console:org:home_delete"
+                   description="Manage deletes of home settings in the organization from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Secret Management Feature" identifier="console:secretsManagement"
@@ -2116,6 +2434,12 @@
                     description="Manage views of certificates from the Console"/>
             <Scope displayName="Certificate Edit Feature" name="console:certificates_edit"
                     description="Manage edits of certificates from the Console"/>
+            <Scope displayName="Certificate Update Feature" name="console:certificates_update"
+                    description="Manage updates of certificates from the Console"/>
+            <Scope displayName="Certificate Create Feature" name="console:certificates_create"
+                    description="Manage creates of certificates from the Console"/>
+            <Scope displayName="Certificate Delete Feature" name="console:certificates_delete"
+                    description="Manage deletes of certificates from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Action Management Feature" identifier="console:actions"
@@ -2129,6 +2453,12 @@
                     description="Manage views of actions from the Console"/>
             <Scope displayName="Action Edit Feature" name="console:actions_edit"
                     description="Manage edits of actions from the Console"/>
+            <Scope displayName="Action Update Feature" name="console:actions_update"
+                    description="Manage updates of actions from the Console"/>
+            <Scope displayName="Action Create Feature" name="console:actions_create"
+                    description="Manage creates of actions from the Console"/>
+            <Scope displayName="Action Delete Feature" name="console:actions_delete"
+                    description="Manage deletes of actions from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Action Management Feature" identifier="console:org:actions"
@@ -2142,6 +2472,12 @@
                 description="Manage views of actions from the Console"/>
             <Scope displayName="Action Edit Feature" name="console:org:actions_edit"
                 description="Manage edits of actions from the Console"/>
+            <Scope displayName="Action Update Feature" name="console:org:actions_update"
+                description="Manage updates of actions from the Console"/>
+            <Scope displayName="Action Create Feature" name="console:org:actions_create"
+                description="Manage creates of actions from the Console"/>
+            <Scope displayName="Action Delete Feature" name="console:org:actions_delete"
+                description="Manage deletes of actions from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Webhook Management Feature" identifier="console:webhooks"
@@ -2155,6 +2491,12 @@
                    description="Manage views of webhooks from the Console"/>
             <Scope displayName="Webhook Edit Feature" name="console:webhooks_edit"
                    description="Manage edits of webhooks from the Console"/>
+            <Scope displayName="Webhook Update Feature" name="console:webhooks_update"
+                   description="Manage updates of webhooks from the Console"/>
+            <Scope displayName="Webhook Create Feature" name="console:webhooks_create"
+                   description="Manage creates of webhooks from the Console"/>
+            <Scope displayName="Webhook Delete Feature" name="console:webhooks_delete"
+                   description="Manage deletes of webhooks from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Tenant Management Feature" identifier="console:tenants"
@@ -2168,6 +2510,12 @@
                    description="Manage views of tenants from the Console"/>
             <Scope displayName="Tenants Edit Feature" name="console:tenants_edit"
                    description="Manage edits of tenants from the Console"/>
+            <Scope displayName="Tenants Update Feature" name="console:tenants_update"
+                   description="Manage updates of tenants from the Console"/>
+            <Scope displayName="Tenants Create Feature" name="console:tenants_create"
+                   description="Manage creates of tenants from the Console"/>
+            <Scope displayName="Tenants Delete Feature" name="console:tenants_delete"
+                   description="Manage deletes of tenants from the Console"/>
         </Scopes>
     </APIResource>
     {% if consent_mgt.enable_v2_api %}
@@ -2182,6 +2530,12 @@
                    description="Manage views of consent from the Console"/>
             <Scope displayName="Consent Management Edit Feature" name="console:consents_edit"
                    description="Manage edits of consent from the Console"/>
+            <Scope displayName="Consent Management Update Feature" name="console:consents_update"
+                   description="Manage updates of consent from the Console"/>
+            <Scope displayName="Consent Management Create Feature" name="console:consents_create"
+                   description="Manage creates of consent from the Console"/>
+            <Scope displayName="Consent Management Delete Feature" name="console:consents_delete"
+                   description="Manage deletes of consent from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Consent Management Feature" identifier="console:org:consents"
@@ -2195,6 +2549,12 @@
                    description="Manage views of consent in the organization from the Console"/>
             <Scope displayName="Consent Management Edit Feature" name="console:org:consents_edit"
                    description="Manage edits of consent in the organization from the Console"/>
+            <Scope displayName="Consent Management Update Feature" name="console:org:consents_update"
+                   description="Manage updates of consent in the organization from the Console"/>
+            <Scope displayName="Consent Management Create Feature" name="console:org:consents_create"
+                   description="Manage creates of consent in the organization from the Console"/>
+            <Scope displayName="Consent Management Delete Feature" name="console:org:consents_delete"
+                   description="Manage deletes of consent in the organization from the Console"/>
         </Scopes>
     </APIResource>
     {% endif %}
@@ -2209,6 +2569,12 @@
                    description="Manage views of flows from the Console"/>
             <Scope displayName="Flows Edit Feature" name="console:flows_edit"
                    description="Manage edits of flows from the Console"/>
+            <Scope displayName="Flows Update Feature" name="console:flows_update"
+                   description="Manage updates of flows from the Console"/>
+            <Scope displayName="Flows Create Feature" name="console:flows_create"
+                   description="Manage creates of flows from the Console"/>
+            <Scope displayName="Flows Delete Feature" name="console:flows_delete"
+                   description="Manage deletes of flows from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Flows Feature" identifier="console:org:flows"
@@ -2222,6 +2588,12 @@
                    description="Manage views of flows from the Console"/>
             <Scope displayName="Flows Edit Feature" name="console:org:flows_edit"
                    description="Manage edits of flows from the Console"/>
+            <Scope displayName="Flows Update Feature" name="console:org:flows_update"
+                   description="Manage updates of flows from the Console"/>
+            <Scope displayName="Flows Create Feature" name="console:org:flows_create"
+                   description="Manage creates of flows from the Console"/>
+            <Scope displayName="Flows Delete Feature" name="console:org:flows_delete"
+                   description="Manage deletes of flows from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Flow Extensions Feature" identifier="console:flowExtensions"
@@ -2235,6 +2607,12 @@
                    description="Manage views of flow extensions from the Console"/>
             <Scope displayName="Flow Extensions Edit Feature" name="console:flowExtensions_edit"
                    description="Manage edits of flow extensions from the Console"/>
+            <Scope displayName="Flow Extensions Update Feature" name="console:flowExtensions_update"
+                   description="Manage updates of flow extensions from the Console"/>
+            <Scope displayName="Flow Extensions Create Feature" name="console:flowExtensions_create"
+                   description="Manage creates of flow extensions from the Console"/>
+            <Scope displayName="Flow Extensions Delete Feature" name="console:flowExtensions_delete"
+                   description="Manage deletes of flow extensions from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Flow Extensions Feature" identifier="console:org:flowExtensions"
@@ -2248,6 +2626,12 @@
                    description="Manage views of flow extensions from the Console"/>
             <Scope displayName="Flow Extensions Edit Feature" name="console:org:flowExtensions_edit"
                    description="Manage edits of flow extensions from the Console"/>
+            <Scope displayName="Flow Extensions Update Feature" name="console:org:flowExtensions_update"
+                   description="Manage updates of flow extensions from the Console"/>
+            <Scope displayName="Flow Extensions Create Feature" name="console:org:flowExtensions_create"
+                   description="Manage creates of flow extensions from the Console"/>
+            <Scope displayName="Flow Extensions Delete Feature" name="console:org:flowExtensions_delete"
+                   description="Manage deletes of flow extensions from the Console"/>
         </Scopes>
     </APIResource>
     <APIResource name="Offline User Onboard API" identifier="/o/api/users/v1/offline-invite-link/"
@@ -2553,6 +2937,12 @@
                                    description="Manage views of VC templates from the Console"/>
             <Scope displayName="VC Templates Edit Feature" name="console:vc_templates_edit"
                                    description="Manage edits of VC templates from the Console"/>
+            <Scope displayName="VC Templates Update Feature" name="console:vc_templates_update"
+                                   description="Manage updates of VC templates from the Console"/>
+            <Scope displayName="VC Templates Create Feature" name="console:vc_templates_create"
+                                   description="Manage creates of VC templates from the Console"/>
+            <Scope displayName="VC Templates Delete Feature" name="console:vc_templates_delete"
+                                   description="Manage deletes of VC templates from the Console"/>
         </Scopes>
     </APIResource>
 </APIResources>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2981,6 +2981,11 @@
         </Username>
     </InputValidation>
 
+    <!-- Console settings -->
+    <ConsoleSettings>
+        <UseGranularConsolePermissions>true</UseGranularConsolePermissions>
+    </ConsoleSettings>
+
     <!-- Configuration settings for the API responses. -->
     <APIResponse>
         <!-- When set to true, this enables sending a specific authentication failure message in the API response

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -5085,6 +5085,11 @@
         <Origin>{{console.origin}}</Origin>
     </Console>
 
+    <!-- Console settings -->
+    <ConsoleSettings>
+        <UseGranularConsolePermissions>{{console.console_settings.use_granular_console_permissions | default('true')}}</UseGranularConsolePermissions>
+    </ConsoleSettings>
+
     <!-- MyAccount Application configurations -->
     <MyAccount>
         <CallbackURL>{{myaccount.callback_url}}</CallbackURL>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -2047,6 +2047,7 @@
     "internal_validation_rule_mgt_update"
   ],
   "console.console_settings.enabled": true,
+  "console.console_settings.use_granular_console_permissions": true,
   "console.console_settings.disabled_features": [
     "consoleSettings.invitedExternalAdmins",
     "consoleSettings.privilegedUsers"

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -340,7 +340,13 @@
       "enhanced_organization_authentication.enabled_by_default_for_new_apps" : false,
       "saas.enable_app_creation": true,
       "saas.enable_cross_tenant_operations": false,
-      "identity_mgt.inactive_account_suspension.revoke_grant_cache_upon_login": true
+      "identity_mgt.inactive_account_suspension.revoke_grant_cache_upon_login": true,
+      "console.console_settings.use_granular_console_permissions": false,
+      "console.console_settings.disabled_features": [
+        "consoleSettings.invitedExternalAdmins",
+        "consoleSettings.privilegedUsers",
+        "consoleSettings.useGranularConsolePermissions"
+      ]
     },
     "IS_7.1.0": {
       "oauth.dcrm.return_null_fields_in_response": true,
@@ -457,7 +463,6 @@
         "https://schemas.identity.wso2.org/events/consent-purpose",
         "https://schemas.identity.wso2.org/events/consent"
       ],
-      "saas.enable_cross_tenant_operations": false,
       "console.console_settings.use_granular_console_permissions": false,
       "console.console_settings.disabled_features": [
         "consoleSettings.invitedExternalAdmins",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -409,7 +409,13 @@
       "actions.action_request.case_insensitive_header_filtering": false,
       "enhanced_organization_authentication.enabled_by_default_for_new_apps" : false,
       "saas.enable_app_creation": true,
-      "saas.enable_cross_tenant_operations": false
+      "saas.enable_cross_tenant_operations": false,
+      "console.console_settings.use_granular_console_permissions": false,
+      "console.console_settings.disabled_features": [
+        "consoleSettings.invitedExternalAdmins",
+        "consoleSettings.privilegedUsers",
+        "consoleSettings.useGranularConsolePermissions"
+      ]
     },
     "IS_7.2.0": {
       "authenticationendpoint.authenticator_validation.enabled": false,
@@ -450,6 +456,13 @@
       "webhooks.event_profiles.disabled_channels": [
         "https://schemas.identity.wso2.org/events/consent-purpose",
         "https://schemas.identity.wso2.org/events/consent"
+      ],
+      "saas.enable_cross_tenant_operations": false,
+      "console.console_settings.use_granular_console_permissions": false,
+      "console.console_settings.disabled_features": [
+        "consoleSettings.invitedExternalAdmins",
+        "consoleSettings.privilegedUsers",
+        "consoleSettings.useGranularConsolePermissions"
       ]
     }
   }


### PR DESCRIPTION
## Purpose

Resolve console feature action scopes (e.g. `console:applications_edit`, `console:applications_create`) as **holders** when they appear inside another collection's `<Read>` / `<Create>` / `<Update>` / `<Delete>` block. The holder is replaced by the leaf scopes from the matching action block of the owning collection, and the holder name itself is dropped from the bucket — so the `apiResources` payload of `/api-resource-collections/{id}` surfaces the underlying internal scopes (and their owning API resource) instead of an opaque console scope that no API resource owns.

## Changes

- **Parser** (`APIResourceCollectionMgtConfigBuilder`): pre-build a `holder → leaf scopes` map from each collection's `<Feature>` block + matching action block. `_view` → owner Read, `_create`/`_update`/`_delete` → matching owner block, `_edit` → owner Create + Update + Delete (legacy coarse write). Resolution is recursive with cycle protection + memoisation so an owner's action block can itself reference another holder.
- **`api-resource-collection.xml.j2`**: declare `_create`/`_update`/`_delete` siblings next to every `_edit` holder inside non-`<Feature>` blocks (8 sites: `applicationAuthenticationScript`, `applicationClientSecretManagement`, `applicationInternalAPIAuthorization`, `userSharingV2`, and the four `org_*` counterparts).
- **Tests**: 7 new cases in `APIResourceCollectionMgtConfigBuilderTest` — update/view/edit holder resolution, write-bucket propagation, transitive recursion, literal scopes preserved alongside holders, owner collection unaffected.

## Related Issues
- https://github.com/wso2/product-is/issues/27974
