### PR TITLE
Bump httpcore5 to 5.4.3.wso2v1 and httpclient5 to 5.6.3.wso2v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2084,8 +2084,8 @@
         <codehaus.jettison.version>1.4.0</codehaus.jettison.version>
         <jaxrx.jsr311.api.version>1.1.1</jaxrx.jsr311.api.version>
         <apache.httpcomponents.httpclient.version>4.3.5</apache.httpcomponents.httpclient.version>
-        <orbit.version.httpcore5>5.3.1.wso2v1</orbit.version.httpcore5>
-        <orbit.version.httpclient5>5.4.1.wso2v1</orbit.version.httpclient5>
+        <orbit.version.httpcore5>5.4.3.wso2v1</orbit.version.httpcore5>
+        <orbit.version.httpclient5>5.6.3.wso2v1</orbit.version.httpclient5>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
## Purpose

| CVE | Severity | Affected artifact | Installed | Fixed in |
|---|---|---|---|---|
| [CVE-2026-54399](https://avd.aquasec.com/nvd/cve-2026-54399) | HIGH | `httpcore5` — DoS via excessive HTTP headers | 5.3.1 | 5.4.3 |
| [CVE-2026-54428](https://avd.aquasec.com/nvd/cve-2026-54428) | HIGH | `httpcore5-h2` — DoS via oversized HTTP/2 HPACK headers | 5.3.1 | 5.4.3 |
| [CVE-2026-64607](https://avd.aquasec.com/nvd/cve-2026-64607) | MEDIUM | `httpclient5` — connection leak on Content-Encoding decode error → pool exhaustion | 5.4.1 | 5.6.3 |

This repo pins its own `httpcore5`/`httpclient5` orbit versions rather than inheriting them, so it needs the bump independently of carbon-kernel.

## Why the scanner missed this

The IS distribution ships these as orbit bundles that **inline** the upstream classes and carry only a WSO2 GAV in `META-INF/maven/.../pom.properties`, so version matching against the upstream coordinates fails. The CVEs still apply: 5.4.1 < 5.6.3 and 5.3.1 < 5.4.3.

## Version pairing

`httpclient5-parent-5.6.3` sets `httpcore.version=5.4.3`, so 5.6.3 + 5.4.3 is the combination upstream builds against.

## Related

- wso2/orbit#1405 — adds the `httpclient5 5.6.3.wso2v1` bundle
- wso2/carbon-kernel#4619 — same bump in carbon-kernel

🤖 Generated with [Claude Code](https://claude.com/claude-code)