### PR TITLE
[carbon-identity-framework] Bump Jackson to 2.22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2306,11 +2306,11 @@
         <kaptcha.wso2.version>2.3.0.wso2v1</kaptcha.wso2.version>
         <json.wso2.version>3.0.0.wso2v4</json.wso2.version>
         <json.wso2.version.range>[3.0.0.wso2v1, 4.0.0)</json.wso2.version.range>
-        <com.fasterxml.jackson.version>2.21.2</com.fasterxml.jackson.version>
-        <com.fasterxml.jackson.annotation.version>2.21</com.fasterxml.jackson.annotation.version>
-        <com.fasterxml.jackson.databind.version>2.21.2</com.fasterxml.jackson.databind.version>
-        <com.fasterxml.jackson.cbor.version>2.21.2</com.fasterxml.jackson.cbor.version>
-        <com.fasterxml.jackson.jaxrs-json-provider-version>2.21.2</com.fasterxml.jackson.jaxrs-json-provider-version>
+        <com.fasterxml.jackson.version>2.22.2</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.annotation.version>2.22</com.fasterxml.jackson.annotation.version>
+        <com.fasterxml.jackson.databind.version>2.22.2</com.fasterxml.jackson.databind.version>
+        <com.fasterxml.jackson.cbor.version>2.22.2</com.fasterxml.jackson.cbor.version>
+        <com.fasterxml.jackson.jaxrs-json-provider-version>2.22.2</com.fasterxml.jackson.jaxrs-json-provider-version>
         <com.fasterxml.jackson.annotation.version.range>[2.13.0, 3.0.0)</com.fasterxml.jackson.annotation.version.range>
         <com.fasterxml.jackson.databind.version.range>[2.13.0, 3.0.0)</com.fasterxml.jackson.databind.version.range>
 


### PR DESCRIPTION
## Purpose

Upgrade the Jackson artifacts to the latest stable 2.x release, `2.22.2`.

`2.21.2` is still within the affected range of GHSA-r7wm-3cxj-wff9 (`[2.19.0, 2.21.4)`), which is
the follow-up to CVE-2026-18401 and is described upstream as an incomplete fix for it. `2.22.2` is
the current latest on the 2.x line and is clear of both.

## Approach

Version property bumps only — no code or logic changes.

`pom.xml`:

- `com.fasterxml.jackson.version`: `2.21.2` → `2.22.2`
- `com.fasterxml.jackson.databind.version`: `2.21.2` → `2.22.2`
- `com.fasterxml.jackson.cbor.version`: `2.21.2` → `2.22.2`
- `com.fasterxml.jackson.jaxrs-json-provider-version`: `2.21.2` → `2.22.2`
- `com.fasterxml.jackson.annotation.version`: `2.21` → `2.22`

> `jackson-annotations` follows a two-segment version scheme, so it keeps its own property value.
