### PR TITLE
Fix application certificate deletion/update not being transactional

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+    {
+        "type": "java",
+        "name": "Java Remote Debugger",
+        "request": "attach",
+        "hostName": "127.0.0.1",
+        "port": "5005"
+    }
+    ]
+}

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/dao/impl/ApplicationDAOImpl.java
@@ -629,7 +629,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         // you can change application name, description, isSasApp...
         updateBasicApplicationData(serviceProvider, connection);
 
-        updateApplicationCertificate(serviceProvider, tenantID);
+        updateApplicationCertificate(serviceProvider, tenantID, connection);
 
         updateInboundProvisioningConfiguration(applicationId, serviceProvider.getInboundProvisioningConfig(),
                 connection);
@@ -670,10 +670,10 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         }
 
         updateConfigurationsAsServiceProperties(serviceProvider);
-        if (ArrayUtils.isNotEmpty(serviceProvider.getSpProperties())) {
-            ServiceProviderProperty[] spProperties = serviceProvider.getSpProperties();
-            updateServiceProviderProperties(connection, applicationId, Arrays.asList(spProperties), tenantID);
-        }
+        ServiceProviderProperty[] spPropertiesArr = serviceProvider.getSpProperties();
+        List<ServiceProviderProperty> spProperties = spPropertiesArr == null
+                ? Collections.emptyList() : Arrays.asList(spPropertiesArr);
+        updateServiceProviderProperties(connection, applicationId, spProperties, tenantID);
 
         // Will be supported with 'Advance Consent Management Feature'.
             /*
@@ -798,19 +798,21 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
      *
      * @param serviceProvider Service provider object.
      * @param tenantID        Tenant ID.
+     * @param connection      The connection used for the enclosing application-update transaction.
      * @throws IdentityApplicationManagementException If an error occurs while updating the certificate.
      */
-    private void updateApplicationCertificate(ServiceProvider serviceProvider, int tenantID)
+    private void updateApplicationCertificate(ServiceProvider serviceProvider, int tenantID, Connection connection)
             throws IdentityApplicationManagementException {
 
         if (StringUtils.isBlank(serviceProvider.getCertificateContent())) {
             // Remove the certificate reference property if exists and remove the certificate.
-            removeCertificateReferenceAndDelete(serviceProvider, tenantID);
+            removeCertificateReferenceAndDelete(serviceProvider, tenantID, connection);
         } else {
             String certificateReferenceIdString = getCertificateReferenceID(serviceProvider.getSpProperties());
             if (certificateReferenceIdString != null) {
                 // If there is a reference, update the relevant existing certificate record.
-                updateCertificate(certificateReferenceIdString, serviceProvider.getCertificateContent(), tenantID);
+                updateCertificate(certificateReferenceIdString, serviceProvider.getCertificateContent(), tenantID,
+                        connection);
             } else {
                 // There is no existing reference. Persisting the certificate as a new record.
                 persistApplicationCertificate(serviceProvider, tenantID);
@@ -820,13 +822,15 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
 
     /**
      * Removes the certificate reference property from the given service provider object and deletes the certificate
-     * record from the database.
+     * record from the database, on the given connection so the delete becomes part of the caller's transaction.
      *
      * @param serviceProvider Service provider object.
      * @param tenantID        Tenant ID.
+     * @param connection      Connection of the enclosing application-update transaction.
      * @throws IdentityApplicationManagementException If an error occurs while removing the certificate reference.
      */
-    private void removeCertificateReferenceAndDelete(ServiceProvider serviceProvider, int tenantID)
+    private void removeCertificateReferenceAndDelete(ServiceProvider serviceProvider, int tenantID,
+                                                      Connection connection)
             throws IdentityApplicationManagementException {
 
         ServiceProviderProperty[] spProperties = serviceProvider.getSpProperties();
@@ -844,7 +848,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
             int certificateID = Integer.parseInt(spProperties[certificateReferenceIndex].getValue());
 
             serviceProvider.setSpProperties(getFilteredSpProperties(spProperties, certificateReferenceIndex));
-            deleteCertificate(certificateID, IdentityTenantUtil.getTenantDomain(tenantID));
+            deleteCertificate(certificateID, IdentityTenantUtil.getTenantDomain(tenantID), connection);
         }
     }
 
@@ -868,20 +872,23 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
     }
 
     /**
-     * Update the existing certificate record with the given certificate ID.
+     * Update the existing certificate record with the given certificate ID, on the given connection so the update
+     * becomes part of the caller's transaction.
      *
      * @param certificateId      Certificate ID.
      * @param certificateContent Certificate content to be updated.
      * @param tenantID           Tenant ID.
+     * @param connection         Connection of the enclosing application-update transaction.
      * @throws IdentityApplicationManagementException If an error occurs while updating the certificate.
      */
-    private void updateCertificate(String certificateId, String certificateContent, int tenantID)
+    private void updateCertificate(String certificateId, String certificateContent, int tenantID,
+                                   Connection connection)
             throws IdentityApplicationManagementException {
 
         try {
             ApplicationManagementServiceComponentHolder.getInstance().getApplicationCertificateMgtService()
                     .updateCertificateContent(Integer.parseInt(certificateId), certificateContent,
-                            IdentityTenantUtil.getTenantDomain(tenantID));
+                            IdentityTenantUtil.getTenantDomain(tenantID), connection);
         } catch (CertificateMgtClientException e) {
             throw new IdentityApplicationManagementClientException(INVALID_REQUEST.getCode(), e.getDescription(), e);
         } catch (CertificateMgtException e) {
@@ -4345,7 +4352,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         try {
 
             // Delete the application certificate if there is any.
-            deleteCertificate(appName, tenantID);
+            deleteCertificate(appName, tenantID, connection);
 
             // First, delete all the clients of the application
             int applicationID = getApplicationIDByName(appName, tenantID, connection);
@@ -4716,7 +4723,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
      * @throws IdentityApplicationManagementException If an error occurred while retrieving the application or
      *                                                deleting the certificate.
      */
-    private void deleteCertificate(String appName, int tenantID) throws UserStoreException,
+    private void deleteCertificate(String appName, int tenantID, Connection connection) throws UserStoreException,
             IdentityApplicationManagementException {
 
         String tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
@@ -4731,7 +4738,8 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         String certificateReferenceID = getCertificateReferenceID(application.getSpProperties());
 
         if (certificateReferenceID != null) {
-            deleteCertificate(Integer.parseInt(certificateReferenceID), IdentityTenantUtil.getTenantDomain(tenantID));
+            deleteCertificate(Integer.parseInt(certificateReferenceID), IdentityTenantUtil.getTenantDomain(tenantID),
+                    connection);
         }
     }
 
@@ -4747,6 +4755,26 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         try {
             ApplicationManagementServiceComponentHolder.getInstance().getApplicationCertificateMgtService()
                     .deleteCertificate(id, tenantDomain);
+        } catch (CertificateMgtException e) {
+            throw new IdentityApplicationManagementException("Error while deleting certificate", e);
+        }
+    }
+
+    /**
+     * Deletes the certificate for given ID from the database, on the given connection, so that the delete
+     * commits or rolls back together with the enclosing application transaction instead of independently.
+     *
+     * @param id           Certificate ID.
+     * @param tenantDomain Tenant domain.
+     * @param connection   Connection of the enclosing application transaction.
+     * @throws IdentityApplicationManagementException If an error occurred while deleting the certificate.
+     */
+    private void deleteCertificate(int id, String tenantDomain, Connection connection)
+            throws IdentityApplicationManagementException {
+
+        try {
+            ApplicationManagementServiceComponentHolder.getInstance().getApplicationCertificateMgtService()
+                    .deleteCertificate(id, tenantDomain, connection);
         } catch (CertificateMgtException e) {
             throw new IdentityApplicationManagementException("Error while deleting certificate", e);
         }
@@ -5932,7 +5960,7 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
 
             if (application != null) {
                 // Delete the application certificate if there is any
-                deleteApplicationCertificate(application, tenantDomain);
+                deleteApplicationCertificate(application, tenantDomain, connection);
                 // Delete android attestation service credentials if there is any
                 deleteAndroidAttestationCredentials(application);
 
@@ -6736,6 +6764,24 @@ public class ApplicationDAOImpl extends AbstractApplicationDAOImpl implements Pa
         String certificateReferenceID = getCertificateReferenceID(application.getSpProperties());
         if (certificateReferenceID != null) {
             deleteCertificate(Integer.parseInt(certificateReferenceID), tenantDomain);
+        }
+    }
+
+    /**
+     * Deletes the application's certificate, if any, on the given connection so the delete commits or rolls
+     * back together with the enclosing application-delete transaction.
+     *
+     * @param application  Service provider object of the application being deleted.
+     * @param tenantDomain Tenant domain.
+     * @param connection   Connection of the enclosing application-delete transaction.
+     * @throws IdentityApplicationManagementException If an error occurred while deleting the certificate.
+     */
+    private void deleteApplicationCertificate(ServiceProvider application, String tenantDomain, Connection connection)
+            throws IdentityApplicationManagementException {
+
+        String certificateReferenceID = getCertificateReferenceID(application.getSpProperties());
+        if (certificateReferenceID != null) {
+            deleteCertificate(Integer.parseInt(certificateReferenceID), tenantDomain, connection);
         }
     }
 

--- a/components/certificate-mgt/org.wso2.carbon.identity.certificate.management/src/main/java/org/wso2/carbon/identity/certificate/management/dao/ApplicationCertificateManagementDAO.java
+++ b/components/certificate-mgt/org.wso2.carbon.identity.certificate.management/src/main/java/org/wso2/carbon/identity/certificate/management/dao/ApplicationCertificateManagementDAO.java
@@ -21,6 +21,8 @@ package org.wso2.carbon.identity.certificate.management.dao;
 import org.wso2.carbon.identity.certificate.management.exception.CertificateMgtException;
 import org.wso2.carbon.identity.certificate.management.model.Certificate;
 
+import java.sql.Connection;
+
 /**
  * This interface defines the Application Certificate Management DAO.
  * This supports using auto-incremented IDs for certificate management operations in application-mgt.
@@ -78,6 +80,24 @@ public interface ApplicationCertificateManagementDAO {
             throws CertificateMgtException;
 
     /**
+     * Update a certificate's content with given id, executing on the given connection instead of a new,
+     * independently committed one.
+     *
+     * @param certificateId      Certificate ID.
+     * @param certificateContent Certificate content.
+     * @param tenantId           Tenant Id.
+     * @param connection         Connection on which the update should be executed. The caller owns the connection's
+     *                           lifecycle (commit/rollback/close).
+     * @throws CertificateMgtException If an error occurs while updating the certificate.
+     */
+    @Deprecated
+    default void updateCertificateContent(int certificateId, String certificateContent, int tenantId,
+                                          Connection connection) throws CertificateMgtException {
+
+        updateCertificateContent(certificateId, certificateContent, tenantId);
+    }
+
+    /**
      * Delete a certificate with given id.
      *
      * @param certificateId Certificate ID.
@@ -86,4 +106,21 @@ public interface ApplicationCertificateManagementDAO {
      */
     @Deprecated
     void deleteCertificate(int certificateId, int tenantId) throws CertificateMgtException;
+
+    /**
+     * Delete a certificate with given id, executing on the given connection instead of a new, independently
+     * committed one.
+     *
+     * @param certificateId Certificate ID.
+     * @param tenantId      Tenant Id.
+     * @param connection    Connection on which the delete should be executed. The caller owns the connection's
+     *                      lifecycle (commit/rollback/close).
+     * @throws CertificateMgtException If an error occurs while deleting the certificate.
+     */
+    @Deprecated
+    default void deleteCertificate(int certificateId, int tenantId, Connection connection)
+            throws CertificateMgtException {
+
+        deleteCertificate(certificateId, tenantId);
+    }
 }

--- a/components/certificate-mgt/org.wso2.carbon.identity.certificate.management/src/main/java/org/wso2/carbon/identity/certificate/management/dao/impl/ApplicationCertificateManagementDAOImpl.java
+++ b/components/certificate-mgt/org.wso2.carbon.identity.certificate.management/src/main/java/org/wso2/carbon/identity/certificate/management/dao/impl/ApplicationCertificateManagementDAOImpl.java
@@ -37,6 +37,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 
 /**
  * This class is the implementation of the Application Certificate Management DAO.
@@ -159,6 +162,24 @@ public class ApplicationCertificateManagementDAOImpl implements ApplicationCerti
 
     @Override
     @Deprecated
+    public void updateCertificateContent(int certificateId, String certificateContent, int tenantId,
+                                         Connection connection) throws CertificateMgtException {
+
+        try (PreparedStatement preparedStatement =
+                     connection.prepareStatement(ApplicationCertificateMgtSQLQueries.UPDATE_CERTIFICATE_CONTENT)) {
+            InputStream certByteStream = getCertificateByteStream(certificateContent);
+            preparedStatement.setBinaryStream(1, certByteStream, certByteStream.available());
+            preparedStatement.setInt(2, certificateId);
+            preparedStatement.setInt(3, tenantId);
+            preparedStatement.executeUpdate();
+        } catch (SQLException | IOException e) {
+            CertificateMgtExceptionHandler.throwServerException(CertificateMgtErrors.ERROR_WHILE_UPDATING_CERTIFICATE,
+                    e, String.valueOf(certificateId));
+        }
+    }
+
+    @Override
+    @Deprecated
     public void deleteCertificate(int certificateId, int tenantId) throws CertificateMgtException {
 
         NamedJdbcTemplate jdbcTemplate = new NamedJdbcTemplate(IdentityDatabaseUtil.getDataSource());
@@ -172,6 +193,22 @@ public class ApplicationCertificateManagementDAOImpl implements ApplicationCerti
                 return null;
             });
         } catch (TransactionException e) {
+            CertificateMgtExceptionHandler.throwServerException(CertificateMgtErrors.ERROR_WHILE_DELETING_CERTIFICATE,
+                    e, String.valueOf(certificateId));
+        }
+    }
+
+    @Override
+    @Deprecated
+    public void deleteCertificate(int certificateId, int tenantId, Connection connection)
+            throws CertificateMgtException {
+
+        try (PreparedStatement preparedStatement =
+                     connection.prepareStatement(ApplicationCertificateMgtSQLQueries.DELETE_CERTIFICATE)) {
+            preparedStatement.setInt(1, certificateId);
+            preparedStatement.setInt(2, tenantId);
+            preparedStatement.executeUpdate();
+        } catch (SQLException e) {
             CertificateMgtExceptionHandler.throwServerException(CertificateMgtErrors.ERROR_WHILE_DELETING_CERTIFICATE,
                     e, String.valueOf(certificateId));
         }

--- a/components/certificate-mgt/org.wso2.carbon.identity.certificate.management/src/main/java/org/wso2/carbon/identity/certificate/management/dao/impl/CacheBackedApplicationCertificateMgtDAO.java
+++ b/components/certificate-mgt/org.wso2.carbon.identity.certificate.management/src/main/java/org/wso2/carbon/identity/certificate/management/dao/impl/CacheBackedApplicationCertificateMgtDAO.java
@@ -27,6 +27,8 @@ import org.wso2.carbon.identity.certificate.management.dao.ApplicationCertificat
 import org.wso2.carbon.identity.certificate.management.exception.CertificateMgtException;
 import org.wso2.carbon.identity.certificate.management.model.Certificate;
 
+import java.sql.Connection;
+
 /**
  * This class represents the caching layer of Application Certificate Management.
  * This supports using auto-incremented IDs for certificate management operations in application-mgt.
@@ -105,9 +107,28 @@ public class CacheBackedApplicationCertificateMgtDAO implements ApplicationCerti
 
     @Override
     @Deprecated
+    public void updateCertificateContent(int certificateId, String certificateContent, int tenantId,
+                                         Connection connection) throws CertificateMgtException {
+
+        certificateCacheById.clearCacheEntry(new CertificateIdCacheKey(String.valueOf(certificateId)), tenantId);
+        applicationCertificateMgtDAO.updateCertificateContent(certificateId, certificateContent, tenantId,
+                connection);
+    }
+
+    @Override
+    @Deprecated
     public void deleteCertificate(int certificateId, int tenantId) throws CertificateMgtException {
 
         certificateCacheById.clearCacheEntry(new CertificateIdCacheKey(String.valueOf(certificateId)), tenantId);
         applicationCertificateMgtDAO.deleteCertificate(certificateId, tenantId);
+    }
+
+    @Override
+    @Deprecated
+    public void deleteCertificate(int certificateId, int tenantId, Connection connection)
+            throws CertificateMgtException {
+
+        certificateCacheById.clearCacheEntry(new CertificateIdCacheKey(String.valueOf(certificateId)), tenantId);
+        applicationCertificateMgtDAO.deleteCertificate(certificateId, tenantId, connection);
     }
 }

--- a/components/certificate-mgt/org.wso2.carbon.identity.certificate.management/src/main/java/org/wso2/carbon/identity/certificate/management/service/ApplicationCertificateManagementService.java
+++ b/components/certificate-mgt/org.wso2.carbon.identity.certificate.management/src/main/java/org/wso2/carbon/identity/certificate/management/service/ApplicationCertificateManagementService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -20,6 +20,8 @@ package org.wso2.carbon.identity.certificate.management.service;
 
 import org.wso2.carbon.identity.certificate.management.exception.CertificateMgtException;
 import org.wso2.carbon.identity.certificate.management.model.Certificate;
+
+import java.sql.Connection;
 
 /**
  * Interface for managing trusted certificates of applications of a tenant.
@@ -76,6 +78,24 @@ public interface ApplicationCertificateManagementService {
             throws CertificateMgtException;
 
     /**
+     * Update a certificate's content with given id, executing on the given connection instead of a new,
+     * independently committed one.
+     *
+     * @param certificateId      Certificate ID.
+     * @param certificateContent Certificate content.
+     * @param tenantDomain       Tenant domain.
+     * @param connection         Connection on which the update should be executed. The caller owns the connection's
+     *                           lifecycle (commit/rollback/close).
+     * @throws CertificateMgtException If an error occurs while updating the certificate.
+     */
+    @Deprecated
+    default void updateCertificateContent(int certificateId, String certificateContent, String tenantDomain,
+                                          Connection connection) throws CertificateMgtException {
+
+        updateCertificateContent(certificateId, certificateContent, tenantDomain);
+    }
+
+    /**
      * Delete a certificate with given id.
      *
      * @param certificateId Certificate ID.
@@ -84,4 +104,21 @@ public interface ApplicationCertificateManagementService {
      */
     @Deprecated
     void deleteCertificate(int certificateId, String tenantDomain) throws CertificateMgtException;
+
+    /**
+     * Delete a certificate with given id, executing on the given connection instead of a new, independently
+     * committed one.
+     *
+     * @param certificateId Certificate ID.
+     * @param tenantDomain  Tenant domain.
+     * @param connection    Connection on which the delete should be executed. The caller owns the connection's
+     *                      lifecycle (commit/rollback/close).
+     * @throws CertificateMgtException If an error occurs while deleting the certificate.
+     */
+    @Deprecated
+    default void deleteCertificate(int certificateId, String tenantDomain, Connection connection)
+            throws CertificateMgtException {
+
+        deleteCertificate(certificateId, tenantDomain);
+    }
 }

--- a/components/certificate-mgt/org.wso2.carbon.identity.certificate.management/src/main/java/org/wso2/carbon/identity/certificate/management/service/impl/ApplicationCertificateManagementServiceImpl.java
+++ b/components/certificate-mgt/org.wso2.carbon.identity.certificate.management/src/main/java/org/wso2/carbon/identity/certificate/management/service/impl/ApplicationCertificateManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.certificate.management.util.CertificateMgtExcept
 import org.wso2.carbon.identity.certificate.management.util.CertificateValidator;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 
+import java.sql.Connection;
 import java.util.UUID;
 
 /**
@@ -155,6 +156,27 @@ public class ApplicationCertificateManagementServiceImpl implements ApplicationC
     }
 
     /**
+     * Update a certificate with given id, executing on the given connection so the update can participate in a
+     * caller-managed transaction.
+     *
+     * @param certificateId      Certificate ID.
+     * @param certificateContent Certificate content.
+     * @param tenantDomain       Tenant domain.
+     * @param connection         Connection on which the update should be executed.
+     * @throws CertificateMgtException If an error occurs while updating the certificate.
+     */
+    @Override
+    @Deprecated
+    public void updateCertificateContent(int certificateId, String certificateContent, String tenantDomain,
+                                         Connection connection) throws CertificateMgtException {
+
+        LOG.debug("Updating certificate with id: " + certificateId);
+        doPreUpdateValidations(certificateId, certificateContent, tenantDomain);
+        CACHE_BACKED_DAO.updateCertificateContent(certificateId, certificateContent,
+                IdentityTenantUtil.getTenantId(tenantDomain), connection);
+    }
+
+    /**
      * Delete a certificate with given id.
      *
      * @param certificateId Certificate ID.
@@ -167,6 +189,24 @@ public class ApplicationCertificateManagementServiceImpl implements ApplicationC
 
         LOG.debug("Deleting certificate with id: " + certificateId);
         CACHE_BACKED_DAO.deleteCertificate(certificateId, IdentityTenantUtil.getTenantId(tenantDomain));
+    }
+
+    /**
+     * Delete a certificate with given id, executing on the given connection so the delete can participate in a
+     * caller-managed transaction.
+     *
+     * @param certificateId Certificate ID.
+     * @param tenantDomain  Tenant domain.
+     * @param connection    Connection on which the delete should be executed.
+     * @throws CertificateMgtException If an error occurs while deleting the certificate.
+     */
+    @Override
+    @Deprecated
+    public void deleteCertificate(int certificateId, String tenantDomain, Connection connection)
+            throws CertificateMgtException {
+
+        LOG.debug("Deleting certificate with id: " + certificateId);
+        CACHE_BACKED_DAO.deleteCertificate(certificateId, IdentityTenantUtil.getTenantId(tenantDomain), connection);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Application certificate delete/update ran on its own, independently committed connection instead of the enclosing application transaction's connection.
- If a later step in that transaction failed and rolled back, the `SP_METADATA` `CERTIFICATE` reference survived while the `IDN_CERTIFICATE` row it pointed to was already deleted/updated, permanently breaking reads/updates/deletes of the affected application.
- Threads the caller's `Connection` through `ApplicationCertificateManagementService`/DAO so certificate writes commit and roll back together with the application transaction.

Fixes wso2/product-is#28238