### PR TITLE
add isTemporary attribute to PushAuthStatusCache and PushAuthContext in Cache Settings

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -1644,6 +1644,8 @@
             <Cache name="IdPCacheByName"             enable="true"  timeout="900" capacity="5000" isDistributed="false"/>
             <Cache name="PrivateKeyJWT"              enable="true"  timeout="10" capacity="5000" isDistributed="false"/>
             <Cache id="saml_cert_cache" name="SAMLCertCache" enable="true" timeout="900" capacity="5000" isDistributed="false"/>
+            <Cache id="push_auth_context_cache" name="PushAuthContextCache" enable="true" timeout="300" capacity="5000" isDistributed="false" isTemporary="true"/>
+            <Cache id="push_auth_status_cache" name="PushAuthStatusCache" enable="true" timeout="300" capacity="5000" isDistributed="false" isTemporary="true"/>
         </CacheManager>
     </CacheConfig>
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -3134,12 +3134,14 @@
                    enable="{{cache.push_auth_context_cache.enable}}"
                    timeout="{{cache.push_auth_context_cache.timeout}}"
                    capacity="{{cache.push_auth_context_cache.capacity}}"
-                   isDistributed="false"/>
+                   isDistributed="false"
+                   isTemporary="true"/>
             <Cache id="push_auth_status_cache" name="PushAuthStatusCache"
                    enable="{{cache.push_auth_status_cache.enable}}"
-                   timeout="{{cache.push_auth_status_cache_cache.timeout}}"
-                   capacity="{{cache.push_auth_status_cache_cache.capacity}}"
-                   isDistributed="false"/>
+                   timeout="{{cache.push_auth_status_cache.timeout}}"
+                   capacity="{{cache.push_auth_status_cache.capacity}}"
+                   isDistributed="false"
+                   isTemporary="true"/>
             <Cache id="push_device_registration_request_cache" name="PushDeviceRegistrationRequestCache"
                    enable="{{cache.push_device_registration_request_cache.enable}}"
                    timeout="{{cache.push_device_registration_request_cache.timeout}}"


### PR DESCRIPTION
This pull request makes a configuration update to the cache settings in the `identity.xml.j2` template. The main change is the addition of the `isTemporary="true"` attribute to specific cache definitions, which likely affects how these caches are managed in memory and their persistence.

**Cache configuration updates:**

* Added `isTemporary="true"` to the `push_auth_context_cache` and `push_auth_status_cache` definitions in `identity.xml.j2` to mark these caches as temporary.

Related Issue
- https://github.com/wso2/product-is/issues/27801