### PR TITLE
Add a config to control the app level custom layout inheritance

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -2415,6 +2415,7 @@
   "tenant_level_application_authentication_config.enabled_for_auth_sequence": true,
   "branding_configuration.use_intermediate_loader_page": false,
   "branding_configuration.use_invalid_tenant_domain_error_page_from_auth_portal": false,
+  "webappscommon.inherit_app_level_custom_layout": true,
 
   "enhanced_organization_authentication_feature.enabled": true,
 

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.infer.json
@@ -350,7 +350,8 @@
       ],
       "oauth.oidc.honor_multivalued_claim_metadata": false,
       "token_exchange.limit_scopes_to_subject_token": false,
-      "legacy_claims.return_legacy_role_claim_in_application_response": true
+      "legacy_claims.return_legacy_role_claim_in_application_response": true,
+      "webappscommon.inherit_app_level_custom_layout": false
     },
     "IS_7.1.0": {
       "legacy_claims.allow_userstore_domain_removal_from_legacy_role_claim": false,
@@ -429,7 +430,8 @@
       ],
       "oauth.oidc.honor_multivalued_claim_metadata": false,
       "token_exchange.limit_scopes_to_subject_token": false,
-      "legacy_claims.return_legacy_role_claim_in_application_response": true
+      "legacy_claims.return_legacy_role_claim_in_application_response": true,
+      "webappscommon.inherit_app_level_custom_layout": false
     },
     "IS_7.2.0": {
       "legacy_claims.allow_userstore_domain_removal_from_legacy_role_claim": false,
@@ -465,7 +467,8 @@
       "oauth.oidc.honor_multivalued_claim_metadata": false,
       "ai_services.http_client_use_system_properties": false,
       "token_exchange.limit_scopes_to_subject_token": false,
-      "legacy_claims.return_legacy_role_claim_in_application_response": true
+      "legacy_claims.return_legacy_role_claim_in_application_response": true,
+      "webappscommon.inherit_app_level_custom_layout": false
     },
     "IS_7.3.0": {
       "legacy_claims.allow_userstore_domain_removal_from_legacy_role_claim": false,
@@ -486,7 +489,8 @@
       "oauth.oidc.honor_multivalued_claim_metadata": false,
       "ai_services.http_client_use_system_properties": false,
       "token_exchange.limit_scopes_to_subject_token": false,
-      "legacy_claims.return_legacy_role_claim_in_application_response": true
+      "legacy_claims.return_legacy_role_claim_in_application_response": true,
+      "webappscommon.inherit_app_level_custom_layout": false
     }
   }
 }


### PR DESCRIPTION
Adds `webappscommon.inherit_app_level_custom_layout`, which controls the application level custom layout inheritance only.

When an application in a sub-organization inherits its branding from an ancestor organization's application level branding, the custom layout is read from the organization and the application the branding was resolved from. Setting this to `false` reads it from the requesting organization and application instead, which is how it behaved before.

The config has no effect when the branding is resolved from an organization. In that case the custom layout is always read from the organization the branding was resolved from, which was already corrected earlier and stays as it is.

The default is `true`, so new deployments get the corrected behaviour. `infer.json` sets it to `false` for IS 7.0.0, 7.1.0, 7.2.0 and 7.3.0, so customers migrating from those versions keep their current behaviour until they choose to change it.

The config is read by the login, recovery, x509 certificate and account portals. See https://github.com/wso2/identity-apps/pull/10663.

Related to https://github.com/wso2/product-is/issues/28242
