### PR TITLE
Add template ID support in IDP management API

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -458,6 +458,7 @@ public class IdPManagementDAO {
         Map<Integer, String> filterAttributeValue = filterQueryBuilder.getFilterAttributeValue();
         int filterAttributeValueSize = filterAttributeValue.entrySet().size();
         String databaseProductName = dbConnection.getMetaData().getDatabaseProductName();
+        resolveMetadataValueColumn(filterQueryBuilder, databaseProductName);
         if (databaseProductName.contains("Microsoft") || databaseProductName.contains("H2")) {
             sqlQuery = IdPManagementConstants.SQLQueries.GET_TRUSTED_TOKEN_ISSUER_TENANT_MSSQL;
             sqlQuery = appendRequiredAttributes(sqlQuery, requiredAttributes);
@@ -508,6 +509,7 @@ public class IdPManagementDAO {
         Map<Integer, String> filterAttributeValue = filterQueryBuilder.getFilterAttributeValue();
         int filterAttributeValueSize = filterAttributeValue.entrySet().size();
         String databaseProductName = dbConnection.getMetaData().getDatabaseProductName();
+        resolveMetadataValueColumn(filterQueryBuilder, databaseProductName);
         if (databaseProductName.contains("MySQL")
                 || databaseProductName.contains("MariaDB")
                 || databaseProductName.contains("H2")) {
@@ -664,6 +666,9 @@ public class IdPManagementDAO {
                     case IdPManagementConstants.IDP_GROUPS:
                         // Skip since the IDP groups are resolved and added to the IDP object separately.
                         break;
+                    case IdPManagementConstants.IDP_TEMPLATE_ID:
+                        // Skip since the template id is resolved from the IDP metadata properties separately.
+                        break;
                     default:
                         throw IdPManagementUtil.handleClientException(
                                 IdPManagementConstants.ErrorMessage.ERROR_CODE_IDP_ATTRIBUTE_INVALID, attribute);
@@ -717,6 +722,14 @@ public class IdPManagementDAO {
             List<IdentityProviderProperty> propertyList = getIdentityPropertiesByIdpId(dbConnection,
                     Integer.parseInt(resultSet.getString("ID")), tenantId);
             identityProvider.setIdpProperties(propertyList.toArray(new IdentityProviderProperty[0]));
+            if (requiredAttributes != null
+                    && requiredAttributes.contains(IdPManagementConstants.IDP_TEMPLATE_ID)) {
+                String templateId = getTemplateId(propertyList);
+                // Left unset for IdPs created without a template, matching the single IdP retrieval.
+                if (StringUtils.isNotEmpty(templateId)) {
+                    identityProvider.setTemplateId(templateId);
+                }
+            }
         }
         return identityProviderList;
     }
@@ -864,11 +877,12 @@ public class IdPManagementDAO {
         int countOfFilteredIdp = 0;
         FilterQueryBuilder filterQueryBuilder = new FilterQueryBuilder();
         appendFilterQuery(expressionNode, filterQueryBuilder);
-        String filterClause = filterQueryBuilder.getFilterQuery();
         Map<Integer, String> filterValues = filterQueryBuilder.getFilterAttributeValue();
 
         try (Connection dbConnection = IdentityDatabaseUtil.getDBConnection(false)) {
             String dbName = dbConnection.getMetaData().getDatabaseProductName();
+            resolveMetadataValueColumn(filterQueryBuilder, dbName);
+            String filterClause = filterQueryBuilder.getFilterQuery();
 
             String sqlTail;
             if (dbName.contains("MySQL") || dbName.contains("MariaDB") || dbName.contains("H2")) {
@@ -928,17 +942,19 @@ public class IdPManagementDAO {
         String filter = IdPManagementConstants.SQLQueries.TRUSTED_TOKEN_ISSUER_FILTER_SQL;
         filterQueryBuilder.setFilterQuery(filterQueryBuilder.getFilterQuery() + filter);
         Map<Integer, String> filterAttributeValue = filterQueryBuilder.getFilterAttributeValue();
-        sqlStmt = sqlStmt + filterQueryBuilder.getFilterQuery() +
-                IdPManagementConstants.SQLQueries.GET_TRUSTED_TOKEN_ISSUER_COUNT_SQL_TAIL;
-        try (Connection dbConnection = IdentityDatabaseUtil.getDBConnection(false);
-             PreparedStatement prepStmt = dbConnection.prepareStatement(sqlStmt)) {
-            for (Map.Entry<Integer, String> prepareStatement : filterAttributeValue.entrySet()) {
-                prepStmt.setString(prepareStatement.getKey(), prepareStatement.getValue());
-            }
-            prepStmt.setInt(filterAttributeValue.entrySet().size() + 1, tenantId);
-            try (ResultSet rs = prepStmt.executeQuery()) {
-                if (rs.next()) {
-                    countOfFilteredIdp = Integer.parseInt(rs.getString(1));
+        try (Connection dbConnection = IdentityDatabaseUtil.getDBConnection(false)) {
+            resolveMetadataValueColumn(filterQueryBuilder, dbConnection.getMetaData().getDatabaseProductName());
+            sqlStmt = sqlStmt + filterQueryBuilder.getFilterQuery() +
+                    IdPManagementConstants.SQLQueries.GET_TRUSTED_TOKEN_ISSUER_COUNT_SQL_TAIL;
+            try (PreparedStatement prepStmt = dbConnection.prepareStatement(sqlStmt)) {
+                for (Map.Entry<Integer, String> prepareStatement : filterAttributeValue.entrySet()) {
+                    prepStmt.setString(prepareStatement.getKey(), prepareStatement.getValue());
+                }
+                prepStmt.setInt(filterAttributeValue.entrySet().size() + 1, tenantId);
+                try (ResultSet rs = prepStmt.executeQuery()) {
+                    if (rs.next()) {
+                        countOfFilteredIdp = Integer.parseInt(rs.getString(1));
+                    }
                 }
             }
         } catch (SQLException e) {
@@ -982,6 +998,8 @@ public class IdPManagementDAO {
                 String operation = expressionNode.getOperation();
                 String value = expressionNode.getValue();
                 String attributeName = expressionNode.getAttributeValue();
+                // Set for attributes that are matched through a sub query and therefore have to be closed.
+                String attributeSuffix = IdPManagementConstants.EMPTY_STRING;
                 if (StringUtils.isNotBlank(attributeName) && StringUtils.isNotBlank(value) && StringUtils
                         .isNotBlank(operation)) {
                     switch (attributeName) {
@@ -1001,25 +1019,32 @@ public class IdPManagementDAO {
                         case IdPManagementConstants.IDP_UUID:
                             attributeName = IdPManagementConstants.UUID;
                             break;
+                        case IdPManagementConstants.IDP_TEMPLATE_ID:
+                            attributeName = isTrustedTokenIssuer
+                                    ? IdPManagementConstants.SQLQueries
+                                            .TEMPLATE_ID_FILTER_TRUSTED_TOKEN_ISSUER_SQL
+                                    : IdPManagementConstants.SQLQueries.TEMPLATE_ID_FILTER_SQL;
+                            attributeSuffix = IdPManagementConstants.CLOSING_PARENTHESIS;
+                            break;
                         default:
                             String message = "Invalid filter attribute name. Filter attribute : " + attributeName;
                             throw IdPManagementUtil.handleClientException(IdPManagementConstants.ErrorMessage
                                     .ERROR_CODE_RETRIEVE_IDP, message);
                     }
                     if (IdPManagementConstants.EQ.equals(operation)) {
-                        filter.append(attributeName).append(" = ? AND ");
+                        filter.append(attributeName).append(" = ?").append(attributeSuffix).append(" AND ");
                         filterQueryBuilder.setFilterAttributeValue(value);
                     } else if (IdPManagementConstants.SW.equals(operation)) {
                         value = IdentityUtil.processSingleCharWildcard(value);
-                        filter.append(attributeName).append(" like ? AND ");
+                        filter.append(attributeName).append(" like ?").append(attributeSuffix).append(" AND ");
                         filterQueryBuilder.setFilterAttributeValue(value + "%");
                     } else if (IdPManagementConstants.EW.equals(operation)) {
                         value = IdentityUtil.processSingleCharWildcard(value);
-                        filter.append(attributeName).append(" like ? AND ");
+                        filter.append(attributeName).append(" like ?").append(attributeSuffix).append(" AND ");
                         filterQueryBuilder.setFilterAttributeValue("%" + value);
                     } else if (IdPManagementConstants.CO.equals(operation)) {
                         value = IdentityUtil.processSingleCharWildcard(value);
-                        filter.append(attributeName).append(" like ? AND ");
+                        filter.append(attributeName).append(" like ?").append(attributeSuffix).append(" AND ");
                         filterQueryBuilder.setFilterAttributeValue("%" + value + "%");
                     } else {
                         String message = "Invalid filter value. filter: " + operation;
@@ -1034,6 +1059,44 @@ public class IdPManagementDAO {
                 filterQueryBuilder.setFilterQuery(filter.toString());
             }
         }
+    }
+
+    /**
+     * Resolve the placeholder of the IDP_METADATA 'VALUE' column in the built filter query to the quoting the given
+     * database expects. The filter query is built before a connection is acquired, hence the placeholder.
+     *
+     * @param filterQueryBuilder  SQL builder object holding the filter query.
+     * @param databaseProductName Database product name of the connection the query will run on.
+     */
+    private void resolveMetadataValueColumn(FilterQueryBuilder filterQueryBuilder, String databaseProductName) {
+
+        String filterQuery = filterQueryBuilder.getFilterQuery();
+        if (StringUtils.isBlank(filterQuery)
+                || !filterQuery.contains(IdPManagementConstants.IDP_METADATA_VALUE_COLUMN_PLACEHOLDER)) {
+            return;
+        }
+        filterQueryBuilder.setFilterQuery(filterQuery.replace(
+                IdPManagementConstants.IDP_METADATA_VALUE_COLUMN_PLACEHOLDER,
+                getMetadataValueColumn(databaseProductName)));
+    }
+
+    /**
+     * Get the IDP_METADATA 'VALUE' column reference quoted the way the given database expects it.
+     *
+     * @param databaseProductName Database product name.
+     * @return Quoted 'VALUE' column reference.
+     */
+    private String getMetadataValueColumn(String databaseProductName) {
+
+        if (databaseProductName.contains("MySQL")
+                || databaseProductName.contains("MariaDB")
+                || databaseProductName.contains("H2")) {
+            return IdPManagementConstants.METADATA_VALUE_COLUMN_BACKTICK_QUOTED;
+        }
+        if (databaseProductName.contains("Microsoft") || databaseProductName.contains("PostgreSQL")) {
+            return IdPManagementConstants.METADATA_VALUE_COLUMN;
+        }
+        return IdPManagementConstants.METADATA_VALUE_COLUMN_DOUBLE_QUOTED;
     }
 
     /**
@@ -1486,8 +1549,8 @@ public class IdPManagementDAO {
         }
 
         if (isReadIDP) {
-            /* 
-            If the operation is read IDP configs, read value of onlyNumericCharactersForOtp and 
+            /*
+            If the operation is read IDP configs, read value of onlyNumericCharactersForOtp and
             set the value of alphaNumericCharactersForOtp accordingly.
             */
             if (StringUtils.isNotBlank(onlyNumericCharactersForOtp.getValue())) {
@@ -6714,7 +6777,7 @@ public class IdPManagementDAO {
             maximumSessionTimeOut.setValue(configuredMaximumSessionTimeout);
             propertiesFromConnectors.put(MAXIMUM_SESSION_TIME_OUT, maximumSessionTimeOut);
         }
-      
+
         if (propertiesFromConnectors.get(PRESERVE_CURRENT_SESSION_AT_PASSWORD_UPDATE) == null) {
             String preserveLoggedInSessionAtPasswordUpdate = IdentityUtil.getProperty(
                     IdentityConstants.ServerConfig.PRESERVE_LOGGED_IN_SESSION_AT_PASSWORD_UPDATE);

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
@@ -31,6 +31,7 @@ public class IdPManagementConstants {
     public static final String SCOPE_LIST_PLACEHOLDER = "_SCOPE_LIST_";
     public static final String IDP_GROUP_LIST_PLACEHOLDER = "_IDP_GROUP_LIST_";
     public static final String IDP_METADATA_PROPERTY_LIST_PLACEHOLDER = "_IDP_METADATA_PROPERTY_LIST_";
+    public static final String IDP_METADATA_VALUE_COLUMN_PLACEHOLDER = "_IDP_METADATA_VALUE_COLUMN_";
     public static final String MULTI_VALUED_PROPERTY_CHARACTER = ".";
     public static final String IS_TRUE_VALUE = "1";
     public static final String IS_FALSE_VALUE = "0";
@@ -85,6 +86,13 @@ public class IdPManagementConstants {
     public static final String IDP_PROVISIONING = "provisioning";
     public static final String PROVISIONING =
             "INBOUND_PROV_ENABLED, INBOUND_PROV_USER_STORE_ID, DEFAULT_PRO_CONNECTOR_NAME";
+    public static final String IDP_TEMPLATE_ID = "templateId";
+
+    // 'VALUE' is a reserved word, hence the IDP_METADATA value column needs to be quoted differently per database.
+    public static final String METADATA_VALUE_COLUMN = "VALUE";
+    public static final String METADATA_VALUE_COLUMN_BACKTICK_QUOTED = "`VALUE`";
+    public static final String METADATA_VALUE_COLUMN_DOUBLE_QUOTED = "\"VALUE\"";
+    public static final String CLOSING_PARENTHESIS = ")";
 
     // Flag to indicate if an IdP is a system reserved IdP.
     public static final String IS_SYSTEM_RESERVED_IDP_FLAG = "isSystemReservedIdP";
@@ -439,6 +447,20 @@ public class IdPManagementConstants {
                 "VALUES (?, ?, ?,?,?, ?, ?, ?, ?, ?,?,?, ?,?,? ,?, ?, ?, ?, ?)";
 
         public static final String TRUSTED_TOKEN_ISSUER_FILTER_SQL = "IDP_METADATA.\"VALUE\" = 'true' AND ";
+
+        /*
+         * Template ids live in IDP_METADATA while the rest of the filterable attributes are IDP columns, hence the
+         * template id filter is applied as a sub query. The operator, the bind parameter and the closing parenthesis
+         * are appended by the caller. IDP_ID is a foreign key to the globally unique IDP.ID, so the sub query needs no
+         * tenant correlation, the outer query is already restricted to the tenant.
+         */
+        public static final String TEMPLATE_ID_FILTER_SQL = "ID IN (SELECT IDP_METADATA_FILTER.IDP_ID FROM "
+                + "IDP_METADATA IDP_METADATA_FILTER WHERE IDP_METADATA_FILTER.NAME = '"
+                + TEMPLATE_ID_IDP_PROPERTY_NAME + "' AND IDP_METADATA_FILTER."
+                + IDP_METADATA_VALUE_COLUMN_PLACEHOLDER;
+
+        // IDP_METADATA is already joined in the trusted token issuer query, so 'ID' has to be qualified there.
+        public static final String TEMPLATE_ID_FILTER_TRUSTED_TOKEN_ISSUER_SQL = "IDP." + TEMPLATE_ID_FILTER_SQL;
 
         public static final String ADD_IDP_AUTH_SQL = "INSERT INTO IDP_AUTHENTICATOR " +
                 "(IDP_ID, TENANT_ID, IS_ENABLED, NAME, DISPLAY_NAME, DEFINED_BY, AUTHENTICATION_TYPE) VALUES " +

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAOTest.java
@@ -571,6 +571,143 @@ public class IdPManagementDAOTest {
         }
     }
 
+    private static final String GOOGLE_TEMPLATE_ID = "google-idp";
+    private static final String OIDC_TEMPLATE_ID = "enterprise-oidc-idp";
+
+    /**
+     * Add three IdPs to SAMPLE_TENANT_ID, two carrying a template id and one without.
+     */
+    private void addTemplatedTestIdps() throws IdentityProviderManagementException {
+
+        IdentityProvider googleIdP = new IdentityProvider();
+        googleIdP.setIdentityProviderName("googleIdP");
+        googleIdP.setTemplateId(GOOGLE_TEMPLATE_ID);
+
+        IdentityProvider oidcIdP = new IdentityProvider();
+        oidcIdP.setIdentityProviderName("oidcIdP");
+        oidcIdP.setTemplateId(OIDC_TEMPLATE_ID);
+
+        IdentityProvider plainIdP = new IdentityProvider();
+        plainIdP.setIdentityProviderName("plainIdP");
+
+        idPManagementDAO.addIdP(googleIdP, SAMPLE_TENANT_ID);
+        idPManagementDAO.addIdP(oidcIdP, SAMPLE_TENANT_ID);
+        idPManagementDAO.addIdP(plainIdP, SAMPLE_TENANT_ID);
+    }
+
+    private static List<ExpressionNode> templateIdFilter(String operation, String value) {
+
+        ExpressionNode expressionNode = new ExpressionNode();
+        expressionNode.setAttributeValue("templateId");
+        expressionNode.setOperation(operation);
+        expressionNode.setValue(value);
+        List<ExpressionNode> expressionNodes = new ArrayList<>();
+        expressionNodes.add(expressionNode);
+        return expressionNodes;
+    }
+
+    @Test
+    public void testGetIdPsSearchWithTemplateIdAttribute() throws Exception {
+
+        try (MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class);
+             Connection connection = getConnection(DB_NAME)) {
+            identityDatabaseUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(connection);
+            identityDatabaseUtil.when(IdentityDatabaseUtil::getDBConnection).thenReturn(connection);
+            identityDatabaseUtil.when(IdentityDatabaseUtil::getDataSource).thenReturn(dataSourceMap.get(DB_NAME));
+            addTemplatedTestIdps();
+
+            List<IdentityProvider> idps = idPManagementDAO.getIdPsSearch(SAMPLE_TENANT_ID, new ArrayList<>(), 10, 0,
+                    "ASC", "NAME", Arrays.asList("templateId"));
+
+            Map<String, String> templateIds = new HashMap<>();
+            for (IdentityProvider idp : idps) {
+                templateIds.put(idp.getIdentityProviderName(), idp.getTemplateId());
+            }
+            assertEquals(templateIds.get("googleIdP"), GOOGLE_TEMPLATE_ID);
+            assertEquals(templateIds.get("oidcIdP"), OIDC_TEMPLATE_ID);
+            // An IdP created without a template id has no templateId property to resolve.
+            assertNull(templateIds.get("plainIdP"));
+        }
+    }
+
+    @Test
+    public void testGetIdPsSearchWithoutTemplateIdAttribute() throws Exception {
+
+        try (MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class);
+             Connection connection = getConnection(DB_NAME)) {
+            identityDatabaseUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(connection);
+            identityDatabaseUtil.when(IdentityDatabaseUtil::getDBConnection).thenReturn(connection);
+            identityDatabaseUtil.when(IdentityDatabaseUtil::getDataSource).thenReturn(dataSourceMap.get(DB_NAME));
+            addTemplatedTestIdps();
+
+            List<IdentityProvider> idps = idPManagementDAO.getIdPsSearch(SAMPLE_TENANT_ID, new ArrayList<>(), 10, 0,
+                    "ASC", "NAME", Arrays.asList("isPrimary"));
+
+            for (IdentityProvider idp : idps) {
+                assertNull(idp.getTemplateId(), "Template id must not be resolved unless it is requested.");
+            }
+        }
+    }
+
+    @DataProvider
+    public Object[][] getIdPsSearchFilteredByTemplateIdData() {
+
+        return new Object[][]{
+                {templateIdFilter("eq", GOOGLE_TEMPLATE_ID), 1, "googleIdP"},
+                {templateIdFilter("eq", OIDC_TEMPLATE_ID), 1, "oidcIdP"},
+                {templateIdFilter("eq", "no-such-template"), 0, null},
+                {templateIdFilter("co", "idp"), 2, "googleIdP"},
+                {templateIdFilter("sw", "google"), 1, "googleIdP"},
+                {templateIdFilter("ew", "oidc-idp"), 1, "oidcIdP"},
+        };
+    }
+
+    @Test(dataProvider = "getIdPsSearchFilteredByTemplateIdData")
+    public void testGetIdPsSearchFilteredByTemplateId(List<ExpressionNode> expressionNodes, int count,
+                                                      String firstIdp) throws Exception {
+
+        try (MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class);
+             Connection connection = getConnection(DB_NAME)) {
+            identityDatabaseUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(connection);
+            identityDatabaseUtil.when(IdentityDatabaseUtil::getDBConnection).thenReturn(connection);
+            identityDatabaseUtil.when(IdentityDatabaseUtil::getDataSource).thenReturn(dataSourceMap.get(DB_NAME));
+            addTemplatedTestIdps();
+
+            List<IdentityProvider> idps = idPManagementDAO.getIdPsSearch(SAMPLE_TENANT_ID, expressionNodes, 10, 0,
+                    "ASC", "NAME", Arrays.asList("templateId"));
+
+            assertEquals(idps.size(), count);
+            if (count > 0) {
+                assertEquals(idps.get(0).getIdentityProviderName(), firstIdp);
+            }
+        }
+    }
+
+    @DataProvider
+    public Object[][] getCountOfIdPsFilteredByTemplateIdData() {
+
+        return new Object[][]{
+                {templateIdFilter("eq", GOOGLE_TEMPLATE_ID), 1},
+                {templateIdFilter("eq", "no-such-template"), 0},
+                {templateIdFilter("co", "idp"), 2},
+        };
+    }
+
+    @Test(dataProvider = "getCountOfIdPsFilteredByTemplateIdData")
+    public void testGetCountOfIdPsFilteredByTemplateId(List<ExpressionNode> expressionNodes, int count)
+            throws Exception {
+
+        try (MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class);
+             Connection connection = getConnection(DB_NAME)) {
+            identityDatabaseUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(connection);
+            identityDatabaseUtil.when(IdentityDatabaseUtil::getDBConnection).thenReturn(connection);
+            identityDatabaseUtil.when(IdentityDatabaseUtil::getDataSource).thenReturn(dataSourceMap.get(DB_NAME));
+            addTemplatedTestIdps();
+
+            assertEquals(idPManagementDAO.getCountOfFilteredIdPs(SAMPLE_TENANT_ID, expressionNodes), count);
+        }
+    }
+
     @DataProvider
     public Object[][] getCountOfFilteredIdPsData() {
 


### PR DESCRIPTION
## Purpose

This pull request adds support for filtering and retrieving Identity Providers (IdPs) by their `templateId` attribute, with proper handling for different database dialects due to the reserved nature of the `VALUE` column. The changes ensure that template IDs can be used in search and filter queries, and that the quoting of SQL column names is handled correctly across supported databases. Comprehensive tests are also added to validate the new functionality.

## Approach

**IdP Template ID Filtering and Retrieval:**

* Added support for filtering IdPs by `templateId` in search queries and counting methods, including proper handling for different SQL dialects by introducing a placeholder and runtime resolution for the `VALUE` column quoting. (`IdPManagementDAO.java`, `IdPManagementConstants.java`)

* Updated the filter query builder to support subqueries for template ID filtering, with correct SQL syntax and attribute suffix handling. (`IdPManagementDAO.java`)

* Modified the population logic for IdP objects to set the `templateId` property only when requested in the attributes list. (`IdPManagementDAO.java`)

**Backward Compatibility and Error Handling:**

* Updated attribute handling to skip `templateId` when not requested, preventing errors for IdPs created without a template. (`IdPManagementDAO.java`)

**Testing:**

* Added comprehensive unit tests to verify filtering, retrieval, and counting of IdPs by `templateId`, including cases with and without the attribute and across different filter operations. (`IdPManagementDAOTest.java`)