### PR TITLE
Add config to remove user store domain from the legacy role claim

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandler.java
@@ -81,6 +81,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ADD_USER_STORE_DOMAIN_TO_GROUPS_CLAIM;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ALLOW_USERSTORE_DOMAIN_REMOVAL_FROM_LEGACY_ROLE_CLAIM;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AdaptiveAuthentication.ALLOW_AUTHENTICATED_SUB_UPDATE;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Config.SEND_ONLY_LOCALLY_MAPPED_ROLES_OF_IDP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.JSAttributes.PROP_USERNAME_UPDATED_EXTERNALLY;
@@ -1409,16 +1410,31 @@ public class DefaultClaimHandler implements ClaimHandler {
      */
     private void handleRoleClaim(AuthenticationContext context, Map<String, String> mappedAttrs) {
 
-        if (mappedAttrs.containsKey(getLocalGroupsClaimURI())) {
-            String[] groups = mappedAttrs.get(getLocalGroupsClaimURI()).split(Pattern
-                    .quote(FrameworkUtils.getMultiAttributeSeparator()));
-            SequenceConfig sequenceConfig = context.getSequenceConfig();
-            // Execute only if it has allowed removing userstore domain from the sp level configurations.
-            if (isRemoveUserDomainInRole(sequenceConfig)) {
-                mappedAttrs.put(getLocalGroupsClaimURI(), FrameworkUtils
-                        .removeDomainFromNamesExcludeHybrid(Arrays.asList(groups)));
-            }
+        SequenceConfig sequenceConfig = context.getSequenceConfig();
+        removeUserStoreDomainFromClaim(sequenceConfig, mappedAttrs, getLocalGroupsClaimURI());
+        if (Boolean.parseBoolean(IdentityUtil.getProperty(ALLOW_USERSTORE_DOMAIN_REMOVAL_FROM_LEGACY_ROLE_CLAIM))
+                && IdentityUtil.isGroupsVsRolesSeparationImprovementsEnabled()
+                && IdentityUtil.isShowLegacyRoleClaimOnGroupRoleSeparationEnabled()) {
+            removeUserStoreDomainFromClaim(sequenceConfig, mappedAttrs, UserCoreConstants.ROLE_CLAIM);
         }
+    }
+
+    /**
+     * Remove the user store domain from the values of the given claim, keeping the hybrid domains intact.
+     *
+     * @param sequenceConfig Sequence configuration.
+     * @param mappedAttrs    Mapped claim attributes.
+     * @param claimURI       Claim URI of which the values should be domain free.
+     */
+    private void removeUserStoreDomainFromClaim(SequenceConfig sequenceConfig, Map<String, String> mappedAttrs,
+                                                String claimURI) {
+
+        String claimValue = mappedAttrs.get(claimURI);
+        if (StringUtils.isBlank(claimValue) || !isRemoveUserDomainInRole(sequenceConfig)) {
+            return;
+        }
+        String[] names = claimValue.split(Pattern.quote(FrameworkUtils.getMultiAttributeSeparator()));
+        mappedAttrs.put(claimURI, FrameworkUtils.removeDomainFromNamesExcludeHybrid(Arrays.asList(names)));
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkConstants.java
@@ -90,6 +90,8 @@ public abstract class FrameworkConstants {
     public static final String IS_AUTH_FLOW_CONCLUDED = "isAuthFlowConcluded";
     public static final String IS_API_BASED_AUTH_FLOW = "isAPIBasedAuthFlow";
     public static final String ADD_USER_STORE_DOMAIN_TO_GROUPS_CLAIM = "AddUserStoreDomainToGroupClaims";
+    public static final String ALLOW_USERSTORE_DOMAIN_REMOVAL_FROM_LEGACY_ROLE_CLAIM =
+            "AllowUserstoreDomainRemovalFromLegacyRoleClaim";
     public static final String IS_OTP_VERIFICATION_TRIGGERED = "isOtpVerificationTriggered";
     public static final String OTP_VERIFICATION_PENDING_CLAIM = "otpVerificationPendingClaim";
     public static final String CLAIM_FOR_PENDING_OTP_VERIFICATION = "claimForPendingOtpVerification";

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandlerTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/handler/claims/impl/DefaultClaimHandlerTest.java
@@ -39,15 +39,18 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.IdPGroup;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.tenant.TenantManager;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -320,6 +323,115 @@ public class DefaultClaimHandlerTest {
 
             // Claims are fetched using the shared user's ID in the org's tenant domain.
             Assert.assertEquals(result.get(TEST_SP_CLAIM_URI), TEST_CLAIM_VALUE);
+        }
+    }
+
+    @Test
+    public void testHandleRoleClaimRemovesDomainFromLegacyRoleClaimOnGroupRoleSeparation() throws Exception {
+
+        Map<String, String> mappedAttrs = new HashMap<>();
+        mappedAttrs.put(UserCoreConstants.ROLE_CLAIM, "Internal/everyone,SECONDARY/therole");
+        mappedAttrs.put(UserCoreConstants.INTERNAL_ROLES_CLAIM, "Internal/everyone");
+        mappedAttrs.put(UserCoreConstants.USER_STORE_GROUPS_CLAIM, "therole");
+        mappedAttrs.put(FrameworkConstants.USERNAME_CLAIM, "theuser");
+
+        invokeHandleRoleClaim(mappedAttrs, false, true, true, true);
+
+        Assert.assertEquals(mappedAttrs.get(UserCoreConstants.ROLE_CLAIM), "Internal/everyone,therole",
+                "User store domain should be removed from the legacy role claim while the hybrid domain is kept.");
+        Assert.assertEquals(mappedAttrs.get(UserCoreConstants.INTERNAL_ROLES_CLAIM), "Internal/everyone",
+                "Hybrid domains should never be removed from the internal roles claim.");
+        Assert.assertEquals(mappedAttrs.get(UserCoreConstants.USER_STORE_GROUPS_CLAIM), "therole",
+                "The groups claim should not be touched.");
+        Assert.assertEquals(mappedAttrs.get(FrameworkConstants.USERNAME_CLAIM), "theuser",
+                "Non role claims should be left untouched.");
+    }
+
+    @Test
+    public void testHandleRoleClaimRemovesDomainFromLegacyRoleClaimWithoutGroupRoleSeparation() throws Exception {
+
+        Map<String, String> mappedAttrs = new HashMap<>();
+        mappedAttrs.put(UserCoreConstants.ROLE_CLAIM, "Internal/everyone,SECONDARY/therole");
+
+        invokeHandleRoleClaim(mappedAttrs, false, false, false, false);
+
+        Assert.assertEquals(mappedAttrs.get(UserCoreConstants.ROLE_CLAIM), "Internal/everyone,therole");
+    }
+
+    /**
+     * The domain has to be preserved when the application keeps 'Use user store domain in roles' enabled.
+     */
+    @Test
+    public void testHandleRoleClaimKeepsDomainWhenUseUserstoreDomainInRolesEnabled() throws Exception {
+
+        Map<String, String> mappedAttrs = new HashMap<>();
+        mappedAttrs.put(UserCoreConstants.ROLE_CLAIM, "Internal/everyone,SECONDARY/therole");
+
+        invokeHandleRoleClaim(mappedAttrs, true, true, true, true);
+
+        Assert.assertEquals(mappedAttrs.get(UserCoreConstants.ROLE_CLAIM), "Internal/everyone,SECONDARY/therole");
+    }
+
+    /**
+     * The legacy role claim should be left as it is when it is not shown on group vs role separation.
+     */
+    @Test
+    public void testHandleRoleClaimSkipsLegacyRoleClaimWhenNotShown() throws Exception {
+
+        Map<String, String> mappedAttrs = new HashMap<>();
+        mappedAttrs.put(UserCoreConstants.ROLE_CLAIM, "Internal/everyone,SECONDARY/therole");
+
+        invokeHandleRoleClaim(mappedAttrs, false, true, false, true);
+
+        Assert.assertEquals(mappedAttrs.get(UserCoreConstants.ROLE_CLAIM), "Internal/everyone,SECONDARY/therole");
+    }
+
+    @Test
+    public void testHandleRoleClaimKeepsDomainWhenDomainRemovalNotAllowed() throws Exception {
+
+        Map<String, String> mappedAttrs = new HashMap<>();
+        mappedAttrs.put(UserCoreConstants.ROLE_CLAIM, "Internal/everyone,SECONDARY/therole");
+
+        invokeHandleRoleClaim(mappedAttrs, false, true, true, false);
+
+        Assert.assertEquals(mappedAttrs.get(UserCoreConstants.ROLE_CLAIM), "Internal/everyone,SECONDARY/therole");
+    }
+
+    private void invokeHandleRoleClaim(Map<String, String> mappedAttrs, boolean useUserstoreDomainInRoles,
+                                       boolean groupRoleSeparationEnabled, boolean showLegacyRoleClaim,
+                                       boolean allowDomainRemovalFromLegacyRoleClaim) throws Exception {
+
+        LocalAndOutboundAuthenticationConfig localAndOutboundConfig = new LocalAndOutboundAuthenticationConfig();
+        localAndOutboundConfig.setUseUserstoreDomainInRoles(useUserstoreDomainInRoles);
+        ServiceProvider serviceProvider = new ServiceProvider();
+        serviceProvider.setLocalAndOutBoundAuthenticationConfig(localAndOutboundConfig);
+
+        when(authenticationContext.getSequenceConfig()).thenReturn(sequenceConfig);
+        when(sequenceConfig.getApplicationConfig()).thenReturn(applicationConfig);
+        when(applicationConfig.getServiceProvider()).thenReturn(serviceProvider);
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class)) {
+
+            identityUtil.when(IdentityUtil::isGroupsVsRolesSeparationImprovementsEnabled)
+                    .thenReturn(groupRoleSeparationEnabled);
+            identityUtil.when(IdentityUtil::getLocalGroupsClaimURI).thenReturn(groupRoleSeparationEnabled
+                    ? UserCoreConstants.INTERNAL_ROLES_CLAIM : UserCoreConstants.ROLE_CLAIM);
+            identityUtil.when(IdentityUtil::isShowLegacyRoleClaimOnGroupRoleSeparationEnabled)
+                    .thenReturn(showLegacyRoleClaim);
+            identityUtil.when(() -> IdentityUtil.getProperty(
+                            FrameworkConstants.ALLOW_USERSTORE_DOMAIN_REMOVAL_FROM_LEGACY_ROLE_CLAIM))
+                    .thenReturn(String.valueOf(allowDomainRemovalFromLegacyRoleClaim));
+            identityUtil.when(() -> IdentityUtil.extractDomainFromName(anyString())).thenCallRealMethod();
+            // The separator is resolved from the server configuration, hence it is the only stubbed behaviour.
+            frameworkUtils.when(FrameworkUtils::getMultiAttributeSeparator).thenReturn(",");
+            frameworkUtils.when(() -> FrameworkUtils.removeDomainFromNamesExcludeHybrid(any()))
+                    .thenCallRealMethod();
+
+            Method handleRoleClaim = DefaultClaimHandler.class
+                    .getDeclaredMethod("handleRoleClaim", AuthenticationContext.class, Map.class);
+            handleRoleClaim.setAccessible(true);
+            handleRoleClaim.invoke(new DefaultClaimHandler(), authenticationContext, mappedAttrs);
         }
     }
 }

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2
@@ -5149,6 +5149,13 @@
     <AllowLegacyRoleClaimBehaviour>{{legacy_claims.allow_legacy_role_claim_behaviour}}</AllowLegacyRoleClaimBehaviour>
     {% endif %}
 
+    {% if legacy_claims.allow_userstore_domain_removal_from_legacy_role_claim is defined %}
+    <!-- When enabled, protocols such as SAML and Passive STS apply the application-level Use user store domain
+         in roles configuration to the legacy role claim. OIDC applications, as well as deployments with
+         group-role separation disabled, already apply this configuration regardless of this setting. -->
+    <AllowUserstoreDomainRemovalFromLegacyRoleClaim>{{legacy_claims.allow_userstore_domain_removal_from_legacy_role_claim}}</AllowUserstoreDomainRemovalFromLegacyRoleClaim>
+    {% endif %}
+
      {% if scim2.enable_legacy_enterprise_user is defined %}
      <!-- Config to allow legacy SCIM enterprise user behavior -->
      <EnableSCIMLegacyEnterpriseUser>{{scim2.enable_legacy_enterprise_user}}</EnableSCIMLegacyEnterpriseUser>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -593,6 +593,8 @@
   "identity_mgt.user_claim_update.enable_multiple_emails_and_mobile_numbers": true,
   "identity_mgt.user_claim_update.restrict_immutable_local_claim_update": true,
 
+  "legacy_claims.allow_userstore_domain_removal_from_legacy_role_claim": true,
+
   "identity_mgt.claims.hidden_claims": [
     "http://wso2.org/claims/identity/askPassword",
     "http://wso2.org/claims/identity/tenantAdminAskPassword",

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -279,6 +279,7 @@
   },
   "preserve_previous_product_behaviour.version": {
     "IS_7.0.0": {
+      "legacy_claims.allow_userstore_domain_removal_from_legacy_role_claim": false,
       "oauth.dcrm.return_null_fields_in_response": true,
       "oauth.oidc.user_info.return_only_app_associated_roles": false,
       "oauth.oidc.user_info.remove_internal_prefix_from_roles": false,
@@ -351,6 +352,7 @@
       "token_exchange.limit_scopes_to_subject_token": false
     },
     "IS_7.1.0": {
+      "legacy_claims.allow_userstore_domain_removal_from_legacy_role_claim": false,
       "oauth.dcrm.return_null_fields_in_response": true,
       "oauth.return_sp_id_to_apps": true,
       "oauth.jwt.return_only_app_associated_roles": false,
@@ -428,6 +430,7 @@
       "token_exchange.limit_scopes_to_subject_token": false
     },
     "IS_7.2.0": {
+      "legacy_claims.allow_userstore_domain_removal_from_legacy_role_claim": false,
       "authenticationendpoint.authenticator_validation.enabled": false,
       "application_mgt.enable_cross_tenant_authorized_api_validation": false,
       "oauth.callback.restrict_fragment_components": false,
@@ -462,6 +465,7 @@
       "token_exchange.limit_scopes_to_subject_token": false
     },
     "IS_7.3.0": {
+      "legacy_claims.allow_userstore_domain_removal_from_legacy_role_claim": false,
       "oauth.dcrm.decode_redirect_uris_in_response": false,
       "consent_mgt.enable_v2_api": false,
       "identity_mgt.events.schemes.ConsentEventHook.properties.enable": false,


### PR DESCRIPTION
### Summary

`DefaultClaimHandler.handleRoleClaim` removed the user store domain only from the claim URI returned by `IdentityUtil.getLocalGroupsClaimURI()`. With group vs role separation enabled that resolves to the internal roles claim, whose values only carry hybrid domains, so the application level `Use user store domain in roles` setting had no effect on the legacy role claim.

Added the `AllowUserstoreDomainRemovalFromLegacyRoleClaim` server configuration. When enabled, the application level setting is applied to the legacy role claim as well.

The configuration is enabled by default, and `infer.json` keeps it disabled for deployments that preserve the behaviour of IS 7.0.0, 7.1.0, 7.2.0 and 7.3.0.

Added unit tests covering the separation enabled and disabled paths, and the configuration enabled and disabled paths.

### Related issue

https://github.com/wso2/product-is/issues/28218