### PR TITLE
Surface Play Integrity device recognition verdicts

### DIFF
--- a/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/main/java/org/wso2/carbon/identity/client/attestation/mgt/model/ClientAttestationContext.java
+++ b/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/main/java/org/wso2/carbon/identity/client/attestation/mgt/model/ClientAttestationContext.java
@@ -104,7 +104,7 @@ public class ClientAttestationContext extends MessageContext {
 
     /**
      * Returns Google-verified device recognition verdicts extracted from the Play Integrity response.
-     * Null until set by AndroidAttestationValidator; empty list when testing response or no verdicts.
+     * Null until set by AndroidAttestationValidator; empty list when no verdicts.
      *
      * @return List of device recognition verdict strings, or null if not yet set.
      */

--- a/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/main/java/org/wso2/carbon/identity/client/attestation/mgt/model/ClientAttestationContext.java
+++ b/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/main/java/org/wso2/carbon/identity/client/attestation/mgt/model/ClientAttestationContext.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *  Copyright (c) 2023-2026, WSO2 LLC. (http://www.wso2.com).
  *
  *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/main/java/org/wso2/carbon/identity/client/attestation/mgt/model/ClientAttestationContext.java
+++ b/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/main/java/org/wso2/carbon/identity/client/attestation/mgt/model/ClientAttestationContext.java
@@ -22,6 +22,8 @@ package org.wso2.carbon.identity.client.attestation.mgt.model;
 import org.wso2.carbon.identity.client.attestation.mgt.utils.Constants;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 
+import java.util.List;
+
 
 /**
  * The object which will contain context information which are passed through API based Authentication process.
@@ -38,6 +40,7 @@ public class ClientAttestationContext extends MessageContext {
     private Constants.ClientTypes clientType;
     private String validationFailureMessage;
     private final boolean attestationEnabled;
+    private List<String> deviceIntegrityVerdicts;
 
     public ClientAttestationContext(boolean attestationEnabled) {
 
@@ -99,6 +102,27 @@ public class ClientAttestationContext extends MessageContext {
         this.validationFailureMessage = validationFailureMessage;
     }
 
+    /**
+     * Returns Google-verified device recognition verdicts extracted from the Play Integrity response.
+     * Null until set by AndroidAttestationValidator; empty list when testing response or no verdicts.
+     *
+     * @return List of device recognition verdict strings, or null if not yet set.
+     */
+    public List<String> getDeviceIntegrityVerdicts() {
+
+        return deviceIntegrityVerdicts;
+    }
+
+    /**
+     * Sets the device recognition verdicts obtained from the Google Play Integrity API response.
+     *
+     * @param deviceIntegrityVerdicts List of verdict strings from deviceIntegrity.deviceRecognitionVerdict.
+     */
+    public void setDeviceIntegrityVerdicts(List<String> deviceIntegrityVerdicts) {
+
+        this.deviceIntegrityVerdicts = deviceIntegrityVerdicts;
+    }
+
     @Override
     public String toString() {
 
@@ -109,6 +133,7 @@ public class ClientAttestationContext extends MessageContext {
                 ", isAttested=" + isAttested +
                 ", clientType=" + clientType +
                 ", errorMessage='" + validationFailureMessage + '\'' +
+                ", deviceIntegrityVerdicts=" + deviceIntegrityVerdicts +
                 '}';
     }
 }

--- a/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/main/java/org/wso2/carbon/identity/client/attestation/mgt/validators/AndroidAttestationValidator.java
+++ b/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/main/java/org/wso2/carbon/identity/client/attestation/mgt/validators/AndroidAttestationValidator.java
@@ -30,7 +30,6 @@ import com.google.api.services.playintegrity.v1.model.DecodeIntegrityTokenReques
 import com.google.api.services.playintegrity.v1.model.DecodeIntegrityTokenResponse;
 import com.google.api.services.playintegrity.v1.model.DeviceIntegrity;
 import com.google.api.services.playintegrity.v1.model.RequestDetails;
-import com.google.api.services.playintegrity.v1.model.TestingDetails;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import org.apache.commons.lang.StringUtils;
@@ -101,14 +100,6 @@ public class AndroidAttestationValidator implements ClientAttestationValidator {
                 clientAttestationContext);
 
         if (decodeIntegrityTokenResponse != null) {
-
-            // Log the full, raw response returned by the Google Play Integrity API for this token.
-            // This includes requestDetails, appIntegrity, deviceIntegrity, accountDetails and
-            // testingDetails, and is the authoritative record of what Google decided for the token.
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Google Play Integrity API decoded response for application: " + applicationResourceId
-                        + " in tenant: " + tenantDomain + " : " + decodeIntegrityTokenResponse.toString());
-            }
 
             validateIntegrityResponse(decodeIntegrityTokenResponse, clientAttestationContext);
         } else {
@@ -193,18 +184,7 @@ public class AndroidAttestationValidator implements ClientAttestationValidator {
             clientAttestationContext.setAttested(true);
         }
 
-        // Reject test responses — device verdicts from test tokens are not real Google evaluations.
-        TestingDetails testing = decodeIntegrityTokenResponse.getTokenPayloadExternal().getTestingDetails();
-        if (testing != null && Boolean.TRUE.equals(testing.getIsTestingResponse())) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Play Integrity response is a test response for application: " + applicationResourceId
-                        + " in tenant: " + tenantDomain + ". Device verdicts will not be trusted.");
-            }
-            clientAttestationContext.setDeviceIntegrityVerdicts(Collections.emptyList());
-            return;
-        }
-
-        // Extract real device recognition verdicts from the Google response.
+        // Extract device recognition verdicts from the Google response.
         DeviceIntegrity deviceIntegrity =
                 decodeIntegrityTokenResponse.getTokenPayloadExternal().getDeviceIntegrity();
         if (deviceIntegrity != null && deviceIntegrity.getDeviceRecognitionVerdict() != null) {

--- a/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/main/java/org/wso2/carbon/identity/client/attestation/mgt/validators/AndroidAttestationValidator.java
+++ b/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/main/java/org/wso2/carbon/identity/client/attestation/mgt/validators/AndroidAttestationValidator.java
@@ -28,7 +28,9 @@ import com.google.api.services.playintegrity.v1.PlayIntegrityRequestInitializer;
 import com.google.api.services.playintegrity.v1.model.AppIntegrity;
 import com.google.api.services.playintegrity.v1.model.DecodeIntegrityTokenRequest;
 import com.google.api.services.playintegrity.v1.model.DecodeIntegrityTokenResponse;
+import com.google.api.services.playintegrity.v1.model.DeviceIntegrity;
 import com.google.api.services.playintegrity.v1.model.RequestDetails;
+import com.google.api.services.playintegrity.v1.model.TestingDetails;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import org.apache.commons.lang.StringUtils;
@@ -44,6 +46,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.TimeZone;
 
 import static org.wso2.carbon.identity.client.attestation.mgt.utils.Constants.CLIENT_ATTESTATION_ALLOWED_WINDOW_IN_MILL_SECOND;
@@ -98,6 +101,14 @@ public class AndroidAttestationValidator implements ClientAttestationValidator {
                 clientAttestationContext);
 
         if (decodeIntegrityTokenResponse != null) {
+
+            // Log the full, raw response returned by the Google Play Integrity API for this token.
+            // This includes requestDetails, appIntegrity, deviceIntegrity, accountDetails and
+            // testingDetails, and is the authoritative record of what Google decided for the token.
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Google Play Integrity API decoded response for application: " + applicationResourceId
+                        + " in tenant: " + tenantDomain + " : " + decodeIntegrityTokenResponse.toString());
+            }
 
             validateIntegrityResponse(decodeIntegrityTokenResponse, clientAttestationContext);
         } else {
@@ -168,6 +179,7 @@ public class AndroidAttestationValidator implements ClientAttestationValidator {
     /**
      * Validates the overall integrity of the response by checking various components including
      * request details, device integrity, account details, and application integrity.
+     * Also extracts Google-verified device recognition verdicts into the context.
      *
      * @param decodeIntegrityTokenResponse The response containing the integrity token and various integrity details.
      * @param clientAttestationContext  The context to store the validation results and updated information.
@@ -175,10 +187,30 @@ public class AndroidAttestationValidator implements ClientAttestationValidator {
     private void validateIntegrityResponse(DecodeIntegrityTokenResponse decodeIntegrityTokenResponse,
                                            ClientAttestationContext clientAttestationContext) {
 
-        // Validate different aspects of the integrity response, and return true if all checks pass.
+        // Existing — controls isAttested for the token endpoint. Unchanged.
         if (validateRequestDetails(decodeIntegrityTokenResponse, clientAttestationContext) &&
                 validateAppIntegrity(decodeIntegrityTokenResponse, clientAttestationContext)) {
             clientAttestationContext.setAttested(true);
+        }
+
+        // Reject test responses — device verdicts from test tokens are not real Google evaluations.
+        TestingDetails testing = decodeIntegrityTokenResponse.getTokenPayloadExternal().getTestingDetails();
+        if (testing != null && Boolean.TRUE.equals(testing.getIsTestingResponse())) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Play Integrity response is a test response for application: " + applicationResourceId
+                        + " in tenant: " + tenantDomain + ". Device verdicts will not be trusted.");
+            }
+            clientAttestationContext.setDeviceIntegrityVerdicts(Collections.emptyList());
+            return;
+        }
+
+        // Extract real device recognition verdicts from the Google response.
+        DeviceIntegrity deviceIntegrity =
+                decodeIntegrityTokenResponse.getTokenPayloadExternal().getDeviceIntegrity();
+        if (deviceIntegrity != null && deviceIntegrity.getDeviceRecognitionVerdict() != null) {
+            clientAttestationContext.setDeviceIntegrityVerdicts(deviceIntegrity.getDeviceRecognitionVerdict());
+        } else {
+            clientAttestationContext.setDeviceIntegrityVerdicts(Collections.emptyList());
         }
     }
 

--- a/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/main/java/org/wso2/carbon/identity/client/attestation/mgt/validators/AndroidAttestationValidator.java
+++ b/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/main/java/org/wso2/carbon/identity/client/attestation/mgt/validators/AndroidAttestationValidator.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *  Copyright (c) 2023-2026, WSO2 LLC. (http://www.wso2.com).
  *
  *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -168,9 +168,12 @@ public class AndroidAttestationValidator implements ClientAttestationValidator {
     }
 
     /**
-     * Validates the overall integrity of the response by checking various components including
-     * request details, device integrity, account details, and application integrity.
-     * Also extracts Google-verified device recognition verdicts into the context.
+     * Validates the integrity response and records its outcome on the context.
+     *
+     * <p>Marks the context as attested when both the request details and the application integrity
+     * checks pass, and stores the device recognition verdicts reported by Google. The verdicts are
+     * recorded regardless of the attestation outcome, since a device that fails attestation is
+     * exactly the case a device policy needs the verdicts for.
      *
      * @param decodeIntegrityTokenResponse The response containing the integrity token and various integrity details.
      * @param clientAttestationContext  The context to store the validation results and updated information.
@@ -178,13 +181,13 @@ public class AndroidAttestationValidator implements ClientAttestationValidator {
     private void validateIntegrityResponse(DecodeIntegrityTokenResponse decodeIntegrityTokenResponse,
                                            ClientAttestationContext clientAttestationContext) {
 
-        // Existing — controls isAttested for the token endpoint. Unchanged.
+        // Mark the client as attested only when both checks pass; nothing is returned to the caller.
         if (validateRequestDetails(decodeIntegrityTokenResponse, clientAttestationContext) &&
                 validateAppIntegrity(decodeIntegrityTokenResponse, clientAttestationContext)) {
             clientAttestationContext.setAttested(true);
         }
 
-        // Extract device recognition verdicts from the Google response.
+        // Record the verdicts Google reported, falling back to an empty list when it reported none.
         DeviceIntegrity deviceIntegrity =
                 decodeIntegrityTokenResponse.getTokenPayloadExternal().getDeviceIntegrity();
         if (deviceIntegrity != null && deviceIntegrity.getDeviceRecognitionVerdict() != null) {

--- a/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/test/java/org/wso2/carbon/identity/client/attestation/mgt/model/ClientAttestationContextTest.java
+++ b/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/test/java/org/wso2/carbon/identity/client/attestation/mgt/model/ClientAttestationContextTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.client.attestation.mgt.model;
+
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for the device recognition verdicts carried on {@link ClientAttestationContext}.
+ */
+public class ClientAttestationContextTest {
+
+    private static final String MEETS_DEVICE_INTEGRITY = "MEETS_DEVICE_INTEGRITY";
+    private static final String MEETS_STRONG_INTEGRITY = "MEETS_STRONG_INTEGRITY";
+
+    @Test
+    public void testDeviceIntegrityVerdictsDefaultToNull() {
+
+        ClientAttestationContext context = new ClientAttestationContext(true);
+
+        assertNull(context.getDeviceIntegrityVerdicts(),
+                "Verdicts must stay null until the validator sets them, so callers can distinguish " +
+                        "'attestation never ran' from 'attestation ran and returned no verdicts'.");
+    }
+
+    @Test
+    public void testSetAndGetDeviceIntegrityVerdicts() {
+
+        ClientAttestationContext context = new ClientAttestationContext(true);
+        List<String> verdicts = Arrays.asList(MEETS_DEVICE_INTEGRITY, MEETS_STRONG_INTEGRITY);
+
+        context.setDeviceIntegrityVerdicts(verdicts);
+
+        assertEquals(context.getDeviceIntegrityVerdicts(), verdicts);
+    }
+
+    @Test
+    public void testSetDeviceIntegrityVerdictsToEmptyListIsDistinctFromNull() {
+
+        ClientAttestationContext context = new ClientAttestationContext(true);
+
+        context.setDeviceIntegrityVerdicts(Collections.emptyList());
+
+        assertNotNull(context.getDeviceIntegrityVerdicts());
+        assertTrue(context.getDeviceIntegrityVerdicts().isEmpty());
+    }
+
+    @Test
+    public void testSetDeviceIntegrityVerdictsBackToNull() {
+
+        ClientAttestationContext context = new ClientAttestationContext(true);
+        context.setDeviceIntegrityVerdicts(Collections.singletonList(MEETS_DEVICE_INTEGRITY));
+
+        context.setDeviceIntegrityVerdicts(null);
+
+        assertNull(context.getDeviceIntegrityVerdicts());
+    }
+
+    @Test
+    public void testToStringIncludesDeviceIntegrityVerdicts() {
+
+        ClientAttestationContext context = new ClientAttestationContext(true);
+        context.setDeviceIntegrityVerdicts(Arrays.asList(MEETS_DEVICE_INTEGRITY, MEETS_STRONG_INTEGRITY));
+
+        String rendered = context.toString();
+
+        assertTrue(rendered.contains("deviceIntegrityVerdicts="),
+                "toString must expose the field for diagnostics: " + rendered);
+        assertTrue(rendered.contains(MEETS_DEVICE_INTEGRITY), rendered);
+        assertTrue(rendered.contains(MEETS_STRONG_INTEGRITY), rendered);
+    }
+
+    @Test
+    public void testToStringWithNullVerdictsDoesNotThrow() {
+
+        ClientAttestationContext context = new ClientAttestationContext(false);
+
+        String rendered = context.toString();
+
+        assertTrue(rendered.contains("deviceIntegrityVerdicts=null"), rendered);
+    }
+}

--- a/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/test/java/org/wso2/carbon/identity/client/attestation/mgt/validators/AndroidAttestationValidatorTest.java
+++ b/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/test/java/org/wso2/carbon/identity/client/attestation/mgt/validators/AndroidAttestationValidatorTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.client.attestation.mgt.validators;
+
+import com.google.api.services.playintegrity.v1.model.AppIntegrity;
+import com.google.api.services.playintegrity.v1.model.DecodeIntegrityTokenResponse;
+import com.google.api.services.playintegrity.v1.model.DeviceIntegrity;
+import com.google.api.services.playintegrity.v1.model.RequestDetails;
+import com.google.api.services.playintegrity.v1.model.TokenPayloadExternal;
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.model.ClientAttestationMetaData;
+import org.wso2.carbon.identity.client.attestation.mgt.model.ClientAttestationContext;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for the device recognition verdict extraction added to
+ * {@link AndroidAttestationValidator#validateAttestation}.
+ *
+ * <p>The extraction lives in the private {@code validateIntegrityResponse}, invoked here by
+ * reflection. Going through the public {@code validateAttestation} is not viable: it first calls
+ * {@code decodeIntegrityToken}, which opens a real HTTPS transport to the Google Play Integrity
+ * service.
+ */
+public class AndroidAttestationValidatorTest {
+
+    private static final String PACKAGE_NAME = "com.wso2.sample.android";
+    private static final String OTHER_PACKAGE_NAME = "com.attacker.other";
+    private static final String PLAY_RECOGNIZED = "PLAY_RECOGNIZED";
+    private static final String UNRECOGNIZED_VERSION = "UNRECOGNIZED_VERSION";
+    private static final String APP_ID = "app-resource-id";
+    private static final String TENANT_DOMAIN = "carbon.super";
+
+    private static final String MEETS_DEVICE_INTEGRITY = "MEETS_DEVICE_INTEGRITY";
+    private static final String MEETS_STRONG_INTEGRITY = "MEETS_STRONG_INTEGRITY";
+
+    private AndroidAttestationValidator validator;
+    private MockedStatic<IdentityUtil> mockedIdentityUtil;
+
+    @BeforeMethod
+    public void setUp() {
+
+        ClientAttestationMetaData metaData = new ClientAttestationMetaData();
+        metaData.setAndroidPackageName(PACKAGE_NAME);
+        validator = new AndroidAttestationValidator(APP_ID, TENANT_DOMAIN, metaData);
+
+        // No allowed-window configured, so validateRequestDetails takes its "details are valid" branch
+        // and the tests stay independent of wall-clock time.
+        mockedIdentityUtil = mockStatic(IdentityUtil.class);
+        mockedIdentityUtil.when(() -> IdentityUtil.getProperty(anyString())).thenReturn(null);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        mockedIdentityUtil.close();
+    }
+
+    @Test
+    public void testVerdictsAreExtractedWhenPresent() throws Exception {
+
+        DecodeIntegrityTokenResponse response = buildResponse(PACKAGE_NAME, PLAY_RECOGNIZED,
+                deviceIntegrity(Arrays.asList(MEETS_DEVICE_INTEGRITY, MEETS_STRONG_INTEGRITY)));
+        ClientAttestationContext context = new ClientAttestationContext(true);
+
+        invokeValidateIntegrityResponse(response, context);
+
+        assertEquals(context.getDeviceIntegrityVerdicts(),
+                Arrays.asList(MEETS_DEVICE_INTEGRITY, MEETS_STRONG_INTEGRITY));
+    }
+
+    @Test
+    public void testVerdictsAreEmptyListWhenDeviceIntegrityIsAbsent() throws Exception {
+
+        DecodeIntegrityTokenResponse response = buildResponse(PACKAGE_NAME, PLAY_RECOGNIZED, null);
+        ClientAttestationContext context = new ClientAttestationContext(true);
+
+        invokeValidateIntegrityResponse(response, context);
+
+        assertNotNull(context.getDeviceIntegrityVerdicts(),
+                "An absent deviceIntegrity block must yield an empty list, never null.");
+        assertTrue(context.getDeviceIntegrityVerdicts().isEmpty());
+    }
+
+    @Test
+    public void testVerdictsAreEmptyListWhenRecognitionVerdictIsAbsent() throws Exception {
+
+        DecodeIntegrityTokenResponse response = buildResponse(PACKAGE_NAME, PLAY_RECOGNIZED,
+                deviceIntegrity(null));
+        ClientAttestationContext context = new ClientAttestationContext(true);
+
+        invokeValidateIntegrityResponse(response, context);
+
+        assertNotNull(context.getDeviceIntegrityVerdicts());
+        assertTrue(context.getDeviceIntegrityVerdicts().isEmpty());
+    }
+
+    @Test
+    public void testEmptyVerdictListFromGoogleIsPreserved() throws Exception {
+
+        DecodeIntegrityTokenResponse response = buildResponse(PACKAGE_NAME, PLAY_RECOGNIZED,
+                deviceIntegrity(Collections.emptyList()));
+        ClientAttestationContext context = new ClientAttestationContext(true);
+
+        invokeValidateIntegrityResponse(response, context);
+
+        assertNotNull(context.getDeviceIntegrityVerdicts());
+        assertTrue(context.getDeviceIntegrityVerdicts().isEmpty());
+    }
+
+    @Test
+    public void testVerdictsAreExtractedEvenWhenPackageNameDoesNotMatch() throws Exception {
+
+        // A device that fails attestation still reports verdicts; the device policy component needs
+        // them precisely in this case, so extraction must sit outside the isAttested branch.
+        DecodeIntegrityTokenResponse response = buildResponse(OTHER_PACKAGE_NAME, PLAY_RECOGNIZED,
+                deviceIntegrity(Collections.singletonList(MEETS_DEVICE_INTEGRITY)));
+        ClientAttestationContext context = new ClientAttestationContext(true);
+
+        invokeValidateIntegrityResponse(response, context);
+
+        assertFalse(context.isAttested(), "Package name mismatch must fail attestation.");
+        assertEquals(context.getDeviceIntegrityVerdicts(),
+                Collections.singletonList(MEETS_DEVICE_INTEGRITY),
+                "Verdicts must be extracted regardless of the attestation outcome.");
+    }
+
+    @Test
+    public void testVerdictsAreExtractedEvenWhenAppIsNotPlayRecognized() throws Exception {
+
+        DecodeIntegrityTokenResponse response = buildResponse(PACKAGE_NAME, UNRECOGNIZED_VERSION,
+                deviceIntegrity(Collections.singletonList(MEETS_STRONG_INTEGRITY)));
+        ClientAttestationContext context = new ClientAttestationContext(true);
+
+        invokeValidateIntegrityResponse(response, context);
+
+        assertFalse(context.isAttested(), "An unrecognised app must fail attestation.");
+        assertEquals(context.getDeviceIntegrityVerdicts(),
+                Collections.singletonList(MEETS_STRONG_INTEGRITY));
+    }
+
+    @Test
+    public void testAttestationStillSucceedsForAValidResponse() throws Exception {
+
+        // Guards the pre-existing isAttested behaviour against regression from the new extraction.
+        DecodeIntegrityTokenResponse response = buildResponse(PACKAGE_NAME, PLAY_RECOGNIZED,
+                deviceIntegrity(Collections.singletonList(MEETS_DEVICE_INTEGRITY)));
+        ClientAttestationContext context = new ClientAttestationContext(true);
+
+        invokeValidateIntegrityResponse(response, context);
+
+        assertTrue(context.isAttested());
+        assertNull(context.getValidationFailureMessage());
+    }
+
+    /*
+     * The Play Integrity model classes are Google API generated types whose constructors reach into
+     * Guava, which is not on this module's test classpath. Mockito instantiates via Objenesis without
+     * running constructors, so mocks sidestep that without adding a test-only dependency.
+     */
+    private DeviceIntegrity deviceIntegrity(List<String> verdicts) {
+
+        DeviceIntegrity deviceIntegrity = mock(DeviceIntegrity.class);
+        when(deviceIntegrity.getDeviceRecognitionVerdict()).thenReturn(verdicts);
+        return deviceIntegrity;
+    }
+
+    private DecodeIntegrityTokenResponse buildResponse(String requestPackageName, String appRecognitionVerdict,
+                                                       DeviceIntegrity deviceIntegrity) {
+
+        RequestDetails requestDetails = mock(RequestDetails.class);
+        when(requestDetails.getRequestPackageName()).thenReturn(requestPackageName);
+        when(requestDetails.getTimestampMillis()).thenReturn(System.currentTimeMillis());
+
+        AppIntegrity appIntegrity = mock(AppIntegrity.class);
+        when(appIntegrity.getAppRecognitionVerdict()).thenReturn(appRecognitionVerdict);
+
+        TokenPayloadExternal payload = mock(TokenPayloadExternal.class);
+        when(payload.getRequestDetails()).thenReturn(requestDetails);
+        when(payload.getAppIntegrity()).thenReturn(appIntegrity);
+        when(payload.getDeviceIntegrity()).thenReturn(deviceIntegrity);
+
+        DecodeIntegrityTokenResponse response = mock(DecodeIntegrityTokenResponse.class);
+        when(response.getTokenPayloadExternal()).thenReturn(payload);
+        return response;
+    }
+
+    private void invokeValidateIntegrityResponse(DecodeIntegrityTokenResponse response,
+                                                 ClientAttestationContext context) throws Exception {
+
+        Method method = AndroidAttestationValidator.class.getDeclaredMethod("validateIntegrityResponse",
+                DecodeIntegrityTokenResponse.class, ClientAttestationContext.class);
+        method.setAccessible(true);
+        method.invoke(validator, response, context);
+    }
+}

--- a/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/test/resources/testng.xml
+++ b/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/test/resources/testng.xml
@@ -20,6 +20,8 @@
     <test name="org.wso2.carbon.identity.client.attestation.mgt.test" preserve-order="false" parallel="false">
         <classes>
             <class name="org.wso2.carbon.identity.client.attestation.mgt.ClientAttestationServiceImplTest"/>
+            <class name="org.wso2.carbon.identity.client.attestation.mgt.model.ClientAttestationContextTest"/>
+            <class name="org.wso2.carbon.identity.client.attestation.mgt.validators.AndroidAttestationValidatorTest"/>
         </classes>
     </test>
 </suite>

--- a/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/test/resources/testng.xml
+++ b/components/client-attestation-mgt/org.wso2.carbon.identity.client.attestation.mgt/src/test/resources/testng.xml
@@ -1,17 +1,19 @@
 <!--
-  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2019-2026, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
   ~ http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >


### PR DESCRIPTION
## Proposed changes in this pull request

The Play Integrity API returns several sections for every attestation token — `requestDetails`, `appIntegrity`, `deviceIntegrity`, `accountDetails`. Today `AndroidAttestationValidator` reads only `appIntegrity`, which answers "is this a genuine copy of the app". The `deviceIntegrity` section, which answers "is this a genuine, uncompromised Android device", arrives in every response and is discarded.

This PR surfaces it so callers can act on it.

- **`ClientAttestationContext`** — adds a `deviceIntegrityVerdicts` field with a getter, a setter, and inclusion in `toString()`.
- **`AndroidAttestationValidator`** — reads `deviceIntegrity.deviceRecognitionVerdict` from the decoded response onto the context, defaulting to an empty list when the response omits the section.

## When should this PR be merged

No preconditions.

## Follow up actions

N/A
