### PR TITLE
Make the date of birth future-date rule fixed instead of configurable

### DIFF
--- a/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
+++ b/components/claim-mgt/org.wso2.carbon.identity.claim.metadata.mgt/src/main/java/org/wso2/carbon/identity/claim/metadata/mgt/util/ClaimConstants.java
@@ -64,7 +64,6 @@ public class ClaimConstants {
     public static final String EXTERNAL_CLAIM_ADDITION_NOT_ALLOWED_FOR_DIALECT =
             "ExternalClaimAdditionNotAllowedForDialect";
     public static final String DATA_TYPE_PROPERTY = "dataType";
-    public static final String DISALLOW_FUTURE_DATE_PROPERTY = "disallowFutureDate";
     public static final String MULTI_VALUED_PROPERTY = "multiValued";
     public static final String SUB_ATTRIBUTES_PROPERTY = "subAttributes";
     public static final String SUB_ATTRIBUTE_PREFIX = "subAttribute.";

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/Constants.java
@@ -30,6 +30,7 @@ public class Constants {
     // Constants for user attributes.
     public static final String CLAIM_URI_PREFIX = "http://wso2.org/claims/";
     public static final String USERNAME_CLAIM_URI = "http://wso2.org/claims/username";
+    public static final String DOB_CLAIM_URI = "http://wso2.org/claims/dob";
     public static final String PASSWORD_KEY = "password";
     public static final String CONSENT_KEY = "consent";
     public static final String PREFERENCE_KEY = "preference";

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
@@ -50,6 +50,7 @@ import org.wso2.carbon.user.api.UserStoreException;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -60,6 +61,7 @@ import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.CLAIM_URI_PREFIX;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.DEFAULT_ACTION;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.DOB_CLAIM_URI;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_META_DATA_NOT_FOUND;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_REGEX_VALIDATION_FAILED;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_UNIQUENESS_VALIDATION_FAILED;
@@ -101,6 +103,10 @@ public class InputValidationService {
     private static final String DATE_VARIANT = "DATE";
     private static final String DATE_VALIDATOR = "DateValidator";
     private static final String DISALLOW_FUTURE_CONDITION = "disallow.future";
+    // Claims whose value can never be a future date. Kept as a fixed set rather than claim
+    // configuration so the rule applies uniformly to every tenant without provisioning changes.
+    // Not every date claim belongs here: expiry or renewal dates are legitimately in the future.
+    private static final Set<String> NO_FUTURE_DATE_CLAIMS = Collections.singleton(DOB_CLAIM_URI);
 
     private InputValidationService() {
 
@@ -667,12 +673,11 @@ public class InputValidationService {
             }
         }
         // Process all components and apply validations at once.
-        processComponentValidations(dataDTO.getComponents(), validationMap, context.getTenantDomain());
+        processComponentValidations(dataDTO.getComponents(), validationMap);
     }
 
     private void processComponentValidations(List<ComponentDTO> components,
-                                             Map<String, ArrayList<ValidationDTO>> validationMap,
-                                             String tenantDomain) {
+                                             Map<String, ArrayList<ValidationDTO>> validationMap) {
 
         if (components == null || components.isEmpty()) {
             return;
@@ -682,10 +687,10 @@ public class InputValidationService {
             if (Constants.ComponentTypes.INPUT.equals(component.getType())) {
                 String identifier = (String) component.getConfigs().get(IDENTIFIER);
                 applyValidationIfNeeded(component, identifier, validationMap);
-                applyDateValidationIfNeeded(component, identifier, tenantDomain);
+                applyDateValidationIfNeeded(component, identifier);
             } else if (Constants.ComponentTypes.FORM.equals(component.getType())) {
                 // Process nested components.
-                processComponentValidations(component.getComponents(), validationMap, tenantDomain);
+                processComponentValidations(component.getComponents(), validationMap);
             }
         }
     }
@@ -699,48 +704,29 @@ public class InputValidationService {
     }
 
     /**
-     * Attach a client-side date validation rule to a date input component when its claim is
-     * configured to disallow future values (claim property {@code disallowFutureDate=true}).
-     * The rule is consumed by the client to show an inline error before submission. Server-side
-     * enforcement is handled separately by the user store operation listeners.
+     * Attach a client-side date validation rule to a date input component backed by a claim whose
+     * value can never be a future date. The rule is consumed by the client to show an inline error
+     * before submission. Server-side enforcement is handled separately by the user store operation
+     * listeners, which apply the same rule regardless of what the client was told.
      *
-     * @param component    Input component.
-     * @param identifier   Component identifier (claim URI for claim-backed inputs).
-     * @param tenantDomain Tenant domain.
+     * @param component  Input component.
+     * @param identifier Component identifier (claim URI for claim-backed inputs).
      */
-    private void applyDateValidationIfNeeded(ComponentDTO component, String identifier, String tenantDomain) {
+    private void applyDateValidationIfNeeded(ComponentDTO component, String identifier) {
 
-        if (identifier == null || !DATE_VARIANT.equalsIgnoreCase(component.getVariant())) {
+        if (!NO_FUTURE_DATE_CLAIMS.contains(identifier) ||
+                !DATE_VARIANT.equalsIgnoreCase(component.getVariant())) {
             return;
         }
-        if (FlowExecutionEngineDataHolder.getInstance().getClaimMetadataManagementService() == null) {
-            return;
-        }
-        try {
-            Optional<LocalClaim> localClaim = FlowExecutionEngineDataHolder.getInstance()
-                    .getClaimMetadataManagementService().getLocalClaim(identifier, tenantDomain);
-            if (!localClaim.isPresent()) {
-                return;
-            }
-            String disallowFutureDate = localClaim.get()
-                    .getClaimProperty(ClaimConstants.DISALLOW_FUTURE_DATE_PROPERTY);
-            if (!Boolean.parseBoolean(disallowFutureDate)) {
-                return;
-            }
-            ValidationDTO dateValidation = new ValidationDTO();
-            dateValidation.setName(DATE_VALIDATOR);
-            dateValidation.setType(RULES);
-            List<ValidationDTO.Condition> conditions = new ArrayList<>();
-            conditions.add(new ValidationDTO.Condition(DISALLOW_FUTURE_CONDITION, Boolean.TRUE.toString()));
-            dateValidation.setConditions(conditions);
-            addValidationToComponent(component, dateValidation);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Attached future-date validation for claim: " + identifier);
-            }
-        } catch (ClaimMetadataException e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Error while retrieving claim metadata for date validation of claim: " + identifier);
-            }
+        ValidationDTO dateValidation = new ValidationDTO();
+        dateValidation.setName(DATE_VALIDATOR);
+        dateValidation.setType(RULES);
+        List<ValidationDTO.Condition> conditions = new ArrayList<>();
+        conditions.add(new ValidationDTO.Condition(DISALLOW_FUTURE_CONDITION, Boolean.TRUE.toString()));
+        dateValidation.setConditions(conditions);
+        addValidationToComponent(component, dateValidation);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Attached future-date validation for claim: " + identifier);
         }
     }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
@@ -70,6 +70,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.CLAIM_URI_PREFIX;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.CONSENT_KEY;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.DOB_CLAIM_URI;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.DEFAULT_ACTION;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_META_DATA_NOT_FOUND;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_REGEX_VALIDATION_FAILED;
@@ -1708,26 +1709,18 @@ public class InputValidationServiceTest {
     }
 
     @Test
-    public void testPrepareStepInputsAddsDateValidatorRuleWhenClaimDisallowsFutureDate() throws Exception {
+    public void testPrepareStepInputsAddsDateValidatorRuleForDateOfBirth() throws Exception {
 
         FlowExecutionContext = initiateFlowContext();
         FlowExecutionContext.setGraphConfig(defaultGraph);
 
-        ClaimMetadataManagementService mockClaimService = mock(ClaimMetadataManagementService.class);
-        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(mockClaimService);
-
-        LocalClaim mockLocalClaim = mock(LocalClaim.class);
-        when(mockLocalClaim.getClaimProperty(ClaimConstants.DISALLOW_FUTURE_DATE_PROPERTY)).thenReturn("true");
-        when(mockClaimService.getLocalClaim(CLAIM_URI_PREFIX + "dob", "test.com"))
-                .thenReturn(Optional.of(mockLocalClaim));
-
-        DataDTO dataDTO = buildDateFieldDataDTO(CLAIM_URI_PREFIX + "dob", "DATE", null);
+        DataDTO dataDTO = buildDateFieldDataDTO(DOB_CLAIM_URI, "DATE", null);
         inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
 
         ComponentDTO processedDateInput = dataDTO.getComponents().get(0).getComponents().get(0);
         Object validations = processedDateInput.getConfigs().get(VALIDATIONS);
 
-        Assert.assertNotNull(validations, "Date field should have validations when claim disallows future dates");
+        Assert.assertNotNull(validations, "The date of birth field should carry a DateValidator rule");
         List<?> validationsList = (List<?>) validations;
         Assert.assertEquals(validationsList.size(), 1);
         ValidationDTO dateValidator = (ValidationDTO) validationsList.get(0);
@@ -1739,26 +1732,20 @@ public class InputValidationServiceTest {
     }
 
     @Test
-    public void testPrepareStepInputsNoDateValidatorWhenClaimPropertyAbsent() throws Exception {
+    public void testPrepareStepInputsNoDateValidatorForOtherDateClaims() throws Exception {
 
         FlowExecutionContext = initiateFlowContext();
         FlowExecutionContext.setGraphConfig(defaultGraph);
 
-        ClaimMetadataManagementService mockClaimService = mock(ClaimMetadataManagementService.class);
-        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(mockClaimService);
-
-        LocalClaim mockLocalClaim = mock(LocalClaim.class);
-        when(mockLocalClaim.getClaimProperty(ClaimConstants.DISALLOW_FUTURE_DATE_PROPERTY)).thenReturn(null);
-        when(mockClaimService.getLocalClaim(CLAIM_URI_PREFIX + "startdate", "test.com"))
-                .thenReturn(Optional.of(mockLocalClaim));
-
+        // Date claims other than date of birth may legitimately hold a future value
+        // (for example an expiry or renewal date), so they must not get the rule.
         DataDTO dataDTO = buildDateFieldDataDTO(CLAIM_URI_PREFIX + "startdate", "DATE", null);
         inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
 
         ComponentDTO processedDateInput = dataDTO.getComponents().get(0).getComponents().get(0);
         Object validations = processedDateInput.getConfigs().get(VALIDATIONS);
         Assert.assertTrue(validations == null || ((List<?>) validations).isEmpty(),
-                "Date field should not have validations when claim does not disallow future dates");
+                "Date claims other than date of birth should not disallow future dates");
     }
 
     @Test
@@ -1767,73 +1754,47 @@ public class InputValidationServiceTest {
         FlowExecutionContext = initiateFlowContext();
         FlowExecutionContext.setGraphConfig(defaultGraph);
 
-        ClaimMetadataManagementService mockClaimService = mock(ClaimMetadataManagementService.class);
-        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(mockClaimService);
-
-        DataDTO dataDTO = buildDateFieldDataDTO(CLAIM_URI_PREFIX + "dob", "TEXT", null);
+        DataDTO dataDTO = buildDateFieldDataDTO(DOB_CLAIM_URI, "TEXT", null);
         inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
 
         ComponentDTO processedInput = dataDTO.getComponents().get(0).getComponents().get(0);
         Object validations = processedInput.getConfigs().get(VALIDATIONS);
         Assert.assertTrue(validations == null || ((List<?>) validations).isEmpty(),
                 "Non-date field should not have a DateValidator rule added");
+    }
+
+    @Test
+    public void testPrepareStepInputsNoDateValidatorForUnmappedInput() throws Exception {
+
+        FlowExecutionContext = initiateFlowContext();
+        FlowExecutionContext.setGraphConfig(defaultGraph);
+
+        // A date input that has not been mapped to a claim yet has no identifier.
+        DataDTO dataDTO = buildDateFieldDataDTO(null, "DATE", null);
+        inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
+
+        ComponentDTO processedDateInput = dataDTO.getComponents().get(0).getComponents().get(0);
+        Object validations = processedDateInput.getConfigs().get(VALIDATIONS);
+        Assert.assertTrue(validations == null || ((List<?>) validations).isEmpty());
+    }
+
+    @Test
+    public void testPrepareStepInputsDateValidationDoesNotDependOnClaimMetadata() throws Exception {
+
+        FlowExecutionContext = initiateFlowContext();
+        FlowExecutionContext.setGraphConfig(defaultGraph);
+
+        ClaimMetadataManagementService mockClaimService = mock(ClaimMetadataManagementService.class);
+        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(mockClaimService);
+
+        DataDTO dataDTO = buildDateFieldDataDTO(DOB_CLAIM_URI, "DATE", null);
+        inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
+
+        ComponentDTO processedDateInput = dataDTO.getComponents().get(0).getComponents().get(0);
+        List<?> validationsList = (List<?>) processedDateInput.getConfigs().get(VALIDATIONS);
+        Assert.assertEquals(validationsList.size(), 1);
+        // The rule is fixed in code, so no claim metadata lookup should be needed to resolve it.
         verify(mockClaimService, never()).getLocalClaim(anyString(), anyString());
-    }
-
-    @Test
-    public void testPrepareStepInputsNoDateValidatorWhenClaimMetadataServiceIsNull() throws Exception {
-
-        FlowExecutionContext = initiateFlowContext();
-        FlowExecutionContext.setGraphConfig(defaultGraph);
-        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(null);
-
-        DataDTO dataDTO = buildDateFieldDataDTO(CLAIM_URI_PREFIX + "dob", "DATE", null);
-
-        // Should not throw any exception when ClaimMetadataManagementService is unavailable.
-        inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
-
-        ComponentDTO processedDateInput = dataDTO.getComponents().get(0).getComponents().get(0);
-        Object validations = processedDateInput.getConfigs().get(VALIDATIONS);
-        Assert.assertTrue(validations == null || ((List<?>) validations).isEmpty());
-    }
-
-    @Test
-    public void testPrepareStepInputsNoDateValidatorWhenLocalClaimNotPresent() throws Exception {
-
-        FlowExecutionContext = initiateFlowContext();
-        FlowExecutionContext.setGraphConfig(defaultGraph);
-
-        ClaimMetadataManagementService mockClaimService = mock(ClaimMetadataManagementService.class);
-        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(mockClaimService);
-        when(mockClaimService.getLocalClaim(anyString(), anyString())).thenReturn(Optional.empty());
-
-        DataDTO dataDTO = buildDateFieldDataDTO(CLAIM_URI_PREFIX + "dob", "DATE", null);
-        inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
-
-        ComponentDTO processedDateInput = dataDTO.getComponents().get(0).getComponents().get(0);
-        Object validations = processedDateInput.getConfigs().get(VALIDATIONS);
-        Assert.assertTrue(validations == null || ((List<?>) validations).isEmpty());
-    }
-
-    @Test
-    public void testPrepareStepInputsNoDateValidatorWhenClaimMetadataExceptionThrown() throws Exception {
-
-        FlowExecutionContext = initiateFlowContext();
-        FlowExecutionContext.setGraphConfig(defaultGraph);
-
-        ClaimMetadataManagementService mockClaimService = mock(ClaimMetadataManagementService.class);
-        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(mockClaimService);
-        when(mockClaimService.getLocalClaim(anyString(), anyString()))
-                .thenThrow(new ClaimMetadataException("Test exception"));
-
-        DataDTO dataDTO = buildDateFieldDataDTO(CLAIM_URI_PREFIX + "dob", "DATE", null);
-
-        // Should not propagate the ClaimMetadataException; it is caught and logged.
-        inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
-
-        ComponentDTO processedDateInput = dataDTO.getComponents().get(0).getComponents().get(0);
-        Object validations = processedDateInput.getConfigs().get(VALIDATIONS);
-        Assert.assertTrue(validations == null || ((List<?>) validations).isEmpty());
     }
 
     @Test
@@ -1842,27 +1803,20 @@ public class InputValidationServiceTest {
         FlowExecutionContext = initiateFlowContext();
         FlowExecutionContext.setGraphConfig(defaultGraph);
 
-        ClaimMetadataManagementService mockClaimService = mock(ClaimMetadataManagementService.class);
-        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(mockClaimService);
-
-        LocalClaim mockLocalClaim = mock(LocalClaim.class);
-        when(mockLocalClaim.getClaimProperty(ClaimConstants.DISALLOW_FUTURE_DATE_PROPERTY)).thenReturn("true");
-        when(mockClaimService.getLocalClaim(CLAIM_URI_PREFIX + "dob", "test.com"))
-                .thenReturn(Optional.of(mockLocalClaim));
-
         ValidationDTO existingRule = new ValidationDTO();
         existingRule.setName("RequiredValidator");
         existingRule.setType("RULE");
         List<ValidationDTO> existingValidations = new ArrayList<>();
         existingValidations.add(existingRule);
 
-        DataDTO dataDTO = buildDateFieldDataDTO(CLAIM_URI_PREFIX + "dob", "DATE", existingValidations);
+        DataDTO dataDTO = buildDateFieldDataDTO(DOB_CLAIM_URI, "DATE", existingValidations);
         inputValidationService.prepareStepInputs(dataDTO, FlowExecutionContext);
 
         ComponentDTO processedDateInput = dataDTO.getComponents().get(0).getComponents().get(0);
         List<?> validationsList = (List<?>) processedDateInput.getConfigs().get(VALIDATIONS);
 
-        Assert.assertEquals(validationsList.size(), 2, "The DateValidator rule should be appended, not replace existing rules");
+        Assert.assertEquals(validationsList.size(), 2,
+                "The DateValidator rule should be appended, not replace existing rules");
         Assert.assertEquals(((ValidationDTO) validationsList.get(0)).getName(), "RequiredValidator");
         Assert.assertEquals(((ValidationDTO) validationsList.get(1)).getName(), "DateValidator");
     }

--- a/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
+++ b/features/claim-mgt/org.wso2.carbon.claim.mgt.server.feature/resources/conf/claim-config.xml
@@ -180,7 +180,6 @@
 				<Description>Birth Date</Description>
 				<RegEx>^\d{4}-\d{2}-\d{2}$</RegEx>
 				<dataType>date</dataType>
-				<disallowFutureDate>true</disallowFutureDate>
 				<RegExValidationError>Date of Birth is not in the correct format of YYYY-MM-DD</RegExValidationError>
 				<SharedProfileValueResolvingMethod>FromOrigin</SharedProfileValueResolvingMethod>
 			</Claim>


### PR DESCRIPTION
## Purpose

Related issue: https://github.com/wso2-enterprise/wso2-iam-internal/issues/7266
Follow-up to: #8212

#8212 made the dynamic registration flow emit a `DateValidator` client rule only when the backing claim carried a `disallowFutureDate=true` property, seeded from `claim-config.xml`.

That gate turned out to be the wrong mechanism:

1. **It never reaches existing tenants.** `claim-config.xml` seeds claim metadata at tenant provisioning. Tenants created before the property existed keep their old metadata, so they never get the rule. Verified against a real dev-tier tenant: the dynamic flow accepted a future date of birth with no inline error.
2. **It disagreed with the server.** `SCIMUserOperationListener` already rejects a future date of birth for every tenant, unconditionally, with no configuration ([identity-inbound-provisioning-scim2#800](https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/800)). Gating only the client hint meant a user on an unseeded tenant got no inline error, submitted, and then hit a server error.

This resolves the rule in code so it applies to every tenant as soon as the change is deployed, and matches what the server already enforces.

## Changes

1. `InputValidationService`
   - Added `NO_FUTURE_DATE_CLAIMS`, the set of claims whose value can never be a future date. It contains only the date of birth claim.
   - `applyDateValidationIfNeeded` now checks membership in that set instead of reading claim metadata. The `ClaimMetadataManagementService` lookup, its null-service guard, and the `ClaimMetadataException` handling are gone, along with the `tenantDomain` plumbing #8212 threaded through `processComponentValidations`.
2. `Constants` — added `DOB_CLAIM_URI`, alongside the existing `USERNAME_CLAIM_URI`.
3. `ClaimConstants` — removed `DISALLOW_FUTURE_DATE_PROPERTY`.
4. `claim-config.xml` — removed the `<disallowFutureDate>` entry from the date of birth claim.

Net effect is 61 fewer lines, and one fewer claim metadata fetch per date field on every flow render.

## Scoping note

The set is deliberately limited to date of birth rather than applied to every `DATE` variant input. The flow builder lets an administrator map a date input to any claim, and claims such as expiry or renewal dates are legitimately in the future. `testPrepareStepInputsNoDateValidatorForOtherDateClaims` guards this.

## Tradeoff

Adding another no-future date claim now needs a code change rather than configuration, and the rule can no longer be switched off per tenant. That is intended here: a date of birth is never legitimately in the future, and the server already enforces it unconditionally, so there is no tenant for which the client should say otherwise.

## Leftover data

Tenants provisioned while #8212 was in place will still have `disallowFutureDate=true` in their claim metadata. Nothing reads it after this change, so it is inert and needs no migration.

## Testing

- Full reactor build and `InputValidationServiceTest` pass on JDK 21: 63 tests, 0 failures.
- Checkstyle clean on both changed modules.
- Six tests cover the new behaviour: rule added for date of birth, not added for another date claim, not added for a non-`DATE` variant, not added for an input with no claim mapping, appended alongside existing rules, and resolved without any claim metadata lookup.

## Related PRs

- [identity-inbound-provisioning-scim2#800](https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/800) — server-side enforcement, unchanged by this
- [identity-apps#10558](https://github.com/wso2/identity-apps/pull/10558) — the generic client-side `DateValidator`, unchanged by this; it still enforces whatever rule it is handed