### PR TITLE
Resolve roles of a shared user signing in at a sub-organization, including sub-organization native organization roles

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/approles/impl/AppAssociatedRolesResolverImpl.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/approles/impl/AppAssociatedRolesResolverImpl.java
@@ -37,9 +37,11 @@ import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.RoleV2;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.Role;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.model.SharedIdPResolveType;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -59,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.application.authentication.framework.handler.approles.constant.AppRolesConstants.ErrorMessages.ERROR_CODE_RETRIEVING_APP_ROLES;
 import static org.wso2.carbon.identity.application.authentication.framework.handler.approles.constant.AppRolesConstants.ErrorMessages.ERROR_CODE_RETRIEVING_IDENTITY_PROVIDER;
@@ -180,7 +183,8 @@ public class AppAssociatedRolesResolverImpl implements ApplicationRolesResolver 
         List<RoleV2> rolesAssociatedWithApp = getRolesAssociatedWithApplication(applicationId, appTenantDomain);
         if (StringUtils.isNotEmpty(authenticatedUser.getSharedUserId())) {
             // Add the shared role details to the roles list which are associated with the application.
-            addSharedRoleAssociations(authenticatedUser, rolesAssociatedWithApp, userRoleIds);
+            addSharedRoleAssociations(authenticatedUser, rolesAssociatedWithApp, userRoleIds, applicationId,
+                    appTenantDomain);
         }
 
         return rolesAssociatedWithApp.stream()
@@ -217,7 +221,8 @@ public class AppAssociatedRolesResolverImpl implements ApplicationRolesResolver 
     }
 
     private void addSharedRoleAssociations(AuthenticatedUser authenticatedUser, List<RoleV2> rolesAssociatedWithApp,
-                                           Set<String> userRoleIds) throws ApplicationRolesException {
+                                           Set<String> userRoleIds, String applicationId, String appTenantDomain)
+            throws ApplicationRolesException {
 
         if (!isSharedUserAccessingSharedOrg(authenticatedUser)) {
             return;
@@ -251,12 +256,59 @@ public class AppAssociatedRolesResolverImpl implements ApplicationRolesResolver 
                     }
                 }
             }
+            /*
+            For organization audience applications, every organization role of the organization is associated with
+            the application. Roles created within the shared organization have no main role to map from, hence they
+            are resolved here from the roles assigned to the user in that organization.
+            */
+            if (isOrganizationAudienceApp(applicationId, appTenantDomain)) {
+                addOrganizationAudienceRolesOfSharedOrg(sharedTenantDomain, rolesAssociatedWithApp, userRoleIds);
+            }
         } catch (OrganizationManagementException e) {
             throw new ApplicationRolesException("Error while resolving the tenant domain from the organization " +
                     "id: " + authenticatedUser.getAccessingOrganization(), e.getMessage());
         } catch (IdentityRoleManagementException e) {
             throw new ApplicationRolesException("Error while extracting the role details for the organization " +
                     "id: " + authenticatedUser.getAccessingOrganization(), e.getMessage());
+        }
+    }
+
+    /**
+     * Add the organization audience roles of the shared organization which are assigned to the user. These are the
+     * roles created within the shared organization itself, which have no counterpart in the main organization.
+     *
+     * @param sharedTenantDomain     Tenant domain of the shared organization.
+     * @param rolesAssociatedWithApp Roles associated with the application.
+     * @param userRoleIds            Role IDs assigned to the user in the shared organization.
+     * @throws IdentityRoleManagementException If an error occurred while retrieving the role details.
+     */
+    private void addOrganizationAudienceRolesOfSharedOrg(String sharedTenantDomain,
+                                                         List<RoleV2> rolesAssociatedWithApp, Set<String> userRoleIds)
+            throws IdentityRoleManagementException {
+
+        Set<String> resolvedRoleIds = rolesAssociatedWithApp.stream().map(RoleV2::getId).collect(Collectors.toSet());
+        RoleManagementService roleManagementService =
+                FrameworkServiceDataHolder.getInstance().getRoleManagementServiceV2();
+        for (String userRoleId : userRoleIds) {
+            if (resolvedRoleIds.contains(userRoleId)) {
+                continue;
+            }
+            RoleBasicInfo role = roleManagementService.getRoleBasicInfoById(userRoleId, sharedTenantDomain);
+            if (role != null && RoleConstants.ORGANIZATION.equalsIgnoreCase(role.getAudience())) {
+                rolesAssociatedWithApp.add(new RoleV2(role.getId(), role.getName()));
+            }
+        }
+    }
+
+    private boolean isOrganizationAudienceApp(String applicationId, String appTenantDomain)
+            throws ApplicationRolesException {
+
+        try {
+            return RoleConstants.ORGANIZATION.equalsIgnoreCase(FrameworkServiceDataHolder.getInstance()
+                    .getApplicationManagementService()
+                    .getAllowedAudienceForRoleAssociation(applicationId, appTenantDomain));
+        } catch (IdentityApplicationManagementException e) {
+            throw RoleResolverUtils.handleServerException(ERROR_CODE_RETRIEVING_APP_ROLES, e);
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
@@ -430,14 +430,21 @@ public class DefaultClaimHandler implements ClaimHandler {
         if (serviceProvider == null) {
             return null;
         }
+        /* A user shared into the organization the application belongs to is not accessing a SaaS application of
+           another tenant, even though the user is resident in a different tenant. Their roles are resolved within
+           the accessed organization, so the SaaS restriction below does not apply. */
+        boolean isSharedUserOfAppOrganization = authenticatedUser.isSharedUser() &&
+                StringUtils.isNotEmpty(authenticatedUser.getAccessingOrganization());
         /* If the application and user are in different tenant domains and the ReturnRolesInSaaSAppsInIDToken config
            is disabled, return an empty list. */
-        if (!StringUtils.equals(serviceProvider.getTenantDomain(), authenticatedUser.getTenantDomain()) &&
+        if (!isSharedUserOfAppOrganization &&
+                !StringUtils.equals(serviceProvider.getTenantDomain(), authenticatedUser.getTenantDomain()) &&
                 !Boolean.parseBoolean(IdentityUtil.getProperty(RETURN_ROLES_IN_SAAS_APPS_IN_ID_TOKEN))) {
             return new ArrayList<>();
         }
         String applicationId = serviceProvider.getApplicationResourceId();
-        return FrameworkUtils.getAppAssociatedRolesOfLocalUser(authenticatedUser, applicationId);
+        return FrameworkUtils.getAppAssociatedRolesOfLocalUser(authenticatedUser, applicationId,
+                serviceProvider.getTenantDomain());
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -247,6 +247,12 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
         SequenceConfig sequenceConfig = context.getSequenceConfig();
         StringBuilder jsonBuilder = new StringBuilder();
 
+        /* The shared user details resolved by the SharedUserIdentifierHandler are carried on the authenticated user
+           of that step alone. Subsequent steps build their own authenticated user, so the details have to be copied
+           over before claim handling runs, otherwise claims and app associated roles are resolved against the user's
+           resident organization instead of the organization being accessed. */
+        enrichSharedUserDetailsOfSteps(context);
+
         boolean subjectFoundInStep = false;
         boolean subjectAttributesFoundInStep = false;
         int stepCount = 1;
@@ -466,6 +472,33 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
         enrichAuthenticatedUserForLocalIdp(context);
     }
 
+    /**
+     * Copy the shared user details resolved by the SharedUserIdentifierHandler onto the authenticated user of every
+     * other step of the sequence.
+     *
+     * @param context Authentication context.
+     */
+    private void enrichSharedUserDetailsOfSteps(AuthenticationContext context) {
+
+        Optional<AuthenticatedUser> sharedUserIdentifiedInSequence =
+                FrameworkUtils.getSharedUserIdentifiedInSequence(context);
+        if (!sharedUserIdentifiedInSequence.isPresent()) {
+            return;
+        }
+        AuthenticatedUser sharedUser = sharedUserIdentifiedInSequence.get();
+        for (StepConfig stepConfig : context.getSequenceConfig().getStepMap().values()) {
+            AuthenticatedUser stepUser = stepConfig.getAuthenticatedUser();
+            if (stepUser == null || stepUser.isSharedUser()) {
+                continue;
+            }
+            stepUser.setSharedUser(true);
+            stepUser.setUserResidentOrganization(sharedUser.getUserResidentOrganization());
+            stepUser.setAccessingOrganization(sharedUser.getAccessingOrganization());
+            stepUser.setUserSharedOrganizationId(sharedUser.getAccessingOrganization());
+            stepUser.setSharedUserId(sharedUser.getSharedUserId());
+        }
+    }
+
     private void enrichSequenceConfig(AuthenticationContext context) {
 
         if (context.getSequenceConfig().getAuthenticatedUser() == null ||
@@ -490,6 +523,7 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
         authenticatedUser.setUserResidentOrganization(sharedUserIdentifiedInSequence
                 .getUserResidentOrganization());
         authenticatedUser.setAccessingOrganization(sharedUserIdentifiedInSequence.getAccessingOrganization());
+        authenticatedUser.setUserSharedOrganizationId(sharedUserIdentifiedInSequence.getAccessingOrganization());
         authenticatedUser.setSharedUserId(sharedUserIdentifiedInSequence.getSharedUserId());
         return authenticatedUser;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java
@@ -113,6 +113,7 @@ public class AuthenticatedUser extends User {
         this.userResidentOrganization = authenticatedUser.getUserResidentOrganization();
         this.isSharedUser = authenticatedUser.isSharedUser();
         this.sharedUserId = authenticatedUser.getSharedUserId();
+        this.userSharedOrganizationId = authenticatedUser.getUserSharedOrganizationId();
         this.impersonatedUser = authenticatedUser.getImpersonatedUser();
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -2874,6 +2874,23 @@ public class FrameworkUtils {
     public static List<String> getAppAssociatedRolesOfLocalUser(AuthenticatedUser authenticatedUser,
                                                                 String applicationId) throws FrameworkException {
 
+        return getAppAssociatedRolesOfLocalUser(authenticatedUser, applicationId,
+                authenticatedUser.getTenantDomain());
+    }
+
+    /**
+     * Get app associated roles of local user.
+     *
+     * @param authenticatedUser Authenticated user.
+     * @param applicationId     Application ID.
+     * @param appTenantDomain   Tenant domain of the application.
+     * @return List of app associated roles of local user.
+     * @throws FrameworkException If an error occurred while getting app associated roles of local user.
+     */
+    public static List<String> getAppAssociatedRolesOfLocalUser(AuthenticatedUser authenticatedUser,
+                                                                String applicationId, String appTenantDomain)
+            throws FrameworkException {
+
         ApplicationRolesResolver appRolesResolver = FrameworkServiceDataHolder.getInstance()
                 .getHighestPriorityApplicationRolesResolver();
         if (appRolesResolver == null) {
@@ -2884,7 +2901,7 @@ public class FrameworkUtils {
         String[] appAssociatedRolesOfUser;
         try {
             appAssociatedRolesOfUser = appRolesResolver.getAppAssociatedRolesOfLocalUser(authenticatedUser,
-                    applicationId);
+                    applicationId, appTenantDomain);
             if (appAssociatedRolesOfUser == null) {
                 return new ArrayList<>();
             }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandlerTest.java
@@ -179,18 +179,20 @@ public class DefaultClaimHandlerTest {
             StepConfig stepConfig = new StepConfig();
             stepConfig.setSubjectAttributeStep(true);
             AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+            authenticatedUser.setTenantDomain(TEST_TENANT_DOMAIN);
             stepConfig.setAuthenticatedUser(authenticatedUser);
 
             ServiceProvider serviceProvider = new ServiceProvider();
             serviceProvider.setApplicationResourceId(applicationId);
+            serviceProvider.setTenantDomain(TEST_TENANT_DOMAIN);
 
             when(authenticationContext.getSequenceConfig()).thenReturn(sequenceConfig);
             when(sequenceConfig.getApplicationConfig()).thenReturn(applicationConfig);
             when(applicationConfig.getServiceProvider()).thenReturn(serviceProvider);
 
             frameworkUtils.when(FrameworkUtils::getMultiAttributeSeparator).thenReturn(",");
-            frameworkUtils.when(() -> FrameworkUtils
-                            .getAppAssociatedRolesOfLocalUser(eq(authenticatedUser), eq(applicationId)))
+            frameworkUtils.when(() -> FrameworkUtils.getAppAssociatedRolesOfLocalUser(eq(authenticatedUser),
+                            eq(applicationId), eq(TEST_TENANT_DOMAIN)))
                     .thenReturn(mappedApplicationRoles);
 
             List<String> applicationRoles =


### PR DESCRIPTION
Resolves part (1) of wso2/product-is#28338.

This PR now carries both framework-side changes (previously #8245 and #8247), since they touch the same subsystem and are both required for the same symptom.

Related PRs: wso2-extensions/identity-auth-organization-login#78, wso2-extensions/identity-organization-management#649. All three are required for a shared user to receive their organization roles in a sub-organization.

## Purpose
A user shared into an organization receives no `roles` claim when they sign in directly at that organization. The same user gets their roles correctly when they reach the organization through the `organization_switch` grant, so the gap is specific to direct sign-in at the sub organization.

The organization's own application, and an application shared into the organization, are both affected.

## Goals
A shared user signing in directly at an organization should receive the same roles claim as a user native to that organization.

## Approach
`SharedUserIdentifierHandler` resolves the shared user and records the details on the authenticated user of its own step. The following step authenticates the user and builds its own `AuthenticatedUser`, which carries none of those details. The claim handler resolves the roles claim from the subject step's user, so by the time roles are resolved the shared user context is gone and the lookup falls back to the user's resident organization.

`enrichSharedUserDetails` already exists for this, but it runs at the end of `handlePostAuthentication` - after claim handling - and only updates the sequence config and the local IdP data, not the step configs that claim handling reads.

Four changes:

- `DefaultStepBasedSequenceHandler` - new `enrichSharedUserDetailsOfSteps`, called before the step loop, copies the shared user details onto the authenticated user of every step that is not already a shared user. Steps already resolved as shared users are left untouched.
- `DefaultClaimHandler` - a user shared into the organization the application belongs to is not accessing a SaaS application of another tenant, so the `ReturnRolesInSaaSAppsInIDToken` restriction no longer applies to them. Their tenant domain is their resident tenant, which is what made the existing check treat them as cross-tenant SaaS access and return an empty role list.
- `DefaultClaimHandler` - the application's own tenant domain is now passed to the roles resolver rather than the user's. The resolver's existing cross-tenant branch expects the application tenant, and could not be reached from this caller before because the two arguments were always the same value.
- `AuthenticatedUser` - the copy constructor did not carry `userSharedOrganizationId`, so the value was lost whenever the authenticated user was copied. The remaining shared user fields were already copied.

`FrameworkUtils#getAppAssociatedRolesOfLocalUser` gains an overload taking the application tenant domain. The existing two argument method delegates to it with the user's tenant domain, so callers are unaffected.

## User stories
As a user shared into an organization, signing in at that organization returns my roles in the ID token.

## Release note
Fixed an issue where a user shared into an organization received no roles claim when signing in directly at that organization.

## Documentation
N/A - no new configuration or API surface. `ReturnRolesInSaaSAppsInIDToken` keeps its current meaning and default for genuine cross tenant SaaS access.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests
   > Still to be added.
 - Integration tests
   > Verified at runtime on a `wso2is-7.4.0-SNAPSHOT` pack with configuration left at shipped defaults, through the real authorization code browser flow. A 12 case matrix was run before and after the change on the same pack and database.
   >
   > Fixed - a shared user signing in at the organization, on the organization's own application and on a shared application, with and without an API scope requested: roles claim went from absent to the expected roles in all four cases.
   >
   > Unchanged - a user native to the organization on both applications, a user in the root organization on a root organization application, a shared user in their own resident organization, and a user holding no roles. Seven cases, identical results before and after, and the granted scopes were identical in all twelve cases.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Depends on https://github.com/wso2/carbon-identity-framework/pull/8245 for organization audience roles created inside the shared organization to appear in the claim. Without it a shared user signing in directly at the organization receives only the roles inherited from the root organization. The two changes touch different files and can be reviewed independently.

Also relates to https://github.com/wso2-extensions/identity-organization-management/pull/649.

## Migrations (if applicable)
No migration required.

## Test environment
JDK 21, macOS 15 (Darwin 25.5.0), H2 (default), Chromium via Playwright for the browser flows.

## Learning
The shared user details were being set correctly and then discarded, so the fix was in ordering rather than in resolution. Logging the authenticated user of every step alongside the sequence subject made that visible immediately, where reading the resolver alone did not.

---

# Folded in from #8245: resolve sub-organization native organization roles for shared applications

## Purpose
For a B2B SaaS application shared with an organization, the `roles` claim in the ID token only carries the organization roles shared down from the root organization. Organization roles created **within the sub organization itself** are dropped.

This PR covers the path where the user was **shared** into the sub organization from an ancestor organization. The companion PR in `identity-organization-management` covers users created natively inside the sub organization.


> **Scope of this PR.** This is one of three changes; each covers a distinct hop and all three are
> required for organization roles to reach the token of a shared application:
> - Organization resolves its own organization audience roles: https://github.com/wso2-extensions/identity-organization-management/pull/649
> - Shared user accessing the shared organization: https://github.com/wso2/carbon-identity-framework/pull/8245
> - Carrying the claim across the legacy organization login hop: https://github.com/wso2-extensions/identity-auth-organization-login/pull/77
>
> They are independent at compile time and can be merged in any order. On its own this PR does not
> make the roles claim reach applications that use legacy organization login
> (`enhancedOrgAuthenticationEnabled = false`).

## Goals
When a shared user accesses an `ORGANIZATION` role-audience application in the organization they are shared into, the organization roles they hold in that organization should reach the `roles` claim — whether those roles were inherited from the main organization or created locally.

## Approach
`AppAssociatedRolesResolverImpl` builds the claim as the intersection of *roles associated with the application* and *all roles of the user*. The user side is already resolved against the accessed organization and is correct.

For a shared user (`isSharedUserAccessingSharedOrg`), the resolver never switches to the shared application — it stays on the main application in the main organization and augments the associated-roles list purely from `getMainRoleToSharedRoleMappingsBySubOrg(...)` in `addSharedRoleAssociations`. A role created inside the sub organization has no main role to map from, so it is never in the associated set and gets filtered out.

`addSharedRoleAssociations` now additionally resolves the organization-audience roles the user holds in the accessed organization, when the application's allowed audience for role association is `ORGANIZATION`. This mirrors the root-organization semantics, where "audience = Organization" already means every organization role of that organization is associated with the application. Roles already contributed by the main-to-shared mapping are de-duplicated by role id.

`APPLICATION`-audience applications take an early exit and are unaffected.

## User stories
As a user shared into a customer organization, when the organization's administrator grants me a role they defined locally, my token for the shared application reflects that role.

## Release note
Organization roles created within a sub organization are now included in the tokens issued to users shared into that organization, for B2B applications whose role audience is Organization.

## Documentation
N/A — no new configuration or API surface. The behaviour now matches the documented meaning of the Organization role audience.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
 - Unit tests
   > Existing `AppAssociatedRolesResolverImplTest` passes (8/8). Dedicated unit tests for the new branch in `addSharedRoleAssociations` are still to be added.
 - Integration tests
   > Verified at runtime against a `wso2is-7.4.0-SNAPSHOT` pack. The shared-user path was exercised through the `organization_switch` grant, confirming `shared_user_id` was present on the issued token so the intended branch was reached. Results: with this change absent the sub organization's local role is missing from the claim; with it applied the claim carries both the locally-created role and the one inherited from the main organization. Regression coverage confirms root-organization users on non-shared and main applications are unchanged, and that unheld roles do not appear.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- Organization resolves its own organization audience roles: https://github.com/wso2-extensions/identity-organization-management/pull/649
- Carrying the claim across the legacy organization login hop: https://github.com/wso2-extensions/identity-auth-organization-login/pull/77

The two are independent at compile time and can be merged in either order. Each alone fixes a disjoint set of login paths; both are needed for full coverage.

## Migrations (if applicable)
No migration required. Behaviour changes on upgrade for existing `ORGANIZATION`-audience shared applications: applications that authorize on the `roles` claim will observe role names chosen by sub organization administrators, not only the vocabulary defined in the root organization. This change is not gated behind a configuration knob or organization version.

## Test environment
JDK 21, macOS 15 (Darwin 25.5.0), H2 (default), Chromium via Playwright for the organization-login flow.

## Learning
Traced the `roles` claim from `DefaultClaimHandler` / `FrameworkUtils` into `AppAssociatedRolesResolverImpl`, then into `ApplicationManagementService#getAssociatedRolesOfApplication` and the shared-application listener, to separate the two distinct paths by which a shared application's associated roles are resolved.
