### PR TITLE
Fix isTableColumnExists() leaking column checks across MySQL catalogs

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -3858,7 +3858,8 @@ public class FrameworkUtils {
                 // in all users in the DB unless specified.
                 schemaPattern = metaData.getUserName();
             }
-            try (ResultSet resultSet = metaData.getColumns(null, schemaPattern, tableName, columnName)) {
+            try (ResultSet resultSet = metaData.getColumns(connection.getCatalog(), schemaPattern, tableName,
+                    columnName)) {
                 if (resultSet.next()) {
                     if (log.isDebugEnabled()) {
                         log.debug("Column - " + columnName + " in table - " + tableName + " is available in the " +


### PR DESCRIPTION
metaData.getColumns() was called with catalog=null, which on MySQL (via DatabaseMetaDataUsingInfoSchema) omits the TABLE_SCHEMA filter entirely and searches every catalog visible to the connecting DB user instead of just the current connection's own database. On a MySQL server hosting multiple databases with same-named tables, this can report a column as present when it only exists in a sibling database, silently corrupting a startup feature-detection check that is cached for the process lifetime.

Pass connection.getCatalog() instead of null to scope the metadata lookup to the connection's own database, matching the intent of the check.

### Proposed changes in this pull request

- Scope the JDBC metadata lookup in `FrameworkUtils.isTableColumnExists()` to the connection's own database by passing `connection.getCatalog()` instead of `null` as the `catalog` argument to `DatabaseMetaData.getColumns()`.
- Resolves https://github.com/wso2/product-is/issues/28331

### Developer Checklist (Mandatory)

- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be marked for translation.

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?** There must be a test case for the bug to ensure the issue won't regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
```

