### PR TITLE
Retain tenant qualification for configured server URL in account recovery endpoint

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/main/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtil.java
@@ -898,9 +898,11 @@ public class IdentityManagementEndpointUtil {
                     }
                 }
             } else {
+                // A configured server URL is a bare base URL, so qualify it with the tenant here unless it
+                // already carries one.
                 if (StringUtils.isNotBlank(tenantDomain) && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME
                         .equalsIgnoreCase(tenantDomain) && isEndpointTenantAware
-                        && !isServerURLAlreadyTenanted(tenantDomain)) {
+                        && !serverUrl.contains(FrameworkConstants.TENANT_CONTEXT_PREFIX)) {
                     basePath = serverUrl + FrameworkConstants.TENANT_CONTEXT_PREFIX + tenantDomain + context;
                 } else {
                     basePath = serverUrl + context;

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/test/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtilTest.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt.endpoint.util/src/test/java/org/wso2/carbon/identity/mgt/endpoint/util/IdentityManagementEndpointUtilTest.java
@@ -373,6 +373,62 @@ public class IdentityManagementEndpointUtilTest {
         }
     }
 
+    @DataProvider(name = "getBasePathConfiguredServerUrlData")
+    public Object[][] getBasePathConfiguredServerUrlData() {
+
+        return new Object[][] {
+                // contextUrl (configured server URL)
+                // tenantDomain
+                // isEndpointTenantAware
+                // inboundPath (stubbed serviceURL.getPath() - already tenant-qualified, the case that regressed)
+                // expected value
+
+                // A configured server URL is tenant-qualified even when the inbound request path already
+                // carries the tenant (the fix - the tenant must not be dropped here).
+                { "https://foo.com",
+                  SAMPLE_TENANT_DOMAIN,
+                  true,
+                  "/t/test.com/api/identity/recovery/v0.9",
+                  "https://foo.com/t/test.com/api/identity/recovery/v0.9"
+                },
+                // Configured server URL already carries a tenant: no second /t/ prefix is added.
+                { "https://foo.com/t/test.com",
+                  SAMPLE_TENANT_DOMAIN,
+                  true,
+                  "/t/test.com/api/identity/recovery/v0.9",
+                  "https://foo.com/t/test.com/api/identity/recovery/v0.9"
+                },
+                // Super tenant: no /t/ prefix.
+                { "https://foo.com",
+                  MultitenantConstants.SUPER_TENANT_DOMAIN_NAME,
+                  true,
+                  "/t/carbon.super/api/identity/recovery/v0.9",
+                  "https://foo.com/api/identity/recovery/v0.9"
+                },
+                // Not endpoint-tenant-aware: no /t/ prefix.
+                { "https://foo.com",
+                  SAMPLE_TENANT_DOMAIN,
+                  false,
+                  "/t/test.com/api/identity/recovery/v0.9",
+                  "https://foo.com/api/identity/recovery/v0.9"
+                }
+        };
+    }
+
+    @Test(dataProvider = "getBasePathConfiguredServerUrlData")
+    public void testGetBasePathConfiguredServerUrl(String contextUrl, String tenantDomain,
+            boolean isEndpointTenantAware, String inboundPath, String expected) throws Exception {
+
+        String context = IdentityManagementEndpointConstants.UserInfoRecovery.RECOVERY_API_RELATIVE_PATH;
+        try (MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<ServiceURLBuilder> serviceURLBuilder = mockStatic(ServiceURLBuilder.class)) {
+            prepareGetBasePathTest(contextUrl, context, identityTenantUtil, serviceURLBuilder, true, false);
+            lenient().when(serviceURL.getPath()).thenReturn(inboundPath);
+            assertEquals(IdentityManagementEndpointUtil.getBasePath(tenantDomain, context, isEndpointTenantAware),
+                    expected);
+        }
+    }
+
     @DataProvider(name = "getBasePathUseOrgHandleFalseTestData")
     public Object[][] getBasePathUseOrgHandleFalseTestData() {
 


### PR DESCRIPTION
## Purpose

`IdentityManagementEndpointUtil.getBasePath()` drops the `/t/<tenant>` segment from the account recovery endpoint's internal REST calls when a server URL is configured (`identity_server_service_url`) and tenant-qualified URLs are enabled.

The configured-server-URL branch reused `isServerURLAlreadyTenanted()`, which inspects the inbound request path rather than the configured URL. For a non-super tenant the inbound path is already tenant-qualified, so the guard dropped the tenant prefix and the internal call resolved against `carbon.super`. This caused tenant self-registration confirmation (and related recovery flows) to fail with `Invalid tenant 'carbon.super'`.

## Approach

In the configured-server-URL branch, decide tenant qualification from the configured URL itself (`serverUrl.contains("/t/")`) instead of the inbound request path, and append `/t/<tenant>` when it is not already present. The blank-server-URL branch is unchanged. Keying off the configured URL also avoids a double `/t/<tenant>/t/<tenant>` prefix when a tenant is baked into the configured URL.

Added regression coverage in `IdentityManagementEndpointUtilTest` for the configured-server-URL branch with a tenant-qualified inbound path (previously uncovered), plus the already-tenanted-URL, super-tenant, and non-tenant-aware cases.

## Testing

`IdentityManagementEndpointUtilTest` passes (JDK 21, module build), including the new cases.
