### PR TITLE
Split the client ID at the first '@' to keep the previous lookup behaviour

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java
@@ -1481,8 +1481,11 @@ public class ApplicationManagementServiceImpl extends ApplicationManagementServi
             }
         }
         // client id can contain the @ to identify the tenant domain.
-        if (StringUtils.isNotBlank(clientId) && clientId.contains("@")) {
-            clientId = clientId.substring(0, clientId.lastIndexOf('@'));
+        if (clientId != null) {
+            int tenantSeparatorIndex = clientId.indexOf('@');
+            if (tenantSeparatorIndex > 0) {
+                clientId = clientId.substring(0, tenantSeparatorIndex);
+            }
         }
 
         String serviceProviderName;

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/test/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImplTest.java
@@ -1203,15 +1203,14 @@ public class ApplicationManagementServiceImplTest {
     }
 
     @Test
-    public void testGetServiceProviderByClientIdWithEmbeddedAtSymbol()
+    public void testGetServiceProviderByClientIdWithMultipleAtSymbols()
             throws IdentityApplicationManagementException {
 
-        // Only the appended tenant domain should be removed from the client id. A client id that itself contains
-        // an '@' must still resolve its application.
+        // The client id is split at the first '@', so a client id carrying more than one '@' must keep resolving
+        // the same application as before.
         ServiceProvider inputSP = new ServiceProvider();
         inputSP.setApplicationName(APPLICATION_NAME_1);
         addApplicationConfigurations(inputSP);
-        setApplicationInboundAuthConfigs(inputSP, "auth@key", "oauth2");
 
         applicationManagementService.createApplication(inputSP, SUPER_TENANT_DOMAIN_NAME, USERNAME_1);
 
@@ -1222,7 +1221,7 @@ public class ApplicationManagementServiceImplTest {
         ApplicationManagementServiceComponent.getFileBasedSPs().put(DEFAULT_SP_CONFIG, defaultSP);
         try {
             ServiceProvider actual = applicationManagementService.getServiceProviderByClientId(
-                    "auth@key@" + SUPER_TENANT_DOMAIN_NAME, "oauth2", SUPER_TENANT_DOMAIN_NAME);
+                    "auth key@extra@" + SUPER_TENANT_DOMAIN_NAME, "oauth2", SUPER_TENANT_DOMAIN_NAME);
 
             Assert.assertNotNull(actual);
             Assert.assertEquals(actual.getApplicationName(), inputSP.getApplicationName());


### PR DESCRIPTION
## Purpose

Follow up to https://github.com/wso2/carbon-identity-framework/pull/8248, which resolved https://github.com/wso2/product-is/issues/28187.

That PR fixed the `ArrayIndexOutOfBoundsException` for client IDs made up only of `@` characters by replacing `clientId.split("@")[0]` with `substring(0, lastIndexOf('@'))`, matching the SAML inbound authenticator.

Moving from the first `@` to the last one also changed the resolved lookup key for any value carrying more than one `@`:

| client ID | before #8248 | after #8248 |
| --- | --- | --- |
| `a@b@carbon.super` | `a` | `a@b` |

`getServiceProviderByClientId` is shared by several inbound paths. The value passed in is not always an OAuth client ID: it is also a SAML issuer, a passive STS `wtrealm`, a WS-Trust endpoint reference and a CAS service. A passive STS request has been confirmed to reach this method with the tenant domain still appended, so the change is reachable in practice.

Whether that change is an improvement or a regression depends on which form is registered for the application:

1. If the application is registered under `a@b`, it previously did not resolve and now does.
2. If the application is registered under `a`, it previously resolved and now does not.

Case 2 is a regression, and it cannot be ruled out for callers that pass a URL or a realm-style identifier, which may legitimately contain `@`.

## Goals

Keep the crash fixed, and bound the change to the crash by restoring the previous lookup key for every value that did not throw.

## Approach

Take the substring up to the first `@`, and only when there is something before it:

```java
if (clientId != null) {
    int tenantSeparatorIndex = clientId.indexOf('@');
    if (tenantSeparatorIndex > 0) {
        clientId = clientId.substring(0, tenantSeparatorIndex);
    }
}
```

| client ID | original | #8248 | this PR |
| --- | --- | --- | --- |
| `@`, `@@`, `@@@` | exception | `` / `@` / `@@` | unchanged, no application found |
| `abc@carbon.super` | `abc` | `abc` | `abc` |
| `abc@` | `abc` | `abc` | `abc` |
| `a@b@carbon.super` | `a` | `a@b` | `a` |
| `@abc` | `` (empty) | `` (empty) | unchanged, no application found |

Every value that resolved an application before #8248 resolves the same application again. The `@abc` row keeps the same outcome: the lookup runs against `@abc` rather than an empty string, and neither matches an application.

## User stories

N/A

## Release note

The client ID is split at the first `@` when removing an appended tenant domain, restoring the lookup behaviour that applied before the fix for the `@` only client ID crash.

## Documentation

N/A - restores previously documented behaviour.

## Training

N/A

## Certification

N/A - no impact on certification exams.

## Marketing

N/A

## Automation tests

 - Unit tests
   > `testGetServiceProviderByClientIdWithEmbeddedAtSymbol` asserted the `lastIndexOf` result, so it is replaced by `testGetServiceProviderByClientIdWithMultipleAtSymbols`, which looks up an application registered under `auth key` using `auth key@extra@carbon.super`. That test passes both before and after the original crash fix, which is the point: it pins the unchanged behaviour.
   >
   > `testGetServiceProviderByClientIdWithOnlyAtSymbols` is unchanged and still fails on the pre-#8248 code with `ArrayIndexOutOfBoundsException`, so the crash stays covered.
   >
   > The full test class passes at 138 tests.
 - Integration tests
   > N/A

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

https://github.com/wso2/carbon-identity-framework/pull/8248

## Migrations (if applicable)

N/A

## Test environment

`ApplicationManagementServiceImplTest` was run locally on macOS, against the pre-fix code as well, to confirm which tests change state.
