### PR TITLE
Add proxy_context_path support for redirect URLs and tenanted session cookies

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultAuthenticationRequestHandler.java
@@ -1242,18 +1242,21 @@ public class DefaultAuthenticationRequestHandler implements AuthenticationReques
                         MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
                     path = "/";
                 } else {
-                    path = FrameworkConstants.TENANT_CONTEXT_PREFIX + tenantDomain + "/";
+                    path = FrameworkUtils.prependProxyContextPath(
+                            FrameworkConstants.TENANT_CONTEXT_PREFIX + tenantDomain + "/");
                 }
             } else if (FrameworkUtils.isOrganizationQualifiedRequest()) {
                 // Handling the cookie path for requests coming with the path `/o/<org-id>`.
                 String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
-                path = FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX + organizationId + "/";
+                path = FrameworkUtils.prependProxyContextPath(
+                        FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX + organizationId + "/");
             } else {
                 if (!IdentityTenantUtil.isSuperTenantAppendInCookiePath() &&
                         MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(context.getLoginTenantDomain())) {
                     path = "/";
                 } else {
-                    path = FrameworkConstants.TENANT_CONTEXT_PREFIX + context.getLoginTenantDomain() + "/";
+                    path = FrameworkUtils.prependProxyContextPath(
+                            FrameworkConstants.TENANT_CONTEXT_PREFIX + context.getLoginTenantDomain() + "/");
                 }
             }
         }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtils.java
@@ -1030,13 +1030,15 @@ public class FrameworkUtils {
         if (isOrganizationQualifiedRequest()) {
             // Handling the cookie path for requests coming with the path `/o/<org-id>`.
             String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
-            path = FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX + organizationId + "/";
+            path = prependProxyContextPath(
+                    FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX + organizationId + "/");
         } else {
             if (!IdentityTenantUtil.isSuperTenantRequiredInUrl() &&
                     MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
                 path = "/";
             } else {
-                path = FrameworkConstants.TENANT_CONTEXT_PREFIX + tenantDomain + "/";
+                path = prependProxyContextPath(
+                        FrameworkConstants.TENANT_CONTEXT_PREFIX + tenantDomain + "/");
             }
         }
         removeCookie(req, resp, FrameworkConstants.COMMONAUTH_COOKIE, SameSiteCookie.NONE, path);
@@ -4691,8 +4693,47 @@ public class FrameworkUtils {
                         .setTenant(context.getLoginTenantDomain()).setOrganization(callerOrgId)
                         .build().getAbsolutePublicURL();
             }
+        } else {
+            return prependProxyContextPath(callerPath);
         }
         return callerPath;
+    }
+
+    /**
+     * Prepend the configured proxy context path to a server relative path.
+     * <p>
+     * Used for both redirect URLs and cookie paths: when the server is fronted by a proxy that
+     * exposes it under a context path, the externally visible path carries that prefix, so a path
+     * built from internal context alone (for example {@code /t/<tenant-domain>/}) would not match
+     * the URL the browser actually requests.
+     *
+     * @param path Server relative path, or an absolute URL.
+     * @return Path with the proxy context path applied when applicable.
+     */
+    public static String prependProxyContextPath(String path) {
+
+        if (StringUtils.isBlank(path) || !path.startsWith("/")) {
+            return path;
+        }
+        String proxyContextPath = ServerConfiguration.getInstance()
+                .getFirstProperty(IdentityCoreConstants.PROXY_CONTEXT_PATH);
+        if (StringUtils.isBlank(proxyContextPath)) {
+            return path;
+        }
+        String normalizedProxyContextPath = "/" + StringUtils.strip(proxyContextPath.trim(), "/");
+        if (ROOT_DOMAIN.equals(normalizedProxyContextPath)) {
+            // The proxy context path resolved to the root path, nothing to prepend.
+            return path;
+        }
+        if (path.equals(normalizedProxyContextPath)
+                || path.startsWith(normalizedProxyContextPath + "/")
+                || path.startsWith(normalizedProxyContextPath + "?")
+                || path.startsWith(normalizedProxyContextPath + "#")) {
+            // Already prefixed: the prefix is either the whole path, or is delimited by a path
+            // separator, a query string or a fragment.
+            return path;
+        }
+        return normalizedProxyContextPath + path;
     }
 
     /**

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/test/java/org/wso2/carbon/identity/application/authentication/framework/util/FrameworkUtilsTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.core.SameSiteCookie;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
@@ -79,6 +80,7 @@ import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.model.IdentityCookieConfig;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
@@ -136,6 +138,8 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Application.CONSOLE_APP;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Application.MY_ACCOUNT_APP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.CREATED_TIMESTAMP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.GROUPS_CLAIM;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.OrgDiscoveryInputParameters.LOGIN_HINT;
@@ -2058,4 +2062,138 @@ public class FrameworkUtilsTest extends IdentityBaseTest {
             assertEquals(result, expectedResult);
         }
     }
+
+    @DataProvider(name = "buildCallerPathRedirectURLDataProvider")
+    public Object[][] provideBuildCallerPathRedirectURLData() {
+
+        return new Object[][]{
+                // applicationName, callerPath, proxyContextPath, expectedResult
+
+                {MY_ACCOUNT_APP, "/myaccount", "auth", "/auth/myaccount"},
+                {CONSOLE_APP, "/console", "auth", "/auth/console"},
+                {MY_ACCOUNT_APP, "/t/foo.com/myaccount", "auth", "/auth/t/foo.com/myaccount"},
+                {CONSOLE_APP, "/t/foo.com/o/orgid/console", "auth", "/auth/t/foo.com/o/orgid/console"},
+
+                {CONSOLE_APP, "/console", "/auth/", "/auth/console"},
+                {CONSOLE_APP, "/console", "  auth  ", "/auth/console"},
+
+                {MY_ACCOUNT_APP, "/auth/myaccount", "auth", "/auth/myaccount"},
+                {CONSOLE_APP, "/auth", "auth", "/auth"},
+
+                {CONSOLE_APP, "/authenticate", "auth", "/auth/authenticate"},
+
+                {MY_ACCOUNT_APP, "/myaccount", "", "/myaccount"},
+                {CONSOLE_APP, "/console", null, "/console"},
+
+                {MY_ACCOUNT_APP, "https://example.com/myaccount", "auth", "https://example.com/myaccount"},
+                {CONSOLE_APP, null, "auth", null},
+                {CONSOLE_APP, "", "auth", ""},
+
+                {"custom-sp", "/customapp", "auth", "/customapp"},
+
+                {null, "/somepath", "auth", "/somepath"},
+        };
+    }
+
+    @Test(dataProvider = "buildCallerPathRedirectURLDataProvider")
+    public void testBuildCallerPathRedirectURL(String applicationName, String callerPath, String proxyContextPath,
+                                               String expected) throws URLBuilderException {
+
+        AuthenticationContext authContext = new AuthenticationContext();
+        if (applicationName != null) {
+            SequenceConfig sequenceConfig = new SequenceConfig();
+            ApplicationConfig applicationConfig = mock(ApplicationConfig.class);
+            when(applicationConfig.getApplicationName()).thenReturn(applicationName);
+            sequenceConfig.setApplicationConfig(applicationConfig);
+            authContext.setSequenceConfig(sequenceConfig);
+        }
+
+        try (MockedStatic<ServerConfiguration> serverConfiguration = mockStatic(ServerConfiguration.class)) {
+            ServerConfiguration mockServerConfiguration = mock(ServerConfiguration.class);
+            serverConfiguration.when(ServerConfiguration::getInstance).thenReturn(mockServerConfiguration);
+            lenient().when(mockServerConfiguration.getFirstProperty(IdentityCoreConstants.PROXY_CONTEXT_PATH))
+                    .thenReturn(proxyContextPath);
+
+            assertEquals(FrameworkUtils.buildCallerPathRedirectURL(callerPath, authContext), expected);
+        }
+    }
+
+    @DataProvider(name = "prependProxyContextPathDataProvider")
+    public Object[][] providePrependProxyContextPathData() {
+
+        return new Object[][]{
+                // path, proxyContextPath, expectedResult
+
+                // Tenant and organization qualified cookie paths get the prefix applied.
+                {"/t/foo.com/", "auth", "/auth/t/foo.com/"},
+                {"/o/org-id/", "auth", "/auth/o/org-id/"},
+
+                // The configured value is normalized before it is applied.
+                {"/t/foo.com/", "/auth", "/auth/t/foo.com/"},
+                {"/t/foo.com/", "auth/", "/auth/t/foo.com/"},
+                {"/t/foo.com/", "/auth/", "/auth/t/foo.com/"},
+                {"/t/foo.com/", "  auth  ", "/auth/t/foo.com/"},
+
+                // A proxy context path that resolves to the root path leaves the path untouched.
+                {"/t/foo.com/", "/", "/t/foo.com/"},
+
+                // Applying the prefix is idempotent, including when the prefix is followed by a
+                // query string or a fragment rather than a path separator.
+                {"/auth/t/foo.com/", "auth", "/auth/t/foo.com/"},
+                {"/auth", "auth", "/auth"},
+                {"/auth?state=x", "auth", "/auth?state=x"},
+                {"/auth#fragment", "auth", "/auth#fragment"},
+                {"/auth/console?state=x", "auth", "/auth/console?state=x"},
+
+                // A path that merely starts with the same characters is still prefixed.
+                {"/authenticate", "auth", "/auth/authenticate"},
+
+                // A root path is prefixed too. The cookie sites do not rely on this: they keep the
+                // super tenant cookie at the root path instead of calling this method.
+                {"/", "auth", "/auth/"},
+
+                // Nothing to apply when the proxy context path is not configured.
+                {"/t/foo.com/", "", "/t/foo.com/"},
+                {"/t/foo.com/", null, "/t/foo.com/"},
+
+                // Values that are not server relative paths are returned as they are.
+                {"https://example.com/t/foo.com/", "auth", "https://example.com/t/foo.com/"},
+                {null, "auth", null},
+                {"", "auth", ""},
+        };
+    }
+
+    @Test(dataProvider = "prependProxyContextPathDataProvider")
+    public void testPrependProxyContextPath(String path, String proxyContextPath, String expected) {
+
+        try (MockedStatic<ServerConfiguration> serverConfiguration = mockStatic(ServerConfiguration.class)) {
+            ServerConfiguration mockServerConfiguration = mock(ServerConfiguration.class);
+            serverConfiguration.when(ServerConfiguration::getInstance).thenReturn(mockServerConfiguration);
+            lenient().when(mockServerConfiguration.getFirstProperty(IdentityCoreConstants.PROXY_CONTEXT_PATH))
+                    .thenReturn(proxyContextPath);
+
+            assertEquals(FrameworkUtils.prependProxyContextPath(path), expected);
+        }
+    }
+
+    @Test
+    public void testRemoveAuthCookieInTenantWithProxyContextPath() {
+
+        mockCookieTest();
+        try (MockedStatic<ServerConfiguration> serverConfiguration = mockStatic(ServerConfiguration.class)) {
+            ServerConfiguration mockServerConfiguration = mock(ServerConfiguration.class);
+            serverConfiguration.when(ServerConfiguration::getInstance).thenReturn(mockServerConfiguration);
+            lenient().when(mockServerConfiguration.getFirstProperty(IdentityCoreConstants.PROXY_CONTEXT_PATH))
+                    .thenReturn("auth");
+
+            FrameworkUtils.removeAuthCookie(request, response, DUMMY_TENANT_DOMAIN);
+        }
+
+        verify(response, times(1)).addCookie(cookieCaptor.capture());
+        Cookie removedCookie = cookieCaptor.getAllValues().get(0);
+        assertEquals(removedCookie.getName(), FrameworkConstants.COMMONAUTH_COOKIE);
+        assertEquals(removedCookie.getPath(),
+                "/auth" + FrameworkConstants.TENANT_CONTEXT_PREFIX + DUMMY_TENANT_DOMAIN + "/");
+    }
+
 }


### PR DESCRIPTION
## Summary

Applies the configured `proxy_context_path` wherever the framework builds an externally visible path by hand, so both post-authentication redirects and tenanted session cookies match the URL the browser actually requests when the server sits behind a reverse-proxy prefix.

### Redirect URLs

- **Framework redirect fix** — `buildCallerPathRedirectURL` used to skip `ServiceURLBuilder` for Console / My Account (custom-domain branding is not supported there) and return the caller path verbatim, dropping the proxy context path. It now applies the prefix via a small helper (`prependProxyContextPath`) for those two applications; all other call flows are unchanged.
- **Scoped else branch** — the prefix step is scoped strictly to Console / My Account; non-matching service providers still return the caller path untouched.

### Tenanted session cookies

- **Cookie path fix** — with `EnableTenantedSessions` enabled, the `commonAuthId` cookie path is built by hand as `/t/<tenant-domain>/` (or `/o/<org-id>/`), bypassing `ServiceURLBuilder` and therefore omitting the proxy context path. Behind a prefix the browser sits at `/<prefix>/t/<tenant-domain>/...` and never returns that cookie, so every request after a successful login is unauthenticated: an OIDC `prompt=none` request comes back as `login_required` and the portal falls back to the login page, looping. The prefix is now applied at both the write site (`DefaultAuthenticationRequestHandler#setAuthCookie`) and the remove site (`FrameworkUtils#removeAuthCookie`), so logout still clears the cookie at the path it was set on.
- **Super tenant unchanged** — where the cookie path resolves to the root path it is left as `/`, which already covers any prefix.

### Shared helper

- **Idempotent prefixing** — `prependProxyContextPath` is a no-op when the path is already prefixed, when it is absolute or blank, when `proxy_context_path` is not configured, and when the configured value normalizes to the root path. Configured values are trimmed and stripped of surrounding slashes, so `auth`, `/auth`, `auth/` and `/auth/` behave identically. The helper is `public` so the redirect and cookie call sites share one implementation.

### Tests

- `FrameworkUtilsTest#testBuildCallerPathRedirectURL` — prepend, idempotency, normalization, blank/null/absolute pass-through, and the non-Console/MyAccount fall-through.
- `FrameworkUtilsTest#testPrependProxyContextPath` — the helper directly: tenant and organization cookie paths, normalization variants, the root-path guard, and idempotency.
- `FrameworkUtilsTest#testRemoveAuthCookieInTenantWithProxyContextPath` — the tenanted `commonAuthId` removal path carries the prefix.

The same hand-rolled cookie path exists for the `opbs` cookie in `identity-inbound-auth-oauth` and the `samlssoTokenId` cookie in `identity-inbound-auth-saml`; those are handled in separate PRs that depend on the helper added here.

Fixes: https://github.com/wso2/product-is/issues/18904
