### PR TITLE
Fix Resident IdP edit page crash for users without admin/manage permission

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-local.jsp
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/resources/web/idpmgt/idp-mgt-edit-local.jsp
@@ -76,6 +76,9 @@
     } catch (ClassNotFoundException e) {
         // Fix APIMANAGER-5713 - issue due to removing jars of admin service
         // Intentionally skipping handling the exception for class not found for admin service.
+    } catch (java.rmi.RemoteException e) {
+        // AxisFault thrown when the caller lacks /permission/admin/manage for getConnectorList.
+        // Intentionally skipping - catMap remains empty and the Governance Connectors section is not rendered.
     }
 
     String homeRealmId = residentIdentityProvider.getHomeRealmId();


### PR DESCRIPTION
## Summary
- In APIM, a logged-in user who can view Identity Providers but lacks the broader `/permission/admin/manage` permission gets an `AxisFault` from `IdentityGovernanceAdminService#getConnectorList` when opening the Resident IdP edit page.
- That fault was previously uncaught, crashing the whole page (Tiles `IOException while including page`).
- Catches it the same way the adjacent `ClassNotFoundException` case already is, leaving the Governance Connectors section empty instead of breaking the page.

Resolves https://github.com/wso2/api-manager/issues/5147

## Test plan
- [x] Manually reproduced against a patched pack: logged in as a user with only `Login` + `idpmgt/view` permissions, confirmed the page crashed pre-fix and rendered cleanly post-fix (server log shows the expected `Access Denied` line for `getConnectorList`, no `JSPException`/`IOException` afterward).