### PR TITLE
Emit DateValidator client rule for date claims that disallow future values

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
@@ -64,6 +64,7 @@ public class ClaimConstants {
     public static final String EXTERNAL_CLAIM_ADDITION_NOT_ALLOWED_FOR_DIALECT =
             "ExternalClaimAdditionNotAllowedForDialect";
     public static final String DATA_TYPE_PROPERTY = "dataType";
+    public static final String DISALLOW_FUTURE_DATE_PROPERTY = "disallowFutureDate";
     public static final String MULTI_VALUED_PROPERTY = "multiValued";
     public static final String SUB_ATTRIBUTES_PROPERTY = "subAttributes";
     public static final String SUB_ATTRIBUTE_PREFIX = "subAttribute.";

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
@@ -734,8 +734,13 @@ public class InputValidationService {
             conditions.add(new ValidationDTO.Condition(DISALLOW_FUTURE_CONDITION, Boolean.TRUE.toString()));
             dateValidation.setConditions(conditions);
             addValidationToComponent(component, dateValidation);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Attached future-date validation for claim: " + identifier);
+            }
         } catch (ClaimMetadataException e) {
-            LOG.debug("Error while retrieving claim metadata for date validation of claim: " + identifier, e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while retrieving claim metadata for date validation of claim: " + identifier);
+            }
         }
     }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
@@ -98,6 +98,9 @@ public class InputValidationService {
     private static final Log LOG = LogFactory.getLog(InputValidationService.class);
     private static final InputValidationService instance = new InputValidationService();
     public static final String CONFIRMATION_CODE = "confirmationCode";
+    private static final String DATE_VARIANT = "DATE";
+    private static final String DATE_VALIDATOR = "DateValidator";
+    private static final String DISALLOW_FUTURE_CONDITION = "disallow.future";
 
     private InputValidationService() {
 
@@ -664,11 +667,12 @@ public class InputValidationService {
             }
         }
         // Process all components and apply validations at once.
-        processComponentValidations(dataDTO.getComponents(), validationMap);
+        processComponentValidations(dataDTO.getComponents(), validationMap, context.getTenantDomain());
     }
 
     private void processComponentValidations(List<ComponentDTO> components,
-                                             Map<String, ArrayList<ValidationDTO>> validationMap) {
+                                             Map<String, ArrayList<ValidationDTO>> validationMap,
+                                             String tenantDomain) {
 
         if (components == null || components.isEmpty()) {
             return;
@@ -678,9 +682,10 @@ public class InputValidationService {
             if (Constants.ComponentTypes.INPUT.equals(component.getType())) {
                 String identifier = (String) component.getConfigs().get(IDENTIFIER);
                 applyValidationIfNeeded(component, identifier, validationMap);
+                applyDateValidationIfNeeded(component, identifier, tenantDomain);
             } else if (Constants.ComponentTypes.FORM.equals(component.getType())) {
                 // Process nested components.
-                processComponentValidations(component.getComponents(), validationMap);
+                processComponentValidations(component.getComponents(), validationMap, tenantDomain);
             }
         }
     }
@@ -691,6 +696,61 @@ public class InputValidationService {
         if (identifier != null && validationMap.containsKey(identifier)) {
             component.getConfigs().put(VALIDATIONS, validationMap.get(identifier));
         }
+    }
+
+    /**
+     * Attach a client-side date validation rule to a date input component when its claim is
+     * configured to disallow future values (claim property {@code disallowFutureDate=true}).
+     * The rule is consumed by the client to show an inline error before submission. Server-side
+     * enforcement is handled separately by the user store operation listeners.
+     *
+     * @param component    Input component.
+     * @param identifier   Component identifier (claim URI for claim-backed inputs).
+     * @param tenantDomain Tenant domain.
+     */
+    private void applyDateValidationIfNeeded(ComponentDTO component, String identifier, String tenantDomain) {
+
+        if (identifier == null || !DATE_VARIANT.equalsIgnoreCase(component.getVariant())) {
+            return;
+        }
+        if (FlowExecutionEngineDataHolder.getInstance().getClaimMetadataManagementService() == null) {
+            return;
+        }
+        try {
+            Optional<LocalClaim> localClaim = FlowExecutionEngineDataHolder.getInstance()
+                    .getClaimMetadataManagementService().getLocalClaim(identifier, tenantDomain);
+            if (!localClaim.isPresent()) {
+                return;
+            }
+            String disallowFutureDate = localClaim.get()
+                    .getClaimProperty(ClaimConstants.DISALLOW_FUTURE_DATE_PROPERTY);
+            if (!Boolean.parseBoolean(disallowFutureDate)) {
+                return;
+            }
+            ValidationDTO dateValidation = new ValidationDTO();
+            dateValidation.setName(DATE_VALIDATOR);
+            dateValidation.setType(RULES);
+            List<ValidationDTO.Condition> conditions = new ArrayList<>();
+            conditions.add(new ValidationDTO.Condition(DISALLOW_FUTURE_CONDITION, Boolean.TRUE.toString()));
+            dateValidation.setConditions(conditions);
+            addValidationToComponent(component, dateValidation);
+        } catch (ClaimMetadataException e) {
+            LOG.debug("Error while retrieving claim metadata for date validation of claim: " + identifier, e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void addValidationToComponent(ComponentDTO component, ValidationDTO validationDTO) {
+
+        Object existing = component.getConfigs().get(VALIDATIONS);
+        List<ValidationDTO> validations;
+        if (existing instanceof List) {
+            validations = (List<ValidationDTO>) existing;
+        } else {
+            validations = new ArrayList<>();
+            component.getConfigs().put(VALIDATIONS, validations);
+        }
+        validations.add(validationDTO);
     }
 
     private ArrayList<ValidationDTO> getValidationDTOs(String tenantDomain, String key)

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.flow.mgt.model.DataDTO;
 import org.wso2.carbon.identity.flow.mgt.model.ExecutorDTO;
 import org.wso2.carbon.identity.flow.mgt.model.GraphConfig;
 import org.wso2.carbon.identity.flow.mgt.model.NodeConfig;
+import org.wso2.carbon.identity.flow.mgt.model.ValidationDTO;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtClientException;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtException;
 import org.wso2.carbon.identity.input.validation.mgt.model.RulesConfiguration;
@@ -65,6 +66,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.CLAIM_URI_PREFIX;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.CONSENT_KEY;
@@ -1703,6 +1705,205 @@ public class InputValidationServiceTest {
         } catch (NoSuchMethodException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    public void testPrepareStepInputsAddsDateValidatorRuleWhenClaimDisallowsFutureDate() throws Exception {
+
+        FlowExecutionContext = initiateFlowContext();
+        FlowExecutionContext.setGraphConfig(defaultGraph);
+
+        ClaimMetadataManagementService mockClaimService = mock(ClaimMetadataManagementService.class);
+        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(mockClaimService);
+
+        LocalClaim mockLocalClaim = mock(LocalClaim.class);
+        when(mockLocalClaim.getClaimProperty(ClaimConstants.DISALLOW_FUTURE_DATE_PROPERTY)).thenReturn("true");
+        when(mockClaimService.getLocalClaim(CLAIM_URI_PREFIX + "dob", "test.com"))
+                .thenReturn(Optional.of(mockLocalClaim));
+
+        DataDTO dataDTO = buildDateFieldDataDTO(CLAIM_URI_PREFIX + "dob", "DATE", null);
+        inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
+
+        ComponentDTO processedDateInput = dataDTO.getComponents().get(0).getComponents().get(0);
+        Object validations = processedDateInput.getConfigs().get(VALIDATIONS);
+
+        Assert.assertNotNull(validations, "Date field should have validations when claim disallows future dates");
+        List<?> validationsList = (List<?>) validations;
+        Assert.assertEquals(validationsList.size(), 1);
+        ValidationDTO dateValidator = (ValidationDTO) validationsList.get(0);
+        Assert.assertEquals(dateValidator.getName(), "DateValidator");
+        Assert.assertEquals(dateValidator.getType(), "RULE");
+        Assert.assertEquals(dateValidator.getConditions().size(), 1);
+        Assert.assertEquals(dateValidator.getConditions().get(0).getKey(), "disallow.future");
+        Assert.assertEquals(dateValidator.getConditions().get(0).getValue(), "true");
+    }
+
+    @Test
+    public void testPrepareStepInputsNoDateValidatorWhenClaimPropertyAbsent() throws Exception {
+
+        FlowExecutionContext = initiateFlowContext();
+        FlowExecutionContext.setGraphConfig(defaultGraph);
+
+        ClaimMetadataManagementService mockClaimService = mock(ClaimMetadataManagementService.class);
+        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(mockClaimService);
+
+        LocalClaim mockLocalClaim = mock(LocalClaim.class);
+        when(mockLocalClaim.getClaimProperty(ClaimConstants.DISALLOW_FUTURE_DATE_PROPERTY)).thenReturn(null);
+        when(mockClaimService.getLocalClaim(CLAIM_URI_PREFIX + "startdate", "test.com"))
+                .thenReturn(Optional.of(mockLocalClaim));
+
+        DataDTO dataDTO = buildDateFieldDataDTO(CLAIM_URI_PREFIX + "startdate", "DATE", null);
+        inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
+
+        ComponentDTO processedDateInput = dataDTO.getComponents().get(0).getComponents().get(0);
+        Object validations = processedDateInput.getConfigs().get(VALIDATIONS);
+        Assert.assertTrue(validations == null || ((List<?>) validations).isEmpty(),
+                "Date field should not have validations when claim does not disallow future dates");
+    }
+
+    @Test
+    public void testPrepareStepInputsNoDateValidatorForNonDateVariant() throws Exception {
+
+        FlowExecutionContext = initiateFlowContext();
+        FlowExecutionContext.setGraphConfig(defaultGraph);
+
+        ClaimMetadataManagementService mockClaimService = mock(ClaimMetadataManagementService.class);
+        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(mockClaimService);
+
+        DataDTO dataDTO = buildDateFieldDataDTO(CLAIM_URI_PREFIX + "dob", "TEXT", null);
+        inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
+
+        ComponentDTO processedInput = dataDTO.getComponents().get(0).getComponents().get(0);
+        Object validations = processedInput.getConfigs().get(VALIDATIONS);
+        Assert.assertTrue(validations == null || ((List<?>) validations).isEmpty(),
+                "Non-date field should not have a DateValidator rule added");
+        verify(mockClaimService, never()).getLocalClaim(anyString(), anyString());
+    }
+
+    @Test
+    public void testPrepareStepInputsNoDateValidatorWhenClaimMetadataServiceIsNull() throws Exception {
+
+        FlowExecutionContext = initiateFlowContext();
+        FlowExecutionContext.setGraphConfig(defaultGraph);
+        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(null);
+
+        DataDTO dataDTO = buildDateFieldDataDTO(CLAIM_URI_PREFIX + "dob", "DATE", null);
+
+        // Should not throw any exception when ClaimMetadataManagementService is unavailable.
+        inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
+
+        ComponentDTO processedDateInput = dataDTO.getComponents().get(0).getComponents().get(0);
+        Object validations = processedDateInput.getConfigs().get(VALIDATIONS);
+        Assert.assertTrue(validations == null || ((List<?>) validations).isEmpty());
+    }
+
+    @Test
+    public void testPrepareStepInputsNoDateValidatorWhenLocalClaimNotPresent() throws Exception {
+
+        FlowExecutionContext = initiateFlowContext();
+        FlowExecutionContext.setGraphConfig(defaultGraph);
+
+        ClaimMetadataManagementService mockClaimService = mock(ClaimMetadataManagementService.class);
+        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(mockClaimService);
+        when(mockClaimService.getLocalClaim(anyString(), anyString())).thenReturn(Optional.empty());
+
+        DataDTO dataDTO = buildDateFieldDataDTO(CLAIM_URI_PREFIX + "dob", "DATE", null);
+        inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
+
+        ComponentDTO processedDateInput = dataDTO.getComponents().get(0).getComponents().get(0);
+        Object validations = processedDateInput.getConfigs().get(VALIDATIONS);
+        Assert.assertTrue(validations == null || ((List<?>) validations).isEmpty());
+    }
+
+    @Test
+    public void testPrepareStepInputsNoDateValidatorWhenClaimMetadataExceptionThrown() throws Exception {
+
+        FlowExecutionContext = initiateFlowContext();
+        FlowExecutionContext.setGraphConfig(defaultGraph);
+
+        ClaimMetadataManagementService mockClaimService = mock(ClaimMetadataManagementService.class);
+        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(mockClaimService);
+        when(mockClaimService.getLocalClaim(anyString(), anyString()))
+                .thenThrow(new ClaimMetadataException("Test exception"));
+
+        DataDTO dataDTO = buildDateFieldDataDTO(CLAIM_URI_PREFIX + "dob", "DATE", null);
+
+        // Should not propagate the ClaimMetadataException; it is caught and logged.
+        inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
+
+        ComponentDTO processedDateInput = dataDTO.getComponents().get(0).getComponents().get(0);
+        Object validations = processedDateInput.getConfigs().get(VALIDATIONS);
+        Assert.assertTrue(validations == null || ((List<?>) validations).isEmpty());
+    }
+
+    @Test
+    public void testPrepareStepInputsAppendsDateValidatorToExistingValidations() throws Exception {
+
+        FlowExecutionContext = initiateFlowContext();
+        FlowExecutionContext.setGraphConfig(defaultGraph);
+
+        ClaimMetadataManagementService mockClaimService = mock(ClaimMetadataManagementService.class);
+        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(mockClaimService);
+
+        LocalClaim mockLocalClaim = mock(LocalClaim.class);
+        when(mockLocalClaim.getClaimProperty(ClaimConstants.DISALLOW_FUTURE_DATE_PROPERTY)).thenReturn("true");
+        when(mockClaimService.getLocalClaim(CLAIM_URI_PREFIX + "dob", "test.com"))
+                .thenReturn(Optional.of(mockLocalClaim));
+
+        ValidationDTO existingRule = new ValidationDTO();
+        existingRule.setName("RequiredValidator");
+        existingRule.setType("RULE");
+        List<ValidationDTO> existingValidations = new ArrayList<>();
+        existingValidations.add(existingRule);
+
+        DataDTO dataDTO = buildDateFieldDataDTO(CLAIM_URI_PREFIX + "dob", "DATE", existingValidations);
+        inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
+
+        ComponentDTO processedDateInput = dataDTO.getComponents().get(0).getComponents().get(0);
+        List<?> validationsList = (List<?>) processedDateInput.getConfigs().get(VALIDATIONS);
+
+        Assert.assertEquals(validationsList.size(), 2, "The DateValidator rule should be appended, not replace existing rules");
+        Assert.assertEquals(((ValidationDTO) validationsList.get(0)).getName(), "RequiredValidator");
+        Assert.assertEquals(((ValidationDTO) validationsList.get(1)).getName(), "DateValidator");
+    }
+
+    /**
+     * Build a DataDTO with a single FORM containing one DATE (or other variant) INPUT component with the given
+     * identifier, plus a submit BUTTON so that the input is registered as a current step input.
+     */
+    private DataDTO buildDateFieldDataDTO(String identifier, String variant, List<ValidationDTO> existingValidations) {
+
+        Map<String, Object> dateConfig = new HashMap<>();
+        dateConfig.put(IDENTIFIER, identifier);
+        dateConfig.put("required", false);
+        if (existingValidations != null) {
+            dateConfig.put(VALIDATIONS, existingValidations);
+        }
+        ComponentDTO dateInput = new ComponentDTO.Builder()
+                .type(Constants.ComponentTypes.INPUT)
+                .variant(variant)
+                .configs(dateConfig)
+                .build();
+
+        ComponentDTO button = new ComponentDTO.Builder()
+                .type(Constants.ComponentTypes.BUTTON)
+                .id("submitButton")
+                .action(new ActionDTO.Builder().type(Constants.ActionTypes.EXECUTOR).nextId("action2").build())
+                .build();
+
+        List<ComponentDTO> formComponents = new ArrayList<>();
+        formComponents.add(dateInput);
+        formComponents.add(button);
+
+        ComponentDTO formDTO = new ComponentDTO.Builder()
+                .type(Constants.ComponentTypes.FORM)
+                .components(formComponents)
+                .build();
+
+        List<ComponentDTO> components = new ArrayList<>();
+        components.add(formDTO);
+
+        return new DataDTO.Builder().components(components).build();
     }
 
     private FlowExecutionContext initiateFlowContext() {

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -179,6 +179,7 @@
 				<Description>Birth Date</Description>
 				<RegEx>^\d{4}-\d{2}-\d{2}$</RegEx>
 				<dataType>date</dataType>
+				<disallowFutureDate>true</disallowFutureDate>
 				<RegExValidationError>Date of Birth is not in the correct format of YYYY-MM-DD</RegExValidationError>
 				<SharedProfileValueResolvingMethod>FromOrigin</SharedProfileValueResolvingMethod>
 			</Claim>


### PR DESCRIPTION
## Purpose

The dynamic registration flow (flow-execution-engine) authors client-side validation rules for a component from `InputValidationService`, but this only covers the username and password fields. For a date claim like Date of Birth, no rule is ever sent to the client, so the generic date input has nothing to enforce — a future date passes silently until the server rejects it on submit.

This PR adds the missing piece so the dynamic flow can show an inline "cannot be a future date" error before submit, matching the behavior already present in the classic self-registration page and My Account.

## Changes

1. `ClaimConstants`
   - Added `DISALLOW_FUTURE_DATE_PROPERTY` (`disallowFutureDate`), a new claim property.

2. `claim-config.xml`
   - Marked the `http://wso2.org/claims/dob` claim with `<disallowFutureDate>true</disallowFutureDate>`.

3. `InputValidationService` (flow-execution-engine)
   - When processing component validations, any `INPUT` component with `variant: "DATE"` is now checked against its backing claim's metadata. If the claim has `disallowFutureDate=true`, a `DateValidator` rule (`{ type: "RULE", name: "DateValidator", conditions: [{ key: "disallow.future", value: "true" }] }`) is appended to the component's `validations` config.
   - The engine does not hardcode the DOB claim URI — it reads the property from claim metadata, so any date claim can opt in the same way.

## Why this is a separate change from the claim regex

The claim's existing `RegEx` property only checks the `YYYY-MM-DD` format; a future date like `2027-04-20` matches it. There's no existing mechanism in claim metadata for "this date must not be in the future," so a new property was needed. Server-side, the actual rejection of future dates is enforced in `SCIMUserOperationListener` (see the companion PR below) — this change only makes the client aware of the rule so it can show an inline error before the user submits.

## Related PRs

- Backend enforcement (all create/update paths): wso2-extensions/identity-inbound-provisioning-scim2#800
- Frontend (classic self-registration, dynamic flow date adapter, Console user forms): wso2/identity-apps#10558

## Testing

- Verified end-to-end against a built pack (WSO2 IS 7.4.0): a DOB field added to a registration flow via the Console flow builder now receives the `DateValidator` rule from the server, and the client rejects a future date inline with "Cannot be a future date." A valid past date is accepted and the flow proceeds normally.