### PR TITLE
Allow access to the OID4VCI well-known metadata URLs

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/resource-access-control-v2.xml.j2
@@ -129,6 +129,8 @@
         <Resource context="(.*)/accounts(.*)" secured="false" http-method="all"/>
         <Resource context="(.*)/oid4vci/.well-known/openid-credential-issuer" secured="false" http-method="GET"/>
         <Resource context="(.*)/oid4vci/.well-known/jwt-vc-issuer" secured="false" http-method="GET"/>
+        <Resource context="/.well-known/openid-credential-issuer/(.*)oid4vci" secured="false" http-method="GET"/>
+        <Resource context="/.well-known/jwt-vc-issuer/(.*)oid4vci" secured="false" http-method="GET"/>
         <Resource context="(.*)/oid4vci/credential" secured="true" http-method="POST"/>
         <Resource context="(.*)/oid4vci/credential-offer(.*)" secured="false" http-method="GET"/>
         <Resource context="(.*)/oid4vci/nonce" secured="false" http-method="POST"/>


### PR DESCRIPTION
## Purpose

The OID4VCI credential issuer metadata has to be served from a root-context well-known URL. OpenID4VCI 1.0 §12.2.2 forms the well-known URI by inserting the well-known segment **between the host component and the path component** of the credential issuer identifier, so for an issuer of `https://host/oid4vci` the metadata must be reachable at:

```
https://host/.well-known/openid-credential-issuer/oid4vci
```

`identity-openid4vci` registers servlets for these root-context paths, but the auth valve rejects the requests with `401` before the servlets are ever reached, because `resource-access-control-v2.xml.j2` only lists the nested `/oid4vci/.well-known/...` paths.

Without this change the credential issuer metadata is undiscoverable by any conformant wallet, and every module of the OpenID Foundation `oid4vci-1_0-issuer-test-plan` halts at its first step.

## Goals

Allow unauthenticated `GET` access to the two root-context well-known metadata documents, so the servlets that serve them can be reached.

## Approach

Two entries added alongside the existing OID4VCI rules, following the pattern already used for `/.well-known/oauth-authorization-server`:

```xml
<Resource context="/.well-known/openid-credential-issuer/(.*)oid4vci" secured="false" http-method="GET"/>
<Resource context="/.well-known/jwt-vc-issuer/(.*)oid4vci" secured="false" http-method="GET"/>
```

The `(.*)` segment matches the tenant-qualified form (`/t/{tenant}/oid4vci`) exactly as the authorization server metadata rule does.

Both documents are public by specification — the credential issuer metadata by OpenID4VCI 1.0 §12.2.2, and the JWT VC issuer document by draft-ietf-oauth-sd-jwt-vc — and neither exposes anything beyond what the already-unsecured nested endpoints return today. `GET` only.

## Release note

Fixed the OpenID4VCI credential issuer metadata and JWT VC issuer metadata being unreachable at the well-known URLs required by the specification.

## Documentation

N/A — no user-facing configuration change; this corrects the URL at which an existing document is served.

## Automation tests

- Unit tests — N/A, this is a configuration template. The servlets it exposes are unit tested in https://github.com/wso2-extensions/identity-openid4vc/pull/29.
- Integration tests — verified manually at runtime, see Test environment.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — no Java changes in this PR
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Related PRs

Requires https://github.com/wso2-extensions/identity-openid4vc/pull/29, which registers the servlets that serve these paths. Neither PR is useful alone: without the servlets these paths 404, and without this change they return 401.

## Test environment

A **product-is master build — WSO2 IS 7.4.0-SNAPSHOT**. JDK 21 (Zulu 21.0.10), macOS 15.

Verified with the companion change applied:

```
GET /.well-known/openid-credential-issuer/oid4vci                  200
GET /.well-known/jwt-vc-issuer/oid4vci                             200
GET /.well-known/openid-credential-issuer/t/carbon.super/oid4vci   200
GET /.well-known/openid-credential-issuer/t/foo.com/oid4vci        404   (unknown tenant)
GET /oid4vci/.well-known/openid-credential-issuer                  200   (existing path, unchanged)
```

Without these entries every one of those root-context requests is answered `401` by the auth valve before the servlets are reached.

Also verified with the OpenID Foundation conformance suite (self-hosted, master @ `7d6fa05`) running `oid4vci-1_0-issuer-test-plan` against the patched build with no proxy or rewrite in front of the server: `oid4vci-1_0-issuer-metadata-test` passes and `oid4vci-1_0-issuer-metadata-test-signed` skips cleanly. Before, both modules could only run behind an nginx rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
