### PR TITLE
Add ResolveExistingUserBeforeConsentPrompt config to link existing local users before JIT prompt-consent redirect

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java
@@ -97,6 +97,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.hand
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ALLOW_LOGIN_TO_IDP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Config.SEND_ONLY_LOCALLY_MAPPED_ROLES_OF_IDP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.EMAIL_ADDRESS_CLAIM;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RESOLVE_EXISTING_USER_BEFORE_CONSENT_PROMPT;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_ENCRYPTING_TOTP_SECRET_KEY;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_GETTING_IDP_BY_NAME;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_GETTING_REALM_IN_POST_AUTHENTICATION;
@@ -339,6 +340,16 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                     boolean isUserAllowsToLoginIdp =  Boolean.parseBoolean(IdentityUtil
                             .getProperty(ALLOW_LOGIN_TO_IDP));
 
+                    // When enabled, resolve and link the federated identity to an existing local account before the
+                    // prompt-consent sign-up redirect, so an existing user is logged in instead of being redirected
+                    // to the sign-up form. Applies only to IdPs that have associate-local-user enabled.
+                    if (isResolveExistingUserBeforeConsentPromptEnabled()
+                            && externalIdPConfig.isAssociateLocalUserEnabled()
+                            && StringUtils.isEmpty(associatedLocalUser)
+                            && externalIdPConfig.isPromptConsentEnabled()) {
+                        associatedLocalUser = resolveAndAssociateExistingLocalUser(externalIdPConfig, context,
+                                localClaimValues, federatedClaimValues, stepConfig, externalSubject);
+                    }
                     // If associatedLocalUser is null, that means relevant association not exist already.
                     if (StringUtils.isEmpty(associatedLocalUser) && externalIdPConfig.isPromptConsentEnabled()) {
                         if (log.isDebugEnabled()) {
@@ -355,71 +366,8 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
                         return PostAuthnHandlerFlowStatus.INCOMPLETE;
                     }
                     if (StringUtils.isEmpty(associatedLocalUser) && externalIdPConfig.isAssociateLocalUserEnabled()) {
-
-                        AccountLookupAttributeMappingConfig[] accountLookupAttributeMappingConfigs =
-                                externalIdPConfig.getAccountLookupAttributeMappings();
-                        boolean isEmailUsernameLookup =
-                                ArrayUtils.isEmpty(accountLookupAttributeMappingConfigs);
-                        if (log.isDebugEnabled()) {
-                            log.debug("Account lookup attribute mappings are not configured for the IDP: "
-                                    + externalIdPConfig.getIdPName() + ". Hence, using email address claim for account "
-                                    + "lookup matching with local username.");
-                        }
-                        if (isEmailUsernameLookup &&
-                                StringUtils.isNotBlank(localClaimValues.get(EMAIL_ADDRESS_CLAIM))) {
-                            try {
-                                String emailUsername = localClaimValues.get(EMAIL_ADDRESS_CLAIM);
-                                UserRealm realm = getUserRealm(context.getTenantDomain());
-                                AbstractUserStoreManager userStoreManager =
-                                        (AbstractUserStoreManager) getUserStoreManager(context.getExternalIdP()
-                                                .getProvisioningUserStoreId(), realm, emailUsername);
-                                if (userStoreManager.isExistingUser(emailUsername)) {
-                                    org.wso2.carbon.user.core.common.User user =
-                                            userStoreManager.getUser(null, emailUsername);
-                                    //associate user
-                                    FrameworkUtils.getFederatedAssociationManager()
-                                            .createFederatedAssociation(new User(user),
-                                                    stepConfig.getAuthenticatedIdP(),
-                                                    externalSubject);
-                                    associatedLocalUser = user.getDomainQualifiedUsername();
-                                }
-                            } catch (UserStoreException e) {
-                                handleExceptions(ErrorMessages.ERROR_WHILE_CHECKING_USERNAME_EXISTENCE.getMessage(),
-                                        "error.user.existence", e);
-                            } catch (FrameworkException | FederatedAssociationManagerException e) {
-                                handleExceptions(e.getMessage(), e.getErrorCode(), e);
-                            }
-                        } else {
-                            if (log.isDebugEnabled()) {
-                                log.debug("Account lookup attribute mappings configured for IDP: " +
-                                        externalIdPConfig.getIdPName() + ". Attempting to match user using mapped " +
-                                        "attributes.");
-                            }
-                            Map<String, String> localClaimValuesForLookup =
-                                    getLocalClaimsForAccountLookup(federatedClaimValues,
-                                            externalIdPConfig.getAccountLookupAttributeMappings());
-
-                            org.wso2.carbon.user.core.common.User user = getLocalUser(context.getTenantDomain(),
-                                    externalIdPConfig.getProvisioningUserStoreId(), localClaimValuesForLookup);
-
-                            try {
-                                if (user != null) {
-                                    FrameworkUtils.getFederatedAssociationManager()
-                                            .createFederatedAssociation(new User(user),
-                                                    stepConfig.getAuthenticatedIdP(),
-                                                    externalSubject);
-                                    associatedLocalUser = user.getDomainQualifiedUsername();
-                                } else {
-                                    if (log.isDebugEnabled()) {
-                                        log.debug("No local user found for the account lookup attributes: "
-                                                + localClaimValuesForLookup + " in tenant domain: "
-                                                + context.getTenantDomain());
-                                    }
-                                }
-                            } catch (FederatedAssociationManagerException | FrameworkException e) {
-                                handleExceptions(e.getMessage(), e.getErrorCode(), e);
-                            }
-                        }
+                        associatedLocalUser = resolveAndAssociateExistingLocalUser(externalIdPConfig, context,
+                                localClaimValues, federatedClaimValues, stepConfig, externalSubject);
                     }
                     if (externalIdPConfig.isSkipJITOnAttrAccountLookupEnabled() &&
                             StringUtils.isEmpty(associatedLocalUser)) {
@@ -824,6 +772,137 @@ public class JITProvisioningPostAuthenticationHandler extends AbstractPostAuthnH
             throws PostAuthenticationFailedException {
 
         throw new PostAuthenticationFailedException(errorCode, errorMessage, e);
+    }
+
+    /**
+     * Whether resolving an existing local user before the prompt-consent sign-up redirect is enabled.
+     *
+     * @return true if resolving existing users before prompt consent is enabled.
+     */
+    private boolean isResolveExistingUserBeforeConsentPromptEnabled() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(RESOLVE_EXISTING_USER_BEFORE_CONSENT_PROMPT));
+    }
+
+    /**
+     * Resolve an existing local account for the federated user and, if found, create the federated association.
+     * Uses the IdP's account lookup attribute mappings when configured, otherwise falls back to matching the
+     * email address claim against the local username.
+     *
+     * @param externalIdPConfig    Relevant external IDP.
+     * @param context              Authentication context.
+     * @param localClaimValues     Local claim values of the user.
+     * @param federatedClaimValues Federated claim values of the user.
+     * @param stepConfig           The authentication step config.
+     * @param externalSubject      The federated subject identifier.
+     * @return The domain-qualified username of the linked local account, or null when no matching account exists.
+     * @throws PostAuthenticationFailedException If the user-store lookup or association fails.
+     */
+    private String resolveAndAssociateExistingLocalUser(ExternalIdPConfig externalIdPConfig,
+                                                        AuthenticationContext context,
+                                                        Map<String, String> localClaimValues,
+                                                        Map<ClaimMapping, String> federatedClaimValues,
+                                                        StepConfig stepConfig, String externalSubject)
+            throws PostAuthenticationFailedException {
+
+        boolean isEmailUsernameLookup =
+                ArrayUtils.isEmpty(externalIdPConfig.getAccountLookupAttributeMappings());
+        if (isEmailUsernameLookup && StringUtils.isNotBlank(localClaimValues.get(EMAIL_ADDRESS_CLAIM))) {
+            return associateByEmailUsername(externalIdPConfig, context, localClaimValues, stepConfig,
+                    externalSubject);
+        }
+        return associateByLookupAttributes(externalIdPConfig, context, federatedClaimValues, stepConfig,
+                externalSubject);
+    }
+
+    /**
+     * Resolve the local account by matching the email address claim against the local username and, if found,
+     * create the federated association.
+     *
+     * @param externalIdPConfig Relevant external IDP.
+     * @param context           Authentication context.
+     * @param localClaimValues  Local claim values of the user.
+     * @param stepConfig        The authentication step config.
+     * @param externalSubject   The federated subject identifier.
+     * @return The domain-qualified username of the linked local account, or null when no matching account exists.
+     * @throws PostAuthenticationFailedException If the user-store lookup or association fails.
+     */
+    private String associateByEmailUsername(ExternalIdPConfig externalIdPConfig, AuthenticationContext context,
+                                            Map<String, String> localClaimValues, StepConfig stepConfig,
+                                            String externalSubject) throws PostAuthenticationFailedException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Account lookup attribute mappings are not configured for the IDP: "
+                    + externalIdPConfig.getIdPName() + ". Hence, using email address claim for account "
+                    + "lookup matching with local username.");
+        }
+        try {
+            String emailUsername = localClaimValues.get(EMAIL_ADDRESS_CLAIM);
+            UserRealm realm = getUserRealm(context.getTenantDomain());
+            AbstractUserStoreManager userStoreManager =
+                    (AbstractUserStoreManager) getUserStoreManager(context.getExternalIdP()
+                            .getProvisioningUserStoreId(), realm, emailUsername);
+            if (userStoreManager.isExistingUser(emailUsername)) {
+                org.wso2.carbon.user.core.common.User user = userStoreManager.getUser(null, emailUsername);
+                //associate user
+                FrameworkUtils.getFederatedAssociationManager()
+                        .createFederatedAssociation(new User(user), stepConfig.getAuthenticatedIdP(),
+                                externalSubject);
+                return user.getDomainQualifiedUsername();
+            }
+        } catch (UserStoreException e) {
+            handleExceptions(ErrorMessages.ERROR_WHILE_CHECKING_USERNAME_EXISTENCE.getMessage(),
+                    "error.user.existence", e);
+        } catch (FrameworkException | FederatedAssociationManagerException e) {
+            handleExceptions(e.getMessage(), e.getErrorCode(), e);
+        }
+        return null;
+    }
+
+    /**
+     * Resolve the local account using the IdP's account lookup attribute mappings and, if found, create the
+     * federated association.
+     *
+     * @param externalIdPConfig    Relevant external IDP.
+     * @param context              Authentication context.
+     * @param federatedClaimValues Federated claim values of the user.
+     * @param stepConfig           The authentication step config.
+     * @param externalSubject      The federated subject identifier.
+     * @return The domain-qualified username of the linked local account, or null when no matching account exists.
+     * @throws PostAuthenticationFailedException If the user-store lookup or association fails.
+     */
+    private String associateByLookupAttributes(ExternalIdPConfig externalIdPConfig, AuthenticationContext context,
+                                               Map<ClaimMapping, String> federatedClaimValues,
+                                               StepConfig stepConfig, String externalSubject)
+            throws PostAuthenticationFailedException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Account lookup attribute mappings configured for IDP: " + externalIdPConfig.getIdPName()
+                    + ". Attempting to match user using mapped attributes.");
+        }
+        Map<String, String> localClaimValuesForLookup =
+                getLocalClaimsForAccountLookup(federatedClaimValues,
+                        externalIdPConfig.getAccountLookupAttributeMappings());
+
+        org.wso2.carbon.user.core.common.User user = getLocalUser(context.getTenantDomain(),
+                externalIdPConfig.getProvisioningUserStoreId(), localClaimValuesForLookup);
+
+        if (user == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("No local user found for the account lookup attributes: " + localClaimValuesForLookup
+                        + " in tenant domain: " + context.getTenantDomain());
+            }
+            return null;
+        }
+        try {
+            FrameworkUtils.getFederatedAssociationManager()
+                    .createFederatedAssociation(new User(user), stepConfig.getAuthenticatedIdP(),
+                            externalSubject);
+            return user.getDomainQualifiedUsername();
+        } catch (FederatedAssociationManagerException | FrameworkException e) {
+            handleExceptions(e.getMessage(), e.getErrorCode(), e);
+        }
+        return null;
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -293,6 +293,8 @@ public abstract class FrameworkConstants {
     public static final String REQ_ATTR_RETRY_STATUS = "retryStatus";
     public static final String IDP_MAPPED_USER_ROLES = "identityProviderMappedUserRoles";
     public static final String ALLOW_ASSOCIATING_TO_EXISTING_USER = "JITProvisioning.AllowAssociatingToExistingUser";
+    public static final String RESOLVE_EXISTING_USER_BEFORE_CONSENT_PROMPT =
+            "JITProvisioning.ResolveExistingUserBeforeConsentPrompt";
 
     // The constant to used as the attribute key or the property key of the federated tokens.
     public static final String FEDERATED_TOKENS = "federated_tokens";

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -296,6 +296,7 @@
 
   "oauth.allow_disabled_application_credentials_for_authentication": false,
   "authentication.jit_provisioning.associating_to_existing_user": false,
+  "authentication.jit_provisioning.resolve_existing_user_before_consent_prompt": false,
   "authentication.jit_provisioning.enable_configured_idp_sub_for_federated_user_association": false,
 
   "ai_services.token_endpoint": "https://api.asgardeo.io/t/wso2devtools/oauth2/token",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2346,6 +2346,9 @@
             <AllowLoginToIDP>{{authentication.jit_provisioning.allow_idp_login}}</AllowLoginToIDP>
         {% endif %}
         <AllowAssociatingToExistingUser>{{authentication.jit_provisioning.associating_to_existing_user}}</AllowAssociatingToExistingUser>
+        {% if authentication.jit_provisioning.resolve_existing_user_before_consent_prompt is defined %}
+        <ResolveExistingUserBeforeConsentPrompt>{{authentication.jit_provisioning.resolve_existing_user_before_consent_prompt}}</ResolveExistingUserBeforeConsentPrompt>
+        {% endif %}
         <EnableConfiguredIdpSubForFederatedUserAssociation>{{authentication.jit_provisioning.enable_configured_idp_sub_for_federated_user_association}}</EnableConfiguredIdpSubForFederatedUserAssociation>
         <AllowNonStandardClaimURI>{{authentication.jit_provisioning.allow_non_Standard_claim_uri}}</AllowNonStandardClaimURI>
         {% if authentication.jit_provisioning.show_failure_reason is defined %}

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2346,6 +2346,7 @@
             <AllowLoginToIDP>{{authentication.jit_provisioning.allow_idp_login}}</AllowLoginToIDP>
         {% endif %}
         <AllowAssociatingToExistingUser>{{authentication.jit_provisioning.associating_to_existing_user}}</AllowAssociatingToExistingUser>
+        <ResolveExistingUserBeforeConsentPrompt>{{authentication.jit_provisioning.resolve_existing_user_before_consent_prompt}}</ResolveExistingUserBeforeConsentPrompt>
         <EnableConfiguredIdpSubForFederatedUserAssociation>{{authentication.jit_provisioning.enable_configured_idp_sub_for_federated_user_association}}</EnableConfiguredIdpSubForFederatedUserAssociation>
         <AllowNonStandardClaimURI>{{authentication.jit_provisioning.allow_non_Standard_claim_uri}}</AllowNonStandardClaimURI>
         {% if authentication.jit_provisioning.show_failure_reason is defined %}


### PR DESCRIPTION
## Purpose

Fixes wso2/product-is#27811.

With JIT provisioning in a prompt scheme (**Provisioning with Consent** / **with Password & Consent** / **with Username, Password & Consent**), a user who already has a local account and authenticates through a **second** federated IdP is redirected to the account-create (sign-up) form instead of being linked to their existing account and logged in. No new account is created — the existing user is simply, and misleadingly, shown a sign-up form.

## Root cause

In `JITProvisioningPostAuthenticationHandler.handleRequestFlow()`, the `isPromptConsentEnabled()` → `redirectToAccountCreateUI()` block runs **before** the `isAssociateLocalUserEnabled()` existing-account lookup. Under a prompt scheme the consent flow short-circuits to sign-up (`return INCOMPLETE`) before any existing local account can be matched and linked.

## Fix

Resolve and link the federated identity to an existing local account **before** the prompt-consent redirect; the sign-up redirect then fires only when no local account is matched. The change is gated by two flags:

- **`isResolveExistingUserBeforeConsentPromptEnabled()`** — a new **server-level** config; the master switch for the behaviour (default **off**).
- **`externalIdPConfig.isAssociateLocalUserEnabled()`** — the existing **per-IdP** setting; selects which IdPs the behaviour applies to.

So the behaviour is off unless the server config is enabled **and** the IdP has associate-local-user enabled — per-IdP control rather than a server-wide all-or-nothing change. The duplicated inline lookup is collapsed into a shared `resolveAndAssociateExistingLocalUser(...)` helper (covering both the email-username and account-lookup-attribute-mapping paths).

## Configuration

New server-level config `JITProvisioning.ResolveExistingUserBeforeConsentPrompt`, disabled by default and emitted into `identity.xml` only when the operator defines the key:

```toml
[authentication.jit_provisioning]
resolve_existing_user_before_consent_prompt = true
```

## Behavioural change

With the server config enabled, an existing local user authenticating through a federated IdP that has associate-local-user enabled, under a prompt scheme, is linked to their existing account and logged in instead of being shown the sign-up form. With the config disabled (default) — or for IdPs without associate-local-user — behaviour is unchanged.

## Testing

Verified at runtime on a dual-IS OIDC-federation setup (primary + a second WSO2 IS as IdP-B, both JIT "Password & Consent" with associate-local-user + email→username lookup), against an existing local user provisioned earlier via Google:

- **Config ON** — login via IdP-B links to the existing local account and issues an auth code to the app callback (no sign-up redirect); debug log: `... coming from <IdP> do have a local account, with the username <user>`.
- **Config OFF (default)** — login via IdP-B lands on `/accountrecoveryendpoint/signup.do` exactly as before; the `ResolveExistingUserBeforeConsentPrompt` element is absent from `identity.xml` and the new block is a no-op. Behaviour identical to the unpatched build.

## Related issue

- https://github.com/wso2/product-is/issues/27811

## Developer checklist

- [x] **[Behavioural Change]** Does this change introduce a behavioral change to the product? — yes, gated behind the new config, default off.
  - [ ] ↳ Approved by team lead
  - [ ] ↳ Label `impact/behavioral-change` added
- [x] **[New Configuration]** Does this change introduce a new configuration? — `JITProvisioning.ResolveExistingUserBeforeConsentPrompt` (default off).
  - [ ] ↳ Label `config` added
  - [ ] ↳ Configuration is properly documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)
