### PR TITLE
Make analytics data initialization idempotent on login flow restart

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
@@ -645,7 +645,8 @@ public class AuthenticationContext extends MessageContext implements Serializabl
     public void initializeAnalyticsData() {
 
         Map<String, Serializable> analyticsData = new HashMap<>();
-        this.addParameter(FrameworkConstants.AnalyticsData.DATA_MAP, analyticsData);
+        // Replace the analytics data map to start fresh collection on flow restart.
+        this.setParameter(FrameworkConstants.AnalyticsData.DATA_MAP, analyticsData);
         this.setAnalyticsData(FrameworkConstants.AnalyticsData.AUTHENTICATION_START_TIME,
                 System.currentTimeMillis());
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContextTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContextTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.framework.context;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Unit tests for {@link AuthenticationContext}.
+ */
+public class AuthenticationContextTest {
+
+    /**
+     * The login flow restart path (DefaultRequestCoordinator, RESTART_LOGIN_FLOW branch) can call
+     * initializeAnalyticsData() on a context which was already initialized, when the same context
+     * instance is reached by more than one request. Re-initializing must reset the analytics data
+     * rather than fail with "Parameters map trying to override existing key dataMap".
+     */
+    @Test
+    public void testInitializeAnalyticsDataIsIdempotent() {
+
+        AuthenticationContext context = new AuthenticationContext();
+
+        context.initializeAnalyticsData();
+        context.setAnalyticsData("stale-key", "stale-value");
+        assertNotNull(context.getAnalyticsData("stale-key"));
+
+        // Must not throw, and must start from a clean analytics data map.
+        context.initializeAnalyticsData();
+
+        assertNull(context.getAnalyticsData("stale-key"),
+                "Analytics data should be reset when the context is re-initialized.");
+        assertNotNull(context.getParameter(FrameworkConstants.AnalyticsData.DATA_MAP),
+                "Analytics data map should be present after re-initialization.");
+        assertNotNull(context.getAnalyticsData(FrameworkConstants.AnalyticsData.AUTHENTICATION_START_TIME),
+                "Authentication start time should be re-recorded on re-initialization.");
+    }
+
+    /**
+     * A restarted login flow can reach the same context instance from more than one thread, so the
+     * re-initialization must hold up under concurrent callers as well as sequential ones.
+     */
+    @Test
+    public void testInitializeAnalyticsDataUnderConcurrentCalls() throws Exception {
+
+        int threads = 8;
+        int iterationsPerThread = 200;
+        AuthenticationContext context = new AuthenticationContext();
+
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+        try {
+            for (int i = 0; i < threads; i++) {
+                futures.add(executor.submit(() -> {
+                    start.await();
+                    for (int j = 0; j < iterationsPerThread; j++) {
+                        context.initializeAnalyticsData();
+                    }
+                    return null;
+                }));
+            }
+            start.countDown();
+            for (Future<?> future : futures) {
+                // Surfaces IdentityRuntimeException from any worker as a test failure.
+                future.get();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertNotNull(context.getParameter(FrameworkConstants.AnalyticsData.DATA_MAP));
+        assertNotNull(context.getAnalyticsData(FrameworkConstants.AnalyticsData.AUTHENTICATION_START_TIME));
+    }
+}

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/testng.xml
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/resources/testng.xml
@@ -25,6 +25,7 @@
             <class name="org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticationServiceTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.AbstractAppAuthSkipRetryTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.CommonAuthenticationHandlerTest"/>
+            <class name="org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContextTest"/>
 
             <class name="org.wso2.carbon.identity.application.authentication.framework.handler.claims.impl.DefaultClaimHandlerTest"/>
             <class name="org.wso2.carbon.identity.application.authentication.framework.handler.hrd.impl.DefaultHomeRealmDiscovererTest"/>

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/bean/context/MessageContext.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/bean/context/MessageContext.java
@@ -56,6 +56,18 @@ public abstract class MessageContext<T1 extends Object,T2 extends Object> implem
         }
     }
 
+    /**
+     * Adds the parameter to the parameters map, replacing any value already mapped to the key.
+     * Unlike {@link #addParameter(Object, Object)} this does not fail when the key is already
+     * present, so it can be used where a parameter is legitimately re-set.
+     *
+     * @param key   Key of the parameter.
+     * @param value Value of the parameter.
+     */
+    public void setParameter(T1 key, T2 value){
+        parameters.put(key, value);
+    }
+
     public Map<T1,T2> getParameters(){
         return Collections.unmodifiableMap(parameters);
     }

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/bean/context/MessageContextTest.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/java/org/wso2/carbon/identity/core/bean/context/MessageContextTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.core.bean.context;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+/**
+ * Unit tests for {@link MessageContext}.
+ */
+public class MessageContextTest {
+
+    /**
+     * Concrete stand-in, since MessageContext is abstract.
+     */
+    private static class TestMessageContext extends MessageContext<String, String> {
+    }
+
+    private TestMessageContext messageContext;
+
+    @BeforeMethod
+    public void setUp() {
+
+        messageContext = new TestMessageContext();
+    }
+
+    @Test
+    public void testAddParameterRejectsAnExistingKey() {
+
+        messageContext.addParameter("key", "first");
+
+        assertThrows(IdentityRuntimeException.class, () -> messageContext.addParameter("key", "second"));
+        assertEquals(messageContext.getParameter("key"), "first",
+                "A rejected addParameter() should leave the existing value untouched.");
+    }
+
+    @Test
+    public void testSetParameterReplacesAnExistingKey() {
+
+        messageContext.setParameter("key", "first");
+        assertEquals(messageContext.getParameter("key"), "first");
+
+        // Unlike addParameter(), this must not throw on an existing key.
+        messageContext.setParameter("key", "second");
+
+        assertEquals(messageContext.getParameter("key"), "second");
+        assertEquals(messageContext.getParameters().size(), 1,
+                "Replacing a value should not add a second entry.");
+    }
+
+    @Test
+    public void testSetParameterAddsANewKey() {
+
+        messageContext.setParameter("key", "value");
+
+        assertEquals(messageContext.getParameter("key"), "value");
+        assertEquals(messageContext.getParameters().size(), 1);
+    }
+}

--- a/components/identity-core/org.wso2.carbon.identity.core/src/test/resources/testng.xml
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/test/resources/testng.xml
@@ -22,6 +22,7 @@
 <suite name="identity-core-test-suite" parallel="false">
     <test name="identity-core-test-all">
         <classes>
+            <class name="org.wso2.carbon.identity.core.bean.context.MessageContextTest"/>
             <class name="org.wso2.carbon.identity.core.util.IdentityUtilTest"/>
             <class name="org.wso2.carbon.identity.core.util.IdentityConfigParserTest"/>
             <class name="org.wso2.carbon.identity.core.dao.SAMLServiceProviderPersistenceManagerFactoryTest"/>


### PR DESCRIPTION
### Proposed changes in this pull request

**Issue.** When a login flow is restarted (session nonce cookie mismatch, mismatching tenant domain, or invalid user assertion), `DefaultRequestCoordinator` takes the stored `INITIAL_CONTEXT` object as the working context and calls `initializeAnalyticsData()` on it in place. Since `FrameworkUtils.getContextData()` returns the same cached context reference for a given `sessionDataKey`, two concurrent requests that both restart the flow read the same
`INITIAL_CONTEXT` instance and the second initialization fails:

```
IdentityRuntimeException: Parameters map trying to override existing key dataMap
  at MessageContext.addParameter(MessageContext.java:44)
  at AuthenticationContext.initializeAnalyticsData(AuthenticationContext.java:648)
  at DefaultRequestCoordinator.handle(DefaultRequestCoordinator.java:293)
```

The double submit guard is `synchronized` on the context but sits *after* the restart branch, so it does not cover this path.

**Fix.** A restart is meant to start collecting analytics data afresh, so re-initializing an already initialized context is legitimate.

- `MessageContext.setParameter()` — new; an overwriting put, unlike `addParameter()` which fails on an existing key. `addParameter()`'s contract is deliberately left unchanged, since other identity-core consumers rely on it.
- `AuthenticationContext.initializeAnalyticsData()` — replaces the analytics map via `setParameter()` and is `synchronized`, so the replacement and the start-time write cannot interleave between concurrent restarts.

Behaviour is unchanged — the affected request still ends on the retry page through the existing double submit guard; only the spurious error stack trace goes away.

Deliberately *not* cloning `INITIAL_CONTEXT` instead of mutating it: that would give each thread a different context object and stop the double submit guard from catching the pair.

**Tests.** `AuthenticationContextTest` adds an idempotency test and an 8-thread concurrency test. Both fail without this change.

### When should this PR be merged

No preconditions. Self-contained; no config, migration, or API change.

### Follow up actions

- None required for this change.
- `EnableSessionNonceCookie` must be enabled for the affected path to be reachable at all
  (it is on by default).

### Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

  No behavioral change and no migration impact: the fix removes an exception on a path whose
  user-visible outcome (retry page) is unchanged.