### PR TITLE
Skip legacy role claim deletion during JIT provisioning when group-role separation is enabled

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/provisioning/impl/DefaultProvisioningHandler.java
@@ -275,9 +275,15 @@ public class DefaultProvisioningHandler implements ProvisioningHandler {
 
                     // Claim mappings which do not come with the IDP claim mapping set but must not delete.
                     Set<String> indelibleClaimSet = getIndelibleClaims();
+                    boolean isGroupAndRoleSeparationEnabled = IdentityUtil
+                            .isGroupsVsRolesSeparationImprovementsEnabled();
+                    boolean showLegacyRoleClaim = IdentityUtil.isShowLegacyRoleClaimOnGroupRoleSeparationEnabled();
                     toBeDeletedFromExistingUserClaims.removeIf(claim -> claim.getClaimUri().contains("/identity/")
-                            || indelibleClaimSet.contains(claim.getClaimUri()) ||
-                            userClaims.containsKey(claim.getClaimUri()));
+                            || indelibleClaimSet.contains(claim.getClaimUri())
+                            || (isGroupAndRoleSeparationEnabled
+                                    && !showLegacyRoleClaim
+                                    && FrameworkConstants.LOCAL_ROLE_CLAIM_URI.equals(claim.getClaimUri()))
+                            || userClaims.containsKey(claim.getClaimUri()));
 
                     // Do not delete the claims updated locally if the attributeSyncMethod is set to preserve
                     // the local claims.


### PR DESCRIPTION
## Issue
During JIT user provisioning into a secondary LDAP userstore (external IDP + JIT
enabled), provisioning/login fails with:

`org.wso2.carbon.user.core.UserStoreException: One or more attributes you are trying
to add/update are not supported by underlying LDAP` (LDAP error 16 `NO_SUCH_ATTRIBUTE`)
on the `role` attribute.

For an existing JIT user, the claim-sync step in `DefaultProvisioningHandler` builds
the to-be-deleted claim list from all current userstore claims, dropping only
`/identity/` claims, configured indelible claims, and claims sent by the IDP. The
legacy role claim `http://wso2.org/claims/role` (present via `Internal/Everyone`)
survives this filter and is scheduled for deletion. When group-role separation is
enabled, this claim is managed separately by the role-handling step and does not map
to a real userstore attribute, so `deleteUserClaimValue(...)` fails on the LDAP
userstore and the whole provisioning flow errors out.

## Fix
Exclude the legacy role claim (`FrameworkConstants.LOCAL_ROLE_CLAIM_URI`) from the
claim-sync deletion set when group-and-role separation is enabled
(`IdentityUtil.isGroupsVsRolesSeparationImprovementsEnabled()`) and the legacy role
claim is not being shown
(`IdentityUtil.isShowLegacyRoleClaimOnGroupRoleSeparationEnabled()`). When separation
is disabled, the existing legacy behavior is preserved.

## Related issue
https://github.com/wso2/product-is/issues/28066
