### PR TITLE
[Temporary][Do not release] Add AUTHDIAG logs to trace user id resolution

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsAuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/graph/js/JsAuthenticatedUser.java
@@ -178,6 +178,10 @@ public abstract class JsAuthenticatedUser extends AbstractJSObjectWrapper<Authen
                 getContext().setProperty(PROP_USERNAME_UPDATED_EXTERNALLY, "true");
                 break;
             case FrameworkConstants.JSAttributes.JS_USER_STORE_DOMAIN:
+                // AUTHDIAG (temporary) - the adaptive script changing the user store domain.
+                // Note this does not touch the user id, so ordering against AUTHDIAG resolve-* matters.
+                LOG.info("AUTHDIAG script-set-domain old=" + getWrapped().getUserStoreDomain()
+                        + " new=" + value + " userIdAlreadySet=" + getWrapped().isUserIdExists());
                 getWrapped().setUserStoreDomain((String) value);
                 break;
             default:

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
@@ -796,6 +796,13 @@ public class DefaultClaimHandler implements ClaimHandler {
         allLocalClaims = retrieveAllNunNullUserClaimValues(authenticatedUser, claimManager,
                 authenticatedUserId, userStore);
 
+        // AUTHDIAG (temporary) - which record the claims were actually read from. Note the claims are
+        // fetched by user id, while the subject carries a possibly different user store domain.
+        log.info("AUTHDIAG claims userId=" + authenticatedUserId
+                + " subjectDomain=" + authenticatedUser.getUserStoreDomain()
+                + " tenant=" + tenantDomain + " claimCount=" + allLocalClaims.size()
+                + " hasGroups=" + allLocalClaims.containsKey(IdentityUtil.getLocalGroupsClaimURI()));
+
         boolean useAppAssociatedRoles = isAppRoleResolverExists() || !CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME;
         boolean isRoleClaimRequested = (requestedClaimMappings.get(FrameworkConstants.ROLES_CLAIM) != null);
         boolean isAppRoleClaimRequested = (requestedClaimMappings.get(FrameworkConstants.APP_ROLES_CLAIM) != null);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -83,6 +83,10 @@ public class AuthenticatedUser extends User {
      */
     public AuthenticatedUser(AuthenticatedUser authenticatedUser) {
 
+        // AUTHDIAG (temporary) - copying calls getUserId() below, which resolves and caches the id
+        // on the source object using whatever user store domain is set at this moment.
+        log.info("AUTHDIAG copy-ctor srcDomain=" + authenticatedUser.getUserStoreDomain()
+                + " srcUserIdSet=" + authenticatedUser.isUserIdExists() + " caller=" + authDiagCaller());
         this.authenticatedSubjectIdentifier = authenticatedUser.getAuthenticatedSubjectIdentifier();
         this.tenantDomain = authenticatedUser.getTenantDomain();
         try {
@@ -314,12 +318,32 @@ public class AuthenticatedUser extends User {
         if (this.userId != null) {
             return this.userId;
         }
+        // AUTHDIAG (temporary) - the first lazy resolution decides sub and all claims.
+        log.info("AUTHDIAG resolve-start domain=" + this.userStoreDomain + " tenant=" + this.tenantDomain
+                + " federated=" + isFederatedUser() + " caller=" + authDiagCaller());
         // User id can be null sometimes in some flows. Hence trying to resolve it here.
         this.userId = resolveUserIdInternal();
+        log.info("AUTHDIAG resolve-end domain=" + this.userStoreDomain + " userId=" + this.userId);
         if (this.userId == null) {
             throw new UserIdNotFoundException("User id is not available for user.");
         }
         return this.userId;
+    }
+
+    /**
+     * AUTHDIAG (temporary). Compact caller trace, so a log line says which code path triggered it.
+     * Class names and line numbers only - carries no user data.
+     */
+    private static String authDiagCaller() {
+
+        StackTraceElement[] frames = Thread.currentThread().getStackTrace();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 3; i < Math.min(frames.length, 10); i++) {
+            String cls = frames[i].getClassName();
+            sb.append(cls.substring(cls.lastIndexOf('.') + 1)).append('#')
+                    .append(frames[i].getMethodName()).append(':').append(frames[i].getLineNumber()).append(" < ");
+        }
+        return sb.toString();
     }
 
     public boolean isUserIdExists() {
@@ -329,6 +353,9 @@ public class AuthenticatedUser extends User {
 
     public void setUserId(String userId) {
 
+        // AUTHDIAG (temporary) - explicit writes of the user id.
+        log.info("AUTHDIAG setUserId old=" + this.userId + " new=" + userId + " domain=" + this.userStoreDomain
+                + " caller=" + authDiagCaller());
         this.userId = userId;
     }
 
@@ -369,6 +396,10 @@ public class AuthenticatedUser extends User {
             return userId;
         }
 
+        // AUTHDIAG (temporary) - this resolves against the user store but does NOT cache the result,
+        // so it produces a DB lookup without binding the id. Logged so such lookups are attributable.
+        log.info("AUTHDIAG loggable-resolve variant=plain domain=" + this.userStoreDomain
+                + " caller=" + authDiagCaller());
         // User id can be null sometimes in some flows. Hence, trying to resolve it here.
         String loggableUserId = resolveUserIdInternal();
         if (loggableUserId == null) {
@@ -392,6 +423,9 @@ public class AuthenticatedUser extends User {
             return userId;
         }
 
+        // AUTHDIAG (temporary) - same as above: resolves without caching.
+        log.info("AUTHDIAG loggable-resolve variant=masked domain=" + this.userStoreDomain
+                + " caller=" + authDiagCaller());
         // User id can be null sometimes in some flows. Hence, trying to resolve it here.
         String loggableUserId = resolveUserIdInternal();
         if (loggableUserId == null) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -85,8 +85,10 @@ public class AuthenticatedUser extends User {
 
         // AUTHDIAG (temporary) - copying calls getUserId() below, which resolves and caches the id
         // on the source object using whatever user store domain is set at this moment.
+        // The id is read from the field directly - calling getUserId() here would resolve it early
+        // and change the behaviour being investigated.
         log.info("AUTHDIAG copy-ctor srcDomain=" + authenticatedUser.getUserStoreDomain()
-                + " srcUserIdSet=" + authenticatedUser.isUserIdExists() + " caller=" + authDiagCaller());
+                + " srcUserId=" + authenticatedUser.userId + " caller=" + authDiagCaller());
         this.authenticatedSubjectIdentifier = authenticatedUser.getAuthenticatedSubjectIdentifier();
         this.tenantDomain = authenticatedUser.getTenantDomain();
         try {

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java
@@ -1962,6 +1962,11 @@ public class IdentityUtil {
                 if (userStoreManager instanceof AbstractUserStoreManager) {
                     String userId = ((AbstractUserStoreManager) userStoreManager).getUserIDFromUserName(username);
 
+                    // AUTHDIAG (temporary) - did the domain-scoped lookup find the user?
+                    log.info("AUTHDIAG direct-lookup domain=" + userStoreDomain + " tenantId=" + tenantId
+                            + " storeClass=" + userStoreManager.getClass().getSimpleName()
+                            + " found=" + StringUtils.isNotBlank(userId) + " userId=" + userId);
+
                     // If the user id could not be resolved, probably user does not exist in the user store.
                     if (StringUtils.isBlank(userId)) {
                         if (log.isDebugEnabled()) {
@@ -1976,12 +1981,18 @@ public class IdentityUtil {
                             return userId;
                         }
                         String associatedOrganizationUUID = tenant.getAssociatedOrganizationUUID();
+                        // AUTHDIAG (temporary) - the resident organization fallback.
+                        log.info("AUTHDIAG fallback-considered domain=" + userStoreDomain + " tenantId=" + tenantId
+                                + " associatedOrgUUID=" + associatedOrganizationUUID);
                         if (StringUtils.isNotBlank(associatedOrganizationUUID)) {
                             // Trying to resolve the user from the Resident Organization if the user is not found in
                             // the user store of the current organization.
                             Optional<User> user = IdentityCoreServiceDataHolder.getInstance()
                                     .getOrganizationUserResidentResolverService().resolveUserFromResidentOrganization(
                                             username, null, associatedOrganizationUUID);
+                            log.info("AUTHDIAG fallback-result resolved=" + user.isPresent()
+                                    + " userId=" + user.map(User::getUserID).orElse(null)
+                                    + " domain=" + user.map(User::getUserStoreDomain).orElse(null));
                             if (user.isPresent()) {
                                 return user.get().getUserID();
                             }


### PR DESCRIPTION
> **This is temporary diagnostic logging. It will be reverted once the flow is identified, and must not reach production.**

## Purpose

Identify which code path first resolves `AuthenticatedUser.userId` during an identifier-first +
passkey login, and what user store domain is in effect at that moment.

## Why it is needed

For affected logins the token carries the wrong user record — `sub` and all claims resolve to one
record while the passkey resolves against another. We have confirmed from dev diagnostic logs that
the `userId` is **null** at the end of the identifier-first step, so the ID is bound lazily somewhere
later. Which path does it, and with which domain, is the open question.

Correlation logs cannot answer this on their own: `AuthenticatedUser.getLoggableUserId()` and
`getLoggableMaskedUserId()` resolve the ID against the user store but never cache it, so a
`UM_USER_ID` query in the SQL log does not imply the ID was bound.

## Notes

- Every line is prefixed `AUTHDIAG` and marked `// AUTHDIAG (temporary)`, so the revert is a
  single grep.
- No usernames are logged in any form. User IDs are logged as-is, consistent with existing platform
  behaviour — `getLoggableMaskedUserId()` returns the user ID unmasked and masks only the username
  fallback, and `IdentifierHandler` / `FIDOAuthenticator` already log `USER_ID` raw. Caller traces
  contain class names and line numbers only.

## What is logged here

| file | marker | records |
|---|---|---|
| `AuthenticatedUser` | `resolve-start` / `resolve-end` | the first **caching** resolution: domain in effect, result, caller |
| `AuthenticatedUser` | `set` | explicit writes of the user id |
| `AuthenticatedUser` | `copy-ctor` | whether copying the subject triggers an early resolution |
| `AuthenticatedUser` | `loggable-resolve` | resolutions that hit the DB but do **not** cache |
| `IdentityUtil` | `direct-lookup` | did the domain-scoped lookup find the user, and against which store class |
| `IdentityUtil` | `fallback-considered` / `fallback-result` | whether the resident-organization fallback ran, and what it returned |
| `JsAuthenticatedUser` | `script-set-domain` | the adaptive script changing the domain, and whether the id was already set |
| `DefaultClaimHandler` | `claims` | which user id the claims were read with, and whether groups came back |

## Log volume

`getUserId()` and `setUserId()` are hot paths hit on every authentication flow. Expect significant
volume on a busy node. Intended for a dev deployment only.
