### PR TITLE
Fix NPE in LoggerUtils.getSanitizedErrorMessage when errorMessage is null

### DIFF
--- a/components/central-logger/org.wso2.carbon.identity.central.log.mgt/src/main/java/org/wso2/carbon/identity/central/log/mgt/utils/LoggerUtils.java
+++ b/components/central-logger/org.wso2.carbon.identity.central.log.mgt/src/main/java/org/wso2/carbon/identity/central/log/mgt/utils/LoggerUtils.java
@@ -332,7 +332,8 @@ public class LoggerUtils {
      */
     public static String getSanitizedErrorMessage(String errorMessage, String userName) {
 
-        if (LoggerUtils.isLogMaskingEnable && userName != null && errorMessage.contains(userName)) {
+        if (LoggerUtils.isLogMaskingEnable && errorMessage != null && userName != null
+                && errorMessage.contains(userName)) {
             return errorMessage.replace(userName, LoggerUtils.getMaskedContent(userName));
         }
         return errorMessage;

--- a/components/central-logger/org.wso2.carbon.identity.central.log.mgt/src/test/java/org/wso2/carbon/identity/central/log/mgt/utils/LoggerUtilsTest.java
+++ b/components/central-logger/org.wso2.carbon.identity.central.log.mgt/src/test/java/org/wso2/carbon/identity/central/log/mgt/utils/LoggerUtilsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.central.log.mgt.utils;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link LoggerUtils}.
+ */
+public class LoggerUtilsTest {
+
+    @AfterMethod
+    public void tearDown() {
+
+        LoggerUtils.isLogMaskingEnable = false;
+    }
+
+    @Test
+    public void testGetSanitizedErrorMessageWithNullErrorMessage() {
+
+        LoggerUtils.isLogMaskingEnable = true;
+        Assert.assertNull(LoggerUtils.getSanitizedErrorMessage(null, "testUser"));
+    }
+
+    @Test
+    public void testGetSanitizedErrorMessageMasksUserName() {
+
+        LoggerUtils.isLogMaskingEnable = true;
+        String sanitized = LoggerUtils.getSanitizedErrorMessage("Error for user testUser", "testUser");
+        Assert.assertFalse(sanitized.contains("testUser"));
+    }
+
+    @Test
+    public void testGetSanitizedErrorMessageWithMaskingDisabled() {
+
+        LoggerUtils.isLogMaskingEnable = false;
+        String errorMessage = "Error for user testUser";
+        Assert.assertEquals(LoggerUtils.getSanitizedErrorMessage(errorMessage, "testUser"), errorMessage);
+    }
+}

--- a/components/central-logger/org.wso2.carbon.identity.central.log.mgt/src/test/resources/testng.xml
+++ b/components/central-logger/org.wso2.carbon.identity.central.log.mgt/src/test/resources/testng.xml
@@ -21,6 +21,7 @@
 <suite name="org.wso2.carbon.identity.central.log.mgt.suite">
     <test name="org.wso2.carbon.identity.central.log.mgt.tests" preserve-order="true" parallel="false">
         <classes>
+            <class name="org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtilsTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose

Fixes wso2/product-is#28034.

`LoggerUtils.getSanitizedErrorMessage(String errorMessage, String userName)` null-checks `userName` but not `errorMessage` before calling `errorMessage.contains(userName)`. When `errorMessage` is `null` (e.g. an `IdentityOAuth2Exception` with a null message thrown while validating a CIBA grant with `client_secret_post` client authentication), this throws a `NullPointerException` from `AccessTokenIssuer.validateGrantAndIssueToken`, surfacing as a 500 server error instead of the expected `invalid_grant` OAuth error response.

## Changes

- Add the missing `errorMessage != null` check in `LoggerUtils.getSanitizedErrorMessage`.
- Add unit tests covering: null `errorMessage`, masking a username in a non-null message, and masking disabled.

## Testing

Unit tests added (`LoggerUtilsTest`) and registered in the module's `testng.xml`. I wasn't able to run the full Maven reactor build in my environment (no local Maven install), so please let me know if CI surfaces anything and I'll follow up.