### PR TITLE
Expose the fields that caused a rule to fail in the rule evaluation result

### DIFF
--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/api/model/RuleEvaluationResult.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/api/model/RuleEvaluationResult.java
@@ -18,6 +18,9 @@
 
 package org.wso2.carbon.identity.rule.evaluation.api.model;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Rule evaluation result.
  * This class is used to represent the result of a rule evaluation.
@@ -26,11 +29,18 @@ public class RuleEvaluationResult {
 
     private final String ruleId;
     private final boolean ruleSatisfied;
+    private final List<String> failedFields;
 
     public RuleEvaluationResult(String ruleId, boolean ruleSatisfied) {
 
+        this(ruleId, ruleSatisfied, Collections.emptyList());
+    }
+
+    public RuleEvaluationResult(String ruleId, boolean ruleSatisfied, List<String> failedFields) {
+
         this.ruleId = ruleId;
         this.ruleSatisfied = ruleSatisfied;
+        this.failedFields = failedFields != null ? failedFields : Collections.emptyList();
     }
 
     public String getRuleId() {
@@ -41,5 +51,14 @@ public class RuleEvaluationResult {
     public boolean isRuleSatisfied() {
 
         return ruleSatisfied;
+    }
+
+    /**
+     * Returns the list of fields that failed evaluation.
+     * Empty when the rule is satisfied.
+     */
+    public List<String> getFailedFields() {
+
+        return Collections.unmodifiableList(failedFields);
     }
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/api/model/RuleEvaluationResult.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/api/model/RuleEvaluationResult.java
@@ -48,7 +48,6 @@ public class RuleEvaluationResult {
 
         this.ruleId = ruleId;
         this.ruleSatisfied = ruleSatisfied;
-        // Keep as-is: null means the failed fields were not set, which is different from an empty list.
         this.failedFields = failedFields;
     }
 

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/api/model/RuleEvaluationResult.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/api/model/RuleEvaluationResult.java
@@ -31,16 +31,25 @@ public class RuleEvaluationResult {
     private final boolean ruleSatisfied;
     private final List<String> failedFields;
 
+    /**
+     * Creates a result without setting the failed fields.
+     *
+     * @deprecated Use {@link #RuleEvaluationResult(String, boolean, List)} which also captures the failed
+     *             fields. This constructor leaves the failed fields unset ({@code null}), so callers cannot
+     *             distinguish "no fields failed" from "failed fields were not computed".
+     */
+    @Deprecated
     public RuleEvaluationResult(String ruleId, boolean ruleSatisfied) {
 
-        this(ruleId, ruleSatisfied, Collections.emptyList());
+        this(ruleId, ruleSatisfied, null);
     }
 
     public RuleEvaluationResult(String ruleId, boolean ruleSatisfied, List<String> failedFields) {
 
         this.ruleId = ruleId;
         this.ruleSatisfied = ruleSatisfied;
-        this.failedFields = failedFields != null ? failedFields : Collections.emptyList();
+        // Keep as-is: null means the failed fields were not set, which is different from an empty list.
+        this.failedFields = failedFields;
     }
 
     public String getRuleId() {
@@ -54,11 +63,13 @@ public class RuleEvaluationResult {
     }
 
     /**
-     * Returns the list of fields that failed evaluation.
+     * Returns the list of fields that failed evaluation, or {@code null} if the failed fields were not set.
      * Empty when the rule is satisfied.
+     *
+     * @return Unmodifiable list of failed field names, or {@code null} if not set.
      */
     public List<String> getFailedFields() {
 
-        return Collections.unmodifiableList(failedFields);
+        return failedFields == null ? null : Collections.unmodifiableList(failedFields);
     }
 }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluationServiceImpl.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluationServiceImpl.java
@@ -76,7 +76,7 @@ public class RuleEvaluationServiceImpl implements RuleEvaluationService {
 
         RuleEvaluator ruleEvaluator = new RuleEvaluator(RuleEvaluationComponentServiceHolder.getInstance()
                 .getOperatorRegistry());
-        RuleEvaluationResult result = ruleEvaluator.evaluateResult(rule, evaluationData);
+        RuleEvaluationResult result = ruleEvaluator.evaluate(rule, evaluationData);
         if (LOG.isDebugEnabled()) {
             LOG.debug("Evaluated rule: " + rule.getId() + " to: " + result.isRuleSatisfied() + ".");
         }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluationServiceImpl.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluationServiceImpl.java
@@ -79,7 +79,7 @@ public class RuleEvaluationServiceImpl implements RuleEvaluationService {
         boolean evaluationStatus = ruleEvaluator.evaluate(rule, evaluationData);
         LOG.debug("Evaluated rule: " + rule.getId() + " to: " + evaluationStatus + ".");
 
-        return new RuleEvaluationResult(ruleId, evaluationStatus);
+        return new RuleEvaluationResult(ruleId, evaluationStatus, ruleEvaluator.getFailedFields());
     }
 
     private Map<String, FieldValue> getEvaluationData(String ruleId, FlowContext flowContext,

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluationServiceImpl.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluationServiceImpl.java
@@ -76,7 +76,7 @@ public class RuleEvaluationServiceImpl implements RuleEvaluationService {
 
         RuleEvaluator ruleEvaluator = new RuleEvaluator(RuleEvaluationComponentServiceHolder.getInstance()
                 .getOperatorRegistry());
-        RuleEvaluationResult result = ruleEvaluator.evaluate(ruleId, rule, evaluationData);
+        RuleEvaluationResult result = ruleEvaluator.evaluateResult(rule, evaluationData);
         if (LOG.isDebugEnabled()) {
             LOG.debug("Evaluated rule: " + rule.getId() + " to: " + result.isRuleSatisfied() + ".");
         }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluationServiceImpl.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluationServiceImpl.java
@@ -62,7 +62,7 @@ public class RuleEvaluationServiceImpl implements RuleEvaluationService {
 
         if (!rule.isActive()) {
             LOG.debug("Rule: " + rule.getId() + " is inactive. Skip evaluation of rule.");
-            return new RuleEvaluationResult(ruleId, false);
+            return new RuleEvaluationResult(ruleId, false, null);
         }
 
         LOG.debug("Starting to evaluate rule: " + rule.getId() + ".");
@@ -76,10 +76,10 @@ public class RuleEvaluationServiceImpl implements RuleEvaluationService {
 
         RuleEvaluator ruleEvaluator = new RuleEvaluator(RuleEvaluationComponentServiceHolder.getInstance()
                 .getOperatorRegistry());
-        boolean evaluationStatus = ruleEvaluator.evaluate(rule, evaluationData);
-        LOG.debug("Evaluated rule: " + rule.getId() + " to: " + evaluationStatus + ".");
+        RuleEvaluationResult result = ruleEvaluator.evaluate(ruleId, rule, evaluationData);
+        LOG.debug("Evaluated rule: " + rule.getId() + " to: " + result.isRuleSatisfied() + ".");
 
-        return new RuleEvaluationResult(ruleId, evaluationStatus, ruleEvaluator.getFailedFields());
+        return result;
     }
 
     private Map<String, FieldValue> getEvaluationData(String ruleId, FlowContext flowContext,

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluationServiceImpl.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluationServiceImpl.java
@@ -77,7 +77,9 @@ public class RuleEvaluationServiceImpl implements RuleEvaluationService {
         RuleEvaluator ruleEvaluator = new RuleEvaluator(RuleEvaluationComponentServiceHolder.getInstance()
                 .getOperatorRegistry());
         RuleEvaluationResult result = ruleEvaluator.evaluate(ruleId, rule, evaluationData);
-        LOG.debug("Evaluated rule: " + rule.getId() + " to: " + result.isRuleSatisfied() + ".");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Evaluated rule: " + rule.getId() + " to: " + result.isRuleSatisfied() + ".");
+        }
 
         return result;
     }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluator.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluator.java
@@ -70,25 +70,24 @@ public class RuleEvaluator {
      */
     public boolean evaluate(Rule rule, Map<String, FieldValue> evaluationData) throws RuleEvaluationException {
 
-        return evaluate(null, rule, evaluationData).isRuleSatisfied();
+        return evaluateResult(rule, evaluationData).isRuleSatisfied();
     }
 
     /**
      * Evaluate a given rule and return the result, including the fields that failed evaluation.
      *
-     * @param ruleId         Rule ID.
      * @param rule           Rule to evaluate.
      * @param evaluationData Evaluation data.
      * @return Rule evaluation result with the satisfied status and the failed fields.
      * @throws RuleEvaluationException If an error occurs while evaluating the rule.
      */
-    public RuleEvaluationResult evaluate(String ruleId, Rule rule, Map<String, FieldValue> evaluationData)
+    public RuleEvaluationResult evaluateResult(Rule rule, Map<String, FieldValue> evaluationData)
             throws RuleEvaluationException {
 
         List<String> failedFields = new ArrayList<>();
         ORCombinedRule orRule = (ORCombinedRule) rule;
         boolean ruleSatisfied = evaluateORCombinedRule(orRule, evaluationData, failedFields);
-        return new RuleEvaluationResult(ruleId, ruleSatisfied, failedFields);
+        return new RuleEvaluationResult(rule.getId(), ruleSatisfied, failedFields);
     }
 
     private boolean evaluateORCombinedRule(ORCombinedRule orRule, Map<String, FieldValue> evaluationData,

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluator.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluator.java
@@ -30,7 +30,6 @@ import org.wso2.carbon.identity.rule.management.api.model.ORCombinedRule;
 import org.wso2.carbon.identity.rule.management.api.model.Rule;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluator.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluator.java
@@ -61,19 +61,6 @@ public class RuleEvaluator {
     }
 
     /**
-     * Evaluate a given rule.
-     *
-     * @param rule           Rule to evaluate.
-     * @param evaluationData Evaluation data.
-     * @return Evaluation result.
-     * @throws RuleEvaluationException If an error occurs while evaluating the rule.
-     */
-    public boolean evaluate(Rule rule, Map<String, FieldValue> evaluationData) throws RuleEvaluationException {
-
-        return evaluateResult(rule, evaluationData).isRuleSatisfied();
-    }
-
-    /**
      * Evaluate a given rule and return the result, including the fields that failed evaluation.
      *
      * @param rule           Rule to evaluate.
@@ -81,7 +68,7 @@ public class RuleEvaluator {
      * @return Rule evaluation result with the satisfied status and the failed fields.
      * @throws RuleEvaluationException If an error occurs while evaluating the rule.
      */
-    public RuleEvaluationResult evaluateResult(Rule rule, Map<String, FieldValue> evaluationData)
+    public RuleEvaluationResult evaluate(Rule rule, Map<String, FieldValue> evaluationData)
             throws RuleEvaluationException {
 
         List<String> failedFields = new ArrayList<>();

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluator.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluator.java
@@ -28,6 +28,8 @@ import org.wso2.carbon.identity.rule.management.api.model.Expression;
 import org.wso2.carbon.identity.rule.management.api.model.ORCombinedRule;
 import org.wso2.carbon.identity.rule.management.api.model.Rule;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -46,6 +48,7 @@ public class RuleEvaluator {
     private static final Log LOG = LogFactory.getLog(RuleEvaluator.class);
 
     private final OperatorRegistry operatorRegistry;
+    private final List<String> failedFields = new ArrayList<>();
 
     // Operators
     private static final String EQUALS = "equals";
@@ -71,22 +74,38 @@ public class RuleEvaluator {
         return evaluateORCombinedRule(orRule, evaluationData);
     }
 
+    /**
+     * Returns the list of fields that failed evaluation for the last evaluated rule.
+     * Empty when the rule is satisfied.
+     *
+     * @return List of failed field names.
+     */
+    public List<String> getFailedFields() {
+
+        return Collections.unmodifiableList(failedFields);
+    }
+
     private boolean evaluateORCombinedRule(ORCombinedRule orRule, Map<String, FieldValue> evaluationData)
             throws RuleEvaluationException {
 
         for (ANDCombinedRule andRule : orRule.getRules()) {
-            if (evaluateANDCombinedRule(andRule, evaluationData)) {
+            List<String> branchFailedFields = new ArrayList<>();
+            if (evaluateANDCombinedRule(andRule, evaluationData, branchFailedFields)) {
+                failedFields.clear();
                 return true; // If any ANDCombinedRule evaluates to true, the ORCombinedRule passes
             }
+            failedFields.addAll(branchFailedFields);
         }
         return false; // If none of the ANDCombinedRules pass, the ORCombinedRule fails
     }
 
-    private boolean evaluateANDCombinedRule(ANDCombinedRule andRule, Map<String, FieldValue> evaluationData)
+    private boolean evaluateANDCombinedRule(ANDCombinedRule andRule, Map<String, FieldValue> evaluationData,
+                                            List<String> branchFailedFields)
             throws RuleEvaluationException {
 
         for (Expression expression : andRule.getExpressions()) {
             if (!evaluateExpression(expression, evaluationData)) {
+                branchFailedFields.add(expression.getField());
                 return false; // If any expression fails, the ANDCombinedRule fails
             }
         }

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluator.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/main/java/org/wso2/carbon/identity/rule/evaluation/internal/service/impl/RuleEvaluator.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.rule.evaluation.api.exception.RuleEvaluationException;
 import org.wso2.carbon.identity.rule.evaluation.api.model.FieldValue;
 import org.wso2.carbon.identity.rule.evaluation.api.model.Operator;
+import org.wso2.carbon.identity.rule.evaluation.api.model.RuleEvaluationResult;
 import org.wso2.carbon.identity.rule.management.api.model.ANDCombinedRule;
 import org.wso2.carbon.identity.rule.management.api.model.Expression;
 import org.wso2.carbon.identity.rule.management.api.model.ORCombinedRule;
@@ -48,7 +49,6 @@ public class RuleEvaluator {
     private static final Log LOG = LogFactory.getLog(RuleEvaluator.class);
 
     private final OperatorRegistry operatorRegistry;
-    private final List<String> failedFields = new ArrayList<>();
 
     // Operators
     private static final String EQUALS = "equals";
@@ -70,22 +70,29 @@ public class RuleEvaluator {
      */
     public boolean evaluate(Rule rule, Map<String, FieldValue> evaluationData) throws RuleEvaluationException {
 
-        ORCombinedRule orRule = (ORCombinedRule) rule;
-        return evaluateORCombinedRule(orRule, evaluationData);
+        return evaluate(null, rule, evaluationData).isRuleSatisfied();
     }
 
     /**
-     * Returns the list of fields that failed evaluation for the last evaluated rule.
-     * Empty when the rule is satisfied.
+     * Evaluate a given rule and return the result, including the fields that failed evaluation.
      *
-     * @return List of failed field names.
+     * @param ruleId         Rule ID.
+     * @param rule           Rule to evaluate.
+     * @param evaluationData Evaluation data.
+     * @return Rule evaluation result with the satisfied status and the failed fields.
+     * @throws RuleEvaluationException If an error occurs while evaluating the rule.
      */
-    public List<String> getFailedFields() {
+    public RuleEvaluationResult evaluate(String ruleId, Rule rule, Map<String, FieldValue> evaluationData)
+            throws RuleEvaluationException {
 
-        return Collections.unmodifiableList(failedFields);
+        List<String> failedFields = new ArrayList<>();
+        ORCombinedRule orRule = (ORCombinedRule) rule;
+        boolean ruleSatisfied = evaluateORCombinedRule(orRule, evaluationData, failedFields);
+        return new RuleEvaluationResult(ruleId, ruleSatisfied, failedFields);
     }
 
-    private boolean evaluateORCombinedRule(ORCombinedRule orRule, Map<String, FieldValue> evaluationData)
+    private boolean evaluateORCombinedRule(ORCombinedRule orRule, Map<String, FieldValue> evaluationData,
+                                           List<String> failedFields)
             throws RuleEvaluationException {
 
         for (ANDCombinedRule andRule : orRule.getRules()) {

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/test/java/org/wso2/carbon/identity/rule/evaluation/core/RuleEvaluatorTest.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/test/java/org/wso2/carbon/identity/rule/evaluation/core/RuleEvaluatorTest.java
@@ -60,6 +60,7 @@ import java.util.Objects;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -175,6 +176,29 @@ public class RuleEvaluatorTest {
 
         ruleEvaluator.evaluate(createRuleWithTwoANDExpressionsUsingReferenceAndStringValueTypes(),
                 Collections.emptyMap());
+    }
+
+    @Test
+    public void testFailedFieldsPopulatedWhenRuleFails() throws Exception {
+
+        boolean result = ruleEvaluator.evaluate(
+                createRuleWithTwoANDExpressionsUsingReferenceAndStringValueTypes(),
+                createEvaluationData("testApp", "client-credentials"));
+
+        assertFalse(result);
+        // The rule fails on the first failing expression (application), so it is reported as a failed field.
+        assertEquals(ruleEvaluator.getFailedFields(), Collections.singletonList("application"));
+    }
+
+    @Test
+    public void testFailedFieldsEmptyWhenRulePasses() throws Exception {
+
+        boolean result = ruleEvaluator.evaluate(
+                createRuleWithTwoANDExpressionsUsingReferenceAndStringValueTypes(),
+                createEvaluationData("testapp", "authorization_code"));
+
+        assertTrue(result);
+        assertTrue(ruleEvaluator.getFailedFields().isEmpty());
     }
 
     private Rule createRuleWithTwoANDExpressionsUsingReferenceAndStringValueTypes() throws Exception {

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/test/java/org/wso2/carbon/identity/rule/evaluation/core/RuleEvaluatorTest.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/test/java/org/wso2/carbon/identity/rule/evaluation/core/RuleEvaluatorTest.java
@@ -163,7 +163,7 @@ public class RuleEvaluatorTest {
     public void testEvaluateRule(Rule rule, Map<String, FieldValue> evaluationData, boolean expectedResult) throws
             RuleEvaluationException {
 
-        boolean result = ruleEvaluator.evaluate(rule, evaluationData);
+        boolean result = ruleEvaluator.evaluate(rule, evaluationData).isRuleSatisfied();
         if (expectedResult) {
             assertTrue(result);
         } else {
@@ -182,7 +182,7 @@ public class RuleEvaluatorTest {
     @Test
     public void testFailedFieldsPopulatedWhenRuleFails() throws Exception {
 
-        RuleEvaluationResult result = ruleEvaluator.evaluateResult(
+        RuleEvaluationResult result = ruleEvaluator.evaluate(
                 createRuleWithTwoANDExpressionsUsingReferenceAndStringValueTypes(),
                 createEvaluationData("testApp", "client-credentials"));
 
@@ -194,7 +194,7 @@ public class RuleEvaluatorTest {
     @Test
     public void testFailedFieldsEmptyWhenRulePasses() throws Exception {
 
-        RuleEvaluationResult result = ruleEvaluator.evaluateResult(
+        RuleEvaluationResult result = ruleEvaluator.evaluate(
                 createRuleWithTwoANDExpressionsUsingReferenceAndStringValueTypes(),
                 createEvaluationData("testapp", "authorization_code"));
 

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/test/java/org/wso2/carbon/identity/rule/evaluation/core/RuleEvaluatorTest.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/test/java/org/wso2/carbon/identity/rule/evaluation/core/RuleEvaluatorTest.java
@@ -182,7 +182,7 @@ public class RuleEvaluatorTest {
     @Test
     public void testFailedFieldsPopulatedWhenRuleFails() throws Exception {
 
-        RuleEvaluationResult result = ruleEvaluator.evaluate("rule1",
+        RuleEvaluationResult result = ruleEvaluator.evaluateResult(
                 createRuleWithTwoANDExpressionsUsingReferenceAndStringValueTypes(),
                 createEvaluationData("testApp", "client-credentials"));
 
@@ -194,7 +194,7 @@ public class RuleEvaluatorTest {
     @Test
     public void testFailedFieldsEmptyWhenRulePasses() throws Exception {
 
-        RuleEvaluationResult result = ruleEvaluator.evaluate("rule1",
+        RuleEvaluationResult result = ruleEvaluator.evaluateResult(
                 createRuleWithTwoANDExpressionsUsingReferenceAndStringValueTypes(),
                 createEvaluationData("testapp", "authorization_code"));
 

--- a/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/test/java/org/wso2/carbon/identity/rule/evaluation/core/RuleEvaluatorTest.java
+++ b/components/rule-mgt/org.wso2.carbon.identity.rule.evaluation/src/test/java/org/wso2/carbon/identity/rule/evaluation/core/RuleEvaluatorTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.rule.evaluation.api.exception.RuleEvaluationException;
 import org.wso2.carbon.identity.rule.evaluation.api.model.FieldValue;
+import org.wso2.carbon.identity.rule.evaluation.api.model.RuleEvaluationResult;
 import org.wso2.carbon.identity.rule.evaluation.api.model.ValueType;
 import org.wso2.carbon.identity.rule.evaluation.internal.component.RuleEvaluationComponentServiceHolder;
 import org.wso2.carbon.identity.rule.evaluation.internal.service.impl.OperatorRegistry;
@@ -181,24 +182,24 @@ public class RuleEvaluatorTest {
     @Test
     public void testFailedFieldsPopulatedWhenRuleFails() throws Exception {
 
-        boolean result = ruleEvaluator.evaluate(
+        RuleEvaluationResult result = ruleEvaluator.evaluate("rule1",
                 createRuleWithTwoANDExpressionsUsingReferenceAndStringValueTypes(),
                 createEvaluationData("testApp", "client-credentials"));
 
-        assertFalse(result);
+        assertFalse(result.isRuleSatisfied());
         // The rule fails on the first failing expression (application), so it is reported as a failed field.
-        assertEquals(ruleEvaluator.getFailedFields(), Collections.singletonList("application"));
+        assertEquals(result.getFailedFields(), Collections.singletonList("application"));
     }
 
     @Test
     public void testFailedFieldsEmptyWhenRulePasses() throws Exception {
 
-        boolean result = ruleEvaluator.evaluate(
+        RuleEvaluationResult result = ruleEvaluator.evaluate("rule1",
                 createRuleWithTwoANDExpressionsUsingReferenceAndStringValueTypes(),
                 createEvaluationData("testapp", "authorization_code"));
 
-        assertTrue(result);
-        assertTrue(ruleEvaluator.getFailedFields().isEmpty());
+        assertTrue(result.isRuleSatisfied());
+        assertTrue(result.getFailedFields().isEmpty());
     }
 
     private Rule createRuleWithTwoANDExpressionsUsingReferenceAndStringValueTypes() throws Exception {


### PR DESCRIPTION
## Proposed changes in this pull request

This PR adds the ability to know **which fields caused a rule to fail** during evaluation, and exposes them on the `RuleEvaluationResult`.

Previously, `RuleEvaluationResult` only reported **whether** a rule was satisfied (a boolean). Callers had no way to tell **why** a rule did not match. This PR adds a `failedFields` list so callers can see the specific field names that failed, which is useful for diagnostics, user feedback, and debugging.

The change is confined to the rule evaluation module and is additive and backward compatible:

- **`RuleEvaluationResult`** — add a `failedFields` list, a constructor that accepts it, and a `getFailedFields()` accessor. The existing constructor is kept (it delegates with an empty list), and the accessor returns an unmodifiable, never-null list (empty when the rule is satisfied).
- **`RuleEvaluator`** — while evaluating the OR-of-ANDs rule tree, collect the field names of the failing expressions per OR branch. If a branch passes, the collected failed fields are cleared (the rule is satisfied, so nothing failed); if all branches fail, the failing fields from the branches are retained. Exposed via `getFailedFields()`.
- **`RuleEvaluationServiceImpl`** — pass the evaluator's failed fields into the returned `RuleEvaluationResult`.

The component provides:

- The list of fields responsible for a rule not matching, in addition to the existing pass/fail result.
- Backward compatibility: existing callers that use the boolean result and the old constructor are unaffected. `failedFields` is an additive side output and does not change the evaluation outcome.

Unit tests assert that the failed fields are reported when a rule fails and are empty when the rule passes.

## When should this PR be merged

No preconditions.

## Follow up actions

N/A