### PR TITLE
Fix unmapped idp claims not being populated in the ID token when `authentication.allow_sp_requested_fed_claims_only=false` is configured

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java
@@ -379,8 +379,9 @@ public class DefaultStepBasedSequenceHandler implements StepBasedSequenceHandler
 
                             if (MapUtils.isNotEmpty(localClaimValues)) {
                                 mappedAttrs = localClaimValues;
-                            } else if (MapUtils.isNotEmpty(idpClaimValues)) {
-                                mappedAttrs = idpClaimValues;
+                            }
+                            if (MapUtils.isNotEmpty(idpClaimValues)) {
+                                mappedAttrs.putAll(idpClaimValues);
                             }
                         }
                         authenticatedUserAttributes = FrameworkUtils.buildClaimMappings(mappedAttrs);


### PR DESCRIPTION
## Purpose

Fixes an issue where unmapped IDP claims were not populated in the ID token when `authentication.allow_sp_requested_fed_claims_only` is set to `false`.

Previously, when no requested claims were selected, local mapped claim values took precedence over IDP claim values entirely (an `if/else if`), so any IDP claims not present in the local claim values were dropped. This change merges the IDP claim values into the local claim values instead of overwriting/skipping them, so both sets of attributes are populated as expected.

## Related issues

fixes https://github.com/wso2/product-is/issues/28192