### PR TITLE
Add configuration to control SAML authentication failure responses.

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -903,6 +903,7 @@
         <SAML2AuthnRequestsSigningEnabled>false</SAML2AuthnRequestsSigningEnabled>
         <SAMLAssertionEncyptWithAppCert>true</SAMLAssertionEncyptWithAppCert>
         <SAMLAllowNestedAssertionsInResponse>false</SAMLAllowNestedAssertionsInResponse>
+        <SendSAMLAuthFailureResponseToSP>false</SendSAMLAuthFailureResponseToSP>
     </SSOService>
 
     <Consent>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1617,6 +1617,7 @@
         <SAMLIdpInitLogoutResponseSigningEnabled>{{saml.enable_saml_idp_init_logout_response_signing}}</SAMLIdpInitLogoutResponseSigningEnabled>
         <SAML2AuthnRequestsSigningEnabled>{{saml.metadata.enable_authentication_requests_signing}}</SAML2AuthnRequestsSigningEnabled>
         <SAMLAssertionEncyptWithAppCert>{{saml.metadata.assertion_encrypt_with_app_cert}}</SAMLAssertionEncyptWithAppCert>
+        <SendSAMLAuthFailureResponseToSP>{{saml.send_saml_auth_failure_response_to_sp}}</SendSAMLAuthFailureResponseToSP>
         {% if saml.metadata.define_name_id_policy_if_unspecified is defined %}
             <SAML2AuthnRequestNameIdPolicyDefinedIfUnspecified>{{saml.metadata.define_name_id_policy_if_unspecified}}</SAML2AuthnRequestNameIdPolicyDefinedIfUnspecified>
         {% endif %}

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -387,6 +387,7 @@
   "saml.metadata.assertion_encrypt_with_app_cert": true,
   "saml.enable_saml_sp_certificate_expiry_validation": true,
   "saml.enable_saml_idp_init_logout_response_signing": true,
+  "saml.send_saml_auth_failure_response_to_sp": false,
   "saml.return_valid_name_id_format": false,
   "saml.response.allow_nested_assertions": false,
 


### PR DESCRIPTION
Related Issues:

- [x] https://github.com/wso2/product-is/issues/27601

This pull request introduces a new configuration option to control whether SAML authentication failure responses are sent to the Service Provider (SP). The change is implemented across the default configuration, template, and main configuration files to ensure consistency and enable easy customization.

SAML Authentication Failure Response Handling:

* Added a new property `SendSAMLAuthFailureResponseToSP` (and corresponding template variable) to `identity.xml` and `identity.xml.j2` to control sending SAML authentication failure responses to the SP. [[1]](diffhunk://#diff-682dcc48fdd68c1974091fb760d1cbfb8b2bf80e05becd70d2c55f5b887b00baR906) [[2]](diffhunk://#diff-1ece24b053d1b4af23eb3fdd3af75e2f8816c34a5685ece650c7882061dff696R1620)
* Introduced the default value for this property (`saml.send_saml_auth_failure_response_to_sp: false`) in `org.wso2.carbon.identity.core.server.feature.default.json`.