### PR TITLE
Register DEVICE_REGISTRATION as a flow type

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/FlowExecutionService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/FlowExecutionService.java
@@ -209,6 +209,12 @@ public class FlowExecutionService {
                         .initiatingPersona(Flow.InitiatingPersona.ADMIN)
                         .build());
                 return true;
+            case DEVICE_REGISTRATION:
+                IdentityContext.getThreadLocalIdentityContext().enterFlow(new Flow.Builder()
+                        .name(Flow.Name.DEVICE_REGISTER)
+                        .initiatingPersona(Flow.InitiatingPersona.USER)
+                        .build());
+                return true;
             default:
                 return false;
         }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/main/java/org/wso2/carbon/identity/flow/mgt/Constants.java
@@ -152,6 +152,8 @@ public class Constants {
                 FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED),
         INVITED_USER_REGISTRATION("INVITED_USER_REGISTRATION", "defaultEnableInvitedUserRegistration",
                 FlowCompletionConfig.IS_AUTO_LOGIN_ENABLED,
+                FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED),
+        DEVICE_REGISTRATION("DEVICE_REGISTRATION", "defaultEnableDeviceRegistration",
                 FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED);
 
         private final String type;

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.mgt/src/test/java/org/wso2/carbon/identity/flow/mgt/utils/FlowMgtConfigUtilsTest.java
@@ -75,6 +75,7 @@ public class FlowMgtConfigUtilsTest {
     private static final String FLOW_TYPE_REGISTRATION = "REGISTRATION";
     private static final String FLOW_TYPE_PASSWORD_RECOVERY = "PASSWORD_RECOVERY";
     private static final String FLOW_TYPE_INVITED_USER_REGISTRATION = "INVITED_USER_REGISTRATION";
+    private static final String FLOW_TYPE_DEVICE_REGISTRATION = "DEVICE_REGISTRATION";
 
     @BeforeMethod
     public void setUp() {
@@ -237,9 +238,10 @@ public class FlowMgtConfigUtilsTest {
         List<FlowConfigDTO> result = FlowMgtConfigUtils.getFlowConfigs(TENANT_DOMAIN);
 
         Assert.assertNotNull(result);
-        Assert.assertEquals(result.size(), 3);
+        Assert.assertEquals(result.size(), 4);
 
-        List<String> flowTypes = Arrays.asList("REGISTRATION", "PASSWORD_RECOVERY", "INVITED_USER_REGISTRATION");
+        List<String> flowTypes = Arrays.asList("REGISTRATION", "PASSWORD_RECOVERY", "INVITED_USER_REGISTRATION",
+                "DEVICE_REGISTRATION");
         for (String flowType : flowTypes) {
             Assert.assertTrue(result.stream().anyMatch(config -> config.getFlowType().equals(flowType)));
         }
@@ -253,7 +255,7 @@ public class FlowMgtConfigUtilsTest {
         List<FlowConfigDTO> result = FlowMgtConfigUtils.getFlowConfigs(TENANT_DOMAIN);
 
         Assert.assertNotNull(result);
-        Assert.assertEquals(result.size(), 3);
+        Assert.assertEquals(result.size(), 4);
         for (FlowConfigDTO config : result) {
 
             Assert.assertFalse(config.getIsEnabled());
@@ -270,6 +272,7 @@ public class FlowMgtConfigUtilsTest {
                     break;
                 case FLOW_TYPE_PASSWORD_RECOVERY:
                 case FLOW_TYPE_INVITED_USER_REGISTRATION:
+                case FLOW_TYPE_DEVICE_REGISTRATION:
                     Assert.assertFalse(Boolean.parseBoolean(config.getFlowCompletionConfig(
                             Constants.FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED)));
                     break;
@@ -289,7 +292,7 @@ public class FlowMgtConfigUtilsTest {
         List<FlowConfigDTO> result = FlowMgtConfigUtils.getFlowConfigs(TENANT_DOMAIN);
 
         Assert.assertNotNull(result);
-        Assert.assertEquals(result.size(), 3);
+        Assert.assertEquals(result.size(), 4);
     }
 
     @Test
@@ -302,7 +305,7 @@ public class FlowMgtConfigUtilsTest {
         List<FlowConfigDTO> result = FlowMgtConfigUtils.getFlowConfigs(TENANT_DOMAIN);
 
         Assert.assertNotNull(result);
-        Assert.assertEquals(result.size(), 3);
+        Assert.assertEquals(result.size(), 4);
         for (FlowConfigDTO config : result) {
             Assert.assertFalse(config.getIsEnabled());
             Assert.assertFalse(Boolean.parseBoolean(config.getFlowCompletionConfig(
@@ -318,6 +321,7 @@ public class FlowMgtConfigUtilsTest {
                     break;
                 case FLOW_TYPE_PASSWORD_RECOVERY:
                 case FLOW_TYPE_INVITED_USER_REGISTRATION:
+                case FLOW_TYPE_DEVICE_REGISTRATION:
                     Assert.assertFalse(Boolean.parseBoolean(config.getFlowCompletionConfig(
                             Constants.FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED)));
                     break;
@@ -478,7 +482,7 @@ public class FlowMgtConfigUtilsTest {
         List<FlowConfigDTO> result = FlowMgtConfigUtils.getFlowConfigs(TENANT_DOMAIN);
 
         Assert.assertNotNull(result);
-        Assert.assertEquals(result.size(), 3);
+        Assert.assertEquals(result.size(), 4);
         for (FlowConfigDTO config : result) {
             Assert.assertFalse(config.getIsEnabled());
             Assert.assertFalse(Boolean.parseBoolean(config.getFlowCompletionConfig(
@@ -501,7 +505,7 @@ public class FlowMgtConfigUtilsTest {
         List<FlowConfigDTO> result = FlowMgtConfigUtils.getFlowConfigs(TENANT_DOMAIN);
 
         Assert.assertNotNull(result);
-        Assert.assertEquals(result.size(), 3);
+        Assert.assertEquals(result.size(), 4);
 
         long registrationCount = result.stream()
                 .filter(config -> "REGISTRATION".equals(config.getFlowType()))

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Flow.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/context/model/Flow.java
@@ -144,6 +144,10 @@ public class Flow {
 
         FLOW_DEFINITIONS.put(Name.PURPOSE_UPDATE, EnumSet.of(InitiatingPersona.ADMIN));
         // -----------------------------------------------------------------------------------------------
+
+        // ------------------------------ Device management flows ----------------------------------------
+        FLOW_DEFINITIONS.put(Name.DEVICE_REGISTER, EnumSet.of(InitiatingPersona.USER));
+        // -----------------------------------------------------------------------------------------------
     }
 
     /**
@@ -227,7 +231,11 @@ public class Flow {
         CONSENT_CREATE,
         CONSENT_GRANT,
         CONSENT_REVOKE,
-        PURPOSE_UPDATE
+        PURPOSE_UPDATE,
+        // --------------------------------------------------
+
+        // ---------Device management flows------------------
+        DEVICE_REGISTER
         // --------------------------------------------------
     }
 


### PR DESCRIPTION
## Proposed changes in this pull request

This PR registers `DEVICE_REGISTRATION` as a flow type in the flow orchestration framework so that device registration can be executed through the generic flow engine. Without this, the engine rejects the flow type as unknown and never reaches the device registration executor.

### This PR includes

- **`Flow` (identity-core)** – Adds `DEVICE_REGISTER` to the `Flow.Name` enum along with its `FLOW_DEFINITIONS` entry allowing the `USER` initiating persona. The entry is required because `Flow.Builder.build()` rejects any flow name that is not registered in `FLOW_DEFINITIONS`.
- **`Constants` (flow.mgt)** – Adds the `DEVICE_REGISTRATION` flow type. It declares only the flow completion notification config, since the remaining completion configs are user onboarding concerns that do not apply to device registration.
- **`FlowExecutionService` (flow.execution.engine)** – Enters a `DEVICE_REGISTER` flow in the `IdentityContext` for the `DEVICE_REGISTRATION` flow type, following the same pattern used by the existing flow types.

Auto login is intentionally not enabled for this flow type. Device registration happens for an already authenticated user, so no authentication assertion is generated when the flow completes.

### Testing

`FlowMgtConfigUtilsTest` is updated to account for the newly added flow type in the flow configuration results.

## When should this PR be merged

This PR has no dependency on other pull requests and can be merged independently.

## Follow up actions

N/A
