### PR TITLE
Add support for honoring multivalued claim metadata

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -662,6 +662,7 @@
                 <EnableSecurityProfile>false</EnableSecurityProfile>
             </FAPI>
             <EnableClaimsSeparationForAccessToken>true</EnableClaimsSeparationForAccessToken>
+            <HonorMultivaluedClaimMetadata>true</HonorMultivaluedClaimMetadata>
         </OpenIDConnect>
 
         <!--

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -1173,6 +1173,7 @@
             <EnableHybridFlowAppLevelValidation>{{oauth.oidc.enable_hybrid_flow_app_level_validation}}</EnableHybridFlowAppLevelValidation>
             <EnableClaimsSeparationForAccessToken>{{oauth.oidc.enable_claims_separation_for_access_tokens}}</EnableClaimsSeparationForAccessToken>
             <RestrictAssertionClaimsToConfiguredAttributes>{{oauth.oidc.restrict_assertion_claims_to_configured_attributes}}</RestrictAssertionClaimsToConfiguredAttributes>
+            <HonorMultivaluedClaimMetadata>{{oauth.oidc.honor_multivalued_claim_metadata}}</HonorMultivaluedClaimMetadata>
         </OpenIDConnect>
 
         <!-- OIDCSessionStateManager configuration -->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -325,6 +325,7 @@
   "oauth.oidc.enable_hybrid_flow_app_level_validation": true,
   "oauth.oidc.enable_claims_separation_for_access_tokens": true,
   "oauth.oidc.restrict_assertion_claims_to_configured_attributes": false,
+  "oauth.oidc.honor_multivalued_claim_metadata": true,
 
   "oauth.oidc.fapi.enable_ciba_profile": false,
   "oauth.oidc.fapi.enable_security_profile": false,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -346,7 +346,8 @@
         "consoleSettings.invitedExternalAdmins",
         "consoleSettings.privilegedUsers",
         "consoleSettings.useGranularConsolePermissions"
-      ]
+      ],
+      "oauth.oidc.honor_multivalued_claim_metadata": false
     },
     "IS_7.1.0": {
       "oauth.dcrm.return_null_fields_in_response": true,
@@ -421,7 +422,8 @@
         "consoleSettings.invitedExternalAdmins",
         "consoleSettings.privilegedUsers",
         "consoleSettings.useGranularConsolePermissions"
-      ]
+      ],
+      "oauth.oidc.honor_multivalued_claim_metadata": false
     },
     "IS_7.2.0": {
       "authenticationendpoint.authenticator_validation.enabled": false,
@@ -452,7 +454,8 @@
       "enhanced_organization_authentication.enabled_by_default_for_new_apps" : false,
       "saas.enable_app_creation": true,
       "saas.enable_cross_tenant_operations": false,
-      "oauth.dcrm.decode_redirect_uris_in_response": false
+      "oauth.dcrm.decode_redirect_uris_in_response": false,
+      "oauth.oidc.honor_multivalued_claim_metadata": false
     },
     "IS_7.3.0": {
       "oauth.dcrm.decode_redirect_uris_in_response": false,
@@ -468,7 +471,8 @@
         "consoleSettings.invitedExternalAdmins",
         "consoleSettings.privilegedUsers",
         "consoleSettings.useGranularConsolePermissions"
-      ]
+      ],
+      "oauth.oidc.honor_multivalued_claim_metadata": false
     }
   }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces support for honoring multivalued claim metadata in OpenID Connect (OIDC) configurations. It adds a new configuration property, `HonorMultivaluedClaimMetadata`, to multiple configuration files, enabling or disabling this feature at both the template and environment-specific levels.

**OIDC Configuration Enhancements:**

* Added the `HonorMultivaluedClaimMetadata` property to the main OIDC configuration in `identity.xml` to control whether multivalued claim metadata is honored.
* Updated the Jinja template `identity.xml.j2` to include the new property, allowing it to be set via templating.

**Default and Environment-specific Settings:**

* Set the default value for `oauth.oidc.honor_multivalued_claim_metadata` to `true` in `org.wso2.carbon.identity.core.server.feature.default.json`.
* Added the property with a value of `false` in various environments (`IS_7.0.0`, `IS_7.2.0`, `IS_7.3.0`, and the base environment) in `org.wso2.carbon.identity.core.server.feature.infer.json` to allow for environment-specific overrides. [[1]](diffhunk://#diff-5a320fb31fe6943d6aca55d4c6e464e2680d1a1e5d2222d79fc6c95cd1f7033fL349-R350) [[2]](diffhunk://#diff-5a320fb31fe6943d6aca55d4c6e464e2680d1a1e5d2222d79fc6c95cd1f7033fL424-R426) [[3]](diffhunk://#diff-5a320fb31fe6943d6aca55d4c6e464e2680d1a1e5d2222d79fc6c95cd1f7033fL455-R458) [[4]](diffhunk://#diff-5a320fb31fe6943d6aca55d4c6e464e2680d1a1e5d2222d79fc6c95cd1f7033fL471-R475)

### Related Issues
- https://github.com/wso2/product-is/issues/27652