### PR TITLE
Resolve sub organization native organization roles for shared applications

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/approles/impl/AppAssociatedRolesResolverImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/approles/impl/AppAssociatedRolesResolverImpl.java
@@ -37,9 +37,11 @@ import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.RoleV2;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.Role;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.model.SharedIdPResolveType;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -59,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.application.authentication.framework.handler.approles.constant.AppRolesConstants.ErrorMessages.ERROR_CODE_RETRIEVING_APP_ROLES;
 import static org.wso2.carbon.identity.application.authentication.framework.handler.approles.constant.AppRolesConstants.ErrorMessages.ERROR_CODE_RETRIEVING_IDENTITY_PROVIDER;
@@ -180,7 +183,8 @@ public class AppAssociatedRolesResolverImpl implements ApplicationRolesResolver 
         List<RoleV2> rolesAssociatedWithApp = getRolesAssociatedWithApplication(applicationId, appTenantDomain);
         if (StringUtils.isNotEmpty(authenticatedUser.getSharedUserId())) {
             // Add the shared role details to the roles list which are associated with the application.
-            addSharedRoleAssociations(authenticatedUser, rolesAssociatedWithApp, userRoleIds);
+            addSharedRoleAssociations(authenticatedUser, rolesAssociatedWithApp, userRoleIds, applicationId,
+                    appTenantDomain);
         }
 
         return rolesAssociatedWithApp.stream()
@@ -217,7 +221,8 @@ public class AppAssociatedRolesResolverImpl implements ApplicationRolesResolver 
     }
 
     private void addSharedRoleAssociations(AuthenticatedUser authenticatedUser, List<RoleV2> rolesAssociatedWithApp,
-                                           Set<String> userRoleIds) throws ApplicationRolesException {
+                                           Set<String> userRoleIds, String applicationId, String appTenantDomain)
+            throws ApplicationRolesException {
 
         if (!isSharedUserAccessingSharedOrg(authenticatedUser)) {
             return;
@@ -251,12 +256,59 @@ public class AppAssociatedRolesResolverImpl implements ApplicationRolesResolver 
                     }
                 }
             }
+            /*
+            For organization audience applications, every organization role of the organization is associated with
+            the application. Roles created within the shared organization have no main role to map from, hence they
+            are resolved here from the roles assigned to the user in that organization.
+            */
+            if (isOrganizationAudienceApp(applicationId, appTenantDomain)) {
+                addOrganizationAudienceRolesOfSharedOrg(sharedTenantDomain, rolesAssociatedWithApp, userRoleIds);
+            }
         } catch (OrganizationManagementException e) {
             throw new ApplicationRolesException("Error while resolving the tenant domain from the organization " +
                     "id: " + authenticatedUser.getAccessingOrganization(), e.getMessage());
         } catch (IdentityRoleManagementException e) {
             throw new ApplicationRolesException("Error while extracting the role details for the organization " +
                     "id: " + authenticatedUser.getAccessingOrganization(), e.getMessage());
+        }
+    }
+
+    /**
+     * Add the organization audience roles of the shared organization which are assigned to the user. These are the
+     * roles created within the shared organization itself, which have no counterpart in the main organization.
+     *
+     * @param sharedTenantDomain     Tenant domain of the shared organization.
+     * @param rolesAssociatedWithApp Roles associated with the application.
+     * @param userRoleIds            Role IDs assigned to the user in the shared organization.
+     * @throws IdentityRoleManagementException If an error occurred while retrieving the role details.
+     */
+    private void addOrganizationAudienceRolesOfSharedOrg(String sharedTenantDomain,
+                                                         List<RoleV2> rolesAssociatedWithApp, Set<String> userRoleIds)
+            throws IdentityRoleManagementException {
+
+        Set<String> resolvedRoleIds = rolesAssociatedWithApp.stream().map(RoleV2::getId).collect(Collectors.toSet());
+        RoleManagementService roleManagementService =
+                FrameworkServiceDataHolder.getInstance().getRoleManagementServiceV2();
+        for (String userRoleId : userRoleIds) {
+            if (resolvedRoleIds.contains(userRoleId)) {
+                continue;
+            }
+            RoleBasicInfo role = roleManagementService.getRoleBasicInfoById(userRoleId, sharedTenantDomain);
+            if (role != null && RoleConstants.ORGANIZATION.equalsIgnoreCase(role.getAudience())) {
+                rolesAssociatedWithApp.add(new RoleV2(role.getId(), role.getName()));
+            }
+        }
+    }
+
+    private boolean isOrganizationAudienceApp(String applicationId, String appTenantDomain)
+            throws ApplicationRolesException {
+
+        try {
+            return RoleConstants.ORGANIZATION.equalsIgnoreCase(FrameworkServiceDataHolder.getInstance()
+                    .getApplicationManagementService()
+                    .getAllowedAudienceForRoleAssociation(applicationId, appTenantDomain));
+        } catch (IdentityApplicationManagementException e) {
+            throw RoleResolverUtils.handleServerException(ERROR_CODE_RETRIEVING_APP_ROLES, e);
         }
     }
 


### PR DESCRIPTION
Resolves part (1) of wso2/product-is#28338.

Related PRs: wso2/carbon-identity-framework#8247, wso2-extensions/identity-auth-organization-login#78, wso2-extensions/identity-organization-management#649. All four are required for a shared user to receive their organization roles in a sub-organization.

## Purpose
For a B2B SaaS application shared with an organization, the `roles` claim in the ID token only carries the organization roles shared down from the root organization. Organization roles created **within the sub organization itself** are dropped.

This PR covers the path where the user was **shared** into the sub organization from an ancestor organization. The companion PR in `identity-organization-management` covers users created natively inside the sub organization.


> **Scope of this PR.** This is one of three changes; each covers a distinct hop and all three are
> required for organization roles to reach the token of a shared application:
> - Organization resolves its own organization audience roles: https://github.com/wso2-extensions/identity-organization-management/pull/649
> - Shared user accessing the shared organization: https://github.com/wso2/carbon-identity-framework/pull/8245
> - Carrying the claim across the legacy organization login hop: https://github.com/wso2-extensions/identity-auth-organization-login/pull/77
>
> They are independent at compile time and can be merged in any order. On its own this PR does not
> make the roles claim reach applications that use legacy organization login
> (`enhancedOrgAuthenticationEnabled = false`).

## Goals
When a shared user accesses an `ORGANIZATION` role-audience application in the organization they are shared into, the organization roles they hold in that organization should reach the `roles` claim — whether those roles were inherited from the main organization or created locally.

## Approach
`AppAssociatedRolesResolverImpl` builds the claim as the intersection of *roles associated with the application* and *all roles of the user*. The user side is already resolved against the accessed organization and is correct.

For a shared user (`isSharedUserAccessingSharedOrg`), the resolver never switches to the shared application — it stays on the main application in the main organization and augments the associated-roles list purely from `getMainRoleToSharedRoleMappingsBySubOrg(...)` in `addSharedRoleAssociations`. A role created inside the sub organization has no main role to map from, so it is never in the associated set and gets filtered out.

`addSharedRoleAssociations` now additionally resolves the organization-audience roles the user holds in the accessed organization, when the application's allowed audience for role association is `ORGANIZATION`. This mirrors the root-organization semantics, where "audience = Organization" already means every organization role of that organization is associated with the application. Roles already contributed by the main-to-shared mapping are de-duplicated by role id.

`APPLICATION`-audience applications take an early exit and are unaffected.

## User stories
As a user shared into a customer organization, when the organization's administrator grants me a role they defined locally, my token for the shared application reflects that role.

## Release note
Organization roles created within a sub organization are now included in the tokens issued to users shared into that organization, for B2B applications whose role audience is Organization.

## Documentation
N/A — no new configuration or API surface. The behaviour now matches the documented meaning of the Organization role audience.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
 - Unit tests
   > Existing `AppAssociatedRolesResolverImplTest` passes (8/8). Dedicated unit tests for the new branch in `addSharedRoleAssociations` are still to be added.
 - Integration tests
   > Verified at runtime against a `wso2is-7.4.0-SNAPSHOT` pack. The shared-user path was exercised through the `organization_switch` grant, confirming `shared_user_id` was present on the issued token so the intended branch was reached. Results: with this change absent the sub organization's local role is missing from the claim; with it applied the claim carries both the locally-created role and the one inherited from the main organization. Regression coverage confirms root-organization users on non-shared and main applications are unchanged, and that unheld roles do not appear.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- Organization resolves its own organization audience roles: https://github.com/wso2-extensions/identity-organization-management/pull/649
- Carrying the claim across the legacy organization login hop: https://github.com/wso2-extensions/identity-auth-organization-login/pull/77

The two are independent at compile time and can be merged in either order. Each alone fixes a disjoint set of login paths; both are needed for full coverage.

## Migrations (if applicable)
No migration required. Behaviour changes on upgrade for existing `ORGANIZATION`-audience shared applications: applications that authorize on the `roles` claim will observe role names chosen by sub organization administrators, not only the vocabulary defined in the root organization. This change is not gated behind a configuration knob or organization version.

## Test environment
JDK 21, macOS 15 (Darwin 25.5.0), H2 (default), Chromium via Playwright for the organization-login flow.

## Learning
Traced the `roles` claim from `DefaultClaimHandler` / `FrameworkUtils` into `AppAssociatedRolesResolverImpl`, then into `ApplicationManagementService#getAssociatedRolesOfApplication` and the shared-application listener, to separate the two distinct paths by which a shared application's associated roles are resolved.

