### PR TITLE
Validate the no-future-date claim rule at flow step submit

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/Constants.java
@@ -224,7 +224,13 @@ public class Constants {
                 "The provided password does not meet the configured format requirements."),
         ERROR_CODE_INFLOW_EXTENSION_FAILURE("60017",
                 "Flow extension execution failed.",
-                "Something went wrong while executing the flow extension. Please try again.")
+                "Something went wrong while executing the flow extension. Please try again."),
+        ERROR_CODE_CLAIM_FUTURE_DATE_NOT_ALLOWED("60018",
+                "Cannot be a future date.",
+                "The value provided for %s cannot be a future date."),
+        ERROR_CODE_CLAIM_INVALID_DATE("60019",
+                "Must be a valid date in the format YYYY-MM-DD.",
+                "The value provided for %s is not an existing calendar date.")
         ;
 
         private static final String ERROR_PREFIX = "FE";

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
@@ -48,6 +48,9 @@ import org.wso2.carbon.identity.input.validation.mgt.model.ValidationContext;
 import org.wso2.carbon.identity.input.validation.mgt.model.Validator;
 import org.wso2.carbon.user.api.UserStoreException;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -62,6 +65,8 @@ import java.util.stream.Collectors;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.CLAIM_URI_PREFIX;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.DEFAULT_ACTION;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.DOB_CLAIM_URI;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_FUTURE_DATE_NOT_ALLOWED;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_INVALID_DATE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_META_DATA_NOT_FOUND;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_REGEX_VALIDATION_FAILED;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_UNIQUENESS_VALIDATION_FAILED;
@@ -295,18 +300,61 @@ public class InputValidationService {
     }
 
     /**
-     * Retrieve validation rules from claim metadata for the given claim URI.
-     * Validates claim uniqueness if configured and throws exception on failure.
+     * Validate a claim whose value can never be a future date.
+     * <p>
+     * Deliberately independent of claim metadata: the rule is fixed in {@link #NO_FUTURE_DATE_CLAIMS} rather than
+     * configured per tenant, so it is applied before the metadata lookup in
+     * {@link #validateUserClaims(String, String, String, boolean)}, which returns early when the claim or the
+     * metadata service is unavailable. The same rule is enforced again at user creation by the user store
+     * operation listeners; validating here lets the flow re-render the offending step with an inline error
+     * instead of failing at the end of the flow.
+     *
+     * @param claimUri   Claim URI.
+     * @param claimValue Submitted claim value.
+     * @throws FlowEngineClientException If the value is not an existing calendar date, or is a future date.
+     */
+    private void validateNoFutureDateClaim(String claimUri, String claimValue) throws FlowEngineClientException {
+
+        if (!NO_FUTURE_DATE_CLAIMS.contains(claimUri) || StringUtils.isBlank(claimValue)) {
+            return;
+        }
+        LocalDate date;
+        try {
+            date = LocalDate.parse(claimValue);
+        } catch (DateTimeParseException e) {
+            // Reachable when the value matches the claim's YYYY-MM-DD pattern but is not a real date. Ex: 2025-02-30.
+            throw handleClientException(ERROR_CODE_CLAIM_INVALID_DATE, claimUri);
+        }
+        /*
+         * The server's own notion of today, matching LocalDate.now() in the user store operation listener that
+         * enforces the same rule at user creation. The zone is stated explicitly rather than left implicit, but
+         * it is deliberately the system zone and not UTC: if the two layers disagreed on where the day boundary
+         * falls, a value one accepted the other would reject.
+         */
+        if (date.isAfter(LocalDate.now(ZoneId.systemDefault()))) {
+            throw handleClientException(ERROR_CODE_CLAIM_FUTURE_DATE_NOT_ALLOWED, claimUri);
+        }
+    }
+
+    /**
+     * Validate a submitted claim value.
+     * <p>
+     * Applies the rules that are fixed in code first, then the rules configured in the claim's metadata
+     * (regex, and uniqueness where configured). The fixed rules run before the metadata lookup on purpose,
+     * because that lookup returns early when the claim or the metadata service is unavailable.
      *
      * @param tenantDomain             Tenant domain.
      * @param claimUri                 Claim URI.
      * @param claimValue               Claim value to validate.
      * @param skipUniquenessValidation Whether to skip claim uniqueness validation.
-     * @throws FlowEngineException If claim uniqueness validation fails.
+     * @throws FlowEngineException If the value fails a fixed rule, the configured regex, or uniqueness.
      */
     private void validateUserClaims(String tenantDomain, String claimUri, String claimValue,
                                    boolean skipUniquenessValidation)
             throws FlowEngineException {
+
+        // Must stay outside the try below: everything in it is skipped when claim metadata is unavailable.
+        validateNoFutureDateClaim(claimUri, claimValue);
 
         try {
             if (FlowExecutionEngineDataHolder.getInstance().getClaimMetadataManagementService() == null) {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
@@ -22,6 +22,7 @@ import org.mockito.MockedStatic;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
@@ -51,6 +52,8 @@ import org.wso2.carbon.identity.input.validation.mgt.model.ValidationContext;
 import org.wso2.carbon.identity.input.validation.mgt.model.Validator;
 import org.wso2.carbon.identity.input.validation.mgt.services.InputValidationManagementService;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -72,6 +75,8 @@ import static org.wso2.carbon.identity.flow.execution.engine.Constants.CLAIM_URI
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.CONSENT_KEY;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.DOB_CLAIM_URI;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.DEFAULT_ACTION;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_FUTURE_DATE_NOT_ALLOWED;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_INVALID_DATE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_META_DATA_NOT_FOUND;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_REGEX_VALIDATION_FAILED;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_CLAIM_UNIQUENESS_VALIDATION_FAILED;
@@ -1858,6 +1863,65 @@ public class InputValidationServiceTest {
         components.add(formDTO);
 
         return new DataDTO.Builder().components(components).build();
+    }
+
+    @DataProvider(name = "noFutureDateClaimData")
+    public Object[][] noFutureDateClaimData() {
+
+        return new Object[][]{
+                // Future dates are rejected. A fixed far-future date is used so the fixture cannot flip to "today"
+                // if a midnight boundary is crossed between data provider evaluation and test execution.
+                {DOB_CLAIM_URI, "9999-12-31", STATUS_RETRY},
+                {DOB_CLAIM_URI, LocalDate.now(ZoneId.systemDefault()).plusYears(2).toString(), STATUS_RETRY},
+                // Values matching the YYYY-MM-DD pattern that are not existing calendar dates.
+                {DOB_CLAIM_URI, "2025-02-30", STATUS_RETRY},
+                {DOB_CLAIM_URI, "2023-02-29", STATUS_RETRY},
+                {DOB_CLAIM_URI, "2025-13-01", STATUS_RETRY},
+                // Today is not a future date.
+                {DOB_CLAIM_URI, LocalDate.now(ZoneId.systemDefault()).toString(), STATUS_COMPLETE},
+                // Past dates, including a valid leap day.
+                {DOB_CLAIM_URI, "1990-05-15", STATUS_COMPLETE},
+                {DOB_CLAIM_URI, "2024-02-29", STATUS_COMPLETE},
+                // Blank values are skipped so an existing value can be cleared.
+                {DOB_CLAIM_URI, "", STATUS_COMPLETE},
+                // The rule is scoped to the claims in NO_FUTURE_DATE_CLAIMS. Other date claims, such as an expiry
+                // date, are legitimately in the future and must not be rejected.
+                {CLAIM_URI_PREFIX + "membershipExpiryDate", "9999-12-31", STATUS_COMPLETE},
+                {CLAIM_URI_PREFIX + "membershipExpiryDate", "2025-02-30", STATUS_COMPLETE}
+        };
+    }
+
+    @Test(dataProvider = "noFutureDateClaimData")
+    public void testValidateNoFutureDateClaim(String claimUri, String claimValue, String expectedStatus) {
+
+        FlowExecutionContext = initiateFlowContext();
+        FlowExecutionContext.getUserInputData().put(claimUri, claimValue);
+
+        // No claim metadata service is registered, so validateUserClaims returns early. Only the fixed
+        // future-date rule can produce a result here, which is the point of validating it outside the
+        // metadata lookup.
+        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(null);
+
+        ExecutorResponse response = inputValidationService.resolveInputValidationResponse(FlowExecutionContext);
+        Assert.assertEquals(response.getResult(), expectedStatus);
+    }
+
+    @Test
+    public void testValidateNoFutureDateClaimReportsDistinctErrorCodes() {
+
+        FlowExecutionEngineDataHolder.getInstance().setClaimMetadataManagementService(null);
+
+        FlowExecutionContext futureContext = initiateFlowContext();
+        futureContext.getUserInputData().put(DOB_CLAIM_URI, "9999-12-31");
+        ExecutorResponse futureResponse = inputValidationService.resolveInputValidationResponse(futureContext);
+        Assert.assertEquals(futureResponse.getErrorCode(), ERROR_CODE_CLAIM_FUTURE_DATE_NOT_ALLOWED.getCode());
+
+        FlowExecutionContext invalidContext = initiateFlowContext();
+        invalidContext.getUserInputData().put(DOB_CLAIM_URI, "2025-02-30");
+        ExecutorResponse invalidResponse = inputValidationService.resolveInputValidationResponse(invalidContext);
+        Assert.assertEquals(invalidResponse.getErrorCode(), ERROR_CODE_CLAIM_INVALID_DATE.getCode());
+
+        Assert.assertNotEquals(futureResponse.getErrorCode(), invalidResponse.getErrorCode());
     }
 
     private FlowExecutionContext initiateFlowContext() {


### PR DESCRIPTION
## Purpose

`InputValidationService` tells the client to enforce a future-date rule on the date of birth claim, but never enforces it server side. Posting a future date straight to the flow API is accepted:

```
POST /flow/execute
{ "flowId": "…", "actionId": "…",
  "inputs": { "http://wso2.org/claims/dob": "2030-01-01", … } }

HTTP 200 — flow advances to the OTP step
```

Verified on a dev tenant with no browser and no JavaScript involved.

## Why this is worth fixing

Nothing is persisted, so this is **not** a data integrity issue. `SCIMUserOperationListener` still rejects the value at user creation, and a lookup at the OTP step confirmed no user exists (with a control query proving the filter finds a known-present user). It is a feedback problem, and a consistency one:

- A caller that skips the client rule clears step one and email OTP before failing, and then fails with a generic flow error rather than a field error.
- `validateUserClaims` already validates claim regex and uniqueness at step level; `validateUsernameFormat` and `validatePasswordFormat` do the same for username and password. The date rule was the only one emitted to the client that had no server-side counterpart.
- It left the flow engine depending entirely on the listener, which is itself behind the `UserClaimUpdate.EnableUserClaimInputRegexValidation` deployment property. That property defaults to `true`, so this is not a live hole — but the flow engine had no defence of its own.

`NO_FUTURE_DATE_CLAIMS` had exactly one reader before this change, on the rule-emission path.

## Approach

Add `validateNoFutureDateClaim`, called from `validateUserInputs`. It rejects values that are not existing calendar dates and values later than today, throwing `FlowEngineClientException` so the existing `STATUS_RETRY` path re-renders the offending step with an inline error. No new machinery — that path is what username, password, regex and uniqueness failures already use.

Three deliberate choices:

**Placed in `validateUserInputs`, not `validateUserClaims`.** `validateUserClaims` returns early when the claim metadata service is unavailable or the claim has no metadata. This rule is fixed in `NO_FUTURE_DATE_CLAIMS` rather than configured per tenant, so it must not inherit those skip paths — a rule that silently does nothing on some tenants is the failure mode this feature already hit once, when the same rule was driven by a `claim-config.xml` property that only seeds at tenant creation.

**Scoped to `NO_FUTURE_DATE_CLAIMS`, not to all `DATE` inputs.** A flow can map a date input to any claim, and expiry or renewal dates are legitimately in the future.

**Two distinct error codes**, so an impossible date is not reported as a future one:

| Code | Message |
|---|---|
| `FE-60018` | `Cannot be a future date.` |
| `FE-60019` | `Must be a valid date in the format YYYY-MM-DD.` |

Wording matches `use-field-validations.js` in `identity-apps`, since both render in the same place and the user should not see two phrasings of one rule.

Blank values are skipped, so an existing value can still be cleared.

## Testing

`InputValidationServiceTest`: 63 → 75 cases. Full module suite **167 pass, 0 fail**.

New coverage:

- future dates rejected (`9999-12-31`, `now + 2 years`)
- impossible dates rejected (`2025-02-30`, `2023-02-29`, `2025-13-01`)
- today accepted, past accepted, valid leap day `2024-02-29` accepted
- blank accepted
- **`membershipExpiryDate` with `9999-12-31` and `2025-02-30` accepted** — this pins the claim scoping; generalising the rule to all date inputs fails these rows
- distinct error codes asserted for the future and impossible cases

The data-provider test sets `ClaimMetadataManagementService` to `null`, so only the fixed rule can produce a result. Had the check been placed inside `validateUserClaims`, every one of those rows would silently pass as `STATUS_COMPLETE`.

Control run: with the call to `validateNoFutureDateClaim` removed, exactly 6 tests fail — the 5 rejection rows and the error-code test. The accepting rows still pass, since unfixed code also returns `STATUS_COMPLETE`, so the suite distinguishes fixed from unfixed rather than passing vacuously.

## Related

- Follows #8250, which made this rule fixed in code instead of read from claim metadata.
- Server-side enforcement at user creation: wso2-extensions/identity-inbound-provisioning-scim2#800.
- Client-side rule consumption: wso2/identity-apps#10558, and wso2/identity-apps#10631 for a crash in the same date field.



## Related issue

wso2/product-is#28342
