### PR TITLE
Fix ArrayIndexOutOfBoundsException for client IDs consisting only of '@'

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -1481,8 +1481,8 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
             }
         }
         // client id can contain the @ to identify the tenant domain.
-        if (clientId != null && clientId.contains("@")) {
-            clientId = clientId.split("@")[0];
+        if (StringUtils.isNotBlank(clientId) && clientId.contains("@")) {
+            clientId = clientId.substring(0, clientId.lastIndexOf('@'));
         }
 
         String serviceProviderName;

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
@@ -69,6 +69,7 @@ import org.wso2.carbon.identity.application.mgt.inbound.dto.ApplicationDTO;
 import org.wso2.carbon.identity.application.mgt.inbound.dto.InboundProtocolConfigurationDTO;
 import org.wso2.carbon.identity.application.mgt.inbound.dto.InboundProtocolsDTO;
 import org.wso2.carbon.identity.application.mgt.inbound.protocol.ApplicationInboundAuthConfigHandler;
+import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponent;
 import org.wso2.carbon.identity.application.mgt.internal.ApplicationManagementServiceComponentHolder;
 import org.wso2.carbon.identity.application.mgt.provider.ApplicationPermissionProvider;
 import org.wso2.carbon.identity.application.mgt.provider.RegistryBasedApplicationPermissionProvider;
@@ -148,6 +149,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.wso2.carbon.CarbonConstants.REGISTRY_SYSTEM_USERNAME;
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.DEFAULT_SP_CONFIG;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.Error.INVALID_REQUEST;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.TEMPLATE_ID_SP_PROPERTY_NAME;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.TEMPLATE_VERSION_SP_PROPERTY_NAME;
@@ -1165,6 +1167,70 @@ public class ApplicationManagementServiceImplTest {
 
         // Deleting all added application.
         applicationManagementService.deleteApplications(SUPER_TENANT_ID);
+    }
+
+    @DataProvider(name = "clientIdWithOnlyAtSymbolsDataProvider")
+    public Object[][] clientIdWithOnlyAtSymbolsDataProvider() {
+
+        return new Object[][]{
+                {"@"},
+                {"@@"},
+                {"@@@"}
+        };
+    }
+
+    @Test(dataProvider = "clientIdWithOnlyAtSymbolsDataProvider")
+    public void testGetServiceProviderByClientIdWithOnlyAtSymbols(String clientId)
+            throws IdentityApplicationManagementException {
+
+        // An unresolvable client id falls back to the default service provider. A client id made up of only '@'
+        // characters has no application either, so it must follow that same path instead of failing while the
+        // appended tenant domain is split off.
+        ServiceProvider defaultSP = new ServiceProvider();
+        defaultSP.setApplicationName(DEFAULT_SP_CONFIG);
+        ApplicationManagementServiceComponent.getFileBasedSPs().put(DEFAULT_SP_CONFIG, defaultSP);
+        try {
+            ServiceProvider expected = applicationManagementService.getServiceProviderByClientId(
+                    "unknown auth key", "oauth2", SUPER_TENANT_DOMAIN_NAME);
+            ServiceProvider actual = applicationManagementService.getServiceProviderByClientId(clientId, "oauth2",
+                    SUPER_TENANT_DOMAIN_NAME);
+
+            Assert.assertNotNull(actual);
+            Assert.assertEquals(actual.getApplicationName(), expected.getApplicationName());
+        } finally {
+            ApplicationManagementServiceComponent.getFileBasedSPs().remove(DEFAULT_SP_CONFIG);
+        }
+    }
+
+    @Test
+    public void testGetServiceProviderByClientIdWithEmbeddedAtSymbol()
+            throws IdentityApplicationManagementException {
+
+        // Only the appended tenant domain should be removed from the client id. A client id that itself contains
+        // an '@' must still resolve its application.
+        ServiceProvider inputSP = new ServiceProvider();
+        inputSP.setApplicationName(APPLICATION_NAME_1);
+        addApplicationConfigurations(inputSP);
+        setApplicationInboundAuthConfigs(inputSP, "auth@key", "oauth2");
+
+        applicationManagementService.createApplication(inputSP, SUPER_TENANT_DOMAIN_NAME, USERNAME_1);
+
+        // Registered so that a client id which resolves no application returns the default service provider
+        // instead of failing, which keeps the assertion below on the resolved application name.
+        ServiceProvider defaultSP = new ServiceProvider();
+        defaultSP.setApplicationName(DEFAULT_SP_CONFIG);
+        ApplicationManagementServiceComponent.getFileBasedSPs().put(DEFAULT_SP_CONFIG, defaultSP);
+        try {
+            ServiceProvider actual = applicationManagementService.getServiceProviderByClientId(
+                    "auth@key@" + SUPER_TENANT_DOMAIN_NAME, "oauth2", SUPER_TENANT_DOMAIN_NAME);
+
+            Assert.assertNotNull(actual);
+            Assert.assertEquals(actual.getApplicationName(), inputSP.getApplicationName());
+        } finally {
+            ApplicationManagementServiceComponent.getFileBasedSPs().remove(DEFAULT_SP_CONFIG);
+            // Deleting all added application.
+            applicationManagementService.deleteApplications(SUPER_TENANT_ID);
+        }
     }
 
     @DataProvider(name = "testAddApplicationWithIsManagementApplicationData")


### PR DESCRIPTION
## Purpose

Resolves https://github.com/wso2/product-is/issues/28187

`ApplicationManagementServiceImpl.getServiceProviderByClientId` strips an appended tenant domain from the client ID with `clientId.split("@")[0]`.

`String.split` removes trailing empty strings, so a client ID made up only of `@` characters returns a zero length array and the index access throws `ArrayIndexOutOfBoundsException`:

| client ID | `split("@")` result |
| --- | --- |
| `@` | length 0 |
| `@@` | length 0 |
| `@@@` | length 0 |

Callers translate this into a 500 response instead of the usual 400 for an unknown client.

## Goals

Handle client IDs that consist only of `@` characters without throwing, without changing the resolved client ID for any other value.

## Approach

Take the substring up to the first `@` only when there is something before it, instead of indexing into the `split` result. The lookup key is unchanged for every value that does not throw today:

| client ID | before | after |
| --- | --- | --- |
| `@`, `@@`, `@@@` | exception | unchanged, no application found |
| `abc@carbon.super` | `abc` | `abc` |
| `abc@` | `abc` | `abc` |
| `a@b@carbon.super` | `a` | `a` |
| `@abc` | `` (empty), no application found | unchanged, no application found |

The `@abc` row keeps the same outcome. The lookup runs against `@abc` rather than an empty string, and neither matches an application.

Note that this deliberately keeps the split at the first `@` rather than the last. Splitting at the last `@` would let identifiers that themselves contain `@` resolve, but it would also change the resolved value for any caller that passes more than one `@`, and this method is shared by several inbound paths (`clientId`, SAML issuer, passive STS `wtrealm`, WS-Trust endpoint reference, CAS service). Keeping the first `@` bounds this change to the crash.

## User stories

N/A

## Release note

Fixed an `ArrayIndexOutOfBoundsException` thrown while resolving an application when the client ID consists only of `@` characters.

## Documentation

N/A - internal fix, no documented behaviour changes.

## Training

N/A

## Certification

N/A - no impact on certification exams.

## Marketing

N/A

## Automation tests

 - Unit tests
   > Added to `ApplicationManagementServiceImplTest`:
   > - `testGetServiceProviderByClientIdWithOnlyAtSymbols` for `@`, `@@` and `@@@`. Asserts the result matches that of an unknown client ID instead of throwing. Fails on the old code with `ArrayIndexOutOfBoundsException`.
   > - `testGetServiceProviderByClientIdWithMultipleAtSymbols` looks up an application registered under `auth key` using `auth key@extra@carbon.super`. This passes both before and after the change, which is the point: it pins the unchanged behaviour for values carrying more than one `@`.
   >
   > The full test class passes at 138 tests.
 - Integration tests
   > N/A

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

N/A

## Test environment

`ApplicationManagementServiceImplTest` was run locally on macOS, against both the old and the new code to confirm which tests change state.
