### PR TITLE
Add organization data collection to flow execution

### DIFF
--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/Constants.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/Constants.java
@@ -29,6 +29,12 @@ public class Constants {
     public static final String STATUS_PROMPT_ONLY = "PROMPT_ONLY";
     // Constants for user attributes.
     public static final String CLAIM_URI_PREFIX = "http://wso2.org/claims/";
+    // Constants for organization details collected during a flow.
+    public static final String IDENTIFIER_TYPE_CONFIG = "identifierType";
+    public static final String ORGANIZATION_IDENTIFIER_TYPE = "ORGANIZATION";
+    public static final String ORG_NAME_KEY = "organizationName";
+    public static final String ORG_HANDLE_KEY = "organizationHandle";
+    public static final String ORG_DESCRIPTION_KEY = "organizationDescription";
     public static final String USERNAME_CLAIM_URI = "http://wso2.org/claims/username";
     public static final String DOB_CLAIM_URI = "http://wso2.org/claims/dob";
     public static final String PASSWORD_KEY = "password";

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowExecutionContext.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowExecutionContext.java
@@ -48,6 +48,7 @@ public class FlowExecutionContext implements Serializable {
     private NodeConfig currentNode;
     private GraphConfig graphConfig;
     private FlowUser flowUser = new FlowUser();
+    private FlowOrganization flowOrganization = new FlowOrganization();
     private String tenantDomain;
     private String contextIdentifier;
     private String currentActionId;
@@ -122,6 +123,16 @@ public class FlowExecutionContext implements Serializable {
     public void setFlowUser(FlowUser flowUser) {
 
         this.flowUser = flowUser;
+    }
+
+    public FlowOrganization getFlowOrganization() {
+
+        return flowOrganization;
+    }
+
+    public void setFlowOrganization(FlowOrganization flowOrganization) {
+
+        this.flowOrganization = flowOrganization;
     }
 
     public Map<String, Object> getProperties() {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowOrganization.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowOrganization.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.flow.execution.engine.model;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Holds the organization details collected during a flow execution.
+ * <p>
+ * Inputs whose {@code identifierType} marks them as organization data are routed here by the flow
+ * engine, so that an executor can create or update an organization without inspecting raw user input.
+ * The name, handle and description are first class fields because the engine and its executors
+ * reference them directly; anything else the flow collects is kept in {@link #getAttributes()}.
+ */
+public class FlowOrganization implements Serializable {
+
+    private static final long serialVersionUID = -6069004467814244409L;
+
+    private String organizationName;
+    private String organizationHandle;
+    private String organizationDescription;
+    private String creatorId;
+    private String flowState;
+    private Map<String, String> attributes = new HashMap<>();
+
+    public String getOrganizationName() {
+
+        return organizationName;
+    }
+
+    public void setOrganizationName(String organizationName) {
+
+        this.organizationName = organizationName;
+    }
+
+    public String getOrganizationHandle() {
+
+        return organizationHandle;
+    }
+
+    public void setOrganizationHandle(String organizationHandle) {
+
+        this.organizationHandle = organizationHandle;
+    }
+
+    public String getOrganizationDescription() {
+
+        return organizationDescription;
+    }
+
+    public void setOrganizationDescription(String organizationDescription) {
+
+        this.organizationDescription = organizationDescription;
+    }
+
+    public String getCreatorId() {
+
+        return creatorId;
+    }
+
+    public void setCreatorId(String creatorId) {
+
+        this.creatorId = creatorId;
+    }
+
+    public String getFlowState() {
+
+        return flowState;
+    }
+
+    public void setFlowState(String flowState) {
+
+        this.flowState = flowState;
+    }
+
+    public Map<String, String> getAttributes() {
+
+        return attributes;
+    }
+
+    public String getAttribute(String key) {
+
+        return attributes.get(key);
+    }
+
+    public void setAttribute(String key, String value) {
+
+        this.attributes.put(key, value);
+    }
+}

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowOrganization.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowOrganization.java
@@ -37,7 +37,6 @@ public class FlowOrganization implements Serializable {
     private String organizationName;
     private String organizationHandle;
     private String organizationDescription;
-    private String creatorId;
     private String flowState;
     private Map<String, String> attributes = new HashMap<>();
 
@@ -69,16 +68,6 @@ public class FlowOrganization implements Serializable {
     public void setOrganizationDescription(String organizationDescription) {
 
         this.organizationDescription = organizationDescription;
-    }
-
-    public String getCreatorId() {
-
-        return creatorId;
-    }
-
-    public void setCreatorId(String creatorId) {
-
-        this.creatorId = creatorId;
     }
 
     public String getFlowState() {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowOrganization.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/model/FlowOrganization.java
@@ -37,7 +37,7 @@ public class FlowOrganization implements Serializable {
     private String organizationName;
     private String organizationHandle;
     private String organizationDescription;
-    private String flowState;
+    private String organizationStatus;
     private Map<String, String> attributes = new HashMap<>();
 
     public String getOrganizationName() {
@@ -70,14 +70,14 @@ public class FlowOrganization implements Serializable {
         this.organizationDescription = organizationDescription;
     }
 
-    public String getFlowState() {
+    public String getOrganizationStatus() {
 
-        return flowState;
+        return organizationStatus;
     }
 
-    public void setFlowState(String flowState) {
+    public void setOrganizationStatus(String organizationStatus) {
 
-        this.flowState = flowState;
+        this.organizationStatus = organizationStatus;
     }
 
     public Map<String, String> getAttributes() {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
@@ -298,11 +298,16 @@ public class InputValidationService {
         boolean skipUniquenessValidation = isUserResolveExecutor(context);
         Map<String, String> identifierTypes = resolveIdentifierTypes(context);
         for (Map.Entry<String, String> userInput : context.getUserInputData().entrySet()) {
-            if (userInput.getKey().startsWith(CLAIM_URI_PREFIX)) {
+            // The identifier type is declared by the flow, so it decides before the claim URI prefix,
+            // which is only an inference from the shape of the identifier. Checking the prefix first
+            // would let an organization input whose identifier happens to look like a claim URI be
+            // routed to the user claims instead, and a flow authored through the management API is not
+            // bound by the console's restrictions on organization attribute keys.
+            if (ORGANIZATION_IDENTIFIER_TYPE.equals(identifierTypes.get(userInput.getKey()))) {
+                setOrganizationInput(context.getFlowOrganization(), userInput.getKey(), userInput.getValue());
+            } else if (userInput.getKey().startsWith(CLAIM_URI_PREFIX)) {
                 validateUserClaims(context.getTenantDomain(), userInput.getKey(), userInput.getValue(),
                         skipUniquenessValidation);
-            } else if (ORGANIZATION_IDENTIFIER_TYPE.equals(identifierTypes.get(userInput.getKey()))) {
-                setOrganizationInput(context.getFlowOrganization(), userInput.getKey(), userInput.getValue());
             } else if (userInput.getKey().equals(PASSWORD_KEY)) {
                 validatePasswordFormat(context.getTenantDomain(), userInput.getValue());
             }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
@@ -33,12 +33,14 @@ import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineServer
 import org.wso2.carbon.identity.flow.execution.engine.internal.FlowExecutionEngineDataHolder;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowOrganization;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
 import org.wso2.carbon.identity.flow.execution.engine.model.NodeResponse;
 import org.wso2.carbon.identity.flow.execution.engine.util.FlowExecutionEngineUtils;
 import org.wso2.carbon.identity.flow.mgt.Constants;
 import org.wso2.carbon.identity.flow.mgt.model.ComponentDTO;
 import org.wso2.carbon.identity.flow.mgt.model.DataDTO;
+import org.wso2.carbon.identity.flow.mgt.model.StepDTO;
 import org.wso2.carbon.identity.flow.mgt.model.ValidationDTO;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtClientException;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtException;
@@ -81,6 +83,11 @@ import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorS
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_RETRY;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.IDENTIFIER;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.IDENTIFIER_TYPE_CONFIG;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ORGANIZATION_IDENTIFIER_TYPE;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ORG_DESCRIPTION_KEY;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ORG_HANDLE_KEY;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ORG_NAME_KEY;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.LENGTH_CONFIG;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.OTP_LENGTH;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.OTP_VARIANT;
@@ -289,13 +296,93 @@ public class InputValidationService {
         // The proper fix is to introduce an attribute collector executor for the flow, which would allow this
         // to be handled in the graph building phase itself.
         boolean skipUniquenessValidation = isUserResolveExecutor(context);
+        Map<String, String> identifierTypes = resolveIdentifierTypes(context);
         for (Map.Entry<String, String> userInput : context.getUserInputData().entrySet()) {
             if (userInput.getKey().startsWith(CLAIM_URI_PREFIX)) {
                 validateUserClaims(context.getTenantDomain(), userInput.getKey(), userInput.getValue(),
                         skipUniquenessValidation);
+            } else if (ORGANIZATION_IDENTIFIER_TYPE.equals(identifierTypes.get(userInput.getKey()))) {
+                setOrganizationInput(context.getFlowOrganization(), userInput.getKey(), userInput.getValue());
             } else if (userInput.getKey().equals(PASSWORD_KEY)) {
                 validatePasswordFormat(context.getTenantDomain(), userInput.getValue());
             }
+        }
+    }
+
+    /**
+     * Routes an organization input onto the flow organization. The fields the engine and its executors
+     * reference directly are set as first class fields; anything else the flow collects is kept as a
+     * custom attribute.
+     *
+     * @param organization Organization details collected by the flow.
+     * @param identifier   Identifier of the input field.
+     * @param value        Value submitted for the field.
+     */
+    private void setOrganizationInput(FlowOrganization organization, String identifier, String value) {
+
+        switch (identifier) {
+            case ORG_NAME_KEY:
+                organization.setOrganizationName(value);
+                break;
+            case ORG_HANDLE_KEY:
+                organization.setOrganizationHandle(value);
+                break;
+            case ORG_DESCRIPTION_KEY:
+                organization.setOrganizationDescription(value);
+                break;
+            default:
+                organization.setAttribute(identifier, value);
+        }
+    }
+
+    /**
+     * Builds a map of input identifier to its configured {@code identifierType}, by walking every step
+     * of the flow graph and the components nested within each step.
+     * <p>
+     * All steps are scanned rather than only the current node: input validation runs before the node
+     * executes, so the step an input belongs to is ambiguous at this point, and identifiers are unique
+     * within a flow.
+     *
+     * @param context Flow execution context.
+     * @return Identifier to identifier type; empty when the graph declares none.
+     */
+    private Map<String, String> resolveIdentifierTypes(FlowExecutionContext context) {
+
+        Map<String, String> identifierTypes = new HashMap<>();
+        if (context.getGraphConfig() == null || context.getGraphConfig().getNodePageMappings() == null) {
+            return identifierTypes;
+        }
+        for (StepDTO step : context.getGraphConfig().getNodePageMappings().values()) {
+            if (step != null && step.getData() != null) {
+                collectIdentifierTypes(step.getData().getComponents(), identifierTypes);
+            }
+        }
+        return identifierTypes;
+    }
+
+    /**
+     * Collects the {@code identifierType} of each component, recursing into nested components.
+     *
+     * @param components      Components to walk.
+     * @param identifierTypes Map collecting identifier to identifier type.
+     */
+    private void collectIdentifierTypes(List<ComponentDTO> components, Map<String, String> identifierTypes) {
+
+        if (components == null) {
+            return;
+        }
+        for (ComponentDTO component : components) {
+            if (component == null) {
+                continue;
+            }
+            if (MapUtils.isNotEmpty(component.getConfigs())) {
+                Object identifier = component.getConfigs().get(IDENTIFIER);
+                Object identifierType = component.getConfigs().get(IDENTIFIER_TYPE_CONFIG);
+                if (identifier != null && identifierType != null) {
+                    identifierTypes.put(String.valueOf(identifier), String.valueOf(identifierType));
+                }
+            }
+            collectIdentifierTypes(component.getComponents(), identifierTypes);
         }
     }
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
@@ -213,9 +213,7 @@ public class InputValidationService {
         Map<String, String> identifierTypes = resolveIdentifierTypes(context);
         context.getUserInputData().forEach(
                 (key, value) -> {
-                    // The identifier type is declared by the flow, so it decides before the claim URI
-                    // prefix, which is only an inference from the shape of the identifier. Without it an
-                    // organization identifier shaped like a claim URI would also be stored on the user.
+                    // A flow organization input takes priority over the claim URI prefix.
                     if (ORGANIZATION_IDENTIFIER_TYPE.equals(identifierTypes.get(key))) {
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("Routing organization input: " + key);
@@ -307,10 +305,7 @@ public class InputValidationService {
         boolean skipUniquenessValidation = isUserResolveExecutor(context);
         Map<String, String> identifierTypes = resolveIdentifierTypes(context);
         for (Map.Entry<String, String> userInput : context.getUserInputData().entrySet()) {
-            // An organization input is not a user claim, so the claim validations do not apply to it.
-            // The identifier type is declared by the flow and decides before the claim URI prefix,
-            // which is only an inference from the shape of the identifier: a flow authored through the
-            // management API is not bound by the console's restrictions on organization attribute keys.
+            // Organization inputs are not user claims, so the claim validations do not apply.
             if (ORGANIZATION_IDENTIFIER_TYPE.equals(identifierTypes.get(userInput.getKey()))) {
                 continue;
             }

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
@@ -210,9 +210,15 @@ public class InputValidationService {
      */
     public void handleUserInputs(FlowExecutionContext context) {
 
+        Map<String, String> identifierTypes = resolveIdentifierTypes(context);
         context.getUserInputData().forEach(
                 (key, value) -> {
-                    if (key.startsWith(CLAIM_URI_PREFIX)) {
+                    // The identifier type is declared by the flow, so it decides before the claim URI
+                    // prefix, which is only an inference from the shape of the identifier. Without it an
+                    // organization identifier shaped like a claim URI would also be stored on the user.
+                    if (ORGANIZATION_IDENTIFIER_TYPE.equals(identifierTypes.get(key))) {
+                        setOrganizationInput(context.getFlowOrganization(), key, value);
+                    } else if (key.startsWith(CLAIM_URI_PREFIX)) {
                         context.getFlowUser().addUpdatedClaim(key, value);
                     } else if (CONSENT_KEY.equals(key) || PREFERENCE_KEY.equals(key)) {
                         context.getFlowUser().addUserConsents(FlowUser.UserConsent.fromJson(value));
@@ -298,14 +304,14 @@ public class InputValidationService {
         boolean skipUniquenessValidation = isUserResolveExecutor(context);
         Map<String, String> identifierTypes = resolveIdentifierTypes(context);
         for (Map.Entry<String, String> userInput : context.getUserInputData().entrySet()) {
-            // The identifier type is declared by the flow, so it decides before the claim URI prefix,
-            // which is only an inference from the shape of the identifier. Checking the prefix first
-            // would let an organization input whose identifier happens to look like a claim URI be
-            // routed to the user claims instead, and a flow authored through the management API is not
-            // bound by the console's restrictions on organization attribute keys.
+            // An organization input is not a user claim, so the claim validations do not apply to it.
+            // The identifier type is declared by the flow and decides before the claim URI prefix,
+            // which is only an inference from the shape of the identifier: a flow authored through the
+            // management API is not bound by the console's restrictions on organization attribute keys.
             if (ORGANIZATION_IDENTIFIER_TYPE.equals(identifierTypes.get(userInput.getKey()))) {
-                setOrganizationInput(context.getFlowOrganization(), userInput.getKey(), userInput.getValue());
-            } else if (userInput.getKey().startsWith(CLAIM_URI_PREFIX)) {
+                continue;
+            }
+            if (userInput.getKey().startsWith(CLAIM_URI_PREFIX)) {
                 validateUserClaims(context.getTenantDomain(), userInput.getKey(), userInput.getValue(),
                         skipUniquenessValidation);
             } else if (userInput.getKey().equals(PASSWORD_KEY)) {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/main/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationService.java
@@ -217,6 +217,9 @@ public class InputValidationService {
                     // prefix, which is only an inference from the shape of the identifier. Without it an
                     // organization identifier shaped like a claim URI would also be stored on the user.
                     if (ORGANIZATION_IDENTIFIER_TYPE.equals(identifierTypes.get(key))) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Routing organization input: " + key);
+                        }
                         setOrganizationInput(context.getFlowOrganization(), key, value);
                     } else if (key.startsWith(CLAIM_URI_PREFIX)) {
                         context.getFlowUser().addUpdatedClaim(key, value);

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
@@ -1992,6 +1992,21 @@ public class InputValidationServiceTest {
                 "An input named like an organization field must not be routed without identifierType.");
     }
 
+    @Test(description = "A declared organization identifier type wins over a claim URI shaped identifier.")
+    public void testOrganizationIdentifierTypeWinsOverClaimUriPrefix() throws Exception {
+
+        String claimShapedIdentifier = CLAIM_URI_PREFIX + "organization";
+        FlowExecutionContext context = organizationFlowContext(claimShapedIdentifier);
+        context.getUserInputData().put(claimShapedIdentifier, "Acme Corporation");
+
+        invokeValidateUserInputs(context);
+
+        Assert.assertEquals(context.getFlowOrganization().getAttribute(claimShapedIdentifier),
+                "Acme Corporation",
+                "An input declared as organization data must not be routed to the user claims because "
+                        + "its identifier happens to start with the claim URI prefix.");
+    }
+
     @Test(description = "Organization fields nested inside a form component are still resolved.")
     public void testNestedComponentIdentifierTypesAreResolved() throws Exception {
 

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineServer
 import org.wso2.carbon.identity.flow.execution.engine.internal.FlowExecutionEngineDataHolder;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowOrganization;
 import org.wso2.carbon.identity.flow.mgt.Constants;
 import org.wso2.carbon.identity.flow.mgt.model.ActionDTO;
 import org.wso2.carbon.identity.flow.mgt.model.ComponentDTO;
@@ -43,6 +44,7 @@ import org.wso2.carbon.identity.flow.mgt.model.DataDTO;
 import org.wso2.carbon.identity.flow.mgt.model.ExecutorDTO;
 import org.wso2.carbon.identity.flow.mgt.model.GraphConfig;
 import org.wso2.carbon.identity.flow.mgt.model.NodeConfig;
+import org.wso2.carbon.identity.flow.mgt.model.StepDTO;
 import org.wso2.carbon.identity.flow.mgt.model.ValidationDTO;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtClientException;
 import org.wso2.carbon.identity.input.validation.mgt.exceptions.InputValidationMgtException;
@@ -88,6 +90,11 @@ import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorS
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_RETRY;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.IDENTIFIER;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.IDENTIFIER_TYPE_CONFIG;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ORGANIZATION_IDENTIFIER_TYPE;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ORG_DESCRIPTION_KEY;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ORG_HANDLE_KEY;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ORG_NAME_KEY;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.USERNAME_CLAIM_URI;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.VALIDATIONS;
 
@@ -1922,6 +1929,163 @@ public class InputValidationServiceTest {
         Assert.assertEquals(invalidResponse.getErrorCode(), ERROR_CODE_CLAIM_INVALID_DATE.getCode());
 
         Assert.assertNotEquals(futureResponse.getErrorCode(), invalidResponse.getErrorCode());
+    }
+
+    @Test(dataProvider = "organizationFieldProvider",
+            description = "Core organization fields are routed onto their own field on the flow organization.")
+    public void testCoreOrganizationFieldsAreRouted(String identifier, String value) throws Exception {
+
+        FlowExecutionContext context = organizationFlowContext(identifier);
+        context.getUserInputData().put(identifier, value);
+
+        invokeValidateUserInputs(context);
+
+        FlowOrganization organization = context.getFlowOrganization();
+        if (ORG_NAME_KEY.equals(identifier)) {
+            Assert.assertEquals(organization.getOrganizationName(), value);
+        } else if (ORG_HANDLE_KEY.equals(identifier)) {
+            Assert.assertEquals(organization.getOrganizationHandle(), value);
+        } else {
+            Assert.assertEquals(organization.getOrganizationDescription(), value);
+        }
+        Assert.assertTrue(organization.getAttributes().isEmpty(),
+                "A core field must not also be stored as a custom attribute.");
+    }
+
+    @DataProvider(name = "organizationFieldProvider")
+    public Object[][] organizationFieldProvider() {
+
+        return new Object[][]{
+                {ORG_NAME_KEY, "Acme Corporation"},
+                {ORG_HANDLE_KEY, "acmecorporation"},
+                {ORG_DESCRIPTION_KEY, "A real business"}
+        };
+    }
+
+    @Test(description = "An organization input that is not a core field is kept as a custom attribute.")
+    public void testCustomOrganizationAttributeIsRouted() throws Exception {
+
+        FlowExecutionContext context = organizationFlowContext("industry");
+        context.getUserInputData().put("industry", "software");
+
+        invokeValidateUserInputs(context);
+
+        Assert.assertEquals(context.getFlowOrganization().getAttribute("industry"), "software");
+        Assert.assertNull(context.getFlowOrganization().getOrganizationName());
+    }
+
+    @Test(description = "Routing is driven by identifierType, not by the identifier name.")
+    public void testInputWithoutOrganizationIdentifierTypeIsNotRouted() throws Exception {
+
+        FlowExecutionContext context = initiateFlowContext();
+        GraphConfig graphConfig = new GraphConfig();
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(IDENTIFIER, ORG_NAME_KEY);
+        graphConfig.addNodePageMapping("step1", stepWithComponents(
+                Collections.singletonList(inputComponent(configs))));
+        context.setGraphConfig(graphConfig);
+        context.getUserInputData().put(ORG_NAME_KEY, "Acme Corporation");
+
+        invokeValidateUserInputs(context);
+
+        Assert.assertNull(context.getFlowOrganization().getOrganizationName(),
+                "An input named like an organization field must not be routed without identifierType.");
+    }
+
+    @Test(description = "Organization fields nested inside a form component are still resolved.")
+    public void testNestedComponentIdentifierTypesAreResolved() throws Exception {
+
+        FlowExecutionContext context = initiateFlowContext();
+        GraphConfig graphConfig = new GraphConfig();
+        ComponentDTO form = new ComponentDTO.Builder()
+                .type(Constants.ComponentTypes.FORM)
+                .components(Collections.singletonList(
+                        inputComponent(organizationFieldConfigs(ORG_NAME_KEY))))
+                .build();
+        graphConfig.addNodePageMapping("step1", stepWithComponents(Collections.singletonList(form)));
+        context.setGraphConfig(graphConfig);
+        context.getUserInputData().put(ORG_NAME_KEY, "Acme Corporation");
+
+        invokeValidateUserInputs(context);
+
+        Assert.assertEquals(context.getFlowOrganization().getOrganizationName(), "Acme Corporation");
+    }
+
+    @Test(description = "Identifiers are resolved across every step, not only the step being executed.")
+    public void testIdentifierTypesAreResolvedAcrossAllSteps() throws Exception {
+
+        FlowExecutionContext context = initiateFlowContext();
+        GraphConfig graphConfig = new GraphConfig();
+        Map<String, Object> usernameConfigs = new HashMap<>();
+        usernameConfigs.put(IDENTIFIER, USERNAME_CLAIM_URI);
+        graphConfig.addNodePageMapping("step1", stepWithComponents(
+                Collections.singletonList(inputComponent(usernameConfigs))));
+        graphConfig.addNodePageMapping("step2", stepWithComponents(
+                Collections.singletonList(inputComponent(organizationFieldConfigs(ORG_NAME_KEY)))));
+        context.setGraphConfig(graphConfig);
+        context.getUserInputData().put(ORG_NAME_KEY, "Acme Corporation");
+
+        invokeValidateUserInputs(context);
+
+        Assert.assertEquals(context.getFlowOrganization().getOrganizationName(), "Acme Corporation");
+    }
+
+    @Test(description = "A flow with no graph config must not fail input validation.")
+    public void testMissingGraphConfigIsTolerated() throws Exception {
+
+        FlowExecutionContext context = initiateFlowContext();
+        context.getUserInputData().put("industry", "software");
+
+        invokeValidateUserInputs(context);
+
+        Assert.assertTrue(context.getFlowOrganization().getAttributes().isEmpty());
+    }
+
+    /**
+     * Builds a context whose graph declares a single organization typed input with the given identifier.
+     *
+     * @param identifier Identifier of the organization input.
+     * @return The flow execution context.
+     */
+    private FlowExecutionContext organizationFlowContext(String identifier) {
+
+        FlowExecutionContext context = initiateFlowContext();
+        GraphConfig graphConfig = new GraphConfig();
+        graphConfig.addNodePageMapping("step1", stepWithComponents(
+                Collections.singletonList(inputComponent(organizationFieldConfigs(identifier)))));
+        context.setGraphConfig(graphConfig);
+        return context;
+    }
+
+    private Map<String, Object> organizationFieldConfigs(String identifier) {
+
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(IDENTIFIER, identifier);
+        configs.put(IDENTIFIER_TYPE_CONFIG, ORGANIZATION_IDENTIFIER_TYPE);
+        return configs;
+    }
+
+    private ComponentDTO inputComponent(Map<String, Object> configs) {
+
+        return new ComponentDTO.Builder()
+                .type(Constants.ComponentTypes.INPUT)
+                .configs(configs)
+                .build();
+    }
+
+    private StepDTO stepWithComponents(List<ComponentDTO> components) {
+
+        return new StepDTO.Builder()
+                .data(new DataDTO.Builder().components(components).build())
+                .build();
+    }
+
+    private void invokeValidateUserInputs(FlowExecutionContext context) throws Exception {
+
+        Method method = InputValidationService.class.getDeclaredMethod(
+                "validateUserInputs", FlowExecutionContext.class);
+        method.setAccessible(true);
+        method.invoke(inputValidationService, context);
     }
 
     private FlowExecutionContext initiateFlowContext() {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
@@ -1938,7 +1938,7 @@ public class InputValidationServiceTest {
         FlowExecutionContext context = organizationFlowContext(identifier);
         context.getUserInputData().put(identifier, value);
 
-        invokeValidateUserInputs(context);
+        inputValidationService.handleUserInputs(context);
 
         FlowOrganization organization = context.getFlowOrganization();
         if (ORG_NAME_KEY.equals(identifier)) {
@@ -1968,7 +1968,7 @@ public class InputValidationServiceTest {
         FlowExecutionContext context = organizationFlowContext("industry");
         context.getUserInputData().put("industry", "software");
 
-        invokeValidateUserInputs(context);
+        inputValidationService.handleUserInputs(context);
 
         Assert.assertEquals(context.getFlowOrganization().getAttribute("industry"), "software");
         Assert.assertNull(context.getFlowOrganization().getOrganizationName());
@@ -1986,7 +1986,7 @@ public class InputValidationServiceTest {
         context.setGraphConfig(graphConfig);
         context.getUserInputData().put(ORG_NAME_KEY, "Acme Corporation");
 
-        invokeValidateUserInputs(context);
+        inputValidationService.handleUserInputs(context);
 
         Assert.assertNull(context.getFlowOrganization().getOrganizationName(),
                 "An input named like an organization field must not be routed without identifierType.");
@@ -1999,12 +1999,16 @@ public class InputValidationServiceTest {
         FlowExecutionContext context = organizationFlowContext(claimShapedIdentifier);
         context.getUserInputData().put(claimShapedIdentifier, "Acme Corporation");
 
-        invokeValidateUserInputs(context);
+        inputValidationService.handleUserInputs(context);
 
         Assert.assertEquals(context.getFlowOrganization().getAttribute(claimShapedIdentifier),
                 "Acme Corporation",
                 "An input declared as organization data must not be routed to the user claims because "
                         + "its identifier happens to start with the claim URI prefix.");
+        Assert.assertFalse(context.getFlowUser().getClaims().containsKey(claimShapedIdentifier),
+                "Organization data stored on the user would be persisted to their profile.");
+        Assert.assertFalse(context.getFlowUser().getUpdatedClaimUris().contains(claimShapedIdentifier),
+                "Organization data stored on the user would be persisted to their profile.");
     }
 
     @Test(description = "Organization fields nested inside a form component are still resolved.")
@@ -2021,7 +2025,7 @@ public class InputValidationServiceTest {
         context.setGraphConfig(graphConfig);
         context.getUserInputData().put(ORG_NAME_KEY, "Acme Corporation");
 
-        invokeValidateUserInputs(context);
+        inputValidationService.handleUserInputs(context);
 
         Assert.assertEquals(context.getFlowOrganization().getOrganizationName(), "Acme Corporation");
     }
@@ -2040,7 +2044,7 @@ public class InputValidationServiceTest {
         context.setGraphConfig(graphConfig);
         context.getUserInputData().put(ORG_NAME_KEY, "Acme Corporation");
 
-        invokeValidateUserInputs(context);
+        inputValidationService.handleUserInputs(context);
 
         Assert.assertEquals(context.getFlowOrganization().getOrganizationName(), "Acme Corporation");
     }
@@ -2051,7 +2055,7 @@ public class InputValidationServiceTest {
         FlowExecutionContext context = initiateFlowContext();
         context.getUserInputData().put("industry", "software");
 
-        invokeValidateUserInputs(context);
+        inputValidationService.handleUserInputs(context);
 
         Assert.assertTrue(context.getFlowOrganization().getAttributes().isEmpty());
     }
@@ -2093,14 +2097,6 @@ public class InputValidationServiceTest {
         return new StepDTO.Builder()
                 .data(new DataDTO.Builder().components(components).build())
                 .build();
-    }
-
-    private void invokeValidateUserInputs(FlowExecutionContext context) throws Exception {
-
-        Method method = InputValidationService.class.getDeclaredMethod(
-                "validateUserInputs", FlowExecutionContext.class);
-        method.setAccessible(true);
-        method.invoke(inputValidationService, context);
     }
 
     private FlowExecutionContext initiateFlowContext() {

--- a/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
+++ b/components/flow-orchestration-framework/org.wso2.carbon.identity.flow.execution.engine/src/test/java/org/wso2/carbon/identity/flow/execution/engine/validation/InputValidationServiceTest.java
@@ -1990,6 +1990,8 @@ public class InputValidationServiceTest {
 
         Assert.assertNull(context.getFlowOrganization().getOrganizationName(),
                 "An input named like an organization field must not be routed without identifierType.");
+        Assert.assertTrue(context.getFlowOrganization().getAttributes().isEmpty(),
+                "An untyped organization-like input must not be stored as a custom attribute either.");
     }
 
     @Test(description = "A declared organization identifier type wins over a claim URI shaped identifier.")


### PR DESCRIPTION
### Proposed changes in this pull request

Related to [wso2/product-is#28396](https://github.com/wso2/product-is/issues/28396)

Lets a flow collect organization details alongside user details, so flows such as organization
self-registration can gather both in the same step.

- **`FlowOrganization`** (new) - holds the organization details collected during a flow. Name,
  handle and description are fields; anything else the flow collects is kept as a custom attribute.
- **`FlowExecutionContext`** - now carries a `FlowOrganization`, alongside the existing `FlowUser`.
- **`Constants`** - adds the organization identifier keys and the identifier type.
- **`InputValidationService`** - routes inputs marked as organization data onto the flow organization.
- **`InputValidationServiceTest`** - 8 new test executions.

An input is marked as organization data in the flow definition:

```json
"config": {
    "label": "Organization Name",
    "identifier": "organizationName",
    "identifierType": "ORGANIZATION"
}
```

Routing is driven by `identifierType`, not by the identifier name - an input called
`organizationName` without that type is left alone.

### When should this PR be merged

No preconditions; this is self contained.

It adds only the part that collects the data. The part that uses it is a flow executor in
`identity-organization-management-core`, so nothing in this repository reads `FlowOrganization` yet.

### Follow up actions

- `OrganizationProvisioningExecutor` in `identity-organization-management` will consume
  `FlowOrganization` to create an organization from a flow.

### Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
