### PR TITLE
Resolve tenant owner from the tenant store in Administrator role guards

### DIFF
--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/RoleManagementServiceImpl.java
@@ -1179,9 +1179,17 @@ public class RoleManagementServiceImpl implements RoleManagementService {
                     && RoleConstants.ORGANIZATION.equals(role.getAudience()))
                     || (RoleConstants.ADMINISTRATOR.equals(role.getName()) &&
                             RoleConstants.CONSOLE_APP_AUDIENCE_NAME.equals(role.getAudienceName()))) {
-                if ((isUseCaseSensitiveUsernameForCacheKeys && !StringUtils.equals(username, adminUserName)) || (
-                        !isUseCaseSensitiveUsernameForCacheKeys && !StringUtils
-                                .equalsIgnoreCase(username, adminUserName))) {
+                /*
+                adminUserName above comes from the node-local realm cache, which is not refreshed when the
+                tenant's admin user changes underneath a running node. Resolve the owner from the tenant
+                store before deciding, so that a stale entry cannot authorise the previous owner and reject
+                the current one. Only reached for the administrator role, so this is not a hot path.
+                 */
+                String tenantOwnerUserName = RoleManagementUtils.resolveTenantOwnerUsername(tenantDomain,
+                        adminUserName);
+                if ((isUseCaseSensitiveUsernameForCacheKeys && !StringUtils.equals(username, tenantOwnerUserName))
+                        || (!isUseCaseSensitiveUsernameForCacheKeys && !StringUtils
+                                .equalsIgnoreCase(username, tenantOwnerUserName))) {
                     Map<String, Object> threadLocalProps = IdentityUtil.threadLocalProperties.get();
                     boolean isJITProvisioningFlow = threadLocalProps != null &&
                             threadLocalProps.get(IS_JIT_PROVISIONING_FLOW) != null &&
@@ -1196,7 +1204,7 @@ public class RoleManagementServiceImpl implements RoleManagementService {
                 } else {
                     List<String> deletedUserNamesList = getUserNamesByIDs(deletedUserIDList, tenantDomain);
                     // Tenant owner cannot be removed from Administrator role.
-                    if (deletedUserNamesList.contains(adminUserName)) {
+                    if (deletedUserNamesList.contains(tenantOwnerUserName)) {
                         String errorMessage = "Invalid operation. Tenant owner cannot be removed from the role: %s";
                         throw new IdentityRoleManagementClientException(RoleConstants.Error.OPERATION_FORBIDDEN
                                 .getCode(),

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/dao/RoleDAOImpl.java
@@ -3364,9 +3364,17 @@ public class RoleDAOImpl implements RoleDAO {
                     .isUseCaseSensitiveUsernameForCacheKeys(userStoreManager);
             // Only the tenant owner can remove groups from Administrator role.
             if (RoleConstants.ADMINISTRATOR.equalsIgnoreCase(roleName)) {
-                if ((isUseCaseSensitiveUsernameForCacheKeys && !StringUtils.equals(username, adminUserName)) || (
-                        !isUseCaseSensitiveUsernameForCacheKeys && !StringUtils
-                                .equalsIgnoreCase(username, adminUserName))) {
+                /*
+                adminUserName above comes from the node-local realm cache, which is not refreshed when the
+                tenant's admin user changes underneath a running node. Resolve the owner from the tenant
+                store before deciding, so that a stale entry cannot authorise the previous owner and reject
+                the current one. Only reached for the administrator role, so this is not a hot path.
+                 */
+                String tenantOwnerUserName = RoleManagementUtils.resolveTenantOwnerUsername(tenantDomain,
+                        adminUserName);
+                if ((isUseCaseSensitiveUsernameForCacheKeys && !StringUtils.equals(username, tenantOwnerUserName))
+                        || (!isUseCaseSensitiveUsernameForCacheKeys && !StringUtils
+                                .equalsIgnoreCase(username, tenantOwnerUserName))) {
                     String errorMessage = "Invalid operation. Only the tenant owner can remove groups from the role: "
                             + "%s";
                     throw new IdentityRoleManagementClientException(OPERATION_FORBIDDEN.getCode(),

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/util/RoleManagementUtils.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/main/java/org/wso2/carbon/identity/role/v2/mgt/core/util/RoleManagementUtils.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.role.v2.mgt.core.util;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
@@ -36,9 +37,14 @@ import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagemen
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementServerException;
 import org.wso2.carbon.identity.role.v2.mgt.core.internal.RoleManagementServiceComponentHolder;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.Permission;
+import org.wso2.carbon.user.api.Tenant;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.tenant.TenantCache;
+import org.wso2.carbon.user.core.tenant.TenantIdKey;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.HashSet;
 import java.util.List;
@@ -267,5 +273,55 @@ public class RoleManagementUtils {
     public static void clearRoleBasicInfoCacheByTenant(String tenantDomain) {
 
         RoleBasicInfoCache.getInstance().clear(tenantDomain);
+    }
+
+    /**
+     * Resolve the username of the tenant owner, tolerating a stale tenant realm cache.
+     * <p>
+     * {@code RealmConfiguration#getAdminUserName()} is served from the node-local realm cache, which is
+     * populated once when the tenant realm is built and is only dropped when that realm is evicted or the
+     * node restarts. If the tenant's admin user changes underneath a running node — an ownership transfer
+     * that rewrites {@code UM_TENANT.UM_USER_CONFIG} directly, for instance — the cached value keeps naming
+     * the previous owner. An ownership check made against it then authorises the previous owner and rejects
+     * the current one, in both directions.
+     * <p>
+     * This re-reads the tenant's realm configuration from the tenant store, bypassing the tenant cache but
+     * leaving the realm itself untouched, so the cost is a single tenant row read rather than a realm
+     * rebuild. If the tenant store cannot answer, the cached value is returned unchanged so that callers
+     * behave exactly as they did before.
+     *
+     * @param tenantDomain          Tenant domain.
+     * @param cachedAdminUserName   Admin username as read from the (possibly stale) realm configuration.
+     * @return The tenant owner's username.
+     */
+    public static String resolveTenantOwnerUsername(String tenantDomain, String cachedAdminUserName) {
+
+        try {
+            RealmService realmService = RoleManagementServiceComponentHolder.getInstance().getRealmService();
+            int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
+            /*
+            The super tenant realm is built from the bootstrap realm configuration rather than from UM_TENANT,
+            so there is nothing fresher to read and the cached value is already authoritative.
+             */
+            if (MultitenantConstants.SUPER_TENANT_ID == tenantId) {
+                return cachedAdminUserName;
+            }
+            TenantCache.getInstance().clearCacheEntry(new TenantIdKey(tenantId));
+            Tenant tenant = realmService.getTenantManager().getTenant(tenantId);
+            if (tenant == null || tenant.getRealmConfig() == null
+                    || StringUtils.isBlank(tenant.getRealmConfig().getAdminUserName())) {
+                return cachedAdminUserName;
+            }
+            String tenantOwnerUserName = tenant.getRealmConfig().getAdminUserName();
+            if (log.isDebugEnabled() && !StringUtils.equals(cachedAdminUserName, tenantOwnerUserName)) {
+                log.debug("Cached admin username of tenant: " + tenantDomain
+                        + " is stale. Using the tenant owner resolved from the tenant store.");
+            }
+            return tenantOwnerUserName;
+        } catch (UserStoreException e) {
+            log.warn("Error while resolving the tenant owner of tenant: " + tenantDomain
+                    + ". Falling back to the cached admin username.", e);
+            return cachedAdminUserName;
+        }
     }
 }

--- a/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/util/RoleManagementUtilsTest.java
+++ b/components/role-mgt/org.wso2.carbon.identity.role.v2.mgt.core/src/test/java/org/wso2/carbon/identity/role/v2/mgt/core/util/RoleManagementUtilsTest.java
@@ -35,13 +35,26 @@ import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagemen
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
 import org.wso2.carbon.identity.role.v2.mgt.core.internal.RoleManagementServiceComponentHolder;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.Permission;
+import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.api.Tenant;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.tenant.TenantCache;
+import org.wso2.carbon.user.core.tenant.TenantIdKey;
+import org.wso2.carbon.user.core.tenant.TenantManager;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.Arrays;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
+import static org.testng.Assert.assertEquals;
 
 public class RoleManagementUtilsTest {
 
@@ -152,5 +165,133 @@ public class RoleManagementUtilsTest {
                 {false, scopes1, permissions2, RoleConstants.ORGANIZATION},
                 {true,  scopes1, permissions1, RoleConstants.APPLICATION},
         };
+    }
+
+    /*
+     * resolveTenantOwnerUsername — see ISSUE-36404. The realm configuration is served from a node-local
+     * cache that is not refreshed when the tenant's admin user changes underneath a running node, so the
+     * tenant store is the authority and the cached value is only a fallback.
+     */
+
+    private static final int TENANT_ID = 11;
+    private static final String CACHED_ADMIN = "ownera";
+    private static final String CURRENT_OWNER = "userb";
+
+    /**
+     * Wire a RealmService whose tenant manager returns the given tenant for {@link #TENANT_ID}.
+     */
+    private TenantManager mockTenantManager(Tenant tenant) throws UserStoreException {
+
+        RealmService realmService = mock(RealmService.class);
+        TenantManager tenantManager = mock(TenantManager.class);
+        when(roleManagementServiceComponentHolder.getRealmService()).thenReturn(realmService);
+        when(realmService.getTenantManager()).thenReturn(tenantManager);
+        when(tenantManager.getTenantId(tenantDomain)).thenReturn(TENANT_ID);
+        when(tenantManager.getTenant(TENANT_ID)).thenReturn(tenant);
+        return tenantManager;
+    }
+
+    private Tenant mockTenant(String adminUserName) {
+
+        Tenant tenant = mock(Tenant.class);
+        RealmConfiguration realmConfiguration = mock(RealmConfiguration.class);
+        when(tenant.getRealmConfig()).thenReturn(realmConfiguration);
+        when(realmConfiguration.getAdminUserName()).thenReturn(adminUserName);
+        return tenant;
+    }
+
+    @Test
+    public void testResolveTenantOwnerUsernameReturnsCurrentOwnerWhenCachedValueIsStale()
+            throws UserStoreException {
+
+        try (MockedStatic<TenantCache> tenantCache = mockStatic(TenantCache.class)) {
+            TenantCache cache = mock(TenantCache.class);
+            tenantCache.when(TenantCache::getInstance).thenReturn(cache);
+            mockTenantManager(mockTenant(CURRENT_OWNER));
+
+            assertEquals(RoleManagementUtils.resolveTenantOwnerUsername(tenantDomain, CACHED_ADMIN),
+                    CURRENT_OWNER);
+            // The tenant cache entry has to be dropped, otherwise the re-read is served from cache too.
+            verify(cache).clearCacheEntry(any(TenantIdKey.class));
+        }
+    }
+
+    @Test
+    public void testResolveTenantOwnerUsernameReturnsCachedValueWhenItIsCurrent() throws UserStoreException {
+
+        try (MockedStatic<TenantCache> tenantCache = mockStatic(TenantCache.class)) {
+            TenantCache cache = mock(TenantCache.class);
+            tenantCache.when(TenantCache::getInstance).thenReturn(cache);
+            mockTenantManager(mockTenant(CACHED_ADMIN));
+
+            assertEquals(RoleManagementUtils.resolveTenantOwnerUsername(tenantDomain, CACHED_ADMIN),
+                    CACHED_ADMIN);
+        }
+    }
+
+    @DataProvider(name = "unusableTenantStoreResponses")
+    public Object[][] unusableTenantStoreResponses() {
+
+        Tenant noRealmConfig = mock(Tenant.class);
+        when(noRealmConfig.getRealmConfig()).thenReturn(null);
+        return new Object[][]{
+                {null},                 // tenant not found
+                {noRealmConfig},        // tenant carries no realm configuration
+                {mockTenant(null)},     // realm configuration carries no admin username
+                {mockTenant("  ")},     // ... or a blank one
+        };
+    }
+
+    @Test(dataProvider = "unusableTenantStoreResponses")
+    public void testResolveTenantOwnerUsernameFallsBackWhenTenantStoreCannotAnswer(Tenant tenant)
+            throws UserStoreException {
+
+        try (MockedStatic<TenantCache> tenantCache = mockStatic(TenantCache.class)) {
+            TenantCache cache = mock(TenantCache.class);
+            tenantCache.when(TenantCache::getInstance).thenReturn(cache);
+            mockTenantManager(tenant);
+
+            assertEquals(RoleManagementUtils.resolveTenantOwnerUsername(tenantDomain, CACHED_ADMIN),
+                    CACHED_ADMIN);
+        }
+    }
+
+    @Test
+    public void testResolveTenantOwnerUsernameFallsBackOnUserStoreException() throws UserStoreException {
+
+        try (MockedStatic<TenantCache> tenantCache = mockStatic(TenantCache.class)) {
+            TenantCache cache = mock(TenantCache.class);
+            tenantCache.when(TenantCache::getInstance).thenReturn(cache);
+            RealmService realmService = mock(RealmService.class);
+            TenantManager tenantManager = mock(TenantManager.class);
+            when(roleManagementServiceComponentHolder.getRealmService()).thenReturn(realmService);
+            when(realmService.getTenantManager()).thenReturn(tenantManager);
+            when(tenantManager.getTenantId(tenantDomain)).thenThrow(new UserStoreException("db down"));
+
+            // A failure to read must not change the decision the caller would have made before this change.
+            assertEquals(RoleManagementUtils.resolveTenantOwnerUsername(tenantDomain, CACHED_ADMIN),
+                    CACHED_ADMIN);
+        }
+    }
+
+    @Test
+    public void testResolveTenantOwnerUsernameSkipsTenantStoreForSuperTenant() throws UserStoreException {
+
+        try (MockedStatic<TenantCache> tenantCache = mockStatic(TenantCache.class)) {
+            TenantCache cache = mock(TenantCache.class);
+            tenantCache.when(TenantCache::getInstance).thenReturn(cache);
+            RealmService realmService = mock(RealmService.class);
+            TenantManager tenantManager = mock(TenantManager.class);
+            when(roleManagementServiceComponentHolder.getRealmService()).thenReturn(realmService);
+            when(realmService.getTenantManager()).thenReturn(tenantManager);
+            when(tenantManager.getTenantId(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME))
+                    .thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+
+            // The super tenant realm is built from the bootstrap configuration, not from UM_TENANT.
+            assertEquals(RoleManagementUtils.resolveTenantOwnerUsername(
+                    MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, CACHED_ADMIN), CACHED_ADMIN);
+            verify(cache, never()).clearCacheEntry(any(TenantIdKey.class));
+            verify(tenantManager, never()).getTenant(MultitenantConstants.SUPER_TENANT_ID);
+        }
     }
 }


### PR DESCRIPTION
## Issue

The guards that enforce "only the tenant owner can remove users/groups from the Administrator role"
compare the caller against `RealmConfiguration.getAdminUserName()`, which is served from the
node-local realm cache. That cache is populated when the tenant realm is built and is never refreshed
when the tenant's admin user changes underneath a running node. Once that happens the decision
inverts: the current owner gets `403 "Invalid operation. Only the tenant owner can remove users from
the role: Administrator"`, while the previous owner keeps full owner authority — until the realm is
evicted or the node is restarted.

## Fix

Inside the administrator-role branch of `RoleManagementServiceImpl.validateUserRemovalFromRole` and
`RoleDAOImpl.validateGroupRemovalFromRole`, re-resolve the owner from the tenant store via a new
`RoleManagementUtils.resolveTenantOwnerUsername(...)` instead of trusting the cached realm
configuration. It reads a single tenant row and leaves the realm itself alone, and it is only reached
for the administrator role. If the tenant store cannot answer — tenant absent, no realm config, or a
`UserStoreException` — the cached value is returned unchanged, so nothing else changes behaviour. The
super tenant short-circuits, since its realm comes from the bootstrap configuration rather than
`UM_TENANT`.

## Testing

8 new unit cases covering the stale, current, super-tenant, and every fallback path (module suite
63 → 71, all green). Also verified end-to-end on a local IS 7.4.0-SNAPSHOT: after changing the
tenant's admin user with the node running, the new owner goes 403 → 200 and the previous owner
200 → 403, with no restart.
