### PR TITLE
Add anonymous profile tracker to identity context

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/FlowExecutionService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/FlowExecutionService.java
@@ -116,8 +116,6 @@ public class FlowExecutionService {
                 }
             }
 
-            isFlowEnteredInIdentityContext = enterFlowInIdentityContext(context.getFlowType());
-
             if (inputs != null) {
                 context.getUserInputData().putAll(inputs);
             }
@@ -130,6 +128,8 @@ public class FlowExecutionService {
                 context.setProperty(ANONYMOUS_PROFILE_TRACKER,
                         context.getUserInputData().remove(ANONYMOUS_PROFILE_TRACKER));
             }
+
+            isFlowEnteredInIdentityContext = enterFlowInIdentityContext(context);
 
             context.setCurrentActionId(actionId);
             for (FlowExecutionListener listener :
@@ -182,8 +182,9 @@ public class FlowExecutionService {
         }
     }
 
-    private boolean enterFlowInIdentityContext(String flowType) {
+    private boolean enterFlowInIdentityContext(FlowExecutionContext context) {
 
+        String flowType = context.getFlowType();
         if (!EnumUtils.isValidEnum(FlowTypes.class, flowType)) {
             LOG.warn("Invalid flow type: " + flowType + " provided. Hence not entering the flow in IdentityContext.");
             return false;
@@ -194,6 +195,7 @@ public class FlowExecutionService {
                 IdentityContext.getThreadLocalIdentityContext().enterFlow(new Flow.Builder()
                         .name(Flow.Name.REGISTER)
                         .initiatingPersona(Flow.InitiatingPersona.USER)
+                        .anonymousProfileTracker((String) context.getProperty(ANONYMOUS_PROFILE_TRACKER))
                         .build());
                 return true;
             case PASSWORD_RECOVERY:

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Flow.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Flow.java
@@ -211,11 +211,13 @@ public class Flow {
     private final Name name;
     private final InitiatingPersona initiatingPersona;
     private CredentialType credentialType;
+    private String anonymousProfileTracker;
 
     private Flow(Builder builder) {
 
         this.name = builder.name;
         this.initiatingPersona = builder.initiatingPersona;
+        this.anonymousProfileTracker = builder.anonymousProfileTracker;
     }
 
     private Flow(CredentialFlowBuilder builder) {
@@ -241,6 +243,18 @@ public class Flow {
     }
 
     /**
+     * Returns the anonymous profile tracker identifier associated with the flow, if any.
+     * This is used to correlate an anonymous, pre-authentication profile (e.g. for external profile linking)
+     * with the user created/updated as a result of this flow.
+     *
+     * @return The anonymous profile tracker identifier, or null if not applicable.
+     */
+    public String getAnonymousProfileTracker() {
+
+        return anonymousProfileTracker;
+    }
+
+    /**
      * Checks if the given flow name corresponds to a credential flow.
      *
      * @param name The name of the flow.
@@ -258,6 +272,7 @@ public class Flow {
 
         private Name name;
         private InitiatingPersona initiatingPersona;
+        private String anonymousProfileTracker;
 
         public Builder name(Name name) {
 
@@ -268,6 +283,12 @@ public class Flow {
         public Builder initiatingPersona(InitiatingPersona initiatingPersona) {
 
             this.initiatingPersona = initiatingPersona;
+            return this;
+        }
+
+        public Builder anonymousProfileTracker(String anonymousProfileTracker) {
+
+            this.anonymousProfileTracker = anonymousProfileTracker;
             return this;
         }
 


### PR DESCRIPTION
## Purpose

Make the anonymous profile tracker available through the identity context during registration flows, so that downstream user operation listeners can consume it without relying on a user claim.

## Changes

- Add an `anonymousProfileTracker` field, builder method, and getter to the `Flow` model.
- Populate the field from the flow execution context when entering the registration flow in `FlowExecutionService`, so the value carried across the flow steps is surfaced on the identity context flow.

