### PR TITLE
Add tenant domain validation for claim access in adaptive scripts

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsClaimsUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsClaimsUtil.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+/**
+ * Utility methods for validating the tenant domain of the authenticated user when claims are accessed
+ * from adaptive authentication scripts. Shared across the Nashorn and OpenJDK Nashorn claim implementations
+ * to avoid duplicating the tenant validation logic in each engine specific class.
+ */
+public class JsClaimsUtil {
+
+    private static final Log LOG = LogFactory.getLog(JsClaimsUtil.class);
+    private static final String SAAS_ENABLE_CROSS_TENANT_OPERATIONS = "SaaS.EnableCrossTenantOperations";
+
+    private JsClaimsUtil() {
+
+    }
+
+    /**
+     * Validate whether the authenticated user belongs to the tenant domain of the current authentication flow.
+     * Cross-tenant claim access is only permitted for SaaS applications when it is explicitly enabled via the
+     * {@code SaaS.EnableCrossTenantOperations} configuration.
+     *
+     * @param authenticatedUser Authenticated user whose claims are being accessed.
+     * @param context           Authentication context of the current flow.
+     * @return {@code true} if the authenticated user belongs to the current tenant (or cross-tenant access is
+     * explicitly permitted for the SaaS application); {@code false} otherwise.
+     */
+    public static boolean isAuthenticatedUserInCurrentTenant(AuthenticatedUser authenticatedUser,
+                                                             AuthenticationContext context) {
+
+        if (authenticatedUser == null) {
+            return false;
+        }
+
+        if (isSaasApp(context) && isSaaSCrossTenantOperationsEnabled()) {
+            return true;
+        }
+
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            return StringUtils.equals(authenticatedUser.getTenantDomain(),
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        }
+
+        if (context == null || StringUtils.isBlank(context.getTenantDomain())) {
+            LOG.warn("Unable to determine the tenant domain from the authentication context. " +
+                    "Hence user tenant domain validation is considered as failed.");
+            return false;
+        }
+        return StringUtils.equals(authenticatedUser.getTenantDomain(), context.getTenantDomain());
+    }
+
+    private static boolean isSaaSCrossTenantOperationsEnabled() {
+
+        String value = IdentityUtil.getProperty(SAAS_ENABLE_CROSS_TENANT_OPERATIONS);
+        if (StringUtils.isBlank(value)) {
+            return false;
+        }
+        return Boolean.parseBoolean(value);
+    }
+
+    private static boolean isSaasApp(AuthenticationContext context) {
+
+        if (context == null || context.getSequenceConfig() == null
+                || context.getSequenceConfig().getApplicationConfig() == null
+                || context.getSequenceConfig().getApplicationConfig().getServiceProvider() == null) {
+            LOG.debug("Unable to determine if the application is a SaaS app. Treating as non-SaaS app.");
+            return false;
+        }
+        return context.getSequenceConfig().getApplicationConfig().getServiceProvider().isSaasApp();
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornClaims.java
@@ -21,12 +21,12 @@ package org.wso2.carbon.identity.application.authentication.framework.config.mod
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.AbstractJSContextMemberObject;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsClaimsUtil;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
@@ -40,7 +40,6 @@ import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.core.IdentityClaimManager;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.user.api.UserRealm;
@@ -61,7 +60,6 @@ import java.util.Optional;
 public class JsNashornClaims extends AbstractJSContextMemberObject implements AbstractJsObject {
 
     private static final Log LOG = LogFactory.getLog(JsNashornClaims.class);
-    private static final String SAAS_ENABLE_CROSS_TENANT_OPERATIONS = "SaaS.EnableCrossTenantOperations";
     private String idp;
     private boolean isRemoteClaimRequest;
     private int step;
@@ -451,45 +449,6 @@ public class JsNashornClaims extends AbstractJSContextMemberObject implements Ab
 
     protected boolean isAuthenticatedUserInCurrentTenant() {
 
-        if (authenticatedUser == null) {
-            return false;
-        }
-
-        if (isSaasApp(getContext()) && isSaaSCrossTenantOperationsEnabled()) {
-            return true;
-        }
-
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-            return StringUtils.equals(authenticatedUser.getTenantDomain(),
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
-        }
-
-        AuthenticationContext context = getContext();
-        if (context == null || StringUtils.isBlank(context.getTenantDomain())) {
-            LOG.warn("Unable to determine the tenant domain from the authentication context. " +
-                    "Hence user tenant domain validation is considered as failed.");
-            return false;
-        }
-        return StringUtils.equals(authenticatedUser.getTenantDomain(), context.getTenantDomain());
-    }
-
-    private static boolean isSaaSCrossTenantOperationsEnabled() {
-
-        String value = IdentityUtil.getProperty(SAAS_ENABLE_CROSS_TENANT_OPERATIONS);
-        if (StringUtils.isBlank(value)) {
-            return false;
-        }
-        return Boolean.parseBoolean(value);
-    }
-
-    private static boolean isSaasApp(AuthenticationContext context) {
-
-        if (context == null || context.getSequenceConfig() == null
-                || context.getSequenceConfig().getApplicationConfig() == null
-                || context.getSequenceConfig().getApplicationConfig().getServiceProvider() == null) {
-            LOG.debug("Unable to determine if the application is a SaaS app. Treating as non-SaaS app.");
-            return false;
-        }
-        return context.getSequenceConfig().getApplicationConfig().getServiceProvider().isSaasApp();
+        return JsClaimsUtil.isAuthenticatedUserInCurrentTenant(authenticatedUser, getContext());
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornClaims.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.application.authentication.framework.config.mod
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
@@ -158,7 +159,7 @@ public class JsNashornClaims extends AbstractJSContextMemberObject implements Ab
     @Override
     public Object getMember(String claimUri) {
 
-        if (authenticatedUser != null) {
+        if (isAuthenticatedUserInCurrentTenant()) {
             if (isRemoteClaimRequest) {
                 return getFederatedClaim(claimUri);
             } else {
@@ -171,7 +172,7 @@ public class JsNashornClaims extends AbstractJSContextMemberObject implements Ab
     @Override
     public boolean hasMember(String claimUri) {
 
-        if (authenticatedUser != null) {
+        if (isAuthenticatedUserInCurrentTenant()) {
             if (isRemoteClaimRequest) {
                 return hasFederatedClaim(claimUri);
             } else {
@@ -184,7 +185,7 @@ public class JsNashornClaims extends AbstractJSContextMemberObject implements Ab
     @Override
     public void setMember(String claimUri, Object claimValue) {
 
-        if (authenticatedUser != null) {
+        if (isAuthenticatedUserInCurrentTenant()) {
             if (isRemoteClaimRequest) {
                 setFederatedClaim(claimUri, claimValue);
                 return;
@@ -444,5 +445,11 @@ public class JsNashornClaims extends AbstractJSContextMemberObject implements Ab
             LOG.error("User id is not available for the user: " + authenticatedUser.getLoggableUserId(), e);
         }
         return null;
+    }
+
+    protected boolean isAuthenticatedUserInCurrentTenant() {
+
+        return authenticatedUser != null && StringUtils.equals(authenticatedUser.getTenantDomain(),
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornClaims.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2018-2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -449,7 +449,14 @@ public class JsNashornClaims extends AbstractJSContextMemberObject implements Ab
 
     protected boolean isAuthenticatedUserInCurrentTenant() {
 
-        return authenticatedUser != null && StringUtils.equals(authenticatedUser.getTenantDomain(),
-                PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        if (authenticatedUser == null) {
+            return false;
+        }
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            return StringUtils.equals(authenticatedUser.getTenantDomain(),
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        }
+        return getContext() != null &&
+                StringUtils.equals(authenticatedUser.getTenantDomain(), getContext().getTenantDomain());
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornClaims.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.core.IdentityClaimManager;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.user.api.UserRealm;
@@ -60,6 +61,7 @@ import java.util.Optional;
 public class JsNashornClaims extends AbstractJSContextMemberObject implements AbstractJsObject {
 
     private static final Log LOG = LogFactory.getLog(JsNashornClaims.class);
+    private static final String SAAS_ENABLE_CROSS_TENANT_OPERATIONS = "SaaS.EnableCrossTenantOperations";
     private String idp;
     private boolean isRemoteClaimRequest;
     private int step;
@@ -453,6 +455,10 @@ public class JsNashornClaims extends AbstractJSContextMemberObject implements Ab
             return false;
         }
 
+        if (isSaasApp(getContext()) && isSaaSCrossTenantOperationsEnabled()) {
+            return true;
+        }
+
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
             return StringUtils.equals(authenticatedUser.getTenantDomain(),
                     PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
@@ -465,5 +471,25 @@ public class JsNashornClaims extends AbstractJSContextMemberObject implements Ab
             return false;
         }
         return StringUtils.equals(authenticatedUser.getTenantDomain(), context.getTenantDomain());
+    }
+
+    private static boolean isSaaSCrossTenantOperationsEnabled() {
+
+        String value = IdentityUtil.getProperty(SAAS_ENABLE_CROSS_TENANT_OPERATIONS);
+        if (StringUtils.isBlank(value)) {
+            return false;
+        }
+        return Boolean.parseBoolean(value);
+    }
+
+    private static boolean isSaasApp(AuthenticationContext context) {
+
+        if (context == null || context.getSequenceConfig() == null
+                || context.getSequenceConfig().getApplicationConfig() == null
+                || context.getSequenceConfig().getApplicationConfig().getServiceProvider() == null) {
+            LOG.debug("Unable to determine if the application is a SaaS app. Treating as non-SaaS app.");
+            return false;
+        }
+        return context.getSequenceConfig().getApplicationConfig().getServiceProvider().isSaasApp();
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornClaims.java
@@ -452,11 +452,18 @@ public class JsNashornClaims extends AbstractJSContextMemberObject implements Ab
         if (authenticatedUser == null) {
             return false;
         }
+
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
             return StringUtils.equals(authenticatedUser.getTenantDomain(),
                     PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
         }
-        return getContext() != null &&
-                StringUtils.equals(authenticatedUser.getTenantDomain(), getContext().getTenantDomain());
+
+        AuthenticationContext context = getContext();
+        if (context == null || StringUtils.isBlank(context.getTenantDomain())) {
+            LOG.warn("Unable to determine the tenant domain from the authentication context. " +
+                    "Hence user tenant domain validation is considered as failed.");
+            return false;
+        }
+        return StringUtils.equals(authenticatedUser.getTenantDomain(), context.getTenantDomain());
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornRuntimeClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/nashorn/JsNashornRuntimeClaims.java
@@ -41,7 +41,7 @@ public class JsNashornRuntimeClaims extends JsNashornClaims {
     @Override
     public Object getMember(String claimUri) {
 
-        if (authenticatedUser != null) {
+        if (isAuthenticatedUserInCurrentTenant()) {
             return getRuntimeClaim(claimUri);
         }
         return null;
@@ -50,7 +50,7 @@ public class JsNashornRuntimeClaims extends JsNashornClaims {
     @Override
     public boolean hasMember(String claimUri) {
 
-        if (authenticatedUser != null) {
+        if (isAuthenticatedUserInCurrentTenant()) {
             return hasRuntimeClaim(claimUri);
         }
         return false;
@@ -59,7 +59,7 @@ public class JsNashornRuntimeClaims extends JsNashornClaims {
     @Override
     public void setMember(String claimUri, Object claimValue) {
 
-        if (authenticatedUser != null) {
+        if (isAuthenticatedUserInCurrentTenant()) {
             setRuntimeClaim(claimUri, claimValue);
         }
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornClaims.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2022-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -450,7 +450,14 @@ public class JsOpenJdkNashornClaims extends AbstractJSContextMemberObject implem
 
     protected boolean isAuthenticatedUserInCurrentTenant() {
 
-        return authenticatedUser != null && StringUtils.equals(authenticatedUser.getTenantDomain(),
-                PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        if (authenticatedUser == null) {
+            return false;
+        }
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            return StringUtils.equals(authenticatedUser.getTenantDomain(),
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        }
+        return getContext() != null &&
+                StringUtils.equals(authenticatedUser.getTenantDomain(), getContext().getTenantDomain());
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornClaims.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.application.authentication.framework.config.mod
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
@@ -159,7 +160,7 @@ public class JsOpenJdkNashornClaims extends AbstractJSContextMemberObject implem
     @Override
     public Object getMember(String claimUri) {
 
-        if (authenticatedUser != null) {
+        if (isAuthenticatedUserInCurrentTenant()) {
             if (isRemoteClaimRequest) {
                 return getFederatedClaim(claimUri);
             } else {
@@ -172,7 +173,7 @@ public class JsOpenJdkNashornClaims extends AbstractJSContextMemberObject implem
     @Override
     public boolean hasMember(String claimUri) {
 
-        if (authenticatedUser != null) {
+        if (isAuthenticatedUserInCurrentTenant()) {
             if (isRemoteClaimRequest) {
                 return hasFederatedClaim(claimUri);
             } else {
@@ -185,7 +186,7 @@ public class JsOpenJdkNashornClaims extends AbstractJSContextMemberObject implem
     @Override
     public void setMember(String claimUri, Object claimValue) {
 
-        if (authenticatedUser != null) {
+        if (isAuthenticatedUserInCurrentTenant()) {
             if (isRemoteClaimRequest) {
                 setFederatedClaim(claimUri, claimValue);
                 return;
@@ -445,5 +446,11 @@ public class JsOpenJdkNashornClaims extends AbstractJSContextMemberObject implem
             LOG.error("User id is not available for the user: " + authenticatedUser.getLoggableUserId(), e);
         }
         return null;
+    }
+
+    protected boolean isAuthenticatedUserInCurrentTenant() {
+
+        return authenticatedUser != null && StringUtils.equals(authenticatedUser.getTenantDomain(),
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornClaims.java
@@ -453,11 +453,18 @@ public class JsOpenJdkNashornClaims extends AbstractJSContextMemberObject implem
         if (authenticatedUser == null) {
             return false;
         }
+
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
             return StringUtils.equals(authenticatedUser.getTenantDomain(),
                     PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
         }
-        return getContext() != null &&
-                StringUtils.equals(authenticatedUser.getTenantDomain(), getContext().getTenantDomain());
+
+        AuthenticationContext context = getContext();
+        if (context == null || StringUtils.isBlank(context.getTenantDomain())) {
+            LOG.warn("Unable to determine the tenant domain from the authentication context. " +
+                    "Hence user tenant domain validation is considered as failed.");
+            return false;
+        }
+        return StringUtils.equals(authenticatedUser.getTenantDomain(), context.getTenantDomain());
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornClaims.java
@@ -21,12 +21,12 @@ package org.wso2.carbon.identity.application.authentication.framework.config.mod
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.AbstractJSContextMemberObject;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js.JsClaimsUtil;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
@@ -40,7 +40,6 @@ import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.core.IdentityClaimManager;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.user.api.UserRealm;
@@ -62,7 +61,6 @@ import java.util.Optional;
 public class JsOpenJdkNashornClaims extends AbstractJSContextMemberObject implements AbstractOpenJdkNashornJsObject {
 
     private static final Log LOG = LogFactory.getLog(JsOpenJdkNashornClaims.class);
-    private static final String SAAS_ENABLE_CROSS_TENANT_OPERATIONS = "SaaS.EnableCrossTenantOperations";
     private String idp;
     private boolean isRemoteClaimRequest;
     private int step;
@@ -452,45 +450,6 @@ public class JsOpenJdkNashornClaims extends AbstractJSContextMemberObject implem
 
     protected boolean isAuthenticatedUserInCurrentTenant() {
 
-        if (authenticatedUser == null) {
-            return false;
-        }
-
-        if (isSaasApp(getContext()) && isSaaSCrossTenantOperationsEnabled()) {
-            return true;
-        }
-
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-            return StringUtils.equals(authenticatedUser.getTenantDomain(),
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
-        }
-
-        AuthenticationContext context = getContext();
-        if (context == null || StringUtils.isBlank(context.getTenantDomain())) {
-            LOG.warn("Unable to determine the tenant domain from the authentication context. " +
-                    "Hence user tenant domain validation is considered as failed.");
-            return false;
-        }
-        return StringUtils.equals(authenticatedUser.getTenantDomain(), context.getTenantDomain());
-    }
-
-    private static boolean isSaaSCrossTenantOperationsEnabled() {
-
-        String value = IdentityUtil.getProperty(SAAS_ENABLE_CROSS_TENANT_OPERATIONS);
-        if (StringUtils.isBlank(value)) {
-            return false;
-        }
-        return Boolean.parseBoolean(value);
-    }
-
-    private static boolean isSaasApp(AuthenticationContext context) {
-
-        if (context == null || context.getSequenceConfig() == null
-                || context.getSequenceConfig().getApplicationConfig() == null
-                || context.getSequenceConfig().getApplicationConfig().getServiceProvider() == null) {
-            LOG.debug("Unable to determine if the application is a SaaS app. Treating as non-SaaS app.");
-            return false;
-        }
-        return context.getSequenceConfig().getApplicationConfig().getServiceProvider().isSaasApp();
+        return JsClaimsUtil.isAuthenticatedUserInCurrentTenant(authenticatedUser, getContext());
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornClaims.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.core.IdentityClaimManager;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.user.api.UserRealm;
@@ -61,6 +62,7 @@ import java.util.Optional;
 public class JsOpenJdkNashornClaims extends AbstractJSContextMemberObject implements AbstractOpenJdkNashornJsObject {
 
     private static final Log LOG = LogFactory.getLog(JsOpenJdkNashornClaims.class);
+    private static final String SAAS_ENABLE_CROSS_TENANT_OPERATIONS = "SaaS.EnableCrossTenantOperations";
     private String idp;
     private boolean isRemoteClaimRequest;
     private int step;
@@ -454,6 +456,10 @@ public class JsOpenJdkNashornClaims extends AbstractJSContextMemberObject implem
             return false;
         }
 
+        if (isSaasApp(getContext()) && isSaaSCrossTenantOperationsEnabled()) {
+            return true;
+        }
+
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
             return StringUtils.equals(authenticatedUser.getTenantDomain(),
                     PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
@@ -466,5 +472,25 @@ public class JsOpenJdkNashornClaims extends AbstractJSContextMemberObject implem
             return false;
         }
         return StringUtils.equals(authenticatedUser.getTenantDomain(), context.getTenantDomain());
+    }
+
+    private static boolean isSaaSCrossTenantOperationsEnabled() {
+
+        String value = IdentityUtil.getProperty(SAAS_ENABLE_CROSS_TENANT_OPERATIONS);
+        if (StringUtils.isBlank(value)) {
+            return false;
+        }
+        return Boolean.parseBoolean(value);
+    }
+
+    private static boolean isSaasApp(AuthenticationContext context) {
+
+        if (context == null || context.getSequenceConfig() == null
+                || context.getSequenceConfig().getApplicationConfig() == null
+                || context.getSequenceConfig().getApplicationConfig().getServiceProvider() == null) {
+            LOG.debug("Unable to determine if the application is a SaaS app. Treating as non-SaaS app.");
+            return false;
+        }
+        return context.getSequenceConfig().getApplicationConfig().getServiceProvider().isSaasApp();
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornRuntimeClaims.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/openjdk/nashorn/JsOpenJdkNashornRuntimeClaims.java
@@ -41,7 +41,7 @@ public class JsOpenJdkNashornRuntimeClaims extends JsOpenJdkNashornClaims {
     @Override
     public Object getMember(String claimUri) {
 
-        if (authenticatedUser != null) {
+        if (isAuthenticatedUserInCurrentTenant()) {
             return getRuntimeClaim(claimUri);
         }
         return null;
@@ -50,7 +50,7 @@ public class JsOpenJdkNashornRuntimeClaims extends JsOpenJdkNashornClaims {
     @Override
     public boolean hasMember(String claimUri) {
 
-        if (authenticatedUser != null) {
+        if (isAuthenticatedUserInCurrentTenant()) {
             return hasRuntimeClaim(claimUri);
         }
         return false;
@@ -59,7 +59,7 @@ public class JsOpenJdkNashornRuntimeClaims extends JsOpenJdkNashornClaims {
     @Override
     public void setMember(String claimUri, Object claimValue) {
 
-        if (authenticatedUser != null) {
+        if (isAuthenticatedUserInCurrentTenant()) {
             setRuntimeClaim(claimUri, claimValue);
         }
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsAuthenticationContextTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsAuthenticationContextTest.java
@@ -18,8 +18,10 @@
 
 package org.wso2.carbon.identity.application.authentication.framework.config.model.graph.js;
 
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.graph.AuthenticationGraph;
@@ -60,6 +62,13 @@ public class JsAuthenticationContextTest {
     public void setUp() {
 
         scriptEngine = new ScriptEngineManager().getEngineByName("nashorn");
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("carbon.super", true);
+    }
+
+    @AfterClass
+    public void tearDown() {
+
+        PrivilegedCarbonContext.destroyCurrentContext();
     }
 
     @Test
@@ -73,6 +82,7 @@ public class JsAuthenticationContextTest {
         AuthenticatedUser authenticatedUser = new AuthenticatedUser();
         authenticatedUser.getUserAttributes().put(claimMapping1, "TestClaimVal1");
         authenticatedUser.getUserAttributes().put(claimMapping2, "TestClaimVal2");
+        authenticatedUser.setTenantDomain("carbon.super");
         AuthenticationContext authenticationContext = new AuthenticationContext();
         setupAuthContextWithStepData(authenticationContext, authenticatedUser);
 
@@ -117,6 +127,7 @@ public class JsAuthenticationContextTest {
     public void testRemoteAddition() throws ScriptException {
 
         AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setTenantDomain("carbon.super");
         AuthenticationContext authenticationContext = new AuthenticationContext();
         setupAuthContextWithStepData(authenticationContext, authenticatedUser);
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsAuthenticationContextTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsAuthenticationContextTest.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -82,8 +83,9 @@ public class JsAuthenticationContextTest {
         AuthenticatedUser authenticatedUser = new AuthenticatedUser();
         authenticatedUser.getUserAttributes().put(claimMapping1, "TestClaimVal1");
         authenticatedUser.getUserAttributes().put(claimMapping2, "TestClaimVal2");
-        authenticatedUser.setTenantDomain("carbon.super");
+        authenticatedUser.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         AuthenticationContext authenticationContext = new AuthenticationContext();
+        authenticationContext.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         setupAuthContextWithStepData(authenticationContext, authenticatedUser);
 
         JsNashornAuthenticationContext jsNashornAuthenticationContext =
@@ -127,8 +129,9 @@ public class JsAuthenticationContextTest {
     public void testRemoteAddition() throws ScriptException {
 
         AuthenticatedUser authenticatedUser = new AuthenticatedUser();
-        authenticatedUser.setTenantDomain("carbon.super");
+        authenticatedUser.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         AuthenticationContext authenticationContext = new AuthenticationContext();
+        authenticationContext.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         setupAuthContextWithStepData(authenticationContext, authenticatedUser);
 
         JsNashornAuthenticationContext jsNashornAuthenticationContext =

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerClaimMappingsTest.java.excluded
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerClaimMappingsTest.java.excluded
@@ -62,6 +62,7 @@ public class GraphBasedSequenceHandlerClaimMappingsTest extends GraphBasedSequen
         ServiceProvider sp1 = getTestServiceProvider("js-sp-4-claim.xml");
 
         AuthenticationContext context = getAuthenticationContext(sp1);
+        context.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
 
         FrameworkServiceDataHolder.getInstance().setAdaptiveAuthenticationAvailable(true);
         SequenceConfig sequenceConfig = configurationLoader

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerClaimsTest.java.excluded
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandlerClaimsTest.java.excluded
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.core.internal.IdentityCoreServiceDataHolder;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.Collections;
 
@@ -52,6 +53,7 @@ public class GraphBasedSequenceHandlerClaimsTest extends GraphBasedSequenceHandl
         ServiceProvider sp1 = getTestServiceProvider("js-sp-5-claim.xml");
 
         AuthenticationContext context = getAuthenticationContext(sp1);
+        context.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
 
         FrameworkServiceDataHolder.getInstance().setAdaptiveAuthenticationAvailable(true);
         SequenceConfig sequenceConfig = configurationLoader

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -2015,6 +2015,13 @@
         </TenantQualifiedUrls>
     </TenantContext>
 
+    <!--
+        SaaS application configurations.
+    -->
+    <SaaS>
+        <EnableCrossTenantOperations>false</EnableCrossTenantOperations>
+    </SaaS>
+
     <TenantContextsToRewrite>
         <WebApp>
             <Context>/api/identity/user/v1.0/</Context>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -2865,6 +2865,21 @@
     -->
     <EnableLegacySaaSAuthentication>{{authentication.enable_legacy_saas_mode | default(false)}}</EnableLegacySaaSAuthentication>
 
+    <!--
+        SaaS application configurations.
+        Note: SaaS applications are deprecated as of WSO2 Identity Server 7.0.0.
+        These configurations are provided solely for backward compatibility.
+    -->
+    <SaaS>
+        <!--
+            Controls whether cross-tenant operations are permitted within adaptive authentication scripts for SaaS applications.
+            When set to 'false', cross-tenant user operations will be blocked.
+            WARNING: Enabling this introduces a known security risk by allowing adaptive scripts to operate on users from other tenants.
+            Default: false.
+        -->
+        <EnableCrossTenantOperations>{{saas.enable_cross_tenant_operations | default(false)}}</EnableCrossTenantOperations>
+    </SaaS>
+
     <EnablePerUserFunctionalityLocking>{{user.enable_per_user_functionality_locking}}</EnablePerUserFunctionalityLocking>
 
     <TenantContextsToRewrite>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -929,5 +929,7 @@
   "identity_util.enable_sha256": false,
   "cert_thumbprint.enable_sha256": false,
   "request_parameters.allow_sensitive_data_in_url": true,
-  "authentication.mark_step_completed_on_interrupt": true
+  "authentication.mark_step_completed_on_interrupt": true,
+
+  "saas.enable_cross_tenant_operations": false
 }


### PR DESCRIPTION
## Description
Ports the adaptive-script claim tenant-domain validation and the SaaS cross-tenant operations config to the 5.27.x line.

Related PRs:
- https://github.com/wso2/carbon-identity-framework/pull/7874
- https://github.com/wso2/carbon-identity-framework/pull/7916

