### PR TITLE
Add default console feature flag configurations for FAPI Security Policy

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -2140,6 +2140,13 @@
     "internal_userstore_view"
   ],
   "console.user_roles_v3.scopes.update": ["internal_role_mgt_meta_update"],
+  "console.fapi.enabled": true,
+  "console.fapi.disabled_features": [],
+  "console.fapi.feature_flags": [],
+  "console.fapi.scopes.create": [],
+  "console.fapi.scopes.read": [],
+  "console.fapi.scopes.update": [],
+  "console.fapi.scopes.delete": [],
   "myaccount.app_base_name": "myaccount",
   "myaccount.client_id": "MY_ACCOUNT",
   "myaccount.login_callback_path": "",


### PR DESCRIPTION
## Purpose

Adds the default configuration entries for the `console.fapi` feature flag to the Identity Server's default configuration file, enabling operators to control the visibility of the FAPI Security Policy tile in the Admin Console via `deployment.toml`.

Resolves wso2-enterprise/iam-product-management#601

## Goals

- Register default `console.fapi.*` configuration properties in `org.wso2.carbon.identity.core.server.feature.default.json`.

## Approach

- Added `console.fapi.enabled`, `console.fapi.disabled_features`, `console.fapi.feature_flags`, and `console.fapi.scopes.*` entries to the server feature default configuration file.
- The feature is enabled by default (`console.fapi.enabled: true`). Operators can disable the FAPI Security Policy tile by setting `console.fapi.enabled = false` in `deployment.toml`.

## Release note

N/A

## Documentation

N/A

## Automation tests

- Unit tests
  > Not applicable for configuration-only changes.
- Integration tests
  > Verified that the `console.fapi.enabled` flag correctly controls the FAPI Security Policy tile visibility in the Admin Console.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs

- https://github.com/wso2/identity-apps/pull/[your-identity-apps-pr]

## Migrations (if applicable)

No migration required. The new entries are default values only.