### PR TITLE
Register the Policy Management API and package the policy management bundles

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml
@@ -1206,6 +1206,20 @@
                    description="View webhook metadata in the organization (root)"/>
         </Scopes>
     </APIResource>
+    <APIResource name="Policy Management API" identifier="/api/server/v1/policies"
+                 requiresAuthorization="true"
+                 description="API representation of the Policy Management API" type="TENANT">
+        <Scopes>
+            <Scope displayName="View Policies" name="internal_policy_mgt_view"
+                   description="View policies in the organization (root)"/>
+            <Scope displayName="Create Policies" name="internal_policy_mgt_create"
+                   description="Create policies in the organization (root)"/>
+            <Scope displayName="Update Policies" name="internal_policy_mgt_update"
+                   description="Update policies in the organization (root)"/>
+            <Scope displayName="Delete Policies" name="internal_policy_mgt_delete"
+                   description="Delete policies in the organization (root)"/>
+        </Scopes>
+    </APIResource>
     <APIResource name="Email Template Management API v1/v2"
                  identifier="/api/server/v(.*)/email/template-types" requiresAuthorization="true"
                  description="API representation of the Email Template Management API" type="TENANT">

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/system-api-resource.xml.j2
@@ -1203,6 +1203,20 @@
                    description="View webhook metadata in the organization (root)"/>
         </Scopes>
     </APIResource>
+    <APIResource name="Policy Management API" identifier="/api/server/v1/policies"
+                 requiresAuthorization="true"
+                 description="API representation of the Policy Management API" type="TENANT">
+        <Scopes>
+            <Scope displayName="View Policies" name="internal_policy_mgt_view"
+                   description="View policies in the organization (root)"/>
+            <Scope displayName="Create Policies" name="internal_policy_mgt_create"
+                   description="Create policies in the organization (root)"/>
+            <Scope displayName="Update Policies" name="internal_policy_mgt_update"
+                   description="Update policies in the organization (root)"/>
+            <Scope displayName="Delete Policies" name="internal_policy_mgt_delete"
+                   description="Delete policies in the organization (root)"/>
+        </Scopes>
+    </APIResource>
     <APIResource name="Email Template Management API v1/v2"
                  identifier="/api/server/v(.*)/email/template-types" requiresAuthorization="true"
                  description="API representation of the Email Template Management API" type="TENANT">

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml
@@ -204,6 +204,20 @@
         <Scopes>internal_webhook_mgt_delete</Scopes>
     </Resource>
 
+    <!-- Policy Management API -->
+    <Resource context="(.*)/api/server/v1/policies(.*)" secured="true" http-method="POST">
+        <Scopes>internal_policy_mgt_create</Scopes>
+    </Resource>
+    <Resource context="(.*)/api/server/v1/policies(.*)" secured="true" http-method="PUT">
+        <Scopes>internal_policy_mgt_update</Scopes>
+    </Resource>
+    <Resource context="(.*)/api/server/v1/policies(.*)" secured="true" http-method="GET">
+        <Scopes>internal_policy_mgt_view</Scopes>
+    </Resource>
+    <Resource context="(.*)/api/server/v1/policies(.*)" secured="true" http-method="DELETE">
+        <Scopes>internal_policy_mgt_delete</Scopes>
+    </Resource>
+
     <!-- [Organization] Secret Management API -->
     <Resource context="(.*)/o/api/server/v1/secrets/(.*)" secured="true" http-method="POST">
         <Scopes>internal_org_secret_mgt_add</Scopes>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -319,6 +319,20 @@
             <Scopes>internal_webhook_mgt_delete</Scopes>
         </Resource>
 
+        <!-- Policy Management API -->
+        <Resource context="(.*)/api/server/v1/policies(.*)" secured="true" http-method="POST">
+            <Scopes>internal_policy_mgt_create</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v1/policies(.*)" secured="true" http-method="PUT">
+            <Scopes>internal_policy_mgt_update</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v1/policies(.*)" secured="true" http-method="GET">
+            <Scopes>internal_policy_mgt_view</Scopes>
+        </Resource>
+        <Resource context="(.*)/api/server/v1/policies(.*)" secured="true" http-method="DELETE">
+            <Scopes>internal_policy_mgt_delete</Scopes>
+        </Resource>
+
         <!-- [Organization] Secret Management API -->
         <Resource context="(.*)/o/api/server/v1/secrets/(.*)" secured="true" http-method="POST">
             <Scopes>internal_org_secret_mgt_add</Scopes>

--- a/features/policy-mgt/org.wso2.carbon.identity.policy.management.server.feature/pom.xml
+++ b/features/policy-mgt/org.wso2.carbon.identity.policy.management.server.feature/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.framework</groupId>
+        <artifactId>policy-management-feature</artifactId>
+        <version>7.11.169-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.policy.management.server.feature</artifactId>
+    <packaging>pom</packaging>
+    <name>Policy Management Server Feature</name>
+    <url>http://wso2.org</url>
+    <description>This feature contains the core bundles required for Policy Management</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.policy.management</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.policy.evaluation</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>carbon-p2-plugin</artifactId>
+                <version>${carbon.p2.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>4-p2-feature-generation</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>p2-feature-gen</goal>
+                        </goals>
+                        <configuration>
+                            <id>org.wso2.carbon.identity.policy.management.server</id>
+                            <propertiesFile>../../etc/feature.properties</propertiesFile>
+                            <adviceFile>
+                                <properties>
+                                    <propertyDef>org.wso2.carbon.p2.category.type:server</propertyDef>
+                                </properties>
+                            </adviceFile>
+                            <bundles>
+                                <bundleDef>
+                                    org.wso2.carbon.identity.framework:org.wso2.carbon.identity.policy.management
+                                </bundleDef>
+                                <bundleDef>
+                                    org.wso2.carbon.identity.framework:org.wso2.carbon.identity.policy.evaluation
+                                </bundleDef>
+                            </bundles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.1</version>
+                <executions>
+                    <execution>
+                        <id>clean_target</id>
+                        <phase>install</phase>
+                        <configuration>
+                            <tasks>
+                                <delete dir="src/main/resources" />
+                                <delete dir="src/main" />
+                                <delete dir="src" />
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/features/policy-mgt/pom.xml
+++ b/features/policy-mgt/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.framework</groupId>
+        <artifactId>identity-framework</artifactId>
+        <version>7.11.169-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>policy-management-feature</artifactId>
+    <packaging>pom</packaging>
+    <name>WSO2 Carbon - Policy Management Feature</name>
+    <url>http://wso2.org</url>
+
+    <modules>
+        <module>org.wso2.carbon.identity.policy.management.server.feature</module>
+    </modules>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
         <module>features/rule-mgt</module>
         <module>features/webhook-mgt</module>
         <module>features/action-mgt</module>
+        <module>features/policy-mgt</module>
         <module>features/ai-services-mgt</module>
         <module>features/certificate-mgt</module>
         <module>features/servlet-mgt</module>


### PR DESCRIPTION

## Proposed changes in this pull request

This PR adds the framework-side wiring required by the new Policy Management REST API (`/api/server/v1/policies`) introduced in `identity-api-server`. It covers two gaps: the API had no registered scopes or access control rules, and the `policy-mgt` bundles were not shipped by any p2 feature.

### API resource and scopes

The Policy Management API is registered as a `TENANT` API resource in `system-api-resource.xml`, with four scopes covering the endpoint's operations:

- `internal_policy_mgt_view`
- `internal_policy_mgt_create`
- `internal_policy_mgt_update`
- `internal_policy_mgt_delete`

`resource-access-control-v2.xml` maps `GET`, `POST`, `PUT` and `DELETE` on `/api/server/v1/policies` to the corresponding scope. Without these entries every request to the endpoint is rejected with `403`, regardless of the scopes carried by the token.

Both the generated XML files and their `.j2` templates are updated, since the deployed configuration is regenerated from the templates on server start.

### Policy management p2 feature

`org.wso2.carbon.identity.policy.management` and `org.wso2.carbon.identity.policy.evaluation` were not referenced by any p2 feature, so the bundles were never installed into the product pack. As a result `PolicyMgtServiceComponent` never activated and `PolicyManagementService` was not available in the OSGi runtime, causing the API layer to fail on startup.

This PR adds `org.wso2.carbon.identity.policy.management.server.feature` packaging both bundles under the `server` category, and registers it in the root pom. The feature follows the `action-mgt` feature layout.

### Testing

No unit tests are added — the changes are packaging and configuration only. Verified that the new feature modules resolve in the reactor and that the updated configuration files remain well formed.

## When should this PR be merged

N/A

## Follow up actions

N/A
