### PR TITLE
Implement getRoleIdListOfGroupNames method and update related interfaces

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementService.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementService.java
@@ -438,6 +438,20 @@ public interface RoleManagementService {
             throws IdentityRoleManagementException;
 
     /**
+     * Get role id list of groups by group names.
+     *
+     * @param groupNames
+     * @param tenantDomain
+     * @return
+     * @throws IdentityRoleManagementException
+     */
+    default List<String> getRoleIdListOfGroupNames(List<String> groupNames, String tenantDomain)
+            throws IdentityRoleManagementException {
+
+        throw new NotImplementedException("getRoleIdListOfGroupNames method is not implemented");
+    }
+
+    /**
      * Get role id list of idp groups.
      *
      * @param groupIds     Idp Group IDs.

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
@@ -917,6 +917,26 @@ public class RoleManagementServiceImpl implements RoleManagementService {
     }
 
     @Override
+    public List<String> getRoleIdListOfGroupNames(List<String> groupNames, String tenantDomain)
+            throws IdentityRoleManagementException {
+
+        List<RoleManagementListener> roleManagementListenerList = RoleManagementServiceComponentHolder.getInstance()
+                .getRoleManagementListenerList();
+        for (RoleManagementListener roleManagementListener : roleManagementListenerList) {
+            if (roleManagementListener.isEnable()) {
+                roleManagementListener.preGetRoleIdListOfGroupNames(groupNames, tenantDomain);
+            }
+        }
+        List<String> roleIDs = roleDAO.getRoleIdListOfGroupNames(groupNames, tenantDomain);
+        for (RoleManagementListener roleManagementListener : roleManagementListenerList) {
+            if (roleManagementListener.isEnable()) {
+                roleManagementListener.postGetRoleIdListOfGroupNames(groupNames, tenantDomain);
+            }
+        }
+        return roleIDs;
+    }
+
+    @Override
     public List<String> getRoleIdListOfIdpGroups(List<String> groupIds, String tenantDomain)
             throws IdentityRoleManagementException {
 

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAO.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAO.java
@@ -459,6 +459,20 @@ public interface RoleDAO {
             throws IdentityRoleManagementException;
 
     /**
+     * Get role id list of groups by group names.
+     *
+     * @param groupNames   Group Names.
+     * @param tenantDomain Tenant domain.
+     * @return The list of role id.
+     * @throws IdentityRoleManagementException IdentityRoleManagementException.
+     */
+    default List<String> getRoleIdListOfGroupNames(List<String> groupNames, String tenantDomain)
+            throws IdentityRoleManagementException {
+
+        throw new NotImplementedException("getRoleIdListOfGroupNames method is not implemented");
+    }
+
+    /**
      * Get role id list of idp groups.
      *
      * @param groupIds     Idp Group IDs.

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -1308,6 +1308,13 @@ public class RoleDAOImpl implements RoleDAO {
 
         Map<String, String> groupIdsToNames = getGroupNamesByIDs(groupIds, tenantDomain);
         List<String> groupNamesList = new ArrayList<>(groupIdsToNames.values());
+        return getRoleIdListOfGroupNames(groupNamesList, tenantDomain);
+    }
+
+    @Override
+    public List<String> getRoleIdListOfGroupNames(List<String> groupNames, String tenantDomain)
+            throws IdentityRoleManagementException {
+
         String primaryDomainName = IdentityUtil.getPrimaryDomainName();
         if (primaryDomainName != null) {
             primaryDomainName = primaryDomainName.toUpperCase(Locale.ENGLISH);
@@ -1316,7 +1323,7 @@ public class RoleDAOImpl implements RoleDAO {
         List<String> roleIds = new ArrayList<>();
         try (Connection connection = IdentityDatabaseUtil.getUserDBConnection(false);
              NamedPreparedStatement statement = new NamedPreparedStatement(connection, GET_ROLE_ID_LIST_OF_GROUP_SQL)) {
-            for (String groupName : groupNamesList) {
+            for (String groupName : groupNames) {
                 // Add domain if not set.
                 groupName = UserCoreUtil.addDomainToName(groupName, primaryDomainName);
                 // Get domain from name.
@@ -1337,8 +1344,8 @@ public class RoleDAOImpl implements RoleDAO {
             }
         } catch (SQLException e) {
             String errorMessage =
-                    "Error while retrieving role list of groups by ids: " + String.join(", ", groupIds)
-                            + " and tenantDomain : " + tenantDomain;
+                    "Error while retrieving role ID list of groups by names: " + String.join(", ", groupNames)
+                            + " and tenantDomain: " + tenantDomain;
             throw new IdentityRoleManagementServerException(UNEXPECTED_SERVER_ERROR.getCode(), errorMessage, e);
         }
         return roleIds.stream().distinct().collect(Collectors.toList());

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/listener/RoleManagementListener.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/listener/RoleManagementListener.java
@@ -623,11 +623,35 @@ public interface RoleManagementListener {
     /**
      * Invoked after retrieving the list of role IDs associated with specific groups in the given tenant domain.
      *
-     * @param roleIds      A list of role IDs retrieved for the specified groups.
+     * @param groupNames  A list of names of the groups for which the role IDs list was retrieved.
      * @param tenantDomain The domain in which the operation was performed.
      * @throws IdentityRoleManagementException If an error occurs during the post-retrieval phase.
      */
-    void postGetRoleIdListOfGroups(List<String> roleIds, String tenantDomain) throws IdentityRoleManagementException;
+    default void preGetRoleIdListOfGroupNames(List<String> groupNames, String tenantDomain)
+            throws IdentityRoleManagementException {
+
+    }
+
+    /**
+     * Invoked after retrieving the list of role IDs associated with specific groups in the given tenant domain.
+     *
+     * @param groupIds     A list of unique identifiers for the groups for which the role IDs list was retrieved.
+     * @param tenantDomain The domain in which the operation was performed.
+     * @throws IdentityRoleManagementException If an error occurs during the post-retrieval phase.
+     */
+    void postGetRoleIdListOfGroups(List<String> groupIds, String tenantDomain) throws IdentityRoleManagementException;
+
+    /**
+     * Invoked after retrieving the list of role IDs associated with specific groups in the given tenant domain.
+     *
+     * @param groupNames  A list of names of the groups for which the role IDs list was retrieved.
+     * @param tenantDomain The domain in which the operation was performed.
+     * @throws IdentityRoleManagementException If an error occurs during the post-retrieval phase.
+     */
+    default void postGetRoleIdListOfGroupNames(List<String> groupNames, String tenantDomain)
+            throws IdentityRoleManagementException {
+
+    }
 
     /**
      * Invoked before retrieving the list of role IDs associated with specific Identity Provider (IdP) groups

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImplTest.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImplTest.java
@@ -35,6 +35,8 @@ import org.wso2.carbon.identity.role.v2.mgt.core.dao.RoleDAO;
 import org.wso2.carbon.identity.role.v2.mgt.core.dao.RoleMgtDAOFactory;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementClientException;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
+import org.wso2.carbon.identity.role.v2.mgt.core.internal.RoleManagementServiceComponentHolder;
+import org.wso2.carbon.identity.role.v2.mgt.core.listener.RoleManagementListener;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.UserBasicInfo;
 import org.wso2.carbon.identity.role.v2.mgt.core.util.RoleManagementUtils;
@@ -306,6 +308,56 @@ public class RoleManagementServiceImplTest extends IdentityBaseTest {
         // No post delete role events should be published when no roles are associated with the application.
         verify(mockRoleMgtEventPublisherProxy, never())
                 .publishPostDeleteRole(any(RoleBasicInfo.class), eq(tenantDomain));
+    }
+
+    @Test
+    public void testGetRoleIdListOfGroupNames() throws IdentityRoleManagementException {
+
+        List<String> groupNames = Arrays.asList("group1", "group2");
+        List<String> expectedRoleIds = Arrays.asList("roleId1", "roleId2");
+        when(roleDAO.getRoleIdListOfGroupNames(groupNames, tenantDomain)).thenReturn(expectedRoleIds);
+
+        RoleManagementListener listener = mock(RoleManagementListener.class);
+        when(listener.isEnable()).thenReturn(true);
+        RoleManagementServiceComponentHolder holder = RoleManagementServiceComponentHolder.getInstance();
+        List<RoleManagementListener> originalListeners = holder.getRoleManagementListenerList();
+        holder.setRoleManagementListenerList(Collections.singletonList(listener));
+
+        try {
+            List<String> roleIds = roleManagementService.getRoleIdListOfGroupNames(groupNames, tenantDomain);
+
+            assertEquals(expectedRoleIds, roleIds);
+            verify(listener, times(1)).preGetRoleIdListOfGroupNames(groupNames, tenantDomain);
+            verify(listener, times(1)).postGetRoleIdListOfGroupNames(groupNames, tenantDomain);
+            verify(roleDAO, times(1)).getRoleIdListOfGroupNames(groupNames, tenantDomain);
+        } finally {
+            holder.setRoleManagementListenerList(originalListeners);
+        }
+    }
+
+    @Test
+    public void testGetRoleIdListOfGroupNamesWithDisabledListener() throws IdentityRoleManagementException {
+
+        List<String> groupNames = Arrays.asList("group1", "group2");
+        List<String> expectedRoleIds = Collections.singletonList("roleId1");
+        when(roleDAO.getRoleIdListOfGroupNames(groupNames, tenantDomain)).thenReturn(expectedRoleIds);
+
+        RoleManagementListener listener = mock(RoleManagementListener.class);
+        when(listener.isEnable()).thenReturn(false);
+        RoleManagementServiceComponentHolder holder = RoleManagementServiceComponentHolder.getInstance();
+        List<RoleManagementListener> originalListeners = holder.getRoleManagementListenerList();
+        holder.setRoleManagementListenerList(Collections.singletonList(listener));
+
+        try {
+            List<String> roleIds = roleManagementService.getRoleIdListOfGroupNames(groupNames, tenantDomain);
+
+            assertEquals(expectedRoleIds, roleIds);
+            verify(listener, never()).preGetRoleIdListOfGroupNames(anyList(), anyString());
+            verify(listener, never()).postGetRoleIdListOfGroupNames(anyList(), anyString());
+            verify(roleDAO, times(1)).getRoleIdListOfGroupNames(groupNames, tenantDomain);
+        } finally {
+            holder.setRoleManagementListenerList(originalListeners);
+        }
     }
 
     private void mockCarbonContextForTenant() {

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOTest.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOTest.java
@@ -1132,6 +1132,30 @@ public class RoleDAOTest {
     }
 
     @Test
+    public void testGetRoleIdListOfGroupNames() throws Exception {
+
+        RoleDAOImpl roleDAO = spy(new RoleDAOImpl());
+        mockCacheClearing(roleDAO);
+        identityDatabaseUtil.when(() -> IdentityDatabaseUtil.getUserDBConnection(anyBoolean()))
+                .thenAnswer(invocation -> getConnection());
+        identityDatabaseUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean()))
+                .thenAnswer(invocation -> getConnection());
+        identityUtil.when(IdentityUtil::getPrimaryDomainName).thenReturn(USER_DOMAIN_PRIMARY);
+        identityUtil.when(() -> IdentityUtil.extractDomainFromName(anyString())).thenCallRealMethod();
+        identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(SAMPLE_TENANT_ID);
+        userCoreUtil.when(() -> UserCoreUtil.isEveryoneRole(anyString(), any(RealmConfiguration.class)))
+                .thenReturn(false);
+        userCoreUtil.when(() -> UserCoreUtil.removeDomainFromName(anyString())).thenCallRealMethod();
+        userCoreUtil.when(() -> UserCoreUtil.extractDomainFromName(anyString())).thenCallRealMethod();
+        userCoreUtil.when(() -> UserCoreUtil.addDomainToName(anyString(), anyString())).thenCallRealMethod();
+        addRole(roleNamesList.get(0), APPLICATION_AUD, SAMPLE_APP_ID, roleDAO);
+        addRole(roleNamesList.get(1), APPLICATION_AUD, SAMPLE_APP_ID, roleDAO);
+
+        List<String> roles = roleDAO.getRoleIdListOfGroupNames(groupNamesList, SAMPLE_TENANT_DOMAIN);
+        assertEquals(roles.size(), 2);
+    }
+
+    @Test
     public void testGetRoleIdListOfIdpGroups() throws Exception {
 
         RoleDAOImpl roleDAO = spy(new RoleDAOImpl());

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOTest.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOTest.java
@@ -1148,11 +1148,28 @@ public class RoleDAOTest {
         userCoreUtil.when(() -> UserCoreUtil.removeDomainFromName(anyString())).thenCallRealMethod();
         userCoreUtil.when(() -> UserCoreUtil.extractDomainFromName(anyString())).thenCallRealMethod();
         userCoreUtil.when(() -> UserCoreUtil.addDomainToName(anyString(), anyString())).thenCallRealMethod();
-        addRole(roleNamesList.get(0), APPLICATION_AUD, SAMPLE_APP_ID, roleDAO);
-        addRole(roleNamesList.get(1), APPLICATION_AUD, SAMPLE_APP_ID, roleDAO);
 
-        List<String> roles = roleDAO.getRoleIdListOfGroupNames(groupNamesList, SAMPLE_TENANT_DOMAIN);
-        assertEquals(roles.size(), 2);
+        // Assign each role to a distinct group so the returned role IDs can be verified per group name.
+        RoleBasicInfo role1 = addRole(roleNamesList.get(0), APPLICATION_AUD, SAMPLE_APP_ID, SAMPLE_TENANT_DOMAIN,
+                permissions, userIDsList, userNamesList,
+                Collections.singletonList("groupID1"), Collections.singletonMap("groupID1", "group1"), roleDAO, false);
+        RoleBasicInfo role2 = addRole(roleNamesList.get(1), APPLICATION_AUD, SAMPLE_APP_ID, SAMPLE_TENANT_DOMAIN,
+                permissions, userIDsList, userNamesList,
+                Collections.singletonList("groupID2"), Collections.singletonMap("groupID2", "group2"), roleDAO, false);
+
+        // A single group name should resolve only to the role associated with that group.
+        List<String> group1Roles = roleDAO.getRoleIdListOfGroupNames(Collections.singletonList("group1"),
+                SAMPLE_TENANT_DOMAIN);
+        assertEquals(group1Roles.size(), 1);
+        assertTrue(group1Roles.contains(role1.getId()));
+        assertFalse(group1Roles.contains(role2.getId()));
+
+        // Both group names should resolve to both associated roles.
+        List<String> allRoles = roleDAO.getRoleIdListOfGroupNames(Arrays.asList("group1", "group2"),
+                SAMPLE_TENANT_DOMAIN);
+        assertEquals(allRoles.size(), 2);
+        assertTrue(allRoles.contains(role1.getId()));
+        assertTrue(allRoles.contains(role2.getId()));
     }
 
     @Test


### PR DESCRIPTION
### Proposed changes in this pull request
This pull request introduces support for retrieving role IDs based on group names, in addition to the existing group ID-based methods. The changes add new methods to the service, DAO, and listener layers, and ensure proper listener hooks are available for pre- and post-processing. The main updates are as follows:

### API and Service Layer Enhancements

* Added the `getRoleIdListOfGroupNames` method to the `RoleManagementService` interface and provided a default implementation that throws a `NotImplementedException`. (`RoleManagementService.java`)
* Implemented the `getRoleIdListOfGroupNames` method in `RoleManagementServiceImpl`, including calls to pre- and post-listener hooks. (`RoleManagementServiceImpl.java`)

### DAO Layer Enhancements

* Added the `getRoleIdListOfGroupNames` method to the `RoleDAO` interface with a default unimplemented version. (`RoleDAO.java`)
* Implemented `getRoleIdListOfGroupNames` in `RoleDAOImpl`, refactored `getRoleIdListOfGroups` to delegate to the new method, and updated error messages and parameter usage to support group names. (`RoleDAOImpl.java`) [[1]](diffhunk://#diff-131b069dbac2f9329a833605dfd5b2da3e2ab3c6d45270f614451bb780a769f6R1311-R1317) [[2]](diffhunk://#diff-131b069dbac2f9329a833605dfd5b2da3e2ab3c6d45270f614451bb780a769f6L1319-R1326) [[3]](diffhunk://#diff-131b069dbac2f9329a833605dfd5b2da3e2ab3c6d45270f614451bb780a769f6L1340-R1347)

### Listener Support

* Added new listener hooks: `preGetRoleIdListOfGroupNames` and `postGetRoleIdListOfGroupNames` to the `RoleManagementListener` interface, allowing extensions to react to these operations. (`RoleManagementListener.java`)

### Related Issues
- https://github.com/wso2/product-is/issues/28229