### PR TITLE
Remove the multiple client secrets enable toggle so the feature is always available

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -298,13 +298,13 @@
         {% else %}
         <RecomputeSubjectClaimForAlternateSubjectIdentifier>false</RecomputeSubjectClaimForAlternateSubjectIdentifier>
         {% endif %}
-        <!-- Multi-secret (multiple client secrets per OAuth application) config.
-             `Enable` toggles the feature at the server level.
-             `MaxSecretCount` acts as the server-level ceiling on the maximum number of
-             secrets an application may hold. Tenant-level overrides are
-             clamped to this value. -->
+        <!--
+            Configuration to support multiple client secrets per OAuth application,
+            facilitating zero-downtime client secret rotation.
+            MaxSecretCount defines the maximum number of client secrets an
+            application is allowed to hold at any given time.
+         -->
         <MultipleClientSecrets>
-            <Enable>{{oauth.multiple_client_secrets.enable}}</Enable>
             <MaxSecretCount>{{oauth.multiple_client_secrets.max_secret_count}}</MaxSecretCount>
         </MultipleClientSecrets>
         <!-- Token cleanup feature config to clean IDN_OAUTH2_ACCESS_TOKEN table-->

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -365,7 +365,6 @@
   "oauth.listener.agent_application_creator.order": "99",
   "oauth.graceful_refresh_token_rotation.maximum_validity_period": "60",
   "oauth.graceful_refresh_token_rotation.maximum_reuse_limit": "5",
-  "oauth.multiple_client_secrets.enable": true,
   "oauth.multiple_client_secrets.max_secret_count": "2",
 
   "rest_api_authentication.add_realm_user_to_error": false,

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -348,8 +348,7 @@
         "consoleSettings.useGranularConsolePermissions"
       ],
       "oauth.oidc.honor_multivalued_claim_metadata": false,
-      "token_exchange.limit_scopes_to_subject_token": false,
-      "oauth.multiple_client_secrets.enable": false
+      "token_exchange.limit_scopes_to_subject_token": false
     },
     "IS_7.1.0": {
       "oauth.dcrm.return_null_fields_in_response": true,
@@ -426,8 +425,7 @@
         "consoleSettings.useGranularConsolePermissions"
       ],
       "oauth.oidc.honor_multivalued_claim_metadata": false,
-      "token_exchange.limit_scopes_to_subject_token": false,
-      "oauth.multiple_client_secrets.enable": false
+      "token_exchange.limit_scopes_to_subject_token": false
     },
     "IS_7.2.0": {
       "authenticationendpoint.authenticator_validation.enabled": false,
@@ -461,8 +459,7 @@
       "oauth.dcrm.decode_redirect_uris_in_response": false,
       "oauth.oidc.honor_multivalued_claim_metadata": false,
       "ai_services.http_client_use_system_properties": false,
-      "token_exchange.limit_scopes_to_subject_token": false,
-      "oauth.multiple_client_secrets.enable": false
+      "token_exchange.limit_scopes_to_subject_token": false
     },
     "IS_7.3.0": {
       "oauth.dcrm.decode_redirect_uris_in_response": false,
@@ -481,8 +478,7 @@
       ],
       "oauth.oidc.honor_multivalued_claim_metadata": false,
       "ai_services.http_client_use_system_properties": false,
-      "token_exchange.limit_scopes_to_subject_token": false,
-      "oauth.multiple_client_secrets.enable": false
+      "token_exchange.limit_scopes_to_subject_token": false
     }
   }
 }


### PR DESCRIPTION
### Purpose

Follow-up to #8226. Removes the server-level `Enable` toggle for the multiple client secrets feature so the feature is always available. The `MaxSecretCount` capacity ceiling is retained.

### Changes

- **`identity.xml.j2`** — drop `<Enable>` from the `<MultipleClientSecrets>` block (keep `<MaxSecretCount>`) and update the accompanying config comment.
- **`default.json`** — remove `oauth.multiple_client_secrets.enable` (keep `oauth.multiple_client_secrets.max_secret_count`).
- **`infer.json`** — remove the `oauth.multiple_client_secrets.enable = false` overrides for `IS_7.0.0`–`IS_7.3.0`.

### Related PR

- #8226

### Related Issue 
 - https://github.com/wso2/product-is/issues/28127
