### PR TITLE
Add claim mutability controls for flow extension actions

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/FlowExtensionConstants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/FlowExtensionConstants.java
@@ -76,6 +76,8 @@ public class FlowExtensionConstants {
         public static final String ICON_URL = "ICON_URL";
         public static final String CERTIFICATE = "CERTIFICATE";
         public static final String CERTIFICATE_NAME_PREFIX = "ACTIONS:";
+        public static final String NON_MODIFIABLE_PATHS_PROPERTY =
+                "Actions.Types.FlowExtension.NonModifiablePaths.Path";
 
         private ActionManagement() {
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/FlowExtensionConstants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/FlowExtensionConstants.java
@@ -76,8 +76,7 @@ public class FlowExtensionConstants {
         public static final String ICON_URL = "ICON_URL";
         public static final String CERTIFICATE = "CERTIFICATE";
         public static final String CERTIFICATE_NAME_PREFIX = "ACTIONS:";
-        public static final String NON_MODIFIABLE_PATHS_PROPERTY =
-                "Actions.Types.FlowExtension.NonModifiablePaths.Path";
+        public static final String NON_MODIFIABLE_PATHS = "Actions.Types.FlowExtension.NonModifiablePaths.Path";
 
         private ActionManagement() {
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
@@ -51,6 +51,7 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants;
 import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.FlowContextPaths;
 import org.wso2.carbon.identity.flow.extension.util.CredentialWireFormatUtil;
+import org.wso2.carbon.identity.flow.extension.util.FlowExtensionUtil;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
 import org.wso2.carbon.user.core.UserCoreConstants;
@@ -102,10 +103,11 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
 
         List<String> exposePaths = resolveExposePaths(accessConfig);
         exposePaths = applyFlowSpecificAccessPolicy(exposePaths, execCtx.getFlowType());
-        List<ContextPath> modifyPaths = resolveModifyPaths(accessConfig);
+        List<ContextPath> modifyPaths = applyModifyPathRestrictions(
+                resolveModifyPaths(accessConfig), execCtx.getFlowType());
         actionFlowContext.add(FlowExtensionConstants.MODIFY_PATHS_KEY, modifyPaths);
 
-        List<AllowedOperation> allowedOperations = buildAllowedOperations(accessConfig, actionFlowContext);
+        List<AllowedOperation> allowedOperations = buildAllowedOperations(modifyPaths, actionFlowContext);
         String certificatePEM = resolveOutboundCertificate(accessConfig, certificate);
         ExposeResolution exposeResolution = pruneEncryptedExposePathsWithoutCertificate(
                 exposePaths, accessConfig, certificatePEM);
@@ -126,17 +128,17 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
      * the {@link FlowContext} under {@link FlowExtensionConstants#PATH_TYPE_ANNOTATIONS_KEY}
      * for the response processor.
      *
-     * @param accessConfig The access config containing modify paths (may be null).
-     * @param actionFlowContext  The FlowContext to store path annotations.
+     * @param modifyPaths       The effective modify paths, already stripped of restricted paths.
+     * @param actionFlowContext The FlowContext to store path annotations.
      * @return List of allowed operations (REPLACE if applicable, plus REDIRECT).
      */
-    private List<AllowedOperation> buildAllowedOperations(AccessConfig accessConfig,
+    private List<AllowedOperation> buildAllowedOperations(List<ContextPath> modifyPaths,
                                                           FlowContext actionFlowContext) {
 
         List<AllowedOperation> allowedOps = new ArrayList<>();
 
-        if (hasModifyPaths(accessConfig)) {
-            AllowedModifyExtraction extraction = extractAllowedModifyPaths(accessConfig.getModify());
+        if (!modifyPaths.isEmpty()) {
+            AllowedModifyExtraction extraction = extractAllowedModifyPaths(modifyPaths);
             addReplaceOperationIfAny(allowedOps, extraction.getCleanPaths());
             storeAnnotationsIfAny(actionFlowContext, extraction.getPathTypeAnnotations());
 
@@ -405,9 +407,50 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
                 .resultStatus(DiagnosticLog.ResultStatus.SUCCESS));
     }
 
-    private boolean hasModifyPaths(AccessConfig accessConfig) {
+    /**
+     * Drop the modify paths the extension must not be permitted to write on this request, so that
+     * they are never advertised as modifiable in the outbound payload.
+     *
+     * @param modifyPaths The modify paths resolved from the access config.
+     * @param flowType    The current flow type (e.g. {@code REGISTRATION}).
+     * @return The modify paths with the restricted ones removed.
+     */
+    private List<ContextPath> applyModifyPathRestrictions(List<ContextPath> modifyPaths, String flowType) {
 
-        return accessConfig != null && accessConfig.getModify() != null && !accessConfig.getModify().isEmpty();
+        if (modifyPaths.isEmpty()) {
+            return modifyPaths;
+        }
+
+        List<ContextPath> effectivePaths = new ArrayList<>();
+        List<String> restrictedPaths = new ArrayList<>();
+
+        for (ContextPath modifyPath : modifyPaths) {
+            String rawPath = modifyPath == null ? null : modifyPath.getPath();
+            String cleanPath = rawPath == null ? null : PathTypeAnnotationUtil.stripAnnotation(rawPath)[0];
+
+            if (cleanPath != null && isRestrictedModifyPath(cleanPath, flowType)) {
+                restrictedPaths.add(cleanPath);
+            } else {
+                effectivePaths.add(modifyPath);
+            }
+        }
+
+        if (LOG.isDebugEnabled() && !restrictedPaths.isEmpty()) {
+            LOG.debug("Dropped " + restrictedPaths.size() + " restricted modify path(s) for flow type "
+                    + flowType + ": " + String.join(", ", restrictedPaths));
+        }
+
+        return effectivePaths;
+    }
+
+    private boolean isRestrictedModifyPath(String cleanPath, String flowType) {
+
+        if (FlowExtensionUtil.isNonModifiablePath(cleanPath)) {
+            return true;
+        }
+
+        return FlowContextPaths.USER_USERNAME_PATH.equals(cleanPath)
+                && !FlowExtensionConstants.ContextTree.FLOW_REGISTRATION.equals(flowType);
     }
 
     private AllowedModifyExtraction extractAllowedModifyPaths(List<ContextPath> modifyPaths) {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
@@ -101,10 +101,8 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
         AccessConfig accessConfig = flowExtensionAction.getAccessConfig();
         Certificate certificate = flowExtensionAction.getCertificate();
 
-        List<String> exposePaths = resolveExposePaths(accessConfig);
-        exposePaths = applyFlowSpecificAccessPolicy(exposePaths, execCtx.getFlowType());
-        List<ContextPath> modifyPaths = applyModifyPathRestrictions(
-                resolveModifyPaths(accessConfig), execCtx.getFlowType());
+        List<String> exposePaths = resolveExposePaths(accessConfig, execCtx.getFlowType());
+        List<ContextPath> modifyPaths = resolveModifyPaths(accessConfig, execCtx.getFlowType());
         actionFlowContext.add(FlowExtensionConstants.MODIFY_PATHS_KEY, modifyPaths);
 
         List<AllowedOperation> allowedOperations = buildAllowedOperations(modifyPaths, actionFlowContext);
@@ -255,12 +253,12 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
         return (FlowExtensionAction) rawAction;
     }
 
-    private List<String> resolveExposePaths(AccessConfig accessConfig) {
+    private List<String> resolveExposePaths(AccessConfig accessConfig, String flowType) {
 
         if (accessConfig == null || accessConfig.getExpose() == null) {
             return Collections.emptyList();
         }
-        return accessConfig.getExposePaths();
+        return applyFlowSpecificAccessPolicy(accessConfig.getExposePaths(), flowType);
     }
 
     /**
@@ -287,12 +285,12 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
         return effectivePaths;
     }
 
-    private List<ContextPath> resolveModifyPaths(AccessConfig accessConfig) {
+    private List<ContextPath> resolveModifyPaths(AccessConfig accessConfig, String flowType) {
 
         if (accessConfig == null || accessConfig.getModify() == null) {
             return Collections.emptyList();
         }
-        return accessConfig.getModify();
+        return applyModifyPathRestrictions(accessConfig.getModify(), flowType);
     }
 
     private String resolveOutboundCertificate(AccessConfig accessConfig, Certificate certificate) {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
@@ -101,6 +101,7 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
         Certificate certificate = flowExtensionAction.getCertificate();
 
         List<String> exposePaths = resolveExposePaths(accessConfig);
+        exposePaths = applyFlowSpecificAccessPolicy(exposePaths, execCtx.getFlowType());
         List<ContextPath> modifyPaths = resolveModifyPaths(accessConfig);
         actionFlowContext.add(FlowExtensionConstants.MODIFY_PATHS_KEY, modifyPaths);
 
@@ -258,6 +259,30 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
             return Collections.emptyList();
         }
         return accessConfig.getExposePaths();
+    }
+
+    /**
+     * Certain claims may only be exposed to an external extension during specific flow types.
+     *
+     * @param exposePaths The resolved expose paths.
+     * @param flowType    The current flow type (e.g. {@code REGISTRATION}).
+     * @return The expose paths with {@code /user/username} removed for non-self-registration flows.
+     */
+    private List<String> applyFlowSpecificAccessPolicy(List<String> exposePaths, String flowType) {
+
+        if (exposePaths.isEmpty()
+                || FlowExtensionConstants.ContextTree.FLOW_REGISTRATION.equals(flowType)
+                || !exposePaths.contains(FlowContextPaths.USER_USERNAME_PATH)) {
+            return exposePaths;
+        }
+
+        List<String> effectivePaths = new ArrayList<>(exposePaths);
+        effectivePaths.remove(FlowContextPaths.USER_USERNAME_PATH);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Dropped '" + FlowContextPaths.USER_USERNAME_PATH
+                    + "' expose path for non self registration flow type: " + flowType);
+        }
+        return effectivePaths;
     }
 
     private List<ContextPath> resolveModifyPaths(AccessConfig accessConfig) {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
@@ -101,7 +101,7 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
         AccessConfig accessConfig = flowExtensionAction.getAccessConfig();
         Certificate certificate = flowExtensionAction.getCertificate();
 
-        List<String> exposePaths = resolveExposePaths(accessConfig, execCtx.getFlowType());
+        List<String> exposePaths = resolveExposePaths(accessConfig);
         List<ContextPath> modifyPaths = resolveModifyPaths(accessConfig, execCtx.getFlowType());
         actionFlowContext.add(FlowExtensionConstants.MODIFY_PATHS_KEY, modifyPaths);
 
@@ -253,36 +253,12 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
         return (FlowExtensionAction) rawAction;
     }
 
-    private List<String> resolveExposePaths(AccessConfig accessConfig, String flowType) {
+    private List<String> resolveExposePaths(AccessConfig accessConfig) {
 
         if (accessConfig == null || accessConfig.getExpose() == null) {
             return Collections.emptyList();
         }
-        return applyFlowSpecificAccessPolicy(accessConfig.getExposePaths(), flowType);
-    }
-
-    /**
-     * Certain claims may only be exposed to an external extension during specific flow types.
-     *
-     * @param exposePaths The resolved expose paths.
-     * @param flowType    The current flow type (e.g. {@code REGISTRATION}).
-     * @return The expose paths with {@code /user/username} removed for non-self-registration flows.
-     */
-    private List<String> applyFlowSpecificAccessPolicy(List<String> exposePaths, String flowType) {
-
-        if (exposePaths.isEmpty()
-                || FlowExtensionConstants.ContextTree.FLOW_REGISTRATION.equals(flowType)
-                || !exposePaths.contains(FlowContextPaths.USER_USERNAME_PATH)) {
-            return exposePaths;
-        }
-
-        List<String> effectivePaths = new ArrayList<>(exposePaths);
-        effectivePaths.remove(FlowContextPaths.USER_USERNAME_PATH);
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Dropped '" + FlowContextPaths.USER_USERNAME_PATH
-                    + "' expose path for non self registration flow type: " + flowType);
-        }
-        return effectivePaths;
+        return accessConfig.getExposePaths();
     }
 
     private List<ContextPath> resolveModifyPaths(AccessConfig accessConfig, String flowType) {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilder.java
@@ -399,10 +399,13 @@ public class FlowExtensionRequestBuilder implements ActionExecutionRequestBuilde
         List<String> restrictedPaths = new ArrayList<>();
 
         for (ContextPath modifyPath : modifyPaths) {
-            String rawPath = modifyPath == null ? null : modifyPath.getPath();
-            String cleanPath = rawPath == null ? null : PathTypeAnnotationUtil.stripAnnotation(rawPath)[0];
+            if (modifyPath == null || modifyPath.getPath() == null) {
+                effectivePaths.add(modifyPath);
+                continue;
+            }
 
-            if (cleanPath != null && isRestrictedModifyPath(cleanPath, flowType)) {
+            String cleanPath = PathTypeAnnotationUtil.stripAnnotation(modifyPath.getPath())[0];
+            if (isRestrictedModifyPath(cleanPath, flowType)) {
                 restrictedPaths.add(cleanPath);
             } else {
                 effectivePaths.add(modifyPath);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
@@ -54,6 +54,7 @@ import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants;
 import org.wso2.carbon.identity.flow.extension.model.AccessConfig;
 import org.wso2.carbon.identity.flow.extension.model.ContextPath;
 import org.wso2.carbon.identity.flow.extension.model.OperationExecutionResult;
+import org.wso2.carbon.identity.flow.extension.util.FlowExtensionUtil;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.utils.DiagnosticLog;
 
@@ -109,7 +110,7 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
                     operation = decryptOperationValueIfNeeded(operation, accessConfig, tenantDomain);
                 }
                 results.add(processOperation(
-                        operation, pendingClaims, pendingCredentials, tenantDomain));
+                        operation, pendingClaims, pendingCredentials, tenantDomain, execCtx.getFlowType()));
             }
         } else {
             if (LOG.isDebugEnabled()) {
@@ -139,12 +140,13 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
      * @param pendingClaims       Accumulator map for user claim updates.
      * @param pendingCredentials  Accumulator map for user credential updates.
      * @param tenantDomain        Tenant domain, used for claim URI validation.
+     * @param flowType            The current flow type (e.g. {@code REGISTRATION}).
      * @return The result of the operation execution.
      */
     private OperationExecutionResult processOperation(PerformableOperation operation,
                                                       Map<String, Object> pendingClaims,
                                                       Map<String, char[]> pendingCredentials,
-                                                      String tenantDomain)
+                                                      String tenantDomain, String flowType)
             throws ActionExecutionResponseProcessorException {
 
         String path = operation.getPath();
@@ -161,6 +163,18 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
         if (AccessConfig.isReadOnly(path)) {
             return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
                     "Modifications are not allowed for the read-only paths" );
+        }
+
+        if (FlowExtensionUtil.isNonModifiablePath(path)) {
+            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
+                    "Modifications are not allowed for the path: " + path);
+        }
+
+        if (FlowExtensionConstants.FlowContextPaths.USER_USERNAME_PATH.equals(path)
+                && !FlowExtensionConstants.ContextTree.FLOW_REGISTRATION.equals(flowType)) {
+            return new OperationExecutionResult(operation, OperationExecutionResult.Status.SUCCESS,
+                    "Ignoring REPLACE on '" + path
+                            + "' for non self registration flow type: " + flowType);
         }
 
         if (path.startsWith(FlowExtensionConstants.FlowContextPaths.USER_CLAIMS_SELECTOR_PREFIX)) {
@@ -206,10 +220,6 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
             return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
                     "Claim URI must be in the local dialect (" +
                             PathTypeAnnotationUtil.LOCAL_CLAIM_DIALECT_PREFIX + "): " + claimUri);
-        }
-        if (claimUri.startsWith(PathTypeAnnotationUtil.IDENTITY_CLAIM_URI_PREFIX)) {
-            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
-                    "Identity-system claims cannot be modified by Flow Extensions: " + claimUri);
         }
 
         Optional<LocalClaim> optionalLocalClaim = getLocalClaim(claimUri, tenantDomain);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
@@ -176,9 +176,8 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
     /**
      * Handle a REPLACE operation on a user claim by validating the claim URI and collecting the value
      * into the pending claims map. The claim URI must be in the WSO2 local dialect
-     * ({@code http://wso2.org/claims/}), must not be an identity-system claim
-     * ({@code http://wso2.org/claims/identity/}), and must resolve to a registered local claim in the
-     * tenant. A single-valued claim takes a {@code String} value and a multi-valued claim takes a list
+     * ({@code http://wso2.org/claims/}) and must resolve to a registered local claim in the tenant.
+     * A single-valued claim takes a {@code String} value and a multi-valued claim takes a list
      * joined with commas. Failing any of these validations drops the operation, while an unavailable
      * claim metadata service or a lookup error aborts the response.
      *

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessor.java
@@ -54,7 +54,6 @@ import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants;
 import org.wso2.carbon.identity.flow.extension.model.AccessConfig;
 import org.wso2.carbon.identity.flow.extension.model.ContextPath;
 import org.wso2.carbon.identity.flow.extension.model.OperationExecutionResult;
-import org.wso2.carbon.identity.flow.extension.util.FlowExtensionUtil;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.utils.DiagnosticLog;
 
@@ -110,7 +109,7 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
                     operation = decryptOperationValueIfNeeded(operation, accessConfig, tenantDomain);
                 }
                 results.add(processOperation(
-                        operation, pendingClaims, pendingCredentials, tenantDomain, execCtx.getFlowType()));
+                        operation, pendingClaims, pendingCredentials, tenantDomain));
             }
         } else {
             if (LOG.isDebugEnabled()) {
@@ -140,13 +139,12 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
      * @param pendingClaims       Accumulator map for user claim updates.
      * @param pendingCredentials  Accumulator map for user credential updates.
      * @param tenantDomain        Tenant domain, used for claim URI validation.
-     * @param flowType            The current flow type (e.g. {@code REGISTRATION}).
      * @return The result of the operation execution.
      */
     private OperationExecutionResult processOperation(PerformableOperation operation,
                                                       Map<String, Object> pendingClaims,
                                                       Map<String, char[]> pendingCredentials,
-                                                      String tenantDomain, String flowType)
+                                                      String tenantDomain)
             throws ActionExecutionResponseProcessorException {
 
         String path = operation.getPath();
@@ -163,18 +161,6 @@ public class FlowExtensionResponseProcessor implements ActionExecutionResponsePr
         if (AccessConfig.isReadOnly(path)) {
             return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
                     "Modifications are not allowed for the read-only paths" );
-        }
-
-        if (FlowExtensionUtil.isNonModifiablePath(path)) {
-            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
-                    "Modifications are not allowed for the path: " + path);
-        }
-
-        if (FlowExtensionConstants.FlowContextPaths.USER_USERNAME_PATH.equals(path)
-                && !FlowExtensionConstants.ContextTree.FLOW_REGISTRATION.equals(flowType)) {
-            return new OperationExecutionResult(operation, OperationExecutionResult.Status.SUCCESS,
-                    "Ignoring REPLACE on '" + path
-                            + "' for non self registration flow type: " + flowType);
         }
 
         if (path.startsWith(FlowExtensionConstants.FlowContextPaths.USER_CLAIMS_SELECTOR_PREFIX)) {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/PathTypeAnnotationUtil.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/executor/PathTypeAnnotationUtil.java
@@ -30,7 +30,6 @@ public final class PathTypeAnnotationUtil {
 
     static final Pattern ANNOTATION_PATTERN = Pattern.compile("\\{([^}]*)}$");
     static final String LOCAL_CLAIM_DIALECT_PREFIX = "http://wso2.org/claims/";
-    static final String IDENTITY_CLAIM_URI_PREFIX = "http://wso2.org/claims/identity/";
     static final int MAX_ATTRIBUTES_PER_OBJECT = 10;
 
     private PathTypeAnnotationUtil() {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolver.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolver.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.identity.certificate.management.exception.CertificateMgtE
 import org.wso2.carbon.identity.certificate.management.model.Certificate;
 import org.wso2.carbon.identity.certificate.management.service.CertificateManagementService;
 import org.wso2.carbon.identity.flow.extension.model.ContextPath;
+import org.wso2.carbon.identity.flow.extension.util.FlowExtensionUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -89,6 +90,7 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
         Object modifyValue = actionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY);
         if (modifyValue != null) {
             List<ContextPath> validatedModify = validateAccessConfig(modifyValue);
+            FlowExtensionUtil.validateModifyPaths(validatedModify);
             properties.put(ACCESS_CONFIG_MODIFY, createBlobProperty(validatedModify));
         }
 
@@ -206,7 +208,10 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
             throws ActionDTOModelResolverException {
 
         if (updatingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY) != null) {
-            return validateAccessConfig(updatingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY));
+            List<ContextPath> validatedModify =
+                    validateAccessConfig(updatingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY));
+            FlowExtensionUtil.validateModifyPaths(validatedModify);
+            return validatedModify;
         } else if (existingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY) != null) {
             return (List<ContextPath>) existingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY);
         }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolver.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolver.java
@@ -194,8 +194,7 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
             throws ActionDTOModelResolverException {
 
         if (updatingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE) != null) {
-            return validateAccessConfig(ACCESS_CONFIG_EXPOSE,
-                    updatingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE));
+            return validateAccessConfig(ACCESS_CONFIG_EXPOSE, updatingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE));
         } else if (existingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE) != null) {
             return (List<ContextPath>) existingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE);
         }
@@ -208,8 +207,7 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
             throws ActionDTOModelResolverException {
 
         if (updatingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY) != null) {
-            return validateAccessConfig(ACCESS_CONFIG_MODIFY,
-                    updatingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY));
+            return validateAccessConfig(ACCESS_CONFIG_MODIFY, updatingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY));
         } else if (existingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY) != null) {
             return (List<ContextPath>) existingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY);
         }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolver.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolver.java
@@ -83,14 +83,13 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
 
         Object exposeValue = actionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE);
         if (exposeValue != null) {
-            List<ContextPath> validatedExpose = validateAccessConfig(exposeValue);
+            List<ContextPath> validatedExpose = validateAccessConfig(ACCESS_CONFIG_EXPOSE, exposeValue);
             properties.put(ACCESS_CONFIG_EXPOSE, createBlobProperty(validatedExpose));
         }
 
         Object modifyValue = actionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY);
         if (modifyValue != null) {
-            List<ContextPath> validatedModify = validateAccessConfig(modifyValue);
-            FlowExtensionUtil.validateModifyPaths(validatedModify);
+            List<ContextPath> validatedModify = validateAccessConfig(ACCESS_CONFIG_MODIFY, modifyValue);
             properties.put(ACCESS_CONFIG_MODIFY, createBlobProperty(validatedModify));
         }
 
@@ -195,7 +194,8 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
             throws ActionDTOModelResolverException {
 
         if (updatingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE) != null) {
-            return validateAccessConfig(updatingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE));
+            return validateAccessConfig(ACCESS_CONFIG_EXPOSE,
+                    updatingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE));
         } else if (existingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE) != null) {
             return (List<ContextPath>) existingActionDTO.getPropertyValue(ACCESS_CONFIG_EXPOSE);
         }
@@ -208,10 +208,8 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
             throws ActionDTOModelResolverException {
 
         if (updatingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY) != null) {
-            List<ContextPath> validatedModify =
-                    validateAccessConfig(updatingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY));
-            FlowExtensionUtil.validateModifyPaths(validatedModify);
-            return validatedModify;
+            return validateAccessConfig(ACCESS_CONFIG_MODIFY,
+                    updatingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY));
         } else if (existingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY) != null) {
             return (List<ContextPath>) existingActionDTO.getPropertyValue(ACCESS_CONFIG_MODIFY);
         }
@@ -219,7 +217,8 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
     }
 
     @SuppressWarnings("unchecked")
-    private List<ContextPath> validateAccessConfig(Object exposeValue) throws ActionDTOModelResolverException {
+    private List<ContextPath> validateAccessConfig(String accessConfig, Object exposeValue)
+            throws ActionDTOModelResolverException {
 
         if (!(exposeValue instanceof List<?>)) {
             throw new ActionDTOModelResolverClientException("Invalid expose format.",
@@ -248,6 +247,9 @@ public class FlowExtensionActionDTOModelResolver implements ActionDTOModelResolv
         }
 
         validateContextPathFormat(result);
+        if (ACCESS_CONFIG_MODIFY.equals(accessConfig)) {
+            FlowExtensionUtil.validateModifyPaths(result);
+        }
         return result;
     }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/util/FlowExtensionUtil.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/util/FlowExtensionUtil.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverClientException;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.flow.extension.executor.PathTypeAnnotationUtil;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
 import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.HandoverPolicy;
@@ -65,9 +66,15 @@ public final class FlowExtensionUtil {
         }
 
         for (ContextPath modifyPath : modify) {
-            if (nonModifiablePaths.contains(modifyPath.getPath())) {
+            String rawPath = modifyPath == null ? null : modifyPath.getPath();
+            if (rawPath == null) {
+                continue;
+            }
+
+            String cleanPath = PathTypeAnnotationUtil.stripAnnotation(rawPath)[0];
+            if (nonModifiablePaths.contains(cleanPath)) {
                 throw new ActionDTOModelResolverClientException("Invalid modify path.",
-                        String.format("Path '%s' cannot be marked as modifiable.", modifyPath.getPath()));
+                        String.format("Path '%s' cannot be marked as modifiable.", cleanPath));
             }
         }
     }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/util/FlowExtensionUtil.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/util/FlowExtensionUtil.java
@@ -33,7 +33,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS_PROPERTY;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS;
 
 /**
  * Utilities for the Flow Extension module.
@@ -57,8 +57,7 @@ public final class FlowExtensionUtil {
      * @param modify The modify context paths declared in an action's access config.
      * @throws ActionDTOModelResolverClientException if any path is configured as non-modifiable.
      */
-    public static void validateModifyPaths(List<ContextPath> modify)
-            throws ActionDTOModelResolverClientException {
+    public static void validateModifyPaths(List<ContextPath> modify) throws ActionDTOModelResolverClientException {
 
         List<String> nonModifiablePaths = getNonModifiablePaths();
         if (nonModifiablePaths.isEmpty()) {
@@ -66,7 +65,10 @@ public final class FlowExtensionUtil {
         }
 
         for (ContextPath modifyPath : modify) {
-            String rawPath = modifyPath == null ? null : modifyPath.getPath();
+            if (modifyPath == null) {
+                continue;
+            }
+            String rawPath = modifyPath.getPath();
             if (rawPath == null) {
                 continue;
             }
@@ -92,7 +94,7 @@ public final class FlowExtensionUtil {
 
     private static List<String> getNonModifiablePaths() {
 
-        return IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS_PROPERTY);
+        return IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS);
     }
 
     /**

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/util/FlowExtensionUtil.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/main/java/org/wso2/carbon/identity/flow/extension/util/FlowExtensionUtil.java
@@ -20,13 +20,19 @@ package org.wso2.carbon.identity.flow.extension.util;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverClientException;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
 import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.HandoverPolicy;
+import org.wso2.carbon.identity.flow.extension.model.ContextPath;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS_PROPERTY;
 
 /**
  * Utilities for the Flow Extension module.
@@ -42,6 +48,44 @@ public final class FlowExtensionUtil {
 
     private FlowExtensionUtil() {
 
+    }
+
+    /**
+     * Validate that no declared modify path is configured as non-modifiable.
+     *
+     * @param modify The modify context paths declared in an action's access config.
+     * @throws ActionDTOModelResolverClientException if any path is configured as non-modifiable.
+     */
+    public static void validateModifyPaths(List<ContextPath> modify)
+            throws ActionDTOModelResolverClientException {
+
+        List<String> nonModifiablePaths = getNonModifiablePaths();
+        if (nonModifiablePaths.isEmpty()) {
+            return;
+        }
+
+        for (ContextPath modifyPath : modify) {
+            if (nonModifiablePaths.contains(modifyPath.getPath())) {
+                throw new ActionDTOModelResolverClientException("Invalid modify path.",
+                        String.format("Path '%s' cannot be marked as modifiable.", modifyPath.getPath()));
+            }
+        }
+    }
+
+    /**
+     * Check a single context path against the non-modifiable path configuration.
+     *
+     * @param path The context path targeted by an operation.
+     * @return {@code true} if the path is configured as non-modifiable.
+     */
+    public static boolean isNonModifiablePath(String path) {
+
+        return getNonModifiablePaths().contains(path);
+    }
+
+    private static List<String> getNonModifiablePaths() {
+
+        return IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS_PROPERTY);
     }
 
     /**

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilderTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilderTest.java
@@ -299,7 +299,10 @@ public class FlowExtensionRequestBuilderTest {
         assertNull(event.getFlow().getUser());
     }
 
-    // ------------------------------------------------------------------ flow-specific expose policy
+    // ------------------------------------------------------------------ expose is not flow scoped
+
+    // Exposure is opted into explicitly through the access config, so it is honoured on every flow
+    // type. Only modification of the username is scoped to self registration.
 
     @Test
     public void testUsernameExposedForSelfRegistrationFlow() throws Exception {
@@ -317,10 +320,8 @@ public class FlowExtensionRequestBuilderTest {
     }
 
     @Test
-    public void testUsernameExposeDroppedForNonSelfRegistrationFlow() throws Exception {
+    public void testUsernameExposedForNonSelfRegistrationFlow() throws Exception {
 
-        // '/user/username' is only exposable during self registration; on any other flow type the
-        // path is silently dropped while the rest of the expose configuration is honoured.
         AccessConfig accessConfig = new AccessConfig(
                 Arrays.asList(new ContextPath("/user/id", false), new ContextPath(USERNAME_PATH, false)), null);
 
@@ -328,34 +329,9 @@ public class FlowExtensionRequestBuilderTest {
                 flowContextWith(execContext("PASSWORD_RECOVERY")), actionContext(accessConfig));
 
         FlowExtensionUser user = (FlowExtensionUser) ((FlowExtensionEvent) request.getEvent()).getFlow().getUser();
-        assertNotNull(user, "Remaining expose paths must still produce a user.");
-        assertEquals(user.getId(), "uid");
-        assertNull(user.getUsername(), "Username must not be exposed outside self registration.");
-    }
-
-    @Test
-    public void testExposeUntouchedWhenUsernameNotExposed() throws Exception {
-
-        // Nothing to drop: the policy must leave a username-free expose list alone.
-        AccessConfig accessConfig = new AccessConfig(
-                Collections.singletonList(new ContextPath("/user/id", false)), null);
-
-        ActionExecutionRequest request = builder.buildActionExecutionRequest(
-                flowContextWith(execContext("PASSWORD_RECOVERY")), actionContext(accessConfig));
-
-        FlowExtensionUser user = (FlowExtensionUser) ((FlowExtensionEvent) request.getEvent()).getFlow().getUser();
         assertNotNull(user);
         assertEquals(user.getId(), "uid");
-    }
-
-    @Test
-    public void testEmptyExposeToleratedOnNonSelfRegistrationFlow() throws Exception {
-
-        ActionExecutionRequest request = builder.buildActionExecutionRequest(
-                flowContextWith(execContext("PASSWORD_RECOVERY")),
-                actionContext(new AccessConfig(null, null)));
-
-        assertNull(((FlowExtensionEvent) request.getEvent()).getFlow().getUser());
+        assertEquals(user.getUsername(), "alice", "Expose config must be honoured on every flow type.");
     }
 
     // ------------------------------------------------------------------ modify path restrictions

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilderTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilderTest.java
@@ -54,7 +54,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS_PROPERTY;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS;
 
 /**
  * Unit tests for {@link FlowExtensionRequestBuilder}: expose-based filtering into the event model,
@@ -352,7 +352,7 @@ public class FlowExtensionRequestBuilderTest {
                                                                String... nonModifiablePaths) throws Exception {
 
         try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
-            identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS_PROPERTY))
+            identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS))
                     .thenReturn(Arrays.asList(nonModifiablePaths));
 
             return builder.buildActionExecutionRequest(
@@ -388,7 +388,7 @@ public class FlowExtensionRequestBuilderTest {
                 flowContextWith(execContext());
 
         try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
-            identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS_PROPERTY))
+            identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS))
                     .thenReturn(Collections.singletonList(USER_ID_CLAIM_PATH));
 
             builder.buildActionExecutionRequest(actionFlowContext, actionContext(accessConfig));

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilderTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilderTest.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.action.management.api.model.Action;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.certificate.management.model.Certificate;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
 import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants;
@@ -53,6 +54,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS_PROPERTY;
 
 /**
  * Unit tests for {@link FlowExtensionRequestBuilder}: expose-based filtering into the event model,
@@ -65,6 +67,7 @@ public class FlowExtensionRequestBuilderTest {
     private static final String CLAIM_PATH = "/user/claims[uri=http://wso2.org/claims/givenname]";
     private static final String CREDENTIAL_PATH = "/user/credentials/password";
     private static final String USERNAME_PATH = "/user/username";
+    private static final String USER_ID_CLAIM_PATH = "/user/claims[uri=http://wso2.org/claims/userid]";
 
     // A self-signed RSA X.509 certificate (base64-encoded DER, CN=flow-ext-test), valid until 2300.
     // Used only to exercise the outbound credential encryption path.
@@ -353,6 +356,159 @@ public class FlowExtensionRequestBuilderTest {
                 actionContext(new AccessConfig(null, null)));
 
         assertNull(((FlowExtensionEvent) request.getEvent()).getFlow().getUser());
+    }
+
+    // ------------------------------------------------------------------ modify path restrictions
+
+    // Restricted paths are stripped before the allowed operations are built, so the extension is
+    // never told it may modify a path whose modification would be discarded. An operation on a path
+    // that was never advertised is dropped by the action execution framework.
+
+    private AllowedOperation replaceOperation(ActionExecutionRequest request) {
+
+        return request.getAllowedOperations().stream()
+                .filter(op -> op.getOp() == Operation.REPLACE)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private ActionExecutionRequest buildWithNonModifiablePaths(AccessConfig accessConfig, String flowType,
+                                                               String... nonModifiablePaths) throws Exception {
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS_PROPERTY))
+                    .thenReturn(Arrays.asList(nonModifiablePaths));
+
+            return builder.buildActionExecutionRequest(
+                    flowContextWith(execContext(flowType)), actionContext(accessConfig));
+        }
+    }
+
+    @Test
+    public void testNonModifiablePathNotAdvertisedAsModifiable() throws Exception {
+
+        AccessConfig accessConfig = new AccessConfig(null, Arrays.asList(
+                new ContextPath(USER_ID_CLAIM_PATH, false), new ContextPath(CLAIM_PATH, false)));
+
+        ActionExecutionRequest request = buildWithNonModifiablePaths(
+                accessConfig, FlowExtensionConstants.ContextTree.FLOW_REGISTRATION, USER_ID_CLAIM_PATH);
+
+        AllowedOperation replaceOp = replaceOperation(request);
+        assertNotNull(replaceOp);
+        assertFalse(replaceOp.getPaths().contains(USER_ID_CLAIM_PATH),
+                "A non-modifiable path must not be advertised as modifiable.");
+        assertTrue(replaceOp.getPaths().contains(CLAIM_PATH));
+    }
+
+    @Test
+    public void testNonModifiablePathRemovedFromStoredModifyPaths() throws Exception {
+
+        // The response processor reads MODIFY_PATHS_KEY for its decryption decisions, so the
+        // dropped path must not survive there either.
+        AccessConfig accessConfig = new AccessConfig(null, Arrays.asList(
+                new ContextPath(USER_ID_CLAIM_PATH, false), new ContextPath(CLAIM_PATH, false)));
+
+        org.wso2.carbon.identity.action.execution.api.model.FlowContext actionFlowContext =
+                flowContextWith(execContext());
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS_PROPERTY))
+                    .thenReturn(Collections.singletonList(USER_ID_CLAIM_PATH));
+
+            builder.buildActionExecutionRequest(actionFlowContext, actionContext(accessConfig));
+        }
+
+        List<?> storedPaths = (List<?>) actionFlowContext.getContextData()
+                .get(FlowExtensionConstants.MODIFY_PATHS_KEY);
+        assertEquals(storedPaths.size(), 1);
+        assertEquals(((ContextPath) storedPaths.get(0)).getPath(), CLAIM_PATH);
+    }
+
+    @Test
+    public void testNonModifiablePathMatchedAfterStrippingTypeAnnotation() throws Exception {
+
+        // Restrictions are configured against clean paths, so an annotated modify path must still
+        // be matched once the annotation is stripped.
+        AccessConfig accessConfig = new AccessConfig(null, Collections.singletonList(
+                new ContextPath(USER_ID_CLAIM_PATH + "{[string]}", false)));
+
+        ActionExecutionRequest request = buildWithNonModifiablePaths(
+                accessConfig, FlowExtensionConstants.ContextTree.FLOW_REGISTRATION, USER_ID_CLAIM_PATH);
+
+        assertNull(replaceOperation(request), "Only the REDIRECT operation should remain.");
+        assertEquals(request.getAllowedOperations().size(), 1);
+    }
+
+    @Test
+    public void testAllModifyPathsRestrictedLeavesRedirectOnly() throws Exception {
+
+        AccessConfig accessConfig = new AccessConfig(null, Collections.singletonList(
+                new ContextPath(USER_ID_CLAIM_PATH, false)));
+
+        ActionExecutionRequest request = buildWithNonModifiablePaths(
+                accessConfig, FlowExtensionConstants.ContextTree.FLOW_REGISTRATION, USER_ID_CLAIM_PATH);
+
+        assertEquals(request.getAllowedOperations().size(), 1);
+        assertEquals(request.getAllowedOperations().get(0).getOp(), Operation.REDIRECT);
+    }
+
+    @Test
+    public void testUnrestrictedModifyPathStillAdvertised() throws Exception {
+
+        AccessConfig accessConfig = new AccessConfig(null, Collections.singletonList(
+                new ContextPath(CLAIM_PATH, false)));
+
+        ActionExecutionRequest request = buildWithNonModifiablePaths(
+                accessConfig, FlowExtensionConstants.ContextTree.FLOW_REGISTRATION, USER_ID_CLAIM_PATH);
+
+        AllowedOperation replaceOp = replaceOperation(request);
+        assertNotNull(replaceOp);
+        assertTrue(replaceOp.getPaths().contains(CLAIM_PATH));
+    }
+
+    @Test
+    public void testNullModifyPathEntriesToleratedByRestrictionFilter() throws Exception {
+
+        // Null entries are skipped downstream by extractAllowedModifyPaths; the restriction filter
+        // runs first and must not trip over them.
+        AccessConfig accessConfig = new AccessConfig(null, Arrays.asList(
+                null, new ContextPath(null, false), new ContextPath(CLAIM_PATH, false)));
+
+        ActionExecutionRequest request = buildWithNonModifiablePaths(
+                accessConfig, FlowExtensionConstants.ContextTree.FLOW_REGISTRATION, USER_ID_CLAIM_PATH);
+
+        AllowedOperation replaceOp = replaceOperation(request);
+        assertNotNull(replaceOp);
+        assertEquals(replaceOp.getPaths(), Collections.singletonList(CLAIM_PATH));
+    }
+
+    @Test
+    public void testUsernameModifyPathNotAdvertisedForNonSelfRegistrationFlow() throws Exception {
+
+        AccessConfig accessConfig = new AccessConfig(null, Arrays.asList(
+                new ContextPath(USERNAME_PATH, false), new ContextPath(CLAIM_PATH, false)));
+
+        ActionExecutionRequest request = buildWithNonModifiablePaths(accessConfig, "PASSWORD_RECOVERY");
+
+        AllowedOperation replaceOp = replaceOperation(request);
+        assertNotNull(replaceOp);
+        assertFalse(replaceOp.getPaths().contains(USERNAME_PATH),
+                "Username must not be advertised as modifiable outside self registration.");
+        assertTrue(replaceOp.getPaths().contains(CLAIM_PATH));
+    }
+
+    @Test
+    public void testUsernameModifyPathAdvertisedForSelfRegistrationFlow() throws Exception {
+
+        AccessConfig accessConfig = new AccessConfig(null, Collections.singletonList(
+                new ContextPath(USERNAME_PATH, false)));
+
+        ActionExecutionRequest request = buildWithNonModifiablePaths(
+                accessConfig, FlowExtensionConstants.ContextTree.FLOW_REGISTRATION);
+
+        AllowedOperation replaceOp = replaceOperation(request);
+        assertNotNull(replaceOp);
+        assertTrue(replaceOp.getPaths().contains(USERNAME_PATH));
     }
 
     @Test(expectedExceptions = ActionExecutionRequestBuilderException.class)

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilderTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionRequestBuilderTest.java
@@ -64,6 +64,7 @@ public class FlowExtensionRequestBuilderTest {
     private static final String TENANT = "carbon.super";
     private static final String CLAIM_PATH = "/user/claims[uri=http://wso2.org/claims/givenname]";
     private static final String CREDENTIAL_PATH = "/user/credentials/password";
+    private static final String USERNAME_PATH = "/user/username";
 
     // A self-signed RSA X.509 certificate (base64-encoded DER, CN=flow-ext-test), valid until 2300.
     // Used only to exercise the outbound credential encryption path.
@@ -102,11 +103,16 @@ public class FlowExtensionRequestBuilderTest {
 
     private FlowExecutionContext execContext() {
 
+        return execContext(FlowExtensionConstants.ContextTree.FLOW_REGISTRATION);
+    }
+
+    private FlowExecutionContext execContext(String flowType) {
+
         FlowExecutionContext execCtx = new FlowExecutionContext();
         execCtx.setContextIdentifier("ctx-1");
         execCtx.setTenantDomain(TENANT);
         execCtx.setApplicationId("app-1");
-        execCtx.setFlowType("REGISTRATION");
+        execCtx.setFlowType(flowType);
         execCtx.setPortalUrl("https://portal");
 
         FlowUser user = new FlowUser();
@@ -288,6 +294,65 @@ public class FlowExtensionRequestBuilderTest {
 
         FlowExtensionEvent event = (FlowExtensionEvent) request.getEvent();
         assertNull(event.getFlow().getUser());
+    }
+
+    // ------------------------------------------------------------------ flow-specific expose policy
+
+    @Test
+    public void testUsernameExposedForSelfRegistrationFlow() throws Exception {
+
+        AccessConfig accessConfig = new AccessConfig(
+                Arrays.asList(new ContextPath("/user/id", false), new ContextPath(USERNAME_PATH, false)), null);
+
+        ActionExecutionRequest request = builder.buildActionExecutionRequest(
+                flowContextWith(execContext(FlowExtensionConstants.ContextTree.FLOW_REGISTRATION)),
+                actionContext(accessConfig));
+
+        FlowExtensionUser user = (FlowExtensionUser) ((FlowExtensionEvent) request.getEvent()).getFlow().getUser();
+        assertNotNull(user);
+        assertEquals(user.getUsername(), "alice");
+    }
+
+    @Test
+    public void testUsernameExposeDroppedForNonSelfRegistrationFlow() throws Exception {
+
+        // '/user/username' is only exposable during self registration; on any other flow type the
+        // path is silently dropped while the rest of the expose configuration is honoured.
+        AccessConfig accessConfig = new AccessConfig(
+                Arrays.asList(new ContextPath("/user/id", false), new ContextPath(USERNAME_PATH, false)), null);
+
+        ActionExecutionRequest request = builder.buildActionExecutionRequest(
+                flowContextWith(execContext("PASSWORD_RECOVERY")), actionContext(accessConfig));
+
+        FlowExtensionUser user = (FlowExtensionUser) ((FlowExtensionEvent) request.getEvent()).getFlow().getUser();
+        assertNotNull(user, "Remaining expose paths must still produce a user.");
+        assertEquals(user.getId(), "uid");
+        assertNull(user.getUsername(), "Username must not be exposed outside self registration.");
+    }
+
+    @Test
+    public void testExposeUntouchedWhenUsernameNotExposed() throws Exception {
+
+        // Nothing to drop: the policy must leave a username-free expose list alone.
+        AccessConfig accessConfig = new AccessConfig(
+                Collections.singletonList(new ContextPath("/user/id", false)), null);
+
+        ActionExecutionRequest request = builder.buildActionExecutionRequest(
+                flowContextWith(execContext("PASSWORD_RECOVERY")), actionContext(accessConfig));
+
+        FlowExtensionUser user = (FlowExtensionUser) ((FlowExtensionEvent) request.getEvent()).getFlow().getUser();
+        assertNotNull(user);
+        assertEquals(user.getId(), "uid");
+    }
+
+    @Test
+    public void testEmptyExposeToleratedOnNonSelfRegistrationFlow() throws Exception {
+
+        ActionExecutionRequest request = builder.buildActionExecutionRequest(
+                flowContextWith(execContext("PASSWORD_RECOVERY")),
+                actionContext(new AccessConfig(null, null)));
+
+        assertNull(((FlowExtensionEvent) request.getEvent()).getFlow().getUser());
     }
 
     @Test(expectedExceptions = ActionExecutionRequestBuilderException.class)

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessorTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessorTest.java
@@ -39,7 +39,6 @@ import org.wso2.carbon.identity.action.execution.api.model.PerformableOperation;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants;
 import org.wso2.carbon.identity.flow.extension.internal.FlowExtensionDataHolder;
@@ -61,7 +60,6 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS_PROPERTY;
 
 /**
  * Unit tests for {@link FlowExtensionResponseProcessor}: REPLACE operation handling for user
@@ -101,14 +99,8 @@ public class FlowExtensionResponseProcessorTest {
 
     private FlowContext actionFlowContext() {
 
-        return actionFlowContext(null);
-    }
-
-    private FlowContext actionFlowContext(String flowType) {
-
         FlowExecutionContext execCtx = new FlowExecutionContext();
         execCtx.setTenantDomain(TENANT);
-        execCtx.setFlowType(flowType);
         return FlowContext.create().add(FlowExtensionConstants.FLOW_EXECUTION_CONTEXT_KEY, execCtx);
     }
 
@@ -315,105 +307,6 @@ public class FlowExtensionResponseProcessorTest {
 
         processor.processSuccessResponse(FlowContext.create(),
                 successContext(Collections.emptyList()));
-    }
-
-    // ------------------------------------------------------------------ non-modifiable path gate
-
-    @Test
-    public void testReplaceOnNonModifiablePathIsDropped() throws Exception {
-
-        // The claim service is deliberately left unstubbed: a non-modifiable path must be rejected
-        // before the operation reaches the claim handler.
-        String claimPath = "/user/claims[uri=" + GIVEN_NAME_CLAIM + "]";
-        FlowContext actionFlowContext = actionFlowContext();
-        List<PerformableOperation> ops = Collections.singletonList(replace(claimPath, "John"));
-
-        ActionExecutionStatus<?> status;
-        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
-            identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS_PROPERTY))
-                    .thenReturn(Collections.singletonList(claimPath));
-
-            status = processor.processSuccessResponse(actionFlowContext, successContext(ops));
-        }
-
-        assertEquals(status.getStatus(), ActionExecutionStatus.Status.SUCCESS);
-        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CLAIMS_KEY));
-    }
-
-    @Test
-    public void testReplaceOnPathOutsideNonModifiableListIsApplied() throws Exception {
-
-        when(claimService.getLocalClaim(eq(GIVEN_NAME_CLAIM), eq(TENANT)))
-                .thenReturn(Optional.of(new LocalClaim(GIVEN_NAME_CLAIM)));
-
-        String claimPath = "/user/claims[uri=" + GIVEN_NAME_CLAIM + "]";
-        FlowContext actionFlowContext = actionFlowContext();
-        List<PerformableOperation> ops = Collections.singletonList(replace(claimPath, "John"));
-
-        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
-            identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS_PROPERTY))
-                    .thenReturn(Collections.singletonList("/user/claims[uri=http://wso2.org/claims/userid]"));
-
-            processor.processSuccessResponse(actionFlowContext, successContext(ops));
-        }
-
-        Map<?, ?> pending = (Map<?, ?>) actionFlowContext.getContextData()
-                .get(FlowExtensionConstants.PENDING_CLAIMS_KEY);
-        assertNotNull(pending);
-        assertEquals(pending.get(GIVEN_NAME_CLAIM), "John");
-    }
-
-    // ------------------------------------------------------------------ username modification gate
-
-    // A REPLACE on '/user/username' never reaches a handler: outside self registration it is ignored
-    // by the flow-type gate, and inside it, it falls through to the unknown-path branch. Neither
-    // records a pending update, so these cases assert the gate is inert on observable state and that
-    // a misbehaving extension cannot abort the flow through either branch.
-
-    @Test
-    public void testUsernameReplaceIgnoredForNonSelfRegistrationFlow() throws Exception {
-
-        FlowContext actionFlowContext = actionFlowContext("PASSWORD_RECOVERY");
-        List<PerformableOperation> ops = Collections.singletonList(replace("/user/username", "bob"));
-
-        ActionExecutionStatus<?> status = processor.processSuccessResponse(actionFlowContext, successContext(ops));
-
-        assertEquals(status.getStatus(), ActionExecutionStatus.Status.SUCCESS);
-        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CLAIMS_KEY));
-        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CREDENTIALS_KEY));
-    }
-
-    @Test
-    public void testUsernameReplaceNotGatedOnSelfRegistrationFlow() throws Exception {
-
-        FlowContext actionFlowContext =
-                actionFlowContext(FlowExtensionConstants.ContextTree.FLOW_REGISTRATION);
-        List<PerformableOperation> ops = Collections.singletonList(replace("/user/username", "bob"));
-
-        ActionExecutionStatus<?> status = processor.processSuccessResponse(actionFlowContext, successContext(ops));
-
-        assertEquals(status.getStatus(), ActionExecutionStatus.Status.SUCCESS);
-        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CLAIMS_KEY));
-        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CREDENTIALS_KEY));
-    }
-
-    @Test
-    public void testClaimReplaceStillAppliedOnNonSelfRegistrationFlow() throws Exception {
-
-        // The gate is scoped to '/user/username'; other modifiable paths are unaffected by flow type.
-        when(claimService.getLocalClaim(eq(GIVEN_NAME_CLAIM), eq(TENANT)))
-                .thenReturn(Optional.of(new LocalClaim(GIVEN_NAME_CLAIM)));
-
-        FlowContext actionFlowContext = actionFlowContext("PASSWORD_RECOVERY");
-        List<PerformableOperation> ops = Collections.singletonList(
-                replace("/user/claims[uri=" + GIVEN_NAME_CLAIM + "]", "John"));
-
-        processor.processSuccessResponse(actionFlowContext, successContext(ops));
-
-        Map<?, ?> pending = (Map<?, ?>) actionFlowContext.getContextData()
-                .get(FlowExtensionConstants.PENDING_CLAIMS_KEY);
-        assertNotNull(pending);
-        assertEquals(pending.get(GIVEN_NAME_CLAIM), "John");
     }
 
     // ------------------------------------------------------------------ inbound JWE decryption contract

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessorTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/executor/FlowExtensionResponseProcessorTest.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.identity.action.execution.api.model.PerformableOperation;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.extension.FlowExtensionConstants;
 import org.wso2.carbon.identity.flow.extension.internal.FlowExtensionDataHolder;
@@ -60,6 +61,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS_PROPERTY;
 
 /**
  * Unit tests for {@link FlowExtensionResponseProcessor}: REPLACE operation handling for user
@@ -99,8 +101,14 @@ public class FlowExtensionResponseProcessorTest {
 
     private FlowContext actionFlowContext() {
 
+        return actionFlowContext(null);
+    }
+
+    private FlowContext actionFlowContext(String flowType) {
+
         FlowExecutionContext execCtx = new FlowExecutionContext();
         execCtx.setTenantDomain(TENANT);
+        execCtx.setFlowType(flowType);
         return FlowContext.create().add(FlowExtensionConstants.FLOW_EXECUTION_CONTEXT_KEY, execCtx);
     }
 
@@ -307,6 +315,105 @@ public class FlowExtensionResponseProcessorTest {
 
         processor.processSuccessResponse(FlowContext.create(),
                 successContext(Collections.emptyList()));
+    }
+
+    // ------------------------------------------------------------------ non-modifiable path gate
+
+    @Test
+    public void testReplaceOnNonModifiablePathIsDropped() throws Exception {
+
+        // The claim service is deliberately left unstubbed: a non-modifiable path must be rejected
+        // before the operation reaches the claim handler.
+        String claimPath = "/user/claims[uri=" + GIVEN_NAME_CLAIM + "]";
+        FlowContext actionFlowContext = actionFlowContext();
+        List<PerformableOperation> ops = Collections.singletonList(replace(claimPath, "John"));
+
+        ActionExecutionStatus<?> status;
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS_PROPERTY))
+                    .thenReturn(Collections.singletonList(claimPath));
+
+            status = processor.processSuccessResponse(actionFlowContext, successContext(ops));
+        }
+
+        assertEquals(status.getStatus(), ActionExecutionStatus.Status.SUCCESS);
+        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CLAIMS_KEY));
+    }
+
+    @Test
+    public void testReplaceOnPathOutsideNonModifiableListIsApplied() throws Exception {
+
+        when(claimService.getLocalClaim(eq(GIVEN_NAME_CLAIM), eq(TENANT)))
+                .thenReturn(Optional.of(new LocalClaim(GIVEN_NAME_CLAIM)));
+
+        String claimPath = "/user/claims[uri=" + GIVEN_NAME_CLAIM + "]";
+        FlowContext actionFlowContext = actionFlowContext();
+        List<PerformableOperation> ops = Collections.singletonList(replace(claimPath, "John"));
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS_PROPERTY))
+                    .thenReturn(Collections.singletonList("/user/claims[uri=http://wso2.org/claims/userid]"));
+
+            processor.processSuccessResponse(actionFlowContext, successContext(ops));
+        }
+
+        Map<?, ?> pending = (Map<?, ?>) actionFlowContext.getContextData()
+                .get(FlowExtensionConstants.PENDING_CLAIMS_KEY);
+        assertNotNull(pending);
+        assertEquals(pending.get(GIVEN_NAME_CLAIM), "John");
+    }
+
+    // ------------------------------------------------------------------ username modification gate
+
+    // A REPLACE on '/user/username' never reaches a handler: outside self registration it is ignored
+    // by the flow-type gate, and inside it, it falls through to the unknown-path branch. Neither
+    // records a pending update, so these cases assert the gate is inert on observable state and that
+    // a misbehaving extension cannot abort the flow through either branch.
+
+    @Test
+    public void testUsernameReplaceIgnoredForNonSelfRegistrationFlow() throws Exception {
+
+        FlowContext actionFlowContext = actionFlowContext("PASSWORD_RECOVERY");
+        List<PerformableOperation> ops = Collections.singletonList(replace("/user/username", "bob"));
+
+        ActionExecutionStatus<?> status = processor.processSuccessResponse(actionFlowContext, successContext(ops));
+
+        assertEquals(status.getStatus(), ActionExecutionStatus.Status.SUCCESS);
+        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CLAIMS_KEY));
+        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CREDENTIALS_KEY));
+    }
+
+    @Test
+    public void testUsernameReplaceNotGatedOnSelfRegistrationFlow() throws Exception {
+
+        FlowContext actionFlowContext =
+                actionFlowContext(FlowExtensionConstants.ContextTree.FLOW_REGISTRATION);
+        List<PerformableOperation> ops = Collections.singletonList(replace("/user/username", "bob"));
+
+        ActionExecutionStatus<?> status = processor.processSuccessResponse(actionFlowContext, successContext(ops));
+
+        assertEquals(status.getStatus(), ActionExecutionStatus.Status.SUCCESS);
+        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CLAIMS_KEY));
+        assertNull(actionFlowContext.getContextData().get(FlowExtensionConstants.PENDING_CREDENTIALS_KEY));
+    }
+
+    @Test
+    public void testClaimReplaceStillAppliedOnNonSelfRegistrationFlow() throws Exception {
+
+        // The gate is scoped to '/user/username'; other modifiable paths are unaffected by flow type.
+        when(claimService.getLocalClaim(eq(GIVEN_NAME_CLAIM), eq(TENANT)))
+                .thenReturn(Optional.of(new LocalClaim(GIVEN_NAME_CLAIM)));
+
+        FlowContext actionFlowContext = actionFlowContext("PASSWORD_RECOVERY");
+        List<PerformableOperation> ops = Collections.singletonList(
+                replace("/user/claims[uri=" + GIVEN_NAME_CLAIM + "]", "John"));
+
+        processor.processSuccessResponse(actionFlowContext, successContext(ops));
+
+        Map<?, ?> pending = (Map<?, ?>) actionFlowContext.getContextData()
+                .get(FlowExtensionConstants.PENDING_CLAIMS_KEY);
+        assertNotNull(pending);
+        assertEquals(pending.get(GIVEN_NAME_CLAIM), "John");
     }
 
     // ------------------------------------------------------------------ inbound JWE decryption contract

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolverTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolverTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.management;
+
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverClientException;
+import org.wso2.carbon.identity.action.management.api.model.Action;
+import org.wso2.carbon.identity.action.management.api.model.ActionDTO;
+import org.wso2.carbon.identity.action.management.api.model.ActionProperty;
+import org.wso2.carbon.identity.certificate.management.service.CertificateManagementService;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.flow.extension.model.ContextPath;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.ACCESS_CONFIG_MODIFY;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS_PROPERTY;
+
+/**
+ * Unit tests for {@link FlowExtensionActionDTOModelResolver}: enforcement of the server-configured
+ * non-modifiable context paths on the add and update paths of the modify access config.
+ */
+public class FlowExtensionActionDTOModelResolverTest {
+
+    private static final String TENANT = "carbon.super";
+    private static final String USER_ID_PATH = "/user/claims[uri=http://wso2.org/claims/userid]";
+    private static final String GIVEN_NAME_PATH = "/user/claims[uri=http://wso2.org/claims/givenname]";
+
+    private FlowExtensionActionDTOModelResolver resolver;
+    private MockedStatic<IdentityUtil> identityUtil;
+
+    @BeforeMethod
+    public void setUp() {
+
+        resolver = new FlowExtensionActionDTOModelResolver(mock(CertificateManagementService.class));
+        // The non-modifiable path list is read from identity.xml, which is unavailable in a plain
+        // unit test; stub the lookup so each test can declare its own server configuration.
+        identityUtil = mockStatic(IdentityUtil.class);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        identityUtil.close();
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private void withNonModifiablePaths(String... paths) {
+
+        identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS_PROPERTY))
+                .thenReturn(Arrays.asList(paths));
+    }
+
+    private ActionDTO actionDTO(List<ContextPath> modify) {
+
+        Map<String, ActionProperty> properties = new HashMap<>();
+        if (modify != null) {
+            properties.put(ACCESS_CONFIG_MODIFY, new ActionProperty.BuilderForService(modify).build());
+        }
+        return new ActionDTO.Builder(new Action.ActionResponseBuilder().name("ext").build())
+                .properties(properties)
+                .build();
+    }
+
+    private ActionDTO emptyActionDTO() {
+
+        return actionDTO(null);
+    }
+
+    // ------------------------------------------------------------------ add
+
+    @Test(expectedExceptions = ActionDTOModelResolverClientException.class)
+    public void testAddRejectsNonModifiablePath() throws Exception {
+
+        withNonModifiablePaths(USER_ID_PATH);
+
+        resolver.resolveForAddOperation(
+                actionDTO(Collections.singletonList(new ContextPath(USER_ID_PATH, false))), TENANT);
+    }
+
+    @Test(expectedExceptions = ActionDTOModelResolverClientException.class)
+    public void testAddRejectsNonModifiablePathAmongAllowedOnes() throws Exception {
+
+        withNonModifiablePaths(USER_ID_PATH);
+
+        resolver.resolveForAddOperation(
+                actionDTO(Arrays.asList(new ContextPath(GIVEN_NAME_PATH, false),
+                        new ContextPath(USER_ID_PATH, true))), TENANT);
+    }
+
+    @Test
+    public void testAddAcceptsPathOutsideTheNonModifiableList() throws Exception {
+
+        withNonModifiablePaths(USER_ID_PATH);
+
+        ActionDTO resolved = resolver.resolveForAddOperation(
+                actionDTO(Collections.singletonList(new ContextPath(GIVEN_NAME_PATH, false))), TENANT);
+
+        assertNotNull(resolved.getPropertyValue(ACCESS_CONFIG_MODIFY));
+    }
+
+    @Test
+    public void testAddAcceptsAnyPathWhenNoRestrictionConfigured() throws Exception {
+
+        withNonModifiablePaths();
+
+        ActionDTO resolved = resolver.resolveForAddOperation(
+                actionDTO(Collections.singletonList(new ContextPath(USER_ID_PATH, false))), TENANT);
+
+        assertNotNull(resolved.getPropertyValue(ACCESS_CONFIG_MODIFY));
+    }
+
+    @Test
+    public void testAddWithoutModifyConfigSkipsValidation() throws Exception {
+
+        withNonModifiablePaths(USER_ID_PATH);
+
+        ActionDTO resolved = resolver.resolveForAddOperation(emptyActionDTO(), TENANT);
+
+        assertNull(resolved.getPropertyValue(ACCESS_CONFIG_MODIFY));
+    }
+
+    // ------------------------------------------------------------------ update
+
+    @Test(expectedExceptions = ActionDTOModelResolverClientException.class)
+    public void testUpdateRejectsNonModifiablePath() throws Exception {
+
+        withNonModifiablePaths(USER_ID_PATH);
+
+        resolver.resolveForUpdateOperation(
+                actionDTO(Collections.singletonList(new ContextPath(USER_ID_PATH, false))),
+                emptyActionDTO(), TENANT);
+    }
+
+    @Test
+    public void testUpdateAcceptsPathOutsideTheNonModifiableList() throws Exception {
+
+        withNonModifiablePaths(USER_ID_PATH);
+
+        ActionDTO resolved = resolver.resolveForUpdateOperation(
+                actionDTO(Collections.singletonList(new ContextPath(GIVEN_NAME_PATH, false))),
+                emptyActionDTO(), TENANT);
+
+        assertNotNull(resolved.getPropertyValue(ACCESS_CONFIG_MODIFY));
+    }
+
+    @Test
+    public void testUpdateCarriesForwardExistingModifyWithoutRevalidation() throws Exception {
+
+        // Untouched modify config is re-sent as-is (the DAO treats updates as PUT), so a value
+        // already persisted before the restriction was configured must not fail the update.
+        withNonModifiablePaths(USER_ID_PATH);
+
+        ActionDTO resolved = resolver.resolveForUpdateOperation(
+                emptyActionDTO(),
+                actionDTO(Collections.singletonList(new ContextPath(USER_ID_PATH, false))),
+                TENANT);
+
+        assertNotNull(resolved.getPropertyValue(ACCESS_CONFIG_MODIFY));
+    }
+
+    @Test
+    public void testUpdateWithNoModifyConfigOnEitherSideSkipsValidation() throws Exception {
+
+        withNonModifiablePaths(USER_ID_PATH);
+
+        ActionDTO resolved = resolver.resolveForUpdateOperation(emptyActionDTO(), emptyActionDTO(), TENANT);
+
+        assertNull(resolved.getPropertyValue(ACCESS_CONFIG_MODIFY));
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolverTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolverTest.java
@@ -116,6 +116,17 @@ public class FlowExtensionActionDTOModelResolverTest {
                         new ContextPath(USER_ID_PATH, true))), TENANT);
     }
 
+    @Test(expectedExceptions = ActionDTOModelResolverClientException.class)
+    public void testAddRejectsNonModifiablePathCarryingTypeAnnotation() throws Exception {
+
+        // The path type annotation is stripped before the path is advertised as modifiable, so it
+        // must not be usable to slip a restricted path past validation.
+        withNonModifiablePaths(USER_ID_PATH);
+
+        resolver.resolveForAddOperation(
+                actionDTO(Collections.singletonList(new ContextPath(USER_ID_PATH + "{[string]}", false))), TENANT);
+    }
+
     @Test
     public void testAddAcceptsPathOutsideTheNonModifiableList() throws Exception {
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolverTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/management/FlowExtensionActionDTOModelResolverTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.ACCESS_CONFIG_MODIFY;
-import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS_PROPERTY;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS;
 
 /**
  * Unit tests for {@link FlowExtensionActionDTOModelResolver}: enforcement of the server-configured
@@ -75,7 +75,7 @@ public class FlowExtensionActionDTOModelResolverTest {
 
     private void withNonModifiablePaths(String... paths) {
 
-        identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS_PROPERTY))
+        identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS))
                 .thenReturn(Arrays.asList(paths));
     }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/util/FlowExtensionUtilTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/util/FlowExtensionUtilTest.java
@@ -32,7 +32,7 @@ import java.util.Collections;
 import static org.mockito.Mockito.mockStatic;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
-import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS_PROPERTY;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS;
 
 /**
  * Unit tests for the non-modifiable context path helpers in {@link FlowExtensionUtil}, shared by
@@ -62,7 +62,7 @@ public class FlowExtensionUtilTest {
 
     private void withNonModifiablePaths(String... paths) {
 
-        identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS_PROPERTY))
+        identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS))
                 .thenReturn(Arrays.asList(paths));
     }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/util/FlowExtensionUtilTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/util/FlowExtensionUtilTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.extension.util;
+
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.management.api.exception.ActionDTOModelResolverClientException;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.flow.extension.model.ContextPath;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.mockito.Mockito.mockStatic;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.flow.extension.FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS_PROPERTY;
+
+/**
+ * Unit tests for the non-modifiable context path helpers in {@link FlowExtensionUtil}, shared by
+ * the management layer ({@link FlowExtensionUtil#validateModifyPaths}) and the runtime response
+ * processor ({@link FlowExtensionUtil#isNonModifiablePath}).
+ */
+public class FlowExtensionUtilTest {
+
+    private static final String USER_ID_PATH = "/user/claims[uri=http://wso2.org/claims/userid]";
+    private static final String GIVEN_NAME_PATH = "/user/claims[uri=http://wso2.org/claims/givenname]";
+
+    private MockedStatic<IdentityUtil> identityUtil;
+
+    @BeforeMethod
+    public void setUp() {
+
+        // The non-modifiable path list is read from identity.xml, which is unavailable in a plain
+        // unit test; stub the lookup so each test can declare its own server configuration.
+        identityUtil = mockStatic(IdentityUtil.class);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        identityUtil.close();
+    }
+
+    private void withNonModifiablePaths(String... paths) {
+
+        identityUtil.when(() -> IdentityUtil.getPropertyAsList(NON_MODIFIABLE_PATHS_PROPERTY))
+                .thenReturn(Arrays.asList(paths));
+    }
+
+    // ------------------------------------------------------------------ validateModifyPaths
+
+    @Test(expectedExceptions = ActionDTOModelResolverClientException.class)
+    public void testValidateRejectsConfiguredPath() throws Exception {
+
+        withNonModifiablePaths(USER_ID_PATH);
+
+        FlowExtensionUtil.validateModifyPaths(
+                Collections.singletonList(new ContextPath(USER_ID_PATH, false)));
+    }
+
+    @Test
+    public void testValidateAcceptsUnlistedPath() throws Exception {
+
+        withNonModifiablePaths(USER_ID_PATH);
+
+        FlowExtensionUtil.validateModifyPaths(
+                Collections.singletonList(new ContextPath(GIVEN_NAME_PATH, false)));
+    }
+
+    @Test
+    public void testValidateSkippedWhenNoPathsConfigured() throws Exception {
+
+        withNonModifiablePaths();
+
+        FlowExtensionUtil.validateModifyPaths(
+                Collections.singletonList(new ContextPath(USER_ID_PATH, false)));
+    }
+
+    @Test
+    public void testValidateAcceptsEmptyModifyList() throws Exception {
+
+        withNonModifiablePaths(USER_ID_PATH);
+
+        FlowExtensionUtil.validateModifyPaths(Collections.emptyList());
+    }
+
+    // ------------------------------------------------------------------ isNonModifiablePath
+
+    @Test
+    public void testIsNonModifiablePathMatchesConfiguredPath() {
+
+        withNonModifiablePaths(USER_ID_PATH, GIVEN_NAME_PATH);
+
+        assertTrue(FlowExtensionUtil.isNonModifiablePath(USER_ID_PATH));
+        assertTrue(FlowExtensionUtil.isNonModifiablePath(GIVEN_NAME_PATH));
+    }
+
+    @Test
+    public void testIsNonModifiablePathRejectsUnlistedPath() {
+
+        withNonModifiablePaths(USER_ID_PATH);
+
+        assertFalse(FlowExtensionUtil.isNonModifiablePath(GIVEN_NAME_PATH));
+    }
+
+    @Test
+    public void testIsNonModifiablePathWhenNothingConfigured() {
+
+        withNonModifiablePaths();
+
+        assertFalse(FlowExtensionUtil.isNonModifiablePath(USER_ID_PATH));
+    }
+
+    @Test
+    public void testIsNonModifiablePathIsExactMatch() {
+
+        // Matching is exact: a prefix of a configured path must not be treated as non-modifiable.
+        withNonModifiablePaths(USER_ID_PATH);
+
+        assertFalse(FlowExtensionUtil.isNonModifiablePath("/user/claims"));
+        assertFalse(FlowExtensionUtil.isNonModifiablePath(USER_ID_PATH + "{[string]}"));
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/util/FlowExtensionUtilTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/java/org/wso2/carbon/identity/flow/extension/util/FlowExtensionUtilTest.java
@@ -77,6 +77,17 @@ public class FlowExtensionUtilTest {
                 Collections.singletonList(new ContextPath(USER_ID_PATH, false)));
     }
 
+    @Test(expectedExceptions = ActionDTOModelResolverClientException.class)
+    public void testValidateRejectsConfiguredPathCarryingTypeAnnotation() throws Exception {
+
+        // Modify paths may carry a path type annotation (stripped later by the request builder),
+        // but restrictions are configured against clean paths — the annotation must not defeat them.
+        withNonModifiablePaths(USER_ID_PATH);
+
+        FlowExtensionUtil.validateModifyPaths(
+                Collections.singletonList(new ContextPath(USER_ID_PATH + "{[string]}", false)));
+    }
+
     @Test
     public void testValidateAcceptsUnlistedPath() throws Exception {
 
@@ -93,6 +104,24 @@ public class FlowExtensionUtilTest {
 
         FlowExtensionUtil.validateModifyPaths(
                 Collections.singletonList(new ContextPath(USER_ID_PATH, false)));
+    }
+
+    @Test
+    public void testValidateAcceptsAnnotatedUnlistedPath() throws Exception {
+
+        withNonModifiablePaths(USER_ID_PATH);
+
+        FlowExtensionUtil.validateModifyPaths(
+                Collections.singletonList(new ContextPath(GIVEN_NAME_PATH + "{[string]}", false)));
+    }
+
+    @Test
+    public void testValidateToleratesNullEntries() throws Exception {
+
+        withNonModifiablePaths(USER_ID_PATH);
+
+        FlowExtensionUtil.validateModifyPaths(
+                Arrays.asList(null, new ContextPath(null, false), new ContextPath(GIVEN_NAME_PATH, false)));
     }
 
     @Test

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/resources/testng.xml
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.extension/src/test/resources/testng.xml
@@ -25,6 +25,7 @@
             <class name="org.wso2.carbon.identity.flow.extension.executor.FlowExtensionResponseProcessorTest"/>
             <class name="org.wso2.carbon.identity.flow.extension.executor.JWEEncryptionUtilTest"/>
             <class name="org.wso2.carbon.identity.flow.extension.executor.PathTypeAnnotationUtilTest"/>
+            <class name="org.wso2.carbon.identity.flow.extension.management.FlowExtensionActionDTOModelResolverTest"/>
             <class name="org.wso2.carbon.identity.flow.extension.metadata.FlowExtensionContextTreeBuilderTest"/>
             <class name="org.wso2.carbon.identity.flow.extension.model.AccessConfigTest"/>
             <class name="org.wso2.carbon.identity.flow.extension.model.ContextPathTest"/>
@@ -33,6 +34,7 @@
             <class name="org.wso2.carbon.identity.flow.extension.model.FlowExtensionFlowTest"/>
             <class name="org.wso2.carbon.identity.flow.extension.model.FlowExtensionUserTest"/>
             <class name="org.wso2.carbon.identity.flow.extension.model.OperationExecutionResultTest"/>
+            <class name="org.wso2.carbon.identity.flow.extension.util.FlowExtensionUtilTest"/>
         </classes>
     </test>
 </suite>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2554,6 +2554,11 @@
                <Version>
                    <Latest>{{actions.types.flow_extension.version.latest}}</Latest>
                </Version>
+               <NonModifiablePaths>
+                   {% for path in actions.types.flow_extension.non_modifiable_paths %}
+                   <Path>{{path}}</Path>
+                   {% endfor %}
+               </NonModifiablePaths>
             </FlowExtension>
         </Types>
     </Actions>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -2316,6 +2316,9 @@
   "actions.types.pre_update_password.version.latest": "v2",
   "actions.types.flow_extension.enable": true,
   "actions.types.flow_extension.version.latest": "v1",
+  "actions.types.flow_extension.non_modifiable_paths": [
+  "/user/claims[uri=http://wso2.org/claims/userid]",
+  "/user/claims[uri=http://wso2.org/claims/created]"],
 
   "external_api_client.http_client.connection_timeout": "2000",
   "external_api_client.http_client.read_timeout": "3000",


### PR DESCRIPTION
## Purpose

Flow extension actions could read and write the user's username on any flow, and an action's access config could declare any context path as modifiable. This change scopes username access to self registration flows and lets the server declare context paths that can never be marked modifiable.

## Related Issue

- https://github.com/wso2/product-is/issues/28330

## Implementation

**Flow-type scoping for `/user/username`**

- `FlowExtensionRequestBuilder.applyFlowSpecificAccessPolicy()` drops `/user/username` from the resolved expose paths when the flow type is not `REGISTRATION`, so the outbound payload omits the username. The rest of the expose config is honoured unchanged.
- `FlowExtensionResponseProcessor.processOperation()` now receives the flow type and ignores a `REPLACE` on `/user/username` outside `REGISTRATION`, recording the skip in the operation results instead of applying it.

**Configurable non-modifiable paths**

- `FlowExtensionConstants.ActionManagement.NON_MODIFIABLE_PATHS_PROPERTY` maps to the new `Actions.Types.FlowExtension.NonModifiablePaths.Path` property.
- `FlowExtensionActionDTOModelResolver.validateModifyPaths()` rejects any modify path present in that list with an `ActionDTOModelResolverClientException`, on both the add and update resolution paths. An empty list disables the check, and modify config carried forward from an existing action is not revalidated.
- `identity.xml.j2` and `org.wso2.carbon.identity.core.server.feature.default.json` expose `actions.types.flow_extension.non_modifiable_paths`, defaulting to the `userid` claim path.

**Tests**

17 tests added in `org.wso2.carbon.identity.flow.extension`:

- `FlowExtensionRequestBuilderTest` — username exposed on `REGISTRATION` and dropped on other flow types while sibling paths survive; empty and username-free expose lists left untouched.
- `FlowExtensionResponseProcessorTest` — the username gate on both flow-type branches, and other modifiable paths staying unaffected by flow type.
- `FlowExtensionActionDTOModelResolverTest` (new) — non-modifiable path rejection on add and update, acceptance of unlisted paths, empty restriction list, absent modify config, and carry-forward of existing config.

Every line introduced by this PR is covered by the new tests. The module suite passes at 87 tests.
