### PR TITLE
Add encryption support for flow extensions

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/FlowExtensionConstants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/FlowExtensionConstants.java
@@ -24,7 +24,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Constants for the In-Flow Extension executor pipeline.
+ * Constants for the Flow Extension executor pipeline.
  */
 public class FlowExtensionConstants {
 
@@ -37,37 +37,13 @@ public class FlowExtensionConstants {
     public static final String MODIFY_PATHS_KEY = "modifyPaths";
     public static final String PENDING_CLAIMS_KEY = "pendingClaims";
     public static final String PENDING_CREDENTIALS_KEY = "pendingCredentials";
-    public static final String PENDING_PROPERTIES_KEY = "pendingProperties";
     public static final String PENDING_REDIRECT_URL_KEY = "pendingRedirectUrl";
-
-    public static final String FAILURE_TYPE_KEY = "failureType";
-    public static final String FLOW_EXTENSION_FAILURE_TYPE = "FLOW_EXTENSION_FAILURE";
-    public static final String FAILURE_MESSAGE_KEY = "failureMessage";
-    public static final String FAILURE_DESCRIPTION_KEY = "failureDescription";
 
     public static final String ACTION_ID_METADATA_KEY = "actionId";
 
     /**
-     * Centralized constants for the Flow Extension framework, covering execution keys,
-     * error messages, handover policies, and JSON pointer style context paths.
-     */
-    public static final class ResponseContext {
-
-        public static final String FAILED_OPERATIONS_KEY = "failedOperations";
-        public static final String TOTAL_OPERATIONS_KEY = "totalOperations";
-
-        public static final String OP_PATH_KEY = "path";
-        public static final String OP_TYPE_KEY = "op";
-        public static final String OP_MESSAGE_KEY = "message";
-
-        private ResponseContext() {
-
-        }
-    }
-
-    /**
      * User-facing error message / description pairs returned via {@code ExecutorResponse}
-     * when In-Flow Extension execution fails or is unavailable.
+     * when Flow Extension execution fails or is unavailable.
      */
     public static final class ErrorMessages {
 
@@ -106,25 +82,6 @@ public class FlowExtensionConstants {
         }
     }
 
-    public static final class Log {
-
-        public static final String COMPONENT_ID = "inflow-extension";
-
-        private Log() {
-
-        }
-
-        public static final class ActionIDs {
-
-            public static final String EXECUTE = "execute-inflow-extension";
-            public static final String PROCESS_RESPONSE = "process-inflow-extension-response";
-
-            private ActionIDs() {
-
-            }
-        }
-    }
-
     /**
      * Default handover policy: which {@code FlowExecutionContext} and {@code FlowUser} fields
      * are forwarded to the action framework. Serves as the documented defaults for the
@@ -132,9 +89,6 @@ public class FlowExtensionConstants {
      */
     public static final class HandoverPolicy {
 
-        public static final String ATTR_FLOW_USER = "flowUser";
-        public static final String ATTR_CONTEXT_IDENTIFIER = "contextIdentifier";
-        public static final String ATTR_USER_CREDENTIALS = "userCredentials";
         public static final Set<String> INCLUDED_ATTRIBUTES = Collections.unmodifiableSet(
                 new HashSet<>(Arrays.asList(
                         "contextIdentifier",
@@ -161,7 +115,7 @@ public class FlowExtensionConstants {
     }
 
     /**
-     * Constants used when building the controlled In-Flow Extension context tree returned
+     * Constants used when building the controlled Flow Extension context tree returned
      * by the metadata endpoint.
      */
     public static final class ContextTree {
@@ -175,7 +129,6 @@ public class FlowExtensionConstants {
         public static final String NODE_OBJECT = "OBJECT";
         public static final String NODE_LEAF = "LEAF";
         public static final String NODE_MAP = "MAP";
-        public static final String NODE_COMPLEX_MAP = "COMPLEX_MAP";
 
         public static final String OP_EXPOSE = "EXPOSE";
         public static final String OP_MODIFY = "MODIFY";
@@ -187,19 +140,33 @@ public class FlowExtensionConstants {
     }
 
     /**
-     * JSON-pointer-style path constants for the In-Flow Extension context tree.
+     * Wire-format constants for the typed user credential object exposed on the read side.
+     * An unencrypted credential is sent as {@code {"type": "PLAIN_TEXT", "value": "<secret>"}};
+     * an encrypted credential is the JWE compact string of that same object.
+     */
+    public static final class Credentials {
+
+        public static final String TYPE_KEY = "type";
+        public static final String VALUE_KEY = "value";
+        public static final String TYPE_PLAIN_TEXT = "PLAIN_TEXT";
+
+        private Credentials() {
+
+        }
+    }
+
+    /**
+     * JSON-pointer-style path constants for the Flow Extension context tree.
      */
     public static final class FlowContextPaths {
 
         public static final String USER_PREFIX = "/user/";
         public static final String USER_ID_PATH = "/user/id";
+        public static final String USER_USERNAME_PATH = "/user/username";
         public static final String USER_STORE_DOMAIN_PATH = "/user/userStoreDomain";
-        public static final String USER_CLAIMS_PATH_PREFIX = "/user/claims/";
         public static final String USER_CLAIMS_SELECTOR_PREFIX = "/user/claims[uri=";
         public static final String USER_CLAIMS_SELECTOR_SUFFIX = "]";
         public static final String USER_CREDENTIALS_PATH_PREFIX = "/user/credentials/";
-
-        public static final String PROPERTIES_PATH_PREFIX = "/properties/";
 
         public static final String FLOW_PREFIX = "/flow/";
         public static final String FLOW_TYPE_PATH = "/flow/flowType";

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionExecutor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionExecutor.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.flow.extension.executor;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.action.execution.api.constant.ActionExecutionLogConstants;
 import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionException;
 import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionRequestBuilderException;
 import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionResponseProcessorException;
@@ -51,9 +52,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Executes In-Flow Extension actions during flow execution by delegating to
+ * Executes Flow Extension actions during flow execution by delegating to
  * {@link ActionExecutorService} and mapping the result to an {@link ExecutorResponse}.
- * On success, pending context updates (claims, credentials, properties) are forwarded
+ * On success, pending context updates (claims, credentials) are forwarded
  * to the flow engine through the response object.
  */
 public class FlowExtensionExecutor implements Executor {
@@ -62,6 +63,7 @@ public class FlowExtensionExecutor implements Executor {
     private static final String EXECUTOR_NAME = "FlowExtensionExecutor";
     private static final String CONFIG_PARAM_ACTION_TYPE = "actionType";
     private static final String CONFIG_PARAM_ACTION_ID = "actionId";
+
     @Override
     public String getName() {
 
@@ -73,7 +75,7 @@ public class FlowExtensionExecutor implements Executor {
 
         String actionId = getMetadataValue(context, FlowExtensionConstants.ACTION_ID_METADATA_KEY);
         if (actionId == null || actionId.isEmpty()) {
-            triggerDiagnosticFailure(FlowExtensionConstants.Log.ActionIDs.EXECUTE, null,
+            triggerDiagnosticFailure(ActionExecutionLogConstants.ActionIDs.EXECUTE_ACTION, null,
                 "Flow Extension action execution failed: action ID is not configured.");
             return buildErrorResponse(FlowExtensionConstants.ErrorMessages.NOT_CONFIGURED_MESSAGE,
                 FlowExtensionConstants.ErrorMessages.NOT_CONFIGURED_DESCRIPTION);
@@ -85,7 +87,7 @@ public class FlowExtensionExecutor implements Executor {
                     + ", tenant: " + context.getTenantDomain());
         }
 
-        ActionExecutorService actionExecutorService = getActionExecutorService(actionId);
+        ActionExecutorService actionExecutorService = getActionExecutorService();
 
         if (!actionExecutorService.isExecutionEnabled(ActionType.FLOW_EXTENSION)) {
             if (LOG.isDebugEnabled()) {
@@ -97,22 +99,19 @@ public class FlowExtensionExecutor implements Executor {
         }
 
         try {
-            // Hand the action framework only a FILTERED copy of the FlowExecutionContext
-            // (non-whitelisted fields nulled out). Policy is sourced from compile-time constants.
+            // Pass only the filtered copy of the FlowExecutionContext to the action framework.
             FlowExecutionContext filteredContext = FlowExtensionUtil.filterContext(context);
 
-            FlowContext flowContext = FlowContext.create()
+            FlowContext actionFlowContext = FlowContext.create()
                     .add(FlowExtensionConstants.FLOW_EXECUTION_CONTEXT_KEY, filteredContext);
 
             ActionExecutionStatus<?> executionStatus = actionExecutorService.execute(
-                    ActionType.FLOW_EXTENSION, actionId, flowContext, context.getTenantDomain());
+                    ActionType.FLOW_EXTENSION, actionId, actionFlowContext, context.getTenantDomain());
 
-            ExecutorResponse executionResponse = mapExecutionStatus(executionStatus, flowContext, context, actionId);
+            ExecutorResponse executionResponse = mapExecutionStatus(executionStatus, actionFlowContext, actionId);
 
-            // On success, extract pending context updates collected by the response processor
-            // and forward them to TaskExecutionNode via ExecutorResponse fields.
             if (ExecutorStatus.STATUS_COMPLETE.equals(executionResponse.getResult())) {
-                applyPendingContextUpdates(executionResponse, flowContext, actionId);
+                applyPendingContextUpdates(executionResponse, actionFlowContext, actionId);
             }
 
             return executionResponse;
@@ -143,13 +142,12 @@ public class FlowExtensionExecutor implements Executor {
      * maintains between its own redirect-side identifier and the IS flow context).
      *
      * @param executionStatus The status returned by ActionExecutorService.
-     * @param flowContext     The action {@link FlowContext} where the response processor stashed the redirect URL.
-     * @param context         The engine {@link FlowExecutionContext}.
+     * @param actionFlowContext     The action {@link FlowContext} where the response processor stashed the redirect URL.
      * @param actionId        The action ID for logging retry metadata.
      * @return The ExecutorResponse for the flow execution engine.
      */
     private ExecutorResponse mapExecutionStatus(ActionExecutionStatus<?> executionStatus,
-                                                FlowContext flowContext, FlowExecutionContext context, String actionId) {
+                                                FlowContext actionFlowContext, String actionId) {
 
         ExecutorResponse response = new ExecutorResponse();
 
@@ -175,7 +173,7 @@ public class FlowExtensionExecutor implements Executor {
                 return response;
 
             case INCOMPLETE:
-                return handleIncompleteExecutionStatus(response, flowContext, context);
+                return handleIncompleteExecutionStatus(response, actionFlowContext, actionId);
 
             default:
                 return handleUnknownExecutionStatus(response, executionStatus);
@@ -190,22 +188,6 @@ public class FlowExtensionExecutor implements Executor {
         response.setErrorMessage(errorMessage);
         response.setErrorDescription(errorDescription);
         return response;
-    }
-
-    private void applyRetryMetadata(ExecutorResponse response, String actionId) {
-
-        Map<String, String> additionalInfo = response.getAdditionalInfo();
-        if (additionalInfo == null) {
-            additionalInfo = new HashMap<>();
-        }
-        additionalInfo.put(FlowExtensionConstants.FAILURE_TYPE_KEY,
-                FlowExtensionConstants.FLOW_EXTENSION_FAILURE_TYPE);
-        response.setAdditionalInfo(additionalInfo);
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Flow Extension action returned FAILED. actionId: " + actionId
-                    + ", reason: " + additionalInfo.get(FlowExtensionConstants.FAILURE_MESSAGE_KEY));
-        }
     }
 
     private void handleFailedStatus(ExecutorResponse response, ActionExecutionStatus<?> executionStatus) {
@@ -241,14 +223,14 @@ public class FlowExtensionExecutor implements Executor {
         response.setErrorDescription(errorDescription);
     }
 
-    private ExecutorResponse handleIncompleteExecutionStatus(ExecutorResponse response, FlowContext flowContext,
-                                                             FlowExecutionContext context) {
+    private ExecutorResponse handleIncompleteExecutionStatus(ExecutorResponse response, FlowContext actionFlowContext,
+                                                             String actionId) {
 
-        String redirectUrl = flowContext.getValue(FlowExtensionConstants.PENDING_REDIRECT_URL_KEY, String.class);
+        String redirectUrl = actionFlowContext.getValue(FlowExtensionConstants.PENDING_REDIRECT_URL_KEY, String.class);
         if (redirectUrl == null || redirectUrl.isEmpty()) {
             // Defensive: response processor should have rejected this earlier.
             LOG.debug("Flow Extension returned INCOMPLETE without a redirect URL.");
-            triggerDiagnosticFailure(FlowExtensionConstants.Log.ActionIDs.PROCESS_RESPONSE, null,
+            triggerDiagnosticFailure(ActionExecutionLogConstants.ActionIDs.PROCESS_ACTION_RESPONSE, actionId,
                 "Flow Extension returned INCOMPLETE without a redirect URL.");
             return buildErrorResponse(FlowExtensionConstants.ErrorMessages.INCOMPLETE_NO_REDIRECT_MESSAGE,
                 FlowExtensionConstants.ErrorMessages.INCOMPLETE_NO_REDIRECT_DESCRIPTION);
@@ -259,7 +241,7 @@ public class FlowExtensionExecutor implements Executor {
         response.setAdditionalInfo(redirectInfo);
 
         response.setResult(ExecutorStatus.STATUS_EXTERNAL_REDIRECTION);
-        triggerDiagnosticSuccess(FlowExtensionConstants.Log.ActionIDs.PROCESS_RESPONSE, null,
+        triggerDiagnosticSuccess(ActionExecutionLogConstants.ActionIDs.PROCESS_ACTION_RESPONSE, actionId,
                 "Flow Extension returned INCOMPLETE with a redirect URL.");
 
         if (LOG.isDebugEnabled()) {
@@ -280,32 +262,24 @@ public class FlowExtensionExecutor implements Executor {
         return response;
     }
 
-    @SuppressWarnings("unchecked")
-    private void applyPendingContextUpdates(ExecutorResponse response, FlowContext flowContext, String actionId) {
+    private void applyPendingContextUpdates(ExecutorResponse response, FlowContext actionFlowContext, String actionId) {
 
         Map<String, Object> pendingClaims =
-                flowContext.getValue(FlowExtensionConstants.PENDING_CLAIMS_KEY, Map.class);
+                actionFlowContext.getValue(FlowExtensionConstants.PENDING_CLAIMS_KEY, Map.class);
         if (pendingClaims != null && !pendingClaims.isEmpty()) {
             response.setUpdatedUserClaims(pendingClaims);
         }
 
         Map<String, char[]> pendingCredentials =
-                flowContext.getValue(FlowExtensionConstants.PENDING_CREDENTIALS_KEY, Map.class);
+                actionFlowContext.getValue(FlowExtensionConstants.PENDING_CREDENTIALS_KEY, Map.class);
         if (pendingCredentials != null && !pendingCredentials.isEmpty()) {
             response.setUserCredentials(pendingCredentials);
-        }
-
-        Map<String, Object> pendingProperties =
-                flowContext.getValue(FlowExtensionConstants.PENDING_PROPERTIES_KEY, Map.class);
-        if (pendingProperties != null && !pendingProperties.isEmpty()) {
-            response.setContextProperty(pendingProperties);
         }
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Flow Extension action succeeded. actionId: " + actionId
                     + ", pendingClaims: " + (pendingClaims != null ? pendingClaims.size() : 0)
-                    + ", pendingCredentials: " + (pendingCredentials != null ? pendingCredentials.size() : 0)
-                    + ", pendingProperties: " + (pendingProperties != null ? pendingProperties.size() : 0));
+                    + ", pendingCredentials: " + (pendingCredentials != null ? pendingCredentials.size() : 0));
         }
     }
 
@@ -316,7 +290,7 @@ public class FlowExtensionExecutor implements Executor {
         }
 
         DiagnosticLog.DiagnosticLogBuilder builder = new DiagnosticLog.DiagnosticLogBuilder(
-            FlowExtensionConstants.Log.COMPONENT_ID, diagnosticActionId)
+            ActionExecutionLogConstants.ACTION_EXECUTION_COMPONENT_ID, diagnosticActionId)
                 .resultMessage(resultMessage)
                 .configParam(CONFIG_PARAM_ACTION_TYPE, ActionType.FLOW_EXTENSION.getDisplayName())
                 .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
@@ -336,7 +310,7 @@ public class FlowExtensionExecutor implements Executor {
         }
 
         DiagnosticLog.DiagnosticLogBuilder builder = new DiagnosticLog.DiagnosticLogBuilder(
-            FlowExtensionConstants.Log.COMPONENT_ID, diagnosticActionId)
+            ActionExecutionLogConstants.ACTION_EXECUTION_COMPONENT_ID, diagnosticActionId)
                 .resultMessage(resultMessage)
                 .configParam(CONFIG_PARAM_ACTION_TYPE, ActionType.FLOW_EXTENSION.getDisplayName())
                 .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
@@ -349,7 +323,7 @@ public class FlowExtensionExecutor implements Executor {
         LoggerUtils.triggerDiagnosticLogEvent(builder);
     }
 
-    private ActionExecutorService getActionExecutorService(String actionId) throws FlowEngineException {
+    private ActionExecutorService getActionExecutorService() throws FlowEngineException {
 
         ActionExecutorService actionExecutorService =
                 FlowExtensionDataHolder.getInstance().getActionExecutorService();

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
@@ -18,9 +18,11 @@
 
 package org.wso2.carbon.identity.flow.extension.executor;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.action.execution.api.constant.ActionExecutionLogConstants;
+import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionException;
 import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionRequestBuilderException;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.flow.extension.model.AccessConfig;
@@ -28,6 +30,7 @@ import org.wso2.carbon.identity.flow.extension.model.ContextPath;
 import org.wso2.carbon.identity.flow.extension.model.FlowExtensionAction;
 import org.wso2.carbon.identity.flow.extension.model.FlowExtensionEvent;
 import org.wso2.carbon.identity.flow.extension.model.FlowExtensionFlow;
+import org.wso2.carbon.identity.flow.extension.model.FlowExtensionUser;
 import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.carbon.identity.action.execution.api.model.ActionExecutionRequest;
 import org.wso2.carbon.identity.action.execution.api.model.ActionExecutionRequestContext;
@@ -47,17 +50,24 @@ import org.wso2.carbon.identity.core.context.IdentityContext;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants;
 import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.FlowContextPaths;
+import org.wso2.carbon.identity.flow.extension.util.CredentialWireFormatUtil;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
+import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.wso2.carbon.identity.flow.extension.executor.JWEEncryptionUtil.encrypt;
+
 /**
- * This class is responsible for building the {@link ActionExecutionRequest} for In-Flow Extension
+ * This class is responsible for building the {@link ActionExecutionRequest} for Flow Extension
  * actions.
  *
  * <p><b>Responsibility</b>: expose-based filtering and request construction.
@@ -80,11 +90,11 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
     }
 
     @Override
-    public ActionExecutionRequest buildActionExecutionRequest(FlowContext flowContext,
+    public ActionExecutionRequest buildActionExecutionRequest(FlowContext actionFlowContext,
                                                               ActionExecutionRequestContext actionExecutionContext)
             throws ActionExecutionRequestBuilderException {
 
-        FlowExecutionContext execCtx = getFlowExecutionContext(flowContext);
+        FlowExecutionContext execCtx = getFlowExecutionContext(actionFlowContext);
         FlowExtensionAction flowExtensionAction = getFlowExtensionAction(actionExecutionContext);
 
         AccessConfig accessConfig = flowExtensionAction.getAccessConfig();
@@ -92,9 +102,9 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
 
         List<String> exposePaths = resolveExposePaths(accessConfig);
         List<ContextPath> modifyPaths = resolveModifyPaths(accessConfig);
-        flowContext.add(FlowExtensionConstants.MODIFY_PATHS_KEY, modifyPaths);
+        actionFlowContext.add(FlowExtensionConstants.MODIFY_PATHS_KEY, modifyPaths);
 
-        List<AllowedOperation> allowedOperations = buildAllowedOperations(accessConfig, flowContext);
+        List<AllowedOperation> allowedOperations = buildAllowedOperations(accessConfig, actionFlowContext);
         String certificatePEM = resolveOutboundCertificate(accessConfig, certificate);
         ExposeResolution exposeResolution = pruneEncryptedExposePathsWithoutCertificate(
                 exposePaths, accessConfig, certificatePEM);
@@ -116,18 +126,18 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
      * for the response processor.
      *
      * @param accessConfig The access config containing modify paths (may be null).
-     * @param flowContext  The FlowContext to store path annotations.
+     * @param actionFlowContext  The FlowContext to store path annotations.
      * @return List of allowed operations (REPLACE if applicable, plus REDIRECT).
      */
     private List<AllowedOperation> buildAllowedOperations(AccessConfig accessConfig,
-                                                          FlowContext flowContext) {
+                                                          FlowContext actionFlowContext) {
 
         List<AllowedOperation> allowedOps = new ArrayList<>();
 
         if (hasModifyPaths(accessConfig)) {
             AllowedModifyExtraction extraction = extractAllowedModifyPaths(accessConfig.getModify());
             addReplaceOperationIfAny(allowedOps, extraction.getCleanPaths());
-            storeAnnotationsIfAny(flowContext, extraction.getPathTypeAnnotations());
+            storeAnnotationsIfAny(actionFlowContext, extraction.getPathTypeAnnotations());
 
             if (LOG.isDebugEnabled() && !extraction.getSkippedPaths().isEmpty()) {
                 LOG.debug("Skipped " + extraction.getSkippedPaths().size()
@@ -150,7 +160,7 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
      * @param expose         The expose prefix list controlling which data is included.
      * @param accessConfig   The access config (may be null if no encryption).
      * @param certificatePEM The external service's certificate PEM for JWE encryption (may be null).
-     * @return The InFlowExtensionEvent.
+     * @return The FlowExtensionEvent.
      */
     private FlowExtensionEvent buildEvent(FlowExecutionContext context, List<String> expose,
                                             AccessConfig accessConfig, String certificatePEM)
@@ -162,9 +172,8 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
         applyTenant(eventBuilder, context, expose);
         applyOrganization(eventBuilder, expose);
         applyApplication(eventBuilder, context, expose);
-        applyUserAndUserStore(flowBuilder, context, expose, accessConfig, certificatePEM);
+        applyUser(flowBuilder, context, expose, accessConfig, certificatePEM);
         applyFlowMetadata(flowBuilder, context, expose);
-        applyFlowProperties(eventBuilder, context, expose, accessConfig, certificatePEM);
 
         eventBuilder.flow(flowBuilder.build());
         return eventBuilder.build();
@@ -184,19 +193,45 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
                            AccessConfig accessConfig, String certificatePEM)
             throws ActionExecutionRequestBuilderException {
 
-        User.Builder userBuilder = new User.Builder(resolveUserId(flowUser, expose));
+        FlowExtensionUser.Builder userBuilder =
+                new FlowExtensionUser.Builder(resolveUserId(flowUser, expose, accessConfig, certificatePEM));
+
+
+
+        if (isLeafExposed(FlowContextPaths.USER_USERNAME_PATH, expose)) {
+            String username = encryptIfConfigured(
+                    FlowContextPaths.USER_USERNAME_PATH, UserCoreUtil.removeDomainFromName(flowUser.getUsername()),
+                    accessConfig, certificatePEM);
+            if (username != null) {
+                userBuilder.username(username);
+            }
+        }
+        if (isLeafExposed(FlowContextPaths.USER_STORE_DOMAIN_PATH, expose)) {
+            String userStoreDomain = encryptIfConfigured(
+                    FlowContextPaths.USER_STORE_DOMAIN_PATH, normalizeUserStoreDomain(flowUser.getUsername(),
+                            flowUser.getUserStoreDomain()), accessConfig, certificatePEM);
+            if (userStoreDomain != null) {
+                userBuilder.userStoreDomain(userStoreDomain);
+            }
+        }
+
         List<UserClaim> userClaims = buildFilteredClaims(flowUser, expose, accessConfig, certificatePEM);
         if (!userClaims.isEmpty()) {
             userBuilder.claims(userClaims);
         }
 
+        Map<String, Object> credentials = buildFilteredCredentials(flowUser, expose, accessConfig, certificatePEM);
+        if (!credentials.isEmpty()) {
+            userBuilder.credentials(credentials);
+        }
+
         return userBuilder.build();
     }
 
-    private FlowExecutionContext getFlowExecutionContext(FlowContext flowContext)
+    private FlowExecutionContext getFlowExecutionContext(FlowContext actionFlowContext)
             throws ActionExecutionRequestBuilderException {
 
-        FlowExecutionContext execCtx = flowContext.getValue(
+        FlowExecutionContext execCtx = actionFlowContext.getValue(
                 FlowExtensionConstants.FLOW_EXECUTION_CONTEXT_KEY, FlowExecutionContext.class);
         if (execCtx == null) {
             throw new ActionExecutionRequestBuilderException("FlowExecutionContext not found in FlowContext.");
@@ -395,10 +430,10 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
         allowedOperations.add(replaceOp);
     }
 
-    private void storeAnnotationsIfAny(FlowContext flowContext, Map<String, String> pathTypeAnnotations) {
+    private void storeAnnotationsIfAny(FlowContext actionFlowContext, Map<String, String> pathTypeAnnotations) {
 
         if (!pathTypeAnnotations.isEmpty()) {
-            flowContext.add(FlowExtensionConstants.PATH_TYPE_ANNOTATIONS_KEY, pathTypeAnnotations);
+            actionFlowContext.add(FlowExtensionConstants.PATH_TYPE_ANNOTATIONS_KEY, pathTypeAnnotations);
         }
     }
 
@@ -470,9 +505,9 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
         eventBuilder.application(new Application(appId != null ? appId : "", null));
     }
 
-    private void applyUserAndUserStore(FlowExtensionFlow.Builder flowBuilder, FlowExecutionContext context,
-                                       List<String> expose, AccessConfig accessConfig,
-                                       String certificatePEM) throws ActionExecutionRequestBuilderException {
+    private void applyUser(FlowExtensionFlow.Builder flowBuilder, FlowExecutionContext context,
+                           List<String> expose, AccessConfig accessConfig,
+                           String certificatePEM) throws ActionExecutionRequestBuilderException {
 
         if (!isAreaExposed(FlowContextPaths.USER_PREFIX, expose)) {
             return;
@@ -502,37 +537,13 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
         }
     }
 
-    private void applyFlowProperties(FlowExtensionEvent.Builder eventBuilder, FlowExecutionContext context,
-                                     List<String> expose, AccessConfig accessConfig,
-                                     String certificatePEM) throws ActionExecutionRequestBuilderException {
-
-        if (!isAreaExposed(FlowContextPaths.PROPERTIES_PATH_PREFIX, expose)) {
-            return;
-        }
-
-        Map<String, Object> properties = context.getProperties();
-        Map<String, Object> filteredProperties = new HashMap<>();
-
-        for (String exposePath : expose) {
-            if (!exposePath.startsWith(FlowContextPaths.PROPERTIES_PATH_PREFIX)) {
-                continue;
-            }
-            String propKey = exposePath.substring(FlowContextPaths.PROPERTIES_PATH_PREFIX.length());
-            Object value = properties != null ? properties.get(propKey) : null;
-            if (value != null && shouldEncrypt(exposePath, accessConfig, certificatePEM)) {
-                value = encryptValue(String.valueOf(value), certificatePEM);
-            }
-            filteredProperties.put(propKey, value != null ? value : "");
-        }
-
-        eventBuilder.flowProperties(filteredProperties);
-    }
-
-    private String resolveUserId(FlowUser flowUser, List<String> expose) {
+    private String resolveUserId(FlowUser flowUser, List<String> expose,
+                                 AccessConfig accessConfig, String certificatePEM)
+            throws ActionExecutionRequestBuilderException {
 
         if (isLeafExposed(FlowContextPaths.USER_ID_PATH, expose)) {
-            String userId = flowUser.getUserId();
-            return userId != null ? userId : "";
+            return encryptIfConfigured(
+                    FlowContextPaths.USER_ID_PATH, flowUser.getUserId(), accessConfig, certificatePEM);
         }
         return null;
     }
@@ -554,13 +565,116 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
                 continue;
             }
             String claimValue = claims != null ? claims.get(claimUri) : null;
-            claimValue = claimValue != null ? claimValue : "";
-            if (!claimValue.isEmpty() && shouldEncrypt(exposePath, accessConfig, certificatePEM)) {
-                claimValue = encryptValue(claimValue, certificatePEM);
+            claimValue = encryptIfConfigured(exposePath, claimValue, accessConfig, certificatePEM);
+            if (claimValue != null) {
+                userClaims.add(new UserClaim(claimUri, claimValue));
             }
-            userClaims.add(new UserClaim(claimUri, claimValue));
         }
         return userClaims;
+    }
+
+    /**
+     * Build the exposed user credentials map, reading each exposed {@code /user/credentials/<key>}
+     * leaf from {@link FlowUser#getUserCredentials()} and routing it through
+     * {@link #buildCredentialValue} to produce its per-path wire form (typed object when plaintext,
+     * JWE compact string when {@code encrypted: true}).
+     */
+    private Map<String, Object> buildFilteredCredentials(FlowUser flowUser, List<String> expose,
+                                                         AccessConfig accessConfig, String certificatePEM)
+            throws ActionExecutionRequestBuilderException {
+
+        if (!isAreaExposed(FlowContextPaths.USER_CREDENTIALS_PATH_PREFIX, expose)) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, char[]> userCredentials = flowUser.getUserCredentials();
+        if (userCredentials == null || userCredentials.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, Object> credentials = new HashMap<>();
+        for (String exposePath : expose) {
+            String credentialKey = extractCredentialKeyFromPath(exposePath);
+            if (credentialKey == null) {
+                continue;
+            }
+            char[] secret = userCredentials.get(credentialKey);
+            if (isBlankExposedValue(secret)) {
+                continue;
+            }
+            credentials.put(credentialKey,
+                    buildCredentialValue(exposePath, secret, accessConfig, certificatePEM));
+        }
+        return credentials;
+    }
+
+    /**
+     * Build the wire form of a single exposed credential. The secret is always wrapped in the typed
+     * credential object {@code {"type": "PLAIN_TEXT", "value": "<secret>"}}. When the path is
+     * configured for encryption that object is serialized and JWE-encrypted, and the returned value
+     * is the JWE compact string; otherwise the typed object is returned directly for the mapper to
+     * serialize as a nested JSON object.
+     *
+     * @param exposePath     The credential expose path, used to look up the {@code encrypted} flag.
+     * @param secret         The raw credential secret.
+     * @param accessConfig   The access config with encryption flags (may be null).
+     * @param certificatePEM The certificate PEM for JWE encryption (may be null).
+     * @return A {@code Map} typed credential object, or a JWE compact {@code String} when encrypted.
+     * @throws ActionExecutionRequestBuilderException if the path requires encryption but no
+     *                                                outbound certificate is configured.
+     */
+    private Object buildCredentialValue(String exposePath, char[] secret, AccessConfig accessConfig,
+                                        String certificatePEM) throws ActionExecutionRequestBuilderException {
+
+        boolean encryptionRequired = accessConfig != null && accessConfig.isExposePathEncrypted(exposePath);
+        if (!encryptionRequired) {
+            return buildPlainTextCredential(secret);
+        }
+
+        if (certificatePEM == null) {
+            LOG.error("Outbound encryption is configured for path: " + exposePath
+                    + " but no outbound certificate is available.");
+            throw new ActionExecutionRequestBuilderException(
+                    "Missing outbound certificate for encrypted expose path: " + exposePath);
+        }
+
+        char[] credentialJson = CredentialWireFormatUtil.toPlainTextCredentialJson(secret);
+        try {
+            return encryptValue(credentialJson, certificatePEM);
+        } finally {
+            Arrays.fill(credentialJson, '\0');
+        }
+    }
+
+    /**
+     * Build the typed credential object {@code {"type": "PLAIN_TEXT", "value": "<secret>"}} for the
+     * unencrypted path, to be serialized by the mapper as a nested JSON object.
+     */
+    private Map<String, String> buildPlainTextCredential(char[] secret) {
+
+        Map<String, String> credential = new LinkedHashMap<>();
+        credential.put(FlowExtensionConstants.Credentials.TYPE_KEY,
+                FlowExtensionConstants.Credentials.TYPE_PLAIN_TEXT);
+        credential.put(FlowExtensionConstants.Credentials.VALUE_KEY, new String(secret));
+        return credential;
+    }
+
+    /**
+     * Extract the credential key from a credentials leaf path.
+     * Accepts {@code /user/credentials/<key>} and returns {@code <key>}.
+     * Returns {@code null} if the path is not a single-segment credentials leaf.
+     */
+    private static String extractCredentialKeyFromPath(String path) {
+
+        String prefix = FlowContextPaths.USER_CREDENTIALS_PATH_PREFIX;
+        if (path == null || !path.startsWith(prefix)) {
+            return null;
+        }
+        String remaining = path.substring(prefix.length());
+        if (remaining.isEmpty() || remaining.contains("/")) {
+            return null;
+        }
+        return remaining;
     }
 
     /**
@@ -634,7 +748,7 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
 
     /**
      * Check if any exposed leaf path falls under the given area prefix.
-     * Used as a gate before iterating a data block (claims, credentials, properties).
+     * Used as a gate before iterating a data block (claims, credentials).
      */
     private boolean isAreaExposed(String areaPrefix, List<String> expose) {
 
@@ -651,38 +765,104 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
     }
 
     /**
-     * Determine if a value at the given path should be JWE-encrypted before sending to the
-     * external service. Only expose paths with {@code encrypted: true} trigger outbound encryption.
+     * Outbound encryption gate for every exposed user value: returns {@code null} to signal the value
+     * must be omitted from the payload when it is blank, the JWE compact form when the path is
+     * configured for encryption, otherwise the value unchanged. Blank values are never emitted, so an
+     * encrypted path that yields a value always yields a JWE compact string.
      *
-     * @param path           The expose path.
-     * @param accessConfig   The access config with encryption flags.
-     * @param certificatePEM The certificate PEM (null if no encryption configured).
-     * @return {@code true} if the value should be encrypted.
+     * @param path           The target context path to check for encryption rules.
+     * @param value          The raw value to be evaluated and potentially encrypted.
+     * @param accessConfig   The access configuration containing encryption rules.
+     * @param certificatePEM The public certificate content used for encryption.
+     * @return The plain text string, the encrypted payload, or null if the value is blank.
+     * @throws ActionExecutionRequestBuilderException If encryption is required but the certificate is missing.
      */
-    private boolean shouldEncrypt(String path, AccessConfig accessConfig, String certificatePEM) {
+    private String encryptIfConfigured(String path, Object value, AccessConfig accessConfig,
+                                       String certificatePEM) throws ActionExecutionRequestBuilderException {
 
-        if (certificatePEM == null || accessConfig == null) {
-            return false;
+        if (isBlankExposedValue(value)) {
+            return null;
         }
-        return accessConfig.isExposePathEncrypted(path);
+
+        boolean encryptionRequired = accessConfig != null && accessConfig.isExposePathEncrypted(path);
+        if (!encryptionRequired) {
+            return value instanceof char[] ? new String((char[]) value) : value.toString();
+        }
+
+        if (certificatePEM == null) {
+            throw new ActionExecutionRequestBuilderException(
+                    "Missing outbound certificate for encrypted expose path: " + path);
+        }
+
+        return encryptValue(value, certificatePEM);
     }
 
     /**
-     * JWE-encrypt a plaintext value using the external service's certificate.
+     * JWE-encrypt a value using the external service's certificate.
      *
-     * @param plaintext      The value to encrypt.
+     * @param value      The value to encrypt.
      * @param certificatePEM The external service's certificate PEM.
      * @return The JWE compact serialization string.
      * @throws ActionExecutionRequestBuilderException If encryption fails.
      */
-    private String encryptValue(String plaintext, String certificatePEM)
+    private String encryptValue(Object value, String certificatePEM)
             throws ActionExecutionRequestBuilderException {
 
         try {
-            return JWEEncryptionUtil.encrypt(plaintext, certificatePEM);
-        } catch (Exception e) {
+            if (value instanceof char[]) {
+                return encrypt((char[]) value, certificatePEM);
+            } else if (value instanceof String) {
+                return encrypt((String) value, certificatePEM);
+            } else {
+                throw new ActionExecutionRequestBuilderException(
+                        "Unsupported value type for JWE encryption: " +
+                                (value == null ? "null" : value.getClass().getName()));
+            }
+        } catch (ActionExecutionException e) {
             throw new ActionExecutionRequestBuilderException(
-                    "Failed to JWE-encrypt outbound value for In-Flow Extension action.", e);
+                    "Failed to JWE-encrypt outbound value for Flow Extension action.", e);
         }
+    }
+
+    /**
+     * Resolve the userstore domain, deriving it from a domain-qualified username (e.g. {@code "LDAP/john"} -> {@code
+     * "LDAP"}) when it is not already set explicitly.
+     *
+     * @param username        The raw username (may be null or domain-qualified).
+     * @param userStoreDomain The raw userstore domain (may be null or blank).
+     * @return The resolved userstore domain.
+     */
+    private String normalizeUserStoreDomain(String username, String userStoreDomain) {
+
+        userStoreDomain = userStoreDomain != null ? userStoreDomain : "";
+        if (StringUtils.isBlank(userStoreDomain) && username != null
+                && username.indexOf(UserCoreConstants.DOMAIN_SEPARATOR) > 0) {
+            userStoreDomain = UserCoreUtil.extractDomainFromName(username);
+        }
+        return userStoreDomain;
+    }
+
+    /**
+     * Determines whether an exposed value should be treated as blank: null, an empty or
+     * all-whitespace char array, or a blank String. Any other type is never blank.
+     */
+    private boolean isBlankExposedValue(Object value) {
+
+        if (value == null) {
+            return true;
+        }
+        if (value instanceof char[]) {
+            char[] chars = (char[]) value;
+            for (char c : chars) {
+                if (!Character.isWhitespace(c)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        if (value instanceof String) {
+            return StringUtils.isBlank((String) value);
+        }
+        return false;
     }
 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.action.execution.api.constant.ActionExecutionLog
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.flow.extension.internal.FlowExtensionDataHolder;
+import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionException;
 import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionResponseProcessorException;
 import org.wso2.carbon.identity.action.execution.api.model.ActionExecutionResponseContext;
 import org.wso2.carbon.identity.action.execution.api.model.ActionExecutionStatus;
@@ -57,29 +58,16 @@ import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext
 import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 /**
- * Processes responses from In-Flow Extension actions, applying {@code REPLACE} operations on
- * flow properties, user claims, and user credentials. Updates are collected into pending maps on
- * {@link FlowContext} for the executor to forward via
- * {@link org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse}.
- *
- * <p>Only {@code REPLACE} is supported; gating is done upstream via {@code allowedOperations}
- * (enforced by {@code ActionExecutorServiceImpl}). {@code /flow/} paths are read-only.</p>
- *
- * <p><b>Failure handling.</b> Contract-level failures (non-String on an encrypted path, missing
- * JWE envelope, JWE decryption failure) abort the call via
- * {@link ActionExecutionResponseProcessorException}. Per-operation validation failures (unknown
- * path, read-only path, missing value, unknown claim URI, unknown credential key) drop the
- * offending op, keep the rest, and return {@link SuccessStatus} — surfaced under
- * {@link FlowExtensionConstants.ResponseContext#FAILED_OPERATIONS_KEY} alongside
- * {@link FlowExtensionConstants.ResponseContext#TOTAL_OPERATIONS_KEY} for callers wanting strict
- * semantics.</p>
+ * Processes responses from Flow Extension actions, applying {@code REPLACE} operations on user
+ * claims and credentials into pending maps on the {@link FlowContext} for the executor to forward.
+ * Only {@code REPLACE} is supported and {@code /flow/} paths are read-only.
  */
 public class FlowExtensionResponseProcessor implements ActionExecutionResponseProcessor {
 
@@ -96,26 +84,19 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
 
     @Override
     @SuppressWarnings("unchecked")
-    public ActionExecutionStatus<Success> processSuccessResponse(FlowContext flowContext,
+    public ActionExecutionStatus<Success> processSuccessResponse(FlowContext actionFlowContext,
                                                                  ActionExecutionResponseContext<ActionInvocationSuccessResponse> responseContext)
             throws ActionExecutionResponseProcessorException {
 
-        FlowExecutionContext execCtx = getFlowExecutionContext(flowContext);
+        FlowExecutionContext execCtx = getFlowExecutionContext(actionFlowContext);
         String tenantDomain = execCtx.getTenantDomain();
 
-        Map<String, String> pathTypeAnnotations = flowContext.getValue(
-                FlowExtensionConstants.PATH_TYPE_ANNOTATIONS_KEY, Map.class);
-        if (pathTypeAnnotations == null) {
-            pathTypeAnnotations = Collections.emptyMap();
-        }
-
-        List<ContextPath> modifyPaths = flowContext.getValue(
+        List<ContextPath> modifyPaths = actionFlowContext.getValue(
                 FlowExtensionConstants.MODIFY_PATHS_KEY, List.class);
         AccessConfig accessConfig = modifyPaths != null ? new AccessConfig(null, modifyPaths) : null;
 
         Map<String, Object> pendingClaims = new HashMap<>();
         Map<String, char[]> pendingCredentials = new HashMap<>();
-        Map<String, Object> pendingProperties = new HashMap<>();
 
         List<OperationExecutionResult> results = new ArrayList<>();
 
@@ -128,28 +109,24 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
                     operation = decryptOperationValueIfNeeded(operation, accessConfig, tenantDomain);
                 }
                 results.add(processOperation(
-                        operation, pathTypeAnnotations, pendingClaims, pendingCredentials,
-                        pendingProperties, tenantDomain));
+                        operation, pendingClaims, pendingCredentials, tenantDomain));
             }
         } else {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("In-Flow Extension SUCCESS response contained no operations. No context updates applied.");
+                LOG.debug("Flow Extension SUCCESS response contained no operations. No context updates applied.");
             }
         }
 
         if (!pendingClaims.isEmpty()) {
-            flowContext.add(FlowExtensionConstants.PENDING_CLAIMS_KEY, pendingClaims);
+            actionFlowContext.add(FlowExtensionConstants.PENDING_CLAIMS_KEY, pendingClaims);
         }
         if (!pendingCredentials.isEmpty()) {
-            flowContext.add(FlowExtensionConstants.PENDING_CREDENTIALS_KEY, pendingCredentials);
-        }
-        if (!pendingProperties.isEmpty()) {
-            flowContext.add(FlowExtensionConstants.PENDING_PROPERTIES_KEY, pendingProperties);
+            actionFlowContext.add(FlowExtensionConstants.PENDING_CREDENTIALS_KEY, pendingCredentials);
         }
 
         logOperationExecutionResults(results);
 
-        return new SuccessStatus.Builder().setResponseContext(flowContext.getContextData()).build();
+        return new SuccessStatus.Builder().setResponseContext(actionFlowContext.getContextData()).build();
     }
 
 
@@ -159,18 +136,14 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
      * {@code TaskExecutionNode} via {@link org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse}.
      *
      * @param operation           The operation to process.
-     * @param pathTypeAnnotations Map of clean paths to their type annotations from allowed operations.
      * @param pendingClaims       Accumulator map for user claim updates.
      * @param pendingCredentials  Accumulator map for user credential updates.
-     * @param pendingProperties   Accumulator map for flow property updates.
      * @param tenantDomain        Tenant domain, used for claim URI validation.
      * @return The result of the operation execution.
      */
     private OperationExecutionResult processOperation(PerformableOperation operation,
-                                                      Map<String, String> pathTypeAnnotations,
                                                       Map<String, Object> pendingClaims,
                                                       Map<String, char[]> pendingCredentials,
-                                                      Map<String, Object> pendingProperties,
                                                       String tenantDomain)
             throws ActionExecutionResponseProcessorException {
 
@@ -190,9 +163,7 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
                     "Modifications are not allowed for the read-only paths" );
         }
 
-        if (path.startsWith(FlowExtensionConstants.FlowContextPaths.PROPERTIES_PATH_PREFIX)) {
-            return handlePropertyOperation(operation, pathTypeAnnotations, pendingProperties);
-        } else if (path.startsWith(FlowExtensionConstants.FlowContextPaths.USER_CLAIMS_SELECTOR_PREFIX)) {
+        if (path.startsWith(FlowExtensionConstants.FlowContextPaths.USER_CLAIMS_SELECTOR_PREFIX)) {
             return handleUserClaimOperation(operation, pendingClaims, tenantDomain);
         } else if (path.startsWith(FlowExtensionConstants.FlowContextPaths.USER_CREDENTIALS_PATH_PREFIX)) {
             return handleUserCredentialOperation(operation, pendingCredentials);
@@ -203,69 +174,13 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
     }
 
     /**
-     * Handle operation on flow properties — collect into pending properties map.
-     *
-     * <p>Only flat property paths are supported (e.g., {@code /properties/riskScore}).
-     * Value coercion is applied based on path type annotations from the request builder via
-     * {@link PathTypeAnnotationUtil#coerceValue}.</p>
-     *
-     * @param operation           The performable operation.
-     * @param pathTypeAnnotations Path type annotations map from request builder.
-     * @param pendingProperties   Accumulator map for property updates.
-     */
-    private OperationExecutionResult handlePropertyOperation(PerformableOperation operation,
-                                                             Map<String, String> pathTypeAnnotations, Map<String, Object> pendingProperties) {
-
-        String propertyName = extractNameFromPath(operation.getPath(),
-                FlowExtensionConstants.FlowContextPaths.PROPERTIES_PATH_PREFIX);
-
-        if (StringUtils.isBlank(propertyName)) {
-            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
-                    "Invalid property path. Property name is required.");
-        }
-
-        if (operation.getValue() == null) {
-            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
-                    ERROR_VALUE_REQUIRED_FOR_REPLACE);
-        }
-
-        // Validate complex object structure against annotation schema before coercion.
-        if (!PathTypeAnnotationUtil.validateValueAgainstAnnotation(
-                operation.getPath(), operation.getValue(), pathTypeAnnotations)) {
-            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
-                    "Value does not match annotation schema for path: " + operation.getPath());
-        }
-
-        // Coerce value based on path type annotation.
-        Object coercedValue = PathTypeAnnotationUtil.coerceValue(
-                operation.getPath(), operation.getValue(), pathTypeAnnotations);
-
-        // Enforce array item limits after coercion.
-        if (!PathTypeAnnotationUtil.enforceArrayItemLimit(
-                operation.getPath(), coercedValue, pathTypeAnnotations)) {
-            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
-                    "Array value exceeds maximum item limit for path.");
-        }
-
-        pendingProperties.put(propertyName, coercedValue);
-
-        return new OperationExecutionResult(operation, OperationExecutionResult.Status.SUCCESS,
-                "Property replace applied.");
-    }
-
-    /**
-     * Handle REPLACE operation on user claims — validate the claim URI then collect into pending
-     * claims map. Validation gates:
-     * <ol>
-     *   <li>Claim URI must be in the WSO2 local claim dialect ({@code http://wso2.org/claims/}).</li>
-     *   <li>Identity-system claims ({@code http://wso2.org/claims/identity/}) are rejected.</li>
-     *   <li>The claim URI must correspond to a registered local claim in the tenant; unknown
-     *       claims are rejected per-operation. If the
-     *       {@link org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService}
-     *       is unavailable or the lookup throws, the whole response aborts via
-     *       {@link ActionExecutionResponseProcessorException}.</li>
-     * </ol>
-     * The value is always stringified via {@code String.valueOf()}.
+     * Handle a REPLACE operation on a user claim by validating the claim URI and collecting the value
+     * into the pending claims map. The claim URI must be in the WSO2 local dialect
+     * ({@code http://wso2.org/claims/}), must not be an identity-system claim
+     * ({@code http://wso2.org/claims/identity/}), and must resolve to a registered local claim in the
+     * tenant. A single-valued claim takes a {@code String} value and a multi-valued claim takes a list
+     * joined with commas. Failing any of these validations drops the operation, while an unavailable
+     * claim metadata service or a lookup error aborts the response.
      *
      * @param operation     The performable operation.
      * @param pendingClaims Accumulator map for user claim updates.
@@ -294,7 +209,7 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
         }
         if (claimUri.startsWith(PathTypeAnnotationUtil.IDENTITY_CLAIM_URI_PREFIX)) {
             return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
-                    "Identity-system claims cannot be modified by In-Flow Extensions: " + claimUri);
+                    "Identity-system claims cannot be modified by Flow Extensions: " + claimUri);
         }
 
         Optional<LocalClaim> optionalLocalClaim = getLocalClaim(claimUri, tenantDomain);
@@ -303,7 +218,21 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
                     "Unknown local claim URI: " + claimUri);
         }
 
-        String resolvedClaimValue = getResolvedClaimValue(operation.getValue(), optionalLocalClaim.get());
+        Object claimValue = operation.getValue();
+        String resolvedClaimValue;
+        if (isMultiValuedClaim(optionalLocalClaim.get())) {
+            if (!(claimValue instanceof List)) {
+                return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
+                        "Expected a list value for multi-valued claim: " + claimUri);
+            }
+            resolvedClaimValue = StringUtils.join((List<?>) claimValue, ",");
+        } else if (claimValue instanceof String) {
+            resolvedClaimValue = (String) claimValue;
+        } else {
+            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
+                    "Expected a string value for single-valued claim: " + claimUri);
+        }
+
         pendingClaims.put(claimUri, resolvedClaimValue);
         return new OperationExecutionResult(operation, OperationExecutionResult.Status.SUCCESS,
                 "User claim replace applied.");
@@ -326,27 +255,11 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
         }
     }
 
-    private String getResolvedClaimValue(Object operationValue, LocalClaim localClaim) throws
-            ActionExecutionResponseProcessorException {
-
-        if (isMultiValuedClaim(localClaim)) {
-            if (operationValue instanceof List) {
-                List<String> valueList = (List<String>) operationValue;
-                return StringUtils.join(valueList, ",");
-            }
-            throw new ActionExecutionResponseProcessorException(
-                    "Expected a list value for multi-valued claim: " + localClaim.getClaimURI());
-        } else if (operationValue instanceof String) {
-            return String.valueOf(operationValue);
-        }
-        throw new ActionExecutionResponseProcessorException(
-                "Expected a string value for single-valued claim: " + localClaim.getClaimURI());
-    }
-
     private boolean isMultiValuedClaim(LocalClaim localClaim) {
 
         return Boolean.parseBoolean(localClaim.getClaimProperty(MULTI_VALUED_CLAIM_PROPERTY));
     }
+
     /**
      * Handle REPLACE operation on user credentials — collect into pending credentials map.
      * No key validation is applied; any credential key is accepted. The value is converted
@@ -414,19 +327,8 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
         return null;
     }
 
-    /**
-     * Normalize a claim path for encryption checks.
-     * Internal and external formats now both use the selector form
-     * {@code /user/claims[uri=<claimUri>]}, so no conversion is needed.
-     * All paths are returned unchanged.
-     */
-    private static String normalizeToInternalPath(String path) {
-
-        return path;
-    }
-
     @Override
-    public ActionExecutionStatus<Incomplete> processIncompleteResponse(FlowContext flowContext,
+    public ActionExecutionStatus<Incomplete> processIncompleteResponse(FlowContext actionFlowContext,
                                                                        ActionExecutionResponseContext<ActionInvocationIncompleteResponse> responseContext)
             throws ActionExecutionResponseProcessorException {
 
@@ -435,10 +337,10 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
         validateOperationForIncompleteStatus(operations);
 
         String redirectUrl = operations.get(0).getUrl();
-        flowContext.add(FlowExtensionConstants.PENDING_REDIRECT_URL_KEY, redirectUrl);
+        actionFlowContext.add(FlowExtensionConstants.PENDING_REDIRECT_URL_KEY, redirectUrl);
 
         return new IncompleteStatus.Builder()
-                .responseContext(flowContext.getContextData())
+                .responseContext(actionFlowContext.getContextData())
                 .build();
     }
 
@@ -472,8 +374,8 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
 
         if (LoggerUtils.isDiagnosticLogsEnabled()) {
             LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
-                    FlowExtensionConstants.Log.COMPONENT_ID,
-                    FlowExtensionConstants.Log.ActionIDs.PROCESS_RESPONSE)
+                    ActionExecutionLogConstants.ACTION_EXECUTION_COMPONENT_ID,
+                    ActionExecutionLogConstants.ActionIDs.PROCESS_ACTION_RESPONSE)
                     .resultMessage(message)
                     .configParam(DIAG_PARAM_ACTION_TYPE, ActionType.FLOW_EXTENSION.getDisplayName())
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
@@ -483,7 +385,7 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
     }
 
     @Override
-    public ActionExecutionStatus<Error> processErrorResponse(FlowContext flowContext,
+    public ActionExecutionStatus<Error> processErrorResponse(FlowContext actionFlowContext,
                                                              ActionExecutionResponseContext<ActionInvocationErrorResponse> responseContext)
             throws ActionExecutionResponseProcessorException {
 
@@ -491,7 +393,7 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
         String errorDescription = responseContext.getActionInvocationResponse().getErrorDescription();
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Processing error response from In-Flow Extension. Error: " + errorMessage +
+            LOG.debug("Processing error response from Flow Extension. Error: " + errorMessage +
                     ", Description: " + errorDescription);
         }
 
@@ -499,7 +401,7 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
     }
 
     @Override
-    public ActionExecutionStatus<Failure> processFailureResponse(FlowContext flowContext,
+    public ActionExecutionStatus<Failure> processFailureResponse(FlowContext actionFlowContext,
                                                                  ActionExecutionResponseContext<ActionInvocationFailureResponse> responseContext)
             throws ActionExecutionResponseProcessorException {
 
@@ -507,7 +409,7 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
         String failureDescription = responseContext.getActionInvocationResponse().getFailureDescription();
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Processing failure response from In-Flow Extension. Reason: " + failureReason +
+            LOG.debug("Processing failure response from Flow Extension. Reason: " + failureReason +
                     ", Description: " + failureDescription);
         }
 
@@ -567,14 +469,16 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
 
     /**
      * Decrypt the operation value if the operation path has encryption enabled in the AccessConfig.
-     * Uses {@link AccessConfig#isModifyPathEncrypted(String)} for canonical checking.
-     * For operations with encrypted paths, checks if the value looks like a JWE compact
-     * serialization and decrypts it using the IS's private key.
+     * Uses {@link AccessConfig#isModifyPathEncrypted(String)} for canonical checking. A scalar value
+     * is treated as a single JWE compact string, while a multi-valued claim arrives as a
+     * single-element array holding one JWE string that encrypts the comma-joined values; that element
+     * is decrypted and its plaintext split on commas back into a list. The decrypted value(s) replace
+     * the original on the returned operation.
      *
      * @param operation    The operation to potentially decrypt.
      * @param accessConfig The access config with encryption flags (may be null).
      * @param tenantDomain Tenant domain for IS private key resolution.
-     * @return The operation with decrypted value, or the original operation if no decryption needed.
+     * @return The operation with decrypted value(s), or the original operation if no decryption needed.
      */
     private PerformableOperation decryptOperationValueIfNeeded(PerformableOperation operation,
                                                                AccessConfig accessConfig, String tenantDomain)
@@ -584,53 +488,81 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
             return operation;
         }
 
-        String internalPath = normalizeToInternalPath(operation.getPath());
-        if (!accessConfig.isModifyPathEncrypted(internalPath)) {
+        if (!accessConfig.isModifyPathEncrypted(operation.getPath())) {
             return operation;
         }
 
         Object value = operation.getValue();
+        Object decryptedValue;
+        if (value instanceof List<?> encryptedList) {
+
+            if (encryptedList.size() != 1 || !(encryptedList.getFirst() instanceof String jweString)) {
+                emitEncryptionContractViolation(operation.getPath(),
+                        "Encrypted multi-valued claim must be a single-element array holding one JWE string.");
+                throw new ActionExecutionResponseProcessorException(
+                        "Value for encrypted modify path '" + operation.getPath() +
+                                "' must be a single-element array holding one JWE-encrypted string.");
+            }
+
+            String plaintext = decryptJWEValue(jweString, operation.getPath(), tenantDomain);
+            decryptedValue = Arrays.asList(plaintext.split(","));
+        } else {
+            decryptedValue = decryptJWEValue(value, operation.getPath(), tenantDomain);
+        }
+
+        PerformableOperation decryptedOp = new PerformableOperation();
+        decryptedOp.setOp(operation.getOp());
+        decryptedOp.setPath(operation.getPath());
+        decryptedOp.setValue(decryptedValue);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Successfully decrypted inbound JWE value for path: " + operation.getPath());
+        }
+        return decryptedOp;
+    }
+
+    /**
+     * Decrypt a single JWE-encrypted value from an encrypted modify path using the IS private key.
+     * The value must be a JWE compact string; a non-String value or a non-JWE string breaks the
+     * encryption contract and aborts the response.
+     *
+     * @param value        The value to decrypt, expected to be a JWE compact string.
+     * @param path         The modify path, used for diagnostics and error messages.
+     * @param tenantDomain Tenant domain for IS private key resolution.
+     * @return The decrypted plaintext value.
+     */
+    private String decryptJWEValue(Object value, String path, String tenantDomain)
+            throws ActionExecutionResponseProcessorException {
 
         if (!(value instanceof String)) {
-            emitEncryptionContractViolation(operation.getPath(),
-                    "Value for encrypted modify path is not a String.");
+            emitEncryptionContractViolation(path, "Value for encrypted modify path is not a String.");
             throw new ActionExecutionResponseProcessorException(
-                    "Value for encrypted modify path '" + operation.getPath() +
+                    "Value for encrypted modify path '" + path +
                             "' must be a JWE-encrypted string, but received a non-String value.");
         }
 
         String stringValue = (String) value;
         if (!JWEEncryptionUtil.isJWEEncrypted(stringValue)) {
-            emitEncryptionContractViolation(operation.getPath(),
-                    "Value for encrypted modify path is not JWE-encrypted.");
+            emitEncryptionContractViolation(path, "Value for encrypted modify path is not JWE-encrypted.");
             throw new ActionExecutionResponseProcessorException(
-                    "Value for encrypted modify path '" + operation.getPath() +
+                    "Value for encrypted modify path '" + path +
                             "' must be JWE-encrypted, but received a plaintext value.");
         }
 
         try {
-            String decrypted = JWEEncryptionUtil.decrypt(stringValue, tenantDomain);
-            PerformableOperation decryptedOp = new PerformableOperation();
-            decryptedOp.setOp(operation.getOp());
-            decryptedOp.setPath(operation.getPath());
-            decryptedOp.setValue(decrypted);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Successfully decrypted inbound JWE value for path: " + operation.getPath());
-            }
-            return decryptedOp;
-        } catch (Exception e) {
+            return JWEEncryptionUtil.decrypt(stringValue, tenantDomain);
+        } catch (ActionExecutionException e) {
             if (LoggerUtils.isDiagnosticLogsEnabled()) {
                 LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
-                        FlowExtensionConstants.Log.COMPONENT_ID,
-                        FlowExtensionConstants.Log.ActionIDs.PROCESS_RESPONSE)
+                        ActionExecutionLogConstants.ACTION_EXECUTION_COMPONENT_ID,
+                        ActionExecutionLogConstants.ActionIDs.PROCESS_ACTION_RESPONSE)
                         .resultMessage("Failed to decrypt inbound JWE value for modify path.")
                         .configParam("actionType", ActionType.FLOW_EXTENSION.getDisplayName())
-                        .inputParam("path", operation.getPath())
+                        .inputParam("path", path)
                         .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                         .resultStatus(DiagnosticLog.ResultStatus.FAILED));
             }
             throw new ActionExecutionResponseProcessorException(
-                    "Failed to decrypt inbound JWE value for path: " + operation.getPath(), e);
+                    "Failed to decrypt inbound JWE value for path: " + path, e);
         }
     }
 
@@ -642,8 +574,8 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
 
         if (LoggerUtils.isDiagnosticLogsEnabled()) {
             LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
-                    FlowExtensionConstants.Log.COMPONENT_ID,
-                    FlowExtensionConstants.Log.ActionIDs.PROCESS_RESPONSE)
+                    ActionExecutionLogConstants.ACTION_EXECUTION_COMPONENT_ID,
+                    ActionExecutionLogConstants.ActionIDs.PROCESS_ACTION_RESPONSE)
                     .resultMessage(reason)
                     .configParam(DIAG_PARAM_ACTION_TYPE, ActionType.FLOW_EXTENSION.getDisplayName())
                     .inputParam("path", path)
@@ -652,10 +584,10 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
         }
     }
 
-    private FlowExecutionContext getFlowExecutionContext(FlowContext flowContext)
+    private FlowExecutionContext getFlowExecutionContext(FlowContext actionFlowContext)
             throws ActionExecutionResponseProcessorException {
 
-        FlowExecutionContext execCtx = flowContext.getValue(
+        FlowExecutionContext execCtx = actionFlowContext.getValue(
                 FlowExtensionConstants.FLOW_EXECUTION_CONTEXT_KEY, FlowExecutionContext.class);
         if (execCtx == null) {
             throw new ActionExecutionResponseProcessorException(

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/JWEEncryptionUtil.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/JWEEncryptionUtil.java
@@ -32,11 +32,15 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionException;
+import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 
 import java.io.ByteArrayInputStream;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.security.cert.CertificateException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.CertificateNotYetValidException;
@@ -44,19 +48,17 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
+import java.util.Arrays;
 
 /**
- * JWE encryption and decryption helpers for In-Flow Extension actions.
+ * JWE encryption and decryption helpers for Flow Extension actions.
  */
 public final class JWEEncryptionUtil {
 
     private static final Log LOG = LogFactory.getLog(JWEEncryptionUtil.class);
 
-    private static final Map<String, CachedKey> PRIVATE_KEYS = new ConcurrentHashMap<>();
-    private static final long PRIVATE_KEY_CACHE_TTL_MS = TimeUnit.MINUTES.toMillis(30);
+    // Number of segments in a JWE compact serialization
+    private static final int JWE_COMPACT_SEGMENT_COUNT = 5;
 
     private JWEEncryptionUtil() {
 
@@ -72,6 +74,38 @@ public final class JWEEncryptionUtil {
      */
     public static String encrypt(String plaintext, String certificatePEM) throws ActionExecutionException {
 
+        return encryptPayload(new Payload(plaintext), certificatePEM);
+    }
+
+    /**
+     * Char-array overload of {@link #encrypt(String, String)}. Encrypts credentials held as a
+     * {@code char[]} using JWE, without ever materializing the credentials as an immutable String.
+     *
+     * @param credentials    The credentials JSON content to encrypt, as a char array.
+     * @param certificatePEM The external service's X.509 certificate in PEM format.
+     * @return JWE compact serialization string.
+     * @throws ActionExecutionException If encryption fails.
+     */
+    public static String encrypt(char[] credentials, String certificatePEM) throws ActionExecutionException {
+
+        byte[] credentialsBytes = charsToUtf8Bytes(credentials);
+        try {
+            return encryptPayload(new Payload(credentialsBytes), certificatePEM);
+        } finally {
+            // Securely wipe the temporary byte array
+            Arrays.fill(credentialsBytes, (byte) 0);
+        }
+    }
+
+    /**
+     * Core encryption logic shared by all overloads.
+     * @param payload        The Nimbus Payload object containing the data to encrypt.
+     * @param certificatePEM The external service's X.509 certificate in PEM format.
+     * @return JWE compact serialization string.
+     * @throws ActionExecutionException If encryption fails.
+     */
+    private static String encryptPayload(Payload payload, String certificatePEM) throws ActionExecutionException {
+
         try {
             X509Certificate certificate = parsePEMCertificate(certificatePEM);
             RSAPublicKey publicKey = (RSAPublicKey) certificate.getPublicKey();
@@ -80,14 +114,31 @@ public final class JWEEncryptionUtil {
                     .contentType("application/json")
                     .build();
 
-            JWEObject jweObject = new JWEObject(header, new Payload(plaintext));
+            JWEObject jweObject = new JWEObject(header, payload);
             jweObject.encrypt(new RSAEncrypter(publicKey));
 
             return jweObject.serialize();
         } catch (JOSEException e) {
             throw new ActionExecutionException(
-                    "Failed to JWE-encrypt data for In-Flow Extension action.", e);
+                    "Failed to JWE-encrypt data for Flow Extension action.", e);
         }
+    }
+
+    /**
+     * Converts a char array to UTF-8 encoded bytes without allocating an intermediate String,
+     * so sensitive plaintext never lands in the String pool or as an immutable object.
+     */
+    private static byte[] charsToUtf8Bytes(char[] chars) {
+
+        CharBuffer charBuffer = CharBuffer.wrap(chars);
+        ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(charBuffer);
+        byte[] bytes = new byte[byteBuffer.remaining()];
+        byteBuffer.get(bytes);
+
+        if (byteBuffer.hasArray()) {
+            Arrays.fill(byteBuffer.array(), (byte) 0);
+        }
+        return bytes;
     }
 
     /**
@@ -111,45 +162,29 @@ public final class JWEEncryptionUtil {
             return jweObject.getPayload().toString();
         } catch (ParseException e) {
             throw new ActionExecutionException(
-                    "Failed to parse JWE string from In-Flow Extension response.", e);
+                    "Failed to parse JWE string from Flow Extension response.", e);
         } catch (JOSEException e) {
             throw new ActionExecutionException(
-                    "Failed to decrypt JWE value from In-Flow Extension response.", e);
+                    "Failed to decrypt JWE value from Flow Extension response.", e);
         } catch (ActionExecutionException e) {
             throw e;
         } catch (Exception e) {
             throw new ActionExecutionException(
-                    "Error resolving IS private key for In-Flow Extension JWE decryption.", e);
+                    "Error resolving IS private key for Flow Extension JWE decryption.", e);
         }
     }
 
-    private static Key getPrivateKey(String tenantDomain) throws ActionExecutionException {
+    private static Key getPrivateKey(String tenantDomain) throws Exception {
 
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-        String cacheKey = String.valueOf(tenantId);
-        CachedKey cached = PRIVATE_KEYS.get(cacheKey);
-        if (cached != null && !cached.isExpired()) {
-            return cached.getKey();
+        IdentityTenantUtil.initializeRegistry(tenantId);
+        KeyStoreManager keyStoreManager = KeyStoreManager.getInstance(tenantId);
+
+        if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+            return keyStoreManager.getDefaultPrivateKey();
         }
-
-        try {
-            IdentityTenantUtil.initializeRegistry(tenantId);
-            KeyStoreManager keyStoreManager = KeyStoreManager.getInstance(tenantId);
-            Key privateKey;
-
-            if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
-                privateKey = keyStoreManager.getDefaultPrivateKey();
-            } else {
-                String tenantKeyStoreName = tenantDomain.trim().replace(".", "-") + ".jks";
-                privateKey = keyStoreManager.getPrivateKey(tenantKeyStoreName, tenantDomain);
-            }
-
-            PRIVATE_KEYS.put(cacheKey, new CachedKey(privateKey));
-            return privateKey;
-        } catch (Exception e) {
-            throw new ActionExecutionException(
-                    "Error retrieving private key for tenant: " + tenantDomain, e);
-        }
+        String tenantKeyStoreName = IdentityKeyStoreResolverUtil.buildTenantKeyStoreName(tenantDomain);
+        return keyStoreManager.getPrivateKey(tenantKeyStoreName, tenantDomain);
     }
 
     /**
@@ -163,16 +198,30 @@ public final class JWEEncryptionUtil {
         if (value == null || value.isEmpty()) {
             return false;
         }
-        int dotCount = 0;
-        for (int i = 0; i < value.length(); i++) {
-            if (value.charAt(i) == '.') {
-                dotCount++;
-                if (dotCount > 4) {
-                    return false;
-                }
+        return isJWECompactSerialization(value);
+    }
+
+    /**
+     * Check whether {@code value} has the structure of a JWE compact serialization: exactly
+     * {@value #JWE_COMPACT_SEGMENT_COUNT} non-empty Base64URL segments separated by dots
+     * ({@code header.encryptedKey.iv.ciphertext.tag}). RSA-OAEP always yields a non-empty
+     * encrypted-key segment, so an empty segment means this is not a value we produced.
+     *
+     * @param value The value to check.
+     * @return {@code true} if the value has the JWE compact structure.
+     */
+    private static boolean isJWECompactSerialization(String value) {
+
+        String[] segments = value.split("\\.", -1);
+        if (segments.length != JWE_COMPACT_SEGMENT_COUNT) {
+            return false;
+        }
+        for (String segment : segments) {
+            if (segment.isEmpty()) {
+                return false;
             }
         }
-        return dotCount == 4;
+        return true;
     }
 
     /**
@@ -199,38 +248,16 @@ public final class JWEEncryptionUtil {
 
         } catch (CertificateExpiredException e) {
             throw new ActionExecutionException(
-                    "Certificate has expired for In-Flow Extension action.", e);
+                    "Certificate has expired for Flow Extension action.", e);
         } catch (CertificateNotYetValidException e) {
             throw new ActionExecutionException(
-                    "Certificate is not yet valid for In-Flow Extension action.", e);
+                    "Certificate is not yet valid for Flow Extension action.", e);
         } catch (IllegalArgumentException e) {
             throw new ActionExecutionException(
                     "Failed to decode certificate: Input is not valid Base64.", e);
-        } catch (Exception e) {
+        } catch (CertificateException e) {
             throw new ActionExecutionException(
-                    "Failed to parse the decoded PEM certificate for In-Flow Extension action.", e);
-        }
-    }
-
-    private static class CachedKey {
-
-        private final Key key;
-        private final long createdAt;
-
-        CachedKey(Key key) {
-
-            this.key = key;
-            this.createdAt = System.currentTimeMillis();
-        }
-
-        Key getKey() {
-
-            return key;
-        }
-
-        boolean isExpired() {
-
-            return (System.currentTimeMillis() - createdAt) > PRIVATE_KEY_CACHE_TTL_MS;
+                    "Failed to parse the decoded PEM certificate for Flow Extension action.", e);
         }
     }
 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/PathTypeAnnotationUtil.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/PathTypeAnnotationUtil.java
@@ -18,18 +18,13 @@
 
 package org.wso2.carbon.identity.flow.extension.executor;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Utility for parsing and coercing path type annotations.
+ * Utility for parsing path type annotations.
  */
 public final class PathTypeAnnotationUtil {
 
@@ -37,9 +32,6 @@ public final class PathTypeAnnotationUtil {
     static final String LOCAL_CLAIM_DIALECT_PREFIX = "http://wso2.org/claims/";
     static final String IDENTITY_CLAIM_URI_PREFIX = "http://wso2.org/claims/identity/";
     static final int MAX_ATTRIBUTES_PER_OBJECT = 10;
-    static final int MAX_ARRAY_ITEMS = 10;
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private PathTypeAnnotationUtil() {
     }
@@ -62,43 +54,6 @@ public final class PathTypeAnnotationUtil {
     }
 
     /**
-     * Coerce a value based on its path annotation: complex returned as-is,
-     * primary arrays become {@code List<String>}, others become String.
-     */
-    @SuppressWarnings("unchecked")
-    public static Object coerceValue(String path, Object value, Map<String, String> pathTypeAnnotations) {
-
-        if (value == null) {
-            return null;
-        }
-        String annotation = pathTypeAnnotations.get(path);
-        if (annotation == null) {
-            return String.valueOf(value);
-        }
-        if (annotation.startsWith("[")) {
-            String inner = annotation.substring(1, annotation.length() - 1);
-            if (inner.contains(":")) {
-                return tryParseJsonString(value);
-            }
-            Object resolved = tryParseJsonString(value);
-            if (resolved instanceof List) {
-                List<String> stringList = new ArrayList<>();
-                for (Object item : (List<Object>) resolved) {
-                    stringList.add(item == null ? null : String.valueOf(item));
-                }
-                return stringList;
-            }
-            List<String> singleList = new ArrayList<>();
-            singleList.add(String.valueOf(value));
-            return singleList;
-        }
-        if (annotation.contains(":")) {
-            return tryParseJsonString(value);
-        }
-        return String.valueOf(value);
-    }
-
-    /**
      * Validate a complex annotation does not exceed {@link #MAX_ATTRIBUTES_PER_OBJECT}.
      * Returns {@code true} for non-complex or empty annotations.
      */
@@ -115,81 +70,6 @@ public final class PathTypeAnnotationUtil {
             return true;
         }
         return parseAnnotationAttributes(inner).size() <= MAX_ATTRIBUTES_PER_OBJECT;
-    }
-
-    /**
-     * Validate a complex object/array value against its schema annotation.
-     * Enforces {@link #MAX_ATTRIBUTES_PER_OBJECT} and {@link #MAX_ARRAY_ITEMS}.
-     * Returns {@code true} for non-complex annotations.
-     */
-    @SuppressWarnings("unchecked")
-    public static boolean validateValueAgainstAnnotation(String path, Object value,
-                                                         Map<String, String> pathTypeAnnotations) {
-
-        String annotation = pathTypeAnnotations.get(path);
-        if (annotation == null) {
-            return true;
-        }
-        boolean isArray = annotation.startsWith("[");
-        String inner = isArray ? annotation.substring(1, annotation.length() - 1) : annotation;
-        if (!inner.contains(":")) {
-            return true;
-        }
-        Map<String, String> schema = parseAnnotationAttributes(inner);
-        Object resolved = tryParseJsonString(value);
-        if (!isArray) {
-            return validateSingleComplexObject(resolved, schema);
-        }
-        if (!(resolved instanceof List)) {
-            return false;
-        }
-        List<Object> items = (List<Object>) resolved;
-        if (items.size() > MAX_ARRAY_ITEMS) {
-            return false;
-        }
-        for (Object item : items) {
-            if (!validateSingleComplexObject(item, schema)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Enforce {@link #MAX_ARRAY_ITEMS} on array-typed values.
-     */
-    @SuppressWarnings("unchecked")
-    public static boolean enforceArrayItemLimit(String path, Object value,
-                                                Map<String, String> pathTypeAnnotations) {
-
-        String annotation = pathTypeAnnotations.get(path);
-        if (annotation == null || !annotation.startsWith("[")) {
-            return true;
-        }
-        if (!(value instanceof List)) {
-            return true;
-        }
-        return ((List<Object>) value).size() <= MAX_ARRAY_ITEMS;
-    }
-
-    /**
-     * Parse a String as JSON if it starts with {@code [} or {@code {}; otherwise return as-is.
-     * Handles serialized JSON arriving from external services (e.g. after JWE decryption).
-     */
-    private static Object tryParseJsonString(Object value) {
-
-        if (!(value instanceof String)) {
-            return value;
-        }
-        String str = ((String) value).trim();
-        if (!str.startsWith("[") && !str.startsWith("{")) {
-            return value;
-        }
-        try {
-            return OBJECT_MAPPER.readValue(str, Object.class);
-        } catch (IOException ignored) {
-            return value;
-        }
     }
 
     /**
@@ -210,75 +90,5 @@ public final class PathTypeAnnotationUtil {
             }
         }
         return attributes;
-    }
-
-    /**
-     * Validate a single complex object: must be a Map with schema-only keys,
-     * attribute count within limits, and only single-level nesting.
-     */
-    @SuppressWarnings("unchecked")
-    private static boolean validateSingleComplexObject(Object value, Map<String, String> schema) {
-
-        if (!isMapAndWithinAttributeLimit(value)) {
-            return false;
-        }
-        Map<String, Object> map = (Map<String, Object>) value;
-        if (!containsOnlySchemaKeys(map, schema)) {
-            return false;
-        }
-        for (Map.Entry<String, Object> entry : map.entrySet()) {
-            if (!validateEntryValueAgainstType(entry, schema)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static boolean isMapAndWithinAttributeLimit(Object value) {
-
-        return value instanceof Map && ((Map<?, ?>) value).size() <= MAX_ATTRIBUTES_PER_OBJECT;
-    }
-
-    private static boolean containsOnlySchemaKeys(Map<String, Object> valueMap, Map<String, String> schema) {
-
-        for (String key : valueMap.keySet()) {
-            if (!schema.containsKey(key)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static boolean validateEntryValueAgainstType(Map.Entry<String, Object> entry, Map<String, String> schema) {
-
-        String type = schema.get(entry.getKey());
-        Object attrValue = entry.getValue();
-        if (type != null && type.endsWith("[]")) {
-            return validatePrimaryArrayAttribute(attrValue);
-        }
-        return !isNestedStructure(attrValue);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static boolean validatePrimaryArrayAttribute(Object value) {
-
-        if (!(value instanceof List)) {
-            return false;
-        }
-        List<Object> list = (List<Object>) value;
-        if (list.size() > MAX_ARRAY_ITEMS) {
-            return false;
-        }
-        for (Object item : list) {
-            if (isNestedStructure(item)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static boolean isNestedStructure(Object value) {
-
-        return value instanceof Map || value instanceof List;
     }
 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/internal/FlowExtensionDataHolder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/internal/FlowExtensionDataHolder.java
@@ -24,7 +24,7 @@ import org.wso2.carbon.identity.certificate.management.service.CertificateManage
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 
 /**
- * Data holder for the In-Flow Extension bundle.
+ * Data holder for the Flow Extension bundle.
  *
  * <p>This singleton is used by DS bind/unbind methods to expose dynamic OSGi references
  * to classes outside the component lifecycle methods.</p>

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/internal/FlowExtensionServiceComponent.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/internal/FlowExtensionServiceComponent.java
@@ -44,7 +44,7 @@ import org.wso2.carbon.identity.flow.extension.management.FlowExtensionActionCon
 import org.wso2.carbon.identity.flow.extension.management.FlowExtensionActionDTOModelResolver;
 
 /**
- * OSGi declarative services component which registers the In-Flow Extension services.
+ * OSGi declarative services component which registers the Flow Extension services.
  */
 @Component(
         name = "flow.extension.component",
@@ -72,16 +72,16 @@ public class FlowExtensionServiceComponent {
                             FlowExtensionDataHolder.getInstance().getCertificateManagementService()),
                     null);
 
-            LOG.debug("In-Flow Extension service successfully activated.");
+            LOG.debug("Flow Extension service successfully activated.");
         } catch (Throwable e) {
-            LOG.error("Error while initiating In-Flow Extension service", e);
+            LOG.error("Error while initiating Flow Extension service", e);
         }
     }
 
     @Deactivate
     protected void deactivate(ComponentContext context) {
 
-        LOG.debug("In-Flow Extension service successfully deactivated.");
+        LOG.debug("Flow Extension service successfully deactivated.");
     }
 
     @Reference(
@@ -93,14 +93,14 @@ public class FlowExtensionServiceComponent {
     )
     protected void setActionManagementService(ActionManagementService actionManagementService) {
 
-        LOG.debug("Setting the ActionManagementService in the In-Flow Extension component.");
+        LOG.debug("Setting the ActionManagementService in the Flow Extension component.");
         FlowExtensionDataHolder.getInstance().setActionManagementService(actionManagementService);
     }
 
     protected void unsetActionManagementService(ActionManagementService actionManagementService) {
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Unsetting the ActionManagementService in the In-Flow Extension component. Service: "
+            LOG.debug("Unsetting the ActionManagementService in the Flow Extension component. Service: "
                     + actionManagementService);
         }
         FlowExtensionDataHolder.getInstance().setActionManagementService(null);
@@ -115,14 +115,14 @@ public class FlowExtensionServiceComponent {
     )
     protected void setActionExecutorService(ActionExecutorService actionExecutorService) {
 
-        LOG.debug("Setting the ActionExecutorService in the In-Flow Extension component.");
+        LOG.debug("Setting the ActionExecutorService in the Flow Extension component.");
         FlowExtensionDataHolder.getInstance().setActionExecutorService(actionExecutorService);
     }
 
     protected void unsetActionExecutorService(ActionExecutorService actionExecutorService) {
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Unsetting the ActionExecutorService in the In-Flow Extension component. Service: "
+            LOG.debug("Unsetting the ActionExecutorService in the Flow Extension component. Service: "
                     + actionExecutorService);
         }
         FlowExtensionDataHolder.getInstance().setActionExecutorService(null);
@@ -137,7 +137,7 @@ public class FlowExtensionServiceComponent {
     )
     protected void setCertificateManagementService(CertificateManagementService certificateManagementService) {
 
-        LOG.debug("Setting the CertificateManagementService in the In-Flow Extension component.");
+        LOG.debug("Setting the CertificateManagementService in the Flow Extension component.");
         FlowExtensionDataHolder.getInstance()
                 .setCertificateManagementService(certificateManagementService);
     }
@@ -146,7 +146,7 @@ public class FlowExtensionServiceComponent {
             CertificateManagementService certificateManagementService) {
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Unsetting the CertificateManagementService in the In-Flow Extension component. Service: "
+            LOG.debug("Unsetting the CertificateManagementService in the Flow Extension component. Service: "
                     + certificateManagementService);
         }
         FlowExtensionDataHolder.getInstance().setCertificateManagementService(null);
@@ -162,7 +162,7 @@ public class FlowExtensionServiceComponent {
     protected void setClaimMetadataManagementService(
             ClaimMetadataManagementService claimMetadataManagementService) {
 
-        LOG.debug("Setting the ClaimMetadataManagementService in the In-Flow Extension component.");
+        LOG.debug("Setting the ClaimMetadataManagementService in the Flow Extension component.");
         FlowExtensionDataHolder.getInstance()
                 .setClaimMetadataManagementService(claimMetadataManagementService);
     }
@@ -171,7 +171,7 @@ public class FlowExtensionServiceComponent {
             ClaimMetadataManagementService claimMetadataManagementService) {
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Unsetting the ClaimMetadataManagementService in the In-Flow Extension component. Service: "
+            LOG.debug("Unsetting the ClaimMetadataManagementService in the Flow Extension component. Service: "
                     + claimMetadataManagementService);
         }
         FlowExtensionDataHolder.getInstance().setClaimMetadataManagementService(null);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionConverter.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionConverter.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.identity.flow.extension.management;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.action.management.api.model.Action;
 import org.wso2.carbon.identity.action.management.api.model.ActionDTO;
 import org.wso2.carbon.identity.action.management.api.model.ActionProperty;
@@ -27,8 +27,6 @@ import org.wso2.carbon.identity.certificate.management.model.Certificate;
 import org.wso2.carbon.identity.flow.extension.model.AccessConfig;
 import org.wso2.carbon.identity.flow.extension.model.ContextPath;
 import org.wso2.carbon.identity.flow.extension.model.FlowExtensionAction;
-
-import com.ctc.wstx.util.StringUtil;
 
 import java.util.HashMap;
 import java.util.List;
@@ -41,11 +39,9 @@ import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.Act
 
 /**
  * ActionConverter implementation for Flow Extension actions.
- * <p>
  * Handles the conversion between {@link FlowExtensionAction} (domain model) and
  * {@link ActionDTO} (data transfer object) by mapping the {@link AccessConfig} fields
  * to/from action properties.
- * </p>
  */
 public class FlowExtensionActionConverter implements ActionConverter {
 
@@ -104,12 +100,12 @@ public class FlowExtensionActionConverter implements ActionConverter {
         }
         String content = certificate.getCertificateContent();
         if (StringUtils.isBlank(content)) {
-            properties.put(CERTIFICATE,
-                    new ActionProperty.BuilderForService(certificate).build());
-        } else {
-            // Certificate with no content — signals explicit removal at the resolver layer.
+            // Certificate with no content signals explicit removal at the resolver layer.
             properties.put(CERTIFICATE,
                     new ActionProperty.BuilderForService("").build());
+        } else {
+            properties.put(CERTIFICATE,
+                    new ActionProperty.BuilderForService(certificate).build());
         }
     }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeBuilder.java
@@ -27,15 +27,11 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Builds the controlled In-Flow Extension context tree returned by the metadata endpoint.
+ * Builds the controlled Flow Extension context tree returned by the metadata endpoint.
  * The set of exposed attributes is governed at code level by this builder so the frontend
- * receives the user/flow/properties tree shape the Console UI expects.
+ * receives the user/flow tree shape the Console UI expects.
  */
 public class FlowExtensionContextTreeBuilder {
-
-    // Flow context attributes that appear under the "flow" branch of the tree.
-    private static final List<String> FLOW_BRANCH_ATTRS =
-            Arrays.asList("flowType", "portalUrl");
 
     /**
      * Build the metadata response for the given flow type.
@@ -47,10 +43,9 @@ public class FlowExtensionContextTreeBuilder {
 
         List<FlowExtensionContextTreeNode> tree = new ArrayList<>();
         tree.add(buildUserNode());
-//        tree.add(buildPropertiesNode());
-//        tree.add(buildTenantNode());
+        tree.add(buildTenantNode());
         tree.add(buildApplicationNode());
-//        tree.add(buildOrganizationNode());
+        tree.add(buildOrganizationNode());
         tree.add(buildFlowNode());
 
         return new FlowExtensionContextTreeMetadata(
@@ -70,50 +65,42 @@ public class FlowExtensionContextTreeBuilder {
      * will be wired into.</p>
      */
     static boolean allowReadOnlyClaimsModification(String flowType) {
-
-        if (flowType == null) {
-            return true;
-        }
-        switch (flowType) {
-            case ContextTree.FLOW_REGISTRATION, ContextTree.FLOW_INVITED_USER_REGISTRATION:
-                return true;
-            case ContextTree.FLOW_PASSWORD_RECOVERY:
-            default:
-                return false;
-        }
+        return flowType == null
+                || ContextTree.FLOW_REGISTRATION.equals(flowType)
+                || ContextTree.FLOW_INVITED_USER_REGISTRATION.equals(flowType);
     }
 
     private FlowExtensionContextTreeNode buildUserNode() {
 
         List<FlowExtensionContextTreeNode> children = new ArrayList<>();
 
-//        children.add(FlowExtensionContextTreeNode.builder()
-//                .key("id")
-//                .title("User ID")
-//                .path("/user/id")
-//                .dataType(ContextTree.DATA_TYPE_STRING)
-//                .nodeType(ContextTree.NODE_LEAF)
-//                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
-//                .replaceable(false)
-//                .build());
-//        children.add(FlowExtensionContextTreeNode.builder()
-//                .key("username")
-//                .title("Username")
-//                .path("/user/username")
-//                .dataType(ContextTree.DATA_TYPE_STRING)
-//                .nodeType(ContextTree.NODE_LEAF)
-//                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
-//                .replaceable(false)
-//                .build());
-//        children.add(FlowExtensionContextTreeNode.builder()
-//                .key("userStoreDomain")
-//                .title("User Store Domain")
-//                .path("/user/userStoreDomain")
-//                .dataType(ContextTree.DATA_TYPE_STRING)
-//                .nodeType(ContextTree.NODE_LEAF)
-//                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
-//                .replaceable(false)
-//                .build());
+        children.add(FlowExtensionContextTreeNode.builder()
+                .key("id")
+                .title("User ID")
+                .path(FlowContextPaths.USER_ID_PATH)
+                .dataType(ContextTree.DATA_TYPE_STRING)
+                .nodeType(ContextTree.NODE_LEAF)
+                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
+                .replaceable(false)
+                .build());
+        children.add(FlowExtensionContextTreeNode.builder()
+                .key("username")
+                .title("Username")
+                .path(FlowContextPaths.USER_USERNAME_PATH)
+                .dataType(ContextTree.DATA_TYPE_STRING)
+                .nodeType(ContextTree.NODE_LEAF)
+                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
+                .replaceable(false)
+                .build());
+        children.add(FlowExtensionContextTreeNode.builder()
+                .key("userStoreDomain")
+                .title("User Store Domain")
+                .path(FlowContextPaths.USER_STORE_DOMAIN_PATH)
+                .dataType(ContextTree.DATA_TYPE_STRING)
+                .nodeType(ContextTree.NODE_LEAF)
+                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
+                .replaceable(false)
+                .build());
 
         children.add(FlowExtensionContextTreeNode.builder()
                 .key("claims")
@@ -127,31 +114,30 @@ public class FlowExtensionContextTreeBuilder {
                 .children(Collections.emptyList())
                 .build());
 
-//        List<FlowExtensionContextTreeNode> credentialsChildren = new ArrayList<>();
-//        credentialsChildren.add(FlowExtensionContextTreeNode.builder()
-//                .key("password")
-//                .title("Password")
-//                .path("/user/credentials/password")
-//                .dataType("char[]")
-//                .nodeType(ContextTree.NODE_LEAF)
-//                .allowedOperations(Arrays.asList(ContextTree.OP_EXPOSE, ContextTree.OP_MODIFY))
-//                .build());
-//
-//        children.add(FlowExtensionContextTreeNode.builder()
-//                .key("credentials")
-//                .title("Credentials")
-//                .path("/user/credentials/")
-//                .dataType("Map<String, char[]>")
-//                .nodeType(ContextTree.NODE_MAP)
-//                .allowedOperations(Arrays.asList(ContextTree.OP_EXPOSE, ContextTree.OP_MODIFY))
-//                .dynamicEntryAllowed(false)
-//                .children(credentialsChildren)
-//                .build());
+        List<FlowExtensionContextTreeNode> credentialsChildren = new ArrayList<>();
+        credentialsChildren.add(FlowExtensionContextTreeNode.builder()
+                .key("password")
+                .title("Password")
+                .path(FlowContextPaths.USER_CREDENTIALS_PATH_PREFIX + "password")
+                .dataType("char[]")
+                .nodeType(ContextTree.NODE_LEAF)
+                .allowedOperations(Arrays.asList(ContextTree.OP_EXPOSE, ContextTree.OP_MODIFY))
+                .build());
+        children.add(FlowExtensionContextTreeNode.builder()
+                .key("credentials")
+                .title("Credentials")
+                .path(FlowContextPaths.USER_CREDENTIALS_PATH_PREFIX)
+                .dataType("Map<String, char[]>")
+                .nodeType(ContextTree.NODE_MAP)
+                .allowedOperations(Arrays.asList(ContextTree.OP_EXPOSE, ContextTree.OP_MODIFY))
+                .dynamicEntryAllowed(false)
+                .children(credentialsChildren)
+                .build());
 
         return FlowExtensionContextTreeNode.builder()
                 .key("user")
                 .title("User")
-                .path("/user/")
+                .path(FlowContextPaths.USER_PREFIX)
                 .dataType("")
                 .nodeType(ContextTree.NODE_OBJECT)
                 .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
@@ -162,9 +148,8 @@ public class FlowExtensionContextTreeBuilder {
     private FlowExtensionContextTreeNode buildFlowNode() {
 
         List<FlowExtensionContextTreeNode> children = new ArrayList<>();
-        for (String attr : FLOW_BRANCH_ATTRS) {
-            children.add(readOnlyLeaf(attr, attrTitle(attr), FlowContextPaths.FLOW_PREFIX + attr));
-        }
+        children.add(readOnlyLeaf("flowType", "Flow Type", FlowContextPaths.FLOW_TYPE_PATH));
+        children.add(readOnlyLeaf("portalUrl", "Portal URL", FlowContextPaths.FLOW_PORTAL_URL_PATH));
         return FlowExtensionContextTreeNode.builder()
                 .key("flow")
                 .title("Flow")
@@ -177,21 +162,21 @@ public class FlowExtensionContextTreeBuilder {
                 .build();
     }
 
-//    private FlowExtensionContextTreeNode buildTenantNode() {
-//
-//        List<FlowExtensionContextTreeNode> children = new ArrayList<>();
-//        children.add(readOnlyLeaf("domain", "Tenant Domain", FlowContextPaths.TENANT_DOMAIN_PATH));
-//        return FlowExtensionContextTreeNode.builder()
-//                .key("tenant")
-//                .title("Tenant")
-//                .path(FlowContextPaths.TENANT_PREFIX)
-//                .dataType("")
-//                .nodeType(ContextTree.NODE_OBJECT)
-//                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
-//                .readOnly(true)
-//                .children(children)
-//                .build();
-//    }
+    private FlowExtensionContextTreeNode buildTenantNode() {
+
+        List<FlowExtensionContextTreeNode> children = new ArrayList<>();
+        children.add(readOnlyLeaf("domain", "Tenant Domain", FlowContextPaths.TENANT_DOMAIN_PATH));
+        return FlowExtensionContextTreeNode.builder()
+                .key("tenant")
+                .title("Tenant")
+                .path(FlowContextPaths.TENANT_PREFIX)
+                .dataType("")
+                .nodeType(ContextTree.NODE_OBJECT)
+                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
+                .readOnly(true)
+                .children(children)
+                .build();
+    }
 
     private FlowExtensionContextTreeNode buildApplicationNode() {
 
@@ -209,24 +194,24 @@ public class FlowExtensionContextTreeBuilder {
                 .build();
     }
 
-//    private FlowExtensionContextTreeNode buildOrganizationNode() {
-//
-//        List<FlowExtensionContextTreeNode> children = new ArrayList<>();
-//        children.add(readOnlyLeaf("id", "Organization ID", FlowContextPaths.ORGANIZATION_ID_PATH));
-//        children.add(readOnlyLeaf("name", "Organization Name", FlowContextPaths.ORGANIZATION_NAME_PATH));
-//        children.add(readOnlyLeaf("orgHandle", "Organization Handle", FlowContextPaths.ORGANIZATION_HANDLE_PATH));
-//        children.add(readOnlyLeaf("depth", "Organization Depth", FlowContextPaths.ORGANIZATION_DEPTH_PATH));
-//        return FlowExtensionContextTreeNode.builder()
-//                .key("organization")
-//                .title("Organization")
-//                .path(FlowContextPaths.ORGANIZATION_PREFIX)
-//                .dataType("")
-//                .nodeType(ContextTree.NODE_OBJECT)
-//                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
-//                .readOnly(true)
-//                .children(children)
-//                .build();
-//    }
+    private FlowExtensionContextTreeNode buildOrganizationNode() {
+
+        List<FlowExtensionContextTreeNode> children = new ArrayList<>();
+        children.add(readOnlyLeaf("id", "Organization ID", FlowContextPaths.ORGANIZATION_ID_PATH));
+        children.add(readOnlyLeaf("name", "Organization Name", FlowContextPaths.ORGANIZATION_NAME_PATH));
+        children.add(readOnlyLeaf("orgHandle", "Organization Handle", FlowContextPaths.ORGANIZATION_HANDLE_PATH));
+        children.add(readOnlyLeaf("depth", "Organization Depth", FlowContextPaths.ORGANIZATION_DEPTH_PATH));
+        return FlowExtensionContextTreeNode.builder()
+                .key("organization")
+                .title("Organization")
+                .path(FlowContextPaths.ORGANIZATION_PREFIX)
+                .dataType("")
+                .nodeType(ContextTree.NODE_OBJECT)
+                .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
+                .readOnly(true)
+                .children(children)
+                .build();
+    }
 
     private FlowExtensionContextTreeNode readOnlyLeaf(String key, String title, String path) {
 
@@ -239,29 +224,5 @@ public class FlowExtensionContextTreeBuilder {
                 .allowedOperations(Collections.singletonList(ContextTree.OP_EXPOSE))
                 .readOnly(true)
                 .build();
-    }
-
-//    private FlowExtensionContextTreeNode buildPropertiesNode() {
-//
-//        return FlowExtensionContextTreeNode.builder()
-//                .key("properties")
-//                .title("Properties")
-//                .path("/properties/")
-//                .dataType("Map<String, Object>")
-//                .nodeType(ContextTree.NODE_COMPLEX_MAP)
-//                .allowedOperations(Collections.singletonList(ContextTree.OP_MODIFY))
-//                .dynamicEntryAllowed(true)
-//                .dynamicEntryType("Object")
-//                .children(Collections.emptyList())
-//                .build();
-//    }
-
-    private static String attrTitle(String attr) {
-
-        switch (attr) {
-            case "flowType":       return "Flow Type";
-            case "portalUrl":      return "Portal URL";
-            default:               return attr;
-        }
     }
 }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeNode.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeNode.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Single node in the In-Flow Extension context tree returned by the metadata service.
+ * Single node in the Flow Extension context tree returned by the metadata service.
  * Mirrors the shape of {@code default-flow-context-tree.json} on the Console side so the
  * existing tree component can render this without translation.
  */

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeService.java
@@ -19,7 +19,7 @@
 package org.wso2.carbon.identity.flow.extension.metadata;
 
 /**
- * Public-API entry point for retrieving the controlled In-Flow Extension context tree.
+ * Public-API entry point for retrieving the controlled Flow Extension context tree.
  * Lives in the {@code metadata} package (which is exported by the engine OSGi bundle), so
  * external bundles such as the flow-management API server can call it without depending on
  * the engine's {@code internal} package.

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionAction.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionAction.java
@@ -54,7 +54,7 @@ public class FlowExtensionAction extends Action {
     }
 
     /**
-     * Returns the default access configuration for this In-Flow Extension action.
+     * Returns the default access configuration for this Flow Extension action.
      *
      * @return The access config, or {@code null} if not configured.
      */
@@ -75,7 +75,7 @@ public class FlowExtensionAction extends Action {
     }
 
     /**
-     * Returns the icon URL for this In-Flow Extension action.
+     * Returns the icon URL for this Flow Extension action.
      *
      * @return The icon URL, or {@code null} if not configured.
      */

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionEvent.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionEvent.java
@@ -23,32 +23,23 @@ import org.wso2.carbon.identity.action.execution.api.model.Application;
 import org.wso2.carbon.identity.action.execution.api.model.Event;
 import org.wso2.carbon.identity.action.execution.api.model.Organization;
 import org.wso2.carbon.identity.action.execution.api.model.Tenant;
-import org.wso2.carbon.identity.action.execution.api.model.UserStore;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
- * This class models the In-Flow Extension Event.
- * It represents the event sent to the In-Flow Extension action over the Action Execution Request.
+ * This class models the Flow Extension Event.
+ * It represents the event sent to the Flow Extension action over the Action Execution Request.
  */
 public class FlowExtensionEvent extends Event {
 
     private final FlowExtensionFlow flow;
     private final String callbackUrl;
-    private final Map<String, Object> flowProperties;
 
     private FlowExtensionEvent(Builder builder) {
 
         this.tenant = builder.tenant;
         this.organization = builder.organization;
-        this.userStore = builder.userStore;
         this.application = builder.application;
         this.flow = builder.flow;
         this.callbackUrl = builder.callbackUrl;
-        this.flowProperties = builder.flowProperties != null ?
-                Collections.unmodifiableMap(new HashMap<>(builder.flowProperties)) : Collections.emptyMap();
     }
 
     /**
@@ -76,16 +67,6 @@ public class FlowExtensionEvent extends Event {
     }
 
     /**
-     * Get the flow properties/context data.
-     *
-     * @return Unmodifiable map of flow properties.
-     */
-    public Map<String, Object> getFlowProperties() {
-
-        return flowProperties;
-    }
-
-    /**
      * Builder for the InFlowExtensionEvent.
      */
     public static class Builder {
@@ -93,10 +74,8 @@ public class FlowExtensionEvent extends Event {
         private FlowExtensionFlow flow;
         private Tenant tenant;
         private Organization organization;
-        private UserStore userStore;
         private Application application;
         private String callbackUrl;
-        private Map<String, Object> flowProperties;
 
         public Builder flow(FlowExtensionFlow flow) {
 
@@ -116,12 +95,6 @@ public class FlowExtensionEvent extends Event {
             return this;
         }
 
-        public Builder userStore(UserStore userStore) {
-
-            this.userStore = userStore;
-            return this;
-        }
-
         public Builder application(Application application) {
 
             this.application = application;
@@ -131,12 +104,6 @@ public class FlowExtensionEvent extends Event {
         public Builder callbackUrl(String callbackUrl) {
 
             this.callbackUrl = callbackUrl;
-            return this;
-        }
-
-        public Builder flowProperties(Map<String, Object> flowProperties) {
-
-            this.flowProperties = flowProperties != null ? new HashMap<>(flowProperties) : null;
             return this;
         }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionFlow.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionFlow.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import org.wso2.carbon.identity.action.execution.api.model.User;
 
 /**
- * Models the {@code flow} object nested inside the In-Flow Extension Event.
+ * Models the {@code flow} object nested inside the Flow Extension Event.
  * Groups flow-scoped context: the flow type, flow identifier, and the acting user.
  */
 public class FlowExtensionFlow {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionUser.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionUser.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.wso2.carbon.identity.action.execution.api.model.User;
+import org.wso2.carbon.identity.action.execution.api.model.UserClaim;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class models the user object sent to the Flow Extension action.
+ * It extends the shared {@link User} with the username, user store domain, and credentials specific
+ * to the flow extension contract. All fields are nullable and populated only when the corresponding
+ * path is exposed. Per-property {@link JsonInclude} settings on the getters control how each field
+ * is serialized in the outbound payload.
+ */
+public class FlowExtensionUser extends User {
+
+    private final String username;
+    private final String userStoreDomain;
+    private final Map<String, Object> credentials;
+
+    private FlowExtensionUser(Builder builder) {
+
+        super(new User.Builder(builder.id)
+                .claims(builder.claims));
+        this.username = builder.username;
+        this.userStoreDomain = builder.userStoreDomain;
+        this.credentials = builder.credentials.isEmpty()
+                ? null
+                : new LinkedHashMap<>(builder.credentials);
+    }
+
+    /**
+     * Get the user id.
+     * Overrides {@link User#getId()} purely to relax the inclusion policy: an exposed-but-empty
+     * user id must serialize as {@code ""} rather than be dropped by the mapper's {@code NON_EMPTY}
+     * default. The value itself is still held by the shared {@link User} model.
+     *
+     * @return The user id, or {@code null} if not set.
+     */
+    @Override
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getId() {
+
+        return super.getId();
+    }
+
+    /**
+     * Get the username.
+     *
+     * @return The username, or {@code null} if not exposed.
+     */
+    public String getUsername() {
+
+        return username;
+    }
+
+    /**
+     * Get the user store domain.
+     * NON_NULL overrides the ObjectMapper-level NON_EMPTY so that an exposed user store domain with
+     * no value is serialized as {@code ""} (denoting the primary user store) rather than omitted.
+     *
+     * @return The user store domain, or {@code null} if not exposed.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getUserStoreDomain() {
+
+        return userStoreDomain;
+    }
+
+    /**
+     * Get the exposed user credentials, keyed by credential name (e.g. {@code password}). Each value
+     * is already in its final wire form: when the path is {@code encrypted: true} it is the JWE
+     * compact string of the typed credential object, otherwise it is the typed credential object
+     * itself (e.g. {@code {"type": "PLAIN_TEXT", "value": "<secret>"}}). Omitted from the payload
+     * when empty.
+     *
+     * @return The credentials map, or {@code null} if none are exposed.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, Object> getCredentials() {
+
+        return credentials == null ? null : Collections.unmodifiableMap(credentials);
+    }
+
+    /**
+     * Builder for {@link FlowExtensionUser}.
+     */
+    public static class Builder {
+
+        private final String id;
+        private String username;
+        private String userStoreDomain;
+        private final List<UserClaim> claims = new ArrayList<>();
+        private final Map<String, Object> credentials = new LinkedHashMap<>();
+
+        /**
+         * Create a builder for a user with the given id.
+         *
+         * @param id The user id (may be {@code null} when not exposed).
+         */
+        public Builder(String id) {
+
+            this.id = id;
+        }
+
+        /**
+         * Set the username.
+         *
+         * @param username The username.
+         * @return This builder.
+         */
+        public Builder username(String username) {
+
+            this.username = username;
+            return this;
+        }
+
+        /**
+         * Set the user store domain.
+         *
+         * @param userStoreDomain The user store domain ({@code ""} denotes the primary user store).
+         * @return This builder.
+         */
+        public Builder userStoreDomain(String userStoreDomain) {
+
+            this.userStoreDomain = userStoreDomain;
+            return this;
+        }
+
+        /**
+         * Add the given user claims to the ones already collected.
+         *
+         * @param claims The user claims to add.
+         * @return This builder.
+         */
+        public Builder claims(List<? extends UserClaim> claims) {
+
+            this.claims.addAll(claims);
+            return this;
+        }
+
+        /**
+         * Add the given credentials (keyed by credential name) to the ones already collected. Each
+         * value is expected to be in its final wire form: the JWE compact string when encrypted, or
+         * the typed credential object (e.g. {@code {"type": "PLAIN_TEXT", "value": "<secret>"}})
+         * otherwise. A {@code null} map is ignored.
+         *
+         * @param credentials The credentials to add.
+         * @return This builder.
+         */
+        public Builder credentials(Map<String, Object> credentials) {
+
+            if (credentials != null) {
+                this.credentials.putAll(credentials);
+            }
+            return this;
+        }
+
+        /**
+         * Build the {@link FlowExtensionUser} from the values collected on this builder.
+         *
+         * @return A new {@link FlowExtensionUser} instance.
+         */
+        public FlowExtensionUser build() {
+
+            return new FlowExtensionUser(this);
+        }
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/util/CredentialWireFormatUtil.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/util/CredentialWireFormatUtil.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.util;
+
+import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.Credentials;
+
+import java.util.Arrays;
+
+/**
+ * Utility class for serializing exposed user credentials into a typed JSON wire format.
+ */
+public final class CredentialWireFormatUtil {
+
+    private static final char[] TYPED_CREDENTIAL_PREFIX = ("{\""
+            + Credentials.TYPE_KEY + "\":\""
+            + Credentials.TYPE_PLAIN_TEXT + "\",\""
+            + Credentials.VALUE_KEY + "\":\"").toCharArray();
+    private static final char[] TYPED_CREDENTIAL_SUFFIX = "\"}".toCharArray();
+    private static final char[] HEX_DIGITS = "0123456789abcdef".toCharArray();
+    private static final int MAX_ESCAPE_EXPANSION = 6;
+
+    private CredentialWireFormatUtil() {
+
+    }
+
+    /**
+     * Serializes the secret into a JSON character array formatted as a typed plaintext credential.
+     *
+     * @param secret The raw credential secret.
+     * @return The typed credential JSON payload.
+     */
+    public static char[] toPlainTextCredentialJson(char[] secret) {
+
+        char[] buffer = new char[TYPED_CREDENTIAL_PREFIX.length
+                + secret.length * MAX_ESCAPE_EXPANSION
+                + TYPED_CREDENTIAL_SUFFIX.length];
+        int pos = 0;
+
+        pos = append(buffer, pos, TYPED_CREDENTIAL_PREFIX);
+        for (char c : secret) {
+            pos = appendJsonEscaped(buffer, pos, c);
+        }
+        pos = append(buffer, pos, TYPED_CREDENTIAL_SUFFIX);
+
+        char[] result = Arrays.copyOf(buffer, pos);
+        // Wipe the oversized working buffer; it holds a copy of the (escaped) secret.
+        Arrays.fill(buffer, '\0');
+        return result;
+    }
+
+    /**
+     * Copies the source character array into the destination buffer.
+     *
+     * @param buffer The destination buffer.
+     * @param pos    The starting index position.
+     * @param src    The source array.
+     * @return The next available index position.
+     */
+    private static int append(char[] buffer, int pos, char[] src) {
+
+        System.arraycopy(src, 0, buffer, pos, src.length);
+        return pos + src.length;
+    }
+
+    /**
+     * Appends the JSON-escaped representation of a single character into the target buffer.
+     *
+     * @param buffer The destination buffer.
+     * @param pos    The current index position.
+     * @param c      The character to evaluate and escape.
+     * @return The updated index position.
+     */
+    private static int appendJsonEscaped(char[] buffer, int pos, char c) {
+
+        switch (c) {
+            case '"':
+                return appendEscape(buffer, pos, '"');
+            case '\\':
+                return appendEscape(buffer, pos, '\\');
+            case '\b':
+                return appendEscape(buffer, pos, 'b');
+            case '\f':
+                return appendEscape(buffer, pos, 'f');
+            case '\n':
+                return appendEscape(buffer, pos, 'n');
+            case '\r':
+                return appendEscape(buffer, pos, 'r');
+            case '\t':
+                return appendEscape(buffer, pos, 't');
+            default:
+                if (c < 0x20) {
+                    return appendUnicodeEscape(buffer, pos, c);
+                }
+                buffer[pos] = c;
+                return pos + 1;
+        }
+    }
+
+    /**
+     * Appends a two-character short escape sequence to the buffer.
+     *
+     * @param buffer     The destination buffer.
+     * @param pos        The current index position.
+     * @param escapeChar The character following the backslash.
+     * @return The updated index position.
+     */
+    private static int appendEscape(char[] buffer, int pos, char escapeChar) {
+
+        buffer[pos] = '\\';
+        buffer[pos + 1] = escapeChar;
+        return pos + 2;
+    }
+
+    /**
+     * Appends a six-character Unicode escape sequence for control characters.
+     *
+     * @param buffer The destination buffer.
+     * @param pos    The current index position.
+     * @param c      The control character to convert.
+     * @return The updated index position.
+     */
+    private static int appendUnicodeEscape(char[] buffer, int pos, char c) {
+
+        buffer[pos] = '\\';
+        buffer[pos + 1] = 'u';
+        buffer[pos + 2] = '0';
+        buffer[pos + 3] = '0';
+        buffer[pos + 4] = HEX_DIGITS[(c >> 4) & 0xF];
+        buffer[pos + 5] = HEX_DIGITS[c & 0xF];
+        return pos + 6;
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilderTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilderTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.executor;
+
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionRequestBuilderException;
+import org.wso2.carbon.identity.action.execution.api.model.ActionExecutionRequest;
+import org.wso2.carbon.identity.action.execution.api.model.ActionExecutionRequestContext;
+import org.wso2.carbon.identity.action.execution.api.model.AllowedOperation;
+import org.wso2.carbon.identity.action.execution.api.model.ActionType;
+import org.wso2.carbon.identity.action.execution.api.model.Operation;
+import org.wso2.carbon.identity.action.management.api.model.Action;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.certificate.management.model.Certificate;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
+import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants;
+import org.wso2.carbon.identity.flow.extension.model.AccessConfig;
+import org.wso2.carbon.identity.flow.extension.model.ContextPath;
+import org.wso2.carbon.identity.flow.extension.model.FlowExtensionAction;
+import org.wso2.carbon.identity.flow.extension.model.FlowExtensionEvent;
+import org.wso2.carbon.identity.flow.extension.model.FlowExtensionUser;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mockStatic;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link FlowExtensionRequestBuilder}: expose-based filtering into the event model,
+ * modify-path to REPLACE/REDIRECT allowed-operation construction, path-annotation extraction and
+ * the input-validation error branches.
+ */
+public class FlowExtensionRequestBuilderTest {
+
+    private static final String TENANT = "carbon.super";
+    private static final String CLAIM_PATH = "/user/claims[uri=http://wso2.org/claims/givenname]";
+    private static final String CREDENTIAL_PATH = "/user/credentials/password";
+
+    // A self-signed RSA X.509 certificate (base64-encoded DER, CN=flow-ext-test), valid until 2300.
+    // Used only to exercise the outbound credential encryption path.
+    private static final String TEST_CERTIFICATE =
+            "MIIC1jCCAb6gAwIBAgIJAJW5CSgQetRIMA0GCSqGSIb3DQEBDAUAMBgxFjAUBgNVBAMTDWZsb3ctZXh0LXRlc3Qw"
+            + "IBcNMjYwNzA2MDMyMTI0WhgPMjMwMDA0MjEwMzIxMjRaMBgxFjAUBgNVBAMTDWZsb3ctZXh0LXRlc3QwggEiMA0G"
+            + "CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDfg5WbkayJOskKoWZD/dLMkKNisi+3GaKqLgH9RAIMuy3NKNSQCA9p"
+            + "YV4n8EUZnP0ZyM1Xv1MkB2mQLknpA6+n6fvyBuY6y2V9slIJlvrJvAUKpxhSWeyIyg3qgs2Kb+cX8NTC5vmrfN5"
+            + "pw1QmjYYMAueGEz+z85Tay+C/y+bUns1LrIxTxKzheS9jIkfmAr2LE0DNoCLt7H6GdfLfT+INxfSPHTc1aa1pN4"
+            + "QrQGzw91wOvkv4qIiBStJDB8BGIqsSgRMWAe5YKn0AUzYSGqUfhXJ32AnGZKBc7eFytKlpSUwpOeuwlK3ypApcn"
+            + "VvNN3oAnN04jvZgdDSwGDOpbsNBAgMBAAGjITAfMB0GA1UdDgQWBBRYki8DbI6YT5peKE0DKEA9jUnPmjANBgkq"
+            + "hkiG9w0BAQwFAAOCAQEAWkUK1YgFC+JTVjkhuSEiQIMUiuIprE1yENNaqaYV34LW263aMqc+wor3CDQwWN+8i/w"
+            + "9UUmCqfpf06l7sNitT5XkAZSVXkry3TBqKjHKtG0PeHVbkVI4Pms+ZtLfGZut8N4GN6FJMGlYN8A9iRk5eVy+2r"
+            + "HqbhC8BRVZ04FT2+IQM4F9Psa/hEvIMSF4Srfsn4tYZsiua7LJrNojX2Ai7OaFqg/+Imf/g5edV6UZaL+heERV"
+            + "bRUPynphhy9HQSyR6zcT0UlzfG3G/neiNmbi17Si6LITb4EhfCo/Minv5zsDhWxppHx1YLZ46RvDZAMKKT6lY1E"
+            + "rI+m/yoOhf5cj9g==";
+
+    private final FlowExtensionRequestBuilder builder = new FlowExtensionRequestBuilder();
+
+    private MockedStatic<LoggerUtils> loggerUtils;
+
+    @BeforeMethod
+    public void setUp() {
+
+        // LoggerUtils.isDiagnosticLogsEnabled() touches CarbonContext, which is unavailable in a
+        // plain unit test; stub it off so the diagnostic branches are skipped.
+        loggerUtils = mockStatic(LoggerUtils.class);
+        loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        loggerUtils.close();
+    }
+
+    private FlowExecutionContext execContext() {
+
+        FlowExecutionContext execCtx = new FlowExecutionContext();
+        execCtx.setContextIdentifier("ctx-1");
+        execCtx.setTenantDomain(TENANT);
+        execCtx.setApplicationId("app-1");
+        execCtx.setFlowType("REGISTRATION");
+        execCtx.setPortalUrl("https://portal");
+
+        FlowUser user = new FlowUser();
+        user.setUserId("uid");
+        user.setUsername("alice");
+        user.setUserStoreDomain("PRIMARY");
+        Map<String, String> claims = new HashMap<>();
+        claims.put("http://wso2.org/claims/givenname", "John");
+        user.addClaims(claims);
+        Map<String, char[]> credentials = new HashMap<>();
+        credentials.put("password", "secret".toCharArray());
+        user.setUserCredentials(credentials);
+        execCtx.setFlowUser(user);
+
+        return execCtx;
+    }
+
+    private org.wso2.carbon.identity.action.execution.api.model.FlowContext flowContextWith(
+            FlowExecutionContext execCtx) {
+
+        return org.wso2.carbon.identity.action.execution.api.model.FlowContext.create()
+                .add(FlowExtensionConstants.FLOW_EXECUTION_CONTEXT_KEY, execCtx);
+    }
+
+    private ActionExecutionRequestContext actionContext(AccessConfig accessConfig) {
+
+        return actionContext(accessConfig, null);
+    }
+
+    private ActionExecutionRequestContext actionContext(AccessConfig accessConfig, Certificate certificate) {
+
+        FlowExtensionAction action = new FlowExtensionAction.ResponseBuilder()
+                .name("ext")
+                .type(Action.ActionTypes.FLOW_EXTENSION)
+                .accessConfig(accessConfig)
+                .certificate(certificate)
+                .build();
+        return ActionExecutionRequestContext.create(action);
+    }
+
+    @Test
+    public void testGetSupportedActionType() {
+
+        assertEquals(builder.getSupportedActionType(), ActionType.FLOW_EXTENSION);
+    }
+
+    @Test
+    public void testBuildFullRequest() throws Exception {
+
+        AccessConfig accessConfig = new AccessConfig(
+                Arrays.asList(
+                        new ContextPath("/tenant/domain", false),
+                        new ContextPath("/application/id", false),
+                        new ContextPath("/user/id", false),
+                        new ContextPath("/user/username", false),
+                        new ContextPath("/user/userStoreDomain", false),
+                        new ContextPath(CLAIM_PATH, false),
+                        new ContextPath("/user/credentials/password", false),
+                        new ContextPath("/flow/flowType", false),
+                        new ContextPath("/flow/portalUrl", false)),
+                Arrays.asList(
+                        new ContextPath(CLAIM_PATH + "{[string]}", false),
+                        new ContextPath("/user/credentials/password", false)));
+
+        FlowExecutionContext execCtx = execContext();
+        org.wso2.carbon.identity.action.execution.api.model.FlowContext actionFlowContext =
+                flowContextWith(execCtx);
+
+        ActionExecutionRequest request;
+        try (MockedStatic<IdentityTenantUtil> tenantUtil = mockStatic(IdentityTenantUtil.class)) {
+
+            tenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT)).thenReturn(1);
+
+            request = builder.buildActionExecutionRequest(actionFlowContext, actionContext(accessConfig));
+        }
+
+        assertEquals(request.getActionType(), ActionType.FLOW_EXTENSION);
+
+        // Allowed operations: a REPLACE with both clean modify paths, then a REDIRECT.
+        List<AllowedOperation> allowedOps = request.getAllowedOperations();
+        assertEquals(allowedOps.size(), 2);
+        assertEquals(allowedOps.get(0).getOp(), Operation.REPLACE);
+        assertTrue(allowedOps.get(0).getPaths().contains(CLAIM_PATH));
+        assertTrue(allowedOps.get(0).getPaths().contains("/user/credentials/password"));
+        assertEquals(allowedOps.get(1).getOp(), Operation.REDIRECT);
+
+        // Event carries the exposed, expose-filtered flow/user data.
+        FlowExtensionEvent event = (FlowExtensionEvent) request.getEvent();
+        assertNotNull(event.getFlow());
+        assertEquals(event.getFlow().getFlowType(), "REGISTRATION");
+        assertEquals(event.getFlow().getFlowId(), "ctx-1");
+        assertEquals(event.getFlow().getPortalUrl(), "https://portal");
+        assertEquals(event.getFlow().getUser().getId(), "uid");
+
+        // Modify paths and the stripped path-type annotation are stashed for the response processor.
+        assertNotNull(actionFlowContext.getContextData().get(FlowExtensionConstants.MODIFY_PATHS_KEY));
+        Object annotations = actionFlowContext.getContextData().get(FlowExtensionConstants.PATH_TYPE_ANNOTATIONS_KEY);
+        assertNotNull(annotations);
+        assertEquals(((Map<?, ?>) annotations).get(CLAIM_PATH), "[string]");
+    }
+
+    @Test
+    public void testUnencryptedCredentialWrappedAsTypedObject() throws Exception {
+
+        // A plaintext-exposed credential is wrapped as {"type":"PLAIN_TEXT","value":"<secret>"} and
+        // carried as a nested object (not a bare string) for the mapper to serialize.
+        AccessConfig accessConfig = new AccessConfig(
+                Collections.singletonList(new ContextPath(CREDENTIAL_PATH, false)), null);
+
+        ActionExecutionRequest request;
+        try (MockedStatic<IdentityTenantUtil> tenantUtil = mockStatic(IdentityTenantUtil.class)) {
+            tenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT)).thenReturn(1);
+            request = builder.buildActionExecutionRequest(
+                    flowContextWith(execContext()), actionContext(accessConfig));
+        }
+
+        FlowExtensionUser user = (FlowExtensionUser) ((FlowExtensionEvent) request.getEvent())
+                .getFlow().getUser();
+        Object credential = user.getCredentials().get("password");
+        assertTrue(credential instanceof Map, "Unencrypted credential must be a typed object.");
+        Map<?, ?> typed = (Map<?, ?>) credential;
+        assertEquals(typed.get(FlowExtensionConstants.Credentials.TYPE_KEY),
+                FlowExtensionConstants.Credentials.TYPE_PLAIN_TEXT);
+        assertEquals(typed.get(FlowExtensionConstants.Credentials.VALUE_KEY), "secret");
+    }
+
+    @Test
+    public void testEncryptedCredentialSerializedAsJweString() throws Exception {
+
+        // An encrypted-exposed credential is serialized to a JWE compact string and the plaintext
+        // secret must not appear verbatim in it.
+        AccessConfig accessConfig = new AccessConfig(
+                Collections.singletonList(new ContextPath(CREDENTIAL_PATH, true)), null);
+        Certificate certificate = new Certificate.Builder().certificateContent(TEST_CERTIFICATE).build();
+
+        ActionExecutionRequest request;
+        try (MockedStatic<IdentityTenantUtil> tenantUtil = mockStatic(IdentityTenantUtil.class)) {
+            tenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT)).thenReturn(1);
+            request = builder.buildActionExecutionRequest(
+                    flowContextWith(execContext()), actionContext(accessConfig, certificate));
+        }
+
+        FlowExtensionUser user = (FlowExtensionUser) ((FlowExtensionEvent) request.getEvent())
+                .getFlow().getUser();
+        Object credential = user.getCredentials().get("password");
+        assertTrue(credential instanceof String, "Encrypted credential must be a JWE string.");
+        String jwe = (String) credential;
+        assertTrue(JWEEncryptionUtil.isJWEEncrypted(jwe),
+                "Encrypted credential must be a JWE compact serialization: " + jwe);
+        assertFalse(jwe.contains("secret"), "Ciphertext must not contain the plaintext secret.");
+    }
+
+    @Test
+    public void testNoAccessConfigProducesRedirectOnly() throws Exception {
+
+        ActionExecutionRequest request = builder.buildActionExecutionRequest(
+                flowContextWith(execContext()), actionContext(new AccessConfig(null, null)));
+
+        List<AllowedOperation> allowedOps = request.getAllowedOperations();
+        assertEquals(allowedOps.size(), 1);
+        assertEquals(allowedOps.get(0).getOp(), Operation.REDIRECT);
+
+        // Nothing exposed -> the flow only carries the always-sent flowId.
+        FlowExtensionEvent event = (FlowExtensionEvent) request.getEvent();
+        assertNull(event.getFlow().getUser());
+        assertEquals(event.getFlow().getFlowId(), "ctx-1");
+    }
+
+    @Test
+    public void testEncryptedExposePrunedWhenCertificateAbsent() throws Exception {
+
+        // An encrypted expose path with no outbound certificate is pruned, so the user area ends
+        // up unexposed and no user object is attached.
+        AccessConfig accessConfig = new AccessConfig(
+                Collections.singletonList(new ContextPath("/user/id", true)), null);
+
+        ActionExecutionRequest request = builder.buildActionExecutionRequest(
+                flowContextWith(execContext()), actionContext(accessConfig));
+
+        FlowExtensionEvent event = (FlowExtensionEvent) request.getEvent();
+        assertNull(event.getFlow().getUser());
+    }
+
+    @Test(expectedExceptions = ActionExecutionRequestBuilderException.class)
+    public void testMissingFlowExecutionContextAborts() throws Exception {
+
+        builder.buildActionExecutionRequest(
+                org.wso2.carbon.identity.action.execution.api.model.FlowContext.create(),
+                actionContext(new AccessConfig(null, null)));
+    }
+
+    @Test(expectedExceptions = ActionExecutionRequestBuilderException.class)
+    public void testNonFlowExtensionActionAborts() throws Exception {
+
+        Action plainAction = new Action.ActionResponseBuilder().name("plain").build();
+
+        builder.buildActionExecutionRequest(
+                flowContextWith(execContext()), ActionExecutionRequestContext.create(plainAction));
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessorTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessorTest.java
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.executor;
+
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionResponseProcessorException;
+import org.wso2.carbon.identity.action.execution.api.model.ActionExecutionResponseContext;
+import org.wso2.carbon.identity.action.execution.api.model.ActionExecutionStatus;
+import org.wso2.carbon.identity.action.execution.api.model.ActionInvocationErrorResponse;
+import org.wso2.carbon.identity.action.execution.api.model.ActionInvocationFailureResponse;
+import org.wso2.carbon.identity.action.execution.api.model.ActionInvocationIncompleteResponse;
+import org.wso2.carbon.identity.action.execution.api.model.ActionInvocationResponse;
+import org.wso2.carbon.identity.action.execution.api.model.ActionInvocationSuccessResponse;
+import org.wso2.carbon.identity.action.execution.api.model.ActionType;
+import org.wso2.carbon.identity.action.execution.api.model.Error;
+import org.wso2.carbon.identity.action.execution.api.model.Failure;
+import org.wso2.carbon.identity.action.execution.api.model.FlowContext;
+import org.wso2.carbon.identity.action.execution.api.model.Operation;
+import org.wso2.carbon.identity.action.execution.api.model.PerformableOperation;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
+import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants;
+import org.wso2.carbon.identity.flow.extension.internal.FlowExtensionDataHolder;
+import org.wso2.carbon.identity.flow.extension.model.ContextPath;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link FlowExtensionResponseProcessor}: REPLACE operation handling for user
+ * claims and credentials, per-operation validation, INCOMPLETE/ERROR/FAILURE handling, and the
+ * inbound JWE decryption contract gates.
+ */
+public class FlowExtensionResponseProcessorTest {
+
+    private static final String TENANT = "carbon.super";
+    private static final String GIVEN_NAME_CLAIM = "http://wso2.org/claims/givenname";
+
+    private FlowExtensionResponseProcessor processor;
+    private ClaimMetadataManagementService claimService;
+    private MockedStatic<LoggerUtils> loggerUtils;
+
+    @BeforeMethod
+    public void setUp() {
+
+        // LoggerUtils.isDiagnosticLogsEnabled() touches CarbonContext, which is unavailable in a
+        // plain unit test; stub it off so the production diagnostic branches are skipped.
+        loggerUtils = mockStatic(LoggerUtils.class);
+        loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
+
+        processor = new FlowExtensionResponseProcessor();
+        claimService = mock(ClaimMetadataManagementService.class);
+        FlowExtensionDataHolder.getInstance().setClaimMetadataManagementService(claimService);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        FlowExtensionDataHolder.getInstance().setClaimMetadataManagementService(null);
+        loggerUtils.close();
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private FlowContext actionFlowContext() {
+
+        FlowExecutionContext execCtx = new FlowExecutionContext();
+        execCtx.setTenantDomain(TENANT);
+        return FlowContext.create().add(FlowExtensionConstants.FLOW_EXECUTION_CONTEXT_KEY, execCtx);
+    }
+
+    private PerformableOperation replace(String path, Object value) {
+
+        PerformableOperation op = new PerformableOperation();
+        op.setOp(Operation.REPLACE);
+        op.setPath(path);
+        op.setValue(value);
+        return op;
+    }
+
+    private PerformableOperation redirect(String url) {
+
+        PerformableOperation op = new PerformableOperation();
+        op.setOp(Operation.REDIRECT);
+        op.setUrl(url);
+        return op;
+    }
+
+    private ActionExecutionResponseContext<ActionInvocationSuccessResponse> successContext(
+            List<PerformableOperation> operations) {
+
+        ActionInvocationSuccessResponse response = new ActionInvocationSuccessResponse.Builder()
+                .actionStatus(ActionInvocationResponse.Status.SUCCESS)
+                .operations(operations)
+                .build();
+        return ActionExecutionResponseContext.create(null, response);
+    }
+
+    private ActionExecutionResponseContext<ActionInvocationIncompleteResponse> incompleteContext(
+            List<PerformableOperation> operations) {
+
+        ActionInvocationIncompleteResponse response = new ActionInvocationIncompleteResponse.Builder()
+                .actionStatus(ActionInvocationResponse.Status.INCOMPLETE)
+                .operations(operations)
+                .build();
+        return ActionExecutionResponseContext.create(null, response);
+    }
+
+    // ------------------------------------------------------------------ success: claims / credentials
+
+    @Test
+    public void testGetSupportedActionType() {
+
+        assertEquals(processor.getSupportedActionType(), ActionType.FLOW_EXTENSION);
+    }
+
+    @Test
+    public void testSingleValuedClaimReplaceCollectedAsPending() throws Exception {
+
+        when(claimService.getLocalClaim(eq(GIVEN_NAME_CLAIM), eq(TENANT)))
+                .thenReturn(Optional.of(new LocalClaim(GIVEN_NAME_CLAIM)));
+
+        FlowContext actionFlowContext = actionFlowContext();
+        List<PerformableOperation> ops = Collections.singletonList(
+                replace("/user/claims[uri=" + GIVEN_NAME_CLAIM + "]", "John"));
+
+        ActionExecutionStatus<?> status = processor.processSuccessResponse(actionFlowContext, successContext(ops));
+
+        assertEquals(status.getStatus(), ActionExecutionStatus.Status.SUCCESS);
+        Object pending = actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CLAIMS_KEY);
+        assertNotNull(pending);
+        assertEquals(((Map<?, ?>) pending).get(GIVEN_NAME_CLAIM), "John");
+    }
+
+    @Test
+    public void testMultiValuedClaimReplaceJoinsValues() throws Exception {
+
+        LocalClaim multiValued = new LocalClaim(GIVEN_NAME_CLAIM);
+        multiValued.setClaimProperty("multiValued", "true");
+        when(claimService.getLocalClaim(eq(GIVEN_NAME_CLAIM), eq(TENANT)))
+                .thenReturn(Optional.of(multiValued));
+
+        FlowContext actionFlowContext = actionFlowContext();
+        List<PerformableOperation> ops = Collections.singletonList(
+                replace("/user/claims[uri=" + GIVEN_NAME_CLAIM + "]", Arrays.asList("a", "b")));
+
+        processor.processSuccessResponse(actionFlowContext, successContext(ops));
+
+        Map<?, ?> pending = (Map<?, ?>) actionFlowContext.getContextData()
+                .get(FlowExtensionConstants.PENDING_CLAIMS_KEY);
+        assertEquals(pending.get(GIVEN_NAME_CLAIM), "a,b");
+    }
+
+    @Test
+    public void testCredentialReplaceCollectedAsPending() throws Exception {
+
+        FlowContext actionFlowContext = actionFlowContext();
+        List<PerformableOperation> ops = Collections.singletonList(
+                replace("/user/credentials/password", "secret"));
+
+        processor.processSuccessResponse(actionFlowContext, successContext(ops));
+
+        Object pending = actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CREDENTIALS_KEY);
+        assertNotNull(pending);
+        char[] stored = (char[]) ((Map<?, ?>) pending).get("password");
+        assertEquals(new String(stored), "secret");
+    }
+
+    @Test
+    public void testEmptyOperationsProduceNoPendingUpdates() throws Exception {
+
+        FlowContext actionFlowContext = actionFlowContext();
+
+        ActionExecutionStatus<?> status =
+                processor.processSuccessResponse(actionFlowContext, successContext(Collections.emptyList()));
+
+        assertEquals(status.getStatus(), ActionExecutionStatus.Status.SUCCESS);
+        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CLAIMS_KEY));
+        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CREDENTIALS_KEY));
+    }
+
+    // ------------------------------------------------------------------ success: per-operation validation drops
+
+    @Test
+    public void testInvalidOperationsAreDroppedButResponseSucceeds() throws Exception {
+
+        // Unknown claim URI -> lookup returns empty -> dropped.
+        when(claimService.getLocalClaim(anyString(), eq(TENANT))).thenReturn(Optional.empty());
+
+        FlowContext actionFlowContext = actionFlowContext();
+        List<PerformableOperation> ops = Arrays.asList(
+                replace("", "x"),                                             // blank path
+                replace("/flow/flowType", "x"),                               // read-only
+                replace("/unknown/path", "x"),                                // unknown area
+                replace("/user/claims[uri=http://example.com/foo]", "x"),     // non-local dialect
+                replace("/user/claims[uri=http://wso2.org/claims/identity/x]", "x"), // identity claim
+                replace("/user/claims[uri=http://wso2.org/claims/unknown]", "x"),    // unknown local claim
+                replace("/user/credentials/", "x"));                          // blank credential key
+
+        ActionExecutionStatus<?> status = processor.processSuccessResponse(actionFlowContext, successContext(ops));
+
+        assertEquals(status.getStatus(), ActionExecutionStatus.Status.SUCCESS);
+        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CLAIMS_KEY));
+        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CREDENTIALS_KEY));
+    }
+
+    @Test
+    public void testMissingValueOnReplaceIsDropped() throws Exception {
+
+        when(claimService.getLocalClaim(eq(GIVEN_NAME_CLAIM), eq(TENANT)))
+                .thenReturn(Optional.of(new LocalClaim(GIVEN_NAME_CLAIM)));
+
+        FlowContext actionFlowContext = actionFlowContext();
+        List<PerformableOperation> ops = Collections.singletonList(
+                replace("/user/claims[uri=" + GIVEN_NAME_CLAIM + "]", null));
+
+        processor.processSuccessResponse(actionFlowContext, successContext(ops));
+
+        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CLAIMS_KEY));
+    }
+
+    @Test
+    public void testSingleValuedClaimWithNonStringValueIsDropped() throws Exception {
+
+        // A wrong-typed value is a per-operation validation failure: the op is dropped and the
+        // response still succeeds — a misbehaving extension must not abort the whole flow.
+        when(claimService.getLocalClaim(eq(GIVEN_NAME_CLAIM), eq(TENANT)))
+                .thenReturn(Optional.of(new LocalClaim(GIVEN_NAME_CLAIM)));
+
+        FlowContext actionFlowContext = actionFlowContext();
+        List<PerformableOperation> ops = Collections.singletonList(
+                replace("/user/claims[uri=" + GIVEN_NAME_CLAIM + "]", 42));
+
+        ActionExecutionStatus<?> status = processor.processSuccessResponse(actionFlowContext, successContext(ops));
+
+        assertEquals(status.getStatus(), ActionExecutionStatus.Status.SUCCESS);
+        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CLAIMS_KEY));
+    }
+
+    @Test
+    public void testMultiValuedClaimWithNonListValueIsDropped() throws Exception {
+
+        LocalClaim multiValued = new LocalClaim(GIVEN_NAME_CLAIM);
+        multiValued.setClaimProperty("multiValued", "true");
+        when(claimService.getLocalClaim(eq(GIVEN_NAME_CLAIM), eq(TENANT)))
+                .thenReturn(Optional.of(multiValued));
+
+        FlowContext actionFlowContext = actionFlowContext();
+        List<PerformableOperation> ops = Collections.singletonList(
+                replace("/user/claims[uri=" + GIVEN_NAME_CLAIM + "]", "not-a-list"));
+
+        ActionExecutionStatus<?> status = processor.processSuccessResponse(actionFlowContext, successContext(ops));
+
+        assertEquals(status.getStatus(), ActionExecutionStatus.Status.SUCCESS);
+        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CLAIMS_KEY));
+    }
+
+    @Test(expectedExceptions = ActionExecutionResponseProcessorException.class)
+    public void testMissingClaimServiceAborts() throws Exception {
+
+        FlowExtensionDataHolder.getInstance().setClaimMetadataManagementService(null);
+
+        FlowContext actionFlowContext = actionFlowContext();
+        List<PerformableOperation> ops = Collections.singletonList(
+                replace("/user/claims[uri=" + GIVEN_NAME_CLAIM + "]", "John"));
+
+        processor.processSuccessResponse(actionFlowContext, successContext(ops));
+    }
+
+    @Test(expectedExceptions = ActionExecutionResponseProcessorException.class)
+    public void testMissingFlowExecutionContextAborts() throws Exception {
+
+        processor.processSuccessResponse(FlowContext.create(),
+                successContext(Collections.emptyList()));
+    }
+
+    // ------------------------------------------------------------------ inbound JWE decryption contract
+
+    @Test(expectedExceptions = ActionExecutionResponseProcessorException.class)
+    public void testEncryptedModifyPathWithNonStringValueAborts() throws Exception {
+
+        FlowContext actionFlowContext = actionFlowContext();
+        actionFlowContext.add(FlowExtensionConstants.MODIFY_PATHS_KEY,
+                Collections.singletonList(new ContextPath("/user/credentials/token", true)));
+
+        List<PerformableOperation> ops = Collections.singletonList(
+                replace("/user/credentials/token", 12345));
+
+        processor.processSuccessResponse(actionFlowContext, successContext(ops));
+    }
+
+    @Test(expectedExceptions = ActionExecutionResponseProcessorException.class)
+    public void testEncryptedModifyPathWithPlaintextValueAborts() throws Exception {
+
+        FlowContext actionFlowContext = actionFlowContext();
+        actionFlowContext.add(FlowExtensionConstants.MODIFY_PATHS_KEY,
+                Collections.singletonList(new ContextPath("/user/credentials/token", true)));
+
+        List<PerformableOperation> ops = Collections.singletonList(
+                replace("/user/credentials/token", "not-a-jwe-value"));
+
+        processor.processSuccessResponse(actionFlowContext, successContext(ops));
+    }
+
+    @Test
+    public void testEncryptedMultiValuedClaimDecryptsSingleJweAndSplitsOnComma() throws Exception {
+
+        // A multi-valued claim on an encrypted path arrives as a single-element array holding one JWE
+        // string that encrypts the comma-joined values; the plaintext is split on commas back into a
+        // list and the values joined.
+        LocalClaim multiValued = new LocalClaim(GIVEN_NAME_CLAIM);
+        multiValued.setClaimProperty("multiValued", "true");
+        when(claimService.getLocalClaim(eq(GIVEN_NAME_CLAIM), eq(TENANT)))
+                .thenReturn(Optional.of(multiValued));
+
+        String claimPath = "/user/claims[uri=" + GIVEN_NAME_CLAIM + "]";
+        FlowContext actionFlowContext = actionFlowContext();
+        actionFlowContext.add(FlowExtensionConstants.MODIFY_PATHS_KEY,
+                Collections.singletonList(new ContextPath(claimPath, true)));
+
+        List<PerformableOperation> ops = Collections.singletonList(
+                replace(claimPath, Collections.singletonList("jwe")));
+
+        try (MockedStatic<JWEEncryptionUtil> jwe = mockStatic(JWEEncryptionUtil.class)) {
+            jwe.when(() -> JWEEncryptionUtil.isJWEEncrypted(anyString())).thenReturn(true);
+            jwe.when(() -> JWEEncryptionUtil.decrypt("jwe", TENANT)).thenReturn("one,two");
+
+            processor.processSuccessResponse(actionFlowContext, successContext(ops));
+        }
+
+        Map<?, ?> pending = (Map<?, ?>) actionFlowContext.getContextData()
+                .get(FlowExtensionConstants.PENDING_CLAIMS_KEY);
+        assertNotNull(pending);
+        assertEquals(pending.get(GIVEN_NAME_CLAIM), "one,two");
+    }
+
+    @Test(expectedExceptions = ActionExecutionResponseProcessorException.class)
+    public void testEncryptedMultiValuedClaimWithNonJweElementAborts() throws Exception {
+
+        String claimPath = "/user/claims[uri=" + GIVEN_NAME_CLAIM + "]";
+        FlowContext actionFlowContext = actionFlowContext();
+        actionFlowContext.add(FlowExtensionConstants.MODIFY_PATHS_KEY,
+                Collections.singletonList(new ContextPath(claimPath, true)));
+
+        List<PerformableOperation> ops = Collections.singletonList(
+                replace(claimPath, Collections.singletonList("plaintext-not-jwe")));
+
+        processor.processSuccessResponse(actionFlowContext, successContext(ops));
+    }
+
+    // ------------------------------------------------------------------ incomplete
+
+    @Test
+    public void testIncompleteResponseStoresRedirectUrl() throws Exception {
+
+        FlowContext actionFlowContext = actionFlowContext();
+        ActionExecutionStatus<?> status = processor.processIncompleteResponse(actionFlowContext,
+                incompleteContext(Collections.singletonList(redirect("https://redirect"))));
+
+        assertEquals(status.getStatus(), ActionExecutionStatus.Status.INCOMPLETE);
+        assertEquals(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_REDIRECT_URL_KEY),
+                "https://redirect");
+    }
+
+    @Test(expectedExceptions = ActionExecutionResponseProcessorException.class)
+    public void testIncompleteResponseWithNoOperationsAborts() throws Exception {
+
+        processor.processIncompleteResponse(actionFlowContext(), incompleteContext(Collections.emptyList()));
+    }
+
+    @Test(expectedExceptions = ActionExecutionResponseProcessorException.class)
+    public void testIncompleteResponseWithMultipleOperationsAborts() throws Exception {
+
+        processor.processIncompleteResponse(actionFlowContext(),
+                incompleteContext(Arrays.asList(redirect("https://a"), redirect("https://b"))));
+    }
+
+    @Test(expectedExceptions = ActionExecutionResponseProcessorException.class)
+    public void testIncompleteResponseWithNonRedirectOperationAborts() throws Exception {
+
+        processor.processIncompleteResponse(actionFlowContext(),
+                incompleteContext(Collections.singletonList(replace("/user/credentials/x", "y"))));
+    }
+
+    @Test(expectedExceptions = ActionExecutionResponseProcessorException.class)
+    public void testIncompleteResponseWithEmptyRedirectUrlAborts() throws Exception {
+
+        processor.processIncompleteResponse(actionFlowContext(),
+                incompleteContext(Collections.singletonList(redirect(""))));
+    }
+
+    // ------------------------------------------------------------------ error / failure
+
+    @Test
+    public void testProcessErrorResponse() throws Exception {
+
+        ActionInvocationErrorResponse response = new ActionInvocationErrorResponse.Builder()
+                .actionStatus(ActionInvocationResponse.Status.ERROR)
+                .errorMessage("Something went wrong")
+                .errorDescription("A detailed description")
+                .build();
+
+        ActionExecutionStatus<Error> status = processor.processErrorResponse(
+                actionFlowContext(), ActionExecutionResponseContext.create(null, response));
+
+        assertEquals(status.getStatus(), ActionExecutionStatus.Status.ERROR);
+        assertEquals(status.getResponse().getErrorMessage(), "Something went wrong");
+        assertEquals(status.getResponse().getErrorDescription(), "A detailed description");
+    }
+
+    @Test
+    public void testProcessFailureResponse() throws Exception {
+
+        ActionInvocationFailureResponse response = new ActionInvocationFailureResponse.Builder()
+                .actionStatus(ActionInvocationResponse.Status.FAILED)
+                .failureReason("Failed reason")
+                .failureDescription("Failure description")
+                .build();
+
+        ActionExecutionStatus<Failure> status = processor.processFailureResponse(
+                actionFlowContext(), ActionExecutionResponseContext.create(null, response));
+
+        assertEquals(status.getStatus(), ActionExecutionStatus.Status.FAILED);
+        assertEquals(status.getResponse().getFailureReason(), "Failed reason");
+        assertEquals(status.getResponse().getFailureDescription(), "Failure description");
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/JWEEncryptionUtilTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/JWEEncryptionUtilTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.executor;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionException;
+
+import java.security.cert.X509Certificate;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link JWEEncryptionUtil} covering JWE detection, PEM certificate parsing
+ * (including error branches) and the outbound encryption path against a self-signed certificate.
+ */
+public class JWEEncryptionUtilTest {
+
+    // A self-signed RSA X.509 certificate (base64-encoded DER, CN=flow-ext-test), valid until 2300,
+    // so validity checks never fail. Used only to exercise the outbound encryption path.
+    private static final String TEST_CERTIFICATE =
+            "MIIC1jCCAb6gAwIBAgIJAJW5CSgQetRIMA0GCSqGSIb3DQEBDAUAMBgxFjAUBgNVBAMTDWZsb3ctZXh0LXRlc3Qw"
+            + "IBcNMjYwNzA2MDMyMTI0WhgPMjMwMDA0MjEwMzIxMjRaMBgxFjAUBgNVBAMTDWZsb3ctZXh0LXRlc3QwggEiMA0G"
+            + "CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDfg5WbkayJOskKoWZD/dLMkKNisi+3GaKqLgH9RAIMuy3NKNSQCA9p"
+            + "YV4n8EUZnP0ZyM1Xv1MkB2mQLknpA6+n6fvyBuY6y2V9slIJlvrJvAUKpxhSWeyIyg3qgs2Kb+cX8NTC5vmrfN5"
+            + "pw1QmjYYMAueGEz+z85Tay+C/y+bUns1LrIxTxKzheS9jIkfmAr2LE0DNoCLt7H6GdfLfT+INxfSPHTc1aa1pN4"
+            + "QrQGzw91wOvkv4qIiBStJDB8BGIqsSgRMWAe5YKn0AUzYSGqUfhXJ32AnGZKBc7eFytKlpSUwpOeuwlK3ypApcn"
+            + "VvNN3oAnN04jvZgdDSwGDOpbsNBAgMBAAGjITAfMB0GA1UdDgQWBBRYki8DbI6YT5peKE0DKEA9jUnPmjANBgkq"
+            + "hkiG9w0BAQwFAAOCAQEAWkUK1YgFC+JTVjkhuSEiQIMUiuIprE1yENNaqaYV34LW263aMqc+wor3CDQwWN+8i/w"
+            + "9UUmCqfpf06l7sNitT5XkAZSVXkry3TBqKjHKtG0PeHVbkVI4Pms+ZtLfGZut8N4GN6FJMGlYN8A9iRk5eVy+2r"
+            + "HqbhC8BRVZ04FT2+IQM4F9Psa/hEvIMSF4Srfsn4tYZsiua7LJrNojX2Ai7OaFqg/+Imf/g5edV6UZaL+heERV"
+            + "bRUPynphhy9HQSyR6zcT0UlzfG3G/neiNmbi17Si6LITb4EhfCo/Minv5zsDhWxppHx1YLZ46RvDZAMKKT6lY1E"
+            + "rI+m/yoOhf5cj9g==";
+
+    @Test
+    public void testIsJWEEncrypted() {
+
+        assertFalse(JWEEncryptionUtil.isJWEEncrypted(null));
+        assertFalse(JWEEncryptionUtil.isJWEEncrypted(""));
+        assertFalse(JWEEncryptionUtil.isJWEEncrypted("plaintext"));
+        assertFalse(JWEEncryptionUtil.isJWEEncrypted("a.b.c"));            // 2 dots
+        assertTrue(JWEEncryptionUtil.isJWEEncrypted("a.b.c.d.e"));         // exactly 4 dots
+        assertFalse(JWEEncryptionUtil.isJWEEncrypted("a.b.c.d.e.f"));      // 5 dots
+    }
+
+    @Test
+    public void testParsePEMCertificateValid() throws ActionExecutionException {
+
+        X509Certificate certificate = JWEEncryptionUtil.parsePEMCertificate(TEST_CERTIFICATE);
+
+        assertNotNull(certificate);
+        assertEquals(certificate.getSubjectX500Principal().getName(), "CN=flow-ext-test");
+    }
+
+    @Test(expectedExceptions = ActionExecutionException.class)
+    public void testParsePEMCertificateNull() throws ActionExecutionException {
+
+        JWEEncryptionUtil.parsePEMCertificate(null);
+    }
+
+    @Test(expectedExceptions = ActionExecutionException.class)
+    public void testParsePEMCertificateEmpty() throws ActionExecutionException {
+
+        JWEEncryptionUtil.parsePEMCertificate("   ");
+    }
+
+    @Test(expectedExceptions = ActionExecutionException.class)
+    public void testParsePEMCertificateInvalidBase64() throws ActionExecutionException {
+
+        JWEEncryptionUtil.parsePEMCertificate("not-valid-base64-@@@");
+    }
+
+    @Test
+    public void testEncryptProducesJWECompactSerialization() throws ActionExecutionException {
+
+        String jwe = JWEEncryptionUtil.encrypt("secret-value", TEST_CERTIFICATE);
+
+        assertNotNull(jwe);
+        assertTrue(JWEEncryptionUtil.isJWEEncrypted(jwe),
+                "encrypt() must return a JWE compact serialization with 4 dots: " + jwe);
+        // The plaintext must not appear verbatim in the ciphertext.
+        assertFalse(jwe.contains("secret-value"));
+    }
+
+    @Test(expectedExceptions = ActionExecutionException.class)
+    public void testEncryptWithInvalidCertificateFails() throws ActionExecutionException {
+
+        JWEEncryptionUtil.encrypt("secret-value", "not-a-certificate");
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/PathTypeAnnotationUtilTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/PathTypeAnnotationUtilTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.executor;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link PathTypeAnnotationUtil}: trailing-annotation stripping and the
+ * per-object attribute limit validation.
+ */
+public class PathTypeAnnotationUtilTest {
+
+    @Test
+    public void testStripAnnotationNullPath() {
+
+        String[] result = PathTypeAnnotationUtil.stripAnnotation(null);
+        assertNull(result[0]);
+        assertNull(result[1]);
+    }
+
+    @Test
+    public void testStripAnnotationWithoutAnnotation() {
+
+        String[] result = PathTypeAnnotationUtil.stripAnnotation("/user/claims[uri=http://wso2.org/claims/x]");
+        assertEquals(result[0], "/user/claims[uri=http://wso2.org/claims/x]");
+        assertNull(result[1]);
+    }
+
+    @Test
+    public void testStripAnnotationWithAnnotation() {
+
+        String[] result = PathTypeAnnotationUtil.stripAnnotation("/user/claims[uri=x]{[string]}");
+        assertEquals(result[0], "/user/claims[uri=x]");
+        assertEquals(result[1], "[string]");
+    }
+
+    @Test
+    public void testValidateAnnotationLimitsNullOrEmpty() {
+
+        assertTrue(PathTypeAnnotationUtil.validateAnnotationLimits(null));
+        assertTrue(PathTypeAnnotationUtil.validateAnnotationLimits(""));
+    }
+
+    @Test
+    public void testValidateAnnotationLimitsNonComplex() {
+
+        // No colon -> not a complex/object annotation -> always valid.
+        assertTrue(PathTypeAnnotationUtil.validateAnnotationLimits("string"));
+        assertTrue(PathTypeAnnotationUtil.validateAnnotationLimits("[string]"));
+    }
+
+    @Test
+    public void testValidateAnnotationLimitsWithinLimit() {
+
+        assertTrue(PathTypeAnnotationUtil.validateAnnotationLimits("[a:string,b:int,c:boolean]"));
+    }
+
+    @Test
+    public void testValidateAnnotationLimitsExceedsLimit() {
+
+        StringBuilder complex = new StringBuilder("[");
+        for (int i = 0; i < 11; i++) {
+            if (i > 0) {
+                complex.append(",");
+            }
+            complex.append("attr").append(i).append(":string");
+        }
+        complex.append("]");
+
+        assertFalse(PathTypeAnnotationUtil.validateAnnotationLimits(complex.toString()));
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeBuilderTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/metadata/FlowExtensionContextTreeBuilderTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.metadata;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ContextTree;
+import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.FlowContextPaths;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link FlowExtensionContextTreeBuilder}, focused on the user identity leaves
+ * (id / username / userStoreDomain) exposed under the {@code /user/} branch.
+ */
+public class FlowExtensionContextTreeBuilderTest {
+
+    private Map<String, FlowExtensionContextTreeNode> userLeaves;
+
+    @BeforeClass
+    public void buildTree() {
+
+        FlowExtensionContextTreeMetadata metadata = new FlowExtensionContextTreeBuilder().build(null);
+        FlowExtensionContextTreeNode userNode = metadata.getContextTree().stream()
+                .filter(n -> "user".equals(n.getKey()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(userNode, "The /user/ node must be present in the context tree.");
+        assertEquals(userNode.getPath(), FlowContextPaths.USER_PREFIX);
+
+        userLeaves = userNode.getChildren().stream()
+                .collect(Collectors.toMap(FlowExtensionContextTreeNode::getKey, n -> n));
+    }
+
+    @Test
+    public void testIdentityLeavesPresentUnderUser() {
+
+        assertTrue(userLeaves.containsKey("id"), "/user/id leaf must be advertised.");
+        assertTrue(userLeaves.containsKey("username"), "/user/username leaf must be advertised.");
+        assertTrue(userLeaves.containsKey("userStoreDomain"),
+                "/user/userStoreDomain leaf must be advertised.");
+    }
+
+    @Test
+    public void testIdentityLeafPaths() {
+
+        assertEquals(userLeaves.get("id").getPath(), FlowContextPaths.USER_ID_PATH);
+        assertEquals(userLeaves.get("username").getPath(), FlowContextPaths.USER_USERNAME_PATH);
+        assertEquals(userLeaves.get("userStoreDomain").getPath(), FlowContextPaths.USER_STORE_DOMAIN_PATH);
+    }
+
+    @Test
+    public void testIdentityLeavesAreExposeOnlyAndNonReplaceable() {
+
+        for (String key : new String[]{"id", "username", "userStoreDomain"}) {
+            FlowExtensionContextTreeNode leaf = userLeaves.get(key);
+            assertEquals(leaf.getNodeType(), ContextTree.NODE_LEAF, key + " must be a leaf node.");
+            assertEquals(leaf.getDataType(), ContextTree.DATA_TYPE_STRING, key + " must be a string.");
+            List<String> ops = leaf.getAllowedOperations();
+            assertEquals(ops, java.util.Collections.singletonList(ContextTree.OP_EXPOSE),
+                    key + " must allow EXPOSE only (no MODIFY).");
+            assertFalse(leaf.isReplaceable(), key + " must not be replaceable.");
+        }
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/AccessConfigTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/AccessConfigTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.model;
+
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link AccessConfig}, covering path flattening, per-path encryption lookups
+ * (including annotation stripping on modify paths) and the static area/leaf/read-only helpers.
+ */
+public class AccessConfigTest {
+
+    @Test
+    public void testNullListsYieldEmptyPathsAndNullEntries() {
+
+        AccessConfig config = new AccessConfig(null, null);
+
+        assertEquals(config.getExpose(), null);
+        assertEquals(config.getModify(), null);
+        assertTrue(config.getExposePaths().isEmpty());
+        assertTrue(config.getModifyPaths().isEmpty());
+        assertFalse(config.isExposePathEncrypted("/user/id"));
+        assertFalse(config.isModifyPathEncrypted("/user/claims[uri=x]"));
+    }
+
+    @Test
+    public void testExposeAndModifyPathsAreFlattened() {
+
+        AccessConfig config = new AccessConfig(
+                Arrays.asList(new ContextPath("/user/id", false),
+                        new ContextPath("/user/username", true)),
+                Collections.singletonList(new ContextPath("/user/credentials/password", true)));
+
+        assertEquals(config.getExposePaths(), Arrays.asList("/user/id", "/user/username"));
+        assertEquals(config.getModifyPaths(), Collections.singletonList("/user/credentials/password"));
+        // The stored list is a defensive, unmodifiable copy.
+        assertEquals(config.getExpose().size(), 2);
+        assertEquals(config.getModify().size(), 1);
+    }
+
+    @Test
+    public void testIsExposePathEncrypted() {
+
+        AccessConfig config = new AccessConfig(
+                Arrays.asList(new ContextPath("/user/id", false),
+                        new ContextPath("/user/username", true)),
+                null);
+
+        assertTrue(config.isExposePathEncrypted("/user/username"));
+        assertFalse(config.isExposePathEncrypted("/user/id"));
+        assertFalse(config.isExposePathEncrypted("/user/unknown"));
+    }
+
+    @Test
+    public void testIsModifyPathEncryptedStripsAnnotation() {
+
+        AccessConfig config = new AccessConfig(null,
+                Arrays.asList(new ContextPath("/user/claims[uri=http://wso2.org/claims/x]{[string]}", true),
+                        new ContextPath("/user/credentials/token", false)));
+
+        // The annotation ({[string]}) is stripped before matching the clean path.
+        assertTrue(config.isModifyPathEncrypted("/user/claims[uri=http://wso2.org/claims/x]"));
+        assertFalse(config.isModifyPathEncrypted("/user/credentials/token"));
+        assertFalse(config.isModifyPathEncrypted("/user/credentials/unknown"));
+    }
+
+    @Test
+    public void testIsReadOnly() {
+
+        assertTrue(AccessConfig.isReadOnly("/flow/flowType"));
+        assertFalse(AccessConfig.isReadOnly("/user/id"));
+        assertFalse(AccessConfig.isReadOnly(null));
+    }
+
+    @Test
+    public void testAnyExposedUnder() {
+
+        List<String> leaves = Arrays.asList("/user/id", "/user/credentials/password");
+
+        assertTrue(AccessConfig.anyExposedUnder("/user/credentials/", leaves));
+        assertTrue(AccessConfig.anyExposedUnder("/user/", leaves));
+        assertFalse(AccessConfig.anyExposedUnder("/organization/", leaves));
+        assertFalse(AccessConfig.anyExposedUnder(null, leaves));
+        assertFalse(AccessConfig.anyExposedUnder("/user/", null));
+        assertFalse(AccessConfig.anyExposedUnder("/user/", Collections.emptyList()));
+    }
+
+    @Test
+    public void testIsExposedPath() {
+
+        List<String> leaves = Arrays.asList("/user/id", "/user/username");
+
+        assertTrue(AccessConfig.isExposedPath("/user/id", leaves));
+        assertFalse(AccessConfig.isExposedPath("/user/userStoreDomain", leaves));
+        assertFalse(AccessConfig.isExposedPath(null, leaves));
+        assertFalse(AccessConfig.isExposedPath("/user/id", null));
+        assertFalse(AccessConfig.isExposedPath("/user/id", Collections.emptyList()));
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/ContextPathTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/ContextPathTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.model;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link ContextPath}.
+ */
+public class ContextPathTest {
+
+    @Test
+    public void testGettersCarryConstructorValues() {
+
+        ContextPath encrypted = new ContextPath("/user/credentials/password", true);
+        assertEquals(encrypted.getPath(), "/user/credentials/password");
+        assertTrue(encrypted.isEncrypted());
+
+        ContextPath plain = new ContextPath("/user/id", false);
+        assertEquals(plain.getPath(), "/user/id");
+        assertFalse(plain.isEncrypted());
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionActionTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionActionTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.model;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.management.api.model.Action;
+import org.wso2.carbon.identity.action.management.api.model.EndpointConfig;
+import org.wso2.carbon.identity.certificate.management.model.Certificate;
+
+import java.sql.Timestamp;
+import java.util.Collections;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+/**
+ * Unit tests for {@link FlowExtensionAction} and its {@code ResponseBuilder} / {@code RequestBuilder},
+ * verifying the extra Flow Extension fields (access config, certificate, icon URL) are carried on
+ * top of the inherited {@link Action} fields.
+ */
+public class FlowExtensionActionTest {
+
+    private AccessConfig sampleAccessConfig() {
+
+        return new AccessConfig(
+                Collections.singletonList(new ContextPath("/user/id", false)),
+                Collections.singletonList(new ContextPath("/user/credentials/password", true)));
+    }
+
+    private Certificate sampleCertificate() {
+
+        return new Certificate.Builder()
+                .id("cert-1")
+                .name("cert")
+                .certificateContent("pem-content")
+                .build();
+    }
+
+    @Test
+    public void testResponseBuilderCarriesAllFields() {
+
+        AccessConfig accessConfig = sampleAccessConfig();
+        Certificate certificate = sampleCertificate();
+        EndpointConfig endpoint = new EndpointConfig();
+        Timestamp now = new Timestamp(1_700_000_000_000L);
+
+        FlowExtensionAction action = new FlowExtensionAction.ResponseBuilder()
+                .id("action-1")
+                .type(Action.ActionTypes.FLOW_EXTENSION)
+                .name("my-extension")
+                .description("desc")
+                .status(Action.Status.ACTIVE)
+                .actionVersion("v1")
+                .createdAt(now)
+                .updatedAt(now)
+                .endpoint(endpoint)
+                .accessConfig(accessConfig)
+                .certificate(certificate)
+                .iconUrl("https://icon")
+                .build();
+
+        assertEquals(action.getId(), "action-1");
+        assertEquals(action.getType(), Action.ActionTypes.FLOW_EXTENSION);
+        assertEquals(action.getName(), "my-extension");
+        assertEquals(action.getDescription(), "desc");
+        assertEquals(action.getStatus(), Action.Status.ACTIVE);
+        assertEquals(action.getActionVersion(), "v1");
+        assertEquals(action.getCreatedAt(), now);
+        assertEquals(action.getUpdatedAt(), now);
+        assertSame(action.getEndpoint(), endpoint);
+        assertSame(action.getAccessConfig(), accessConfig);
+        assertSame(action.getCertificate(), certificate);
+        assertEquals(action.getIconUrl(), "https://icon");
+    }
+
+    @Test
+    public void testRequestBuilderCopiesBaseActionAndAddsExtensionFields() {
+
+        EndpointConfig endpoint = new EndpointConfig();
+        Action baseAction = new Action.ActionResponseBuilder()
+                .name("base-name")
+                .description("base-desc")
+                .actionVersion("v2")
+                .endpoint(endpoint)
+                .build();
+
+        AccessConfig accessConfig = sampleAccessConfig();
+        Certificate certificate = sampleCertificate();
+
+        FlowExtensionAction action = new FlowExtensionAction.RequestBuilder(baseAction)
+                .accessConfig(accessConfig)
+                .certificate(certificate)
+                .iconUrl("https://icon")
+                .build();
+
+        assertEquals(action.getName(), "base-name");
+        assertEquals(action.getDescription(), "base-desc");
+        assertEquals(action.getActionVersion(), "v2");
+        assertSame(action.getEndpoint(), endpoint);
+        assertSame(action.getAccessConfig(), accessConfig);
+        assertSame(action.getCertificate(), certificate);
+        assertEquals(action.getIconUrl(), "https://icon");
+    }
+
+    @Test
+    public void testUnsetExtensionFieldsAreNull() {
+
+        FlowExtensionAction action = new FlowExtensionAction.ResponseBuilder()
+                .name("no-extras")
+                .build();
+
+        assertNull(action.getAccessConfig());
+        assertNull(action.getCertificate());
+        assertNull(action.getIconUrl());
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionEventTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionEventTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.model;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.execution.api.model.Application;
+import org.wso2.carbon.identity.action.execution.api.model.Organization;
+import org.wso2.carbon.identity.action.execution.api.model.Tenant;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+/**
+ * Unit tests for {@link FlowExtensionEvent} and its builder, including the nested flow and the
+ * event-scoped fields inherited from {@code Event}.
+ */
+public class FlowExtensionEventTest {
+
+    @Test
+    public void testBuilderCarriesFlowAndCallbackUrl() {
+
+        FlowExtensionFlow flow = new FlowExtensionFlow.Builder().flowId("flow-1").build();
+        FlowExtensionEvent event = new FlowExtensionEvent.Builder()
+                .tenant(new Tenant("1", "carbon.super"))
+                .organization(new Organization.Builder().id("org-1").name("Org").build())
+                .application(new Application("app-1", "App"))
+                .flow(flow)
+                .callbackUrl("https://callback")
+                .build();
+
+        assertSame(event.getFlow(), flow);
+        assertEquals(event.getCallbackUrl(), "https://callback");
+    }
+
+    @Test
+    public void testUnsetFlowAndCallbackUrlAreNull() {
+
+        FlowExtensionEvent event = new FlowExtensionEvent.Builder().build();
+
+        assertNull(event.getFlow());
+        assertNull(event.getCallbackUrl());
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionFlowTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionFlowTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.model;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.execution.api.model.User;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+/**
+ * Unit tests for {@link FlowExtensionFlow} and its builder.
+ */
+public class FlowExtensionFlowTest {
+
+    @Test
+    public void testBuilderCarriesAllFields() {
+
+        User user = new User("uid-1");
+        FlowExtensionFlow flow = new FlowExtensionFlow.Builder()
+                .flowType("REGISTRATION")
+                .flowId("flow-123")
+                .portalUrl("https://portal")
+                .user(user)
+                .build();
+
+        assertEquals(flow.getFlowType(), "REGISTRATION");
+        assertEquals(flow.getFlowId(), "flow-123");
+        assertEquals(flow.getPortalUrl(), "https://portal");
+        assertSame(flow.getUser(), user);
+    }
+
+    @Test
+    public void testUnsetFieldsAreNull() {
+
+        FlowExtensionFlow flow = new FlowExtensionFlow.Builder().build();
+
+        assertNull(flow.getFlowType());
+        assertNull(flow.getFlowId());
+        assertNull(flow.getPortalUrl());
+        assertNull(flow.getUser());
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionUserTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/FlowExtensionUserTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.execution.api.model.User;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for {@link FlowExtensionUser}, verifying the identity leaves the flow extension adds on
+ * top of the shared {@link User} model are carried and serialized, while the shared model stays
+ * free of them.
+ */
+public class FlowExtensionUserTest {
+
+    private ObjectMapper mapper;
+
+    @BeforeClass
+    public void setUp() {
+
+        // Mirror the request mapper configuration in ActionExecutorServiceImpl.
+        mapper = new ObjectMapper();
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+    }
+
+    @Test
+    public void testGettersCarryIdentityLeaves() {
+
+        FlowExtensionUser user = new FlowExtensionUser.Builder("uid-1")
+                .username("alice")
+                .userStoreDomain("PRIMARY")
+                .build();
+
+        assertEquals(user.getId(), "uid-1");
+        assertEquals(user.getUsername(), "alice");
+        assertEquals(user.getUserStoreDomain(), "PRIMARY");
+    }
+
+    @Test
+    public void testIdentityLeavesSerializedPolymorphically() throws Exception {
+
+        User user = new FlowExtensionUser.Builder("uid-1")
+                .username("alice")
+                .userStoreDomain("PRIMARY")
+                .build();
+
+        // Serialized via the static User type — Jackson uses the runtime type, so subclass
+        // getters must still appear.
+        String json = mapper.writeValueAsString(user);
+        assertTrue(json.contains("\"username\":\"alice\""), json);
+        assertTrue(json.contains("\"userStoreDomain\":\"PRIMARY\""), json);
+        assertTrue(json.contains("\"id\":\"uid-1\""), json);
+    }
+
+    @Test
+    public void testUnsetLeavesAreOmitted() throws Exception {
+
+        User user = new FlowExtensionUser.Builder("uid-1").build();
+
+        String json = mapper.writeValueAsString(user);
+        assertFalse(json.contains("username"), json);
+        assertFalse(json.contains("userStoreDomain"), json);
+    }
+
+    @Test
+    public void testEmptyUserIdIsEmittedAsEmptyString() throws Exception {
+
+        // id overrides the mapper's NON_EMPTY with NON_NULL, so an exposed-but-empty id must
+        // survive serialization as "" instead of being dropped.
+        User user = new FlowExtensionUser.Builder("").build();
+
+        String json = mapper.writeValueAsString(user);
+        assertTrue(json.contains("\"id\":\"\""), json);
+    }
+
+    @Test
+    public void testEmptyUserStoreDomainIsEmittedAsEmptyString() throws Exception {
+
+        // userStoreDomain overrides the mapper's NON_EMPTY with NON_NULL, so an exposed-but-empty
+        // value must survive serialization as "" instead of being dropped.
+        User user = new FlowExtensionUser.Builder("uid-1")
+                .username("alice")
+                .userStoreDomain("")
+                .build();
+
+        String json = mapper.writeValueAsString(user);
+        assertTrue(json.contains("\"userStoreDomain\":\"\""), json);
+    }
+
+    @Test
+    public void testEmptyUsernameIsStillDropped() throws Exception {
+
+        // username keeps the default NON_EMPTY behavior — only userStoreDomain is forced present.
+        User user = new FlowExtensionUser.Builder("uid-1")
+                .username("")
+                .build();
+
+        String json = mapper.writeValueAsString(user);
+        assertFalse(json.contains("username"), json);
+    }
+
+    @Test
+    public void testSharedUserModelHasNoIdentityLeaves() {
+
+        // Guard against the regression of leaking these fields into the shared User API.
+        for (java.lang.reflect.Method m : User.class.getMethods()) {
+            assertFalse("getUsername".equals(m.getName()),
+                    "Shared User model must not expose getUsername().");
+            assertFalse("getUserStoreDomain".equals(m.getName()),
+                    "Shared User model must not expose getUserStoreDomain().");
+        }
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/OperationExecutionResultTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/model/OperationExecutionResultTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.model;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.execution.api.model.Operation;
+import org.wso2.carbon.identity.action.execution.api.model.PerformableOperation;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+
+/**
+ * Unit tests for {@link OperationExecutionResult}.
+ */
+public class OperationExecutionResultTest {
+
+    @Test
+    public void testGettersCarryConstructorValues() {
+
+        PerformableOperation operation = new PerformableOperation();
+        operation.setOp(Operation.REPLACE);
+        operation.setPath("/user/claims[uri=http://wso2.org/claims/x]");
+
+        OperationExecutionResult result = new OperationExecutionResult(
+                operation, OperationExecutionResult.Status.SUCCESS, "applied");
+
+        assertSame(result.getOperation(), operation);
+        assertEquals(result.getStatus(), OperationExecutionResult.Status.SUCCESS);
+        assertEquals(result.getMessage(), "applied");
+    }
+
+    @Test
+    public void testStatusEnumValues() {
+
+        assertEquals(OperationExecutionResult.Status.valueOf("SUCCESS"),
+                OperationExecutionResult.Status.SUCCESS);
+        assertEquals(OperationExecutionResult.Status.valueOf("FAILURE"),
+                OperationExecutionResult.Status.FAILURE);
+        assertEquals(OperationExecutionResult.Status.values().length, 2);
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/resources/testng.xml
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/resources/testng.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="org.wso2.carbon.identity.flow.extension">
+    <test name="flow-extension-tests" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.carbon.identity.flow.extension.executor.FlowExtensionRequestBuilderTest"/>
+            <class name="org.wso2.carbon.identity.flow.extension.executor.FlowExtensionResponseProcessorTest"/>
+            <class name="org.wso2.carbon.identity.flow.extension.executor.JWEEncryptionUtilTest"/>
+            <class name="org.wso2.carbon.identity.flow.extension.executor.PathTypeAnnotationUtilTest"/>
+            <class name="org.wso2.carbon.identity.flow.extension.metadata.FlowExtensionContextTreeBuilderTest"/>
+            <class name="org.wso2.carbon.identity.flow.extension.model.AccessConfigTest"/>
+            <class name="org.wso2.carbon.identity.flow.extension.model.ContextPathTest"/>
+            <class name="org.wso2.carbon.identity.flow.extension.model.FlowExtensionActionTest"/>
+            <class name="org.wso2.carbon.identity.flow.extension.model.FlowExtensionEventTest"/>
+            <class name="org.wso2.carbon.identity.flow.extension.model.FlowExtensionFlowTest"/>
+            <class name="org.wso2.carbon.identity.flow.extension.model.FlowExtensionUserTest"/>
+            <class name="org.wso2.carbon.identity.flow.extension.model.OperationExecutionResultTest"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
## Purpose

The In-Flow Extension action forwards flow context data to an external service and applies the values that service returns. This change lets administrators mark individual exposed and modifiable context paths as encrypted, so those values are JWE-encrypted on the wire between the Identity Server and the external extension service. It also introduces a dedicated user object for the flow extension contract and exposes organization details in the forwarded context.

## Related Issue

- https://github.com/wso2/product-is/issues/28129

## Implementation

- Added a per-path `encrypted` flag on expose/modify entries (`AccessConfig` / `ContextPath`).
- Outbound (`FlowExtensionRequestBuilder`): every exposed user value (id, username, userStoreDomain, claims, credentials) is routed through a single gate that JWE-encrypts the value with the external service's certificate when its path is marked `encrypted`. Encrypted expose paths are omitted when no certificate is configured.
- Inbound (`FlowExtensionResponseProcessor`): `REPLACE` values on encrypted modify paths are decrypted with the server key. A non-string or non-JWE value on an encrypted path aborts the response; other per-operation validation failures drop the offending operation and keep the rest.
- Added `JWEEncryptionUtil` for JWE encrypt/decrypt, PEM certificate parsing, and JWE detection.
- Introduced the `FlowExtensionUser` model carrying the flow-extension-specific identity leaves and credentials on top of the shared user model.
- Advertised organization details in the exposed context and refactored the context tree builder and path-annotation handling.
- Added unit tests across the new executor, model, and util classes.