### PR TITLE
Stop a malformed auth context lookup URL from logging a server error

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2014-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -402,7 +402,7 @@ public class AuthenticationEndpointUtil {
              * that resolves nothing.
              */
             if (log.isDebugEnabled()) {
-                log.debug("Skipping " + HTTP_METHOD_GET + " request: " + backendURL + " is not a valid URL.", e);
+                log.debug("Skipping " + HTTP_METHOD_GET + " request: the backend URL is not valid.");
             }
         } catch (IOException e) {
             log.error("Sending " + HTTP_METHOD_GET + " request to URL : " + backendURL + ", failed.", e);
@@ -431,20 +431,24 @@ public class AuthenticationEndpointUtil {
                     responseString.append(inputLine);
                 }
             }
-        } else if (response.getCode() < HttpStatus.SC_INTERNAL_SERVER_ERROR) {
+        } else if (response.getCode() >= HttpStatus.SC_INTERNAL_SERVER_ERROR) {
+            log.error("Response received from the backendURL " + backendURL + " failed with status " +
+                    response.getCode() + ".");
+        } else if (response.getCode() >= HttpStatus.SC_BAD_REQUEST) {
             /*
-             * The request did not identify anything to read - for example the key it carried is
-             * unknown or malformed. That is decided by the incoming request rather than by a server
-             * side failure, so logging it at error level turns malformed requests into server log
-             * noise. SC_NOT_FOUND was already treated this way.
+             * A client error means the request did not identify anything to read - for example the
+             * key it carried is unknown or malformed. That is decided by the incoming request rather
+             * than by a server side failure, so it is not logged at error level. SC_NOT_FOUND was
+             * already handled here.
              */
             if (log.isDebugEnabled()) {
                 log.debug("Response received from the backendURL " + backendURL + " with status " +
                         response.getCode() + ".");
             }
         } else {
-            log.error("Response received from the backendURL " + backendURL + " failed with status " +
-                    response.getCode() + ".");
+            // Informational and redirection responses are not expected from this API.
+            log.error("Unexpected response with status " + response.getCode() +
+                    " received from the backendURL " + backendURL + ".");
         }
 
         return responseString.toString();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtil.java
@@ -393,6 +393,17 @@ public class AuthenticationEndpointUtil {
                 return handleHttpResponse(response, backendURL);
             });
 
+        } catch (IllegalArgumentException e) {
+            /*
+             * The URL was built from a request parameter, so a malformed request makes it unparsable.
+             * URI.create() reports that with an unchecked exception, which no caller of this method
+             * catches, so it used to unwind out of the servlet and be logged with its stack trace.
+             * There are no properties to read for such a URL, which is the same outcome as a lookup
+             * that resolves nothing.
+             */
+            if (log.isDebugEnabled()) {
+                log.debug("Skipping " + HTTP_METHOD_GET + " request: " + backendURL + " is not a valid URL.", e);
+            }
         } catch (IOException e) {
             log.error("Sending " + HTTP_METHOD_GET + " request to URL : " + backendURL + ", failed.", e);
         }
@@ -420,7 +431,13 @@ public class AuthenticationEndpointUtil {
                     responseString.append(inputLine);
                 }
             }
-        } else if (response.getCode() == HttpStatus.SC_NOT_FOUND) {
+        } else if (response.getCode() < HttpStatus.SC_INTERNAL_SERVER_ERROR) {
+            /*
+             * The request did not identify anything to read - for example the key it carried is
+             * unknown or malformed. That is decided by the incoming request rather than by a server
+             * side failure, so logging it at error level turns malformed requests into server log
+             * noise. SC_NOT_FOUND was already treated this way.
+             */
             if (log.isDebugEnabled()) {
                 log.debug("Response received from the backendURL " + backendURL + " with status " +
                         response.getCode() + ".");

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtil.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/main/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtil.java
@@ -431,24 +431,14 @@ public class AuthenticationEndpointUtil {
                     responseString.append(inputLine);
                 }
             }
-        } else if (response.getCode() >= HttpStatus.SC_INTERNAL_SERVER_ERROR) {
-            log.error("Response received from the backendURL " + backendURL + " failed with status " +
-                    response.getCode() + ".");
-        } else if (response.getCode() >= HttpStatus.SC_BAD_REQUEST) {
-            /*
-             * A client error means the request did not identify anything to read - for example the
-             * key it carried is unknown or malformed. That is decided by the incoming request rather
-             * than by a server side failure, so it is not logged at error level. SC_NOT_FOUND was
-             * already handled here.
-             */
+        } else if (response.getCode() == HttpStatus.SC_NOT_FOUND) {
             if (log.isDebugEnabled()) {
                 log.debug("Response received from the backendURL " + backendURL + " with status " +
                         response.getCode() + ".");
             }
         } else {
-            // Informational and redirection responses are not expected from this API.
-            log.error("Unexpected response with status " + response.getCode() +
-                    " received from the backendURL " + backendURL + ".");
+            log.error("Response received from the backendURL " + backendURL + " failed with status " +
+                    response.getCode() + ".");
         }
 
         return responseString.toString();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/test/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtilTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/test/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtilTest.java
@@ -16,6 +16,8 @@
 
 package org.wso2.carbon.identity.application.authentication.endpoint.util;
 
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.commons.lang.StringUtils;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.axis2.engine.AxisConfiguration;
 import org.mockito.Mock;
@@ -29,13 +31,17 @@ import org.wso2.carbon.identity.application.authentication.endpoint.util.bean.Us
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.common.testng.WithAxisConfiguration;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.HTTPClientManager;
 import org.wso2.carbon.identity.core.internal.component.IdentityCoreServiceComponent;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.wso2.carbon.user.core.UserCoreConstants.DOMAIN_SEPARATOR;
@@ -269,5 +275,34 @@ public class AuthenticationEndpointUtilTest {
             Assert.assertEquals(AuthenticationEndpointUtil.isConsentPageRedirectParamsAllowed(),
                     allowConsentPageRedirectParams);
         }
+    }
+
+    @DataProvider(name = "malformedBackendURLProvider")
+    public Object[][] provideMalformedBackendURLs() {
+
+        // These URLs are built by appending a request parameter to an API path, so a malformed
+        // request produces a path that java.net.URI cannot parse.
+        return new Object[][]{
+                {"https://localhost:9443/api/identity/auth/v1.1/data/AuthRequestKey/ehezr\"m628d"},
+                {"https://localhost:9443/api/identity/auth/v1.1/data/OauthConsentKey/a b"},
+                {"https://localhost:9443/api/identity/auth/v1.1/context/a|b"},
+        };
+    }
+
+    @Test(dataProvider = "malformedBackendURLProvider")
+    public void testSendGetRequestWithMalformedURL(String backendURL) {
+
+        CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+        try (MockedStatic<HTTPClientManager> httpClientManager = mockStatic(HTTPClientManager.class)) {
+            httpClientManager.when(() -> HTTPClientManager.executeWithHttpClient(any()))
+                    .thenAnswer(invocation -> ((HTTPClientManager.HttpClientOperation<?, ?>)
+                            invocation.getArgument(0)).execute(httpClient));
+
+            // Must not throw. The unparsable URL used to surface as an unchecked
+            // IllegalArgumentException from URI.create(), which unwound out of the servlet.
+            Assert.assertEquals(AuthenticationEndpointUtil.sendGetRequest(backendURL), StringUtils.EMPTY);
+        }
+        // Nothing was sent, so there is no response to read.
+        verifyNoInteractions(httpClient);
     }
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/test/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtilTest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint.util/src/test/java/org/wso2/carbon/identity/application/authentication/endpoint/util/AuthenticationEndpointUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017-2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Issue

The authentication portal looks up cached authentication parameters by appending a request parameter
to the auth data API path — `AuthParameterFilter` for `sessionDataKey`, `sessionDataKeyConsent` and
`errorKey`, and `generic-exception-response.jsp`, `handle-multiple-sessions.jsp` and
`sms_otp_verify.jsp` for `authFlowId`, `promptId` and `sessionDataKey`. When the parameter carries a
character that is not legal in a URI path (a quote, a space, a pipe), the URL cannot be parsed and
`URI.create()` reports it with an unchecked `IllegalArgumentException`. No caller catches that, so it
unwinds out of the servlet and is logged with its stack trace:

```
ERROR {org.wso2.carbon.tomcat.ext.valves.CompositeValve} - Could not handle request: /authenticationendpoint/login.do
java.lang.IllegalArgumentException: Illegal character in path at index 71:
  https://localhost:9443/api/identity/auth/v1.1/data/AuthRequestKey/ehezr"m628d
```

One malformed request therefore adds a server-log ERROR on pages that receive malformed requests
routinely, which is enough to trip ERROR-count monitoring.

## Fix

`sendGetRequest` catches `IllegalArgumentException` and returns no properties — the same outcome as a
lookup that resolves nothing. A URL that cannot be parsed cannot be sent, so there is nothing else to
do with it. Handling it there rather than at each call site covers the filter and all three JSPs,
since every one of those lookups already passes through this method.

Verified on a 7.4.0-SNAPSHOT pack: 15 malformed requests across those five parameters produced 24
ERROR lines before the change and 0 after. A normal OIDC login is unaffected.
