### PR TITLE
Provision the UI permission tree lazily instead of on every startup

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserRealmProxy.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/UserRealmProxy.java
@@ -55,6 +55,7 @@ import org.wso2.carbon.user.mgt.common.UIPermissionNode;
 import org.wso2.carbon.user.mgt.common.UserAdminException;
 import org.wso2.carbon.user.mgt.common.UserRealmInfo;
 import org.wso2.carbon.user.mgt.common.UserStoreInfo;
+import org.wso2.carbon.user.mgt.permission.UIPermissionProvisioner;
 import org.wso2.carbon.user.mgt.internal.UserMgtDSComponent;
 import org.wso2.carbon.user.mgt.permission.ManagementPermissionUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -2054,6 +2055,7 @@ public class UserRealmProxy {
         Registry tenentRegistry = null;
 
         try {
+            UIPermissionProvisioner.ensureProvisioned();
             Registry registry = UserMgtDSComponent.getRegistryService().getGovernanceSystemRegistry();
             if (tenantId == MultitenantConstants.SUPER_TENANT_ID) {
                 if (CarbonContext.getThreadLocalCarbonContext().getTenantId() != MultitenantConstants.SUPER_TENANT_ID) {
@@ -2113,6 +2115,7 @@ public class UserRealmProxy {
         Registry tenentRegistry = null;
 
         try {
+            UIPermissionProvisioner.ensureProvisioned();
             Registry registry = UserMgtDSComponent.getRegistryService().getGovernanceSystemRegistry();
             if (tenantId == MultitenantConstants.SUPER_TENANT_ID) {
                 regRoot = (Collection) registry.get(UserMgtConstants.UI_PERMISSION_ROOT);
@@ -2497,6 +2500,7 @@ public class UserRealmProxy {
         Registry tenantRegistry = null;
 
         try {
+            UIPermissionProvisioner.ensureProvisioned();
             Registry registry = UserMgtDSComponent.getRegistryService().getGovernanceSystemRegistry();
             if (tenantId == MultitenantConstants.SUPER_TENANT_ID) {
                 regRoot = (Collection) registry.get(UserMgtConstants.UI_PERMISSION_ROOT);

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/internal/UserMgtInitializer.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/internal/UserMgtInitializer.java
@@ -23,17 +23,15 @@ import org.apache.commons.logging.LogFactory;
 import org.osgi.framework.BundleContext;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.registry.core.Collection;
-import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.registry.core.session.UserRegistry;
 import org.wso2.carbon.user.core.AuthorizationManager;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.mgt.UserMgtConstants;
+import org.wso2.carbon.user.mgt.permission.UIPermissionProvisioner;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
-import java.util.HashMap;
-import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -55,7 +53,8 @@ public class UserMgtInitializer {
 
         try {
             UserRegistry registry = registryService.getGovernanceSystemRegistry();
-            Map<String, String> map = new HashMap<String, String>();
+            // Insertion ordered so that parent collections precede their children when written.
+            Map<String, String> map = new LinkedHashMap<String, String>();
             map.put(CarbonConstants.UI_PERMISSION_COLLECTION, "All Permissions");
             map.put(CarbonConstants.UI_ADMIN_PERMISSION_COLLECTION, "Admin Permissions");
             map.put(UserMgtConstants.UI_PROTECTED_PERMISSION_ROOT, "Super Admin Permissions");
@@ -73,25 +72,10 @@ public class UserMgtInitializer {
                     "Profile Management");
             map.put(UserMgtConstants.UI_ADMIN_PERMISSION_ROOT + "login", "Login");
 
-            for (Iterator<Map.Entry<String, String>> ite = map.entrySet().iterator(); ite.hasNext(); ) {
-                Map.Entry<String, String> entry = ite.next();
-                String resourcePath = entry.getKey();
-                String displayName = entry.getValue();
-
-                if (registry.resourceExists(resourcePath)) {
-                    Resource resource = registry.get(resourcePath);
-                    if (resource.getProperty(UserMgtConstants.DISPLAY_NAME) == null) {
-                        resource.setProperty(UserMgtConstants.DISPLAY_NAME, displayName);
-                        registry.put(resourcePath, resource);
-                    }
-                    continue;
-                }
-
-                Collection resource = registry.newCollection();
-                resource.setProperty(UserMgtConstants.DISPLAY_NAME, displayName);
-                registry.put(resourcePath, resource);
-
-            }
+            // Only the management console reads these collections back, so the declarations are buffered
+            // and written to the registry on first use. The admin role authorization below is unrelated -
+            // it lives in the user store tables and is still granted eagerly.
+            UIPermissionProvisioner.declare(map);
 
             // realm is taken from the registry rather than realm service to fix
             // chrooted issues

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/permission/ManagementPermissionsAdder.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/permission/ManagementPermissionsAdder.java
@@ -24,20 +24,15 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
 import org.osgi.framework.BundleListener;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.registry.api.Resource;
-import org.wso2.carbon.registry.core.Collection;
-import org.wso2.carbon.registry.core.Registry;
-import org.wso2.carbon.user.mgt.UserMgtConstants;
-import org.wso2.carbon.user.mgt.internal.UserMgtDSComponent;
 import org.wso2.carbon.utils.component.xml.Component;
 import org.wso2.carbon.utils.component.xml.ComponentConfigFactory;
 import org.wso2.carbon.utils.component.xml.builder.ManagementPermissionsBuilder;
 import org.wso2.carbon.utils.component.xml.config.ManagementPermission;
-import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Adds management permissions declared in component.xml of each bundle.  
@@ -49,10 +44,6 @@ public class ManagementPermissionsAdder implements BundleListener {
     public void bundleChanged(BundleEvent event) {
         Bundle bundle = event.getBundle();
         try {
-            PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
-            carbonContext.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
-            carbonContext.setTenantId(MultitenantConstants.SUPER_TENANT_ID);
-
             if (event.getType() == BundleEvent.STARTED) {
                 addUIPermissionFromBundle(bundle);
             }
@@ -90,23 +81,17 @@ public class ManagementPermissionsAdder implements BundleListener {
                     .getComponentConfig(ManagementPermissionsBuilder.LOCALNAME_MGT_PERMISSIONS);
         }
 
-        if (uiPermissions != null) {
-            // at the starup we are only adding permission only to tenant 0
-            Registry registry = UserMgtDSComponent.getRegistryService().getGovernanceSystemRegistry();
-            for (ManagementPermission uiPermission : uiPermissions) {
-                if (registry.resourceExists(uiPermission.getResourceId())) {
-                    Resource existingResource = registry.get(uiPermission.getResourceId());
-                    if (existingResource.getProperty(UserMgtConstants.DISPLAY_NAME) == null) {
-                        existingResource.setProperty(UserMgtConstants.DISPLAY_NAME, uiPermission.getDisplayName());
-                        registry.put(uiPermission.getResourceId(), existingResource);
-                    }
-                    continue;
-                }
-                Collection resource = registry.newCollection();
-                resource.setProperty(UserMgtConstants.DISPLAY_NAME, uiPermission.getDisplayName());
-                registry.put(uiPermission.getResourceId(), resource);
-            }
+        if (uiPermissions == null) {
+            return;
         }
+
+        // At startup we only ever added permissions to tenant 0, and only the management console reads
+        // them back, so the declarations are buffered here and written to the registry on first use.
+        Map<String, String> declaredPermissions = new LinkedHashMap<>();
+        for (ManagementPermission uiPermission : uiPermissions) {
+            declaredPermissions.put(uiPermission.getResourceId(), uiPermission.getDisplayName());
+        }
+        UIPermissionProvisioner.declare(declaredPermissions);
     }
 
 }

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/permission/ManagementPermissionsAdder.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/permission/ManagementPermissionsAdder.java
@@ -89,6 +89,13 @@ public class ManagementPermissionsAdder implements BundleListener {
         // them back, so the declarations are buffered here and written to the registry on first use.
         Map<String, String> declaredPermissions = new LinkedHashMap<>();
         for (ManagementPermission uiPermission : uiPermissions) {
+            // A malformed component.xml can yield a null resource id, and the buffer would happily accept
+            // it as a map key. Drop it here, while the originating bundle is still known.
+            if (uiPermission == null || uiPermission.getResourceId() == null) {
+                log.warn("Skipping a management permission declared without a resource id in bundle "
+                        + bundle.getSymbolicName());
+                continue;
+            }
             declaredPermissions.put(uiPermission.getResourceId(), uiPermission.getDisplayName());
         }
         UIPermissionProvisioner.declare(declaredPermissions);

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/permission/UIPermissionProvisioner.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/permission/UIPermissionProvisioner.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.user.mgt.permission;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.registry.api.RegistryException;
+import org.wso2.carbon.registry.core.Collection;
+import org.wso2.carbon.registry.core.Registry;
+import org.wso2.carbon.registry.core.Resource;
+import org.wso2.carbon.user.mgt.UserMgtConstants;
+import org.wso2.carbon.user.mgt.internal.UserMgtDSComponent;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Collects the UI (management console) permission tree declared by components and writes it to the
+ * registry only when something actually needs it.
+ * <p>
+ * The permission collections under {@code /_system/governance/permission} carry display metadata for
+ * the legacy management console permission tree. Runtime authorization does not read them - it is
+ * served from the {@code UM_PERMISSION} / {@code UM_ROLE_PERMISSION} tables - so provisioning them is
+ * only required when a caller asks for the tree itself (see {@code UserRealmProxy#getAllUIPermissions}
+ * and {@code UserRealmProxy#getRolePermissions}).
+ * <p>
+ * Writing them during startup cost roughly 2,300 registry SQL statements on every boot, because each of
+ * the ~272 declared nodes was checked with {@code resourceExists()} and then fetched in full just to test
+ * a single display-name property. That is invisible against an embedded database but adds seconds of
+ * sequential round trips against a networked one. Declarations are therefore buffered in memory here and
+ * flushed on first use.
+ *
+ * @see ManagementPermissionsAdder
+ */
+public final class UIPermissionProvisioner {
+
+    private static final Log log = LogFactory.getLog(UIPermissionProvisioner.class);
+
+    /**
+     * Set to {@code true} to restore the legacy behaviour of writing the UI permission tree to the
+     * registry during server startup instead of on first use.
+     */
+    public static final String EAGER_PROVISIONING_PROPERTY = "carbon.ui.permissions.eager";
+
+    /**
+     * Declared permission path -&gt; display name, in declaration order so that parent collections are
+     * created before their children.
+     */
+    private static final Map<String, String> DECLARED_PERMISSIONS = new LinkedHashMap<>();
+
+    private static volatile boolean provisioned = false;
+
+    private UIPermissionProvisioner() {
+
+    }
+
+    /**
+     * Clears the buffered declarations and the provisioned flag. Only intended for tests, which need to
+     * exercise the provisioning state machine more than once per JVM.
+     */
+    static void reset() {
+
+        synchronized (UIPermissionProvisioner.class) {
+            synchronized (DECLARED_PERMISSIONS) {
+                DECLARED_PERMISSIONS.clear();
+            }
+            provisioned = false;
+        }
+    }
+
+    /**
+     * @return whether the UI permission tree should be written to the registry during startup.
+     */
+    public static boolean isEagerProvisioningEnabled() {
+
+        return Boolean.parseBoolean(System.getProperty(EAGER_PROVISIONING_PROPERTY));
+    }
+
+    /**
+     * Records declared permissions. The first declaration of a path wins, matching the legacy behaviour
+     * where a component that found the collection already present left the existing display name alone.
+     * <p>
+     * Under {@link #EAGER_PROVISIONING_PROPERTY} the batch is also written to the registry immediately, so
+     * that components declaring permissions after the server has started are still picked up.
+     *
+     * @param permissions Permission resource path to display name.
+     * @throws RegistryException If eager provisioning is enabled and the registry write fails.
+     */
+    public static void declare(Map<String, String> permissions) throws RegistryException {
+
+        if (permissions == null || permissions.isEmpty()) {
+            return;
+        }
+        synchronized (DECLARED_PERMISSIONS) {
+            for (Map.Entry<String, String> permission : permissions.entrySet()) {
+                DECLARED_PERMISSIONS.putIfAbsent(permission.getKey(), permission.getValue());
+            }
+        }
+        if (isEagerProvisioningEnabled()) {
+            synchronized (UIPermissionProvisioner.class) {
+                writeBatch(permissions);
+            }
+        }
+    }
+
+    /**
+     * Writes every declared permission collection to the registry, unless this has already been done.
+     * <p>
+     * Callers reach this while serving a request that may belong to any tenant, so the work runs inside a
+     * super tenant flow. That matches the legacy startup path, which provisioned the super tenant only.
+     * <p>
+     * A failure leaves the provisioner un-provisioned so that a later call retries rather than silently
+     * serving an incomplete tree forever.
+     *
+     * @throws RegistryException If the permission tree could not be written to the registry.
+     */
+    public static void ensureProvisioned() throws RegistryException {
+
+        if (provisioned) {
+            return;
+        }
+        synchronized (UIPermissionProvisioner.class) {
+            if (provisioned) {
+                return;
+            }
+            if (isEagerProvisioningEnabled()) {
+                // Every declaration was written to the registry as it arrived, so there is nothing to flush.
+                provisioned = true;
+                return;
+            }
+            Map<String, String> permissions;
+            synchronized (DECLARED_PERMISSIONS) {
+                permissions = new LinkedHashMap<>(DECLARED_PERMISSIONS);
+            }
+            writeBatch(permissions);
+            provisioned = true;
+        }
+    }
+
+    /**
+     * Writes a batch of permission collections to the registry under a super tenant flow. Callers reach
+     * the lazy path while serving a request that may belong to any tenant, and the legacy startup path
+     * provisioned the super tenant only, so the tenant is pinned here either way.
+     */
+    private static void writeBatch(Map<String, String> permissions) throws RegistryException {
+
+        if (permissions.isEmpty()) {
+            return;
+        }
+        try {
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+            carbonContext.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+            carbonContext.setTenantId(MultitenantConstants.SUPER_TENANT_ID);
+
+            Registry registry = UserMgtDSComponent.getRegistryService().getGovernanceSystemRegistry();
+            int created = 0;
+            for (Map.Entry<String, String> permission : permissions.entrySet()) {
+                if (addPermission(registry, permission.getKey(), permission.getValue())) {
+                    created++;
+                }
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("Provisioned the UI permission tree: " + created + " of " + permissions.size()
+                        + " declared permissions were created in the registry.");
+            }
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
+    /**
+     * Creates the permission collection if it is missing, or backfills its display name if it is present
+     * without one.
+     *
+     * @param registry    Governance registry to write to.
+     * @param path        Permission resource path.
+     * @param displayName Display name for the permission.
+     * @return {@code true} if the collection was created.
+     * @throws RegistryException If the registry operation fails.
+     */
+    public static boolean addPermission(Registry registry, String path, String displayName)
+            throws RegistryException {
+
+        if (registry.resourceExists(path)) {
+            Resource existingResource = registry.get(path);
+            if (existingResource.getProperty(UserMgtConstants.DISPLAY_NAME) == null) {
+                existingResource.setProperty(UserMgtConstants.DISPLAY_NAME, displayName);
+                registry.put(path, existingResource);
+            }
+            return false;
+        }
+        Collection collection = registry.newCollection();
+        collection.setProperty(UserMgtConstants.DISPLAY_NAME, displayName);
+        registry.put(path, collection);
+        return true;
+    }
+}

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/permission/UIPermissionProvisioner.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/permission/UIPermissionProvisioner.java
@@ -1,19 +1,19 @@
 /*
- * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 LLC. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.user.mgt.permission;
@@ -98,24 +98,29 @@ public final class UIPermissionProvisioner {
      * Records declared permissions. The first declaration of a path wins, matching the legacy behaviour
      * where a component that found the collection already present left the existing display name alone.
      * <p>
-     * Under {@link #EAGER_PROVISIONING_PROPERTY} the batch is also written to the registry immediately, so
-     * that components declaring permissions after the server has started are still picked up.
+     * The batch is written to the registry immediately when the tree has already been flushed, or when
+     * {@link #EAGER_PROVISIONING_PROPERTY} is set. Bundles can start at any point in the server lifecycle,
+     * including after the permission tree has been read, and a declaration that only ever landed in the
+     * buffer would not reach the registry until the next restart.
+     * <p>
+     * This holds the class lock for the whole method so that a declaration cannot slip past the snapshot
+     * taken by {@link #ensureProvisioned()} while that snapshot is being written.
      *
      * @param permissions Permission resource path to display name.
-     * @throws RegistryException If eager provisioning is enabled and the registry write fails.
+     * @throws RegistryException If the batch has to be written now and the registry write fails.
      */
     public static void declare(Map<String, String> permissions) throws RegistryException {
 
         if (permissions == null || permissions.isEmpty()) {
             return;
         }
-        synchronized (DECLARED_PERMISSIONS) {
-            for (Map.Entry<String, String> permission : permissions.entrySet()) {
-                DECLARED_PERMISSIONS.putIfAbsent(permission.getKey(), permission.getValue());
+        synchronized (UIPermissionProvisioner.class) {
+            synchronized (DECLARED_PERMISSIONS) {
+                for (Map.Entry<String, String> permission : permissions.entrySet()) {
+                    DECLARED_PERMISSIONS.putIfAbsent(permission.getKey(), permission.getValue());
+                }
             }
-        }
-        if (isEagerProvisioningEnabled()) {
-            synchronized (UIPermissionProvisioner.class) {
+            if (provisioned || isEagerProvisioningEnabled()) {
                 writeBatch(permissions);
             }
         }
@@ -129,6 +134,9 @@ public final class UIPermissionProvisioner {
      * <p>
      * A failure leaves the provisioner un-provisioned so that a later call retries rather than silently
      * serving an incomplete tree forever.
+     * <p>
+     * Declarations arriving after this has run are written by {@link #declare(Map)} itself, which shares
+     * this lock, so nothing can be buffered and then forgotten.
      *
      * @throws RegistryException If the permission tree could not be written to the registry.
      */
@@ -197,7 +205,7 @@ public final class UIPermissionProvisioner {
      * @return {@code true} if the collection was created.
      * @throws RegistryException If the registry operation fails.
      */
-    public static boolean addPermission(Registry registry, String path, String displayName)
+    private static boolean addPermission(Registry registry, String path, String displayName)
             throws RegistryException {
 
         if (registry.resourceExists(path)) {

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/test/java/org/wso2/carbon/user/mgt/permission/UIPermissionProvisionerTest.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/test/java/org/wso2/carbon/user/mgt/permission/UIPermissionProvisionerTest.java
@@ -1,19 +1,19 @@
 /*
- * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 LLC. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.user.mgt.permission;
@@ -203,6 +203,45 @@ public class UIPermissionProvisionerTest {
     public void testLazyProvisioningIsTheDefault() {
 
         assertFalse(UIPermissionProvisioner.isEagerProvisioningEnabled());
+    }
+
+    /**
+     * A bundle can start after the permission tree has already been read. Its declarations must reach the
+     * registry straight away rather than sitting in the buffer until the next restart.
+     */
+    @Test
+    public void testDeclarationAfterFlushIsWrittenImmediately() throws Exception {
+
+        when(registry.resourceExists(anyString())).thenReturn(false);
+
+        UIPermissionProvisioner.declare(permissions());
+        UIPermissionProvisioner.ensureProvisioned();
+
+        String lateArrival = "/permission/admin/manage/identity/idpmgt";
+        Map<String, String> late = new LinkedHashMap<>();
+        late.put(lateArrival, "Identity Provider Management");
+        UIPermissionProvisioner.declare(late);
+
+        verify(registry).put(eq(lateArrival), any(Collection.class));
+    }
+
+    /**
+     * The late declaration must not cause the whole tree to be rewritten - only the new batch.
+     */
+    @Test
+    public void testDeclarationAfterFlushDoesNotRewriteExistingPermissions() throws Exception {
+
+        when(registry.resourceExists(anyString())).thenReturn(false);
+
+        UIPermissionProvisioner.declare(permissions());
+        UIPermissionProvisioner.ensureProvisioned();
+
+        Map<String, String> late = new LinkedHashMap<>();
+        late.put("/permission/admin/manage/identity/idpmgt", "Identity Provider Management");
+        UIPermissionProvisioner.declare(late);
+
+        verify(registry, times(1)).put(eq(PERMISSION_A), any(Collection.class));
+        verify(registry, times(1)).put(eq(PERMISSION_B), any(Collection.class));
     }
 
     private Map<String, String> permissions() {

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/test/java/org/wso2/carbon/user/mgt/permission/UIPermissionProvisionerTest.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/test/java/org/wso2/carbon/user/mgt/permission/UIPermissionProvisionerTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.user.mgt.permission;
+
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.registry.core.Collection;
+import org.wso2.carbon.registry.core.Resource;
+import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.registry.core.session.UserRegistry;
+import org.wso2.carbon.user.mgt.UserMgtConstants;
+import org.wso2.carbon.user.mgt.internal.UserMgtDSComponent;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests that the UI permission tree is buffered at declaration time and only written to the registry
+ * when a caller actually asks for it.
+ */
+public class UIPermissionProvisionerTest {
+
+    private static final String PERMISSION_A = "/permission/admin/manage/identity/applicationmgt";
+    private static final String PERMISSION_B = "/permission/admin/manage/identity/claimmgt";
+
+    private UserRegistry registry;
+    private MockedStatic<UserMgtDSComponent> dsComponent;
+    private MockedStatic<PrivilegedCarbonContext> carbonContext;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        UIPermissionProvisioner.reset();
+        System.clearProperty(UIPermissionProvisioner.EAGER_PROVISIONING_PROPERTY);
+
+        registry = mock(UserRegistry.class);
+        when(registry.newCollection()).thenAnswer(invocation -> mock(Collection.class));
+
+        RegistryService registryService = mock(RegistryService.class);
+        when(registryService.getGovernanceSystemRegistry()).thenReturn(registry);
+
+        dsComponent = mockStatic(UserMgtDSComponent.class);
+        dsComponent.when(UserMgtDSComponent::getRegistryService).thenReturn(registryService);
+
+        carbonContext = mockStatic(PrivilegedCarbonContext.class);
+        carbonContext.when(PrivilegedCarbonContext::getThreadLocalCarbonContext)
+                .thenReturn(mock(PrivilegedCarbonContext.class));
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        dsComponent.close();
+        carbonContext.close();
+        UIPermissionProvisioner.reset();
+        System.clearProperty(UIPermissionProvisioner.EAGER_PROVISIONING_PROPERTY);
+    }
+
+    @Test
+    public void testDeclareDoesNotTouchTheRegistry() throws Exception {
+
+        UIPermissionProvisioner.declare(permissions());
+
+        verifyNoInteractions(registry);
+    }
+
+    @Test
+    public void testEnsureProvisionedWritesDeclaredPermissions() throws Exception {
+
+        when(registry.resourceExists(anyString())).thenReturn(false);
+
+        UIPermissionProvisioner.declare(permissions());
+        UIPermissionProvisioner.ensureProvisioned();
+
+        verify(registry).put(eq(PERMISSION_A), any(Collection.class));
+        verify(registry).put(eq(PERMISSION_B), any(Collection.class));
+    }
+
+    @Test
+    public void testEnsureProvisionedRunsOnlyOnce() throws Exception {
+
+        when(registry.resourceExists(anyString())).thenReturn(false);
+
+        UIPermissionProvisioner.declare(permissions());
+        UIPermissionProvisioner.ensureProvisioned();
+        UIPermissionProvisioner.ensureProvisioned();
+        UIPermissionProvisioner.ensureProvisioned();
+
+        verify(registry, times(1)).put(eq(PERMISSION_A), any(Collection.class));
+    }
+
+    @Test
+    public void testExistingPermissionWithDisplayNameIsLeftAlone() throws Exception {
+
+        Resource existing = mock(Resource.class);
+        when(existing.getProperty(UserMgtConstants.DISPLAY_NAME)).thenReturn("Application Management");
+        when(registry.resourceExists(PERMISSION_A)).thenReturn(true);
+        when(registry.get(PERMISSION_A)).thenReturn(existing);
+
+        Map<String, String> single = new LinkedHashMap<>();
+        single.put(PERMISSION_A, "Application Management");
+        UIPermissionProvisioner.declare(single);
+        UIPermissionProvisioner.ensureProvisioned();
+
+        verify(registry, never()).put(eq(PERMISSION_A), any(Collection.class));
+        verify(registry, never()).put(eq(PERMISSION_A), any(Resource.class));
+    }
+
+    @Test
+    public void testExistingPermissionWithoutDisplayNameIsBackfilled() throws Exception {
+
+        Resource existing = mock(Resource.class);
+        when(existing.getProperty(UserMgtConstants.DISPLAY_NAME)).thenReturn(null);
+        when(registry.resourceExists(PERMISSION_A)).thenReturn(true);
+        when(registry.get(PERMISSION_A)).thenReturn(existing);
+
+        Map<String, String> single = new LinkedHashMap<>();
+        single.put(PERMISSION_A, "Application Management");
+        UIPermissionProvisioner.declare(single);
+        UIPermissionProvisioner.ensureProvisioned();
+
+        verify(existing).setProperty(UserMgtConstants.DISPLAY_NAME, "Application Management");
+        verify(registry).put(PERMISSION_A, existing);
+    }
+
+    @Test
+    public void testFirstDeclarationOfAPathWins() throws Exception {
+
+        when(registry.resourceExists(anyString())).thenReturn(false);
+
+        Map<String, String> first = new LinkedHashMap<>();
+        first.put(PERMISSION_A, "Original");
+        Map<String, String> second = new LinkedHashMap<>();
+        second.put(PERMISSION_A, "Replacement");
+
+        UIPermissionProvisioner.declare(first);
+        UIPermissionProvisioner.declare(second);
+        UIPermissionProvisioner.ensureProvisioned();
+
+        // The collection is created once, carrying the display name from the first declaration.
+        verify(registry, times(1)).put(eq(PERMISSION_A), any(Collection.class));
+    }
+
+    @Test
+    public void testEagerProvisioningWritesAtDeclarationTime() throws Exception {
+
+        System.setProperty(UIPermissionProvisioner.EAGER_PROVISIONING_PROPERTY, "true");
+        when(registry.resourceExists(anyString())).thenReturn(false);
+        assertTrue(UIPermissionProvisioner.isEagerProvisioningEnabled());
+
+        UIPermissionProvisioner.declare(permissions());
+
+        verify(registry).put(eq(PERMISSION_A), any(Collection.class));
+        verify(registry).put(eq(PERMISSION_B), any(Collection.class));
+    }
+
+    @Test
+    public void testEagerProvisioningDoesNotRewriteOnFirstUse() throws Exception {
+
+        System.setProperty(UIPermissionProvisioner.EAGER_PROVISIONING_PROPERTY, "true");
+        when(registry.resourceExists(anyString())).thenReturn(false);
+
+        UIPermissionProvisioner.declare(permissions());
+        UIPermissionProvisioner.ensureProvisioned();
+
+        // Already written as it was declared, so the lazy flush must not repeat the work.
+        verify(registry, times(1)).put(eq(PERMISSION_A), any(Collection.class));
+    }
+
+    @Test
+    public void testLazyProvisioningIsTheDefault() {
+
+        assertFalse(UIPermissionProvisioner.isEagerProvisioningEnabled());
+    }
+
+    private Map<String, String> permissions() {
+
+        Map<String, String> permissions = new LinkedHashMap<>();
+        permissions.put(PERMISSION_A, "Application Management");
+        permissions.put(PERMISSION_B, "Claim Management");
+        return permissions;
+    }
+}

--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/test/resources/testng.xml
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/test/resources/testng.xml
@@ -23,6 +23,7 @@
     <test name="identity-base-test-all">
         <classes>
             <class name="org.wso2.carbon.user.mgt.UserRealmProxyTest"/>
+            <class name="org.wso2.carbon.user.mgt.permission.UIPermissionProvisionerTest"/>
             <class name="org.wso2.carbon.user.mgt.UserDeletionEventListenerTest"/>
             <class name="org.wso2.carbon.user.mgt.recorder.DefaultUserDeletionEventRecorderTest" />
             <class name="org.wso2.carbon.user.mgt.bulkImport.JsonConverterTest" />


### PR DESCRIPTION
## Problem

`ManagementPermissionsAdder` and `UserMgtInitializer` write the management console permission tree to the registry on **every** server start.

For each of the ~272 declared permission nodes, the code calls `resourceExists()` and then fetches the whole resource just to check one display-name property — which is almost always set, so the resource is discarded:

```java
if (registry.resourceExists(uiPermission.getResourceId())) {
    Resource existingResource = registry.get(uiPermission.getResourceId());   // full fetch
    if (existingResource.getProperty(UserMgtConstants.DISPLAY_NAME) == null) {
        ...
    }
    continue;                                                                 // ...then discarded
}
```

Through the registry handler chain this becomes roughly **2,300 `REG_*` SQL statements per boot**.

## Why this can be deferred

Runtime authorization does not read these collections — it is served from `UM_PERMISSION` / `UM_ROLE_PERMISSION`. The registry collections hold display metadata only.

The only readers are three methods in `UserRealmProxy`: `getAllUIPermissions(int)` and the two `getRolePermissions` overloads. They are reached through the legacy `UserAdmin` admin service.

## Change

Declarations are buffered in memory by a new `UIPermissionProvisioner` and written to the registry on first use, from those three call sites.

- Writes run in a super tenant flow, matching the old behaviour which only provisioned tenant 0.
- First declaration of a path wins, as before.
- Declarations arriving after the first flush are written immediately, so bundles starting later are not lost.
- The admin role authorization in `UserMgtInitializer` is unrelated — it lives in the user store tables — and still runs at startup.
- `-Dcarbon.ui.permissions.eager=true` restores the previous behaviour.

## Result

IS 7.4.0-SNAPSHOT, JDK 21, embedded H2. Interleaved A/B, three pairs:

| | wall clock | JDBC calls | `REG_*` calls |
|---|---|---|---|
| before | 14.16 s | 2,853 | 2,377 |
| after | 14.09 s | **685** | **209** |

**76% fewer database calls at startup; 91% fewer registry calls.**

Wall clock is unchanged on embedded H2, where those statements total only ~55 ms. The gain is 2,168 fewer sequential round trips, which matters against a networked database — about **2 s** of startup at 1 ms RTT. This is invisible in local development and material in a cloud deployment.

## Tests

11 tests in `UIPermissionProvisionerTest` covering buffering, one-shot flush, late declarations, display-name backfill, first-declaration-wins, and eager mode. Full module suite passes at 49/49.