### PR TITLE
Fix UserClaimsAuditLogger dropping identity claims and silently disabling itself

### DIFF
--- a/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserClaimsAuditLogger.java
+++ b/components/user-mgt/org.wso2.carbon.user.mgt/src/main/java/org/wso2/carbon/user/mgt/listeners/UserClaimsAuditLogger.java
@@ -176,8 +176,8 @@ public class UserClaimsAuditLogger extends AbstractIdentityUserOperationEventLis
             Map<String, String> addedClaims = new HashMap<>();
             Map<String, String> updatedClaims = new HashMap<>();
             Map<String, String> removedClaims = new HashMap<>();
-            Map<String, String> loggableClaims = userStoreManager.getUserClaimValues(userName, loggableClaimURIs,
-                    DEFAULT);
+            Map<String, String> loggableClaims = userStoreManager.getUserClaimValues(userName,
+                    loggableClaimURIs.clone(), DEFAULT);
             resolveLoggableClaims(loggableClaims);
 
             for (Map.Entry<String, String> entry : loggableClaims.entrySet()) {
@@ -243,8 +243,8 @@ public class UserClaimsAuditLogger extends AbstractIdentityUserOperationEventLis
     private void logClaims(String userName, String action, UserStoreManager userStoreManager) {
 
         try {
-            Map<String, String> loggableClaims = userStoreManager.getUserClaimValues(userName, loggableClaimURIs,
-                    DEFAULT);
+            Map<String, String> loggableClaims = userStoreManager.getUserClaimValues(userName,
+                    loggableClaimURIs.clone(), DEFAULT);
             if (MapUtils.isNotEmpty(loggableClaims)) {
                 if (LoggerUtils.isLogMaskingEnable) {
                     audit.info(String.format(AUDIT_MESSAGE, ListenerUtils.getInitiatorFromContext(), action, LoggerUtils


### PR DESCRIPTION
## Purpose

`UserClaimsAuditLogger` never logs claims under the `http://wso2.org/claims/identity/` namespace, and after the first claim update it stops logging **any** claim until the server is restarted.

Reproduced on IS 7.1.0 with:

```toml
[event.default_listener.user_claim_audit_logger]
enable = true
LogUpdatedClaimsOnly = true

[audit.log.loggable_user_claim]
claims = ["http://wso2.org/claims/identity/totpEnabled","http://wso2.org/claims/identity/accountLocked","http://wso2.org/claims/givenname"]
```

Three successive SCIM2 PATCH updates to one user:

| Update | Before this change |
|---|---|
| 1. `totpEnabled=true` + `givenname` | `Updated Claims : { ".../givenname" : "Beta" }` — identity claim silently absent |
| 2. `totpEnabled=false` + `accountLocked=true` + `givenname` | no audit line at all |
| 3. `givenname` only (no identity claim in the payload) | no audit line at all |

The claim updates themselves all succeed and return HTTP 200, so the failure is silent from the caller's point of view. `wso2carbon.log` shows:

```
ERROR {org.wso2.carbon.user.mgt.listeners.UserClaimsAuditLogger} - Error occurred while logging updated user claim changes.
...
Caused by: java.lang.NullPointerException: Cannot invoke "String.contains(java.lang.CharSequence)" because "claim" is null
	at org.wso2.carbon.identity.governance.listener.IdentityStoreEventListener.doPostGetUserClaimValues(IdentityStoreEventListener.java:308)
	at org.wso2.carbon.user.core.common.AbstractUserStoreManager.getUserClaimValues(AbstractUserStoreManager.java:2343)
	at org.wso2.carbon.user.mgt.listeners.UserClaimsAuditLogger.logUpdatedClaims(UserClaimsAuditLogger.java:181)
	at org.wso2.carbon.user.mgt.listeners.UserClaimsAuditLogger.doPreSetUserClaimValues(UserClaimsAuditLogger.java:127)
```

## Root cause

`logUpdatedClaims()` and `logClaims()` pass the listener's own `loggableClaimURIs` field straight into `getUserClaimValues(...)`. That field is initialised once, in `UserMgtDSComponent`, on a single registered listener instance.

`AbstractUserStoreManager.getUserClaimValues` is built around pre-listeners filtering the claim array **in place** — it clones the array into `allClaims` up front so post-listeners still see the full list, then calls `removeNullElements()` before the user store read. `IdentityStoreEventListener.doPreGetUserClaimValues` uses that contract to keep identity claims away from the user store, compacting the array and nulling the tail.

Because the array handed in is the listener's long-lived field rather than a copy, that filtering mutates it permanently:

1. Every `.../claims/identity/*` URI is removed from the configured loggable list on the first call, so the "added claims" loop over `loggableClaimURIs` can no longer see them — the identity claim is missing even from the very first update.
2. The field is left with trailing `null` entries, so on every subsequent call `doPostGetUserClaimValues` hits an unguarded `claim.contains(...)`. `callSecure` wraps the NPE as a `UserStoreException`, `logUpdatedClaims` catches it, and the whole audit line is dropped — including non-identity claims.

The mutation itself is correct behaviour for the pre-listener contract (see wso2/product-is#20490 and wso2-extensions/identity-governance#827); the defect is passing a shared, long-lived array into an API that is expected to mutate its argument.

## Fix

Pass a copy at both call sites, so the configured list is never mutated.

## Testing

Verified as an A/B on IS 7.1.0 GA. Both runs use a fresh extract of the same pack and byte-identical audit-logger configuration (one script, `vanilla` vs `patched` argument), so the only variable is the presence of the rebuilt `org.wso2.carbon.user.mgt` bundle in `repository/components/patches/patch9999/`. `org.wso2.carbon.user.mgt` was built at the version the pack ships (7.8.23) and the patch was confirmed loaded (`Patch verification successfully completed`) in the patched run and absent in the stock run.

Same user, three successive SCIM2 PATCH updates, no restart in between:

| Update | Stock 7.1.0 | With this change |
|---|---|---|
| 1. `totpEnabled=true` + `givenname` | `Added : { }`, `Updated : { ".../givenname" : "Beta" }` — identity claim absent | `Added : { ".../identity/totpEnabled" : "true" }`, `Updated : { ".../givenname" : "Beta" }` |
| 2. `totpEnabled=false` + `accountLocked=true` + `givenname` | no audit line | `Added : { ".../identity/accountLocked" : "true" }`, `Updated : { ".../identity/totpEnabled" : "false" , ".../givenname" : "Gamma" }` |
| 3. `givenname` only | no audit line | `Updated : { ".../givenname" : "Delta" }` |
| `NullPointerException` / `Error occurred while logging updated user claim changes` in `wso2carbon.log` | 6 / 3 | 0 / 0 |

Every PATCH returns HTTP 200 in both runs and the claim values are written either way, so on the stock pack the lost audit entries are invisible to the caller. The exact error counts vary between runs with how many nested `setUserClaimValues` calls the account-lock handler makes; what is stable is that all three updates lose their audit line before the change and none do after it.

A claim whose value is unchanged is still correctly omitted from the diff after the change, so the added/updated/removed comparison is unaffected.

Setting `[event.default_listener.governance_identity_store] enable_hybrid_data_store = true` also restores the audit lines, since it makes `doPreGetUserClaimValues` return before the filtering. That independently confirms the cause, but it reintroduces what product-is#20490 fixed and so is not a general workaround.

## Related

A follow-up null guard in `IdentityStoreEventListener.doPostGetUserClaimValues` is worth adding separately in `wso2-extensions/identity-governance`, so that any other caller whose array was compacted by a pre-listener cannot trip the same NPE. It is not required for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
