### PR TITLE
Fix admin role not displayed when admin logs in with different username casing

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/java/org/wso2/carbon/user/mgt/ui/Util.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/java/org/wso2/carbon/user/mgt/ui/Util.java
@@ -466,6 +466,42 @@ public class Util {
         return UserCoreUtil.removeDomainFromName(currentUsername).equalsIgnoreCase(username);
     }
 
+    /**
+     * Returns true if the given logged-in user is the configured admin user, honoring the
+     * case-sensitivity of the admin user's user store. Case is ignored only for case-insensitive
+     * stores (where login itself is case-insensitive, so "admin" and "ADMIN" are the same account);
+     * on case-sensitive stores an exact match is required so that distinct accounts differing only
+     * by case (e.g. "admin" vs "Admin") are never treated as the same admin user.
+     *
+     * @param currentUsername the logged-in user (may carry a domain prefix)
+     * @param userRealmInfo   the user realm info holding the configured admin user and store info
+     * @return true if currentUsername resolves to the configured admin user
+     */
+    public static boolean isRealmAdminUser(String currentUsername, UserRealmInfo userRealmInfo) {
+
+        if (currentUsername == null || userRealmInfo == null || userRealmInfo.getAdminUser() == null) {
+            return false;
+        }
+
+        String adminUser = userRealmInfo.getAdminUser();
+        UserStoreInfo storeInfo = getUserStoreInfoForUser(adminUser, userRealmInfo);
+        // Fall back to case-sensitive (no over-grant) when the store cannot be resolved.
+        boolean caseSensitive = storeInfo == null || storeInfo.getCaseSensitiveUsername();
+
+        if (adminUser.contains(UserCoreConstants.DOMAIN_SEPARATOR)) {
+            return caseSensitive ? currentUsername.equals(adminUser) : currentUsername.equalsIgnoreCase(adminUser);
+        }
+
+        if (currentUsername.contains(UserCoreConstants.DOMAIN_SEPARATOR)
+                && !UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME
+                .equalsIgnoreCase(UserCoreUtil.extractDomainFromName(currentUsername))) {
+            return false;
+        }
+
+        String bareName = UserCoreUtil.removeDomainFromName(currentUsername);
+        return caseSensitive ? bareName.equals(adminUser) : bareName.equalsIgnoreCase(adminUser);
+    }
+
     private static boolean isUsernameEncryptionEnabled() throws CarbonException, UserStoreException {
         return Boolean.parseBoolean(AdminServicesUtil.getUserRealm().getRealmConfiguration()
                 .getRealmProperties().get(ENCRYPT_USERNAME_IN_URL));

--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/java/org/wso2/carbon/user/mgt/ui/Util.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/java/org/wso2/carbon/user/mgt/ui/Util.java
@@ -152,6 +152,9 @@ public class Util {
 
         if (userName != null && userName.contains(UserAdminUIConstants.DOMAIN_SEPARATOR)) {
             String domainName = userName.substring(0, userName.indexOf(UserAdminUIConstants.DOMAIN_SEPARATOR));
+            if (realmInfo.getUserStoresInfo() == null) {
+                return null;
+            }
             for (UserStoreInfo info : realmInfo.getUserStoresInfo()) {
                 if (domainName != null && domainName.equalsIgnoreCase(info.getDomainName())) {
                     return info;

--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/role/role-mgt.jsp
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/role/role-mgt.jsp
@@ -160,8 +160,8 @@
     session.setAttribute(UserAdminUIConstants.ROLE_LIST_FILTER, filter.trim());
     session.setAttribute(UserAdminUIConstants.ROLE_COUNT_FILTER, countFilter.trim());
 
-    String currentUser = (String) session.getAttribute("logged-user");
-    currentUser = UserCoreUtil.removeDomainFromName(currentUser);
+    String loggedInUser = (String) session.getAttribute("logged-user");
+    String currentUser = UserCoreUtil.removeDomainFromName(loggedInUser);
     userRealmInfo = (UserRealmInfo) session.getAttribute(UserAdminUIConstants.USER_STORE_INFO);
     if (userRealmInfo != null) {
         multipleUserStores = userRealmInfo.getMultipleUserStore();
@@ -578,7 +578,7 @@
                                     continue;
                                 }
                                 if (userRealmInfo.getAdminRole().equals(data.getItemName()) &&
-                                        !Util.isRealmAdminUser(currentUser, userRealmInfo)) {
+                                        !Util.isRealmAdminUser(loggedInUser, userRealmInfo)) {
                                     continue;
                                 }
                                 String roleName = data.getItemName();

--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/role/role-mgt.jsp
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/role/role-mgt.jsp
@@ -578,7 +578,7 @@
                                     continue;
                                 }
                                 if (userRealmInfo.getAdminRole().equals(data.getItemName()) &&
-                                        !userRealmInfo.getAdminUser().equals(currentUser)) {
+                                        !Util.isRealmAdminUser(currentUser, userRealmInfo)) {
                                     continue;
                                 }
                                 String roleName = data.getItemName();

--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/user/add-step2.jsp
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/user/add-step2.jsp
@@ -329,7 +329,7 @@
                                                         String doEdit = "";
                                                         if (name.getItemName()
                                                                 .equals(CarbonConstants.REGISTRY_ANONNYMOUS_ROLE_NAME) ||
-                                                                (!currentUser.equals(userRealmInfo.getAdminUser()) && name
+                                                                (!Util.isRealmAdminUser(currentUser, userRealmInfo) && name
                                                                         .getItemName().equals(userRealmInfo.getAdminRole()))) {
                                                             continue;
                                                         } else if (userRealmInfo.getEveryOneRole()

--- a/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/user/edit-user-roles.jsp
+++ b/components/user-mgt/org.wso2.carbon.user.mgt.ui/src/main/resources/web/user/edit-user-roles.jsp
@@ -461,8 +461,8 @@
                                             if (name != null) {
                                                 String doEdit = "";
                                                 String doCheck = "";
-                                                if (name.getItemName().equals(CarbonConstants.REGISTRY_ANONNYMOUS_ROLE_NAME)||(!currentUser
-                                                        .equals(userRealmInfo.getAdminUser()) && name.getItemName()
+                                                if (name.getItemName().equals(CarbonConstants.REGISTRY_ANONNYMOUS_ROLE_NAME)||(!Util
+                                                        .isRealmAdminUser(currentUser, userRealmInfo) && name.getItemName()
                                                         .equals(userRealmInfo.getAdminRole()))) {
                                                     continue;
                                                 } else if (!name.getEditable()) {


### PR DESCRIPTION
 ## Purpose

Public: https://github.com/wso2/product-is/issues/27862

  Fixes the management-console issue where the **admin role** is not displayed when a
  tenant/super-tenant admin logs in using a different letter casing than the stored username
  (e.g. created as `admin`, logs in as `ADMIN`/`Admin`). Login succeeds (auth is case-insensitive
  on case-insensitive stores), but the role was hidden in:

  - **Roles → List**
  - **Users → List → Assign Roles**
  - **Users → Add User → Assign Roles** (step 2)

  Resolves wso2/product-is#27862

  ## Root cause

  These JSPs decide whether the logged-in user is the configured admin user with a case-sensitive
  `String.equals()` comparison of `userRealmInfo.getAdminUser()` against the logged-in user. When the
  login casing differs, the comparison fails, so the admin-role row is skipped (`continue`) and never
  rendered. The backend (`UserRealmProxy`) already compares these case-insensitively, so the UI was
  the only inconsistent layer.

  ## Fix
  
  Introduced `Util.isAdminUser(currentUsername, userRealmInfo)` and use it in the three role-listing
  JSPs instead of the raw `equals()` check. The helper:

  - Resolves the admin user's user store and honors its case-sensitivity flag
    (`UserStoreInfo.getCaseSensitiveUsername()`).
  - **Ignores case only for case-insensitive stores** (where login itself is case-insensitive, so
    `admin` and `ADMIN` are the same account).
  - **Requires an exact match on case-sensitive stores**, so two distinct accounts differing only by
    case (e.g. `admin` vs `Admin`) are never conflated — avoids granting default-admin treatment to a
    different user.
  - Preserves PRIMARY domain-prefix normalization (mirrors `Util.isCurrentUser`), is null-safe, and
    falls back to case-sensitive (no over-grant) when the store cannot be resolved.

  This keeps the existing protection that only the configured admin user can see/manage the admin
  role — it only corrects how that single user is identified across username casing.

  ## Files changed

  - `org.wso2.carbon.user.mgt.ui/.../ui/Util.java` — new `isAdminUser(...)` helper
  - `.../web/role/role-mgt.jsp`
  - `.../web/user/edit-user-roles.jsp`
  - `.../web/user/add-step2.jsp`
