### PR TITLE
Add diagnostic logs for the flowId lifecycle in app native authentication

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationService.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationService.java
@@ -78,7 +78,8 @@ public class AuthenticationService {
     public AuthServiceResponse handleAuthentication(AuthServiceRequest authRequest) throws AuthServiceException {
 
         // Request validation is only required for the initial authentication request.
-        if (isInitialAuthRequest(authRequest)) {
+        boolean isInitialAuthRequest = isInitialAuthRequest(authRequest);
+        if (isInitialAuthRequest) {
             validateRequest(authRequest);
         } else {
             logFlowIdUsage(authRequest);
@@ -93,7 +94,14 @@ public class AuthenticationService {
                     AuthServiceConstants.ErrorMessage.ERROR_UNABLE_TO_PROCEED.description(), e);
         }
 
-        return processCommonAuthResponse(wrappedRequest, wrappedResponse);
+        AuthServiceResponse authServiceResponse = processCommonAuthResponse(wrappedRequest, wrappedResponse);
+        /* The flow identifier is only issued for the initial request of a flow. The subsequent requests of the same
+         flow carry the identifier which was issued here, so recording an issuance for those would make the point at
+         which the identifier was actually issued impossible to find. */
+        if (isInitialAuthRequest) {
+            logFlowIdIssuance(authServiceResponse.getSessionDataKey(), authServiceResponse.getFlowStatus());
+        }
+        return authServiceResponse;
     }
 
     private AuthServiceRequestWrapper getWrappedRequest(HttpServletRequest request, Map<String, String[]> parameters) {
@@ -134,7 +142,6 @@ public class AuthenticationService {
 
         authServiceResponse.setSessionDataKey(request.getSessionDataKey());
         authServiceResponse.setFlowStatus(AuthServiceConstants.FlowStatus.INCOMPLETE);
-        logFlowIdIssuance(request.getSessionDataKey(), AuthServiceConstants.FlowStatus.INCOMPLETE);
         AuthServiceResponseData responseData = new AuthServiceResponseData();
         boolean isMultiOptionsResponse = request.isMultiOptionsResponse();
 
@@ -244,7 +251,6 @@ public class AuthenticationService {
 
         authServiceResponse.setSessionDataKey(request.getSessionDataKey());
         authServiceResponse.setFlowStatus(AuthServiceConstants.FlowStatus.FAIL_INCOMPLETE);
-        logFlowIdIssuance(request.getSessionDataKey(), AuthServiceConstants.FlowStatus.FAIL_INCOMPLETE);
         AuthServiceResponseData responseData = new AuthServiceResponseData();
         List<AuthenticatorData> authenticatorDataList;
         boolean isMultiOptionsResponse = request.isMultiOptionsResponse();
@@ -541,30 +547,34 @@ public class AuthenticationService {
         LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
                 FrameworkConstants.LogConstants.AUTHENTICATION_FRAMEWORK,
                 FrameworkConstants.LogConstants.ActionIDs.VALIDATE_FLOW_ID)
-                .inputParam(FrameworkConstants.LogConstants.FLOW_ID, flowId)
+                .inputParam(FrameworkConstants.LogConstants.CONTEXT_ID, flowId)
                 .resultMessage("Received an app native authentication request with a flowId.")
                 .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                 .resultStatus(DiagnosticLog.ResultStatus.SUCCESS));
     }
 
     /**
-     * Records the flowId returned to the client so that the point at which a flowId was issued can be traced.
+     * Records the flowId returned to the client for the initial request of an authentication flow, so that the
+     * point at which a flowId was issued can be traced. This is only recorded once per flow. The identifier does
+     * not change between the steps of a flow, therefore recording it again for a subsequent step would make the
+     * actual point of issuance impossible to identify.
      *
-     * @param flowId     flowId returned with the authentication response.
-     * @param flowStatus Flow status of the authentication response.
+     * @param flowId     flowId returned with the authentication response. Can be null or blank if the flow was
+     *                   concluded without issuing one.
+     * @param flowStatus Flow status of the authentication response. Can be null.
      */
     private void logFlowIdIssuance(String flowId, AuthServiceConstants.FlowStatus flowStatus) {
 
-        if (StringUtils.isBlank(flowId) || !LoggerUtils.isDiagnosticLogsEnabled()) {
+        if (StringUtils.isBlank(flowId) || flowStatus == null || !LoggerUtils.isDiagnosticLogsEnabled()) {
             return;
         }
         LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
                 FrameworkConstants.LogConstants.AUTHENTICATION_FRAMEWORK,
                 FrameworkConstants.LogConstants.ActionIDs.ISSUE_FLOW_ID)
-                .inputParam(FrameworkConstants.LogConstants.FLOW_ID, flowId)
-                .inputParam("flow status", flowStatus.name())
-                .resultMessage("flowId is issued for the incomplete authentication flow. The same flowId is " +
-                        "expected in the next authentication request of this flow.")
+                .inputParam(FrameworkConstants.LogConstants.CONTEXT_ID, flowId)
+                .inputParam(FrameworkConstants.LogConstants.FLOW_STATUS, flowStatus.name())
+                .resultMessage("A flowId is issued for the authentication flow. The same flowId is expected in " +
+                        "every subsequent authentication request of this flow.")
                 .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                 .resultStatus(DiagnosticLog.ResultStatus.SUCCESS));
     }
@@ -588,8 +598,8 @@ public class AuthenticationService {
         LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
                 FrameworkConstants.LogConstants.AUTHENTICATION_FRAMEWORK,
                 FrameworkConstants.LogConstants.ActionIDs.VALIDATE_FLOW_ID)
-                .inputParam(FrameworkConstants.LogConstants.FLOW_ID, flowId)
-                .inputParam(AuthServiceConstants.ERROR_CODE_PARAM, mappedError.code())
+                .inputParam(FrameworkConstants.LogConstants.CONTEXT_ID, flowId)
+                .inputParam(FrameworkConstants.LogConstants.ERROR_CODE, mappedError.code())
                 .resultMessage("The provided flowId is no longer active. " + mappedError.description()
                         + " A new authentication flow needs to be initiated.")
                 .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationService.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationService.java
@@ -65,6 +65,7 @@ import javax.servlet.http.HttpServletResponse;
 public class AuthenticationService {
 
     private static final Log LOG = LogFactory.getLog(AuthenticationService.class);
+    private static final int MAX_LOGGABLE_FLOW_ID_LENGTH = 64;
     private final CommonAuthenticationHandler commonAuthenticationHandler = new CommonAuthenticationHandler();
 
     /**
@@ -531,7 +532,8 @@ public class AuthenticationService {
 
         String flowId = getFlowId(authServiceRequest);
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Received app native authentication request with the flowId: " + flowId);
+            LOG.debug("Received app native authentication request with the flowId: "
+                    + sanitizeFlowIdForLogging(flowId));
         }
         if (!LoggerUtils.isDiagnosticLogsEnabled()) {
             return;
@@ -578,7 +580,8 @@ public class AuthenticationService {
     private void logInvalidFlowIdUsage(String flowId, AuthServiceConstants.ErrorMessage mappedError) {
 
         LOG.warn("App native authentication request received with a flowId which is no longer active. flowId: "
-                + flowId + ". Error: " + mappedError.code() + " - " + mappedError.description());
+                + sanitizeFlowIdForLogging(flowId) + ". Error: " + mappedError.code() + " - "
+                + mappedError.description());
         if (!LoggerUtils.isDiagnosticLogsEnabled()) {
             return;
         }
@@ -591,6 +594,27 @@ public class AuthenticationService {
                         + " A new authentication flow needs to be initiated.")
                 .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                 .resultStatus(DiagnosticLog.ResultStatus.FAILED));
+    }
+
+    /**
+     * Removes new line characters from the flowId and caps its length before it is written to the server log. The
+     * flowId is fully controlled by the client, therefore writing it as received would allow forged log records to
+     * be injected into the server log through new line characters. Diagnostic log inputs are not sanitized here
+     * since they are recorded as structured data rather than as a log line.
+     *
+     * @param flowId flowId received with the authentication request. Can be null or blank.
+     * @return flowId which is safe to be written to the server log.
+     */
+    private String sanitizeFlowIdForLogging(String flowId) {
+
+        if (StringUtils.isBlank(flowId)) {
+            return flowId;
+        }
+        String sanitizedFlowId = flowId.replaceAll("[\\r\\n]", StringUtils.EMPTY);
+        if (sanitizedFlowId.length() > MAX_LOGGABLE_FLOW_ID_LENGTH) {
+            sanitizedFlowId = sanitizedFlowId.substring(0, MAX_LOGGABLE_FLOW_ID_LENGTH) + "...";
+        }
+        return sanitizedFlowId;
     }
 
     private String getFlowId(AuthServiceRequest authServiceRequest) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationService.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationService.java
@@ -53,6 +53,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.function.Supplier;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -65,7 +66,6 @@ import javax.servlet.http.HttpServletResponse;
 public class AuthenticationService {
 
     private static final Log LOG = LogFactory.getLog(AuthenticationService.class);
-    private static final int MAX_LOGGABLE_FLOW_ID_LENGTH = 64;
     private final CommonAuthenticationHandler commonAuthenticationHandler = new CommonAuthenticationHandler();
 
     /**
@@ -539,12 +539,14 @@ public class AuthenticationService {
         String flowId = getFlowId(authServiceRequest);
         if (LOG.isDebugEnabled()) {
             LOG.debug("Received app native authentication request with the flowId: "
-                    + sanitizeFlowIdForLogging(flowId));
+                    + FrameworkUtils.sanitizeForLogging(flowId));
         }
-        if (!LoggerUtils.isDiagnosticLogsEnabled()) {
+        /* Without a flowId there is nothing to trace, and recording the entry regardless would claim that a flowId
+         was received when it was not. */
+        if (StringUtils.isBlank(flowId)) {
             return;
         }
-        LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
+        recordDiagnosticLog(() -> new DiagnosticLog.DiagnosticLogBuilder(
                 FrameworkConstants.LogConstants.AUTHENTICATION_FRAMEWORK,
                 FrameworkConstants.LogConstants.ActionIDs.VALIDATE_FLOW_ID)
                 .inputParam(FrameworkConstants.LogConstants.CONTEXT_ID, flowId)
@@ -565,10 +567,10 @@ public class AuthenticationService {
      */
     private void logFlowIdIssuance(String flowId, AuthServiceConstants.FlowStatus flowStatus) {
 
-        if (StringUtils.isBlank(flowId) || flowStatus == null || !LoggerUtils.isDiagnosticLogsEnabled()) {
+        if (StringUtils.isBlank(flowId) || !isFlowIdIssuingStatus(flowStatus)) {
             return;
         }
-        LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
+        recordDiagnosticLog(() -> new DiagnosticLog.DiagnosticLogBuilder(
                 FrameworkConstants.LogConstants.AUTHENTICATION_FRAMEWORK,
                 FrameworkConstants.LogConstants.ActionIDs.ISSUE_FLOW_ID)
                 .inputParam(FrameworkConstants.LogConstants.CONTEXT_ID, flowId)
@@ -590,12 +592,9 @@ public class AuthenticationService {
     private void logInvalidFlowIdUsage(String flowId, AuthServiceConstants.ErrorMessage mappedError) {
 
         LOG.warn("App native authentication request received with a flowId which is no longer active. flowId: "
-                + sanitizeFlowIdForLogging(flowId) + ". Error: " + mappedError.code() + " - "
+                + FrameworkUtils.sanitizeForLogging(flowId) + ". Error: " + mappedError.code() + " - "
                 + mappedError.description());
-        if (!LoggerUtils.isDiagnosticLogsEnabled()) {
-            return;
-        }
-        LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
+        recordDiagnosticLog(() -> new DiagnosticLog.DiagnosticLogBuilder(
                 FrameworkConstants.LogConstants.AUTHENTICATION_FRAMEWORK,
                 FrameworkConstants.LogConstants.ActionIDs.VALIDATE_FLOW_ID)
                 .inputParam(FrameworkConstants.LogConstants.CONTEXT_ID, flowId)
@@ -607,24 +606,38 @@ public class AuthenticationService {
     }
 
     /**
-     * Removes new line characters from the flowId and caps its length before it is written to the server log. The
-     * flowId is fully controlled by the client, therefore writing it as received would allow forged log records to
-     * be injected into the server log through new line characters. Diagnostic log inputs are not sanitized here
-     * since they are recorded as structured data rather than as a log line.
+     * Checks whether a flowId is issued to the client along with a response of the given flow status. A flowId is
+     * only issued while the flow is still awaiting a further request from the client. A concluded flow returns the
+     * session key of the inbound protocol instead, which belongs to a different identifier space and must not be
+     * recorded as a flowId issuance.
      *
-     * @param flowId flowId received with the authentication request. Can be null or blank.
-     * @return flowId which is safe to be written to the server log.
+     * @param flowStatus Flow status of the authentication response. Can be null.
+     * @return true if a flowId is issued for a response of the given flow status.
      */
-    private String sanitizeFlowIdForLogging(String flowId) {
+    private boolean isFlowIdIssuingStatus(AuthServiceConstants.FlowStatus flowStatus) {
 
-        if (StringUtils.isBlank(flowId)) {
-            return flowId;
+        return AuthServiceConstants.FlowStatus.INCOMPLETE == flowStatus
+                || AuthServiceConstants.FlowStatus.FAIL_INCOMPLETE == flowStatus;
+    }
+
+    /**
+     * Records the diagnostic log produced by the given supplier, without allowing a failure of the logging
+     * framework itself to affect the authentication flow which is being recorded. Resolving whether diagnostic
+     * logging is enabled requires a resolvable tenant, which is not guaranteed on every path this is reached from.
+     *
+     * @param logBuilderSupplier Supplier of the diagnostic log to be recorded. Only invoked when diagnostic
+     *                           logging is enabled, so that no log is built needlessly.
+     */
+    private void recordDiagnosticLog(Supplier<DiagnosticLog.DiagnosticLogBuilder> logBuilderSupplier) {
+
+        try {
+            if (!LoggerUtils.isDiagnosticLogsEnabled()) {
+                return;
+            }
+            LoggerUtils.triggerDiagnosticLogEvent(logBuilderSupplier.get());
+        } catch (Exception e) {
+            LOG.error("Error while recording a diagnostic log of the app native authentication flow.", e);
         }
-        String sanitizedFlowId = flowId.replaceAll("[\\r\\n]", StringUtils.EMPTY);
-        if (sanitizedFlowId.length() > MAX_LOGGABLE_FLOW_ID_LENGTH) {
-            sanitizedFlowId = sanitizedFlowId.substring(0, MAX_LOGGABLE_FLOW_ID_LENGTH) + "...";
-        }
-        return sanitizedFlowId;
     }
 
     private String getFlowId(AuthServiceRequest authServiceRequest) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationService.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationService.java
@@ -43,8 +43,10 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -77,6 +79,8 @@ public class AuthenticationService {
         // Request validation is only required for the initial authentication request.
         if (isInitialAuthRequest(authRequest)) {
             validateRequest(authRequest);
+        } else {
+            logFlowIdUsage(authRequest);
         }
         AuthServiceRequestWrapper wrappedRequest = getWrappedRequest(authRequest.getRequest(),
                 authRequest.getParameters());
@@ -129,6 +133,7 @@ public class AuthenticationService {
 
         authServiceResponse.setSessionDataKey(request.getSessionDataKey());
         authServiceResponse.setFlowStatus(AuthServiceConstants.FlowStatus.INCOMPLETE);
+        logFlowIdIssuance(request.getSessionDataKey(), AuthServiceConstants.FlowStatus.INCOMPLETE);
         AuthServiceResponseData responseData = new AuthServiceResponseData();
         boolean isMultiOptionsResponse = request.isMultiOptionsResponse();
 
@@ -189,6 +194,10 @@ public class AuthenticationService {
             errorCode = mappedError.code();
             errorMessage = mappedError.message();
             errorDescription = mappedError.description();
+            if (AuthServiceConstants.ErrorMessage.ERROR_AUTHENTICATION_CONTEXT_NULL == mappedError
+                    || AuthServiceConstants.ErrorMessage.ERROR_AUTHENTICATION_FLOW_TIMEOUT == mappedError) {
+                logInvalidFlowIdUsage(request.getSessionDataKey(), mappedError);
+            }
         } else {
             String builtErrorMessage = buildFailedConcludedErrorMessage(internalErrorCode, internalErrorMessage);
             if (StringUtils.isNotBlank(builtErrorMessage)) {
@@ -234,6 +243,7 @@ public class AuthenticationService {
 
         authServiceResponse.setSessionDataKey(request.getSessionDataKey());
         authServiceResponse.setFlowStatus(AuthServiceConstants.FlowStatus.FAIL_INCOMPLETE);
+        logFlowIdIssuance(request.getSessionDataKey(), AuthServiceConstants.FlowStatus.FAIL_INCOMPLETE);
         AuthServiceResponseData responseData = new AuthServiceResponseData();
         List<AuthenticatorData> authenticatorDataList;
         boolean isMultiOptionsResponse = request.isMultiOptionsResponse();
@@ -509,6 +519,88 @@ public class AuthenticationService {
             default:
                 return null;
         }
+    }
+
+    /**
+     * Records the flowId received with a subsequent app native authentication request. This makes it possible to
+     * trace every usage of a given flowId, including usages of a flowId which is no longer active.
+     *
+     * @param authServiceRequest Authentication request received by the service.
+     */
+    private void logFlowIdUsage(AuthServiceRequest authServiceRequest) {
+
+        String flowId = getFlowId(authServiceRequest);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Received app native authentication request with the flowId: " + flowId);
+        }
+        if (!LoggerUtils.isDiagnosticLogsEnabled()) {
+            return;
+        }
+        LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
+                FrameworkConstants.LogConstants.AUTHENTICATION_FRAMEWORK,
+                FrameworkConstants.LogConstants.ActionIDs.VALIDATE_FLOW_ID)
+                .inputParam(FrameworkConstants.LogConstants.FLOW_ID, flowId)
+                .resultMessage("Received an app native authentication request with a flowId.")
+                .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                .resultStatus(DiagnosticLog.ResultStatus.SUCCESS));
+    }
+
+    /**
+     * Records the flowId returned to the client so that the point at which a flowId was issued can be traced.
+     *
+     * @param flowId     flowId returned with the authentication response.
+     * @param flowStatus Flow status of the authentication response.
+     */
+    private void logFlowIdIssuance(String flowId, AuthServiceConstants.FlowStatus flowStatus) {
+
+        if (StringUtils.isBlank(flowId) || !LoggerUtils.isDiagnosticLogsEnabled()) {
+            return;
+        }
+        LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
+                FrameworkConstants.LogConstants.AUTHENTICATION_FRAMEWORK,
+                FrameworkConstants.LogConstants.ActionIDs.ISSUE_FLOW_ID)
+                .inputParam(FrameworkConstants.LogConstants.FLOW_ID, flowId)
+                .inputParam("flow status", flowStatus.name())
+                .resultMessage("flowId is issued for the incomplete authentication flow. The same flowId is " +
+                        "expected in the next authentication request of this flow.")
+                .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                .resultStatus(DiagnosticLog.ResultStatus.SUCCESS));
+    }
+
+    /**
+     * Records that the authentication flow was concluded with a failure because the provided flowId is no longer
+     * usable. The framework invalidates the flowId once the authentication flow is concluded or once the flow has
+     * timed out, hence a flowId can be reported as invalid even if it was valid at the time it was issued.
+     *
+     * @param flowId      flowId received with the authentication request.
+     * @param mappedError Error which the authentication flow concluded with.
+     */
+    private void logInvalidFlowIdUsage(String flowId, AuthServiceConstants.ErrorMessage mappedError) {
+
+        LOG.warn("App native authentication request received with a flowId which is no longer active. flowId: "
+                + flowId + ". Error: " + mappedError.code() + " - " + mappedError.description());
+        if (!LoggerUtils.isDiagnosticLogsEnabled()) {
+            return;
+        }
+        LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
+                FrameworkConstants.LogConstants.AUTHENTICATION_FRAMEWORK,
+                FrameworkConstants.LogConstants.ActionIDs.VALIDATE_FLOW_ID)
+                .inputParam(FrameworkConstants.LogConstants.FLOW_ID, flowId)
+                .inputParam(AuthServiceConstants.ERROR_CODE_PARAM, mappedError.code())
+                .resultMessage("The provided flowId is no longer active. " + mappedError.description()
+                        + " A new authentication flow needs to be initiated.")
+                .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                .resultStatus(DiagnosticLog.ResultStatus.FAILED));
+    }
+
+    private String getFlowId(AuthServiceRequest authServiceRequest) {
+
+        Map<String, String[]> parameters = authServiceRequest.getParameters();
+        if (parameters == null) {
+            return null;
+        }
+        String[] flowIdParam = parameters.get(AuthServiceConstants.FLOW_ID);
+        return flowIdParam != null && flowIdParam.length > 0 ? flowIdParam[0] : null;
     }
 
     private boolean includeMultiOptionsInResponse() {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -861,7 +861,7 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
 
         if (retainCache == null) {
             FrameworkUtils.removeAuthenticationContextFromCache(context.getContextIdentifier(),
-                    FrameworkConstants.LogConstants.AuthContextInvalidationReasons.AUTH_FLOW_CONCLUDED);
+                    FrameworkConstants.LogConstants.AuthContextInvalidationReasons.AUTH_FLOW_CONCLUDED, context);
         }
 
         sendResponse(request, response, context);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -860,7 +860,8 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
         String retainCache = System.getProperty("retainCache");
 
         if (retainCache == null) {
-            FrameworkUtils.removeAuthenticationContextFromCache(context.getContextIdentifier());
+            FrameworkUtils.removeAuthenticationContextFromCache(context.getContextIdentifier(),
+                    FrameworkConstants.LogConstants.AuthContextInvalidationReasons.AUTH_FLOW_CONCLUDED);
         }
 
         sendResponse(request, response, context);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
@@ -491,7 +491,8 @@ public class DefaultLogoutRequestHandler implements LogoutRequestHandler {
         String retainCache = System.getProperty("retainCache");
 
         if (retainCache == null) {
-            FrameworkUtils.removeAuthenticationContextFromCache(context.getContextIdentifier());
+            FrameworkUtils.removeAuthenticationContextFromCache(context.getContextIdentifier(),
+                    FrameworkConstants.LogConstants.AuthContextInvalidationReasons.LOGOUT_FLOW_CONCLUDED);
         }
 
         if (log.isDebugEnabled()) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
@@ -492,7 +492,7 @@ public class DefaultLogoutRequestHandler implements LogoutRequestHandler {
 
         if (retainCache == null) {
             FrameworkUtils.removeAuthenticationContextFromCache(context.getContextIdentifier(),
-                    FrameworkConstants.LogConstants.AuthContextInvalidationReasons.LOGOUT_FLOW_CONCLUDED);
+                    FrameworkConstants.LogConstants.AuthContextInvalidationReasons.LOGOUT_FLOW_CONCLUDED, context);
         }
 
         if (log.isDebugEnabled()) {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -522,8 +522,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                 /* The context identifier is exposed to the client as the flowId in app native authentication.
                  Logging it here makes it possible to trace back to the point where the flow identifier was
                  issued and to the point where it was invalidated. */
-                log.warn("Context does not exist. Probably due to invalidated cache. Flow identifier: " + key
-                        + ". " + message);
+                log.warn("Context does not exist. Probably due to invalidated cache. Flow identifier: "
+                        + FrameworkUtils.sanitizeForLogging(key) + ". " + message);
                 if (LoggerUtils.isDiagnosticLogsEnabled()) {
                     DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder =
                             new DiagnosticLog.DiagnosticLogBuilder(

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -163,6 +163,9 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
     private static final String PROMPT_ID_PARAM = "promptId";
     private static final String PROMPT_RESP_PARAM = "promptResp";
     private static final String SESSION_LIMIT_HANDLER_PARAM = "terminateActiveSessionsAction";
+    /* A header carries more characters than an identifier does. A user agent string of a current browser is around
+     120 characters long, so a tighter cap would remove the part which identifies the browser. */
+    private static final int MAX_LOGGABLE_HEADER_LENGTH = 256;
 
     public static DefaultRequestCoordinator getInstance() {
 
@@ -516,8 +519,16 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                 String userAgent = request.getHeader("User-Agent");
                 String referer = request.getHeader("Referer");
 
-                String message = "Requested client: " + request.getRemoteAddr() + ", URI :" + request.getMethod() +
-                        ":" + request.getRequestURI() + ", User-Agent: " + userAgent + " , Referer: " + referer;
+                /* Every part of this message is taken from the request, so all of them are sanitized before they
+                 are written to the server log. A client controlled value would otherwise allow forged log records
+                 to be injected through new line characters, and an oversized one to flood the log. */
+                String message = "Requested client: "
+                        + FrameworkUtils.sanitizeForLogging(request.getRemoteAddr()) + ", URI :"
+                        + FrameworkUtils.sanitizeForLogging(request.getMethod()) + ":"
+                        + FrameworkUtils.sanitizeForLogging(request.getRequestURI(), MAX_LOGGABLE_HEADER_LENGTH)
+                        + ", User-Agent: "
+                        + FrameworkUtils.sanitizeForLogging(userAgent, MAX_LOGGABLE_HEADER_LENGTH) + " , Referer: "
+                        + FrameworkUtils.sanitizeForLogging(referer, MAX_LOGGABLE_HEADER_LENGTH);
 
                 /* The context identifier is exposed to the client as the flowId in app native authentication.
                  Logging it here makes it possible to trace back to the point where the flow identifier was

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -502,12 +502,14 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     FrameworkUtils.getLogoutRequestHandler().handle(request, responseWrapper, context);
                 }
             } else {
-                String key = request.getParameter(FrameworkConstants.SESSION_DATA_KEY);
+                /* The identifier is resolved the same way the context itself was resolved above, since it is not
+                 necessarily carried in the sessionDataKey parameter. */
+                String key = FrameworkUtils.resolveContextIdentifier(request);
                 if (log.isDebugEnabled()) {
                     if (key == null) {
-                        log.debug("Session data key is null in the request");
+                        log.debug("No context identifier could be resolved from the request");
                     } else {
-                        log.debug("Session data key  :  " + key);
+                        log.debug("Context identifier  :  " + key);
                     }
                 }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java
@@ -502,8 +502,8 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                     FrameworkUtils.getLogoutRequestHandler().handle(request, responseWrapper, context);
                 }
             } else {
+                String key = request.getParameter(FrameworkConstants.SESSION_DATA_KEY);
                 if (log.isDebugEnabled()) {
-                    String key = request.getParameter("sessionDataKey");
                     if (key == null) {
                         log.debug("Session data key is null in the request");
                     } else {
@@ -517,7 +517,28 @@ public class DefaultRequestCoordinator extends AbstractRequestCoordinator implem
                 String message = "Requested client: " + request.getRemoteAddr() + ", URI :" + request.getMethod() +
                         ":" + request.getRequestURI() + ", User-Agent: " + userAgent + " , Referer: " + referer;
 
-                log.warn("Context does not exist. Probably due to invalidated cache. " + message);
+                /* The context identifier is exposed to the client as the flowId in app native authentication.
+                 Logging it here makes it possible to trace back to the point where the flow identifier was
+                 issued and to the point where it was invalidated. */
+                log.warn("Context does not exist. Probably due to invalidated cache. Flow identifier: " + key
+                        + ". " + message);
+                if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                    DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder =
+                            new DiagnosticLog.DiagnosticLogBuilder(
+                                    FrameworkConstants.LogConstants.AUTHENTICATION_FRAMEWORK,
+                                    FrameworkConstants.LogConstants.ActionIDs.HANDLE_AUTH_REQUEST)
+                                    .inputParam(FrameworkConstants.LogConstants.CONTEXT_ID, key)
+                                    .inputParam(FrameworkConstants.LogConstants.ORIGINATING_ADDRESS,
+                                            request.getRemoteAddr())
+                                    .inputParam(FrameworkConstants.LogConstants.USER_AGENT, userAgent)
+                                    .inputParam(FrameworkConstants.LogConstants.REFERER, referer)
+                                    .resultMessage("The authentication flow identified by the provided flow " +
+                                            "identifier is no longer active. The flow identifier is either " +
+                                            "invalid, already used to conclude the flow or expired.")
+                                    .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                                    .resultStatus(DiagnosticLog.ResultStatus.FAILED);
+                    LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+                }
                 FrameworkUtils.sendToRetryPage(request, responseWrapper, context,
                         FrameworkConstants.ERROR_STATUS_AUTH_CONTEXT_NULL,
                         FrameworkConstants.ERROR_DESCRIPTION_AUTH_CONTEXT_NULL);

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -849,6 +849,10 @@ public abstract class FrameworkConstants {
         public static final String AUTHENTICATED_IDPS = "authenticated idps";
         public static final String IDP = "idp";
         public static final String SESSION_CONTEXT_KEY = "session context key";
+        public static final String FLOW_ID = "flow id";
+        public static final String INVALIDATION_REASON = "invalidation reason";
+        public static final String USER_AGENT = "user agent";
+        public static final String REFERER = "referer";
 
         /**
          * Define action IDs for diagnostic logs in the framework component.
@@ -868,6 +872,24 @@ public abstract class FrameworkConstants {
             public static final String EXECUTE_ADAPTIVE_SCRIPT = "execute-adaptive-script";
             public static final String JIT_PROVISIONING = "jit-provisioning";
             public static final String PROCESS_POLICY_CONSENT = "process-policy-consent";
+            public static final String INVALIDATE_AUTH_CONTEXT = "invalidate-authentication-context";
+            public static final String ISSUE_FLOW_ID = "issue-flow-id";
+            public static final String VALIDATE_FLOW_ID = "validate-flow-id";
+        }
+
+        /**
+         * Reasons for which an authentication context is invalidated. The context identifier is exposed as the
+         * flowId in app native authentication, therefore invalidating the context makes the corresponding
+         * flowId unusable.
+         */
+        public static class AuthContextInvalidationReasons {
+
+            public static final String AUTH_FLOW_CONCLUDED = "authentication flow concluded";
+            public static final String LOGOUT_FLOW_CONCLUDED = "logout flow concluded";
+            public static final String PROMPT_RESPONSE_PROCESSED = "prompt response processed";
+
+            private AuthContextInvalidationReasons() {
+            }
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -849,10 +849,14 @@ public abstract class FrameworkConstants {
         public static final String AUTHENTICATED_IDPS = "authenticated idps";
         public static final String IDP = "idp";
         public static final String SESSION_CONTEXT_KEY = "session context key";
-        public static final String FLOW_ID = "flow id";
+        /* The identifier of the authentication context is logged as the context id everywhere it appears, even
+         though app native authentication exposes it to the client as the flowId, so that the whole lifecycle of a
+         single identifier can be retrieved with one query. */
+        public static final String FLOW_STATUS = "flow status";
         public static final String INVALIDATION_REASON = "invalidation reason";
         public static final String USER_AGENT = "user agent";
         public static final String REFERER = "referer";
+        public static final String ERROR_CODE = "error code";
 
         /**
          * Define action IDs for diagnostic logs in the framework component.

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -464,6 +464,51 @@ public class FrameworkUtils {
         return context;
     }
 
+    /**
+     * Resolves the identifier of the authentication context which the given request refers to, following the same
+     * resolution order as {@link #getContextData(HttpServletRequest)} uses to resolve the context itself. This is
+     * needed when the context could not be found, since the identifier is not necessarily carried in the
+     * sessionDataKey parameter. Federated authenticators, for an example, carry it within the state or the
+     * RelayState of the callback.
+     *
+     * @param request Request to resolve the context identifier from.
+     * @return Context identifier which the request refers to, or null if none could be resolved.
+     */
+    public static String resolveContextIdentifier(HttpServletRequest request) {
+
+        if (request.getParameter("promptResp") != null && StringUtils.isNotBlank(request.getParameter("promptId"))) {
+            return request.getParameter("promptId");
+        }
+        String sessionDataKey = request.getParameter(FrameworkConstants.SESSION_DATA_KEY);
+        if (StringUtils.isNotBlank(sessionDataKey)) {
+            return sessionDataKey;
+        }
+
+        List<ApplicationAuthenticator> authenticatorList;
+        try {
+            authenticatorList = ApplicationAuthenticatorManager.getInstance()
+                    .getAllAuthenticators(resolveTenantDomain(request));
+        } catch (FrameworkException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error while getting the application authenticators to resolve the context identifier.", e);
+            }
+            return null;
+        }
+        for (ApplicationAuthenticator authenticator : authenticatorList) {
+            try {
+                String contextIdentifier = authenticator.getContextIdentifier(request);
+                if (StringUtils.isNotBlank(contextIdentifier)) {
+                    return contextIdentifier;
+                }
+            } catch (UnsupportedOperationException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Ignore UnsupportedOperationException.", e);
+                }
+            }
+        }
+        return null;
+    }
+
     public static RequestCoordinator getRequestCoordinator() {
 
         RequestCoordinator requestCoordinator = null;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -557,10 +557,13 @@ public class FrameworkUtils {
      */
     public static String sanitizeForLogging(String value, int maxLength) {
 
-        if (StringUtils.isBlank(value)) {
-            return value;
+        /* Every value which is returned from here is passed through the replacement below, rather than a blank one
+         being returned as it is. A value which reaches the log without being replaced would keep this method from
+         counting as a sanitizer, both for a reader and for static analysis. */
+        if (value == null) {
+            return null;
         }
-        String sanitizedValue = value.replaceAll("[\\r\\n]", StringUtils.EMPTY);
+        String sanitizedValue = value.replaceAll("[\r\n]", "");
         if (sanitizedValue.length() > maxLength) {
             sanitizedValue = sanitizedValue.substring(0, maxLength) + "...";
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -255,6 +255,7 @@ public class FrameworkUtils {
     public static final String TENANT_DOMAIN = "tenantDomain";
     public static final String UTF_8 = "UTF-8";
     private static final Log log = LogFactory.getLog(FrameworkUtils.class);
+    private static final int MAX_LOGGABLE_CLIENT_VALUE_LENGTH = 64;
     private static int maxInactiveInterval;
     private static final String EMAIL = "email";
     private static List<String> cacheDisabledAuthenticators = Arrays
@@ -486,29 +487,52 @@ public class FrameworkUtils {
             return sessionDataKey;
         }
 
-        List<ApplicationAuthenticator> authenticatorList;
+        /* This is only used to enrich the logs of a request whose context could not be found, therefore it must
+         never fail the request it is trying to describe. An authenticator of the tenant is free to throw anything
+         from getContextIdentifier() for a request which was not meant for it. */
         try {
-            authenticatorList = ApplicationAuthenticatorManager.getInstance()
+            List<ApplicationAuthenticator> authenticatorList = ApplicationAuthenticatorManager.getInstance()
                     .getAllAuthenticators(resolveTenantDomain(request));
-        } catch (FrameworkException e) {
+            for (ApplicationAuthenticator authenticator : authenticatorList) {
+                try {
+                    String contextIdentifier = authenticator.getContextIdentifier(request);
+                    if (StringUtils.isNotBlank(contextIdentifier)) {
+                        return contextIdentifier;
+                    }
+                } catch (Exception e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Ignoring the failure of " + authenticator.getName()
+                                + " to resolve a context identifier from the request.", e);
+                    }
+                }
+            }
+        } catch (Exception e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error while getting the application authenticators to resolve the context identifier.", e);
             }
-            return null;
-        }
-        for (ApplicationAuthenticator authenticator : authenticatorList) {
-            try {
-                String contextIdentifier = authenticator.getContextIdentifier(request);
-                if (StringUtils.isNotBlank(contextIdentifier)) {
-                    return contextIdentifier;
-                }
-            } catch (UnsupportedOperationException e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Ignore UnsupportedOperationException.", e);
-                }
-            }
         }
         return null;
+    }
+
+    /**
+     * Removes new line characters from a client supplied value and caps its length, so that it can be written to
+     * the server log. A value which the client controls would otherwise allow forged log records to be injected
+     * into the server log through new line characters, and an oversized value to flood it. Diagnostic log inputs do
+     * not need this, since they are recorded as structured data rather than as a log line.
+     *
+     * @param value Value received from the client. Can be null or blank.
+     * @return Value which is safe to be written to the server log.
+     */
+    public static String sanitizeForLogging(String value) {
+
+        if (StringUtils.isBlank(value)) {
+            return value;
+        }
+        String sanitizedValue = value.replaceAll("[\\r\\n]", StringUtils.EMPTY);
+        if (sanitizedValue.length() > MAX_LOGGABLE_CLIENT_VALUE_LENGTH) {
+            sanitizedValue = sanitizedValue.substring(0, MAX_LOGGABLE_CLIENT_VALUE_LENGTH) + "...";
+        }
+        return sanitizedValue;
     }
 
     public static RequestCoordinator getRequestCoordinator() {
@@ -1852,7 +1876,13 @@ public class FrameworkUtils {
             log.debug("Authentication context with the identifier: " + contextId + " is invalidated."
                     + (StringUtils.isNotBlank(reason) ? " Reason: " + reason + "." : ""));
         }
-        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+        /* The cache entry is already cleared at this point. This method is invoked in the middle of concluding an
+         authentication and a logout flow, so a failure of the logging framework itself, such as a tenant which
+         cannot be resolved, must not be allowed to fail the flow which is being concluded. */
+        try {
+            if (!LoggerUtils.isDiagnosticLogsEnabled()) {
+                return;
+            }
             DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
                     FrameworkConstants.LogConstants.AUTHENTICATION_FRAMEWORK,
                     FrameworkConstants.LogConstants.ActionIDs.INVALIDATE_AUTH_CONTEXT)
@@ -1874,6 +1904,8 @@ public class FrameworkUtils {
                 }
             }
             LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+        } catch (Exception e) {
+            log.error("Error while recording the invalidation of the authentication context.", e);
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -429,7 +429,8 @@ public class FrameworkUtils {
             String promptId = request.getParameter("promptId");
             context = FrameworkUtils.getAuthenticationContextFromCache(promptId);
             if (context != null) {
-                FrameworkUtils.removeAuthenticationContextFromCache(promptId);
+                FrameworkUtils.removeAuthenticationContextFromCache(promptId,
+                        FrameworkConstants.LogConstants.AuthContextInvalidationReasons.PROMPT_RESPONSE_PROCESSED);
                 return context;
             }
         }
@@ -1761,9 +1762,44 @@ public class FrameworkUtils {
      */
     public static void removeAuthenticationContextFromCache(String contextId) {
 
-        if (contextId != null) {
-            AuthenticationContextCacheKey cacheKey = new AuthenticationContextCacheKey(contextId);
-            AuthenticationContextCache.getInstance().clearCacheEntry(cacheKey);
+        removeAuthenticationContextFromCache(contextId, null);
+    }
+
+    /**
+     * Invalidates the authentication context held against the given context identifier. Since the context
+     * identifier is exposed to the client as the flowId in app native authentication, the flowId cannot be used
+     * to continue the authentication flow once this is invoked. The invalidation is recorded as a diagnostic log
+     * so that the complete lifecycle of a flowId can be traced.
+     *
+     * @param contextId Context identifier of the authentication context. This is the flowId in app native
+     *                  authentication.
+     * @param reason    Reason for the invalidation. Used only for logging purposes and can be null.
+     */
+    public static void removeAuthenticationContextFromCache(String contextId, String reason) {
+
+        if (contextId == null) {
+            return;
+        }
+        AuthenticationContextCacheKey cacheKey = new AuthenticationContextCacheKey(contextId);
+        AuthenticationContextCache.getInstance().clearCacheEntry(cacheKey);
+
+        if (log.isDebugEnabled()) {
+            log.debug("Authentication context with the identifier: " + contextId + " is invalidated."
+                    + (StringUtils.isNotBlank(reason) ? " Reason: " + reason + "." : ""));
+        }
+        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    FrameworkConstants.LogConstants.AUTHENTICATION_FRAMEWORK,
+                    FrameworkConstants.LogConstants.ActionIDs.INVALIDATE_AUTH_CONTEXT)
+                    .inputParam(FrameworkConstants.LogConstants.CONTEXT_ID, contextId)
+                    .resultMessage("Authentication context is invalidated. The flow identifier can no longer be " +
+                            "used to continue the authentication flow.")
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS);
+            if (StringUtils.isNotBlank(reason)) {
+                diagnosticLogBuilder.inputParam(FrameworkConstants.LogConstants.INVALIDATION_REASON, reason);
+            }
+            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -256,6 +256,8 @@ public class FrameworkUtils {
     public static final String UTF_8 = "UTF-8";
     private static final Log log = LogFactory.getLog(FrameworkUtils.class);
     private static final int MAX_LOGGABLE_CLIENT_VALUE_LENGTH = 64;
+    private static final String PROMPT_ID_PARAM = "promptId";
+    private static final String PROMPT_RESP_PARAM = "promptResp";
     private static int maxInactiveInterval;
     private static final String EMAIL = "email";
     private static List<String> cacheDisabledAuthenticators = Arrays
@@ -427,8 +429,8 @@ public class FrameworkUtils {
     public static AuthenticationContext getContextData(HttpServletRequest request) throws FrameworkRuntimeException {
 
         AuthenticationContext context = null;
-        if (request.getParameter("promptResp") != null && request.getParameter("promptId") != null) {
-            String promptId = request.getParameter("promptId");
+        if (request.getParameter(PROMPT_RESP_PARAM) != null && request.getParameter(PROMPT_ID_PARAM) != null) {
+            String promptId = request.getParameter(PROMPT_ID_PARAM);
             context = FrameworkUtils.getAuthenticationContextFromCache(promptId);
             if (context != null) {
                 FrameworkUtils.removeAuthenticationContextFromCache(promptId,
@@ -479,8 +481,9 @@ public class FrameworkUtils {
      */
     public static String resolveContextIdentifier(HttpServletRequest request) {
 
-        if (request.getParameter("promptResp") != null && StringUtils.isNotBlank(request.getParameter("promptId"))) {
-            return request.getParameter("promptId");
+        if (request.getParameter(PROMPT_RESP_PARAM) != null
+                && StringUtils.isNotBlank(request.getParameter(PROMPT_ID_PARAM))) {
+            return request.getParameter(PROMPT_ID_PARAM);
         }
         String sessionDataKey = request.getParameter(FrameworkConstants.SESSION_DATA_KEY);
         if (StringUtils.isNotBlank(sessionDataKey)) {
@@ -488,22 +491,14 @@ public class FrameworkUtils {
         }
 
         /* This is only used to enrich the logs of a request whose context could not be found, therefore it must
-         never fail the request it is trying to describe. An authenticator of the tenant is free to throw anything
-         from getContextIdentifier() for a request which was not meant for it. */
+         never fail the request it is trying to describe. */
         try {
             List<ApplicationAuthenticator> authenticatorList = ApplicationAuthenticatorManager.getInstance()
                     .getAllAuthenticators(resolveTenantDomain(request));
             for (ApplicationAuthenticator authenticator : authenticatorList) {
-                try {
-                    String contextIdentifier = authenticator.getContextIdentifier(request);
-                    if (StringUtils.isNotBlank(contextIdentifier)) {
-                        return contextIdentifier;
-                    }
-                } catch (Exception e) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Ignoring the failure of " + authenticator.getName()
-                                + " to resolve a context identifier from the request.", e);
-                    }
+                String contextIdentifier = resolveContextIdentifier(authenticator, request);
+                if (StringUtils.isNotBlank(contextIdentifier)) {
+                    return contextIdentifier;
                 }
             }
         } catch (Exception e) {
@@ -512,6 +507,29 @@ public class FrameworkUtils {
             }
         }
         return null;
+    }
+
+    /**
+     * Resolves the identifier of the authentication context which the given request refers to, using the given
+     * authenticator. An authenticator of the tenant is free to throw anything from getContextIdentifier() for a
+     * request which was not meant for it, so a failure of a single authenticator is ignored rather than propagated.
+     *
+     * @param authenticator Authenticator to resolve the context identifier with.
+     * @param request       Request to resolve the context identifier from.
+     * @return Context identifier which the request refers to, or null if this authenticator could not resolve one.
+     */
+    private static String resolveContextIdentifier(ApplicationAuthenticator authenticator,
+                                                   HttpServletRequest request) {
+
+        try {
+            return authenticator.getContextIdentifier(request);
+        } catch (Exception e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Ignoring the failure of " + authenticator.getName()
+                        + " to resolve a context identifier from the request.", e);
+            }
+            return null;
+        }
     }
 
     /**
@@ -525,12 +543,26 @@ public class FrameworkUtils {
      */
     public static String sanitizeForLogging(String value) {
 
+        return sanitizeForLogging(value, MAX_LOGGABLE_CLIENT_VALUE_LENGTH);
+    }
+
+    /**
+     * Removes new line characters from a client supplied value and caps its length at the given maximum, so that it
+     * can be written to the server log. This overload is for values such as request headers, which are legitimately
+     * longer than an identifier is and would lose their diagnostic value if they were capped as tightly.
+     *
+     * @param value     Value received from the client. Can be null or blank.
+     * @param maxLength Maximum number of characters to keep from the value.
+     * @return Value which is safe to be written to the server log.
+     */
+    public static String sanitizeForLogging(String value, int maxLength) {
+
         if (StringUtils.isBlank(value)) {
             return value;
         }
         String sanitizedValue = value.replaceAll("[\\r\\n]", StringUtils.EMPTY);
-        if (sanitizedValue.length() > MAX_LOGGABLE_CLIENT_VALUE_LENGTH) {
-            sanitizedValue = sanitizedValue.substring(0, MAX_LOGGABLE_CLIENT_VALUE_LENGTH) + "...";
+        if (sanitizedValue.length() > maxLength) {
+            sanitizedValue = sanitizedValue.substring(0, maxLength) + "...";
         }
         return sanitizedValue;
     }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -124,6 +124,7 @@ import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
@@ -430,7 +431,8 @@ public class FrameworkUtils {
             context = FrameworkUtils.getAuthenticationContextFromCache(promptId);
             if (context != null) {
                 FrameworkUtils.removeAuthenticationContextFromCache(promptId,
-                        FrameworkConstants.LogConstants.AuthContextInvalidationReasons.PROMPT_RESPONSE_PROCESSED);
+                        FrameworkConstants.LogConstants.AuthContextInvalidationReasons.PROMPT_RESPONSE_PROCESSED,
+                        context);
                 return context;
             }
         }
@@ -1822,6 +1824,24 @@ public class FrameworkUtils {
      */
     public static void removeAuthenticationContextFromCache(String contextId, String reason) {
 
+        removeAuthenticationContextFromCache(contextId, reason, null);
+    }
+
+    /**
+     * Invalidates the authentication context held against the given context identifier and records the invalidation
+     * as a diagnostic log carrying the application the flow belonged to. The application is needed so that the
+     * logging framework can apply its own filtering, such as leaving out Console traffic, which it decides by
+     * inspecting the client id and the application name of the entry.
+     *
+     * @param contextId Context identifier of the authentication context. This is the flowId in app native
+     *                  authentication.
+     * @param reason    Reason for the invalidation. Used only for logging purposes and can be null.
+     * @param context   Authentication context being invalidated. Used only to resolve the application for logging
+     *                  purposes and can be null.
+     */
+    public static void removeAuthenticationContextFromCache(String contextId, String reason,
+                                                            AuthenticationContext context) {
+
         if (contextId == null) {
             return;
         }
@@ -1843,6 +1863,15 @@ public class FrameworkUtils {
                     .resultStatus(DiagnosticLog.ResultStatus.SUCCESS);
             if (StringUtils.isNotBlank(reason)) {
                 diagnosticLogBuilder.inputParam(FrameworkConstants.LogConstants.INVALIDATION_REASON, reason);
+            }
+            if (context != null) {
+                if (StringUtils.isNotBlank(context.getRelyingParty())) {
+                    diagnosticLogBuilder.inputParam(LogConstants.InputKeys.CLIENT_ID, context.getRelyingParty());
+                }
+                if (StringUtils.isNotBlank(context.getServiceProviderName())) {
+                    diagnosticLogBuilder.inputParam(LogConstants.InputKeys.APPLICATION_NAME,
+                            context.getServiceProviderName());
+                }
             }
             LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
@@ -49,6 +49,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -350,6 +351,32 @@ public class AuthenticationServiceTest extends AbstractFrameworkTest {
                 "Expected error code to match for retry status: " + retryStatus);
         Assert.assertEquals(errorInfo.get().getErrorMessage(), expectedError.message(),
                 "Expected error message to match for retry status: " + retryStatus);
+    }
+
+    /**
+     * Test that new line characters are removed and an oversized value is capped before a client supplied flowId is
+     * written to the server log, so that forged log records cannot be injected through the flowId.
+     */
+    @Test
+    public void testFlowIdIsSanitizedBeforeItIsLogged() throws Exception {
+
+        Method sanitizeMethod = AuthenticationService.class
+                .getDeclaredMethod("sanitizeFlowIdForLogging", String.class);
+        sanitizeMethod.setAccessible(true);
+        AuthenticationService authenticationService = new AuthenticationService();
+
+        String forgedFlowId = "valid-id\r\n2026-08-24 ERROR [forged] admin login succeeded";
+        String sanitized = (String) sanitizeMethod.invoke(authenticationService, forgedFlowId);
+        Assert.assertFalse(sanitized.contains("\r"), "Carriage returns should be removed from the logged flowId.");
+        Assert.assertFalse(sanitized.contains("\n"), "Line feeds should be removed from the logged flowId.");
+
+        String oversizedFlowId = StringUtils.repeat("a", 200);
+        String cappedFlowId = (String) sanitizeMethod.invoke(authenticationService, oversizedFlowId);
+        Assert.assertTrue(cappedFlowId.length() < oversizedFlowId.length(),
+                "An oversized flowId should be capped before it is logged.");
+
+        Assert.assertNull(sanitizeMethod.invoke(authenticationService, (Object) null),
+                "A null flowId should be returned as is.");
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
@@ -50,12 +50,13 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -64,7 +65,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -210,6 +211,76 @@ public class AuthenticationServiceTest extends AbstractFrameworkTest {
             Assert.fail("Expected authServiceErrorInfo to be present as the flow is fail incomplete.");
         }
         Assert.assertEquals(authServiceErrorInfo.get().getErrorMessage(), PASSWORD_EXPIRED_MSG);
+    }
+
+    /**
+     * Test that an initial request which concludes the flow is not recorded as a flowId issuance. A concluded flow
+     * returns the session key of the inbound protocol rather than a flow identifier, so recording it would place an
+     * identifier of a different identifier space into the flowId lifecycle.
+     */
+    @Test
+    public void testFlowIdIssuanceIsNotRecordedWhenTheInitialRequestConcludesTheFlow() throws Exception {
+
+        setUpEnabledApplicationForInitialRequest();
+        when(request.getAttribute(FrameworkConstants.RequestParams.FLOW_STATUS))
+                .thenReturn(AuthenticatorFlowStatus.SUCCESS_COMPLETED);
+        when(request.getAttribute(FrameworkConstants.CONTEXT_IDENTIFIER)).thenReturn(FINAL_SESSION_DATA_KEY);
+        when(response.getHeader(LOCATION_HEADER)).thenReturn(getFinalRedirectUrl(FINAL_SESSION_DATA_KEY));
+
+        new AuthenticationService().handleAuthentication(new AuthServiceRequest(request, response));
+
+        Assert.assertFalse(isDiagnosticLogRecordedFor(FrameworkConstants.LogConstants.ActionIDs.ISSUE_FLOW_ID),
+                "A concluded flow should not be recorded as a flowId issuance.");
+    }
+
+    /**
+     * Test that an initial request which leaves the flow incomplete is recorded as a flowId issuance, since that is
+     * the point at which a flowId is handed to the client.
+     */
+    @Test
+    public void testFlowIdIssuanceIsRecordedWhenTheInitialRequestLeavesTheFlowIncomplete() throws Exception {
+
+        setUpEnabledApplicationForInitialRequest();
+        when(request.getAttribute(FrameworkConstants.RequestParams.FLOW_STATUS))
+                .thenReturn(AuthenticatorFlowStatus.INCOMPLETE);
+        when(request.getAttribute(FrameworkConstants.CONTEXT_IDENTIFIER)).thenReturn(SESSION_DATA_KEY);
+        when(request.getAttribute(AuthServiceConstants.AUTH_SERVICE_AUTH_INITIATION_DATA))
+                .thenReturn(getAuthenticatorData(SINGLE_AUTHENTICATOR));
+        when(response.getHeader(LOCATION_HEADER))
+                .thenReturn(getIntermediateRedirectUrl(SESSION_DATA_KEY, SINGLE_AUTHENTICATOR));
+
+        new AuthenticationService().handleAuthentication(new AuthServiceRequest(request, response));
+
+        Assert.assertTrue(isDiagnosticLogRecordedFor(FrameworkConstants.LogConstants.ActionIDs.ISSUE_FLOW_ID),
+                "An incomplete flow should record the flowId which was issued to the client.");
+    }
+
+    private void setUpEnabledApplicationForInitialRequest() throws Exception {
+
+        ServiceProvider serviceProvider = mock(ServiceProvider.class);
+        when(serviceProvider.isApplicationEnabled()).thenReturn(true);
+        when(serviceProvider.isAPIBasedAuthenticationEnabled()).thenReturn(true);
+        ApplicationManagementServiceImpl mockApplicationManagementService =
+                mock(ApplicationManagementServiceImpl.class);
+        applicationManagementService.when(ApplicationManagementService::getInstance)
+                .thenReturn(mockApplicationManagementService);
+        when(mockApplicationManagementService.getServiceProviderByClientId(anyString(), anyString(), anyString()))
+                .thenReturn(serviceProvider);
+        when(request.getAttribute(AuthServiceConstants.REQ_ATTR_IS_INITIAL_API_BASED_AUTH_REQUEST)).thenReturn(true);
+        when(request.getAttribute(AuthServiceConstants.REQ_ATTR_RELYING_PARTY)).thenReturn("dummyClientId");
+        when(request.getParameter(FrameworkConstants.RequestParams.TENANT_DOMAIN)).thenReturn("dummyTenantDomain");
+    }
+
+    /**
+     * Returns whether a diagnostic log of the given action id was recorded during the test.
+     */
+    private boolean isDiagnosticLogRecordedFor(String actionId) {
+
+        ArgumentCaptor<DiagnosticLog.DiagnosticLogBuilder> captor =
+                ArgumentCaptor.forClass(DiagnosticLog.DiagnosticLogBuilder.class);
+        loggerUtils.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(captor.capture()), atLeast(0));
+        return captor.getAllValues().stream()
+                .anyMatch(builder -> actionId.equals(builder.build().getActionId()));
     }
 
     @Test
@@ -364,9 +435,12 @@ public class AuthenticationServiceTest extends AbstractFrameworkTest {
     public void testFlowIdIssuanceIsNotRecordedForContinuationRequests() throws Exception {
 
         AuthenticationService authenticationService = new AuthenticationService();
-        AuthServiceRequest authServiceRequest = new AuthServiceRequest(request, response);
+        /* The initial request attribute is absent and a flowId is supplied, which is what a continuation request
+         of an already started flow looks like. */
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put(AuthServiceConstants.FLOW_ID, new String[]{SESSION_DATA_KEY});
+        AuthServiceRequest authServiceRequest = new AuthServiceRequest(request, response, parameters);
 
-        // The initial request attribute is absent, which is what a continuation request of a flow looks like.
         when(request.getAttribute(FrameworkConstants.RequestParams.FLOW_STATUS))
                 .thenReturn(AuthenticatorFlowStatus.INCOMPLETE);
         when(request.getAttribute(FrameworkConstants.CONTEXT_IDENTIFIER)).thenReturn(SESSION_DATA_KEY);
@@ -374,41 +448,10 @@ public class AuthenticationServiceTest extends AbstractFrameworkTest {
 
         authenticationService.handleAuthentication(authServiceRequest);
 
-        ArgumentCaptor<DiagnosticLog.DiagnosticLogBuilder> captor =
-                ArgumentCaptor.forClass(DiagnosticLog.DiagnosticLogBuilder.class);
-        loggerUtils.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(captor.capture()), atLeastOnce());
-        for (DiagnosticLog.DiagnosticLogBuilder builder : captor.getAllValues()) {
-            Assert.assertNotEquals(builder.build().getActionId(),
-                    FrameworkConstants.LogConstants.ActionIDs.ISSUE_FLOW_ID,
-                    "A continuation request should not be recorded as a flowId issuance.");
-        }
+        Assert.assertFalse(isDiagnosticLogRecordedFor(FrameworkConstants.LogConstants.ActionIDs.ISSUE_FLOW_ID),
+                "A continuation request should not be recorded as a flowId issuance.");
     }
 
-    /**
-     * Test that new line characters are removed and an oversized value is capped before a client supplied flowId is
-     * written to the server log, so that forged log records cannot be injected through the flowId.
-     */
-    @Test
-    public void testFlowIdIsSanitizedBeforeItIsLogged() throws Exception {
-
-        Method sanitizeMethod = AuthenticationService.class
-                .getDeclaredMethod("sanitizeFlowIdForLogging", String.class);
-        sanitizeMethod.setAccessible(true);
-        AuthenticationService authenticationService = new AuthenticationService();
-
-        String forgedFlowId = "valid-id\r\n2026-08-24 ERROR [forged] admin login succeeded";
-        String sanitized = (String) sanitizeMethod.invoke(authenticationService, forgedFlowId);
-        Assert.assertFalse(sanitized.contains("\r"), "Carriage returns should be removed from the logged flowId.");
-        Assert.assertFalse(sanitized.contains("\n"), "Line feeds should be removed from the logged flowId.");
-
-        String oversizedFlowId = StringUtils.repeat("a", 200);
-        String cappedFlowId = (String) sanitizeMethod.invoke(authenticationService, oversizedFlowId);
-        Assert.assertTrue(cappedFlowId.length() < oversizedFlowId.length(),
-                "An oversized flowId should be capped before it is logged.");
-
-        Assert.assertNull(sanitizeMethod.invoke(authenticationService, (Object) null),
-                "A null flowId should be returned as is.");
-    }
 
     /**
      * Test that a request carrying a flowId which is no longer active is still reported with the invalid flow

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.application.authentication.framework;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
@@ -63,6 +64,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -351,6 +353,35 @@ public class AuthenticationServiceTest extends AbstractFrameworkTest {
                 "Expected error code to match for retry status: " + retryStatus);
         Assert.assertEquals(errorInfo.get().getErrorMessage(), expectedError.message(),
                 "Expected error message to match for retry status: " + retryStatus);
+    }
+
+    /**
+     * Test that no flowId issuance is recorded for a request which is not the initial request of a flow. The
+     * identifier does not change between the steps of a flow, so recording an issuance for a continuation would
+     * make the point at which the identifier was actually issued impossible to find.
+     */
+    @Test
+    public void testFlowIdIssuanceIsNotRecordedForContinuationRequests() throws Exception {
+
+        AuthenticationService authenticationService = new AuthenticationService();
+        AuthServiceRequest authServiceRequest = new AuthServiceRequest(request, response);
+
+        // The initial request attribute is absent, which is what a continuation request of a flow looks like.
+        when(request.getAttribute(FrameworkConstants.RequestParams.FLOW_STATUS))
+                .thenReturn(AuthenticatorFlowStatus.INCOMPLETE);
+        when(request.getAttribute(FrameworkConstants.CONTEXT_IDENTIFIER)).thenReturn(SESSION_DATA_KEY);
+        when(response.getHeader(LOCATION_HEADER)).thenReturn(getFinalRedirectUrl(SESSION_DATA_KEY));
+
+        authenticationService.handleAuthentication(authServiceRequest);
+
+        ArgumentCaptor<DiagnosticLog.DiagnosticLogBuilder> captor =
+                ArgumentCaptor.forClass(DiagnosticLog.DiagnosticLogBuilder.class);
+        loggerUtils.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(captor.capture()), atLeastOnce());
+        for (DiagnosticLog.DiagnosticLogBuilder builder : captor.getAllValues()) {
+            Assert.assertNotEquals(builder.build().getActionId(),
+                    FrameworkConstants.LogConstants.ActionIDs.ISSUE_FLOW_ID,
+                    "A continuation request should not be recorded as a flowId issuance.");
+        }
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementServiceImpl;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -59,10 +60,12 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 /**
@@ -347,6 +350,35 @@ public class AuthenticationServiceTest extends AbstractFrameworkTest {
                 "Expected error code to match for retry status: " + retryStatus);
         Assert.assertEquals(errorInfo.get().getErrorMessage(), expectedError.message(),
                 "Expected error message to match for retry status: " + retryStatus);
+    }
+
+    @Test
+    public void testInvalidFlowIdIsNotLoggedWhenDiagnosticLogsAreDisabled() throws Exception {
+
+        loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
+
+        AuthenticationService authenticationService = new AuthenticationService();
+        // No flowId parameter is supplied, so none can be resolved for the log.
+        AuthServiceRequest authServiceRequest = new AuthServiceRequest(request, response);
+
+        when(request.getAttribute(FrameworkConstants.RequestParams.FLOW_STATUS))
+                .thenReturn(AuthenticatorFlowStatus.FAIL_COMPLETED);
+        when(request.getAttribute(FrameworkConstants.IS_AUTH_FLOW_CONCLUDED)).thenReturn(true);
+        when(request.getAttribute(FrameworkConstants.IS_SENT_TO_RETRY)).thenReturn(true);
+        when(request.getAttribute(FrameworkConstants.REQ_ATTR_RETRY_STATUS))
+                .thenReturn(FrameworkConstants.ERROR_STATUS_AUTH_CONTEXT_NULL);
+        when(request.getAttribute(FrameworkConstants.CONTEXT_IDENTIFIER)).thenReturn(SESSION_DATA_KEY);
+        when(response.getHeader(LOCATION_HEADER)).thenReturn(getFinalRedirectUrl(SESSION_DATA_KEY));
+
+        AuthServiceResponse authServiceResponse = authenticationService.handleAuthentication(authServiceRequest);
+
+        Optional<AuthServiceErrorInfo> errorInfo = authServiceResponse.getErrorInfo();
+        Assert.assertTrue(errorInfo.isPresent(), "Expected error info to be present.");
+        Assert.assertEquals(errorInfo.get().getErrorCode(),
+                AuthServiceConstants.ErrorMessage.ERROR_AUTHENTICATION_CONTEXT_NULL.code(),
+                "An invalid flowId should be reported with the invalid flow identifier error code.");
+        loggerUtils.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(any(
+                DiagnosticLog.DiagnosticLogBuilder.class)), never());
     }
 
     @Test

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
@@ -352,6 +352,10 @@ public class AuthenticationServiceTest extends AbstractFrameworkTest {
                 "Expected error message to match for retry status: " + retryStatus);
     }
 
+    /**
+     * Test that a request carrying a flowId which is no longer active is still reported with the invalid flow
+     * identifier error code, but no diagnostic log is triggered when diagnostic logging is disabled for the tenant.
+     */
     @Test
     public void testInvalidFlowIdIsNotLoggedWhenDiagnosticLogsAreDisabled() throws Exception {
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticationServiceTest.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.identity.application.authentication.framework.util.auth.s
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementServiceImpl;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.io.IOException;
@@ -89,11 +90,18 @@ public class AuthenticationServiceTest extends AbstractFrameworkTest {
     private MockedStatic<FrameworkUtils> frameworkUtils;
 
     private MockedStatic<ApplicationManagementService> applicationManagementService;
+    private MockedStatic<LoggerUtils> loggerUtils;
 
     @BeforeMethod
     public void init() throws IOException {
 
         MockitoAnnotations.initMocks(this);
+
+        /* The service writes diagnostic logs on the flowId lifecycle. Diagnostic logging is mocked as enabled so
+         that the diagnostic log building code is exercised without requiring a carbon context to resolve the
+         tenant. */
+        loggerUtils = mockStatic(LoggerUtils.class);
+        loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
 
         removeAllSystemDefinedAuthenticators();
         configurationFacade = mockStatic(ConfigurationFacade.class);
@@ -115,6 +123,7 @@ public class AuthenticationServiceTest extends AbstractFrameworkTest {
         configurationFacade.close();
         frameworkUtils.close();
         applicationManagementService.close();
+        loggerUtils.close();
     }
 
     @DataProvider(name = "authProvider")

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.application.authentication.framework.handler.request.impl;
 
 import org.junit.Assert;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -65,6 +66,7 @@ import org.wso2.carbon.identity.organization.management.organization.user.sharin
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.testutil.IdentityBaseTest;
+import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -331,6 +333,45 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
             } catch (FrameworkException e) {
                 assertEquals(e.getErrorCode(), NONCE_ERROR_CODE);
             }
+        }
+    }
+
+    @Test(description = "Test that a request with an inactive flow identifier is flagged in the logs")
+    public void testHandleRecordsUsageOfInactiveFlowIdentifier() throws FrameworkException, IOException {
+
+        try (MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class);
+             MockedStatic<LoggerUtils> loggerUtils = mockStatic(LoggerUtils.class)) {
+            HttpServletRequest request = mock(HttpServletRequest.class);
+            when(request.getParameter(FrameworkConstants.SESSION_DATA_KEY)).thenReturn("stale-flow-id");
+            when(request.getRemoteAddr()).thenReturn("10.0.0.1");
+            when(request.getMethod()).thenReturn("POST");
+            when(request.getRequestURI()).thenReturn("/commonauth");
+            when(request.getHeader("User-Agent")).thenReturn("test-agent");
+            when(request.getHeader("Referer")).thenReturn("https://localhost/app");
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+            // A null context is what the framework sees once the flow identifier is no longer active.
+            frameworkUtils.when(() -> FrameworkUtils.getContextData(any())).thenReturn(null);
+            frameworkUtils.when(() -> FrameworkUtils.sendToRetryPage(any(), any(), any(), any(), any()))
+                    .thenAnswer(invocation -> {
+                        ((HttpServletResponse) invocation.getArgument(1)).sendRedirect("dummyUrl");
+                        return null;
+                    });
+
+            DefaultRequestCoordinator coordinator = new DefaultRequestCoordinator();
+            coordinator.handle(request, response);
+
+            ArgumentCaptor<DiagnosticLog.DiagnosticLogBuilder> captor =
+                    ArgumentCaptor.forClass(DiagnosticLog.DiagnosticLogBuilder.class);
+            loggerUtils.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(captor.capture()), atLeastOnce());
+            DiagnosticLog diagnosticLog = captor.getValue().build();
+            assertEquals(diagnosticLog.getResultStatus(), DiagnosticLog.ResultStatus.FAILED.name());
+            assertEquals(diagnosticLog.getInput().get(FrameworkConstants.LogConstants.CONTEXT_ID), "stale-flow-id",
+                    "The flow identifier of the rejected request should be logged.");
+            assertEquals(diagnosticLog.getInput().get(FrameworkConstants.LogConstants.USER_AGENT), "test-agent");
+            assertEquals(diagnosticLog.getInput().get(FrameworkConstants.LogConstants.REFERER),
+                    "https://localhost/app");
         }
     }
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
@@ -84,6 +84,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -340,7 +341,7 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
      * Verifies that an inactive flow identifier is recorded in the diagnostic log.
      */
     @Test(description = "Test that a request with an inactive flow identifier is flagged in the logs")
-    public void testHandleRecordsUsageOfInactiveFlowIdentifier() throws FrameworkException, IOException {
+    public void testHandleRecordsUsageOfInactiveFlowIdentifier() throws IOException {
 
         try (MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class);
              MockedStatic<LoggerUtils> loggerUtils = mockStatic(LoggerUtils.class)) {
@@ -358,6 +359,8 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
             frameworkUtils.when(() -> FrameworkUtils.getContextData(any())).thenReturn(null);
             frameworkUtils.when(() -> FrameworkUtils.resolveContextIdentifier(any())).thenReturn("stale-flow-id");
             frameworkUtils.when(() -> FrameworkUtils.sanitizeForLogging(anyString()))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+            frameworkUtils.when(() -> FrameworkUtils.sanitizeForLogging(anyString(), anyInt()))
                     .thenAnswer(invocation -> invocation.getArgument(0));
             frameworkUtils.when(() -> FrameworkUtils.sendToRetryPage(any(), any(), any(), any(), any()))
                     .thenAnswer(invocation -> {

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
@@ -356,6 +356,7 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
             loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
             // A null context is what the framework sees once the flow identifier is no longer active.
             frameworkUtils.when(() -> FrameworkUtils.getContextData(any())).thenReturn(null);
+            frameworkUtils.when(() -> FrameworkUtils.resolveContextIdentifier(any())).thenReturn("stale-flow-id");
             frameworkUtils.when(() -> FrameworkUtils.sendToRetryPage(any(), any(), any(), any(), any()))
                     .thenAnswer(invocation -> {
                         ((HttpServletResponse) invocation.getArgument(1)).sendRedirect("dummyUrl");

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
@@ -357,6 +357,8 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
             // A null context is what the framework sees once the flow identifier is no longer active.
             frameworkUtils.when(() -> FrameworkUtils.getContextData(any())).thenReturn(null);
             frameworkUtils.when(() -> FrameworkUtils.resolveContextIdentifier(any())).thenReturn("stale-flow-id");
+            frameworkUtils.when(() -> FrameworkUtils.sanitizeForLogging(anyString()))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
             frameworkUtils.when(() -> FrameworkUtils.sendToRetryPage(any(), any(), any(), any(), any()))
                     .thenAnswer(invocation -> {
                         ((HttpServletResponse) invocation.getArgument(1)).sendRedirect("dummyUrl");

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinatorTest.java
@@ -336,6 +336,9 @@ public class DefaultRequestCoordinatorTest extends IdentityBaseTest {
         }
     }
 
+    /**
+     * Verifies that an inactive flow identifier is recorded in the diagnostic log.
+     */
     @Test(description = "Test that a request with an inactive flow identifier is flagged in the logs")
     public void testHandleRecordsUsageOfInactiveFlowIdentifier() throws FrameworkException, IOException {
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -423,6 +423,10 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
         assertEquals(provisioningHandler.getClass(), DefaultProvisioningHandler.class);
     }
 
+    /**
+     * Test that invalidating an authentication context clears the cache entry and records the invalidation as a
+     * diagnostic log carrying the context identifier and the reason for the invalidation.
+     */
     @Test
     public void testRemoveAuthenticationContextFromCacheRecordsInvalidation() {
 
@@ -454,6 +458,10 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
         }
     }
 
+    /**
+     * Test that the single argument variant, which is retained for backward compatibility, still records the
+     * invalidation as a diagnostic log but without an invalidation reason.
+     */
     @Test
     public void testRemoveAuthenticationContextFromCacheWithoutReason() {
 
@@ -464,7 +472,6 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
                     AuthenticationContextCache::getInstance).thenReturn(mockedAuthenticationContextCache);
             loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
 
-            // The single argument variant is retained for backward compatibility and records no reason.
             FrameworkUtils.removeAuthenticationContextFromCache("CONTEXT-ID");
 
             ArgumentCaptor<DiagnosticLog.DiagnosticLogBuilder> captorLog =
@@ -475,6 +482,10 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
         }
     }
 
+    /**
+     * Test that the cache entry is still cleared but no diagnostic log is triggered when diagnostic logging is
+     * disabled for the tenant.
+     */
     @Test
     public void testRemoveAuthenticationContextFromCacheSkipsDiagnosticLogWhenDisabled() {
 
@@ -493,6 +504,9 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
         }
     }
 
+    /**
+     * Test that a null context identifier is ignored without clearing any cache entry.
+     */
     @Test
     public void testRemoveAuthenticationContextFromCacheWithNullContextId() {
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -574,6 +574,11 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
         assertNull(FrameworkUtils.sanitizeForLogging(null), "A null value should be returned as is.");
         assertEquals(FrameworkUtils.sanitizeForLogging("plain-flow-id"), "plain-flow-id",
                 "A value with nothing to sanitize should be returned unchanged.");
+
+        /* New line characters count as whitespace, so a value made up of them is blank. Such a value still has to
+         be sanitized, since returning it as it is would break the log record it is written to. */
+        assertEquals(FrameworkUtils.sanitizeForLogging("\r\n \r\n"), " ",
+                "A blank value should be sanitized rather than returned as it is.");
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -537,13 +537,13 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
                     AuthenticationContextCache::getInstance).thenReturn(mockedAuthenticationContextCache);
             loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
 
-            AuthenticationContext authenticationContext = new AuthenticationContext();
-            authenticationContext.setServiceProviderName("My Application");
-            authenticationContext.setRelyingParty("my-client-id");
+            AuthenticationContext contextOfApplication = new AuthenticationContext();
+            contextOfApplication.setServiceProviderName("My Application");
+            contextOfApplication.setRelyingParty("my-client-id");
 
             FrameworkUtils.removeAuthenticationContextFromCache("CONTEXT-ID",
                     FrameworkConstants.LogConstants.AuthContextInvalidationReasons.AUTH_FLOW_CONCLUDED,
-                    authenticationContext);
+                    contextOfApplication);
 
             ArgumentCaptor<DiagnosticLog.DiagnosticLogBuilder> captorLog =
                     ArgumentCaptor.forClass(DiagnosticLog.DiagnosticLogBuilder.class);
@@ -574,6 +574,26 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
         assertNull(FrameworkUtils.sanitizeForLogging(null), "A null value should be returned as is.");
         assertEquals(FrameworkUtils.sanitizeForLogging("plain-flow-id"), "plain-flow-id",
                 "A value with nothing to sanitize should be returned unchanged.");
+    }
+
+    /**
+     * Test that a caller which logs a value longer than an identifier, such as a request header, can keep more of it
+     * while new line characters are still removed and the length is still capped.
+     */
+    @Test
+    public void testSanitizeForLoggingWithAnExplicitLengthLimit() {
+
+        String userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) "
+                + "Chrome/120.0.0.0 Safari/537.36";
+        assertEquals(FrameworkUtils.sanitizeForLogging(userAgent, 256), userAgent,
+                "A user agent should not be truncated by the limit which applies to headers.");
+        assertTrue(FrameworkUtils.sanitizeForLogging(userAgent).length() < userAgent.length(),
+                "The default limit is meant for identifiers, so it should still truncate a user agent.");
+
+        assertFalse(FrameworkUtils.sanitizeForLogging("agent\r\nforged record", 256).contains("\n"),
+                "New line characters should be removed regardless of the length limit.");
+        assertEquals(FrameworkUtils.sanitizeForLogging("abcdef", 3), "abc...",
+                "A value longer than the given limit should be capped at it.");
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -556,6 +556,27 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
     }
 
     /**
+     * Test that new line characters are removed and an oversized value is capped before a client supplied value is
+     * written to the server log, so that forged log records cannot be injected through it.
+     */
+    @Test
+    public void testSanitizeForLogging() {
+
+        String forgedValue = "valid-id\r\n2026-08-25 ERROR [forged] admin login succeeded";
+        String sanitized = FrameworkUtils.sanitizeForLogging(forgedValue);
+        assertFalse(sanitized.contains("\r"), "Carriage returns should be removed from a logged value.");
+        assertFalse(sanitized.contains("\n"), "Line feeds should be removed from a logged value.");
+
+        String oversizedValue = new String(new char[200]).replace("\0", "a");
+        assertTrue(FrameworkUtils.sanitizeForLogging(oversizedValue).length() < oversizedValue.length(),
+                "An oversized value should be capped before it is logged.");
+
+        assertNull(FrameworkUtils.sanitizeForLogging(null), "A null value should be returned as is.");
+        assertEquals(FrameworkUtils.sanitizeForLogging("plain-flow-id"), "plain-flow-id",
+                "A value with nothing to sanitize should be returned unchanged.");
+    }
+
+    /**
      * Test that the context identifier is resolved from the sessionDataKey parameter when the request carries one.
      */
     @Test

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -78,6 +78,7 @@ import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.URLBuilderException;
@@ -102,6 +103,7 @@ import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.common.User;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.tenant.TenantManager;
+import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
@@ -419,6 +421,91 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
                 .remove(FrameworkConstants.Config.QNAME_EXT_PROVISIONING_HANDLER);
         Object provisioningHandler = FrameworkUtils.getProvisioningHandler();
         assertEquals(provisioningHandler.getClass(), DefaultProvisioningHandler.class);
+    }
+
+    @Test
+    public void testRemoveAuthenticationContextFromCacheRecordsInvalidation() {
+
+        try (MockedStatic<AuthenticationContextCache> authenticationContextCache =
+                mockStatic(AuthenticationContextCache.class);
+             MockedStatic<LoggerUtils> loggerUtils = mockStatic(LoggerUtils.class)) {
+            authenticationContextCache.when(
+                    AuthenticationContextCache::getInstance).thenReturn(mockedAuthenticationContextCache);
+            loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+            String contextId = "CONTEXT-ID";
+
+            FrameworkUtils.removeAuthenticationContextFromCache(contextId,
+                    FrameworkConstants.LogConstants.AuthContextInvalidationReasons.AUTH_FLOW_CONCLUDED);
+
+            ArgumentCaptor<AuthenticationContextCacheKey> captorKey =
+                    ArgumentCaptor.forClass(AuthenticationContextCacheKey.class);
+            verify(mockedAuthenticationContextCache).clearCacheEntry(captorKey.capture());
+            assertEquals(captorKey.getValue().getContextId(), contextId);
+
+            ArgumentCaptor<DiagnosticLog.DiagnosticLogBuilder> captorLog =
+                    ArgumentCaptor.forClass(DiagnosticLog.DiagnosticLogBuilder.class);
+            loggerUtils.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(captorLog.capture()));
+            DiagnosticLog diagnosticLog = captorLog.getValue().build();
+            assertEquals(diagnosticLog.getActionId(),
+                    FrameworkConstants.LogConstants.ActionIDs.INVALIDATE_AUTH_CONTEXT);
+            assertEquals(diagnosticLog.getInput().get(FrameworkConstants.LogConstants.CONTEXT_ID), contextId);
+            assertEquals(diagnosticLog.getInput().get(FrameworkConstants.LogConstants.INVALIDATION_REASON),
+                    FrameworkConstants.LogConstants.AuthContextInvalidationReasons.AUTH_FLOW_CONCLUDED);
+        }
+    }
+
+    @Test
+    public void testRemoveAuthenticationContextFromCacheWithoutReason() {
+
+        try (MockedStatic<AuthenticationContextCache> authenticationContextCache =
+                mockStatic(AuthenticationContextCache.class);
+             MockedStatic<LoggerUtils> loggerUtils = mockStatic(LoggerUtils.class)) {
+            authenticationContextCache.when(
+                    AuthenticationContextCache::getInstance).thenReturn(mockedAuthenticationContextCache);
+            loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+
+            // The single argument variant is retained for backward compatibility and records no reason.
+            FrameworkUtils.removeAuthenticationContextFromCache("CONTEXT-ID");
+
+            ArgumentCaptor<DiagnosticLog.DiagnosticLogBuilder> captorLog =
+                    ArgumentCaptor.forClass(DiagnosticLog.DiagnosticLogBuilder.class);
+            loggerUtils.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(captorLog.capture()));
+            DiagnosticLog diagnosticLog = captorLog.getValue().build();
+            assertNull(diagnosticLog.getInput().get(FrameworkConstants.LogConstants.INVALIDATION_REASON));
+        }
+    }
+
+    @Test
+    public void testRemoveAuthenticationContextFromCacheSkipsDiagnosticLogWhenDisabled() {
+
+        try (MockedStatic<AuthenticationContextCache> authenticationContextCache =
+                mockStatic(AuthenticationContextCache.class);
+             MockedStatic<LoggerUtils> loggerUtils = mockStatic(LoggerUtils.class)) {
+            authenticationContextCache.when(
+                    AuthenticationContextCache::getInstance).thenReturn(mockedAuthenticationContextCache);
+            loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
+
+            FrameworkUtils.removeAuthenticationContextFromCache("CONTEXT-ID", "reason");
+
+            verify(mockedAuthenticationContextCache).clearCacheEntry(any(AuthenticationContextCacheKey.class));
+            loggerUtils.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(
+                    any(DiagnosticLog.DiagnosticLogBuilder.class)), never());
+        }
+    }
+
+    @Test
+    public void testRemoveAuthenticationContextFromCacheWithNullContextId() {
+
+        try (MockedStatic<AuthenticationContextCache> authenticationContextCache =
+                mockStatic(AuthenticationContextCache.class)) {
+            authenticationContextCache.when(
+                    AuthenticationContextCache::getInstance).thenReturn(mockedAuthenticationContextCache);
+
+            FrameworkUtils.removeAuthenticationContextFromCache(null, "reason");
+
+            verify(mockedAuthenticationContextCache, never())
+                    .clearCacheEntry(any(AuthenticationContextCacheKey.class));
+        }
     }
 
     @Test

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -522,6 +522,46 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
         }
     }
 
+    /**
+     * Test that the context identifier is resolved from the sessionDataKey parameter when the request carries one.
+     */
+    @Test
+    public void testResolveContextIdentifierFromSessionDataKey() {
+
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+        lenient().when(httpServletRequest.getParameter(FrameworkConstants.SESSION_DATA_KEY))
+                .thenReturn("session-data-key");
+
+        assertEquals(FrameworkUtils.resolveContextIdentifier(httpServletRequest), "session-data-key");
+    }
+
+    /**
+     * Test that the promptId is resolved as the context identifier for a prompt response, since such requests do
+     * not carry the identifier in the sessionDataKey parameter.
+     */
+    @Test
+    public void testResolveContextIdentifierFromPromptId() {
+
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+        lenient().when(httpServletRequest.getParameter("promptResp")).thenReturn("true");
+        lenient().when(httpServletRequest.getParameter("promptId")).thenReturn("prompt-id");
+
+        assertEquals(FrameworkUtils.resolveContextIdentifier(httpServletRequest), "prompt-id");
+    }
+
+    /**
+     * Test that a blank sessionDataKey falls through to the authenticators, and that a null identifier is returned
+     * when none of them can resolve one from the request.
+     */
+    @Test
+    public void testResolveContextIdentifierWhenNoneCanBeResolved() {
+
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+        lenient().when(httpServletRequest.getParameter(FrameworkConstants.SESSION_DATA_KEY)).thenReturn("");
+
+        assertNull(FrameworkUtils.resolveContextIdentifier(httpServletRequest));
+    }
+
     @Test
     public void getAddAuthenticationContextToCache() {
 

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -78,6 +78,7 @@ import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
@@ -519,6 +520,38 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
 
             verify(mockedAuthenticationContextCache, never())
                     .clearCacheEntry(any(AuthenticationContextCacheKey.class));
+        }
+    }
+
+    /**
+     * Test that the application the flow belonged to is recorded with the invalidation, so that the logging
+     * framework can apply its own filtering, such as leaving out Console traffic.
+     */
+    @Test
+    public void testRemoveAuthenticationContextFromCacheRecordsApplication() {
+
+        try (MockedStatic<AuthenticationContextCache> authenticationContextCache =
+                mockStatic(AuthenticationContextCache.class);
+             MockedStatic<LoggerUtils> loggerUtils = mockStatic(LoggerUtils.class)) {
+            authenticationContextCache.when(
+                    AuthenticationContextCache::getInstance).thenReturn(mockedAuthenticationContextCache);
+            loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+
+            AuthenticationContext authenticationContext = new AuthenticationContext();
+            authenticationContext.setServiceProviderName("My Application");
+            authenticationContext.setRelyingParty("my-client-id");
+
+            FrameworkUtils.removeAuthenticationContextFromCache("CONTEXT-ID",
+                    FrameworkConstants.LogConstants.AuthContextInvalidationReasons.AUTH_FLOW_CONCLUDED,
+                    authenticationContext);
+
+            ArgumentCaptor<DiagnosticLog.DiagnosticLogBuilder> captorLog =
+                    ArgumentCaptor.forClass(DiagnosticLog.DiagnosticLogBuilder.class);
+            loggerUtils.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(captorLog.capture()));
+            DiagnosticLog diagnosticLog = captorLog.getValue().build();
+            assertEquals(diagnosticLog.getInput().get(LogConstants.InputKeys.CLIENT_ID), "my-client-id",
+                    "The client id is required for the logging framework to identify Console traffic.");
+            assertEquals(diagnosticLog.getInput().get(LogConstants.InputKeys.APPLICATION_NAME), "My Application");
         }
     }
 


### PR DESCRIPTION
## Purpose

When an app native login request is sent with an invalid flowId the logs did not provide a trace of what happened to that flowId, which made it hard to explain the cause of the error to application developers.

The flowId exposed to the client is the authentication context identifier, so the complete lifecycle of a flowId is now recorded:

- issue-flow-id: the flowId returned with an incomplete authentication response.
- validate-flow-id: the flowId received with a subsequent authentication request, and a FAILED entry when the provided flowId is no longer active.
- invalidate-authentication-context: the point at which the flowId is invalidated, along with the reason for the invalidation.

The context identifier is also added to the existing warn log printed when the authentication context cannot be found for a request.
