### PR TITLE
Mark roles and groups as multi-valued attributes in claim configuration

### DIFF
--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -140,6 +140,7 @@
 				<Description>Roles</Description>
 				<SupportedByDefault/>
 				<ReadOnly />
+				<multiValued>true</multiValued>
 				<SharedProfileValueResolvingMethod>FromSharedProfile</SharedProfileValueResolvingMethod>
 			</Claim>
 			<Claim>
@@ -473,6 +474,7 @@
 				<Description>Groups</Description>
 				<SupportedByDefault />
 				<ReadOnly />
+				<multiValued>true</multiValued>
 				<SharedProfileValueResolvingMethod>FromSharedProfile</SharedProfileValueResolvingMethod>
 			</Claim>
 			<Claim>


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request makes a small but important configuration update to the `claim-config.xml` file. The changes explicitly mark the `Roles` and `Groups` claims as multi-valued, which clarifies their intended usage and may improve compatibility with systems that process claim metadata.

- Configuration updates to claim definitions:
  * Added `<multiValued>true</multiValued>` to the `Roles` claim to indicate it can hold multiple values.
  * Added `<multiValued>true</multiValued>` to the `Groups` claim to indicate it can hold multiple values.

### Related Issues
- https://github.com/wso2/product-is/issues/27652