### PR TITLE
Add tokenExchange compatibility settings for scope restriction

### DIFF
--- a/features/compatibility-settings-mgt/org.wso2.carbon.identity.compatibility.settings.management.server.feature/resources/identity/compatibilitysettings/compatibility-settings-metadata.json.j2
+++ b/features/compatibility-settings-mgt/org.wso2.carbon.identity.compatibility.settings.management.server.feature/resources/identity/compatibilitysettings/compatibility-settings-metadata.json.j2
@@ -85,5 +85,17 @@
         "targetValue" : {{compatibility_setting.dcr.decode_redirect_uris_in_response.target_value | default("false")}},
         "defaultValue" : {{compatibility_setting.dcr.decode_redirect_uris_in_response.default_value | default("true")}}
     }
+  },
+  "tokenExchange": {
+    "limitScopesToSubjectToken" : {
+        "timestampReference" : "{{compatibility_setting.token_exchange.limit_scopes_to_subject_token.timestamp_reference | default('2026-10-01T00:00:00Z')}}",
+        "targetValue" : {{compatibility_setting.token_exchange.limit_scopes_to_subject_token.target_value | default("false")}},
+        "defaultValue" : {{compatibility_setting.token_exchange.limit_scopes_to_subject_token.default_value | default("true")}}
+    },
+    "defaultRestrictScopeIssuanceForFederatedTokens" : {
+        "timestampReference" : "{{compatibility_setting.token_exchange.default_restrict_scope_issuance_for_federated_tokens.timestamp_reference | default('2026-10-01T00:00:00Z')}}",
+        "targetValue" : {{compatibility_setting.token_exchange.default_restrict_scope_issuance_for_federated_tokens.target_value | default("false")}},
+        "defaultValue" : {{compatibility_setting.token_exchange.default_restrict_scope_issuance_for_federated_tokens.default_value | default("false")}}
+    }
   }
 }


### PR DESCRIPTION
## Purpose

Register the tenant-level compatibility settings that control token exchange scope restriction, so the behaviour can be varied per tenant and defaulted by tenant creation date.

Related issue: https://github.com/wso2/product-is/issues/28406

## Description

Adds a `tokenExchange` group to `compatibility-settings-metadata.json.j2` with two settings:

- `limitScopesToSubjectToken` — `targetValue: true`, `defaultValue: true`. Keeps the compatibility settings config true to all tenants so the behaviour will be decided from the server config. Required deployments can overwrite these values to gain tenant level control.
- `defaultRestrictScopeIssuanceForFederatedTokens` — `targetValue: false`, `defaultValue: false`. Decides the value stamped on the per-application toggle when a new application is created. It does not vary with tenant creation date, so both values are the same.