### PR TITLE
Honor JVM system properties in AI service HTTP clients

### DIFF
--- a/components/ai-services-mgt/org.wso2.carbon.identity.ai.service.mgt/src/main/java/org/wso2/carbon/identity/ai/service/mgt/constants/AIConstants.java
+++ b/components/ai-services-mgt/org.wso2.carbon.identity.ai.service.mgt/src/main/java/org/wso2/carbon/identity/ai/service/mgt/constants/AIConstants.java
@@ -40,6 +40,8 @@ public class AIConstants {
     public static final String HTTP_CONNECTION_REQUEST_TIMEOUT_PROPERTY_NAME = "AIServices" +
             ".HTTPConnectionRequestTimeout";
     public static final String HTTP_SOCKET_TIMEOUT_PROPERTY_NAME = "AIServices.HTTPSocketTimeout";
+    public static final String HTTP_CLIENT_USE_SYSTEM_PROPERTIES_PROPERTY_NAME =
+            "AIServices.HTTPClientUseSystemProperties";
 
     // Http constants.
     public static final String HTTP_BASIC = "Basic";

--- a/components/ai-services-mgt/org.wso2.carbon.identity.ai.service.mgt/src/main/java/org/wso2/carbon/identity/ai/service/mgt/token/AIAccessTokenManager.java
+++ b/components/ai-services-mgt/org.wso2.carbon.identity.ai.service.mgt/src/main/java/org/wso2/carbon/identity/ai/service/mgt/token/AIAccessTokenManager.java
@@ -33,6 +33,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
 import org.wso2.carbon.identity.ai.service.mgt.exceptions.AIServerException;
+import org.wso2.carbon.identity.ai.service.mgt.util.AIHttpClientUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.io.IOException;
@@ -161,8 +162,12 @@ public class AIAccessTokenManager {
                     .setConnectionRequestTimeout(CONNECTION_REQUEST_TIMEOUT)
                     .setSocketTimeout(SOCKET_TIMEOUT)
                     .build();
-            this.client = HttpClientBuilder.create()
-                    .setDefaultRequestConfig(requestConfig).build();
+            HttpClientBuilder clientBuilder = HttpClientBuilder.create()
+                    .setDefaultRequestConfig(requestConfig);
+            if (AIHttpClientUtil.useSystemPropertiesInHttpClient()) {
+                clientBuilder.useSystemProperties();
+            }
+            this.client = clientBuilder.build();
             this.gson = new GsonBuilder().create();
             this.key = key;
             this.tokenRequest = new HttpPost(tokenEndpoint);

--- a/components/ai-services-mgt/org.wso2.carbon.identity.ai.service.mgt/src/main/java/org/wso2/carbon/identity/ai/service/mgt/util/AIHttpClientUtil.java
+++ b/components/ai-services-mgt/org.wso2.carbon.identity.ai.service.mgt/src/main/java/org/wso2/carbon/identity/ai/service/mgt/util/AIHttpClientUtil.java
@@ -28,6 +28,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -51,6 +52,7 @@ import static org.wso2.carbon.identity.ai.service.mgt.constants.AIConstants.Erro
 import static org.wso2.carbon.identity.ai.service.mgt.constants.AIConstants.ErrorMessages.SERVER_ERROR_WHILE_CONNECTING_TO_AI_SERVICE;
 import static org.wso2.carbon.identity.ai.service.mgt.constants.AIConstants.ErrorMessages.UNABLE_TO_ACCESS_AI_SERVICE_WITH_RENEW_ACCESS_TOKEN;
 import static org.wso2.carbon.identity.ai.service.mgt.constants.AIConstants.HTTP_BEARER;
+import static org.wso2.carbon.identity.ai.service.mgt.constants.AIConstants.HTTP_CLIENT_USE_SYSTEM_PROPERTIES_PROPERTY_NAME;
 import static org.wso2.carbon.identity.ai.service.mgt.constants.AIConstants.HTTP_CONNECTION_POOL_SIZE_PROPERTY_NAME;
 import static org.wso2.carbon.identity.ai.service.mgt.constants.AIConstants.HTTP_CONNECTION_REQUEST_TIMEOUT_PROPERTY_NAME;
 import static org.wso2.carbon.identity.ai.service.mgt.constants.AIConstants.HTTP_CONNECTION_TIMEOUT_PROPERTY_NAME;
@@ -76,15 +78,24 @@ public class AIHttpClientUtil {
     private static final String USER_AGENT_VALUE = "IAM-AI-Services";
 
     // Singleton instance of CloseableHttpClient with connection pooling.
-    private static final CloseableHttpClient httpClient = HttpClients.custom()
-            .setMaxConnTotal(HTTP_CONNECTION_POOL_SIZE)
-            .setDefaultRequestConfig(
-                    org.apache.http.client.config.RequestConfig.custom()
-                            .setSocketTimeout(HTTP_SOCKET_TIMEOUT)
-                            .setConnectTimeout(HTTP_CONNECTION_TIMEOUT)
-                            .setConnectionRequestTimeout(HTTP_CONNECTION_REQUEST_TIMEOUT)
-                            .build()
-            ).build();
+    private static final CloseableHttpClient httpClient = buildHttpClient();
+
+    private static CloseableHttpClient buildHttpClient() {
+
+        HttpClientBuilder builder = HttpClients.custom()
+                .setMaxConnTotal(HTTP_CONNECTION_POOL_SIZE)
+                .setDefaultRequestConfig(
+                        org.apache.http.client.config.RequestConfig.custom()
+                                .setSocketTimeout(HTTP_SOCKET_TIMEOUT)
+                                .setConnectTimeout(HTTP_CONNECTION_TIMEOUT)
+                                .setConnectionRequestTimeout(HTTP_CONNECTION_REQUEST_TIMEOUT)
+                                .build()
+                );
+        if (useSystemPropertiesInHttpClient()) {
+            builder.useSystemProperties();
+        }
+        return builder.build();
+    }
 
     private AIHttpClientUtil() {
 
@@ -207,6 +218,17 @@ public class AIHttpClientUtil {
 
         String value = IdentityUtil.getProperty(key);
         return value != null ? Integer.parseInt(value) : defaultValue;
+    }
+
+    /**
+     * Check whether the AI service HTTP clients should honor JVM system properties (e.g. the
+     * standard proxy configurations -Dhttp.proxyHost, -Dhttps.proxyHost and -Dhttp.nonProxyHosts).
+     *
+     * @return true if the AIServices.HTTPClientUseSystemProperties configuration is set to true, false otherwise.
+     */
+    public static boolean useSystemPropertiesInHttpClient() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(HTTP_CLIENT_USE_SYSTEM_PROPERTIES_PROPERTY_NAME));
     }
 
     /**

--- a/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
+++ b/features/authentication-framework/org.wso2.carbon.identity.application.authentication.framework.server.feature/resources/org.wso2.carbon.identity.application.authentication.framework.server.feature.default.json
@@ -311,6 +311,7 @@
   "ai_services.flow_ai.generate_request_path": "/api/server/v1/flow/generate",
   "ai_services.flow_ai.status_request_path": "/api/server/v1/flow/status",
   "ai_services.flow_ai.result_request_path": "/api/server/v1/flow/result",
+  "ai_services.http_client_use_system_properties": true,
 
   "async_operation_status.enable_data_persistence": false
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -5206,6 +5206,7 @@
         <HTTPConnectionTimeout>{{ai_services.http_connection_timeout}}</HTTPConnectionTimeout>
         <HTTPConnectionRequestTimeout>{{ai_services.http_connection_request_timeout}}</HTTPConnectionRequestTimeout>
         <HTTPSocketTimeout>{{ai_services.http_socket_timeout}}</HTTPSocketTimeout>
+        <HTTPClientUseSystemProperties>{{ai_services.http_client_use_system_properties}}</HTTPClientUseSystemProperties>
         <LoginFlowAI>
             <LoginFlowAIEndpoint>{{ai_services.login_flow_ai.endpoint}}</LoginFlowAIEndpoint>
             <LoginFlowAIGenerateRequestPath>{{ai_services.login_flow_ai.generate_request_path}}</LoginFlowAIGenerateRequestPath>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -452,7 +452,8 @@
       "enhanced_organization_authentication.enabled_by_default_for_new_apps" : false,
       "saas.enable_app_creation": true,
       "saas.enable_cross_tenant_operations": false,
-      "oauth.dcrm.decode_redirect_uris_in_response": false
+      "oauth.dcrm.decode_redirect_uris_in_response": false,
+      "ai_services.http_client_use_system_properties": false
     },
     "IS_7.3.0": {
       "oauth.dcrm.decode_redirect_uris_in_response": false,
@@ -468,7 +469,8 @@
         "consoleSettings.invitedExternalAdmins",
         "consoleSettings.privilegedUsers",
         "consoleSettings.useGranularConsolePermissions"
-      ]
+      ],
+      "ai_services.http_client_use_system_properties": false
     }
   }
 }


### PR DESCRIPTION
### Purpose
The AI service HTTP clients (branding/generate client and the token client) did not honor the standard JVM proxy system properties (-Dhttp.proxyHost, -Dhttps.proxyHost, -Dhttp.nonProxyHosts) set in wso2server.sh, so AI branding egress bypassed a configured forward proxy.

This enables `HttpClientBuilder.useSystemProperties()` on both AI HTTP clients, gated by a new configuration.

### Configuration
`AIServices.HTTPClientUseSystemProperties` (toml: `[ai_services] http_client_use_system_properties`)
- default.json: `true` — honoured by default on this release line.
- infer.json (`preserve_previous_product_behaviour.version`): `false` for `IS_7.2.0` and `IS_7.3.0`, so deployments pinned to those versions keep the previous behaviour.

### Related issue
Related to wso2/product-is#28168
