### PR TITLE
Resolve spId and append to redirect URL in getRedirectURL

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -225,6 +225,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.OrgDiscoveryInputParameters.ORG_ID;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.OrgDiscoveryInputParameters.ORG_NAME;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.REQUEST_PARAM_SP;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.REQUEST_PARAM_SP_UUID;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.CORRELATION_ID;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.IS_IDF_INITIATED_FROM_AUTHENTICATOR;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.USER_TENANT_DOMAIN_HINT;
@@ -759,8 +760,8 @@ public class FrameworkUtils {
     }
 
     /**
-     * This method is used to append sp name and sp tenant domain as parameter to a given url. Those information will
-     * be fetched from request parameters or referer.
+     * This method is used to append sp name, sp uuid and sp tenant domain as parameter to a given url. Those
+     * information will be fetched from request parameters or referer.
      *
      * @param redirectURL Redirect URL.
      * @param request     HttpServlet Request.
@@ -769,9 +770,14 @@ public class FrameworkUtils {
     public static String getRedirectURL(String redirectURL, HttpServletRequest request) {
 
         String spName = (String) request.getAttribute(REQUEST_PARAM_SP);
+        String spId = (String) request.getAttribute(REQUEST_PARAM_SP_UUID);
         String tenantDomain = (String) request.getAttribute(TENANT_DOMAIN);
         if (StringUtils.isBlank(spName)) {
             spName = getServiceProviderNameByReferer(request);
+        }
+
+        if (StringUtils.isBlank(spId)) {
+            spId = getServiceProviderUuidByReferer(request);
         }
 
         if (StringUtils.isBlank(tenantDomain)) {
@@ -781,6 +787,10 @@ public class FrameworkUtils {
         try {
             if (StringUtils.isNotBlank(spName)) {
                 redirectURL = appendUri(redirectURL, REQUEST_PARAM_SP, spName);
+            }
+
+            if (StringUtils.isNotBlank(spId)) {
+                redirectURL = appendUri(redirectURL, REQUEST_PARAM_SP_UUID, spId);
             }
 
             if (StringUtils.isNotBlank(MDC.get(CORRELATION_ID_MDC))) {
@@ -943,6 +953,23 @@ public class FrameworkUtils {
         }
 
         return serviceProviderName;
+    }
+
+    private static String getServiceProviderUuidByReferer(HttpServletRequest request) {
+
+        String serviceProviderUuid = null;
+        String refererHeader = request.getHeader("referer");
+        if (StringUtils.isNotBlank(refererHeader)) {
+            String[] queryParams = refererHeader.split(QUERY_SEPARATOR);
+            for (String queryParam : queryParams) {
+                if (queryParam.contains(REQUEST_PARAM_SP_UUID + EQUAL)) {
+                    serviceProviderUuid = queryParam.substring(queryParam.lastIndexOf(EQUAL) + 1);
+                    break;
+                }
+            }
+        }
+
+        return serviceProviderUuid;
     }
 
     private static String getTenantDomainByReferer(HttpServletRequest request) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -144,6 +144,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.OrgDiscoveryInputParameters.ORG_ID;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.OrgDiscoveryInputParameters.ORG_NAME;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.REQUEST_PARAM_SP;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.REQUEST_PARAM_SP_UUID;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ROLES_CLAIM;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USERNAME_CLAIM;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USE_IDP_ROLE_CLAIM_AS_IDP_GROUP_CLAIM;
@@ -158,6 +159,8 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
     private static final String ROOT_DOMAIN = "/";
     private static final String DUMMY_TENANT_DOMAIN = "ABC";
     private static final String DUMMY_SP_NAME = "wso2carbon-local-sp";
+    private static final String DUMMY_SP_UUID = "65ac1c50-7bc4-4aae-971c-d0e824c2a218";
+    private static final String DUMMY_SP_UUID_2 = "11111111-2222-3333-4444-555555555555";
     private static final String REDIRECT_URL = "custom-page?";
     private static final String DUMMY_CACHE_KEY = "cache-key";
 
@@ -677,9 +680,70 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
                 .put(IdentityCoreConstants.ENABLE_TENANT_QUALIFIED_URLS, true);
         when(request.getAttribute(REQUEST_PARAM_SP)).thenReturn(spName);
         when(request.getAttribute(TENANT_DOMAIN)).thenReturn(tenantDomain);
+        lenient().when(request.getAttribute(REQUEST_PARAM_SP_UUID)).thenReturn(null);
 
         String redirectURL = FrameworkUtils.getRedirectURL(REDIRECT_URL, request);
         assertEquals(redirectURL, expectedOut);
+    }
+
+    @DataProvider(name = "provideSpIdRequestAttributes")
+    public Object[][] provideSpIdRequestAttributes() {
+
+        // spName attribute, spId attribute, expected output.
+        return new Object[][]{
+                {DUMMY_SP_NAME, DUMMY_SP_UUID,
+                        REDIRECT_URL + "&sp=" + DUMMY_SP_NAME + "&spId=" + DUMMY_SP_UUID},
+                {null, DUMMY_SP_UUID, REDIRECT_URL + "&spId=" + DUMMY_SP_UUID},
+                {DUMMY_SP_NAME, null, REDIRECT_URL + "&sp=" + DUMMY_SP_NAME},
+                {null, null, REDIRECT_URL}
+        };
+    }
+
+    @Test(dataProvider = "provideSpIdRequestAttributes")
+    public void testGetRedirectURLAppendsSpIdFromAttribute(String spName, String spId, String expectedOut) {
+
+        IdentityConfigParser.getInstance().getConfiguration()
+                .put(IdentityCoreConstants.ENABLE_TENANT_QUALIFIED_URLS, true);
+        when(request.getAttribute(REQUEST_PARAM_SP)).thenReturn(spName);
+        when(request.getAttribute(REQUEST_PARAM_SP_UUID)).thenReturn(spId);
+
+        String redirectURL = FrameworkUtils.getRedirectURL(REDIRECT_URL, request);
+        assertEquals(redirectURL, expectedOut);
+    }
+
+    @DataProvider(name = "provideSpIdRefererHeaders")
+    public Object[][] provideSpIdRefererHeaders() {
+
+        return new Object[][]{
+                {"https://localhost:9443/authenticationendpoint/login.do?sp=" + DUMMY_SP_NAME
+                        + "&spId=" + DUMMY_SP_UUID + "&sessionDataKey=key", DUMMY_SP_UUID},
+                {"https://localhost:9443/authenticationendpoint/login.do?sp=" + DUMMY_SP_NAME
+                        + "&sessionDataKey=key", null},
+                {"https://localhost:9443/authenticationendpoint/login.do?spId=" + DUMMY_SP_UUID
+                        + "&spId=" + DUMMY_SP_UUID_2, DUMMY_SP_UUID},
+                {"https://localhost:9443/authenticationendpoint/login.do?spId=&sessionDataKey=key", null},
+                {null, null}
+        };
+    }
+
+    @Test(dataProvider = "provideSpIdRefererHeaders")
+    public void testGetRedirectURLAppendsSpIdFromReferer(String refererHeader, String expectedSpId) {
+
+        IdentityConfigParser.getInstance().getConfiguration()
+                .put(IdentityCoreConstants.ENABLE_TENANT_QUALIFIED_URLS, true);
+        lenient().when(request.getAttribute(REQUEST_PARAM_SP)).thenReturn(null);
+        lenient().when(request.getAttribute(REQUEST_PARAM_SP_UUID)).thenReturn(null);
+        lenient().when(request.getAttribute(TENANT_DOMAIN)).thenReturn(null);
+        lenient().when(request.getHeader("referer")).thenReturn(refererHeader);
+
+        String redirectURL = FrameworkUtils.getRedirectURL(REDIRECT_URL, request);
+        if (expectedSpId == null) {
+            assertFalse(redirectURL.contains("spId="),
+                    "spId must not be appended when it cannot be resolved. Got: " + redirectURL);
+        } else {
+            assertTrue(redirectURL.contains("spId=" + expectedSpId),
+                    "Expected spId=" + expectedSpId + " in redirect URL. Got: " + redirectURL);
+        }
     }
 
     private Cookie[] getAuthenticationCookies() {


### PR DESCRIPTION
## Purpose

When the framework redirects to the retry page, the `spId` (service provider UUID) parameter was missing from the redirect URL. `FrameworkUtils.getRedirectURL` only propagated the service provider name (`sp`), so the resolved `spId` was dropped and unavailable on the retry page.

This change resolves the `spId` and appends it to the redirect URL so it is preserved across framework redirects, including the retry page.

## Related issue

- https://github.com/wso2/product-is/issues/28099

## Changes

- Resolve `spId` from the request attribute (`REQUEST_PARAM_SP_UUID`), falling back to the `referer` header when not present.
- Append the resolved `spId` to the redirect URL when available.
- Add a `getServiceProviderUuidByReferer` helper that extracts the `spId` query parameter from the `referer` header.

This mirrors the existing resolution of the service provider name via `getServiceProviderNameByReferer`.
