### PR TITLE
Use the caller-supplied device id in device.mgt

### DIFF
--- a/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/main/java/org/wso2/carbon/identity/device/mgt/api/model/Device.java
+++ b/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/main/java/org/wso2/carbon/identity/device/mgt/api/model/Device.java
@@ -216,6 +216,9 @@ public class Device {
          */
         public Device build() {
 
+            if (StringUtils.isBlank(id)) {
+                throw new IllegalArgumentException("Device id cannot be null or blank.");
+            }
             if (StringUtils.isBlank(deviceName)) {
                 throw new IllegalArgumentException("Device name cannot be null or blank.");
             }

--- a/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/main/java/org/wso2/carbon/identity/device/mgt/api/service/DeviceManagementService.java
+++ b/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/main/java/org/wso2/carbon/identity/device/mgt/api/service/DeviceManagementService.java
@@ -30,6 +30,15 @@ import java.util.List;
 public interface DeviceManagementService {
 
     /**
+     * Generates a new unique device identifier. Callers that need to construct a {@link Device}
+     * (e.g. the device registration executor) must obtain the id from here rather than minting
+     * their own, so device.mgt remains the single source of truth for the id format.
+     *
+     * @return A new unique device identifier.
+     */
+    String generateDeviceId();
+
+    /**
      * Registers a pre-verified {@link Device} in the database.
      *
      * @param device       The verified device to register.

--- a/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/main/java/org/wso2/carbon/identity/device/mgt/internal/service/impl/DeviceManagementServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/main/java/org/wso2/carbon/identity/device/mgt/internal/service/impl/DeviceManagementServiceImpl.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.device.mgt.internal.util.DeviceValidator;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Default implementation of {@link DeviceManagementService}.
@@ -66,6 +67,12 @@ public class DeviceManagementServiceImpl implements DeviceManagementService {
      */
     public static DeviceManagementServiceImpl getInstance() {
         return INSTANCE;
+    }
+
+    @Override
+    public String generateDeviceId() {
+
+        return UUID.randomUUID().toString();
     }
 
     @Override

--- a/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/main/java/org/wso2/carbon/identity/device/mgt/internal/service/impl/DeviceManagementServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/main/java/org/wso2/carbon/identity/device/mgt/internal/service/impl/DeviceManagementServiceImpl.java
@@ -37,7 +37,6 @@ import org.wso2.carbon.identity.device.mgt.internal.util.DeviceValidator;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * Default implementation of {@link DeviceManagementService}.
@@ -77,7 +76,7 @@ public class DeviceManagementServiceImpl implements DeviceManagementService {
         DEVICE_VALIDATOR.validateDeviceForRegistration(device);
         DEVICE_VALIDATOR.validateAssociation(association);
 
-        String deviceId = UUID.randomUUID().toString();
+        String deviceId = device.getId();
         Timestamp registeredAt = device.getRegisteredAt() != null
                 ? device.getRegisteredAt() : Timestamp.from(Instant.now());
         device = new Device.Builder(device)

--- a/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/test/java/org/wso2/carbon/identity/device/mgt/model/DeviceTest.java
+++ b/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/test/java/org/wso2/carbon/identity/device/mgt/model/DeviceTest.java
@@ -76,14 +76,13 @@ public class DeviceTest {
         Assert.assertEquals(userDeviceAssociation.getUserId(), "alice@example.com");
     }
 
-    @Test
-    public void testBuildDeviceWithoutIdSucceeds() {
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBuildDeviceWithoutIdThrows() {
 
-        Device device = new Device.Builder()
+        new Device.Builder()
                 .deviceName("Alice's iPhone")
                 .publicKey("dummy-public-key")
                 .build();
-        Assert.assertNull(device.getId());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/test/java/org/wso2/carbon/identity/device/mgt/service/DeviceManagementServiceImplTest.java
+++ b/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/test/java/org/wso2/carbon/identity/device/mgt/service/DeviceManagementServiceImplTest.java
@@ -91,6 +91,17 @@ public class DeviceManagementServiceImplTest {
     }
 
     @Test
+    public void testGenerateDeviceIdReturnsUniqueNonBlankIds() {
+
+        String id1 = service.generateDeviceId();
+        String id2 = service.generateDeviceId();
+
+        Assert.assertNotNull(id1);
+        Assert.assertFalse(id1.isBlank());
+        Assert.assertNotEquals(id1, id2);
+    }
+
+    @Test
     public void testRegisterDeviceDelegatesToDao() throws Exception {
 
         Device device = buildDevice("d1");

--- a/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/test/java/org/wso2/carbon/identity/device/mgt/service/DeviceManagementServiceImplTest.java
+++ b/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/test/java/org/wso2/carbon/identity/device/mgt/service/DeviceManagementServiceImplTest.java
@@ -103,7 +103,7 @@ public class DeviceManagementServiceImplTest {
     }
 
     @Test
-    public void testRegisterDeviceGeneratesDeviceIdAndBindsToAssociation() throws Exception {
+    public void testRegisterDevicePreservesCallerSuppliedIdAndBindsToAssociation() throws Exception {
 
         Device device = buildDevice("d1");
         UserDeviceAssociation association = new UserDeviceAssociation("d2", "alice@example.com");
@@ -111,8 +111,19 @@ public class DeviceManagementServiceImplTest {
 
         Device registered = service.registerDevice(device, association, TENANT_DOMAIN);
 
-        Assert.assertNotNull(registered.getId());
+        // The caller (e.g. device.registration) already communicated this id to the client as the
+        // registrationId; registerDevice() must not replace it with a different generated id, or the
+        // device the client thinks it registered as no longer matches the persisted row.
+        Assert.assertEquals(registered.getId(), "d1");
         verify(dao).registerDevice(any(), any(), eq(TENANT_ID));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBuildDeviceWithoutIdThrows() {
+
+        // device.mgt always relies on the caller (e.g. device.registration) to supply the id;
+        // it must never generate one itself, so a blank id must fail at model construction.
+        buildDevice(null);
     }
 
     @Test

--- a/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/test/java/org/wso2/carbon/identity/device/mgt/service/DeviceManagementServiceImplTest.java
+++ b/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/test/java/org/wso2/carbon/identity/device/mgt/service/DeviceManagementServiceImplTest.java
@@ -111,9 +111,6 @@ public class DeviceManagementServiceImplTest {
 
         Device registered = service.registerDevice(device, association, TENANT_DOMAIN);
 
-        // The caller (e.g. device.registration) already communicated this id to the client as the
-        // registrationId; registerDevice() must not replace it with a different generated id, or the
-        // device the client thinks it registered as no longer matches the persisted row.
         Assert.assertEquals(registered.getId(), "d1");
         verify(dao).registerDevice(any(), any(), eq(TENANT_ID));
     }
@@ -121,8 +118,6 @@ public class DeviceManagementServiceImplTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBuildDeviceWithoutIdThrows() {
 
-        // device.mgt always relies on the caller (e.g. device.registration) to supply the id;
-        // it must never generate one itself, so a blank id must fail at model construction.
         buildDevice(null);
     }
 

--- a/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/test/java/org/wso2/carbon/identity/device/mgt/util/DeviceValidatorTest.java
+++ b/components/device-mgt/org.wso2.carbon.identity.device.mgt/src/test/java/org/wso2/carbon/identity/device/mgt/util/DeviceValidatorTest.java
@@ -119,11 +119,10 @@ public class DeviceValidatorTest {
         deviceValidator.validateAssociation(new UserDeviceAssociation("d1", "alice@example.com"));
     }
 
-    @Test
-    public void testValidateDeviceForRegistrationWithoutIdSucceeds() {
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testValidateDeviceForRegistrationWithoutIdThrows() {
 
-        Device device = completeDeviceBuilder().id(null).build();
-        Assert.assertNull(device.getId());
+        completeDeviceBuilder().id(null).build();
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
## Proposed changes in this pull request

This PR fixes a bug where **`DeviceManagementServiceImpl.registerDevice(...)` silently discarded the device id
supplied by its caller and replaced it with a freshly generated `UUID`**, so the id persisted in `IDN_DEVICE`
no longer matched the id the client had already been told to use.


### Tests

- `DeviceTest` and `DeviceValidatorTest` — the "build without id succeeds" cases are replaced with
  "build without id throws `IllegalArgumentException`" cases, matching the existing `deviceName`/`publicKey`
  validation tests.
- `DeviceManagementServiceImplTest` — the case that asserted a random id gets generated when none is supplied
  is replaced with a case asserting `Device.Builder.build()` rejects a blank id before `registerDevice(...)`
  is ever reached; the existing case asserting a caller-supplied id is preserved end-to-end through the DAO
  call is unchanged.

All 88 tests in `org.wso2.carbon.identity.device.mgt` pass.

## When should this PR be merged

N/A

## Follow up actions

N/A
