### PR TITLE
Fix back-channel logout JWKS URI cross-contamination for sub-organizations

### DIFF
--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/pom.xml
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/pom.xml
@@ -134,6 +134,10 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.action.management</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -195,7 +199,8 @@
                             org.json;version="${json.wso2.version.range}",
                             org.wso2.carbon.database.utils.*;version="${org.wso2.carbon.database.utils.version.range}",
                             org.wso2.carbon.identity.action.management.api.*; version="${carbon.identity.package.import.version.range}",
-                            org.wso2.carbon.tenant.mgt.util.*;version="${carbon.multitenancy.imp.pkg.version.range}"
+                            org.wso2.carbon.tenant.mgt.util.*;version="${carbon.multitenancy.imp.pkg.version.range}",
+                            com.google.gson;version="${com.google.code.gson.osgi.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.idp.mgt.internal,

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -3197,15 +3197,26 @@ public class IdentityProviderManager implements IdpManager {
 
         IdentityProvider identityProvider = dao.getIdPByName(null, ORGANIZATION_LOGIN_IDP_NAME, tenantId, tenantDomain);
         if (identityProvider != null && StringUtils.isNotBlank(identityProvider.getId())) {
-            identityProvider.setIdpProperties(
-                    addJWKSUriProperty(identityProvider.getIdpProperties(), jwtIssuer));
+            /* The IdentityProvider instance returned above may be the same instance held by IdPCacheByName
+            (the DAO cache does not store by value). The per-request JWKS URI derived from the current
+            request's issuer must therefore be set only on a copy, never on the cached instance, otherwise
+            it permanently pins the cached SSO IdP's JWKS URI to whichever organization resolved it first,
+            causing every other organization's back-channel logout token to be validated against the wrong
+            organization's JWKS endpoint. */
+            IdentityProvider identityProviderCopy = IdPManagementUtil.cloneIdentityProvider(identityProvider);
+            identityProviderCopy.setIdpProperties(
+                    addJWKSUriProperty(identityProviderCopy.getIdpProperties(), jwtIssuer));
+            identityProvider = identityProviderCopy;
         }
         return identityProvider;
     }
 
     /**
      * Add JWKS URI property to the identity provider properties for SSO identity provider.
-     * The URI is constructed by replacing the token endpoint with JWKS endpoint.
+     * The URI is constructed by replacing the token endpoint with JWKS endpoint. Any existing jwksUri
+     * property is replaced rather than appended, since JWTSignatureValidationUtils#getJWKSUri returns the
+     * first jwksUri property it finds - an appended, stale value would otherwise be able to shadow the
+     * correct, freshly-resolved one.
      *
      * @param idpProperties Identity provider properties.
      * @param jwtIssuer     JWT issuer.
@@ -3215,7 +3226,11 @@ public class IdentityProviderManager implements IdpManager {
 
         List<IdentityProviderProperty> identityProviderProperties = new ArrayList<>();
         if (ArrayUtils.isNotEmpty(idpProperties)) {
-            identityProviderProperties = new ArrayList<>(Arrays.asList(idpProperties));
+            for (IdentityProviderProperty idpProperty : idpProperties) {
+                if (!StringUtils.equals(idpProperty.getName(), JWKS_URI)) {
+                    identityProviderProperties.add(idpProperty);
+                }
+            }
         }
         String jwksUri = jwtIssuer.replace(OAUTH2_TOKEN_EP_URL, OAUTH2_JWKS_EP_URL);
         IdentityProviderProperty jwksEndpoint = new IdentityProviderProperty();

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementUtil.java
@@ -18,18 +18,22 @@
 
 package org.wso2.carbon.idp.mgt.util;
 
+import com.google.gson.Gson;
 import java.util.Optional;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.IdentityProviderProperty;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.ProvisioningConnectorConfig;
+import org.wso2.carbon.identity.application.common.model.UserDefinedFederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.processors.RandomPasswordProcessor;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
+import org.wso2.carbon.identity.base.AuthenticatorPropertyConstants.DefinedByType;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -257,6 +261,29 @@ public class IdPManagementUtil {
             properties = RandomPasswordProcessor.getInstance().removeRandomPasswords(properties, withCacheClear);
             provisioningConnectorConfig.setProvisioningProperties(properties);
         }
+    }
+
+    /**
+     * Creates a deep clone of the given Identity Provider.
+     *
+     * @param identityProvider Identity Provider to be cloned.
+     * @return Cloned Identity Provider.
+     */
+    public static IdentityProvider cloneIdentityProvider(IdentityProvider identityProvider) {
+
+        Gson gson = new Gson();
+        IdentityProvider clonedIdentityProvider = gson.fromJson(gson.toJson(identityProvider),
+                IdentityProvider.class);
+        FederatedAuthenticatorConfig[] federatedAuthenticatorConfigs =
+                identityProvider.getFederatedAuthenticatorConfigs();
+        if (federatedAuthenticatorConfigs.length == 1 &&
+                federatedAuthenticatorConfigs[0].getDefinedByType() == DefinedByType.USER) {
+            UserDefinedFederatedAuthenticatorConfig clonedFederatedAuthenticatorConfig = gson.fromJson(
+                    gson.toJson(federatedAuthenticatorConfigs[0]), UserDefinedFederatedAuthenticatorConfig.class);
+            clonedIdentityProvider.setFederatedAuthenticatorConfigs(
+                    new FederatedAuthenticatorConfig[]{clonedFederatedAuthenticatorConfig});
+        }
+        return clonedIdentityProvider;
     }
 
     /**

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagerTest.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/test/java/org/wso2/carbon/idp/mgt/IdentityProviderManagerTest.java
@@ -153,6 +153,48 @@ public class IdentityProviderManagerTest {
         }
     }
 
+    @Test(description = "Tests that resolving the SSO IDP's JWKS URI for one sub-organization's back-channel " +
+            "logout request does not mutate the shared/cached SSO IDP instance, so a subsequent request from a " +
+            "different sub-organization resolves its own JWKS URI instead of the previous one.")
+    public void testGetSSOIDPDoesNotMutateSharedIdPInstance() throws IdentityProviderManagementException {
+
+        String jwtIssuerOrgA = "https://localhost/o/org-a-id/oauth2/token";
+        String jwtIssuerOrgB = "https://localhost/o/org-b-id/oauth2/token";
+
+        IdentityProvider ssoIdP = new IdentityProvider();
+        ssoIdP.setId("ssoIdP");
+        ssoIdP.setIdpProperties(new IdentityProviderProperty[0]);
+
+        when(dao.getIdPByName(null, jwtIssuerOrgA, 1, TENANT_DOMAIN)).thenReturn(null);
+        when(dao.getIdPByName(null, jwtIssuerOrgB, 1, TENANT_DOMAIN)).thenReturn(null);
+        // Simulate the DAO cache: the same cached IdentityProvider instance is handed out on every lookup.
+        when(dao.getIdPByName(null, ORGANIZATION_LOGIN_IDP_NAME, 1, TENANT_DOMAIN)).thenReturn(ssoIdP);
+
+        try (MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<IdentityUtil> mockedIdentityUtil = mockStatic(IdentityUtil.class)) {
+
+            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(1);
+            mockedIdentityUtil.when(IdentityUtil::getHostName).thenReturn("localhost");
+
+            // Organization B resolves and "claims" the JWKS URI first.
+            IdentityProvider resultOrgB = identityProviderManager.getIdPByName(jwtIssuerOrgB, TENANT_DOMAIN, true);
+            String jwksUriOrgB = jwtIssuerOrgB.replace(OAUTH2_TOKEN_EP_URL, OAUTH2_JWKS_EP_URL);
+            assertTrue(Arrays.stream(resultOrgB.getIdpProperties())
+                    .anyMatch(p -> JWKS_URI.equals(p.getName()) && p.getValue().equals(jwksUriOrgB)));
+
+            // The cached instance itself must remain untouched by resolving organization B's request.
+            assertEquals(0, ssoIdP.getIdpProperties().length);
+
+            // Organization A resolves next; it must get its own JWKS URI, not organization B's.
+            IdentityProvider resultOrgA = identityProviderManager.getIdPByName(jwtIssuerOrgA, TENANT_DOMAIN, true);
+            String jwksUriOrgA = jwtIssuerOrgA.replace(OAUTH2_TOKEN_EP_URL, OAUTH2_JWKS_EP_URL);
+            assertTrue(Arrays.stream(resultOrgA.getIdpProperties())
+                    .anyMatch(p -> JWKS_URI.equals(p.getName()) && p.getValue().equals(jwksUriOrgA)));
+            assertTrue(Arrays.stream(resultOrgA.getIdpProperties())
+                    .noneMatch(p -> JWKS_URI.equals(p.getName()) && p.getValue().equals(jwksUriOrgB)));
+        }
+    }
+
     @Test(description = "Test validation passes when provisioning role is blank.")
     public void testValidateOutboundProvisioningRolesWithBlankRole() throws Exception {
 


### PR DESCRIPTION
## Summary
In a B2B deployment where an app is shared into multiple sub-organizations (Organization SSO), OIDC back-channel logout (`/identity/oidc/slo`) fails for every sub-org except whichever one first populated the cached shared `SSO` IdP entry on that node:

```
com.nimbusds.jose.KeySourceException: No matching keys found in JWKS endpoint: https://<host>/o/<org-id>/oauth2/jwks
LogoutServerException: Error while validating the logout token signature   [OID-60009]
```

`IdentityProviderManager#getSSOIDP` resolved the shared `SSO` IdP via `CacheBackedIdPMgtDAO`, which returns the cached instance **by reference** (`IdPCacheByName` has `setStoreByValue(false)`), then mutated it by appending a `jwksUri` derived from the current request's issuer. `JWTSignatureValidationUtils#getJWKSUri` returns the **first** `jwksUri` and stops — so the first org to log out on a node pins the JWKS URI for every other org sharing that cache entry until the entry expires (900s sliding expiry).

- `getSSOIDP` now resolves the JWKS URI on a deep copy (`IdPManagementUtil#cloneIdentityProvider`) of the cached `IdentityProvider` instance instead of mutating the shared instance.
- `addJWKSUriProperty` now replaces any existing `jwksUri` property rather than appending, as defence in depth.
- Added `testGetSSOIDPDoesNotMutateSharedIdPInstance`, a regression test simulating two sub-orgs resolving the shared cache entry back-to-back — fails on the old code, passes with the fix.

Fixes https://github.com/wso2/product-is/issues/28210