### PR TITLE
Stop clearing subject identifier and subject attribute steps if adaptive script retries auth step for authenticators with retryAuthenticationEnabled as false.

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/GraphBasedSequenceHandler.java
@@ -575,7 +575,7 @@ public class GraphBasedSequenceHandler extends DefaultStepBasedSequenceHandler i
                 .getAttribute(FrameworkConstants.RequestParams.FLOW_STATUS);
 
         if (flowStatus != SUCCESS_COMPLETED && flowStatus != INCOMPLETE && !(FAIL_COMPLETED.equals(flowStatus) &&
-                context.isRetrying())) {
+                (context.isRetrying() || stepConfigGraphNode.getNext() instanceof DynamicDecisionNode))) {
             stepConfig.setSubjectAttributeStep(false);
             stepConfig.setSubjectIdentifierStep(false);
         }


### PR DESCRIPTION
### Purpose
Fixes the adaptive-authentication bug where subject/attribute step designations are permanently wiped when a step is re-executed from a conditional-auth onFail() handler, causing runtime (script-set) claims to be dropped from the issued token.

- Issue: wso2/product-is#28252

### Problem

In a script-based (adaptive) authentication sequence, when a step that is designated as the subject identifier step and/or attribute step fails with an authenticator whose retryAuthenticationEnabled() returns false (e.g. FIDOAuthenticator, which hardcodes false), the framework permanently clears that step's subjectIdentifierStep / subjectAttributeStep flags — even though the conditional-auth script's onFail() handler is about to re-execute the same step successfully.

Because no step is then flagged as the attribute step, the post-authentication fallback in DefaultStepBasedSequenceHandler silently promotes the last authenticated step to be both the subject and attribute step. If that last step is a FederatedApplicationAuthenticator (EmailOTP, SMSOTP, or any IdP-backed step), post-authentication takes the federated claim path, which builds the released attribute set from that step's authenticated user via the IdP's claim mappings. Any claim set at runtime by the adaptive script (user.claims[...] = ... / subject.claims[...] = ...) lives on the subject step's user and is never consulted, so it is dropped from the token.

The failure is silent — authentication completes successfully and the user is logged in; only the claims are missing.

### Reproduction

- SP with script-based advanced authentication:
  - Step 1: basic + fido, marked Use subject identifier from this step and Use attributes from this step
  - Step 2: a federated authenticator (e.g. EmailOTP configured as a federated IdP)
  - At least one requested claim (e.g. http://wso2.org/claims/country)
- Adaptive script sets a runtime claim in the step-1 success handler and then executes step 2; onFail() for step 1 re-executes step 1 with basic only.

**Control path**: choose Basic directly → the claim is present.

**Failing path**: choose FIDO → cancel/fail it → script re-executes step 1 with Basic → complete step 2 → the script-set claim is absent from the ID token.

