### PR TITLE
Add console connection sharing feature config and scope

### DIFF
--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml
@@ -1523,6 +1523,7 @@
             <Read>
                 <Scope name="console:idps_view"/>
                 <Scope name="internal_idp_shared_access_view"/>
+                <Scope name="internal_organization_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>

--- a/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
+++ b/features/api-resource-mgt/org.wso2.carbon.identity.api.resource.mgt.server.feature/resources/api-resource-collection.xml.j2
@@ -1681,6 +1681,7 @@
             <Read>
                 <Scope name="console:idps_view"/>
                 <Scope name="internal_idp_shared_access_view"/>
+                <Scope name="internal_organization_view"/>
             </Read>
         </Scopes>
     </APIResourceCollection>

--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/org.wso2.carbon.identity.core.server.feature.default.json
@@ -1670,6 +1670,19 @@
   "console.branding.scopes.read": ["internal_application_mgt_view"],
   "console.branding.scopes.update": ["internal_branding_preference_update"],
   "console.branding.scopes.delete": ["internal_branding_preference_update"],
+  "console.connection_sharing.enabled": "$ref{connection_sharing.idp.enable}",
+  "console.connection_sharing.scopes.feature": ["console:connectionSharing"],
+  "console.connection_sharing.disabled_features": [],
+  "console.connection_sharing.scopes.create": ["internal_idp_share"],
+  "console.connection_sharing.scopes.read": [
+    "internal_idp_shared_access_view",
+    "internal_organization_view"
+  ],
+  "console.connection_sharing.scopes.update": [
+    "internal_idp_share",
+    "internal_idp_unshare"
+  ],
+  "console.connection_sharing.scopes.delete": ["internal_idp_unshare"],
   "console.consents.enabled": "$ref{consent_mgt.enable_v2_api}",
   "console.consents.scopes.feature": ["console:consents"],
   "console.consents.disabled_features": [],


### PR DESCRIPTION
## Purpose

Add the server-side console feature configuration for **connection (IdP) sharing** and complete the `internal_organization_view` read scope on the `connectionSharing` API resource collection.

## Changes

- **`default.json`** — new `console.connection_sharing.*` feature config (enabled flag references `connection_sharing.idp.enable`, plus feature/CRUD scopes) consumed by the console `deployment.config.json.j2` template.
- **`api-resource-collection.xml` / `.xml.j2`** — add the missing `internal_organization_view` scope to the `<Read>` block of the `connectionSharing` collection, matching the console read scopes.

## Related

- Issue: wso2/product-is#28391
- Console UI PR: wso2/identity-apps#10653
