### PR TITLE
Update constants related to consent mgt flows

### DIFF
--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Flow.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Flow.java
@@ -120,12 +120,11 @@ public class Flow {
         // -----------------------------------------------------------------------------------------------
 
         // -------------------------- Consent management flows -------------------------------------------
-        FLOW_DEFINITIONS.put(Name.CONSENT_ACCEPT, EnumSet.of(InitiatingPersona.USER));
-        FLOW_DEFINITIONS.put(Name.CONSENT_REJECT, EnumSet.of(InitiatingPersona.USER));
-        FLOW_DEFINITIONS.put(Name.CONSENT_PENDING, EnumSet.of(InitiatingPersona.ADMIN));
+        FLOW_DEFINITIONS.put(Name.CONSENT_GRANT, EnumSet.of(InitiatingPersona.USER));
+        FLOW_DEFINITIONS.put(Name.CONSENT_CREATE, EnumSet.of(InitiatingPersona.ADMIN));
         FLOW_DEFINITIONS.put(Name.CONSENT_REVOKE, EnumSet.of(InitiatingPersona.ADMIN, InitiatingPersona.USER));
 
-        FLOW_DEFINITIONS.put(Name.CONSENT_PURPOSE_VERSION_ADD, EnumSet.of(InitiatingPersona.ADMIN));
+        FLOW_DEFINITIONS.put(Name.PURPOSE_UPDATE, EnumSet.of(InitiatingPersona.ADMIN));
         // -----------------------------------------------------------------------------------------------
     }
 
@@ -195,11 +194,10 @@ public class Flow {
         // --------------------------------------------------
 
         // ---------Consent management flows-----------------
-        CONSENT_ACCEPT,
-        CONSENT_REJECT,
-        CONSENT_PENDING,
+        CONSENT_CREATE,
+        CONSENT_GRANT,
         CONSENT_REVOKE,
-        CONSENT_PURPOSE_VERSION_ADD
+        PURPOSE_UPDATE
         // --------------------------------------------------
     }
 


### PR DESCRIPTION
This pull request updates the consent management flow definitions in the `Flow` class to better align with the intended operations and naming conventions. The main changes include renaming and reorganizing consent-related flow names and their associated initiating personas.

Consent management flow updates:

* Replaced `CONSENT_ACCEPT` and `CONSENT_REJECT` with `CONSENT_GRANT` and changed the initiating persona from `USER` to better reflect the action of granting consent. [[1]](diffhunk://#diff-09ef0a98a09a7a47148bf1796d8d05c85860ac25826ac6a255908b6a5f21b18dL123-R127) [[2]](diffhunk://#diff-09ef0a98a09a7a47148bf1796d8d05c85860ac25826ac6a255908b6a5f21b18dL198-R200)
* Replaced `CONSENT_PENDING` with `CONSENT_CREATE`, changing the initiating persona from `ADMIN` to represent the creation of consent by an admin. [[1]](diffhunk://#diff-09ef0a98a09a7a47148bf1796d8d05c85860ac25826ac6a255908b6a5f21b18dL123-R127) [[2]](diffhunk://#diff-09ef0a98a09a7a47148bf1796d8d05c85860ac25826ac6a255908b6a5f21b18dL198-R200)
* Renamed `CONSENT_PURPOSE_VERSION_ADD` to `PURPOSE_UPDATE`, clarifying the intent of the flow and keeping the initiating persona as `ADMIN`. [[1]](diffhunk://#diff-09ef0a98a09a7a47148bf1796d8d05c85860ac25826ac6a255908b6a5f21b18dL123-R127) [[2]](diffhunk://#diff-09ef0a98a09a7a47148bf1796d8d05c85860ac25826ac6a255908b6a5f21b18dL198-R200)